### PR TITLE
SDK/Components/PythonContainerOp - Fixed string escaping warning

### DIFF
--- a/sdk/python/kfp/compiler/_component_builder.py
+++ b/sdk/python/kfp/compiler/_component_builder.py
@@ -197,7 +197,7 @@ class ImageBuilder(object):
 
     # Follow the same indentation with the component source codes.
     component_src = inspect.getsource(component_func)
-    match = re.search('\n([ \t]+)[\w]+', component_src)
+    match = re.search(r'\n([ \t]+)[\w]+', component_src)
     indentation = match.group(1) if match else '\t'
     codegen = CodeGenerator(indentation=indentation)
 


### PR DESCRIPTION
Fixes `W1401:Anomalous backslash in string: '\w'. String constant might be missing an r prefix.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/208)
<!-- Reviewable:end -->
