### PR TITLE
SDK - Relative imports

### DIFF
--- a/sdk/python/kfp/compiler/_component_builder.py
+++ b/sdk/python/kfp/compiler/_component_builder.py
@@ -21,8 +21,8 @@ import tempfile
 import logging
 from google.cloud import storage
 from pathlib import PurePath, Path
-from kfp import dsl
-from kfp.components._components import _create_task_factory_from_component_dict
+from .. import dsl
+from ..components._components import _create_task_factory_from_component_dict
 from ._k8s_helper import K8sHelper
 
 class GCSHelper(object):

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -16,12 +16,13 @@
 from collections import defaultdict
 import copy
 import inspect
-import kfp.dsl as dsl
 import re
 import string
 import tarfile
 import tempfile
 import yaml
+
+from .. import dsl
 
 
 class Compiler(object):

--- a/sdk/python/kfp/components/_dsl_bridge.py
+++ b/sdk/python/kfp/components/_dsl_bridge.py
@@ -15,7 +15,7 @@
 _dummy_pipeline=None
 
 def _create_task_object(name:str, container_image:str, command=None, arguments=None, file_inputs=None, file_outputs=None):
-    import kfp.dsl as dsl
+    from .. import dsl
     global _dummy_pipeline
     need_dummy = dsl.Pipeline._default_pipeline is None
     if need_dummy:

--- a/sdk/python/kfp/dsl/_component.py
+++ b/sdk/python/kfp/dsl/_component.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kfp import dsl
 def python_component(name, description, base_image):
   """Decorator of component functions.
 
@@ -28,7 +27,7 @@ def python_component(name, description, base_image):
   ```
   """
   def _python_component(func):
-    dsl.PythonComponent.add_python_component(name, description, base_image, func)
+    PythonComponent.add_python_component(name, description, base_image, func)
     return func
 
   return _python_component
@@ -50,7 +49,7 @@ class PythonComponent():
   @staticmethod
   def add_python_component(name, description, base_image, func):
     """ Add a python component """
-    dsl.PythonComponent._component_functions[func] = {
+    PythonComponent._component_functions[func] = {
       'name': name,
       'description': description,
       'base_image': base_image
@@ -59,4 +58,4 @@ class PythonComponent():
   @staticmethod
   def get_python_component(func):
     """ Get a python component """
-    return dsl.PythonComponent._component_functions.get(func, None)
+    return PythonComponent._component_functions.get(func, None)

--- a/sdk/python/kfp/notebook/_magic.py
+++ b/sdk/python/kfp/notebook/_magic.py
@@ -20,9 +20,9 @@ except ImportError:
   raise Exception('This module can only be loaded in Jupyter.')
 
 
-from kfp.compiler import build_docker_image
 import os
 import tempfile
+from ..compiler import build_docker_image
 
 
 @IPython.core.magic.register_cell_magic


### PR DESCRIPTION
Made all SDK import relative so that they files always refer to the sibling files instead of the installed package. This makes debugging and development easier since you can be sure the correct files are used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/156)
<!-- Reviewable:end -->
