### PR TITLE
css fix for breadcrumbs

### DIFF
--- a/frontend/src/Css.tsx
+++ b/frontend/src/Css.tsx
@@ -22,6 +22,7 @@ export const color = {
   activeBg: '#eaf1fd',
   alert: '#f9ab00', // Google yellow 600
   background: '#fff',
+  breadcrumbs: '#5F6368',
   disabledBg: '#ddd',
   divider: '#e0e0e0',
   errorBg: '#FBE9E7',

--- a/frontend/src/components/Toolbar.tsx
+++ b/frontend/src/components/Toolbar.tsx
@@ -23,7 +23,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import { History } from 'history';
 import { Link } from 'react-router-dom';
 import { classes, stylesheet } from 'typestyle';
-import { spacing, fontsize, color, dimension, commonCss } from '../Css';
+import { spacing, fonts, fontsize, color, dimension, commonCss } from '../Css';
 
 export interface ToolbarActionConfig {
   action: () => void;
@@ -55,7 +55,10 @@ const css = stylesheet({
     padding: 3,
   },
   breadcrumbs: {
-    fontSize: fontsize.medium,
+    color: color.breadcrumbs,
+    fontFamily: fonts.secondary,
+    fontSize: fontsize.small,
+    letterSpacing: 0.25,
     margin: '10px 37px',
   },
   chevron: {


### PR DESCRIPTION
Change to the text style of breadcrumbs (color, font size)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/106)
<!-- Reviewable:end -->
