### PR TITLE
Add manifests for CRD, examples

### DIFF
--- a/example/every-minute-cron.yaml
+++ b/example/every-minute-cron.yaml
@@ -1,0 +1,27 @@
+apiVersion: kubeflow.org/v1alpha1
+kind: ScheduledWorkflow
+metadata:
+  name: every-minute-cron
+spec:
+  description: "every-minute-cron"
+  enabled: true
+  maxHistory: 10
+  trigger:
+    cronSchedule:
+      cron: 1 * * * * *
+  workflow:
+    spec:
+      entrypoint: whalesay
+      arguments:
+        parameters:
+        - name: message
+          value: hello world
+      templates:
+      - name: whalesay
+        inputs:
+          parameters:
+          - name: message
+        container:
+          image: docker/whalesay
+          command: [cowsay]
+          args: ["{{inputs.parameters.message}}"]

--- a/example/every-minute-periodic.yaml
+++ b/example/every-minute-periodic.yaml
@@ -1,0 +1,27 @@
+apiVersion: kubeflow.org/v1alpha1
+kind: ScheduledWorkflow
+metadata:
+  name: every-minute-periodic
+spec:
+  description: "every-minute-periodic"
+  enabled: true
+  maxHistory: 10
+  trigger:
+    periodicSchedule:
+      intervalSecond: 60
+  workflow:
+    spec:
+      entrypoint: whalesay
+      arguments:
+        parameters:
+        - name: message
+          value: hello world
+      templates:
+      - name: whalesay
+        inputs:
+          parameters:
+          - name: message
+        container:
+          image: docker/whalesay
+          command: [cowsay]
+          args: ["{{inputs.parameters.message}}"]

--- a/install/manifests/pipelines-crd.yaml
+++ b/install/manifests/pipelines-crd.yaml
@@ -1,0 +1,11 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: scheduledworkflows.kubeflow.org
+spec:
+  group: kubeflow.org
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: ScheduledWorkflow
+    plural: scheduledworkflows


### PR DESCRIPTION
Add manifests to run `scheduledworkflows` and its examples.

for examples:
```
# Run controller
$ go run resources/scheduledworkflow/*.go -kubeconfig $HOME/.kube/config

# Install CRDs
$ argo install
$ kubectl apply -f install/manifests/pipelines-crd.yaml

# Run examples
$ kubectl apply -f example/

# Checking
$ kubectl get scheduledworkflows
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/6)
<!-- Reviewable:end -->
