### PR TITLE
Prevents '0' from showing up on RunDetails config tab when pipeline has no parameters

### DIFF
--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -249,7 +249,7 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
                   ['Duration', getRunTime(workflow)],
                 ]} />
 
-                {workflowParameters && workflowParameters.length && (<div>
+                {workflowParameters && !!workflowParameters.length && (<div>
                   <div className={commonCss.header}>Run parameters</div>
                   <DetailsTable fields={workflowParameters.map(p => [p.name, p.value || ''])} />
                 </div>)}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/147)
<!-- Reviewable:end -->
