### PR TITLE
Fixes off-by-one error with months in Trigger

### DIFF
--- a/frontend/src/lib/TriggerUtils.test.ts
+++ b/frontend/src/lib/TriggerUtils.test.ts
@@ -148,9 +148,10 @@ describe('TriggerUtils', () => {
       expect(pickersToDate(false, 'some string', 'some string')).toBeUndefined();
     });
 
-    const date = new Date(2018, 8, 13, 17, 33);
+    // JS dates are 0-indexed, so 0 here is actually January.
+    const date = new Date(2018, 0, 13, 17, 33);
     it('converts picker format to date if hasDate is true', () => {
-      expect(pickersToDate(true, '2018-8-13', '17:33')!.toISOString()).toBe(date.toISOString());
+      expect(pickersToDate(true, '2018-1-13', '17:33')!.toISOString()).toBe(date.toISOString());
     });
 
     it('throws on bad format', () => {

--- a/frontend/src/lib/TriggerUtils.ts
+++ b/frontend/src/lib/TriggerUtils.ts
@@ -120,7 +120,7 @@ export function pickersToDate(hasDate: boolean, dateStr: string, timeStr: string
     const [year, month, date] = dateStr.split('-');
     const [hour, minute] = timeStr.split(':');
 
-    const d = new Date(+year, +month, +date, +hour, +minute);
+    const d = new Date(+year, (+month - 1), +date, +hour, +minute);
     if (isNaN(d as any)) {
       throw new Error('Invalid picker format');
     }

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -165,7 +165,7 @@ class NewRun extends Page<{}, NewRunState> {
           <div className={commonCss.header}>Run parameters</div>
           <div>{this._runParametersMessage(pipeline)}</div>
 
-          {pipeline && pipeline.parameters && pipeline.parameters.length && (
+          {pipeline && pipeline.parameters && !!pipeline.parameters.length && (
             <div>
               {pipeline && (pipeline.parameters || []).map((param, i) =>
                 <TextField key={i} variant='outlined' label={param.name} value={param.value || ''}


### PR DESCRIPTION
Months in Javascript Dates are 0-indexed, but previously we were treating them as 1-indexed

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/66)
<!-- Reviewable:end -->
