### PR TITLE
Sets min height/width of all fullscreen viewers to 80% 

### DIFF
--- a/frontend/src/components/PlotCard.tsx
+++ b/frontend/src/components/PlotCard.tsx
@@ -41,8 +41,8 @@ const css = stylesheet({
   fullscreenDialog: {
     alignItems: 'center',
     justifyContent: 'center',
-    maxHeight: '80%',
-    maxWidth: '80%',
+    minHeight: '80%',
+    minWidth: '80%',
     padding: 20,
   },
   fullscreenViewerContainer: {


### PR DESCRIPTION
Fixes #160 

Properly sizing the fullscreen viewer for HTML artifacts is difficult because we use iframes.

This is something of a workaround to ensure all viewers expand sufficiently in fullscreen mode until we can determine a better way to size them automatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/167)
<!-- Reviewable:end -->
