### PR TITLE
[WIP] Fix leaking component IDs

### DIFF
--- a/frontend/src/atoms/BusyButton.tsx
+++ b/frontend/src/atoms/BusyButton.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import Button, { ButtonProps } from '@material-ui/core/Button';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { stylesheet, classes } from 'typestyle';
+import { sanitizeProps } from '../lib/Utils';
 
 const css = stylesheet({
   icon: {
@@ -55,15 +56,14 @@ interface BusyButtonProps extends ButtonProps {
 
 class BusyButton extends React.Component<BusyButtonProps> {
   public render(): JSX.Element {
+    // TODO: we should not be passing className here to the child Element button. Instead, we should
+    // allow the parent of BusyButton to declare explicitly which styles should be applied to
+    // BusyButton and which, if any, should be applied to Button, CircularProgress, etc.
     const { title, busy, className, disabled, icon, outlined, ...rest } = this.props;
-
-    return <Button {...rest} color={outlined ? 'primary' : 'secondary'}
-      className={classes(
-        css.root,
-        busy && css.rootBusy,
-        className)}
-      disabled={busy || disabled}>
-      {!!icon && <this.props.icon className={css.icon} />}
+    return <Button {...sanitizeProps(rest)} color={outlined ? 'primary' : 'secondary'}
+        className={classes(css.root, busy && css.rootBusy, className)}
+        disabled={busy || disabled}>
+        {!!icon && <this.props.icon className={css.icon} />}
       <span>{title}</span>
       {busy === true && <CircularProgress size={15}
         className={classes(css.spinner, busy && css.spinnerBusy)} />}

--- a/frontend/src/atoms/BusyButton.tsx
+++ b/frontend/src/atoms/BusyButton.tsx
@@ -59,8 +59,8 @@ class BusyButton extends React.Component<BusyButtonProps> {
     // TODO: we should not be passing className here to the child Element button. Instead, we should
     // allow the parent of BusyButton to declare explicitly which styles should be applied to
     // BusyButton and which, if any, should be applied to Button, CircularProgress, etc.
-    const { title, busy, className, disabled, icon, outlined, ...rest } = this.props;
-    return <Button {...sanitizeProps(rest)} color={outlined ? 'primary' : 'secondary'}
+    const { title, busy, className, disabled, icon, id, outlined, ...rest } = this.props;
+    return <Button {...sanitizeProps(rest)} id={id} color={outlined ? 'primary' : 'secondary'}
         className={classes(css.root, busy && css.rootBusy, className)}
         disabled={busy || disabled}>
         {!!icon && <this.props.icon className={css.icon} />}

--- a/frontend/src/atoms/Hr.tsx
+++ b/frontend/src/atoms/Hr.tsx
@@ -16,6 +16,7 @@
 
 import * as React from 'react';
 import { color, spacing } from '../Css';
+import { sanitizeProps } from '../lib/Utils';
 
 const style = {
   border: '0px none transparent',
@@ -23,4 +24,4 @@ const style = {
   margin: `${spacing.base}px 0`,
 };
 
-export default (props: any) => <hr style={style} {...props} />;
+export default (props: any) => <hr style={style} {...sanitizeProps(props)} />;

--- a/frontend/src/atoms/Input.tsx
+++ b/frontend/src/atoms/Input.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import { commonCss } from '../Css';
+import { sanitizeProps } from '../lib/Utils';
 
 interface InputProps extends TextFieldProps {
   height?: number | string;
@@ -31,7 +32,7 @@ export default (props: InputProps) => {
           height: !!props.multiline ? 'auto' : (height || 40),
           maxWidth: 600,
           width: width || '100%' }}
-        {...rest}>
+        {...sanitizeProps(rest)}>
       {props.children}
     </TextField>
   );

--- a/frontend/src/atoms/__snapshots__/BusyButton.test.tsx.snap
+++ b/frontend/src/atoms/__snapshots__/BusyButton.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`BusyButton renders a primary outlined buton 1`] = `
 <button
   className="MuiButtonBase-root-27 MuiButton-root-1 MuiButton-text-3 MuiButton-textPrimary-4 MuiButton-flat-6 MuiButton-flatPrimary-7 root"
   disabled={false}
+  id={undefined}
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyDown={[Function]}
@@ -34,6 +35,7 @@ exports[`BusyButton renders disabled 1`] = `
 <button
   className="MuiButtonBase-root-27 MuiButtonBase-disabled-28 MuiButton-root-1 MuiButton-text-3 MuiButton-textSecondary-5 MuiButton-flat-6 MuiButton-flatSecondary-8 MuiButton-disabled-21 root"
   disabled={true}
+  id={undefined}
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyDown={[Function]}
@@ -77,6 +79,7 @@ exports[`BusyButton renders with a title and icon 1`] = `
 <button
   className="MuiButtonBase-root-27 MuiButton-root-1 MuiButton-text-3 MuiButton-textSecondary-5 MuiButton-flat-6 MuiButton-flatSecondary-8 root"
   disabled={false}
+  id={undefined}
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyDown={[Function]}
@@ -123,6 +126,7 @@ exports[`BusyButton renders with a title and icon, and busy 1`] = `
 <button
   className="MuiButtonBase-root-27 MuiButtonBase-disabled-28 MuiButton-root-1 MuiButton-text-3 MuiButton-textSecondary-5 MuiButton-flat-6 MuiButton-flatSecondary-8 MuiButton-disabled-21 root rootBusy"
   disabled={true}
+  id={undefined}
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyDown={[Function]}
@@ -191,6 +195,7 @@ exports[`BusyButton renders with just a title 1`] = `
 <button
   className="MuiButtonBase-root-27 MuiButton-root-1 MuiButton-text-3 MuiButton-textSecondary-5 MuiButton-flat-6 MuiButton-flatSecondary-8 root"
   disabled={false}
+  id={undefined}
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyDown={[Function]}

--- a/frontend/src/components/PlotCard.tsx
+++ b/frontend/src/components/PlotCard.tsx
@@ -26,6 +26,7 @@ import ViewerContainer, { componentMap } from '../components/viewers/ViewerConta
 import { ViewerConfig } from '../components/viewers/Viewer';
 import { color, fontsize } from '../Css';
 import { stylesheet, classes } from 'typestyle';
+import { sanitizeProps } from '../lib/Utils';
 
 const css = stylesheet({
   dialogTitle: {
@@ -107,7 +108,7 @@ class PlotCard extends React.Component<PlotCardProps, PlotCardState> {
     }
 
     return <div>
-      <Paper {...otherProps} className={classes(css.plotCard, 'plotCard')}>
+      <Paper {...sanitizeProps(otherProps)} className={classes(css.plotCard, 'plotCard')}>
         <div className={css.plotHeader}>
           <div className={css.plotTitle} title={title}>{title}</div>
           <div>

--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -37,6 +37,7 @@ import Toolbar, { ToolbarProps } from './Toolbar';
 import { Route, Switch, Redirect, HashRouter } from 'react-router-dom';
 import { classes, stylesheet } from 'typestyle';
 import { commonCss } from '../Css';
+import { sanitizeProps } from '../lib/Utils';
 
 const css = stylesheet({
   dialog: {
@@ -89,7 +90,11 @@ class Router extends React.Component<{}, RouteComponentState> {
       bannerProps: {},
       dialogProps: { open: false },
       snackbarProps: { autoHideDuration: 5000, open: false },
-      toolbarProps: { breadcrumbs: [{ displayName: '', href: '' }], actions: [], ...props },
+      toolbarProps: {
+        actions: [],
+        breadcrumbs: [{ displayName: '', href: '' }],
+        ...sanitizeProps(props)
+      },
     };
   }
 
@@ -119,9 +124,11 @@ class Router extends React.Component<{}, RouteComponentState> {
       <HashRouter>
         <div className={commonCss.page}>
           <div className={commonCss.flexGrow}>
-            <Route render={({ ...props }) => (<SideNav page={props.location.pathname} {...props} />)} />
+            <Route render={({ ...props }) =>
+              (<SideNav page={props.location.pathname} {...sanitizeProps(props)} />)} />
             <div className={classes(commonCss.page)}>
-              <Route render={({ ...props }) => (<Toolbar {...this.state.toolbarProps} {...props} />)} />
+              <Route render={({ ...props }) =>
+                (<Toolbar {...sanitizeProps(this.state.toolbarProps)} {...sanitizeProps(props)} />)} />
               {this.state.bannerProps.message
                 && <Banner
                   message={this.state.bannerProps.message}
@@ -129,13 +136,13 @@ class Router extends React.Component<{}, RouteComponentState> {
                   additionalInfo={this.state.bannerProps.additionalInfo}
                   refresh={this.state.bannerProps.refresh} />}
               <Switch>
-                <Route exact={true} path={'/'} render={({ ...props }) => (
-                  <Redirect to={RoutePage.PIPELINES} {...props} />
-                )} />
+                <Route exact={true} path={'/'} render={({ ...props }) =>
+                  (<Redirect to={RoutePage.PIPELINES} {...sanitizeProps(props)} />)} />
                 {routes.map((route, i) => {
                   const { path, Component, ...otherProps } = { ...route };
                   return <Route key={i} exact={true} path={path} render={({ ...props }) => (
-                    <Component {...props} {...childProps} {...otherProps} />
+                    <Component {...sanitizeProps(props)} {...sanitizeProps(childProps)}
+                      {...sanitizeProps(otherProps)} />
                   )} />;
                 })}
 

--- a/frontend/src/lib/Utils.test.ts
+++ b/frontend/src/lib/Utils.test.ts
@@ -19,6 +19,7 @@ import {
   formatDateString,
   enabledDisplayString,
   getRunTime,
+  sanitizeProps,
 } from './Utils';
 
 describe('Utils', () => {
@@ -41,6 +42,33 @@ describe('Utils', () => {
       // tslint:disable-next-line:no-console
       expect(console.error).toBeCalledWith('something to console error');
       global.console.error = backup;
+    });
+  });
+
+  describe('sanitizeProps', () => {
+    it('removes ID from props if present', () => {
+      const props = {
+        bar: 2,
+        foo: 'foo',
+        id: 'some-id',
+        qux: { key: 'value' },
+      };
+
+      expect(sanitizeProps(props)).toEqual({
+        bar: 2,
+        foo: 'foo',
+        qux: { key: 'value' },
+      });
+    });
+
+    it('does not alter props if ID is not present', () => {
+      const props = {
+        bar: 2,
+        foo: 'foo',
+        qux: { key: 'value' },
+      };
+
+      expect(sanitizeProps(props)).toEqual(props);
     });
   });
 

--- a/frontend/src/lib/Utils.ts
+++ b/frontend/src/lib/Utils.ts
@@ -29,6 +29,14 @@ export const logger = {
   },
 };
 
+/**
+ * Removes id from props so it can be safely passed to children
+ */
+export function sanitizeProps(props: any) {
+  const { id, ...rest } = props;
+  return rest;
+}
+
 export function formatDateString(date: Date | string | undefined): string {
   if (typeof date === 'string') {
     return new Date(date).toLocaleString();

--- a/frontend/src/lib/Utils.ts
+++ b/frontend/src/lib/Utils.ts
@@ -30,9 +30,9 @@ export const logger = {
 };
 
 /**
- * Removes id from props so it can be safely passed to children
+ * Removes id from props so that the props object is safe to pass to children
  */
-export function sanitizeProps(props: any) {
+export function sanitizeProps(props: any): any {
   const { id, ...rest } = props;
   return rest;
 }

--- a/frontend/src/pages/AllRunsList.tsx
+++ b/frontend/src/pages/AllRunsList.tsx
@@ -23,6 +23,7 @@ import { ToolbarProps } from '../components/Toolbar';
 import { URLParser, QUERY_PARAMS } from '../lib/URLParser';
 import { classes } from 'typestyle';
 import { commonCss, padding } from '../Css';
+import { sanitizeProps } from '../lib/Utils';
 
 interface AllRunsListState {
   selectedIds: string[];
@@ -77,7 +78,7 @@ class AllRunsList extends Page<{}, AllRunsListState> {
     return <div className={classes(commonCss.page, padding(20, 'lr'))}>
       <RunList onError={this.showPageError.bind(this)} selectedIds={this.state.selectedIds}
         onSelectionChange={this._selectionChanged.bind(this)}
-        {...this.props} ref={this._runlistRef} />
+        {...sanitizeProps(this.props)} ref={this._runlistRef} />
     </div>;
   }
 

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -37,7 +37,7 @@ import { classes, stylesheet } from 'typestyle';
 import { commonCss, padding } from '../Css';
 import { componentMap } from '../components/viewers/ViewerContainer';
 import { loadOutputArtifacts } from '../lib/OutputArtifactLoader';
-import { logger } from '../lib/Utils';
+import { logger, sanitizeProps } from '../lib/Utils';
 
 const css = stylesheet({
   outputsRow: {
@@ -121,7 +121,7 @@ class Compare extends Page<{}, CompareState> {
       <CollapseButton compareComponent={this} sectionName={overviewSectionName} />
       {!collapseSections[overviewSectionName] && (
         <div className={commonCss.noShrink}>
-          <RunList onError={this.showPageError.bind(this)} {...this.props}
+          <RunList onError={this.showPageError.bind(this)} {...sanitizeProps(this.props)}
             selectedIds={selectedIds} runIdListMask={runIds} disablePaging={true}
             onSelectionChange={this._selectionChanged.bind(this)} />
         </div>
@@ -134,7 +134,7 @@ class Compare extends Page<{}, CompareState> {
       {!collapseSections[paramsSectionName] && (
         <div className={classes(commonCss.noShrink, css.outputsRow)}>
           <Separator orientation='vertical' />
-          <CompareTable {...this.state.paramsCompareProps} />
+          <CompareTable {...sanitizeProps(this.state.paramsCompareProps)} />
           <Hr />
         </div>
       )}

--- a/frontend/src/pages/ExperimentDetails.tsx
+++ b/frontend/src/pages/ExperimentDetails.tsx
@@ -34,7 +34,7 @@ import { RoutePage, RouteParams } from '../components/Router';
 import { URLParser, QUERY_PARAMS } from '../lib/URLParser';
 import { classes, stylesheet } from 'typestyle';
 import { color, commonCss, padding } from '../Css';
-import { logger } from '../lib/Utils';
+import { logger, sanitizeProps } from '../lib/Utils';
 
 const css = stylesheet({
   card: {
@@ -218,16 +218,16 @@ class ExperimentDetails extends Page<{}, ExperimentDetailsState> {
                 {description.split('\n').length > 2 ? '...' : ''}
               </Paper>
             </div>
-            <Toolbar {...this.state.runListToolbarProps} />
+            <Toolbar {...sanitizeProps(this.state.runListToolbarProps)} />
             <RunList onError={this.showPageError.bind(this)}
               experimentIdMask={experiment.id} ref={this._runlistRef}
               selectedIds={this.state.selectedRunIds}
-              onSelectionChange={this._selectionChanged.bind(this)} {...this.props} />
+              onSelectionChange={this._selectionChanged.bind(this)} {...sanitizeProps(this.props)} />
 
             <Dialog open={this.state.recurringRunsManagerOpen} classes={{ paper: css.recurringRunsDialog }}
               onClose={this._recurringRunsManagerClosed.bind(this)}>
               <DialogContent>
-                <RecurringRunsManager {...this.props}
+                <RecurringRunsManager {...sanitizeProps(this.props)}
                   experimentId={this.props.match.params[RouteParams.experimentId]} />
               </DialogContent>
               <DialogActions>

--- a/frontend/src/pages/ExperimentList.tsx
+++ b/frontend/src/pages/ExperimentList.tsx
@@ -29,7 +29,7 @@ import { ToolbarProps } from '../components/Toolbar';
 import { URLParser, QUERY_PARAMS } from '../lib/URLParser';
 import { classes } from 'typestyle';
 import { commonCss, padding } from '../Css';
-import { logger } from '../lib/Utils';
+import { logger, sanitizeProps } from '../lib/Utils';
 import { statusToIcon, NodePhase } from './Status';
 
 interface DisplayExperiment extends ApiExperiment {
@@ -241,7 +241,7 @@ class ExperimentList extends Page<{}, ExperimentListState> {
   private _getExpandedExperimentComponent(experimentIndex: number): JSX.Element {
     const experiment = this.state.displayExperiments[experimentIndex];
     const runIds = (experiment.last5Runs || []).map((r) => r.id!);
-    return <RunList runIdListMask={runIds} onError={() => null} {...this.props}
+    return <RunList runIdListMask={runIds} onError={() => null} {...sanitizeProps(this.props)}
       disablePaging={true} selectedIds={this.state.selectedRunIds}
       onSelectionChange={this._runSelectionChanged.bind(this)} disableSorting={true} />;
   }

--- a/frontend/src/pages/ExperimentsAndRuns.tsx
+++ b/frontend/src/pages/ExperimentsAndRuns.tsx
@@ -23,6 +23,7 @@ import { RoutePage } from '../components/Router';
 import { ToolbarProps } from '../components/Toolbar';
 import { classes } from 'typestyle';
 import { commonCss, padding } from '../Css';
+import { sanitizeProps } from '../lib/Utils';
 
 export enum ExperimentsAndRunsTab {
   EXPERIMENTS = 0,
@@ -49,11 +50,11 @@ class ExperimentsAndRuns extends Page<ExperimentAndRunsProps, ExperimentAndRunsS
         <MD2Tabs tabs={['All experiments', 'All runs']} selectedTab={this.props.view}
           onSwitch={this._tabSwitched.bind(this)} />
         {this.props.view === 0 && (
-          <ExperimentList {...this.props} />
+          <ExperimentList {...sanitizeProps(this.props)} />
         )}
 
         {this.props.view === 1 && (
-          <AllRunsList {...this.props} />
+          <AllRunsList {...sanitizeProps(this.props)} />
         )}
       </div>
     );

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -39,7 +39,7 @@ import { URLParser, QUERY_PARAMS } from '../lib/URLParser';
 import { Workflow } from '../../../frontend/third_party/argo-ui/argo_template';
 import { classes, stylesheet } from 'typestyle';
 import { commonCss, padding } from '../Css';
-import { logger, errorToMessage } from '../lib/Utils';
+import { logger, errorToMessage, sanitizeProps } from '../lib/Utils';
 
 interface NewRunState {
   description: string;
@@ -132,7 +132,8 @@ class NewRun extends Page<{}, NewRunState> {
           <Dialog open={pipelineSelectorOpen} classes={{ paper: css.pipelineSelectorDialog }}
             onClose={() => this._pipelineSelectorClosed(false)} PaperProps={{ id: 'pipelineSelectorDialog' }}>
             <DialogContent>
-              <PipelineSelector {...this.props} pipelineSelectionChanged={this._pipelineSelectionChanged.bind(this)} />
+              <PipelineSelector {...sanitizeProps(this.props)}
+                pipelineSelectionChanged={this._pipelineSelectionChanged.bind(this)} />
             </DialogContent>
             <DialogActions>
               <Button onClick={() => this._pipelineSelectorClosed(false)} color='secondary'>


### PR DESCRIPTION
`sanitizeProps` is added to `Utils` to remove ID from `props` if one is present so that the `props` object can be safely passed to child components.

ID is just another `prop` in React, so if `props` are just passed directly to children, like in `BusyButton` for example, then the children will have and potentially propagate the ID as well.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/216)
<!-- Reviewable:end -->
