### PR TITLE
SDK - Replaced .get_bucket() with .bucket() which requires less permissions

### DIFF
--- a/sdk/python/kfp/compiler/_component_builder.py
+++ b/sdk/python/kfp/compiler/_component_builder.py
@@ -34,7 +34,9 @@ class GCSHelper(object):
     gcs_bucket = pure_path.parts[1]
     gcs_blob = '/'.join(pure_path.parts[2:])
     client = storage.Client()
-    bucket = client.get_bucket(gcs_bucket)
+    bucket = client.bucket(gcs_bucket)
+    if not bucket.exists():
+      raise RuntimeError('Bucket {} does not exist (or the user does not have permission to access it).'.format(gcs_bucket))
     blob = bucket.blob(gcs_blob)
     return blob
 


### PR DESCRIPTION
For instance, our runs do not usually have the required permission.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/209)
<!-- Reviewable:end -->
