### PR TITLE
Keep Experiments button in sidenav highlighted on non-pipeline pages

### DIFF
--- a/frontend/src/components/SideNav.test.tsx
+++ b/frontend/src/components/SideNav.test.tsx
@@ -48,13 +48,13 @@ describe('SideNav', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders experiments as active page', () => {
-    const tree = shallow(<SideNav page={RoutePage.EXPERIMENTS} {...routerProps} />);
+  it('renders Pipelines as active when on PipelineDetails page', () => {
+    const tree = shallow(<SideNav page={RoutePage.PIPELINE_DETAILS} {...routerProps} />);
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders Pipelines as active when on PipelineDetails page', () => {
-    const tree = shallow(<SideNav page={RoutePage.PIPELINE_DETAILS} {...routerProps} />);
+  it('renders experiments as active page', () => {
+    const tree = shallow(<SideNav page={RoutePage.EXPERIMENTS} {...routerProps} />);
     expect(tree).toMatchSnapshot();
   });
 
@@ -63,8 +63,33 @@ describe('SideNav', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders nothing as active page', () => {
+  it('renders experiments as active page when on NewExperiment page', () => {
+    const tree = shallow(<SideNav page={RoutePage.NEW_EXPERIMENT} {...routerProps} />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders experiments as active page when on Compare page', () => {
     const tree = shallow(<SideNav page={RoutePage.COMPARE} {...routerProps} />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders experiments as active page when on AllRuns page', () => {
+    const tree = shallow(<SideNav page={RoutePage.RUNS} {...routerProps} />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders experiments as active page when on RunDetails page', () => {
+    const tree = shallow(<SideNav page={RoutePage.RUN_DETAILS} {...routerProps} />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders experiments as active page when on RecurringRunDetails page', () => {
+    const tree = shallow(<SideNav page={RoutePage.RECURRING_RUN} {...routerProps} />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders experiments as active page when on NewRun page', () => {
+    const tree = shallow(<SideNav page={RoutePage.NEW_RUN} {...routerProps} />);
     expect(tree).toMatchSnapshot();
   });
 

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -172,27 +172,27 @@ class SideNav extends React.Component<SideNavProps, SideNavState> {
             Kubeflow
           </span>
         </div>
-        <Link id='pipelinesBtn' to={RoutePage.PIPELINES} className={commonCss.unstyled}>
-          <Button className={classes(css.button,
+        <Link id='pipelinesLink' to={RoutePage.PIPELINES} className={commonCss.unstyled}>
+          <Button id='sideNavPipelinesBtn' className={classes(css.button,
             page.startsWith(RoutePage.PIPELINES) && css.active,
             collapsed && css.collapsedButton)}>
             <PipelinesIcon color={page.startsWith(RoutePage.PIPELINES) ? iconColor.active : iconColor.inactive} />
             <span className={classes(collapsed && css.collapsedLabel, css.label)}>Pipelines</span>
           </Button>
         </Link>
-        <Link id='experimentsBtn' to={RoutePage.EXPERIMENTS} className={commonCss.unstyled}>
-          <Button className={
+        <Link id='experimentsLink' to={RoutePage.EXPERIMENTS} className={commonCss.unstyled}>
+          <Button id='sideNavExperimentsBtn' className={
             classes(
               css.button,
-              page.startsWith(RoutePage.EXPERIMENTS) && css.active,
+              this._highlightExperimentsButton(page) && css.active,
               collapsed && css.collapsedButton)}>
-            <ExperimentsIcon color={page.startsWith(RoutePage.EXPERIMENTS) ? iconColor.active : iconColor.inactive} />
+            <ExperimentsIcon color={this._highlightExperimentsButton(page) ? iconColor.active : iconColor.inactive} />
             <span className={classes(collapsed && css.collapsedLabel, css.label)}>Experiments</span>
           </Button>
         </Link>
         {this.state.jupyterHubAvailable && (
-          <a id='jupyterhubBtn' href={this._HUB_ADDRESS} className={commonCss.unstyled} target='_blank'>
-            <Button className={
+          <a id='jupyterhubLink' href={this._HUB_ADDRESS} className={commonCss.unstyled} target='_blank'>
+            <Button id='sideNavJupyterhubBtn'className={
               classes(css.button, collapsed && css.collapsedButton)}>
               <JupyterhubIcon style={{ height: 20, width: 20 }} />
               <span className={classes(collapsed && css.collapsedLabel, css.label)}>Notebooks</span>
@@ -207,6 +207,15 @@ class SideNav extends React.Component<SideNavProps, SideNavState> {
         </IconButton>
       </div >
     );
+  }
+
+  private _highlightExperimentsButton(page: string): boolean {
+    return page.startsWith(RoutePage.EXPERIMENTS)
+      || page.startsWith(RoutePage.RUNS)
+      // TODO: Router should have a constant for this, but it doesn't follow the naming convention
+      // of the other pages
+      || page.startsWith('/recurringrun')
+      || page.startsWith(RoutePage.COMPARE);
   }
 
   private _toggleNavClicked() {

--- a/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
@@ -24,12 +24,13 @@ exports[`SideNav renders Pipelines as active page 1`] = `
   </div>
   <Link
     className="unstyled"
-    id="pipelinesBtn"
+    id="pipelinesLink"
     replace={false}
     to="/pipelines"
   >
     <WithStyles(Button)
       className="button active"
+      id="sideNavPipelinesBtn"
     >
       <PipelinesIcon
         color="#fff"
@@ -43,12 +44,13 @@ exports[`SideNav renders Pipelines as active page 1`] = `
   </Link>
   <Link
     className="unstyled"
-    id="experimentsBtn"
+    id="experimentsLink"
     replace={false}
     to="/experiments"
   >
     <WithStyles(Button)
       className="button"
+      id="sideNavExperimentsBtn"
     >
       <ExperimentsIcon
         color="#87a1b8"
@@ -96,12 +98,13 @@ exports[`SideNav renders Pipelines as active when on PipelineDetails page 1`] = 
   </div>
   <Link
     className="unstyled"
-    id="pipelinesBtn"
+    id="pipelinesLink"
     replace={false}
     to="/pipelines"
   >
     <WithStyles(Button)
       className="button active"
+      id="sideNavPipelinesBtn"
     >
       <PipelinesIcon
         color="#fff"
@@ -115,12 +118,13 @@ exports[`SideNav renders Pipelines as active when on PipelineDetails page 1`] = 
   </Link>
   <Link
     className="unstyled"
-    id="experimentsBtn"
+    id="experimentsLink"
     replace={false}
     to="/experiments"
   >
     <WithStyles(Button)
       className="button"
+      id="sideNavExperimentsBtn"
     >
       <ExperimentsIcon
         color="#87a1b8"
@@ -168,12 +172,13 @@ exports[`SideNav renders collapsed state 1`] = `
   </div>
   <Link
     className="unstyled"
-    id="pipelinesBtn"
+    id="pipelinesLink"
     replace={false}
     to="/pipelines"
   >
     <WithStyles(Button)
       className="button active collapsedButton"
+      id="sideNavPipelinesBtn"
     >
       <PipelinesIcon
         color="#fff"
@@ -187,12 +192,13 @@ exports[`SideNav renders collapsed state 1`] = `
   </Link>
   <Link
     className="unstyled"
-    id="experimentsBtn"
+    id="experimentsLink"
     replace={false}
     to="/experiments"
   >
     <WithStyles(Button)
       className="button collapsedButton"
+      id="sideNavExperimentsBtn"
     >
       <ExperimentsIcon
         color="#87a1b8"
@@ -240,12 +246,13 @@ exports[`SideNav renders expanded state 1`] = `
   </div>
   <Link
     className="unstyled"
-    id="pipelinesBtn"
+    id="pipelinesLink"
     replace={false}
     to="/pipelines"
   >
     <WithStyles(Button)
       className="button active"
+      id="sideNavPipelinesBtn"
     >
       <PipelinesIcon
         color="#fff"
@@ -259,12 +266,13 @@ exports[`SideNav renders expanded state 1`] = `
   </Link>
   <Link
     className="unstyled"
-    id="experimentsBtn"
+    id="experimentsLink"
     replace={false}
     to="/experiments"
   >
     <WithStyles(Button)
       className="button"
+      id="sideNavExperimentsBtn"
     >
       <ExperimentsIcon
         color="#87a1b8"
@@ -312,12 +320,13 @@ exports[`SideNav renders experiments as active page 1`] = `
   </div>
   <Link
     className="unstyled"
-    id="pipelinesBtn"
+    id="pipelinesLink"
     replace={false}
     to="/pipelines"
   >
     <WithStyles(Button)
       className="button"
+      id="sideNavPipelinesBtn"
     >
       <PipelinesIcon
         color="#87a1b8"
@@ -331,12 +340,457 @@ exports[`SideNav renders experiments as active page 1`] = `
   </Link>
   <Link
     className="unstyled"
-    id="experimentsBtn"
+    id="experimentsLink"
     replace={false}
     to="/experiments"
   >
     <WithStyles(Button)
       className="button active"
+      id="sideNavExperimentsBtn"
+    >
+      <ExperimentsIcon
+        color="#fff"
+      />
+      <span
+        className="label"
+      >
+        Experiments
+      </span>
+    </WithStyles(Button)>
+  </Link>
+  <hr
+    className="separator"
+  />
+  <WithStyles(IconButton)
+    className="chevron"
+    onClick={[Function]}
+  >
+    <pure(ChevronLeftIcon) />
+  </WithStyles(IconButton)>
+</div>
+`;
+
+exports[`SideNav renders experiments as active page when on AllRuns page 1`] = `
+<div
+  className="root noShrink"
+  id="sideNav"
+>
+  <div
+    className="button logo"
+  >
+    <KubeflowLogo
+      color="#fff"
+      style={
+        Object {
+          "flexShrink": 0,
+        }
+      }
+    />
+    <span
+      className="label logoLabel"
+    >
+      Kubeflow
+    </span>
+  </div>
+  <Link
+    className="unstyled"
+    id="pipelinesLink"
+    replace={false}
+    to="/pipelines"
+  >
+    <WithStyles(Button)
+      className="button"
+      id="sideNavPipelinesBtn"
+    >
+      <PipelinesIcon
+        color="#87a1b8"
+      />
+      <span
+        className="label"
+      >
+        Pipelines
+      </span>
+    </WithStyles(Button)>
+  </Link>
+  <Link
+    className="unstyled"
+    id="experimentsLink"
+    replace={false}
+    to="/experiments"
+  >
+    <WithStyles(Button)
+      className="button active"
+      id="sideNavExperimentsBtn"
+    >
+      <ExperimentsIcon
+        color="#fff"
+      />
+      <span
+        className="label"
+      >
+        Experiments
+      </span>
+    </WithStyles(Button)>
+  </Link>
+  <hr
+    className="separator"
+  />
+  <WithStyles(IconButton)
+    className="chevron"
+    onClick={[Function]}
+  >
+    <pure(ChevronLeftIcon) />
+  </WithStyles(IconButton)>
+</div>
+`;
+
+exports[`SideNav renders experiments as active page when on Compare page 1`] = `
+<div
+  className="root noShrink"
+  id="sideNav"
+>
+  <div
+    className="button logo"
+  >
+    <KubeflowLogo
+      color="#fff"
+      style={
+        Object {
+          "flexShrink": 0,
+        }
+      }
+    />
+    <span
+      className="label logoLabel"
+    >
+      Kubeflow
+    </span>
+  </div>
+  <Link
+    className="unstyled"
+    id="pipelinesLink"
+    replace={false}
+    to="/pipelines"
+  >
+    <WithStyles(Button)
+      className="button"
+      id="sideNavPipelinesBtn"
+    >
+      <PipelinesIcon
+        color="#87a1b8"
+      />
+      <span
+        className="label"
+      >
+        Pipelines
+      </span>
+    </WithStyles(Button)>
+  </Link>
+  <Link
+    className="unstyled"
+    id="experimentsLink"
+    replace={false}
+    to="/experiments"
+  >
+    <WithStyles(Button)
+      className="button active"
+      id="sideNavExperimentsBtn"
+    >
+      <ExperimentsIcon
+        color="#fff"
+      />
+      <span
+        className="label"
+      >
+        Experiments
+      </span>
+    </WithStyles(Button)>
+  </Link>
+  <hr
+    className="separator"
+  />
+  <WithStyles(IconButton)
+    className="chevron"
+    onClick={[Function]}
+  >
+    <pure(ChevronLeftIcon) />
+  </WithStyles(IconButton)>
+</div>
+`;
+
+exports[`SideNav renders experiments as active page when on NewExperiment page 1`] = `
+<div
+  className="root noShrink"
+  id="sideNav"
+>
+  <div
+    className="button logo"
+  >
+    <KubeflowLogo
+      color="#fff"
+      style={
+        Object {
+          "flexShrink": 0,
+        }
+      }
+    />
+    <span
+      className="label logoLabel"
+    >
+      Kubeflow
+    </span>
+  </div>
+  <Link
+    className="unstyled"
+    id="pipelinesLink"
+    replace={false}
+    to="/pipelines"
+  >
+    <WithStyles(Button)
+      className="button"
+      id="sideNavPipelinesBtn"
+    >
+      <PipelinesIcon
+        color="#87a1b8"
+      />
+      <span
+        className="label"
+      >
+        Pipelines
+      </span>
+    </WithStyles(Button)>
+  </Link>
+  <Link
+    className="unstyled"
+    id="experimentsLink"
+    replace={false}
+    to="/experiments"
+  >
+    <WithStyles(Button)
+      className="button active"
+      id="sideNavExperimentsBtn"
+    >
+      <ExperimentsIcon
+        color="#fff"
+      />
+      <span
+        className="label"
+      >
+        Experiments
+      </span>
+    </WithStyles(Button)>
+  </Link>
+  <hr
+    className="separator"
+  />
+  <WithStyles(IconButton)
+    className="chevron"
+    onClick={[Function]}
+  >
+    <pure(ChevronLeftIcon) />
+  </WithStyles(IconButton)>
+</div>
+`;
+
+exports[`SideNav renders experiments as active page when on NewRun page 1`] = `
+<div
+  className="root noShrink"
+  id="sideNav"
+>
+  <div
+    className="button logo"
+  >
+    <KubeflowLogo
+      color="#fff"
+      style={
+        Object {
+          "flexShrink": 0,
+        }
+      }
+    />
+    <span
+      className="label logoLabel"
+    >
+      Kubeflow
+    </span>
+  </div>
+  <Link
+    className="unstyled"
+    id="pipelinesLink"
+    replace={false}
+    to="/pipelines"
+  >
+    <WithStyles(Button)
+      className="button"
+      id="sideNavPipelinesBtn"
+    >
+      <PipelinesIcon
+        color="#87a1b8"
+      />
+      <span
+        className="label"
+      >
+        Pipelines
+      </span>
+    </WithStyles(Button)>
+  </Link>
+  <Link
+    className="unstyled"
+    id="experimentsLink"
+    replace={false}
+    to="/experiments"
+  >
+    <WithStyles(Button)
+      className="button active"
+      id="sideNavExperimentsBtn"
+    >
+      <ExperimentsIcon
+        color="#fff"
+      />
+      <span
+        className="label"
+      >
+        Experiments
+      </span>
+    </WithStyles(Button)>
+  </Link>
+  <hr
+    className="separator"
+  />
+  <WithStyles(IconButton)
+    className="chevron"
+    onClick={[Function]}
+  >
+    <pure(ChevronLeftIcon) />
+  </WithStyles(IconButton)>
+</div>
+`;
+
+exports[`SideNav renders experiments as active page when on RecurringRunDetails page 1`] = `
+<div
+  className="root noShrink"
+  id="sideNav"
+>
+  <div
+    className="button logo"
+  >
+    <KubeflowLogo
+      color="#fff"
+      style={
+        Object {
+          "flexShrink": 0,
+        }
+      }
+    />
+    <span
+      className="label logoLabel"
+    >
+      Kubeflow
+    </span>
+  </div>
+  <Link
+    className="unstyled"
+    id="pipelinesLink"
+    replace={false}
+    to="/pipelines"
+  >
+    <WithStyles(Button)
+      className="button"
+      id="sideNavPipelinesBtn"
+    >
+      <PipelinesIcon
+        color="#87a1b8"
+      />
+      <span
+        className="label"
+      >
+        Pipelines
+      </span>
+    </WithStyles(Button)>
+  </Link>
+  <Link
+    className="unstyled"
+    id="experimentsLink"
+    replace={false}
+    to="/experiments"
+  >
+    <WithStyles(Button)
+      className="button active"
+      id="sideNavExperimentsBtn"
+    >
+      <ExperimentsIcon
+        color="#fff"
+      />
+      <span
+        className="label"
+      >
+        Experiments
+      </span>
+    </WithStyles(Button)>
+  </Link>
+  <hr
+    className="separator"
+  />
+  <WithStyles(IconButton)
+    className="chevron"
+    onClick={[Function]}
+  >
+    <pure(ChevronLeftIcon) />
+  </WithStyles(IconButton)>
+</div>
+`;
+
+exports[`SideNav renders experiments as active page when on RunDetails page 1`] = `
+<div
+  className="root noShrink"
+  id="sideNav"
+>
+  <div
+    className="button logo"
+  >
+    <KubeflowLogo
+      color="#fff"
+      style={
+        Object {
+          "flexShrink": 0,
+        }
+      }
+    />
+    <span
+      className="label logoLabel"
+    >
+      Kubeflow
+    </span>
+  </div>
+  <Link
+    className="unstyled"
+    id="pipelinesLink"
+    replace={false}
+    to="/pipelines"
+  >
+    <WithStyles(Button)
+      className="button"
+      id="sideNavPipelinesBtn"
+    >
+      <PipelinesIcon
+        color="#87a1b8"
+      />
+      <span
+        className="label"
+      >
+        Pipelines
+      </span>
+    </WithStyles(Button)>
+  </Link>
+  <Link
+    className="unstyled"
+    id="experimentsLink"
+    replace={false}
+    to="/experiments"
+  >
+    <WithStyles(Button)
+      className="button active"
+      id="sideNavExperimentsBtn"
     >
       <ExperimentsIcon
         color="#fff"
@@ -384,12 +838,13 @@ exports[`SideNav renders experiments as active when on ExperimentDetails page 1`
   </div>
   <Link
     className="unstyled"
-    id="pipelinesBtn"
+    id="pipelinesLink"
     replace={false}
     to="/pipelines"
   >
     <WithStyles(Button)
       className="button"
+      id="sideNavPipelinesBtn"
     >
       <PipelinesIcon
         color="#87a1b8"
@@ -403,87 +858,16 @@ exports[`SideNav renders experiments as active when on ExperimentDetails page 1`
   </Link>
   <Link
     className="unstyled"
-    id="experimentsBtn"
+    id="experimentsLink"
     replace={false}
     to="/experiments"
   >
     <WithStyles(Button)
       className="button active"
+      id="sideNavExperimentsBtn"
     >
       <ExperimentsIcon
         color="#fff"
-      />
-      <span
-        className="label"
-      >
-        Experiments
-      </span>
-    </WithStyles(Button)>
-  </Link>
-  <hr
-    className="separator"
-  />
-  <WithStyles(IconButton)
-    className="chevron"
-    onClick={[Function]}
-  >
-    <pure(ChevronLeftIcon) />
-  </WithStyles(IconButton)>
-</div>
-`;
-
-exports[`SideNav renders nothing as active page 1`] = `
-<div
-  className="root noShrink"
-  id="sideNav"
->
-  <div
-    className="button logo"
-  >
-    <KubeflowLogo
-      color="#fff"
-      style={
-        Object {
-          "flexShrink": 0,
-        }
-      }
-    />
-    <span
-      className="label logoLabel"
-    >
-      Kubeflow
-    </span>
-  </div>
-  <Link
-    className="unstyled"
-    id="pipelinesBtn"
-    replace={false}
-    to="/pipelines"
-  >
-    <WithStyles(Button)
-      className="button"
-    >
-      <PipelinesIcon
-        color="#87a1b8"
-      />
-      <span
-        className="label"
-      >
-        Pipelines
-      </span>
-    </WithStyles(Button)>
-  </Link>
-  <Link
-    className="unstyled"
-    id="experimentsBtn"
-    replace={false}
-    to="/experiments"
-  >
-    <WithStyles(Button)
-      className="button"
-    >
-      <ExperimentsIcon
-        color="#87a1b8"
       />
       <span
         className="label"
@@ -528,12 +912,13 @@ exports[`SideNav show jupyterhub link if accessible 1`] = `
   </div>
   <Link
     className="unstyled"
-    id="pipelinesBtn"
+    id="pipelinesLink"
     replace={false}
     to="/pipelines"
   >
     <WithStyles(Button)
       className="button"
+      id="sideNavPipelinesBtn"
     >
       <PipelinesIcon
         color="#87a1b8"
@@ -547,15 +932,16 @@ exports[`SideNav show jupyterhub link if accessible 1`] = `
   </Link>
   <Link
     className="unstyled"
-    id="experimentsBtn"
+    id="experimentsLink"
     replace={false}
     to="/experiments"
   >
     <WithStyles(Button)
-      className="button"
+      className="button active"
+      id="sideNavExperimentsBtn"
     >
       <ExperimentsIcon
-        color="#87a1b8"
+        color="#fff"
       />
       <span
         className="label"
@@ -567,11 +953,12 @@ exports[`SideNav show jupyterhub link if accessible 1`] = `
   <a
     className="unstyled"
     href="/hub/"
-    id="jupyterhubBtn"
+    id="jupyterhubLink"
     target="_blank"
   >
     <WithStyles(Button)
       className="button"
+      id="sideNavJupyterhubBtn"
     >
       <pure(CodeIcon)
         style={

--- a/frontend/src/pages/AllRunsList.tsx
+++ b/frontend/src/pages/AllRunsList.tsx
@@ -15,6 +15,7 @@
  */
 
 import * as React from 'react';
+import AddIcon from '@material-ui/icons/Add';
 import RunList from './RunList';
 import { Page } from './Page';
 import { RoutePage } from '../components/Router';
@@ -40,31 +41,34 @@ class AllRunsList extends Page<{}, AllRunsListState> {
 
   public getInitialToolbarState() {
     return {
-      actions: [
-        {
-          action: this._compareRuns.bind(this),
-          disabled: true,
-          disabledTitle: 'Select multiple runs to compare',
-          id: 'compareBtn',
-          title: 'Compare runs',
-          tooltip: 'Compare up to 10 selected runs',
-        },
-        {
-          action: this._cloneRun.bind(this),
-          disabled: true,
-          disabledTitle: 'Select a run to clone',
-          id: 'cloneBtn',
-          title: 'Clone run',
-          tooltip: 'Create a copy from this run\s initial state',
-        },
-        {
-          action: this.refresh.bind(this),
-          id: 'refreshBtn',
-          title: 'Refresh',
-          tooltip: 'Refresh',
-        },
-      ],
-      breadcrumbs: [{ displayName: 'All runs', href: '' }],
+      actions: [{
+        action: this._newExperimentClicked.bind(this),
+        icon: AddIcon,
+        id: 'newExperimentBtn',
+        outlined: true,
+        title: 'Create experiment',
+        tooltip: 'Create a new experiment',
+      }, {
+        action: this._compareRuns.bind(this),
+        disabled: true,
+        disabledTitle: 'Select multiple runs to compare',
+        id: 'compareBtn',
+        title: 'Compare runs',
+        tooltip: 'Compare up to 10 selected runs',
+      }, {
+        action: this._cloneRun.bind(this),
+        disabled: true,
+        disabledTitle: 'Select a run to clone',
+        id: 'cloneBtn',
+        title: 'Clone run',
+        tooltip: 'Create a copy from this run\s initial state',
+      }, {
+        action: this.refresh.bind(this),
+        id: 'refreshBtn',
+        title: 'Refresh',
+        tooltip: 'Refresh the list of runs',
+      }],
+      breadcrumbs: [{ displayName: 'Experiments', href: '' }],
     };
   }
 
@@ -84,6 +88,10 @@ class AllRunsList extends Page<{}, AllRunsListState> {
     }
   }
 
+  private _newExperimentClicked() {
+    this.props.history.push(RoutePage.NEW_EXPERIMENT);
+  }
+
   private _compareRuns() {
     const indices = this.state.selectedIds;
     if (indices.length > 1 && indices.length <= 10) {
@@ -98,9 +106,9 @@ class AllRunsList extends Page<{}, AllRunsListState> {
   private _selectionChanged(selectedIds: string[]) {
     const toolbarActions = [...this.props.toolbarProps.actions];
     // Compare runs button
-    toolbarActions[0].disabled = selectedIds.length <= 1 || selectedIds.length > 10;
+    toolbarActions[1].disabled = selectedIds.length <= 1 || selectedIds.length > 10;
     // Clone run button
-    toolbarActions[1].disabled = selectedIds.length !== 1;
+    toolbarActions[2].disabled = selectedIds.length !== 1;
     this.props.updateToolbar({ breadcrumbs: this.props.toolbarProps.breadcrumbs, actions: toolbarActions });
     this.setState({ selectedIds });
   }

--- a/frontend/src/pages/ExperimentList.tsx
+++ b/frontend/src/pages/ExperimentList.tsx
@@ -87,7 +87,7 @@ class ExperimentList extends Page<{}, ExperimentListState> {
         title: 'Refresh',
         tooltip: 'Refresh the list of experiments',
       }],
-      breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
+      breadcrumbs: [{ displayName: 'Experiments', href: '' }],
     };
   }
 

--- a/frontend/src/pages/__snapshots__/AllRunsList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/AllRunsList.test.tsx.snap
@@ -27,6 +27,14 @@ exports[`AllRunsList disables clone button and enables compare button when multi
               "actions": Array [
                 Object {
                   "action": [Function],
+                  "icon": [Function],
+                  "id": "newExperimentBtn",
+                  "outlined": true,
+                  "title": "Create experiment",
+                  "tooltip": "Create a new experiment",
+                },
+                Object {
+                  "action": [Function],
                   "disabled": false,
                   "disabledTitle": "Select multiple runs to compare",
                   "id": "compareBtn",
@@ -45,12 +53,12 @@ exports[`AllRunsList disables clone button and enables compare button when multi
                   "action": [Function],
                   "id": "refreshBtn",
                   "title": "Refresh",
-                  "tooltip": "Refresh",
+                  "tooltip": "Refresh the list of runs",
                 },
               ],
               "breadcrumbs": Array [
                 Object {
-                  "displayName": "All runs",
+                  "displayName": "Experiments",
                   "href": "",
                 },
               ],
@@ -59,6 +67,14 @@ exports[`AllRunsList disables clone button and enables compare button when multi
           Array [
             Object {
               "actions": Array [
+                Object {
+                  "action": [Function],
+                  "icon": [Function],
+                  "id": "newExperimentBtn",
+                  "outlined": true,
+                  "title": "Create experiment",
+                  "tooltip": "Create a new experiment",
+                },
                 Object {
                   "action": [Function],
                   "disabled": true,
@@ -79,12 +95,12 @@ exports[`AllRunsList disables clone button and enables compare button when multi
                   "action": [Function],
                   "id": "refreshBtn",
                   "title": "Refresh",
-                  "tooltip": "Refresh",
+                  "tooltip": "Refresh the list of runs",
                 },
               ],
               "breadcrumbs": Array [
                 Object {
-                  "displayName": "All runs",
+                  "displayName": "Experiments",
                   "href": "",
                 },
               ],
@@ -124,6 +140,14 @@ exports[`AllRunsList enables clone button when one run is selected 1`] = `
               "actions": Array [
                 Object {
                   "action": [Function],
+                  "icon": [Function],
+                  "id": "newExperimentBtn",
+                  "outlined": true,
+                  "title": "Create experiment",
+                  "tooltip": "Create a new experiment",
+                },
+                Object {
+                  "action": [Function],
                   "disabled": true,
                   "disabledTitle": "Select multiple runs to compare",
                   "id": "compareBtn",
@@ -142,12 +166,12 @@ exports[`AllRunsList enables clone button when one run is selected 1`] = `
                   "action": [Function],
                   "id": "refreshBtn",
                   "title": "Refresh",
-                  "tooltip": "Refresh",
+                  "tooltip": "Refresh the list of runs",
                 },
               ],
               "breadcrumbs": Array [
                 Object {
-                  "displayName": "All runs",
+                  "displayName": "Experiments",
                   "href": "",
                 },
               ],
@@ -156,6 +180,14 @@ exports[`AllRunsList enables clone button when one run is selected 1`] = `
           Array [
             Object {
               "actions": Array [
+                Object {
+                  "action": [Function],
+                  "icon": [Function],
+                  "id": "newExperimentBtn",
+                  "outlined": true,
+                  "title": "Create experiment",
+                  "tooltip": "Create a new experiment",
+                },
                 Object {
                   "action": [Function],
                   "disabled": true,
@@ -176,12 +208,12 @@ exports[`AllRunsList enables clone button when one run is selected 1`] = `
                   "action": [Function],
                   "id": "refreshBtn",
                   "title": "Refresh",
-                  "tooltip": "Refresh",
+                  "tooltip": "Refresh the list of runs",
                 },
               ],
               "breadcrumbs": Array [
                 Object {
-                  "displayName": "All runs",
+                  "displayName": "Experiments",
                   "href": "",
                 },
               ],
@@ -214,6 +246,14 @@ exports[`AllRunsList renders all runs 1`] = `
         "actions": Array [
           Object {
             "action": [Function],
+            "icon": [Function],
+            "id": "newExperimentBtn",
+            "outlined": true,
+            "title": "Create experiment",
+            "tooltip": "Create a new experiment",
+          },
+          Object {
+            "action": [Function],
             "disabled": true,
             "disabledTitle": "Select multiple runs to compare",
             "id": "compareBtn",
@@ -232,12 +272,12 @@ exports[`AllRunsList renders all runs 1`] = `
             "action": [Function],
             "id": "refreshBtn",
             "title": "Refresh",
-            "tooltip": "Refresh",
+            "tooltip": "Refresh the list of runs",
           },
         ],
         "breadcrumbs": Array [
           Object {
-            "displayName": "All runs",
+            "displayName": "Experiments",
             "href": "",
           },
         ],


### PR DESCRIPTION
Fixes: #71 

Keeps `Experiments` button/tab on the side-nav highlighted for all non-pipeline pages, including `RecurringRunDetails` and `Compare`.

Changes the title on the `AllRunsList` page to match that of the `ExperimentList` page and adds `Create new experiment` button to `AllRunsList`

Note that we probably should truly merge these pages at some point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/126)
<!-- Reviewable:end -->
