### PR TITLE
Fixes bug where a new recurring run has no default trigger

### DIFF
--- a/frontend/src/components/Trigger.tsx
+++ b/frontend/src/components/Trigger.tsx
@@ -198,6 +198,7 @@ export default class Trigger extends React.Component<TriggerProps, TriggerState>
     const startDateTime = pickersToDate(hasStartDate, startDate, startTime);
     const endDateTime = pickersToDate(hasEndDate, endDate, endTime);
 
+    // TODO: Why build the cron string unless the TriggerType is not CRON?
     // Unless cron editing is enabled, calculate the new cron string, set it in state,
     // then use it to build new trigger object and notify the parent
     this.setState({

--- a/frontend/src/components/__snapshots__/Trigger.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Trigger.test.tsx.snap
@@ -5692,7 +5692,7 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
         "refs": Object {},
         "setState": [Function],
         "state": Object {
-          "cron": "",
+          "cron": "0 * * * * ?",
           "editCron": false,
           "endDate": "2018-12-21",
           "endTime": "07:53",
@@ -5721,7 +5721,29 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
             "_element": <Trigger />,
             "_forcedUpdate": false,
             "_instance": [Circular],
-            "_newState": null,
+            "_newState": Object {
+              "cron": "0 * * * * ?",
+              "editCron": false,
+              "endDate": "2018-12-21",
+              "endTime": "07:53",
+              "hasEndDate": false,
+              "hasStartDate": false,
+              "intervalCategory": "Minute",
+              "intervalValue": 1,
+              "maxConcurrentRuns": "10",
+              "selectedDays": Array [
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+              ],
+              "startDate": "2018-12-21",
+              "startTime": "07:53",
+              "type": 0,
+            },
             "_rendered": <div>
               <Unknown
                 field="type"
@@ -5917,7 +5939,7 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
           "refs": Object {},
           "setState": [Function],
           "state": Object {
-            "cron": "",
+            "cron": "0 * * * * ?",
             "editCron": false,
             "endDate": "2018-12-21",
             "endTime": "07:53",
@@ -5946,7 +5968,29 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
               "_element": <Trigger />,
               "_forcedUpdate": false,
               "_instance": [Circular],
-              "_newState": null,
+              "_newState": Object {
+                "cron": "0 * * * * ?",
+                "editCron": false,
+                "endDate": "2018-12-21",
+                "endTime": "07:53",
+                "hasEndDate": false,
+                "hasStartDate": false,
+                "intervalCategory": "Minute",
+                "intervalValue": 1,
+                "maxConcurrentRuns": "10",
+                "selectedDays": Array [
+                  true,
+                  true,
+                  true,
+                  true,
+                  true,
+                  true,
+                  true,
+                ],
+                "startDate": "2018-12-21",
+                "startTime": "07:53",
+                "type": 0,
+              },
               "_rendered": <div>
                 <Unknown
                   field="type"
@@ -6140,7 +6184,7 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
             "refs": Object {},
             "setState": [Function],
             "state": Object {
-              "cron": "",
+              "cron": "0 * * * * ?",
               "editCron": false,
               "endDate": "2018-12-21",
               "endTime": "07:53",
@@ -6169,7 +6213,29 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
                 "_element": <Trigger />,
                 "_forcedUpdate": false,
                 "_instance": [Circular],
-                "_newState": null,
+                "_newState": Object {
+                  "cron": "0 * * * * ?",
+                  "editCron": false,
+                  "endDate": "2018-12-21",
+                  "endTime": "07:53",
+                  "hasEndDate": false,
+                  "hasStartDate": false,
+                  "intervalCategory": "Minute",
+                  "intervalValue": 1,
+                  "maxConcurrentRuns": "10",
+                  "selectedDays": Array [
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                  ],
+                  "startDate": "2018-12-21",
+                  "startTime": "07:53",
+                  "type": 0,
+                },
                 "_rendered": <div>
                   <Unknown
                     field="type"
@@ -6357,7 +6423,7 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
             "refs": Object {},
             "setState": [Function],
             "state": Object {
-              "cron": "",
+              "cron": "0 * * * * ?",
               "editCron": false,
               "endDate": "2018-12-21",
               "endTime": "07:53",
@@ -6386,7 +6452,29 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
                 "_element": <Trigger />,
                 "_forcedUpdate": false,
                 "_instance": [Circular],
-                "_newState": null,
+                "_newState": Object {
+                  "cron": "0 * * * * ?",
+                  "editCron": false,
+                  "endDate": "2018-12-21",
+                  "endTime": "07:53",
+                  "hasEndDate": false,
+                  "hasStartDate": false,
+                  "intervalCategory": "Minute",
+                  "intervalValue": 1,
+                  "maxConcurrentRuns": "10",
+                  "selectedDays": Array [
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                  ],
+                  "startDate": "2018-12-21",
+                  "startTime": "07:53",
+                  "type": 0,
+                },
                 "_rendered": <div>
                   <Unknown
                     field="type"
@@ -6587,7 +6675,7 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
             "refs": Object {},
             "setState": [Function],
             "state": Object {
-              "cron": "",
+              "cron": "0 * * * * ?",
               "editCron": false,
               "endDate": "2018-12-21",
               "endTime": "07:53",
@@ -6616,7 +6704,29 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
                 "_element": <Trigger />,
                 "_forcedUpdate": false,
                 "_instance": [Circular],
-                "_newState": null,
+                "_newState": Object {
+                  "cron": "0 * * * * ?",
+                  "editCron": false,
+                  "endDate": "2018-12-21",
+                  "endTime": "07:53",
+                  "hasEndDate": false,
+                  "hasStartDate": false,
+                  "intervalCategory": "Minute",
+                  "intervalValue": 1,
+                  "maxConcurrentRuns": "10",
+                  "selectedDays": Array [
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                  ],
+                  "startDate": "2018-12-21",
+                  "startTime": "07:53",
+                  "type": 0,
+                },
                 "_rendered": <div>
                   <Unknown
                     field="type"
@@ -6804,7 +6914,7 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
             "refs": Object {},
             "setState": [Function],
             "state": Object {
-              "cron": "",
+              "cron": "0 * * * * ?",
               "editCron": false,
               "endDate": "2018-12-21",
               "endTime": "07:53",
@@ -6833,7 +6943,29 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
                 "_element": <Trigger />,
                 "_forcedUpdate": false,
                 "_instance": [Circular],
-                "_newState": null,
+                "_newState": Object {
+                  "cron": "0 * * * * ?",
+                  "editCron": false,
+                  "endDate": "2018-12-21",
+                  "endTime": "07:53",
+                  "hasEndDate": false,
+                  "hasStartDate": false,
+                  "intervalCategory": "Minute",
+                  "intervalValue": 1,
+                  "maxConcurrentRuns": "10",
+                  "selectedDays": Array [
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                  ],
+                  "startDate": "2018-12-21",
+                  "startTime": "07:53",
+                  "type": 0,
+                },
                 "_rendered": <div>
                   <Unknown
                     field="type"
@@ -7031,7 +7163,7 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
               "refs": Object {},
               "setState": [Function],
               "state": Object {
-                "cron": "",
+                "cron": "0 * * * * ?",
                 "editCron": false,
                 "endDate": "2018-12-21",
                 "endTime": "07:53",
@@ -7060,7 +7192,29 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
                   "_element": <Trigger />,
                   "_forcedUpdate": false,
                   "_instance": [Circular],
-                  "_newState": null,
+                  "_newState": Object {
+                    "cron": "0 * * * * ?",
+                    "editCron": false,
+                    "endDate": "2018-12-21",
+                    "endTime": "07:53",
+                    "hasEndDate": false,
+                    "hasStartDate": false,
+                    "intervalCategory": "Minute",
+                    "intervalValue": 1,
+                    "maxConcurrentRuns": "10",
+                    "selectedDays": Array [
+                      true,
+                      true,
+                      true,
+                      true,
+                      true,
+                      true,
+                      true,
+                    ],
+                    "startDate": "2018-12-21",
+                    "startTime": "07:53",
+                    "type": 0,
+                  },
                   "_rendered": <div>
                     <Unknown
                       field="type"
@@ -7245,7 +7399,7 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
             "refs": Object {},
             "setState": [Function],
             "state": Object {
-              "cron": "",
+              "cron": "0 * * * * ?",
               "editCron": false,
               "endDate": "2018-12-21",
               "endTime": "07:53",
@@ -7274,7 +7428,29 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
                 "_element": <Trigger />,
                 "_forcedUpdate": false,
                 "_instance": [Circular],
-                "_newState": null,
+                "_newState": Object {
+                  "cron": "0 * * * * ?",
+                  "editCron": false,
+                  "endDate": "2018-12-21",
+                  "endTime": "07:53",
+                  "hasEndDate": false,
+                  "hasStartDate": false,
+                  "intervalCategory": "Minute",
+                  "intervalValue": 1,
+                  "maxConcurrentRuns": "10",
+                  "selectedDays": Array [
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                  ],
+                  "startDate": "2018-12-21",
+                  "startTime": "07:53",
+                  "type": 0,
+                },
                 "_rendered": <div>
                   <Unknown
                     field="type"


### PR DESCRIPTION
`NewRun` only updates its in-state `Trigger` object when its child `Trigger` element calls `onChange`. This means if a user creates a new recurring run without ever interacting with the `Trigger` element, `onChange` is never called, and the resulting recurring run that is created has no `Trigger`.

This PR fixes this bug, but a better solution is to have `NewRun` pass the `Trigger` object to the `Trigger` element as a prop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/144)
<!-- Reviewable:end -->
