### PR TITLE
Adds NewRun tests

### DIFF
--- a/frontend/mock-backend/package-lock.json
+++ b/frontend/mock-backend/package-lock.json
@@ -9,8 +9,8 @@
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
       "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
       "requires": {
-        "@types/connect": "3.4.32",
-        "@types/node": "10.11.6"
+        "@types/connect": "*",
+        "@types/node": "*"
       }
     },
     "@types/connect": {
@@ -18,7 +18,7 @@
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
       "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
       "requires": {
-        "@types/node": "10.11.6"
+        "@types/node": "*"
       }
     },
     "@types/events": {
@@ -31,9 +31,9 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.0.tgz",
       "integrity": "sha512-TtPEYumsmSTtTetAPXlJVf3kEqb6wZK0bZojpJQrnD/djV4q1oB6QQ8aKvKqwNPACoe02GNiy5zDzcYivR5Z2w==",
       "requires": {
-        "@types/body-parser": "1.17.0",
-        "@types/express-serve-static-core": "4.16.0",
-        "@types/serve-static": "1.13.2"
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
@@ -41,9 +41,9 @@
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.0.tgz",
       "integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
       "requires": {
-        "@types/events": "1.2.0",
-        "@types/node": "10.11.6",
-        "@types/range-parser": "1.2.2"
+        "@types/events": "*",
+        "@types/node": "*",
+        "@types/range-parser": "*"
       }
     },
     "@types/mime": {
@@ -66,8 +66,8 @@
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
       "requires": {
-        "@types/express-serve-static-core": "4.16.0",
-        "@types/mime": "2.0.0"
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
       }
     },
     "accepts": {
@@ -75,7 +75,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "2.1.20",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -90,15 +90,15 @@
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.15"
       }
     },
     "bytes": {
@@ -169,36 +169,36 @@
       "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.4",
+        "proxy-addr": "~2.0.3",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0",
-        "type-is": "1.6.16",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       }
     },
     "finalhandler": {
@@ -207,12 +207,12 @@
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.4.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
       }
     },
     "forwarded": {
@@ -230,10 +230,10 @@
       "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "iconv-lite": {
@@ -281,7 +281,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
       "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "requires": {
-        "mime-db": "1.36.0"
+        "mime-db": "~1.36.0"
       }
     },
     "ms": {
@@ -317,7 +317,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
       }
     },
@@ -355,7 +355,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": "1.4.0"
+            "statuses": ">= 1.3.1 < 2"
           }
         },
         "setprototypeof": {
@@ -376,18 +376,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       }
     },
     "serve-static": {
@@ -395,9 +395,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -417,7 +417,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.20"
+        "mime-types": "~2.1.18"
       }
     },
     "unpipe": {

--- a/frontend/server/package-lock.json
+++ b/frontend/server/package-lock.json
@@ -7,24 +7,24 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.17.0.tgz",
       "integrity": "sha512-HRZLSU762E6HaKoGfJGa8W95yRjb9rY7LePhjaHK9ILAnFacMuUGVamDbTHu1csZomm1g3tZTtXfX/aAhtie/Q==",
       "requires": {
-        "array-uniq": "1.0.3",
-        "arrify": "1.0.1",
-        "concat-stream": "1.6.2",
-        "create-error-class": "3.0.2",
-        "duplexify": "3.6.0",
-        "ent": "2.2.0",
-        "extend": "3.0.1",
-        "google-auto-auth": "0.10.1",
-        "is": "3.2.1",
+        "array-uniq": "^1.0.3",
+        "arrify": "^1.0.1",
+        "concat-stream": "^1.6.0",
+        "create-error-class": "^3.0.2",
+        "duplexify": "^3.5.0",
+        "ent": "^2.2.0",
+        "extend": "^3.0.1",
+        "google-auto-auth": "^0.10.0",
+        "is": "^3.2.0",
         "log-driver": "1.2.7",
-        "methmeth": "1.1.0",
-        "modelo": "4.2.3",
-        "request": "2.87.0",
-        "retry-request": "3.3.2",
-        "split-array-stream": "1.0.3",
-        "stream-events": "1.0.4",
-        "string-format-obj": "1.1.1",
-        "through2": "2.0.3"
+        "methmeth": "^1.1.0",
+        "modelo": "^4.2.0",
+        "request": "^2.79.0",
+        "retry-request": "^3.0.0",
+        "split-array-stream": "^1.0.0",
+        "stream-events": "^1.0.1",
+        "string-format-obj": "^1.1.0",
+        "through2": "^2.0.3"
       }
     },
     "@google-cloud/storage": {
@@ -32,27 +32,27 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.7.0.tgz",
       "integrity": "sha512-QaAxzCkbhspwajoaEnT0GcnQcpjPRcBrHYuQsXtD05BtOJgVnHCLXSsfUiRdU0nVpK+Thp7+sTkQ0fvk5PanKg==",
       "requires": {
-        "@google-cloud/common": "0.17.0",
-        "arrify": "1.0.1",
-        "async": "2.6.1",
-        "compressible": "2.0.14",
-        "concat-stream": "1.6.2",
-        "create-error-class": "3.0.2",
-        "duplexify": "3.6.0",
-        "extend": "3.0.1",
-        "gcs-resumable-upload": "0.10.2",
-        "hash-stream-validation": "0.2.1",
-        "is": "3.2.1",
-        "mime": "2.3.1",
-        "mime-types": "2.1.18",
-        "once": "1.4.0",
-        "pumpify": "1.5.1",
-        "request": "2.87.0",
-        "safe-buffer": "5.1.2",
-        "snakeize": "0.1.0",
-        "stream-events": "1.0.4",
-        "through2": "2.0.3",
-        "xdg-basedir": "3.0.0"
+        "@google-cloud/common": "^0.17.0",
+        "arrify": "^1.0.0",
+        "async": "^2.0.1",
+        "compressible": "^2.0.12",
+        "concat-stream": "^1.5.0",
+        "create-error-class": "^3.0.2",
+        "duplexify": "^3.5.0",
+        "extend": "^3.0.0",
+        "gcs-resumable-upload": "^0.10.2",
+        "hash-stream-validation": "^0.2.1",
+        "is": "^3.0.1",
+        "mime": "^2.2.0",
+        "mime-types": "^2.0.8",
+        "once": "^1.3.1",
+        "pumpify": "^1.5.1",
+        "request": "^2.85.0",
+        "safe-buffer": "^5.1.1",
+        "snakeize": "^0.1.0",
+        "stream-events": "^1.0.1",
+        "through2": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "@kubernetes/client-node": {
@@ -60,22 +60,22 @@
       "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.5.2.tgz",
       "integrity": "sha512-toOoGG4oCvl1vOq7ZaMmEYs+Ic2ErjWSLYRutuZdB7BREcgXxLi1RwDIhqRoQg4W9vrVg8QQSpmKlIdyWEm+fQ==",
       "requires": {
-        "@types/base-64": "0.1.2",
-        "@types/bluebird": "3.5.23",
-        "@types/js-yaml": "3.11.2",
-        "@types/node": "8.10.20",
-        "@types/request": "2.47.1",
-        "@types/underscore": "1.8.9",
+        "@types/base-64": "^0.1.2",
+        "@types/bluebird": "^3.5.7",
+        "@types/js-yaml": "^3.5.31",
+        "@types/node": "^8.0.2",
+        "@types/request": "^2.47.0",
+        "@types/underscore": "^1.8.1",
         "@types/websocket": "0.0.38",
-        "base-64": "0.1.0",
-        "bluebird": "3.5.1",
-        "byline": "5.0.0",
-        "js-yaml": "3.12.0",
-        "jsonpath": "0.2.12",
-        "request": "2.87.0",
-        "shelljs": "0.7.8",
-        "underscore": "1.9.1",
-        "websocket": "1.0.26"
+        "base-64": "^0.1.0",
+        "bluebird": "^3.3.5",
+        "byline": "^5.0.0",
+        "js-yaml": "^3.5.2",
+        "jsonpath": "^0.2.11",
+        "request": "^2.72.0",
+        "shelljs": "^0.7.8 ",
+        "underscore": "^1.8.3",
+        "websocket": "^1.0.25"
       }
     },
     "@types/base-64": {
@@ -94,8 +94,8 @@
       "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
       "dev": true,
       "requires": {
-        "@types/connect": "3.4.32",
-        "@types/node": "8.10.20"
+        "@types/connect": "*",
+        "@types/node": "*"
       }
     },
     "@types/caseless": {
@@ -109,7 +109,7 @@
       "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.20"
+        "@types/node": "*"
       }
     },
     "@types/events": {
@@ -123,9 +123,9 @@
       "integrity": "sha512-TtPEYumsmSTtTetAPXlJVf3kEqb6wZK0bZojpJQrnD/djV4q1oB6QQ8aKvKqwNPACoe02GNiy5zDzcYivR5Z2w==",
       "dev": true,
       "requires": {
-        "@types/body-parser": "1.17.0",
-        "@types/express-serve-static-core": "4.16.0",
-        "@types/serve-static": "1.13.2"
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
@@ -134,9 +134,9 @@
       "integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
       "dev": true,
       "requires": {
-        "@types/events": "1.2.0",
-        "@types/node": "8.10.20",
-        "@types/range-parser": "1.2.2"
+        "@types/events": "*",
+        "@types/node": "*",
+        "@types/range-parser": "*"
       }
     },
     "@types/form-data": {
@@ -144,7 +144,7 @@
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "requires": {
-        "@types/node": "8.10.20"
+        "@types/node": "*"
       }
     },
     "@types/google-cloud__storage": {
@@ -153,7 +153,7 @@
       "integrity": "sha512-010Llp+5ze+XWWmZuLDxs0pZgFjOgtJQVt9icJ0Ed67ZFLq7PnXkYx8x/k9nwDojR5/X4XoLPNqB1F627TScdQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.20"
+        "@types/node": "*"
       }
     },
     "@types/js-yaml": {
@@ -173,7 +173,7 @@
       "integrity": "sha512-Zn5W6/NxQJI6Z3OvkLfYkJ0/V+hYLxwIKSQTvohWt5z0PUGvez2M0A6S/E3BHrTRkQ+n0TS8Z5A7itYMwrSQag==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.20"
+        "@types/node": "*"
       }
     },
     "@types/node": {
@@ -187,7 +187,7 @@
       "integrity": "sha512-XroxUzLpKuL+CVkQqXlffRkEPi4Gh3Oui/mWyS7ztKiyqVxiU+h3imCW5I2NQmde5jK+3q++36/Q96cyRWsweg==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.20"
+        "@types/node": "*"
       }
     },
     "@types/range-parser": {
@@ -201,10 +201,10 @@
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.1.tgz",
       "integrity": "sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==",
       "requires": {
-        "@types/caseless": "0.12.1",
-        "@types/form-data": "2.2.1",
-        "@types/node": "8.10.20",
-        "@types/tough-cookie": "2.3.3"
+        "@types/caseless": "*",
+        "@types/form-data": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*"
       }
     },
     "@types/serve-static": {
@@ -213,8 +213,8 @@
       "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.16.0",
-        "@types/mime": "2.0.0"
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
       }
     },
     "@types/tough-cookie": {
@@ -232,8 +232,8 @@
       "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-0.0.38.tgz",
       "integrity": "sha512-Z7dRTAiMoIjz9HBa/xb3k+2mx2uJx2sbnbkRRIvM+l/srNLfthHFBW/jD59thOcEa1/ZooKd30G0D+KGH9wU7Q==",
       "requires": {
-        "@types/events": "1.2.0",
-        "@types/node": "8.10.20"
+        "@types/events": "*",
+        "@types/node": "*"
       }
     },
     "JSONSelect": {
@@ -246,7 +246,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -255,10 +255,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "argparse": {
@@ -266,7 +266,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -324,7 +324,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.17.10"
       }
     },
     "asynckit": {
@@ -352,8 +352,8 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
-        "follow-redirects": "1.5.0",
-        "is-buffer": "1.1.6"
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
       }
     },
     "balanced-match": {
@@ -366,13 +366,13 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -380,7 +380,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -388,7 +388,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -396,7 +396,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -404,9 +404,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -422,7 +422,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "block-stream2": {
@@ -430,9 +430,9 @@
       "resolved": "https://registry.npmjs.org/block-stream2/-/block-stream2-1.1.0.tgz",
       "integrity": "sha1-xzjjqRupd+u14f70MeE8oR2GOeI=",
       "requires": {
-        "defined": "1.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "defined": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
       }
     },
     "bluebird": {
@@ -446,15 +446,15 @@
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.15"
       },
       "dependencies": {
         "debug": {
@@ -477,7 +477,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -486,16 +486,16 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.2",
-        "snapdragon": "0.8.2",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -503,7 +503,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -533,15 +533,15 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "capture-stack-trace": {
@@ -569,10 +569,10 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -580,7 +580,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -595,8 +595,8 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "colors": {
@@ -609,7 +609,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "component-emitter": {
@@ -622,7 +622,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
       "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
       "requires": {
-        "mime-db": "1.34.0"
+        "mime-db": ">= 1.34.0 < 2"
       },
       "dependencies": {
         "mime-db": {
@@ -642,10 +642,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "1.1.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "configstore": {
@@ -653,12 +653,12 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.3.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "content-disposition": {
@@ -696,7 +696,7 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "crypto-random-string": {
@@ -709,7 +709,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "debug": {
@@ -730,8 +730,8 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -739,7 +739,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -747,7 +747,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -755,9 +755,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -787,7 +787,7 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "duplexify": {
@@ -795,10 +795,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
       "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "ebnf-parser": {
@@ -812,7 +812,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -820,7 +820,7 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
       "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -838,7 +838,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "ent": {
@@ -861,9 +861,9 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.21.tgz",
       "integrity": "sha1-U9ZSz6EDA4gnlFilJmxf/HCcY8M=",
       "requires": {
-        "esprima": "1.0.4",
-        "estraverse": "0.0.4",
-        "source-map": "0.7.3"
+        "esprima": "~1.0.2",
+        "estraverse": "~0.0.4",
+        "source-map": ">= 0.1.2"
       },
       "dependencies": {
         "esprima": {
@@ -898,13 +898,13 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "debug": {
@@ -920,7 +920,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -928,7 +928,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -938,36 +938,36 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.3",
+        "proxy-addr": "~2.0.3",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0",
-        "type-is": "1.6.16",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "debug": {
@@ -1000,8 +1000,8 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -1009,7 +1009,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -1019,14 +1019,14 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -1034,7 +1034,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
@@ -1042,7 +1042,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -1050,7 +1050,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1058,7 +1058,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1066,9 +1066,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -1093,10 +1093,10 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1104,7 +1104,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -1115,12 +1115,12 @@
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.4.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1138,7 +1138,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
       "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
       "requires": {
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       }
     },
     "for-in": {
@@ -1156,9 +1156,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -1171,7 +1171,7 @@
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fresh": {
@@ -1184,7 +1184,7 @@
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
       "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "requires": {
-        "minipass": "2.3.4"
+        "minipass": "^2.2.1"
       }
     },
     "fs.realpath": {
@@ -1197,8 +1197,8 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
       "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
       "requires": {
-        "axios": "0.18.0",
-        "extend": "3.0.1",
+        "axios": "^0.18.0",
+        "extend": "^3.0.1",
         "retry-axios": "0.3.2"
       }
     },
@@ -1207,11 +1207,11 @@
       "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.10.2.tgz",
       "integrity": "sha1-fymz7iPc7EFwNnwHEUGCScZgVF8=",
       "requires": {
-        "configstore": "3.1.2",
-        "google-auto-auth": "0.10.1",
-        "pumpify": "1.5.1",
-        "request": "2.87.0",
-        "stream-events": "1.0.4"
+        "configstore": "^3.1.2",
+        "google-auto-auth": "^0.10.0",
+        "pumpify": "^1.4.0",
+        "request": "^2.85.0",
+        "stream-events": "^1.0.3"
       }
     },
     "get-value": {
@@ -1224,7 +1224,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -1232,12 +1232,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "google-auth-library": {
@@ -1245,13 +1245,13 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.6.1.tgz",
       "integrity": "sha512-jYiWC8NA9n9OtQM7ANn0Tk464do9yhKEtaJ72pKcaBiEwn4LwcGYIYOfwtfsSm3aur/ed3tlSxbmg24IAT6gAg==",
       "requires": {
-        "axios": "0.18.0",
-        "gcp-metadata": "0.6.3",
-        "gtoken": "2.3.0",
-        "jws": "3.1.5",
-        "lodash.isstring": "4.0.1",
-        "lru-cache": "4.1.3",
-        "retry-axios": "0.3.2"
+        "axios": "^0.18.0",
+        "gcp-metadata": "^0.6.3",
+        "gtoken": "^2.3.0",
+        "jws": "^3.1.5",
+        "lodash.isstring": "^4.0.1",
+        "lru-cache": "^4.1.3",
+        "retry-axios": "^0.3.2"
       }
     },
     "google-auto-auth": {
@@ -1259,10 +1259,10 @@
       "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.10.1.tgz",
       "integrity": "sha512-iIqSbY7Ypd32mnHGbYctp80vZzXoDlvI9gEfvtl3kmyy5HzOcrZCIGCBdSlIzRsg7nHpQiHE3Zl6Ycur6TSodQ==",
       "requires": {
-        "async": "2.6.1",
-        "gcp-metadata": "0.6.3",
-        "google-auth-library": "1.6.1",
-        "request": "2.87.0"
+        "async": "^2.3.0",
+        "gcp-metadata": "^0.6.1",
+        "google-auth-library": "^1.3.1",
+        "request": "^2.79.0"
       }
     },
     "google-p12-pem": {
@@ -1270,8 +1270,8 @@
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.2.tgz",
       "integrity": "sha512-+EuKr4CLlGsnXx4XIJIVkcKYrsa2xkAmCvxRhX2HsazJzUBAJ35wARGeApHUn4nNfPD03Vl057FskNr20VaCyg==",
       "requires": {
-        "node-forge": "0.7.5",
-        "pify": "3.0.0"
+        "node-forge": "^0.7.4",
+        "pify": "^3.0.0"
       }
     },
     "graceful-fs": {
@@ -1284,11 +1284,11 @@
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
       "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
       "requires": {
-        "axios": "0.18.0",
-        "google-p12-pem": "1.0.2",
-        "jws": "3.1.5",
-        "mime": "2.3.1",
-        "pify": "3.0.0"
+        "axios": "^0.18.0",
+        "google-p12-pem": "^1.0.0",
+        "jws": "^3.1.4",
+        "mime": "^2.2.0",
+        "pify": "^3.0.0"
       }
     },
     "har-schema": {
@@ -1301,8 +1301,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has-value": {
@@ -1310,9 +1310,9 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -1320,8 +1320,8 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -1329,7 +1329,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -1339,7 +1339,7 @@
       "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.1.tgz",
       "integrity": "sha1-7Mm5l7IYvluzEphii7gHhptz3NE=",
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.0"
       }
     },
     "http-errors": {
@@ -1347,10 +1347,10 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-proxy": {
@@ -1358,9 +1358,9 @@
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "requires": {
-        "eventemitter3": "3.1.0",
-        "follow-redirects": "1.5.0",
-        "requires-port": "1.0.0"
+        "eventemitter3": "^3.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "http-proxy-middleware": {
@@ -1368,10 +1368,10 @@
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
       "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
       "requires": {
-        "http-proxy": "1.17.0",
-        "is-glob": "4.0.0",
-        "lodash": "4.17.10",
-        "micromatch": "3.1.10"
+        "http-proxy": "^1.16.2",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.5",
+        "micromatch": "^3.1.9"
       }
     },
     "http-signature": {
@@ -1379,9 +1379,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -1399,8 +1399,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1428,7 +1428,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -1436,7 +1436,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -1451,7 +1451,7 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -1459,7 +1459,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -1469,9 +1469,9 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -1496,7 +1496,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
       "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-number": {
@@ -1504,7 +1504,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -1512,7 +1512,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -1527,7 +1527,7 @@
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "requires": {
-        "is-number": "4.0.0"
+        "is-number": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -1542,7 +1542,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-stream-ended": {
@@ -1581,12 +1581,12 @@
       "integrity": "sha1-kEFwfWIkE2f1iDRTK58ZwsNvrHg=",
       "requires": {
         "JSONSelect": "0.4.0",
-        "cjson": "0.2.1",
-        "ebnf-parser": "0.1.10",
+        "cjson": "~0.2.1",
+        "ebnf-parser": "~0.1.9",
         "escodegen": "0.0.21",
-        "esprima": "1.0.4",
-        "jison-lex": "0.2.1",
-        "lex-parser": "0.1.4",
+        "esprima": "1.0.x",
+        "jison-lex": "0.2.x",
+        "lex-parser": "~0.1.3",
         "nomnom": "1.5.2"
       },
       "dependencies": {
@@ -1602,7 +1602,7 @@
       "resolved": "https://registry.npmjs.org/jison-lex/-/jison-lex-0.2.1.tgz",
       "integrity": "sha1-rEuBXozOUTLrErXfz+jXB7iETf4=",
       "requires": {
-        "lex-parser": "0.1.4",
+        "lex-parser": "0.1.x",
         "nomnom": "1.5.2"
       }
     },
@@ -1611,8 +1611,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -1682,7 +1682,7 @@
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.10",
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "jws": {
@@ -1690,8 +1690,8 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
       "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
       "requires": {
-        "jwa": "1.1.6",
-        "safe-buffer": "5.1.2"
+        "jwa": "^1.1.5",
+        "safe-buffer": "^5.0.1"
       }
     },
     "kind-of": {
@@ -1724,8 +1724,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "make-dir": {
@@ -1733,7 +1733,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "map-cache": {
@@ -1746,7 +1746,7 @@
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "media-typer": {
@@ -1774,19 +1774,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "braces": "2.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "extglob": "2.0.4",
-        "fragment-cache": "0.2.1",
-        "kind-of": "6.0.2",
-        "nanomatch": "1.2.9",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "mime": {
@@ -1804,7 +1804,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "minimatch": {
@@ -1812,7 +1812,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1825,19 +1825,19 @@
       "resolved": "https://registry.npmjs.org/minio/-/minio-7.0.0.tgz",
       "integrity": "sha512-UpOs2+vpHC2ppicw9x3VVRJcJGhcYZwraLJeYXbvc2HQkSoY9Bws1+yEt/5s0dfMk8/gVyWVaTXIJwrcLpzB0g==",
       "requires": {
-        "async": "1.5.2",
-        "block-stream2": "1.1.0",
-        "concat-stream": "1.6.2",
-        "es6-error": "2.1.1",
-        "json-stream": "1.0.0",
-        "lodash": "4.17.10",
-        "mime-types": "2.1.18",
-        "mkdirp": "0.5.1",
+        "async": "^1.5.2",
+        "block-stream2": "^1.0.0",
+        "concat-stream": "^1.4.8",
+        "es6-error": "^2.0.2",
+        "json-stream": "^1.0.0",
+        "lodash": "^4.14.2",
+        "mime-types": "^2.1.14",
+        "mkdirp": "^0.5.1",
         "querystring": "0.2.0",
-        "through2": "0.6.5",
-        "uuid": "3.2.1",
-        "xml": "1.0.1",
-        "xml2js": "0.4.19"
+        "through2": "^0.6.5",
+        "uuid": "^3.1.0",
+        "xml": "^1.0.0",
+        "xml2js": "^0.4.15"
       },
       "dependencies": {
         "async": {
@@ -1855,10 +1855,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -1871,8 +1871,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -1882,8 +1882,8 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
       "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
       "requires": {
-        "safe-buffer": "5.1.2",
-        "yallist": "3.0.2"
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
       },
       "dependencies": {
         "yallist": {
@@ -1898,7 +1898,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
       "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
       "requires": {
-        "minipass": "2.3.4"
+        "minipass": "^2.2.1"
       }
     },
     "mixin-deep": {
@@ -1906,8 +1906,8 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -1915,7 +1915,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -1948,18 +1948,18 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-odd": "2.0.0",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-odd": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       }
     },
     "negotiator": {
@@ -1982,8 +1982,8 @@
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
       "integrity": "sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=",
       "requires": {
-        "colors": "0.5.1",
-        "underscore": "1.1.7"
+        "colors": "0.5.x",
+        "underscore": "1.1.x"
       },
       "dependencies": {
         "underscore": {
@@ -2003,9 +2003,9 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -2013,7 +2013,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "kind-of": {
@@ -2021,7 +2021,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -2031,7 +2031,7 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.pick": {
@@ -2039,7 +2039,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "on-finished": {
@@ -2055,7 +2055,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "parseurl": {
@@ -2108,7 +2108,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
       "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.6.0"
       }
     },
@@ -2122,8 +2122,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -2131,9 +2131,9 @@
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "requires": {
-        "duplexify": "3.6.0",
-        "inherits": "2.0.3",
-        "pump": "2.0.1"
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       }
     },
     "punycode": {
@@ -2180,7 +2180,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": "1.4.0"
+            "statuses": ">= 1.3.1 < 2"
           }
         },
         "setprototypeof": {
@@ -2195,13 +2195,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "rechoir": {
@@ -2209,7 +2209,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "1.8.1"
+        "resolve": "^1.1.6"
       }
     },
     "regex-not": {
@@ -2217,8 +2217,8 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "repeat-element": {
@@ -2236,26 +2236,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "requires-port": {
@@ -2268,7 +2268,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-url": {
@@ -2291,8 +2291,8 @@
       "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.2.tgz",
       "integrity": "sha512-WIiGp37XXDC6e7ku3LFoi7LCL/Gs9luGeeqvbPRb+Zl6OQMw4RCRfSaW+aLfE6lhz1R941UavE6Svl3Dm5xGIQ==",
       "requires": {
-        "request": "2.87.0",
-        "through2": "2.0.3"
+        "request": "^2.81.0",
+        "through2": "^2.0.0"
       }
     },
     "safe-buffer": {
@@ -2305,7 +2305,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
@@ -2324,18 +2324,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       },
       "dependencies": {
         "debug": {
@@ -2358,9 +2358,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -2369,10 +2369,10 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2380,7 +2380,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -2395,9 +2395,9 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "signal-exit": {
@@ -2415,14 +2415,14 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.2",
-        "use": "3.1.0"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -2438,7 +2438,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -2446,7 +2446,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "source-map": {
@@ -2461,9 +2461,9 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -2471,7 +2471,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -2479,7 +2479,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -2487,7 +2487,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -2495,9 +2495,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -2507,7 +2507,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       },
       "dependencies": {
         "kind-of": {
@@ -2515,7 +2515,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -2531,11 +2531,11 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "requires": {
-        "atob": "2.1.1",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-url": {
@@ -2548,8 +2548,8 @@
       "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-1.0.3.tgz",
       "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
       "requires": {
-        "async": "2.6.1",
-        "is-stream-ended": "0.1.4"
+        "async": "^2.4.0",
+        "is-stream-ended": "^0.1.0"
       }
     },
     "split-string": {
@@ -2557,7 +2557,7 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "sprintf-js": {
@@ -2570,15 +2570,15 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "static-eval": {
@@ -2586,7 +2586,7 @@
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.3.tgz",
       "integrity": "sha1-Aj8XrJ/uQm6niMEuo5IG3Bdfiyo=",
       "requires": {
-        "escodegen": "0.0.28"
+        "escodegen": "~0.0.24"
       },
       "dependencies": {
         "escodegen": {
@@ -2594,9 +2594,9 @@
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
           "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
           "requires": {
-            "esprima": "1.0.4",
-            "estraverse": "1.3.2",
-            "source-map": "0.7.3"
+            "esprima": "~1.0.2",
+            "estraverse": "~1.3.0",
+            "source-map": ">= 0.1.2"
           }
         },
         "esprima": {
@@ -2616,8 +2616,8 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -2625,7 +2625,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -2640,7 +2640,7 @@
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.4.tgz",
       "integrity": "sha512-D243NJaYs/xBN2QnoiMDY7IesJFIK7gEhnvAYqJa5JvDdnh2dC4qDBwlCf0ohPpX2QRlA/4gnbnPd3rs3KxVcA==",
       "requires": {
-        "stubs": "3.0.0"
+        "stubs": "^3.0.0"
       }
     },
     "stream-shift": {
@@ -2658,7 +2658,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stubs": {
@@ -2671,13 +2671,13 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
       "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
       "requires": {
-        "chownr": "1.0.1",
-        "fs-minipass": "1.2.5",
-        "minipass": "2.3.4",
-        "minizlib": "1.1.0",
-        "mkdirp": "0.5.1",
-        "safe-buffer": "5.1.2",
-        "yallist": "3.0.2"
+        "chownr": "^1.0.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.3",
+        "minizlib": "^1.1.0",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
       },
       "dependencies": {
         "yallist": {
@@ -2692,8 +2692,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "to-object-path": {
@@ -2701,7 +2701,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -2709,7 +2709,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -2719,10 +2719,10 @@
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -2730,8 +2730,8 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "tough-cookie": {
@@ -2739,7 +2739,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "tunnel-agent": {
@@ -2747,7 +2747,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -2762,7 +2762,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.18"
+        "mime-types": "~2.1.18"
       }
     },
     "typedarray": {
@@ -2775,7 +2775,7 @@
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "requires": {
-        "is-typedarray": "1.0.0"
+        "is-typedarray": "^1.0.0"
       }
     },
     "typescript": {
@@ -2794,10 +2794,10 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2805,7 +2805,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "set-value": {
@@ -2813,10 +2813,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -2826,7 +2826,7 @@
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
-        "crypto-random-string": "1.0.0"
+        "crypto-random-string": "^1.0.0"
       }
     },
     "unpipe": {
@@ -2839,8 +2839,8 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -2848,9 +2848,9 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -2880,7 +2880,7 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
       "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.2"
       }
     },
     "util-deprecate": {
@@ -2908,9 +2908,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "websocket": {
@@ -2918,10 +2918,10 @@
       "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.26.tgz",
       "integrity": "sha512-fjcrYDPIQxpTnqFQ9JjxUQcdvR89MFAOjPBlF+vjOt49w/XW4fJknUoMz/mDIn2eK1AdslVojcaOxOqyZZV8rw==",
       "requires": {
-        "debug": "2.6.9",
-        "nan": "2.10.0",
-        "typedarray-to-buffer": "3.1.5",
-        "yaeti": "0.0.6"
+        "debug": "^2.2.0",
+        "nan": "^2.3.3",
+        "typedarray-to-buffer": "^3.1.2",
+        "yaeti": "^0.0.6"
       },
       "dependencies": {
         "debug": {
@@ -2944,9 +2944,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "xdg-basedir": {
@@ -2964,8 +2964,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.7"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {

--- a/frontend/src/components/UploadPipelineDialog.test.tsx
+++ b/frontend/src/components/UploadPipelineDialog.test.tsx
@@ -44,14 +44,14 @@ describe('UploadPipelineDialog', () => {
   it('calls close callback with null and empty string when canceled', () => {
     const spy = jest.fn();
     const tree = shallow(<UploadPipelineDialog open={false} onClose={spy} />);
-    tree.find('#cancelUploadBtn').at(0).simulate('click');
+    tree.find('#cancelUploadBtn').simulate('click');
     expect(spy).toHaveBeenCalledWith('', null, '');
   });
 
   it('calls close callback with null and empty string when dialog is closed', () => {
     const spy = jest.fn();
     const tree = shallow(<UploadPipelineDialog open={false} onClose={spy} />);
-    tree.find('WithStyles(Dialog)').at(0).simulate('close');
+    tree.find('WithStyles(Dialog)').simulate('close');
     expect(spy).toHaveBeenCalledWith('', null, '');
   });
 
@@ -60,7 +60,7 @@ describe('UploadPipelineDialog', () => {
     const tree = shallow(<UploadPipelineDialog open={false} onClose={spy} />);
     (tree.instance() as any)._dropzoneRef = { current: { open: () => null } };
     (tree.instance() as UploadPipelineDialog).handleChange('uploadPipelineName')({ target: { value: 'test name' } });
-    tree.find('#confirmUploadBtn').at(0).simulate('click');
+    tree.find('#confirmUploadBtn').simulate('click');
     expect(spy).toHaveBeenLastCalledWith('test name', null, '');
   });
 

--- a/frontend/src/lib/Utils.ts
+++ b/frontend/src/lib/Utils.ts
@@ -37,6 +37,7 @@ export function formatDateString(date: Date | string | undefined): string {
   }
 }
 
+// TODO: add tests
 export async function errorToMessage(error: any): Promise<string> {
   if (error instanceof Error) {
     return error.message;
@@ -46,7 +47,7 @@ export async function errorToMessage(error: any): Promise<string> {
     return await error.text();
   }
 
-  return JSON.stringify(error || '');
+  return JSON.stringify(error) || '';
 }
 
 export function enabledDisplayString(trigger: ApiTrigger | undefined, enabled: boolean): string {

--- a/frontend/src/pages/NewExperiment.test.tsx
+++ b/frontend/src/pages/NewExperiment.test.tsx
@@ -21,6 +21,7 @@ import { shallow } from 'enzyme';
 import { PageProps } from './Page';
 import { Apis } from '../lib/Apis';
 import { RoutePage } from '../components/Router';
+import { QUERY_PARAMS } from '../lib/URLParser';
 
 describe('NewExperiment', () => {
   const createExperimentSpy = jest.spyOn(Apis.experimentServiceApi, 'createExperiment');
@@ -73,7 +74,7 @@ describe('NewExperiment', () => {
     tree.unmount();
   });
 
-  it('Enables the \'Next\' button when an experiment name is entered', () => {
+  it('enables the \'Next\' button when an experiment name is entered', () => {
     const tree = shallow(<NewExperiment {...generateProps() as any} />);
     expect(tree.find('#createExperimentBtn').props()).toHaveProperty('disabled', true);
 
@@ -84,7 +85,7 @@ describe('NewExperiment', () => {
     tree.unmount();
   });
 
-  it('Re-disables the \'Next\' button when an experiment name is cleared after having been entered', () => {
+  it('re-disables the \'Next\' button when an experiment name is cleared after having been entered', () => {
     const tree = shallow(<NewExperiment {...generateProps() as any} />);
     expect(tree.find('#createExperimentBtn').props()).toHaveProperty('disabled', true);
 
@@ -97,7 +98,7 @@ describe('NewExperiment', () => {
     tree.unmount();
   });
 
-  it('Updates the experiment name', () => {
+  it('updates the experiment name', () => {
     const tree = shallow(<NewExperiment {...generateProps() as any} />);
     (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment name' } });
 
@@ -110,7 +111,7 @@ describe('NewExperiment', () => {
     tree.unmount();
   });
 
-  it('Updates the experiment description', () => {
+  it('updates the experiment description', () => {
     const tree = shallow(<NewExperiment {...generateProps() as any} />);
     (tree.instance() as any).handleChange('description')({ target: { value: 'a description!' } });
 
@@ -160,6 +161,7 @@ describe('NewExperiment', () => {
     (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment-name' } });
 
     tree.find('#createExperimentBtn').simulate('click');
+    await createExperimentSpy;
     await TestUtils.flushPromises();
 
     expect(historyPushSpy).toHaveBeenCalledWith(
@@ -173,14 +175,15 @@ describe('NewExperiment', () => {
     const experimentId = 'test-exp-id-1';
     createExperimentSpy.mockImplementation(() => ({ id: experimentId }));
 
-    const pipelineId = 'pipelineId=some-pipeline-id';
+    const pipelineId = 'some-pipeline-id';
     const props = generateProps();
-    props.location.search = `?pipelineId=${pipelineId}`;
+    props.location.search = `?${QUERY_PARAMS.pipelineId}=${pipelineId}`;
     const tree = shallow(<NewExperiment {...props as any} />);
 
     (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment-name' } });
 
     tree.find('#createExperimentBtn').simulate('click');
+    await createExperimentSpy;
     await TestUtils.flushPromises();
 
     expect(historyPushSpy).toHaveBeenCalledWith(
@@ -208,6 +211,7 @@ describe('NewExperiment', () => {
   });
 
   it('unsets busy state when creation fails', async () => {
+    // Don't actually log to console.
     // tslint:disable-next-line:no-console
     console.error = jest.spyOn(console, 'error').mockImplementation();
 
@@ -217,6 +221,7 @@ describe('NewExperiment', () => {
 
     TestUtils.makeErrorResponseOnce(createExperimentSpy, 'test error!');
     tree.find('#createExperimentBtn').simulate('click');
+    await createExperimentSpy;
     await TestUtils.flushPromises();
 
     expect(tree.state()).toHaveProperty('isbeingCreated', false);
@@ -224,6 +229,7 @@ describe('NewExperiment', () => {
   });
 
   it('shows error dialog when creation fails', async () => {
+    // Don't actually log to console.
     // tslint:disable-next-line:no-console
     console.error = jest.spyOn(console, 'error').mockImplementation();
 
@@ -233,6 +239,7 @@ describe('NewExperiment', () => {
 
     TestUtils.makeErrorResponseOnce(createExperimentSpy, 'test error!');
     tree.find('#createExperimentBtn').simulate('click');
+    await createExperimentSpy;
     await TestUtils.flushPromises();
 
     const call = updateDialogSpy.mock.calls[0][0];

--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -1,0 +1,486 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import NewRun from './NewRun';
+import TestUtils from '../TestUtils';
+import { shallow } from 'enzyme';
+import { PageProps } from './Page';
+import { Apis } from '../lib/Apis';
+import { RoutePage, RouteParams } from '../components/Router';
+import { ApiExperiment } from '../apis/experiment';
+import { ApiPipeline } from '../apis/pipeline';
+import { QUERY_PARAMS } from '../lib/URLParser';
+
+describe('NewRun', () => {
+  const createJobSpy = jest.spyOn(Apis.jobServiceApi, 'createJob');
+  const createRunSpy = jest.spyOn(Apis.runServiceApi, 'createRun');
+  const getExperimentSpy = jest.spyOn(Apis.experimentServiceApi, 'getExperiment');
+  const getPipelineSpy = jest.spyOn(Apis.pipelineServiceApi, 'getPipeline');
+  const getRunSpy = jest.spyOn(Apis.runServiceApi, 'getRun');
+  const historyPushSpy = jest.fn();
+  const historyReplaceSpy = jest.fn();
+  const updateBannerSpy = jest.fn();
+  const updateDialogSpy = jest.fn();
+  const updateSnackbarSpy = jest.fn();
+  const updateToolbarSpy = jest.fn();
+
+  const mockExperiment: ApiExperiment = {
+    description: 'mock experiment description',
+    id: 'some-mock-experiment-id',
+    name: 'some mock experiment name',
+  };
+
+  const mockPipeline: ApiPipeline = {
+    id: 'some-mock-pipeline-id',
+    name: 'some mock pipeline name',
+  };
+
+  const mockRun: ApiPipeline = {
+    id: 'some-mock-run-id',
+    name: 'some mock run name',
+  };
+
+  function generateProps(): PageProps {
+    return {
+      history: { push: historyPushSpy, replace: historyReplaceSpy } as any,
+      location: { pathname: RoutePage.NEW_RUN } as any,
+      match: '' as any,
+      toolbarProps: NewRun.prototype.getInitialToolbarState(),
+      updateBanner: updateBannerSpy,
+      updateDialog: updateDialogSpy,
+      updateSnackbar: updateSnackbarSpy,
+      updateToolbar: updateToolbarSpy,
+    };
+  }
+
+  beforeEach(() => {
+    // Reset mocks
+    createJobSpy.mockReset();
+    createRunSpy.mockReset();
+    getExperimentSpy.mockReset();
+    getPipelineSpy.mockReset();
+    getRunSpy.mockReset();
+    historyPushSpy.mockReset();
+    historyReplaceSpy.mockReset();
+    updateBannerSpy.mockReset();
+    updateDialogSpy.mockReset();
+    updateSnackbarSpy.mockReset();
+    updateToolbarSpy.mockReset();
+
+    createRunSpy.mockImplementation(() => ({ id: 'new-run-id' }));
+    getExperimentSpy.mockImplementation(() =>({ mockExperiment }));
+    getPipelineSpy.mockImplementation(() =>({ mockPipeline }));
+    getRunSpy.mockImplementation(() =>({ mockRun }));
+  });
+
+  it('renders the new run page', () => {
+    const tree = shallow(<NewRun {...generateProps() as any} />);
+
+    expect(tree).toMatchSnapshot();
+    tree.unmount();
+  });
+
+  it('disables \'Create\' new run button by default', () => {
+    const tree = shallow(<NewRun {...generateProps() as any} />);
+
+    expect(tree.find('#createNewRunBtn').props()).toHaveProperty('disabled', true);
+    tree.unmount();
+  });
+
+  it('does not include any action buttons in the toolbar', () => {
+    const tree = shallow(<NewRun {...generateProps() as any} />);
+
+    expect(updateToolbarSpy).toHaveBeenLastCalledWith({
+      actions: [],
+      breadcrumbs: [
+        { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
+        { displayName: 'Start a new run', href: '' }
+      ],
+    });
+    tree.unmount();
+  });
+
+  it('changes the title if the new run will recur, based on query param', () => {
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.isRecurring}=1`;
+    const tree = shallow(<NewRun {...props as any} />);
+
+    expect(updateToolbarSpy).toHaveBeenLastCalledWith({
+      actions: [],
+      breadcrumbs: [
+        { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
+        { displayName: 'Start a recurring run', href: '' }
+      ],
+    });
+    tree.unmount();
+  });
+
+  it('clears the banner when refresh is called', () => {
+    const tree = shallow(<NewRun {...generateProps() as any} />);
+    expect(updateBannerSpy).toHaveBeenCalledTimes(1);
+    (tree.instance() as NewRun).refresh();
+    expect(updateBannerSpy).toHaveBeenCalledTimes(2);
+    expect(updateBannerSpy).toHaveBeenLastCalledWith({});
+  });
+
+  it('clears the banner when load is called', () => {
+    const tree = shallow(<NewRun {...generateProps() as any} />);
+    expect(updateBannerSpy).toHaveBeenCalledTimes(1);
+    (tree.instance() as NewRun).load();
+    expect(updateBannerSpy).toHaveBeenCalledTimes(2);
+    expect(updateBannerSpy).toHaveBeenLastCalledWith({});
+  });
+
+  it('updates the run name', () => {
+    const tree = shallow(<NewRun {...generateProps() as any} />);
+    (tree.instance() as any).handleChange('runName')({ target: { value: 'run name' } });
+
+    expect(tree.state()).toHaveProperty('runName', 'run name');
+    tree.unmount();
+  });
+
+  it('updates the run description', () => {
+    const tree = shallow(<NewRun {...generateProps() as any} />);
+    (tree.instance() as any).handleChange('description')({ target: { value: 'run description' } });
+
+    expect(tree.state()).toHaveProperty('description', 'run description');
+    tree.unmount();
+  });
+
+  it('fetches the associated experiment if one is present in the query params', async () => {
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.experimentId}=${mockExperiment.id}`;
+
+    getExperimentSpy.mockImplementation(() => mockExperiment);
+
+    const tree = shallow(<NewRun {...props as any} />);
+    await TestUtils.flushPromises();
+
+    expect(getExperimentSpy).toHaveBeenLastCalledWith(mockExperiment.id);
+    tree.unmount();
+  });
+
+  it('updates the run\'s state with the associated experiment if one is present in the query params', async () => {
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.experimentId}=${mockExperiment.id}`;
+
+    getExperimentSpy.mockImplementation(() => mockExperiment);
+
+    const tree = shallow(<NewRun {...props as any} />);
+    await TestUtils.flushPromises();
+
+    expect(tree.state()).toHaveProperty('experiment', mockExperiment);
+    expect(tree.state()).toHaveProperty('experimentName', mockExperiment.name);
+    expect(tree).toMatchSnapshot();
+    tree.unmount();
+  });
+
+  it('updates the breadcrumb with the associated experiment if one is present in the query params', async () => {
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.experimentId}=${mockExperiment.id}`;
+
+    getExperimentSpy.mockImplementation(() => mockExperiment);
+
+    const tree = shallow(<NewRun {...props as any} />);
+    await TestUtils.flushPromises();
+
+    expect(updateToolbarSpy).toHaveBeenLastCalledWith({
+      actions: [],
+      breadcrumbs: [
+        { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
+        {
+          displayName: mockExperiment.name,
+          href: RoutePage.EXPERIMENT_DETAILS.replace(':' + RouteParams.experimentId, mockExperiment.id!)
+        },
+        { displayName: 'Start a new run', href: ''}
+      ],
+    });
+    tree.unmount();
+  });
+
+  it('shows a page error if getExperiment fails', async () => {
+    // Don't actually log to console.
+    // tslint:disable-next-line:no-console
+    console.error = jest.spyOn(console, 'error').mockImplementation();
+
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.experimentId}=${mockExperiment.id}`;
+
+    TestUtils.makeErrorResponseOnce(getExperimentSpy, 'test error message');
+
+    const tree = shallow(<NewRun {...props as any} />);
+    await TestUtils.flushPromises();
+
+    expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+      additionalInfo: 'test error message',
+      message: `Error: failed to retrieve associated experiment: ${mockExperiment.id}. Click Details for more information.`,
+      mode: 'error',
+    }));
+    tree.unmount();
+  });
+
+  it('fetches the associated pipeline if one is present in the query params', async () => {
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.pipelineId}=${mockPipeline.id}`;
+
+    getPipelineSpy.mockImplementation(() => mockPipeline);
+
+    const tree = shallow(<NewRun {...props as any} />);
+    await TestUtils.flushPromises();
+
+    expect(tree.state()).toHaveProperty('pipeline', mockPipeline);
+    expect(tree.state()).toHaveProperty('pipelineName', mockPipeline.name);
+    expect(tree.state()).toHaveProperty('errorMessage', 'Run name is required');
+    expect(tree).toMatchSnapshot();
+    tree.unmount();
+  });
+
+  it('enables the \'Create\' new run button if pipeline ID in query params and run name entered', async () => {
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.pipelineId}=${mockPipeline.id}`;
+
+    const tree = shallow(<NewRun {...props as any} />);
+    (tree.instance() as any).handleChange('runName')({ target: { value: 'run name' } });
+    await TestUtils.flushPromises();
+
+    expect(tree.find('#createNewRunBtn').props()).toHaveProperty('disabled', false);
+    tree.unmount();
+  });
+
+  it('re-disables the \'Create\' new run button if pipeline ID in query params and run name entered then cleared', async () => {
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.pipelineId}=${mockPipeline.id}`;
+
+    const tree = shallow(<NewRun {...props as any} />);
+    (tree.instance() as any).handleChange('runName')({ target: { value: 'run name' } });
+    await TestUtils.flushPromises();
+    expect(tree.find('#createNewRunBtn').props()).toHaveProperty('disabled', false);
+
+    (tree.instance() as any).handleChange('runName')({ target: { value: '' } });
+    expect(tree.find('#createNewRunBtn').props()).toHaveProperty('disabled', true);
+
+    tree.unmount();
+  });
+
+  it('shows a page error if getPipeline fails', async () => {
+    // Don't actually log to console.
+    // tslint:disable-next-line:no-console
+    console.error = jest.spyOn(console, 'error').mockImplementation();
+
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.pipelineId}=${mockPipeline.id}`;
+
+    TestUtils.makeErrorResponseOnce(getPipelineSpy, 'test error message');
+
+    const tree = shallow(<NewRun {...props as any} />);
+    await TestUtils.flushPromises();
+
+    expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+      additionalInfo: 'test error message',
+      message: `Error: failed to retrieve pipeline: ${mockPipeline.id}. Click Details for more information.`,
+      mode: 'error',
+    }));
+    tree.unmount();
+  });
+
+  describe('cloning from a run', () => {
+    it('fetches the original run if an ID is present in the query params', async () => {
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${mockRun.id}`;
+
+      const tree = shallow(<NewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(getRunSpy).toHaveBeenCalledTimes(1);
+      expect(getRunSpy).toHaveBeenLastCalledWith(mockRun.id);
+      tree.unmount();
+    });
+
+    it('shows a page error if getRun fails', async () => {
+      // Don't actually log to console.
+      // tslint:disable-next-line:no-console
+      console.error = jest.spyOn(console, 'error').mockImplementation();
+
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${mockRun.id}`;
+
+      TestUtils.makeErrorResponseOnce(getRunSpy, 'test error message');
+
+      const tree = shallow(<NewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+        additionalInfo: 'test error message',
+        message: `Error: failed to retrieve original run: ${mockRun.id}. Click Details for more information.`,
+        mode: 'error',
+      }));
+      tree.unmount();
+    });
+
+  });
+
+  // it('clears the pipeline ID query param if getPipeline fails', async () => {
+  //   const props = generateProps();
+  //   props.location.search = `?${QUERY_PARAMS.pipelineId}=${mockPipeline.id}`;
+
+  //   TestUtils.makeErrorResponseOnce(getPipelineSpy, 'test error message');
+
+  //   const tree = TestUtils.mountWithRouter(<NewRun {...props as any} />);
+  //   await TestUtils.flushPromises();
+
+  //   expect((tree.instance().props as any).location.search).toBe('test');
+  //   tree.unmount();
+  // });
+  // it('Updates the experiment description', () => {
+  //   const tree = shallow(<NewRun {...generateProps() as any} />);
+  //   (tree.instance() as any).handleChange('description')({ target: { value: 'a description!' } });
+
+  //   expect(tree.state()).toEqual({
+  //     description: 'a description!',
+  //     experimentName: '',
+  //     isbeingCreated: false,
+  //     validationError: 'Experiment name is required',
+  //   });
+  //   tree.unmount();
+  // });
+
+  // it('sets the page to a busy state upon clicking \'Next\'', async () => {
+  //   const tree = shallow(<NewRun {...generateProps() as any} />);
+
+  //   (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment-name' } });
+
+  //   tree.find('#createExperimentBtn').simulate('click');
+  //   await TestUtils.flushPromises();
+
+  //   expect(tree.state()).toHaveProperty('isbeingCreated', true);
+  //   tree.unmount();
+  // });
+
+  // it('calls the createExperiment API with the new experiment upon clicking \'Next\'', async () => {
+  //   const tree = shallow(<NewRun {...generateProps() as any} />);
+
+  //   (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment name' } });
+  //   (tree.instance() as any).handleChange('description')({ target: { value: 'experiment description' } });
+
+  //   tree.find('#createExperimentBtn').simulate('click');
+  //   await TestUtils.flushPromises();
+
+  //   expect(createRunSpy).toHaveBeenCalledWith({
+  //     description: 'experiment description',
+  //     name: 'experiment name',
+  //   });
+  //   tree.unmount();
+  // });
+
+  // it('navigates to NewRun page upon successful creation', async () => {
+  //   const experimentId = 'test-exp-id-1';
+  //   createRunSpy.mockImplementation(() => ({ id: experimentId }));
+  //   const tree = shallow(<NewRun {...generateProps() as any} />);
+
+  //   (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment-name' } });
+
+  //   tree.find('#createExperimentBtn').simulate('click');
+  //   await TestUtils.flushPromises();
+
+  //   expect(historyPushSpy).toHaveBeenCalledWith(
+  //     RoutePage.NEW_RUN
+  //     + `?experimentId=${experimentId}`
+  //     + `&firstRunInExperiment=1`);
+  //   tree.unmount();
+  // });
+
+  // it('includes pipeline ID in NewRun page query params if present', async () => {
+  //   const experimentId = 'test-exp-id-1';
+  //   createRunSpy.mockImplementation(() => ({ id: experimentId }));
+
+  //   const pipelineId = 'pipelineId=some-pipeline-id';
+  //   const props = generateProps();
+  //   props.location.search = `?pipelineId=${pipelineId}`;
+  //   const tree = shallow(<NewRun {...props as any} />);
+
+  //   (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment-name' } });
+
+  //   tree.find('#createExperimentBtn').simulate('click');
+  //   await TestUtils.flushPromises();
+
+  //   expect(historyPushSpy).toHaveBeenCalledWith(
+  //     RoutePage.NEW_RUN
+  //     + `?experimentId=${experimentId}`
+  //     + `&pipelineId=${pipelineId}`
+  //     + `&firstRunInExperiment=1`);
+  //   tree.unmount();
+  // });
+
+  // it('shows snackbar confirmation after experiment is created', async () => {
+  //   const tree = shallow(<NewRun {...generateProps() as any} />);
+
+  //   (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment-name' } });
+
+  //   tree.find('#createExperimentBtn').simulate('click');
+  //   await TestUtils.flushPromises();
+
+  //   expect(updateSnackbarSpy).toHaveBeenLastCalledWith({
+  //     autoHideDuration: 10000,
+  //     message: 'Successfully created new Experiment: experiment-name',
+  //     open: true,
+  //   });
+  //   tree.unmount();
+  // });
+
+  // it('unsets busy state when creation fails', async () => {
+  //   // tslint:disable-next-line:no-console
+  //   console.error = jest.spyOn(console, 'error').mockImplementation();
+
+  //   const tree = shallow(<NewRun {...generateProps() as any} />);
+
+  //   (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment-name' } });
+
+  //   TestUtils.makeErrorResponseOnce(createRunSpy, 'test error!');
+  //   tree.find('#createExperimentBtn').simulate('click');
+  //   await TestUtils.flushPromises();
+
+  //   expect(tree.state()).toHaveProperty('isbeingCreated', false);
+  //   tree.unmount();
+  // });
+
+  // it('shows error dialog when creation fails', async () => {
+  //   // tslint:disable-next-line:no-console
+  //   console.error = jest.spyOn(console, 'error').mockImplementation();
+
+  //   const tree = shallow(<NewRun {...generateProps() as any} />);
+
+  //   (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment-name' } });
+
+  //   TestUtils.makeErrorResponseOnce(createRunSpy, 'test error!');
+  //   tree.find('#createExperimentBtn').simulate('click');
+  //   await TestUtils.flushPromises();
+
+  //   const call = updateDialogSpy.mock.calls[0][0];
+  //   expect(call).toHaveProperty('title', 'Experiment creation failed');
+  //   expect(call).toHaveProperty('content', 'test error!');
+  //   tree.unmount();
+  // });
+
+  // it('navigates to experiment list page upon cancellation', async () => {
+  //   const tree = shallow(<NewRun {...generateProps() as any} />);
+  //   tree.find('#cancelNewRunBtn').simulate('click');
+  //   await TestUtils.flushPromises();
+
+  //   expect(historyPushSpy).toHaveBeenCalledWith(RoutePage.EXPERIMENTS);
+  //   tree.unmount();
+  // });
+});

--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -24,7 +24,18 @@ import { RoutePage, RouteParams } from '../components/Router';
 import { ApiExperiment } from '../apis/experiment';
 import { ApiPipeline } from '../apis/pipeline';
 import { QUERY_PARAMS } from '../lib/URLParser';
-import { ApiRun, ApiResourceType } from '../apis/run';
+import { ApiResourceType, ApiRunDetail, ApiParameter, ApiRelationship } from '../apis/run';
+import { range } from 'lodash';
+
+class TestNewRun extends NewRun {
+  public _pipelineSelectionChanged(selectedId: string): void {
+    return super._pipelineSelectionChanged(selectedId);
+  }
+
+  public async _pipelineSelectorClosed(confirmed: boolean): Promise<void> {
+    return await super._pipelineSelectorClosed(confirmed);
+  }
+}
 
 describe('NewRun', () => {
   const createJobSpy = jest.spyOn(Apis.jobServiceApi, 'createJob');
@@ -34,33 +45,52 @@ describe('NewRun', () => {
   const getRunSpy = jest.spyOn(Apis.runServiceApi, 'getRun');
   const historyPushSpy = jest.fn();
   const historyReplaceSpy = jest.fn();
+  const listPipelinesSpy = jest.spyOn(Apis.pipelineServiceApi, 'listPipelines');
   const updateBannerSpy = jest.fn();
   const updateDialogSpy = jest.fn();
   const updateSnackbarSpy = jest.fn();
   const updateToolbarSpy = jest.fn();
 
-  const mockExperiment: ApiExperiment = {
-    description: 'mock experiment description',
-    id: 'some-mock-experiment-id',
-    name: 'some mock experiment name',
-  };
+  function newMockExperiment(): ApiExperiment {
+    return {
+      description: 'mock experiment description',
+      id: 'some-mock-experiment-id',
+      name: 'some mock experiment name',
+    };
+  }
 
-  const mockPipeline: ApiPipeline = {
-    id: 'some-mock-pipeline-id',
-    name: 'some mock pipeline name',
-  };
+  function newMockPipeline(): ApiPipeline {
+    return {
+      id: 'some-mock-pipeline-id',
+      name: 'some mock pipeline name',
+    };
+  }
 
-  const mockRun: ApiRun = {
-    id: 'some-mock-run-id',
-    name: 'some mock run name',
-  };
+  function newMockRunDetail(): ApiRunDetail {
+    return {
+      pipeline_runtime: {
+        workflow_manifest: '{}'
+      },
+      run: {
+        id: 'some-mock-run-id',
+        name: 'some mock run name',
+        pipeline_spec: {
+          pipeline_id: 'original-run-pipeline-id'
+        },
+      },
+    };
+  }
 
   function generateProps(): PageProps {
     return {
       history: { push: historyPushSpy, replace: historyReplaceSpy } as any,
-      location: { pathname: RoutePage.NEW_RUN } as any,
+      location: {
+        pathname: RoutePage.NEW_RUN,
+        // TODO: this should be removed once experiments are no longer required to reach this page.
+        search: `?${QUERY_PARAMS.experimentId}=${newMockExperiment().id}`
+      } as any,
       match: '' as any,
-      toolbarProps: NewRun.prototype.getInitialToolbarState(),
+      toolbarProps: TestNewRun.prototype.getInitialToolbarState(),
       updateBanner: updateBannerSpy,
       updateDialog: updateDialogSpy,
       updateSnackbar: updateSnackbarSpy,
@@ -77,33 +107,34 @@ describe('NewRun', () => {
     getRunSpy.mockReset();
     historyPushSpy.mockReset();
     historyReplaceSpy.mockReset();
+    listPipelinesSpy.mockReset();
     updateBannerSpy.mockReset();
     updateDialogSpy.mockReset();
     updateSnackbarSpy.mockReset();
     updateToolbarSpy.mockReset();
 
     createRunSpy.mockImplementation(() => ({ id: 'new-run-id' }));
-    getExperimentSpy.mockImplementation(() =>({ mockExperiment }));
-    getPipelineSpy.mockImplementation(() =>({ mockPipeline }));
-    getRunSpy.mockImplementation(() =>({ mockRun }));
+    getExperimentSpy.mockImplementation(() => newMockExperiment());
+    getPipelineSpy.mockImplementation(() => newMockPipeline());
+    getRunSpy.mockImplementation(() => newMockRunDetail());
   });
 
-  it('renders the new run page', () => {
-    const tree = shallow(<NewRun {...generateProps() as any} />);
+  it('renders the new run page', async () => {
+    const tree = shallow(<TestNewRun {...generateProps() as any} />);
+    await TestUtils.flushPromises();
 
     expect(tree).toMatchSnapshot();
     tree.unmount();
   });
 
-  it('disables \'Create\' new run button by default', () => {
-    const tree = shallow(<NewRun {...generateProps() as any} />);
+  it('does not include any action buttons in the toolbar', async () => {
+    const props = generateProps();
+    // Clear the experiment ID from the query params, as it used at some point to update the
+    // breadcrumb, and we cover that in a later test.
+    props.location.search = '';
 
-    expect(tree.find('#createNewRunBtn').props()).toHaveProperty('disabled', true);
-    tree.unmount();
-  });
-
-  it('does not include any action buttons in the toolbar', () => {
-    const tree = shallow(<NewRun {...generateProps() as any} />);
+    const tree = shallow(<TestNewRun {...props as any} />);
+    await TestUtils.flushPromises();
 
     expect(updateToolbarSpy).toHaveBeenLastCalledWith({
       actions: [],
@@ -115,88 +146,94 @@ describe('NewRun', () => {
     tree.unmount();
   });
 
-  it('changes the title if the new run will recur, based on query param', () => {
-    const props = generateProps();
-    props.location.search = `?${QUERY_PARAMS.isRecurring}=1`;
-    const tree = shallow(<NewRun {...props as any} />);
-
-    expect(updateToolbarSpy).toHaveBeenLastCalledWith({
-      actions: [],
-      breadcrumbs: [
-        { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
-        { displayName: 'Start a recurring run', href: '' }
-      ],
-    });
-    tree.unmount();
-  });
-
-  it('clears the banner when refresh is called', () => {
-    const tree = shallow(<NewRun {...generateProps() as any} />);
+  it('clears the banner when refresh is called', async () => {
+    const tree = shallow(<TestNewRun {...generateProps() as any} />);
     expect(updateBannerSpy).toHaveBeenCalledTimes(1);
-    (tree.instance() as NewRun).refresh();
+    (tree.instance() as TestNewRun).refresh();
+    await TestUtils.flushPromises();
     expect(updateBannerSpy).toHaveBeenCalledTimes(2);
     expect(updateBannerSpy).toHaveBeenLastCalledWith({});
   });
 
-  it('clears the banner when load is called', () => {
-    const tree = shallow(<NewRun {...generateProps() as any} />);
+  it('clears the banner when load is called', async () => {
+    const tree = shallow(<TestNewRun {...generateProps() as any} />);
     expect(updateBannerSpy).toHaveBeenCalledTimes(1);
-    (tree.instance() as NewRun).load();
+    (tree.instance() as TestNewRun).load();
+    await TestUtils.flushPromises();
     expect(updateBannerSpy).toHaveBeenCalledTimes(2);
     expect(updateBannerSpy).toHaveBeenLastCalledWith({});
   });
 
-  it('updates the run name', () => {
-    const tree = shallow(<NewRun {...generateProps() as any} />);
+  it('allows updating the run name', async () => {
+    const tree = shallow(<TestNewRun {...generateProps() as any} />);
+    await TestUtils.flushPromises();
+
     (tree.instance() as any).handleChange('runName')({ target: { value: 'run name' } });
 
     expect(tree.state()).toHaveProperty('runName', 'run name');
     tree.unmount();
   });
 
-  it('updates the run description', () => {
-    const tree = shallow(<NewRun {...generateProps() as any} />);
+  it('allows updating the run description', async () => {
+    const tree = shallow(<TestNewRun {...generateProps() as any} />);
+    await TestUtils.flushPromises();
     (tree.instance() as any).handleChange('description')({ target: { value: 'run description' } });
 
     expect(tree.state()).toHaveProperty('description', 'run description');
     tree.unmount();
   });
 
-  it('fetches the associated experiment if one is present in the query params', async () => {
+  it('exits to the AllRuns page if there is no associated experiment', async () => {
     const props = generateProps();
-    props.location.search = `?${QUERY_PARAMS.experimentId}=${mockExperiment.id}`;
+    // Clear query params which might otherwise include an experiment ID.
+    props.location.search = '';
 
-    getExperimentSpy.mockImplementation(() => mockExperiment);
+    const tree = shallow(<TestNewRun {...props as any} />);
+    await TestUtils.flushPromises();
+    tree.find('#exitNewRunPageBtn').simulate('click');
 
-    const tree = shallow(<NewRun {...props as any} />);
+    expect(historyPushSpy).toHaveBeenCalledWith(RoutePage.RUNS);
+    tree.unmount();
+  });
+
+  it('fetches the associated experiment if one is present in the query params', async () => {
+    const experiment = newMockExperiment();
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.experimentId}=${experiment.id}`;
+
+    getExperimentSpy.mockImplementation(() => experiment);
+
+    const tree = shallow(<TestNewRun {...props as any} />);
     await TestUtils.flushPromises();
 
-    expect(getExperimentSpy).toHaveBeenLastCalledWith(mockExperiment.id);
+    expect(getExperimentSpy).toHaveBeenLastCalledWith(experiment.id);
     tree.unmount();
   });
 
   it('updates the run\'s state with the associated experiment if one is present in the query params', async () => {
+    const experiment = newMockExperiment();
     const props = generateProps();
-    props.location.search = `?${QUERY_PARAMS.experimentId}=${mockExperiment.id}`;
+    props.location.search = `?${QUERY_PARAMS.experimentId}=${experiment.id}`;
 
-    getExperimentSpy.mockImplementation(() => mockExperiment);
+    getExperimentSpy.mockImplementation(() => experiment);
 
-    const tree = shallow(<NewRun {...props as any} />);
+    const tree = shallow(<TestNewRun {...props as any} />);
     await TestUtils.flushPromises();
 
-    expect(tree.state()).toHaveProperty('experiment', mockExperiment);
-    expect(tree.state()).toHaveProperty('experimentName', mockExperiment.name);
+    expect(tree.state()).toHaveProperty('experiment', experiment);
+    expect(tree.state()).toHaveProperty('experimentName', experiment.name);
     expect(tree).toMatchSnapshot();
     tree.unmount();
   });
 
   it('updates the breadcrumb with the associated experiment if one is present in the query params', async () => {
+    const experiment = newMockExperiment();
     const props = generateProps();
-    props.location.search = `?${QUERY_PARAMS.experimentId}=${mockExperiment.id}`;
+    props.location.search = `?${QUERY_PARAMS.experimentId}=${experiment.id}`;
 
-    getExperimentSpy.mockImplementation(() => mockExperiment);
+    getExperimentSpy.mockImplementation(() => experiment);
 
-    const tree = shallow(<NewRun {...props as any} />);
+    const tree = shallow(<TestNewRun {...props as any} />);
     await TestUtils.flushPromises();
 
     expect(updateToolbarSpy).toHaveBeenLastCalledWith({
@@ -204,155 +241,473 @@ describe('NewRun', () => {
       breadcrumbs: [
         { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
         {
-          displayName: mockExperiment.name,
-          href: RoutePage.EXPERIMENT_DETAILS.replace(':' + RouteParams.experimentId, mockExperiment.id!)
+          displayName: experiment.name,
+          href: RoutePage.EXPERIMENT_DETAILS.replace(':' + RouteParams.experimentId, experiment.id!)
         },
-        { displayName: 'Start a new run', href: ''}
+        { displayName: 'Start a new run', href: '' }
       ],
     });
+    tree.unmount();
+  });
+
+  it('exits to the associated experiment\'s details page if one is present in the query params', async () => {
+    const experiment = newMockExperiment();
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.experimentId}=${experiment.id}`;
+
+    getExperimentSpy.mockImplementation(() => experiment);
+
+    const tree = shallow(<TestNewRun {...props as any} />);
+    await TestUtils.flushPromises();
+    tree.find('#exitNewRunPageBtn').simulate('click');
+
+    expect(historyPushSpy).toHaveBeenCalledWith(
+      RoutePage.EXPERIMENT_DETAILS.replace(':' + RouteParams.experimentId, experiment.id!)
+    );
+    tree.unmount();
+  });
+
+  it('changes the exit button\'s text if query params indicate this is the first run of an experiment', async () => {
+    const experiment = newMockExperiment();
+    const props = generateProps();
+    props.location.search =
+      `?${QUERY_PARAMS.experimentId}=${experiment.id}`
+      + `&${QUERY_PARAMS.firstRunInExperiment}=1`;
+
+    getExperimentSpy.mockImplementation(() => experiment);
+
+    const tree = shallow(<TestNewRun {...props as any} />);
+    await TestUtils.flushPromises();
+
+    expect(tree).toMatchSnapshot();
     tree.unmount();
   });
 
   it('shows a page error if getExperiment fails', async () => {
     // Don't actually log to console.
     // tslint:disable-next-line:no-console
-    console.error = jest.spyOn(console, 'error').mockImplementation();
+    console.error = jest.spyOn(console, 'error').mockImplementationOnce(() => null);
 
+    const experiment = newMockExperiment();
     const props = generateProps();
-    props.location.search = `?${QUERY_PARAMS.experimentId}=${mockExperiment.id}`;
+    props.location.search = `?${QUERY_PARAMS.experimentId}=${experiment.id}`;
 
     TestUtils.makeErrorResponseOnce(getExperimentSpy, 'test error message');
 
-    const tree = shallow(<NewRun {...props as any} />);
+    const tree = shallow(<TestNewRun {...props as any} />);
     await TestUtils.flushPromises();
 
     expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
       additionalInfo: 'test error message',
-      message: `Error: failed to retrieve associated experiment: ${mockExperiment.id}. Click Details for more information.`,
+      message: `Error: failed to retrieve associated experiment: ${experiment.id}. Click Details for more information.`,
       mode: 'error',
     }));
     tree.unmount();
   });
 
   it('fetches the associated pipeline if one is present in the query params', async () => {
+    const pipeline = newMockPipeline();
     const props = generateProps();
-    props.location.search = `?${QUERY_PARAMS.pipelineId}=${mockPipeline.id}`;
+    props.location.search = `?${QUERY_PARAMS.pipelineId}=${pipeline.id}`;
 
-    getPipelineSpy.mockImplementation(() => mockPipeline);
+    getPipelineSpy.mockImplementation(() => pipeline);
 
-    const tree = shallow(<NewRun {...props as any} />);
+    const tree = shallow(<TestNewRun {...props as any} />);
     await TestUtils.flushPromises();
 
-    expect(tree.state()).toHaveProperty('pipeline', mockPipeline);
-    expect(tree.state()).toHaveProperty('pipelineName', mockPipeline.name);
+    expect(tree.state()).toHaveProperty('pipeline', pipeline);
+    expect(tree.state()).toHaveProperty('pipelineName', pipeline.name);
     expect(tree.state()).toHaveProperty('errorMessage', 'Run name is required');
     expect(tree).toMatchSnapshot();
-    tree.unmount();
-  });
-
-  it('enables the \'Create\' new run button if pipeline ID in query params and run name entered', async () => {
-    const props = generateProps();
-    props.location.search = `?${QUERY_PARAMS.pipelineId}=${mockPipeline.id}`;
-
-    const tree = shallow(<NewRun {...props as any} />);
-    (tree.instance() as any).handleChange('runName')({ target: { value: 'run name' } });
-    await TestUtils.flushPromises();
-
-    expect(tree.find('#createNewRunBtn').props()).toHaveProperty('disabled', false);
-    tree.unmount();
-  });
-
-  it('re-disables the \'Create\' new run button if pipeline ID in query params and run name entered then cleared', async () => {
-    const props = generateProps();
-    props.location.search = `?${QUERY_PARAMS.pipelineId}=${mockPipeline.id}`;
-
-    const tree = shallow(<NewRun {...props as any} />);
-    (tree.instance() as any).handleChange('runName')({ target: { value: 'run name' } });
-    await TestUtils.flushPromises();
-    expect(tree.find('#createNewRunBtn').props()).toHaveProperty('disabled', false);
-
-    (tree.instance() as any).handleChange('runName')({ target: { value: '' } });
-    expect(tree.find('#createNewRunBtn').props()).toHaveProperty('disabled', true);
-
     tree.unmount();
   });
 
   it('shows a page error if getPipeline fails', async () => {
     // Don't actually log to console.
     // tslint:disable-next-line:no-console
-    console.error = jest.spyOn(console, 'error').mockImplementation();
+    console.error = jest.spyOn(console, 'error').mockImplementationOnce(() => null);
 
+    const pipeline = newMockPipeline();
     const props = generateProps();
-    props.location.search = `?${QUERY_PARAMS.pipelineId}=${mockPipeline.id}`;
+    props.location.search = `?${QUERY_PARAMS.pipelineId}=${pipeline.id}`;
 
     TestUtils.makeErrorResponseOnce(getPipelineSpy, 'test error message');
 
-    const tree = shallow(<NewRun {...props as any} />);
+    const tree = shallow(<TestNewRun {...props as any} />);
     await TestUtils.flushPromises();
 
     expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
       additionalInfo: 'test error message',
-      message: `Error: failed to retrieve pipeline: ${mockPipeline.id}. Click Details for more information.`,
+      message: `Error: failed to retrieve pipeline: ${pipeline.id}. Click Details for more information.`,
       mode: 'error',
     }));
     tree.unmount();
   });
 
-  describe('cloning from a run', () => {
-    it('fetches the original run if an ID is present in the query params', async () => {
-      const props = generateProps();
-      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${mockRun.id}`;
+  describe('choosing a pipeline', () => {
 
-      const tree = shallow(<NewRun {...props as any} />);
+    beforeEach(() => {
+      listPipelinesSpy.mockImplementation(() => ({
+        pipelines: range(5).map(i => ({ id: 'test-pipeline-id' + i, name: 'test pipeline name' + i })),
+      }));
+    });
+
+    it('opens up the pipeline selector modal when users clicks \'Choose\'', async () => {
+      const tree = TestUtils.mountWithRouter(<TestNewRun {...generateProps() as any} />);
       await TestUtils.flushPromises();
 
-      expect(getRunSpy).toHaveBeenCalledTimes(1);
-      expect(getRunSpy).toHaveBeenLastCalledWith(mockRun.id);
+      tree.find('#choosePipelineBtn').at(0).simulate('click');
+      await TestUtils.flushPromises();
+      expect(tree.state('pipelineSelectorOpen')).toBe(true);
+
+      // Close and flush this to avoid minor memory leak where PipelineSelector._loadPipelines is
+      // called after the component is unmounted by tree.unmount().
+      tree.setState({ pipelineSelectorOpen: false });
+      await TestUtils.flushPromises();
       tree.unmount();
     });
 
-    it('uses the query param experiment ID over the one in the original run if an ID is present in both', async () => {
-      const run: ApiRun = {
-        id: 'some-mock-run-id',
-        name: 'some mock run name',
-        resource_references: [{
-          key: { id: `${mockExperiment.id}-different`, type: ApiResourceType.EXPERIMENT },
-        }],
-      };
+    it('closes the pipeline selector modal', async () => {
+      const tree = TestUtils.mountWithRouter(<TestNewRun {...generateProps() as any} />);
+      await TestUtils.flushPromises();
+
+      tree.find('#choosePipelineBtn').at(0).simulate('click');
+      expect(tree.state('pipelineSelectorOpen')).toBe(true);
+
+      tree.find('#cancelPipelineSelectionBtn').at(0).simulate('click');
+      expect(tree.state('pipelineSelectorOpen')).toBe(false);
+      // Flush this to avoid minor memory leak where PipelineSelector._loadPipelines is called after
+      // the component is unmounted by tree.unmount().
+      await TestUtils.flushPromises();
+      tree.unmount();
+    });
+
+    it('sets the pipeline ID from the selector modal when confirmed', async () => {
+      const tree = TestUtils.mountWithRouter(<TestNewRun {...generateProps() as any} />);
+      await TestUtils.flushPromises();
+
+      const oldPipeline = newMockPipeline();
+      oldPipeline.id = 'old-pipeline-id';
+      oldPipeline.name = 'old-pipeline-name';
+      const newPipeline = newMockPipeline();
+      newPipeline.id = 'new-pipeline-id';
+      newPipeline.name = 'new-pipeline-name';
+      getPipelineSpy.mockImplementation(() => newPipeline);
+      tree.setState({ pipeline: oldPipeline, pipelineName: oldPipeline.name });
+      const instance = tree.instance() as TestNewRun;
+      instance._pipelineSelectionChanged(newPipeline.id);
+
+      tree.find('#choosePipelineBtn').at(0).simulate('click');
+      expect(tree.state('pipelineSelectorOpen')).toBe(true);
+      // Confirm pipeline selector
+      tree.find('#usePipelineBtn').at(0).simulate('click');
+      await TestUtils.flushPromises();
+      expect(tree.state('pipelineSelectorOpen')).toBe(false);
+
+      expect(tree.state('pipeline')).toEqual(newPipeline);
+      expect(tree.state('pipelineName')).toEqual(newPipeline.name);
+      expect(tree.state('pipelineSelectorOpen')).toBe(false);
+      await TestUtils.flushPromises();
+      tree.unmount();
+    });
+
+    it('does not set the pipeline ID from the selector modal when cancelled', async () => {
+      const tree = TestUtils.mountWithRouter(<TestNewRun {...generateProps() as any} />);
+      await TestUtils.flushPromises();
+
+      const oldPipeline = newMockPipeline();
+      oldPipeline.id = 'old-pipeline-id';
+      oldPipeline.name = 'old-pipeline-name';
+      const newPipeline = newMockPipeline();
+      newPipeline.id = 'new-pipeline-id';
+      newPipeline.name = 'new-pipeline-name';
+      getPipelineSpy.mockImplementation(() => newPipeline);
+      tree.setState({ pipeline: oldPipeline, pipelineName: oldPipeline.name });
+      const instance = tree.instance() as TestNewRun;
+      instance._pipelineSelectionChanged(newPipeline.id);
+
+      tree.find('#choosePipelineBtn').at(0).simulate('click');
+      expect(tree.state('pipelineSelectorOpen')).toBe(true);
+      // Cancel pipeline selector
+      tree.find('#cancelPipelineSelectionBtn').at(0).simulate('click');
+      expect(tree.state('pipelineSelectorOpen')).toBe(false);
+
+      expect(tree.state('pipeline')).toEqual(oldPipeline);
+      expect(tree.state('pipelineName')).toEqual(oldPipeline.name);
+      expect(tree.state('pipelineSelectorOpen')).toBe(false);
+      await TestUtils.flushPromises();
+      tree.unmount();
+    });
+
+    // TODO: Add test for when dialog is dismissed. Due to the particulars of how the Dialog element
+    // works, this will not be possible until it's wrapped in some manner, like UploadPipelineDialog
+    // in PipelineList
+
+    it('shows a page error if fetching the selected pipeline fails', async () => {
+      // Don't actually log to console.
+      // tslint:disable-next-line:no-console
+      console.error = jest.spyOn(console, 'error').mockImplementationOnce(() => null);
+
+      const tree = shallow(<TestNewRun {...generateProps() as any} />);
+      await TestUtils.flushPromises();
+
+      TestUtils.makeErrorResponseOnce(getPipelineSpy, 'test getPipeline error');
+
+      const instance = tree.instance() as TestNewRun;
+      const pipelineId = 'some-pipeline-id';
+      instance._pipelineSelectionChanged(pipelineId);
+      // Confirm pipeline selector
+      await instance._pipelineSelectorClosed(true);
+      await TestUtils.flushPromises();
+
+      expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+        additionalInfo: 'test getPipeline error',
+        message:
+          `Error: failed to retrieve pipeline with ID: ${pipelineId}.`
+          + ' Click Details for more information.',
+        mode: 'error',
+      }));
+      tree.unmount();
+    });
+  });
+
+  describe('cloning from a run', () => {
+    it('fetches the original run if an ID is present in the query params', async () => {
+      const run = newMockRunDetail().run!;
       const props = generateProps();
-      props.location.search =
-        `?${QUERY_PARAMS.cloneFromRun}=${run.id}`
-        + `&${QUERY_PARAMS.experimentId}=${mockExperiment.id}`;
+      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${run.id}`;
 
-      getRunSpy.mockImplementation(() => run);
-
-      const tree = shallow(<NewRun {...props as any} />);
+      const tree = shallow(<TestNewRun {...props as any} />);
       await TestUtils.flushPromises();
 
       expect(getRunSpy).toHaveBeenCalledTimes(1);
       expect(getRunSpy).toHaveBeenLastCalledWith(run.id);
-      expect(getExperimentSpy).toHaveBeenCalledTimes(1);
-      expect(getExperimentSpy).toHaveBeenLastCalledWith(mockExperiment.id);
-      expect(tree.state('experiment')).toHaveProperty('id', mockExperiment.id);
       tree.unmount();
     });
 
-    it('shows a page error if getRun fails', async () => {
+    it('automatically generates the new run name based on the original run\'s name', async () => {
+      const runDetail = newMockRunDetail();
+      runDetail.run!.name = '-original run-';
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${runDetail.run!.id}`;
+
+      getRunSpy.mockImplementation(() => runDetail);
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(tree.state('runName')).toBe('Clone of -original run-');
+      tree.unmount();
+    });
+
+    it('automatically generates the new clone name if the original run was a clone', async () => {
+      const runDetail = newMockRunDetail();
+      runDetail.run!.name = 'Clone of some run';
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${runDetail.run!.id}`;
+
+      getRunSpy.mockImplementation(() => runDetail);
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(tree.state('runName')).toBe('Clone (2) of some run');
+      tree.unmount();
+    });
+
+    it('uses the query param experiment ID over the one in the original run if an ID is present in both', async () => {
+      const experiment = newMockExperiment();
+      const runDetail = newMockRunDetail();
+      runDetail.run!.resource_references = [{
+        key: { id: `${experiment.id}-different`, type: ApiResourceType.EXPERIMENT },
+      }];
+      const props = generateProps();
+      props.location.search =
+        `?${QUERY_PARAMS.cloneFromRun}=${runDetail.run!.id}`
+        + `&${QUERY_PARAMS.experimentId}=${experiment.id}`;
+
+      getRunSpy.mockImplementation(() => runDetail);
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(getRunSpy).toHaveBeenCalledTimes(1);
+      expect(getRunSpy).toHaveBeenLastCalledWith(runDetail.run!.id);
+      expect(getExperimentSpy).toHaveBeenCalledTimes(1);
+      expect(getExperimentSpy).toHaveBeenLastCalledWith(experiment.id);
+      tree.unmount();
+    });
+
+    it('uses the experiment ID in the original run if no experiment ID is present in query params', async () => {
+      const originalRunExperimentId = 'original-run-experiment-id';
+      const runDetail = newMockRunDetail();
+      runDetail.run!.resource_references = [{
+        key: { id: originalRunExperimentId, type: ApiResourceType.EXPERIMENT },
+      }];
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${runDetail.run!.id}`;
+
+      getRunSpy.mockImplementation(() => runDetail);
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(getRunSpy).toHaveBeenCalledTimes(1);
+      expect(getRunSpy).toHaveBeenLastCalledWith(runDetail.run!.id);
+      expect(getExperimentSpy).toHaveBeenCalledTimes(1);
+      expect(getExperimentSpy).toHaveBeenLastCalledWith(originalRunExperimentId);
+      tree.unmount();
+    });
+
+    it('retrieves the pipeline from the original run, even if there is a pipeline ID in the query params', async () => {
+      const runDetail = newMockRunDetail();
+      runDetail.run!.pipeline_spec = { pipeline_id: 'original-run-pipeline-id' };
+      const props = generateProps();
+      props.location.search =
+        `?${QUERY_PARAMS.cloneFromRun}=${runDetail.run!.id}`
+        + `&${QUERY_PARAMS.pipelineId}=some-other-pipeline-id`;
+
+      getRunSpy.mockImplementation(() => runDetail);
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(getPipelineSpy).toHaveBeenCalledTimes(1);
+      expect(getPipelineSpy).toHaveBeenLastCalledWith(runDetail.run!.pipeline_spec!.pipeline_id);
+      tree.unmount();
+    });
+
+    it('shows a page error if getPipeline fails to find the pipeline from the original run', async () => {
       // Don't actually log to console.
       // tslint:disable-next-line:no-console
-      console.error = jest.spyOn(console, 'error').mockImplementation();
+      console.error = jest.spyOn(console, 'error').mockImplementationOnce(() => null);
 
+      const runDetail = newMockRunDetail();
       const props = generateProps();
-      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${mockRun.id}`;
+      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${runDetail.run!.id}`;
 
-      TestUtils.makeErrorResponseOnce(getRunSpy, 'test error message');
+      getRunSpy.mockImplementation(() => runDetail);
+      TestUtils.makeErrorResponseOnce(getPipelineSpy, 'test error message');
 
-      const tree = shallow(<NewRun {...props as any} />);
+      const tree = shallow(<TestNewRun {...props as any} />);
       await TestUtils.flushPromises();
 
       expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
         additionalInfo: 'test error message',
-        message: `Error: failed to retrieve original run: ${mockRun.id}. Click Details for more information.`,
+        message:
+          'Error: failed to find a pipeline corresponding to that of the original run:'
+          + ` ${runDetail.run!.id}. Click Details for more information.`,
+        mode: 'error',
+      }));
+      tree.unmount();
+    });
+
+    it('does not show an error if getPipeline fails to find the pipeline from the original run', async () => {
+      // Don't actually log to console.
+      // tslint:disable-next-line:no-console
+      console.log = jest.spyOn(console, 'log').mockImplementationOnce(() => null);
+
+      const runDetail = newMockRunDetail();
+      runDetail.run!.pipeline_spec!.pipeline_id = undefined;
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${runDetail.run!.id}`;
+
+      getRunSpy.mockImplementation(() => runDetail);
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      // tslint:disable-next-line:no-console
+      expect(console.log).toHaveBeenLastCalledWith('Original run did not have an associated pipeline ID');
+      tree.unmount();
+    });
+
+    it('shows a page error if the original run\'s workflow_manifest is undefined', async () => {
+      // Don't actually log to console.
+      // tslint:disable-next-line:no-console
+      console.error = jest.spyOn(console, 'error').mockImplementationOnce(() => null);
+
+      const runDetail = newMockRunDetail();
+      runDetail.pipeline_runtime!.workflow_manifest = undefined;
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${runDetail.run!.id}`;
+
+      getRunSpy.mockImplementation(() => runDetail);
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+        message: `Error: run ${runDetail.run!.id} had no workflow manifest`,
+        mode: 'error',
+      }));
+      tree.unmount();
+    });
+
+    it('shows a page error if the original run\'s workflow_manifest is invalid JSON', async () => {
+      // Don't actually log to console.
+      // tslint:disable-next-line:no-console
+      console.error = jest.spyOn(console, 'error').mockImplementationOnce(() => null);
+
+      const runDetail = newMockRunDetail();
+      runDetail.pipeline_runtime!.workflow_manifest = 'not json';
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${runDetail.run!.id}`;
+
+      getRunSpy.mockImplementation(() => runDetail);
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+        message: 'Error: failed to parse the original run\'s runtime. Click Details for more information.',
+        mode: 'error',
+      }));
+      tree.unmount();
+    });
+
+    it('gets the pipeline parameter values of the original run\'s pipeline', async () => {
+      const runDetail = newMockRunDetail();
+      const originalRunPipelineParams: ApiParameter[] =
+        [{ name: 'thisTestParam', value: 'thisTestVal' }];
+      runDetail.pipeline_runtime!.workflow_manifest =
+        JSON.stringify({
+          spec: {
+            arguments: {
+              parameters: originalRunPipelineParams
+            },
+          },
+        });
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${runDetail.run!.id}`;
+
+      getRunSpy.mockImplementation(() => runDetail);
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(tree.state('pipeline')).toHaveProperty('parameters', originalRunPipelineParams);
+      tree.unmount();
+    });
+
+
+    it('shows a page error if getRun fails', async () => {
+      // Don't actually log to console.
+      // tslint:disable-next-line:no-console
+      console.error = jest.spyOn(console, 'error').mockImplementationOnce(() => null);
+
+      const runDetail = newMockRunDetail();
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${runDetail.run!.id}`;
+
+      TestUtils.makeErrorResponseOnce(getRunSpy, 'test error message');
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+        additionalInfo: 'test error message',
+        message: `Error: failed to retrieve original run: ${runDetail.run!.id}. Click Details for more information.`,
         mode: 'error',
       }));
       tree.unmount();
@@ -360,154 +715,446 @@ describe('NewRun', () => {
 
   });
 
-  // it('clears the pipeline ID query param if getPipeline fails', async () => {
-  //   const props = generateProps();
-  //   props.location.search = `?${QUERY_PARAMS.pipelineId}=${mockPipeline.id}`;
+  describe('creating a new run', () => {
 
-  //   TestUtils.makeErrorResponseOnce(getPipelineSpy, 'test error message');
+    it('disables \'Create\' new run button by default', async () => {
+      const tree = shallow(<TestNewRun {...generateProps() as any} />);
+      await TestUtils.flushPromises();
 
-  //   const tree = TestUtils.mountWithRouter(<NewRun {...props as any} />);
-  //   await TestUtils.flushPromises();
+      expect(tree.find('#createNewRunBtn').props()).toHaveProperty('disabled', true);
+      tree.unmount();
+    });
 
-  //   expect((tree.instance().props as any).location.search).toBe('test');
-  //   tree.unmount();
-  // });
-  // it('Updates the experiment description', () => {
-  //   const tree = shallow(<NewRun {...generateProps() as any} />);
-  //   (tree.instance() as any).handleChange('description')({ target: { value: 'a description!' } });
+    it('enables the \'Create\' new run button if pipeline ID in query params and run name entered', async () => {
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.pipelineId}=${newMockPipeline().id}`;
 
-  //   expect(tree.state()).toEqual({
-  //     description: 'a description!',
-  //     experimentName: '',
-  //     isbeingCreated: false,
-  //     validationError: 'Experiment name is required',
-  //   });
-  //   tree.unmount();
-  // });
+      const tree = shallow(<TestNewRun {...props as any} />);
+      (tree.instance() as any).handleChange('runName')({ target: { value: 'run name' } });
+      await TestUtils.flushPromises();
 
-  // it('sets the page to a busy state upon clicking \'Next\'', async () => {
-  //   const tree = shallow(<NewRun {...generateProps() as any} />);
+      expect(tree.find('#createNewRunBtn').props()).toHaveProperty('disabled', false);
+      tree.unmount();
+    });
 
-  //   (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment-name' } });
+    it('re-disables the \'Create\' new run button if pipeline ID in query params and run name entered then cleared', async () => {
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.pipelineId}=${newMockPipeline().id}`;
 
-  //   tree.find('#createExperimentBtn').simulate('click');
-  //   await TestUtils.flushPromises();
+      const tree = shallow(<TestNewRun {...props as any} />);
+      (tree.instance() as any).handleChange('runName')({ target: { value: 'run name' } });
+      await TestUtils.flushPromises();
+      expect(tree.find('#createNewRunBtn').props()).toHaveProperty('disabled', false);
 
-  //   expect(tree.state()).toHaveProperty('isbeingCreated', true);
-  //   tree.unmount();
-  // });
+      (tree.instance() as any).handleChange('runName')({ target: { value: '' } });
+      expect(tree.find('#createNewRunBtn').props()).toHaveProperty('disabled', true);
 
-  // it('calls the createExperiment API with the new experiment upon clicking \'Next\'', async () => {
-  //   const tree = shallow(<NewRun {...generateProps() as any} />);
+      tree.unmount();
+    });
 
-  //   (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment name' } });
-  //   (tree.instance() as any).handleChange('description')({ target: { value: 'experiment description' } });
+    it('sends a request to create a new run when \'Create\' is clicked', async () => {
+      const props = generateProps();
+      const experiment = newMockExperiment();
+      const pipeline = newMockPipeline();
+      props.location.search =
+        `?${QUERY_PARAMS.experimentId}=${experiment.id}`
+        + `&${QUERY_PARAMS.pipelineId}=${pipeline.id}`;
 
-  //   tree.find('#createExperimentBtn').simulate('click');
-  //   await TestUtils.flushPromises();
+      getExperimentSpy.mockImplementation(() => experiment);
+      getPipelineSpy.mockImplementation(() => pipeline);
 
-  //   expect(createRunSpy).toHaveBeenCalledWith({
-  //     description: 'experiment description',
-  //     name: 'experiment name',
-  //   });
-  //   tree.unmount();
-  // });
+      const tree = shallow(<TestNewRun {...props as any} />);
+      (tree.instance() as any).handleChange('runName')({ target: { value: 'test run name' } });
+      (tree.instance() as any).handleChange('description')({ target: { value: 'test run description' } });
+      await TestUtils.flushPromises();
 
-  // it('navigates to NewRun page upon successful creation', async () => {
-  //   const experimentId = 'test-exp-id-1';
-  //   createRunSpy.mockImplementation(() => ({ id: experimentId }));
-  //   const tree = shallow(<NewRun {...generateProps() as any} />);
+      tree.find('#createNewRunBtn').simulate('click');
+      // The create APIs are called in a callback triggered by clicking 'Create', so we wait again
+      await TestUtils.flushPromises();
 
-  //   (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment-name' } });
+      expect(createRunSpy).toHaveBeenCalledTimes(1);
+      expect(createRunSpy).toHaveBeenLastCalledWith({
+        description: 'test run description',
+        name: 'test run name',
+        pipeline_spec: {
+          parameters: pipeline.parameters,
+          pipeline_id: pipeline.id,
+        },
+        resource_references: [{
+          key: {
+            id: experiment.id,
+            type: ApiResourceType.EXPERIMENT,
+          },
+          relationship: ApiRelationship.OWNER,
+        }]
+      });
+      tree.unmount();
+    });
 
-  //   tree.find('#createExperimentBtn').simulate('click');
-  //   await TestUtils.flushPromises();
+    it('updates the pipeline in state when a user fills in its params', async () => {
+      const props = generateProps();
+      const pipeline = newMockPipeline();
+      pipeline.parameters = [
+        { name: 'param-1', value: '' },
+        { name: 'param-2', value: 'prefilled value' },
+      ];
+      props.location.search = `?${QUERY_PARAMS.pipelineId}=${pipeline.id}`;
 
-  //   expect(historyPushSpy).toHaveBeenCalledWith(
-  //     RoutePage.NEW_RUN
-  //     + `?experimentId=${experimentId}`
-  //     + `&firstRunInExperiment=1`);
-  //   tree.unmount();
-  // });
+      getPipelineSpy.mockImplementation(() => pipeline);
 
-  // it('includes pipeline ID in NewRun page query params if present', async () => {
-  //   const experimentId = 'test-exp-id-1';
-  //   createRunSpy.mockImplementation(() => ({ id: experimentId }));
+      const tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+      (tree.instance() as any).handleChange('runName')({ target: { value: 'test run name' } });
+      // Fill in the first pipeline parameter
+      tree.find('#newRunPipelineParam0').simulate('change', { target: { value: 'test param value' } });
+      await TestUtils.flushPromises();
 
-  //   const pipelineId = 'pipelineId=some-pipeline-id';
-  //   const props = generateProps();
-  //   props.location.search = `?pipelineId=${pipelineId}`;
-  //   const tree = shallow(<NewRun {...props as any} />);
+      tree.find('#createNewRunBtn').simulate('click');
+      // The create APIs are called in a callback triggered by clicking 'Create', so we wait again
+      await TestUtils.flushPromises();
 
-  //   (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment-name' } });
+      expect(createRunSpy).toHaveBeenCalledTimes(1);
+      expect(createRunSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+        pipeline_spec: {
+          parameters: [
+            { name: 'param-1', value: 'test param value' },
+            { name: 'param-2', value: 'prefilled value' },
+          ],
+          pipeline_id: pipeline.id,
+        },
+      }));
+      tree.unmount();
+    });
 
-  //   tree.find('#createExperimentBtn').simulate('click');
-  //   await TestUtils.flushPromises();
+    it('sets the page to a busy state upon clicking \'Create\' is clicked', async () => {
+      const props = generateProps();
+      props.location.search =
+        `?${QUERY_PARAMS.experimentId}=${newMockExperiment().id}`
+        + `&${QUERY_PARAMS.pipelineId}=${newMockPipeline().id}`;
 
-  //   expect(historyPushSpy).toHaveBeenCalledWith(
-  //     RoutePage.NEW_RUN
-  //     + `?experimentId=${experimentId}`
-  //     + `&pipelineId=${pipelineId}`
-  //     + `&firstRunInExperiment=1`);
-  //   tree.unmount();
-  // });
+      const tree = shallow(<TestNewRun {...props as any} />);
+      (tree.instance() as any).handleChange('runName')({ target: { value: 'test run name' } });
+      await TestUtils.flushPromises();
 
-  // it('shows snackbar confirmation after experiment is created', async () => {
-  //   const tree = shallow(<NewRun {...generateProps() as any} />);
+      tree.find('#createNewRunBtn').simulate('click');
+      // The create APIs are called in a callback triggered by clicking 'Create', so we wait again
+      await TestUtils.flushPromises();
 
-  //   (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment-name' } });
+      expect(tree.state('isBeingCreated')).toBe(true);
+      tree.unmount();
+    });
 
-  //   tree.find('#createExperimentBtn').simulate('click');
-  //   await TestUtils.flushPromises();
+    it('navigates to the ExperimentDetails page upon successful creation if there was an experiment', async () => {
+      const props = generateProps();
+      const experiment = newMockExperiment();
+      props.location.search =
+        `?${QUERY_PARAMS.experimentId}=${experiment.id}`
+        + `&${QUERY_PARAMS.pipelineId}=${newMockPipeline().id}`;
 
-  //   expect(updateSnackbarSpy).toHaveBeenLastCalledWith({
-  //     autoHideDuration: 10000,
-  //     message: 'Successfully created new Experiment: experiment-name',
-  //     open: true,
-  //   });
-  //   tree.unmount();
-  // });
+      const tree = shallow(<TestNewRun {...props as any} />);
+      (tree.instance() as any).handleChange('runName')({ target: { value: 'test run name' } });
+      await TestUtils.flushPromises();
 
-  // it('unsets busy state when creation fails', async () => {
-  //   // tslint:disable-next-line:no-console
-  //   console.error = jest.spyOn(console, 'error').mockImplementation();
+      tree.find('#createNewRunBtn').simulate('click');
+      // The create APIs are called in a callback triggered by clicking 'Create', so we wait again
+      await TestUtils.flushPromises();
 
-  //   const tree = shallow(<NewRun {...generateProps() as any} />);
+      expect(historyPushSpy).toHaveBeenCalledWith(
+        RoutePage.EXPERIMENT_DETAILS.replace(':' + RouteParams.experimentId, experiment.id!));
+      tree.unmount();
+    });
 
-  //   (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment-name' } });
+    it('navigates to the AllRuns page upon successful creation if there was not an experiment', async () => {
+      const props = generateProps();
+      // No experiment in query params
+      props.location.search = `?${QUERY_PARAMS.pipelineId}=${newMockPipeline().id}`;
 
-  //   TestUtils.makeErrorResponseOnce(createRunSpy, 'test error!');
-  //   tree.find('#createExperimentBtn').simulate('click');
-  //   await TestUtils.flushPromises();
+      const tree = shallow(<TestNewRun {...props as any} />);
+      (tree.instance() as any).handleChange('runName')({ target: { value: 'test run name' } });
+      await TestUtils.flushPromises();
 
-  //   expect(tree.state()).toHaveProperty('isbeingCreated', false);
-  //   tree.unmount();
-  // });
+      tree.find('#createNewRunBtn').simulate('click');
+      // The create APIs are called in a callback triggered by clicking 'Create', so we wait again
+      await TestUtils.flushPromises();
 
-  // it('shows error dialog when creation fails', async () => {
-  //   // tslint:disable-next-line:no-console
-  //   console.error = jest.spyOn(console, 'error').mockImplementation();
+      expect(historyPushSpy).toHaveBeenCalledWith(RoutePage.RUNS);
+      tree.unmount();
+    });
 
-  //   const tree = shallow(<NewRun {...generateProps() as any} />);
+    it('shows an error dialog if creating the new run fails', async () => {
+      // Don't actually log to console.
+      // tslint:disable-next-line:no-console
+      console.error = jest.spyOn(console, 'error').mockImplementationOnce(() => null);
 
-  //   (tree.instance() as any).handleChange('experimentName')({ target: { value: 'experiment-name' } });
+      const props = generateProps();
+      props.location.search =
+        `?${QUERY_PARAMS.experimentId}=${newMockExperiment().id}`
+        + `&${QUERY_PARAMS.pipelineId}=${newMockPipeline().id}`;
 
-  //   TestUtils.makeErrorResponseOnce(createRunSpy, 'test error!');
-  //   tree.find('#createExperimentBtn').simulate('click');
-  //   await TestUtils.flushPromises();
+      TestUtils.makeErrorResponseOnce(createRunSpy, 'test error message');
 
-  //   const call = updateDialogSpy.mock.calls[0][0];
-  //   expect(call).toHaveProperty('title', 'Experiment creation failed');
-  //   expect(call).toHaveProperty('content', 'test error!');
-  //   tree.unmount();
-  // });
+      const tree = shallow(<TestNewRun {...props as any} />);
+      (tree.instance() as any).handleChange('runName')({ target: { value: 'test run name' } });
+      await TestUtils.flushPromises();
 
-  // it('navigates to experiment list page upon cancellation', async () => {
-  //   const tree = shallow(<NewRun {...generateProps() as any} />);
-  //   tree.find('#cancelNewRunBtn').simulate('click');
-  //   await TestUtils.flushPromises();
+      tree.find('#createNewRunBtn').simulate('click');
+      // The create APIs are called in a callback triggered by clicking 'Create', so we wait again
+      await TestUtils.flushPromises();
 
-  //   expect(historyPushSpy).toHaveBeenCalledWith(RoutePage.EXPERIMENTS);
-  //   tree.unmount();
-  // });
+      expect(updateDialogSpy).toHaveBeenCalledTimes(1);
+      expect(updateDialogSpy.mock.calls[0][0]).toMatchObject({
+        content: 'test error message',
+        title: 'Run creation failed',
+      });
+      tree.unmount();
+    });
+
+    it('shows an error dialog if \'Create\' is clicked and the new run somehow has no pipeline', async () => {
+      // Don't actually log to console.
+      // tslint:disable-next-line:no-console
+      console.error = jest.spyOn(console, 'error').mockImplementationOnce(() => null);
+
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.experimentId}=${newMockExperiment().id}`;
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      (tree.instance() as any).handleChange('runName')({ target: { value: 'test run name' } });
+      await TestUtils.flushPromises();
+
+      tree.find('#createNewRunBtn').simulate('click');
+      // The create APIs are called in a callback triggered by clicking 'Create', so we wait again
+      await TestUtils.flushPromises();
+
+      expect(updateDialogSpy).toHaveBeenCalledTimes(1);
+      expect(updateDialogSpy.mock.calls[0][0]).toMatchObject({
+        content: 'Cannot create run without pipeline',
+        title: 'Run creation failed',
+      });
+      tree.unmount();
+    });
+
+    it('unsets the page to a busy state if creation fails', async () => {
+      // Don't actually log to console.
+      // tslint:disable-next-line:no-console
+      console.error = jest.spyOn(console, 'error').mockImplementationOnce(() => null);
+
+      const props = generateProps();
+      props.location.search =
+        `?${QUERY_PARAMS.experimentId}=${newMockExperiment().id}`
+        + `&${QUERY_PARAMS.pipelineId}=${newMockPipeline().id}`;
+
+      TestUtils.makeErrorResponseOnce(createRunSpy, 'test error message');
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      (tree.instance() as any).handleChange('runName')({ target: { value: 'test run name' } });
+      await TestUtils.flushPromises();
+
+      tree.find('#createNewRunBtn').simulate('click');
+      // The create APIs are called in a callback triggered by clicking 'Create', so we wait again
+      await TestUtils.flushPromises();
+
+      expect(tree.state('isBeingCreated')).toBe(false);
+      tree.unmount();
+    });
+
+    it('shows snackbar confirmation after experiment is created', async () => {
+      const props = generateProps();
+      props.location.search =
+        `?${QUERY_PARAMS.experimentId}=${newMockExperiment().id}`
+        + `&${QUERY_PARAMS.pipelineId}=${newMockPipeline().id}`;
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      (tree.instance() as any).handleChange('runName')({ target: { value: 'test run name' } });
+      await TestUtils.flushPromises();
+
+      tree.find('#createNewRunBtn').simulate('click');
+      // The create APIs are called in a callback triggered by clicking 'Create', so we wait again
+      await TestUtils.flushPromises();
+
+      expect(updateSnackbarSpy).toHaveBeenLastCalledWith({
+        message: 'Successfully created new Run: test run name',
+        open: true,
+      });
+      tree.unmount();
+    });
+
+  });
+
+  describe('creating a new recurring run', () => {
+
+    it('changes the title if the new run will recur, based on query param', async () => {
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.isRecurring}=1`;
+      const tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(updateToolbarSpy).toHaveBeenLastCalledWith({
+        actions: [],
+        breadcrumbs: [
+          { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
+          { displayName: 'Start a recurring run', href: '' }
+        ],
+      });
+      tree.unmount();
+    });
+
+    it('includes additional trigger input fields if run will be recurring', async () => {
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.isRecurring}=1`;
+      const tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(tree).toMatchSnapshot();
+      tree.unmount();
+    });
+
+    it('sends a request to create a new recurring run when \'Create\' is clicked', async () => {
+
+      const props = generateProps();
+      const experiment = newMockExperiment();
+      const pipeline = newMockPipeline();
+      props.location.search =
+        `?${QUERY_PARAMS.isRecurring}=1`
+        + `&${QUERY_PARAMS.experimentId}=${experiment.id}`
+        + `&${QUERY_PARAMS.pipelineId}=${pipeline.id}`;
+
+      getExperimentSpy.mockImplementation(() => experiment);
+      getPipelineSpy.mockImplementation(() => pipeline);
+
+      const tree = TestUtils.mountWithRouter(<TestNewRun {...props as any} />);
+      (tree.instance() as any).handleChange('runName')({ target: { value: 'test run name' } });
+      (tree.instance() as any).handleChange('description')({ target: { value: 'test run description' } });
+      await TestUtils.flushPromises();
+
+      tree.find('#createNewRunBtn').at(0).simulate('click');
+      // The create APIs are called in a callback triggered by clicking 'Create', so we wait again
+      await TestUtils.flushPromises();
+
+      expect(createRunSpy).toHaveBeenCalledTimes(0);
+      expect(createJobSpy).toHaveBeenCalledTimes(1);
+      expect(createJobSpy).toHaveBeenLastCalledWith({
+        description: 'test run description',
+        enabled: true,
+        max_concurrency: '10',
+        name: 'test run name',
+        pipeline_spec: {
+          parameters: pipeline.parameters,
+          pipeline_id: pipeline.id,
+        },
+        resource_references: [{
+          key: {
+            id: experiment.id,
+            type: ApiResourceType.EXPERIMENT,
+          },
+          relationship: ApiRelationship.OWNER,
+        }],
+        // Default trigger
+        trigger: {
+          periodic_schedule: {
+            end_time: undefined,
+            interval_second: '60',
+            start_time: undefined,
+          },
+        },
+      });
+      tree.unmount();
+    });
+
+    it('displays an error message if periodic schedule end date/time is earlier than start date/time', async () => {
+      const props = generateProps();
+      props.location.search =
+      `?${QUERY_PARAMS.isRecurring}=1`
+      + `&${QUERY_PARAMS.experimentId}=${newMockExperiment().id}`
+      + `&${QUERY_PARAMS.pipelineId}=${newMockPipeline().id}`;
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      (tree.instance() as any).handleChange('runName')({ target: { value: 'test run name' } });
+      // TODO: figure out how to do this by interacting with the Trigger element
+      tree.setState({
+        trigger: {
+          periodic_schedule: {
+            end_time: new Date(2018, 4, 1),
+            start_time: new Date(2018, 5, 1),
+          },
+        }
+      });
+      await TestUtils.flushPromises();
+
+      expect(tree.state('errorMessage')).toBe('End date/time cannot be earlier than start date/time');
+      tree.unmount();
+    });
+
+    it('displays an error message if cron schedule end date/time is earlier than start date/time', async () => {
+      const props = generateProps();
+      props.location.search =
+      `?${QUERY_PARAMS.isRecurring}=1`
+      + `&${QUERY_PARAMS.experimentId}=${newMockExperiment().id}`
+      + `&${QUERY_PARAMS.pipelineId}=${newMockPipeline().id}`;
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      (tree.instance() as any).handleChange('runName')({ target: { value: 'test run name' } });
+      // TODO: figure out how to do this by interacting with the Trigger element
+      tree.setState({
+        trigger: {
+          cron_schedule: {
+            end_time: new Date(2018, 4, 1),
+            start_time: new Date(2018, 5, 1),
+          },
+        }
+      });
+      await TestUtils.flushPromises();
+
+      expect(tree.state('errorMessage')).toBe('End date/time cannot be earlier than start date/time');
+      tree.unmount();
+    });
+
+    it('displays an error message if max concurrent runs is negative', async () => {
+      const props = generateProps();
+      props.location.search =
+      `?${QUERY_PARAMS.isRecurring}=1`
+      + `&${QUERY_PARAMS.experimentId}=${newMockExperiment().id}`
+      + `&${QUERY_PARAMS.pipelineId}=${newMockPipeline().id}`;
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      (tree.instance() as any).handleChange('runName')({ target: { value: 'test run name' } });
+      // TODO: figure out how to do this by interacting with the Trigger element
+      tree.setState({
+        maxConcurrentRuns: -1,
+        trigger: {
+          periodic_schedule: {
+            interval_second: '60',
+          }
+        },
+      });
+      await TestUtils.flushPromises();
+
+      expect(tree.state('errorMessage')).toBe('For triggered runs, maximum concurrent runs must be a positive number');
+      tree.unmount();
+    });
+
+    it('displays an error message if max concurrent runs is not a number', async () => {
+      const props = generateProps();
+      props.location.search =
+      `?${QUERY_PARAMS.isRecurring}=1`
+      + `&${QUERY_PARAMS.experimentId}=${newMockExperiment().id}`
+      + `&${QUERY_PARAMS.pipelineId}=${newMockPipeline().id}`;
+
+      const tree = shallow(<TestNewRun {...props as any} />);
+      (tree.instance() as any).handleChange('runName')({ target: { value: 'test run name' } });
+      // TODO: figure out how to do this by interacting with the Trigger element
+      tree.setState({
+        maxConcurrentRuns: 'not a number',
+        trigger: {
+          periodic_schedule: {
+            interval_second: '60',
+          }
+        },
+      });
+      await TestUtils.flushPromises();
+
+      expect(tree.state('errorMessage')).toBe('For triggered runs, maximum concurrent runs must be a positive number');
+      tree.unmount();
+    });
+
+  });
 });

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -301,8 +301,13 @@ class NewRun extends Page<{}, NewRunState> {
       try {
         pipeline = await Apis.pipelineServiceApi.getPipeline(pipelineId);
       } catch (err) {
-        await this.showPageError(`Error: failed to retrieve pipeline with ID: ${pipelineId}.`, err);
-        logger.error(`Error: failed to retrieve pipeline with ID: ${pipelineId}`, err);
+        this.setState({ pipelineSelectorOpen: false }, async () => {
+          const errorMessage = await errorToMessage(err);
+          await this.showErrorDialog(
+            `Failed to retrieve pipeline with ID: ${pipelineId}`,
+            errorMessage);
+          logger.error(`Error: failed to retrieve pipeline with ID: ${pipelineId}`, err);
+        });
         return;
       }
     }
@@ -318,8 +323,9 @@ class NewRun extends Page<{}, NewRunState> {
 
   private async _prepareFormFromClone(originalRun: ApiRunDetail): Promise<void> {
     const associatedPipelineId = RunUtils.getPipelineId(originalRun.run);
+    // TODO: Support runs without associated pipeline IDs (e.g. those created via notebooks)
     if (!originalRun.run || !associatedPipelineId) {
-      logger.verbose('Original run did not have an associated pipeline ID');
+      logger.error('Original run did not have an associated pipeline ID');
       return;
     }
 

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -226,7 +226,7 @@ class NewRun extends Page<{}, NewRunState> {
         }
       } catch (err) {
         await this.showPageError(`Error: failed to retrieve original run: ${originalRunId}.`, err);
-        logger.error(`Failed find retrieve original run: ${originalRunId}`, err);
+        logger.error(`Failed to retrieve original run: ${originalRunId}`, err);
       }
     } else {
       // Get pipeline id from querystring if any
@@ -238,7 +238,7 @@ class NewRun extends Page<{}, NewRunState> {
         } catch (err) {
           urlParser.clear(QUERY_PARAMS.pipelineId);
           await this.showPageError(`Error: failed to retrieve pipeline: ${possiblePipelineId}.`, err);
-          logger.error(`Failed find retrieve pipeline: ${possiblePipelineId}`, err);
+          logger.error(`Failed to retrieve pipeline: ${possiblePipelineId}`, err);
         }
       }
     }

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -53,6 +53,8 @@ interface NewRunState {
   pipeline?: ApiPipeline;
   // TODO: this is only here to properly display the name in the text field.
   // There is definitely a way to do this that doesn't necessitate this being in state.
+  // Note: this cannot be undefined/optional or the label animation for the input field will not
+  // work properly.
   pipelineName: string;
   pipelineSelectorOpen: boolean;
   runName: string;
@@ -114,8 +116,7 @@ class NewRun extends Page<{}, NewRunState> {
 
           <div className={commonCss.header}>Run details</div>
 
-          <Input onChange={this.handleChange('pipelineName')} value={pipelineName}
-            required={true} label='Pipeline' disabled={true}
+          <Input value={pipelineName} required={true} label='Pipeline' disabled={true}
             InputProps={{
               endAdornment: (
                 <InputAdornment position='end'>
@@ -129,13 +130,15 @@ class NewRun extends Page<{}, NewRunState> {
               readOnly: true,
             }} />
 
-          <Dialog open={pipelineSelectorOpen} classes={{ paper: css.pipelineSelectorDialog }}
-            onClose={() => this._pipelineSelectorClosed(false)} PaperProps={{ id: 'pipelineSelectorDialog' }}>
+          <Dialog open={pipelineSelectorOpen}
+            classes={{ paper: css.pipelineSelectorDialog }}
+            onClose={() => this._pipelineSelectorClosed(false)}
+            PaperProps={{ id: 'pipelineSelectorDialog' }}>
             <DialogContent>
               <PipelineSelector {...this.props} pipelineSelectionChanged={this._pipelineSelectionChanged.bind(this)} />
             </DialogContent>
             <DialogActions>
-              <Button onClick={() => this._pipelineSelectorClosed(false)} color='secondary'>
+              <Button id='cancelPipelineSelectionBtn' onClick={() => this._pipelineSelectorClosed(false)} color='secondary'>
                 Cancel
               </Button>
               <Button id='usePipelineBtn' onClick={() => this._pipelineSelectorClosed(true)}
@@ -172,20 +175,22 @@ class NewRun extends Page<{}, NewRunState> {
           <div className={commonCss.header}>Run parameters</div>
           <div>{this._runParametersMessage(pipeline)}</div>
 
-          {pipeline && pipeline.parameters && !!pipeline.parameters.length && (
+          {pipeline && Array.isArray(pipeline.parameters) && !!pipeline.parameters.length && (
             <div>
-              {pipeline && (pipeline.parameters || []).map((param, i) =>
-                <TextField key={i} variant='outlined' label={param.name} value={param.value || ''}
+              {pipeline.parameters.map((param, i) =>
+                <TextField id={`newRunPipelineParam${i}`} key={i} variant='outlined'
+                  label={param.name} value={param.value || ''}
                   onChange={(ev) => this._handleParamChange(i, ev.target.value || '')}
                   style={{ height: 40, maxWidth: 600 }} className={commonCss.textField} />)}
             </div>
           )}
 
           <div className={classes(commonCss.flex, padding(20, 'tb'))}>
-            <BusyButton id='createNewRunBtn' disabled={!!errorMessage} busy={this.state.isBeingCreated}
+            <BusyButton id='createNewRunBtn' disabled={!!errorMessage}
+              busy={this.state.isBeingCreated}
               className={commonCss.buttonAction} title='Create'
               onClick={this._create.bind(this)} />
-            <Button onClick={() => {
+            <Button id='exitNewRunPageBtn' onClick={() => {
               this.props.history.push(
                 !!this.state.experiment
                   ? RoutePage.EXPERIMENT_DETAILS.replace(
@@ -237,7 +242,8 @@ class NewRun extends Page<{}, NewRunState> {
           this.setState({ pipeline, pipelineName: (pipeline && pipeline.name) || '' });
         } catch (err) {
           urlParser.clear(QUERY_PARAMS.pipelineId);
-          await this.showPageError(`Error: failed to retrieve pipeline: ${possiblePipelineId}.`, err);
+          await this.showPageError(
+            `Error: failed to retrieve pipeline: ${possiblePipelineId}.`, err);
           logger.error(`Failed to retrieve pipeline: ${possiblePipelineId}`, err);
         }
       }
@@ -280,69 +286,22 @@ class NewRun extends Page<{}, NewRunState> {
 
   public handleChange = (name: string) => (event: any) => {
     const value = (event.target as TextFieldProps).value;
-    this.setState({
-      [name]: value,
-    } as any, () => {
-      // Set querystring if pipeline id has changed
-      if (name === 'pipelineId') {
-        const urlParser = new URLParser(this.props);
-        urlParser.set(QUERY_PARAMS.pipelineId, (value || '').toString());
-
-        // Clear other query params so as not to confuse the user
-        urlParser.clear(QUERY_PARAMS.cloneFromRun);
-      }
-
-      this._validate();
-    });
+    this.setState({ [name]: value, } as any, () => { this._validate(); });
   }
 
-  private async _prepareFormFromClone(originalRun: ApiRunDetail): Promise<void> {
-    const associatedPipelineId = RunUtils.getPipelineId(originalRun.run);
-    if (originalRun.run && associatedPipelineId) {
-      let pipeline: ApiPipeline;
-      let workflow: Workflow;
-
-      try {
-        pipeline = await Apis.pipelineServiceApi.getPipeline(associatedPipelineId);
-      } catch (err) {
-        await this.showPageError(
-          'Error: failed to find a pipeline corresponding to that of the original run:'
-          + ` ${originalRun.run.id}.`, err);
-        return;
-      }
-
-      if (originalRun.pipeline_runtime!.workflow_manifest === undefined) {
-        await this.showPageError(`Error: run ${originalRun.run.id} had no workflow manifest`);
-        logger.error(originalRun.pipeline_runtime!.workflow_manifest);
-        return;
-      }
-      try {
-        workflow = JSON.parse(originalRun.pipeline_runtime!.workflow_manifest!) as Workflow;
-      } catch (err) {
-        await this.showPageError('Error: failed to parse the original run\'s runtime', err);
-        logger.error(originalRun.pipeline_runtime!.workflow_manifest);
-        return;
-      }
-
-      pipeline.parameters = WorkflowParser.getParameters(workflow);
-
-      this.setState({
-        pipeline,
-        pipelineName: (pipeline && pipeline.name) || '',
-        runName: this._getCloneName(originalRun.run.name!)
-      });
-      return;
-    }
+  /* This function is passed as a callback to the PipelineSelector dialog. */
+  protected _pipelineSelectionChanged(selectedId: string): void {
+    this.setState({ unconfirmedDialogPipelineId: selectedId });
   }
 
-  private async _pipelineSelectorClosed(confirmed: boolean): Promise<void> {
+  protected async _pipelineSelectorClosed(confirmed: boolean): Promise<void> {
     let { pipeline } = this.state;
     if (confirmed && this.state.unconfirmedDialogPipelineId) {
       const pipelineId = this.state.unconfirmedDialogPipelineId;
       try {
         pipeline = await Apis.pipelineServiceApi.getPipeline(pipelineId);
       } catch (err) {
-        await this.showPageError(`Error: failed to retrieve pipeline with ID: ${pipelineId}`, err);
+        await this.showPageError(`Error: failed to retrieve pipeline with ID: ${pipelineId}.`, err);
         logger.error(`Error: failed to retrieve pipeline with ID: ${pipelineId}`, err);
         return;
       }
@@ -357,9 +316,49 @@ class NewRun extends Page<{}, NewRunState> {
     this._validate();
   }
 
-  /* This function is passed as a callback to the PipelineSelector dialog. */
-  private _pipelineSelectionChanged(selectedId: string): void {
-    this.setState({ unconfirmedDialogPipelineId: selectedId });
+  private async _prepareFormFromClone(originalRun: ApiRunDetail): Promise<void> {
+    const associatedPipelineId = RunUtils.getPipelineId(originalRun.run);
+    if (!originalRun.run || !associatedPipelineId) {
+      logger.verbose('Original run did not have an associated pipeline ID');
+      return;
+    }
+
+    let pipeline: ApiPipeline;
+    let workflow: Workflow;
+
+    try {
+      pipeline = await Apis.pipelineServiceApi.getPipeline(associatedPipelineId);
+    } catch (err) {
+      await this.showPageError(
+        'Error: failed to find a pipeline corresponding to that of the original run:'
+        + ` ${originalRun.run.id}.`, err);
+      return;
+    }
+
+    // TODO: Determine what is actually required from the pipeline if we have this manifest
+    if (originalRun.pipeline_runtime!.workflow_manifest === undefined) {
+      await this.showPageError(`Error: run ${originalRun.run.id} had no workflow manifest`);
+      logger.error(originalRun.pipeline_runtime!.workflow_manifest);
+      return;
+    }
+    try {
+      workflow = JSON.parse(originalRun.pipeline_runtime!.workflow_manifest!) as Workflow;
+    } catch (err) {
+      await this.showPageError('Error: failed to parse the original run\'s runtime.', err);
+      logger.error(originalRun.pipeline_runtime!.workflow_manifest);
+      return;
+    }
+
+    // Set pipeline parameter values from run's workflow
+    pipeline.parameters = WorkflowParser.getParameters(workflow);
+
+    this.setState({
+      pipeline,
+      pipelineName: (pipeline && pipeline.name) || '',
+      runName: this._getCloneName(originalRun.run.name!)
+    });
+
+    this._validate();
   }
 
   private _runParametersMessage(selectedPipeline: ApiPipeline | undefined): string {
@@ -375,6 +374,8 @@ class NewRun extends Page<{}, NewRunState> {
 
   private _create(): void {
     const { pipeline } = this.state;
+    // TODO: This cannot currently be reached because _validate() is called everywhere and blocks
+    // the button from being clicked without first having a pipeline.
     if (!pipeline) {
       this.showErrorDialog('Run creation failed', 'Cannot create run without pipeline');
       logger.error('Cannot create run without pipeline');
@@ -479,13 +480,12 @@ class NewRun extends Page<{}, NewRunState> {
         if (startDate && endDate && startDate > endDate) {
           throw new Error('End date/time cannot be earlier than start date/time');
         }
-      }
-      const validMaxConcurrentRuns = (input: string) =>
-        !isNaN(Number.parseInt(input, 10)) && +input > 0;
+        const validMaxConcurrentRuns = (input: string) =>
+          !isNaN(Number.parseInt(input, 10)) && +input > 0;
 
-      if (hasTrigger && maxConcurrentRuns !== undefined &&
-        !validMaxConcurrentRuns(maxConcurrentRuns)) {
-        throw new Error('For triggered runs, maximum concurrent runs must be a positive number');
+        if (maxConcurrentRuns !== undefined && !validMaxConcurrentRuns(maxConcurrentRuns)) {
+          throw new Error('For triggered runs, maximum concurrent runs must be a positive number');
+        }
       }
 
       this.setState({ errorMessage: '' });

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -182,7 +182,7 @@ class NewRun extends Page<{}, NewRunState> {
           )}
 
           <div className={classes(commonCss.flex, padding(20, 'tb'))}>
-            <BusyButton id='createBtn' disabled={!!errorMessage} busy={this.state.isBeingCreated}
+            <BusyButton id='createNewRunBtn' disabled={!!errorMessage} busy={this.state.isBeingCreated}
               className={commonCss.buttonAction} title='Create'
               onClick={this._create.bind(this)} />
             <Button onClick={() => {
@@ -225,7 +225,8 @@ class NewRun extends Page<{}, NewRunState> {
           experimentId = RunUtils.getFirstExperimentReferenceId(originalRun.run);
         }
       } catch (err) {
-        await this.showPageError(`Error: failed to get original run: ${originalRunId}.`, err);
+        await this.showPageError(`Error: failed to retrieve original run: ${originalRunId}.`, err);
+        logger.error(`Failed find retrieve original run: ${originalRunId}`, err);
       }
     } else {
       // Get pipeline id from querystring if any
@@ -236,9 +237,8 @@ class NewRun extends Page<{}, NewRunState> {
           this.setState({ pipeline, pipelineName: (pipeline && pipeline.name) || '' });
         } catch (err) {
           urlParser.clear(QUERY_PARAMS.pipelineId);
-          await this.showPageError(
-            'Error: failed to find a pipeline corresponding to that of the original run:'
-            + ` ${originalRunId}.`, err);
+          await this.showPageError(`Error: failed to retrieve pipeline: ${possiblePipelineId}.`, err);
+          logger.error(`Failed find retrieve pipeline: ${possiblePipelineId}`, err);
         }
       }
     }
@@ -255,8 +255,9 @@ class NewRun extends Page<{}, NewRunState> {
           href: RoutePage.EXPERIMENT_DETAILS.replace(':' + RouteParams.experimentId, experimentId),
         });
       } catch (err) {
-        await this.showPageError(`Error: failed to get associated experiment: ${experimentId}.`, err);
-        logger.error(`Failed to get associated experiment ${experimentId}`, err);
+        await this.showPageError(
+          `Error: failed to retrieve associated experiment: ${experimentId}.`, err);
+        logger.error(`Failed to retrieve associated experiment: ${experimentId}`, err);
       }
     }
 

--- a/frontend/src/pages/PipelineSelector.tsx
+++ b/frontend/src/pages/PipelineSelector.tsx
@@ -74,9 +74,10 @@ class PipelineSelector extends React.Component<PipelineSelectorProps, PipelineSe
       <React.Fragment>
         <Toolbar actions={toolbarActions} breadcrumbs={[{ displayName: 'Choose a pipeline', href: '' }]} />
         <CustomTable columns={columns} rows={rows} selectedIds={selectedIds} useRadioButtons={true}
-          updateSelection={ids => { this._pipelineSelectionChanged(ids); this.setState({ selectedIds: ids }); }}
+          updateSelection={this._pipelineSelectionChanged.bind(this)}
           initialSortColumn={sortBy} ref={this._tableRef}
-          reload={this._loadPipelines.bind(this)} emptyMessage={'No pipelines found. Upload a pipeline and then try again.'} />
+          reload={this._loadPipelines.bind(this)}
+          emptyMessage={'No pipelines found. Upload a pipeline and then try again.'} />
       </React.Fragment>
     );
   }
@@ -93,6 +94,7 @@ class PipelineSelector extends React.Component<PipelineSelectorProps, PipelineSe
       return;
     }
     this.props.pipelineSelectionChanged(selectedIds[0]);
+    this.setState({ selectedIds });
   }
 
   private async _loadPipelines(request: ListRequest): Promise<string> {
@@ -113,6 +115,9 @@ class PipelineSelector extends React.Component<PipelineSelectorProps, PipelineSe
       logger.error('Could not get list of pipelines', errorMessage);
     }
 
+    // Warnings are showing up here in tests when the NewRun component is unmounted before being
+    // closed, saying setState is being called after the component is unmounted.
+    // The warning doesn't show up when actually using the app though.
     this.setState({ pipelines, sortBy: request.sortBy! });
     return nextPageToken;
   }

--- a/frontend/src/pages/__snapshots__/NewExperiment.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewExperiment.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NewExperiment Enables the 'Next' button when an experiment name is entered 1`] = `
+exports[`NewExperiment enables the 'Next' button when an experiment name is entered 1`] = `
 <div
   className="page"
 >
@@ -62,7 +62,7 @@ exports[`NewExperiment Enables the 'Next' button when an experiment name is ente
 </div>
 `;
 
-exports[`NewExperiment Re-disables the 'Next' button when an experiment name is cleared after having been entered 1`] = `
+exports[`NewExperiment re-disables the 'Next' button when an experiment name is cleared after having been entered 1`] = `
 <div
   className="page"
 >

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -1,0 +1,4666 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NewRun fetches the associated pipeline if one is present in the query params 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="scrollContainer"
+  >
+    <div
+      className="header"
+    >
+      Run details
+    </div>
+    <Component
+      InputProps={
+        Object {
+          "endAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <WithStyles(Button)
+              color="secondary"
+              id="choosePipelineBtn"
+              onClick={[Function]}
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": "3px 5px",
+                }
+              }
+            >
+              Choose
+            </WithStyles(Button)>
+          </WithStyles(InputAdornment)>,
+          "readOnly": true,
+        }
+      }
+      disabled={true}
+      field="pipelineName"
+      instance={
+        NewRun {
+          "_isMounted": true,
+          "context": Object {},
+          "handleChange": [Function],
+          "props": Object {
+            "history": Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            },
+            "location": Object {
+              "pathname": "/runs/new",
+              "search": "?pipelineId=some-mock-pipeline-id",
+            },
+            "match": "",
+            "toolbarProps": Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            },
+            "updateBanner": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            },
+            "updateDialog": [MockFunction],
+            "updateSnackbar": [MockFunction],
+            "updateToolbar": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+          },
+          "refs": Object {},
+          "setState": [Function],
+          "state": Object {
+            "description": "",
+            "errorMessage": "Run name is required",
+            "experiment": undefined,
+            "experimentName": undefined,
+            "isBeingCreated": false,
+            "isFirstRunInExperiment": false,
+            "isRecurringRun": false,
+            "pipeline": Object {
+              "id": "some-mock-pipeline-id",
+              "name": "some mock pipeline name",
+            },
+            "pipelineName": "some mock pipeline name",
+            "pipelineSelectorOpen": false,
+            "runName": "",
+            "unconfirmedDialogPipelineId": "",
+          },
+          "updater": Updater {
+            "_callbacks": Array [],
+            "_renderer": ReactShallowRenderer {
+              "_context": Object {},
+              "_element": <NewRun
+                history={
+                  Object {
+                    "push": [MockFunction],
+                    "replace": [MockFunction],
+                  }
+                }
+                location={
+                  Object {
+                    "pathname": "/runs/new",
+                    "search": "?pipelineId=some-mock-pipeline-id",
+                  }
+                }
+                match=""
+                toolbarProps={
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  }
+                }
+                updateBanner={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {},
+                      ],
+                    ],
+                  }
+                }
+                updateDialog={[MockFunction]}
+                updateSnackbar={[MockFunction]}
+                updateToolbar={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                    ],
+                  }
+                }
+              />,
+              "_forcedUpdate": false,
+              "_instance": [Circular],
+              "_newState": Object {
+                "description": "",
+                "errorMessage": "Run name is required",
+                "experiment": undefined,
+                "experimentName": undefined,
+                "isBeingCreated": false,
+                "isFirstRunInExperiment": false,
+                "isRecurringRun": false,
+                "pipeline": Object {
+                  "id": "some-mock-pipeline-id",
+                  "name": "some mock pipeline name",
+                },
+                "pipelineName": "some mock pipeline name",
+                "pipelineSelectorOpen": false,
+                "runName": "",
+                "unconfirmedDialogPipelineId": "",
+              },
+              "_rendered": <div
+                className="page"
+              >
+                <div
+                  className="scrollContainer"
+                >
+                  <div
+                    className="header"
+                  >
+                    Run details
+                  </div>
+                  <Unknown
+                    InputProps={
+                      Object {
+                        "endAdornment": <WithStyles(InputAdornment)
+                          position="end"
+                        >
+                          <WithStyles(Button)
+                            color="secondary"
+                            id="choosePipelineBtn"
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "margin": 0,
+                                "padding": "3px 5px",
+                              }
+                            }
+                          >
+                            Choose
+                          </WithStyles(Button)>
+                        </WithStyles(InputAdornment)>,
+                        "readOnly": true,
+                      }
+                    }
+                    disabled={true}
+                    field="pipelineName"
+                    instance={[Circular]}
+                    label="Pipeline"
+                    required={true}
+                  />
+                  <WithStyles(Dialog)
+                    PaperProps={
+                      Object {
+                        "id": "pipelineSelectorDialog",
+                      }
+                    }
+                    classes={
+                      Object {
+                        "paper": "pipelineSelectorDialog",
+                      }
+                    }
+                    onClose={[Function]}
+                    open={false}
+                  >
+                    <WithStyles(DialogContent)>
+                      <PipelineSelector
+                        history={
+                          Object {
+                            "push": [MockFunction],
+                            "replace": [MockFunction],
+                          }
+                        }
+                        location={
+                          Object {
+                            "pathname": "/runs/new",
+                            "search": "?pipelineId=some-mock-pipeline-id",
+                          }
+                        }
+                        match=""
+                        pipelineSelectionChanged={[Function]}
+                        toolbarProps={
+                          Object {
+                            "actions": Array [],
+                            "breadcrumbs": Array [
+                              Object {
+                                "displayName": "Experiments",
+                                "href": "/experiments",
+                              },
+                              Object {
+                                "displayName": "Start a new run",
+                                "href": "",
+                              },
+                            ],
+                          }
+                        }
+                        updateBanner={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {},
+                              ],
+                            ],
+                          }
+                        }
+                        updateDialog={[MockFunction]}
+                        updateSnackbar={[MockFunction]}
+                        updateToolbar={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                            ],
+                          }
+                        }
+                      />
+                    </WithStyles(DialogContent)>
+                    <WithStyles(DialogActions)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        onClick={[Function]}
+                      >
+                        Cancel
+                      </WithStyles(Button)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        disabled={true}
+                        id="usePipelineBtn"
+                        onClick={[Function]}
+                      >
+                        Use this pipeline
+                      </WithStyles(Button)>
+                    </WithStyles(DialogActions)>
+                  </WithStyles(Dialog)>
+                  <Unknown
+                    autoFocus={true}
+                    field="runName"
+                    instance={[Circular]}
+                    label="Run name"
+                    required={true}
+                  />
+                  <Unknown
+                    field="description"
+                    height="auto"
+                    instance={[Circular]}
+                    label="Description (optional)"
+                    multiline={true}
+                  />
+                  <div
+                    className="header"
+                  >
+                    Run parameters
+                  </div>
+                  <div>
+                    This pipeline has no parameters
+                  </div>
+                  <div
+                    className="flex"
+                  >
+                    <BusyButton
+                      busy={false}
+                      className="buttonAction"
+                      disabled={true}
+                      id="createNewRunBtn"
+                      onClick={[Function]}
+                      title="Create"
+                    />
+                    <WithStyles(Button)
+                      onClick={[Function]}
+                    >
+                      Cancel
+                    </WithStyles(Button)>
+                    <div
+                      style={
+                        Object {
+                          "color": "red",
+                        }
+                      }
+                    >
+                      Run name is required
+                    </div>
+                  </div>
+                </div>
+              </div>,
+              "_rendering": false,
+              "_updater": [Circular],
+            },
+          },
+          Symbol(enzyme.__setState__): [Function],
+        }
+      }
+      label="Pipeline"
+      required={true}
+    />
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "pipelineSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "pipelineSelectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <PipelineSelector
+          history={
+            Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            }
+          }
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?pipelineId=some-mock-pipeline-id",
+            }
+          }
+          match=""
+          pipelineSelectionChanged={[Function]}
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={[MockFunction]}
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={true}
+          id="usePipelineBtn"
+          onClick={[Function]}
+        >
+          Use this pipeline
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <Component
+      autoFocus={true}
+      field="runName"
+      instance={
+        NewRun {
+          "_isMounted": true,
+          "context": Object {},
+          "handleChange": [Function],
+          "props": Object {
+            "history": Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            },
+            "location": Object {
+              "pathname": "/runs/new",
+              "search": "?pipelineId=some-mock-pipeline-id",
+            },
+            "match": "",
+            "toolbarProps": Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            },
+            "updateBanner": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            },
+            "updateDialog": [MockFunction],
+            "updateSnackbar": [MockFunction],
+            "updateToolbar": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+          },
+          "refs": Object {},
+          "setState": [Function],
+          "state": Object {
+            "description": "",
+            "errorMessage": "Run name is required",
+            "experiment": undefined,
+            "experimentName": undefined,
+            "isBeingCreated": false,
+            "isFirstRunInExperiment": false,
+            "isRecurringRun": false,
+            "pipeline": Object {
+              "id": "some-mock-pipeline-id",
+              "name": "some mock pipeline name",
+            },
+            "pipelineName": "some mock pipeline name",
+            "pipelineSelectorOpen": false,
+            "runName": "",
+            "unconfirmedDialogPipelineId": "",
+          },
+          "updater": Updater {
+            "_callbacks": Array [],
+            "_renderer": ReactShallowRenderer {
+              "_context": Object {},
+              "_element": <NewRun
+                history={
+                  Object {
+                    "push": [MockFunction],
+                    "replace": [MockFunction],
+                  }
+                }
+                location={
+                  Object {
+                    "pathname": "/runs/new",
+                    "search": "?pipelineId=some-mock-pipeline-id",
+                  }
+                }
+                match=""
+                toolbarProps={
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  }
+                }
+                updateBanner={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {},
+                      ],
+                    ],
+                  }
+                }
+                updateDialog={[MockFunction]}
+                updateSnackbar={[MockFunction]}
+                updateToolbar={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                    ],
+                  }
+                }
+              />,
+              "_forcedUpdate": false,
+              "_instance": [Circular],
+              "_newState": Object {
+                "description": "",
+                "errorMessage": "Run name is required",
+                "experiment": undefined,
+                "experimentName": undefined,
+                "isBeingCreated": false,
+                "isFirstRunInExperiment": false,
+                "isRecurringRun": false,
+                "pipeline": Object {
+                  "id": "some-mock-pipeline-id",
+                  "name": "some mock pipeline name",
+                },
+                "pipelineName": "some mock pipeline name",
+                "pipelineSelectorOpen": false,
+                "runName": "",
+                "unconfirmedDialogPipelineId": "",
+              },
+              "_rendered": <div
+                className="page"
+              >
+                <div
+                  className="scrollContainer"
+                >
+                  <div
+                    className="header"
+                  >
+                    Run details
+                  </div>
+                  <Unknown
+                    InputProps={
+                      Object {
+                        "endAdornment": <WithStyles(InputAdornment)
+                          position="end"
+                        >
+                          <WithStyles(Button)
+                            color="secondary"
+                            id="choosePipelineBtn"
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "margin": 0,
+                                "padding": "3px 5px",
+                              }
+                            }
+                          >
+                            Choose
+                          </WithStyles(Button)>
+                        </WithStyles(InputAdornment)>,
+                        "readOnly": true,
+                      }
+                    }
+                    disabled={true}
+                    field="pipelineName"
+                    instance={[Circular]}
+                    label="Pipeline"
+                    required={true}
+                  />
+                  <WithStyles(Dialog)
+                    PaperProps={
+                      Object {
+                        "id": "pipelineSelectorDialog",
+                      }
+                    }
+                    classes={
+                      Object {
+                        "paper": "pipelineSelectorDialog",
+                      }
+                    }
+                    onClose={[Function]}
+                    open={false}
+                  >
+                    <WithStyles(DialogContent)>
+                      <PipelineSelector
+                        history={
+                          Object {
+                            "push": [MockFunction],
+                            "replace": [MockFunction],
+                          }
+                        }
+                        location={
+                          Object {
+                            "pathname": "/runs/new",
+                            "search": "?pipelineId=some-mock-pipeline-id",
+                          }
+                        }
+                        match=""
+                        pipelineSelectionChanged={[Function]}
+                        toolbarProps={
+                          Object {
+                            "actions": Array [],
+                            "breadcrumbs": Array [
+                              Object {
+                                "displayName": "Experiments",
+                                "href": "/experiments",
+                              },
+                              Object {
+                                "displayName": "Start a new run",
+                                "href": "",
+                              },
+                            ],
+                          }
+                        }
+                        updateBanner={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {},
+                              ],
+                            ],
+                          }
+                        }
+                        updateDialog={[MockFunction]}
+                        updateSnackbar={[MockFunction]}
+                        updateToolbar={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                            ],
+                          }
+                        }
+                      />
+                    </WithStyles(DialogContent)>
+                    <WithStyles(DialogActions)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        onClick={[Function]}
+                      >
+                        Cancel
+                      </WithStyles(Button)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        disabled={true}
+                        id="usePipelineBtn"
+                        onClick={[Function]}
+                      >
+                        Use this pipeline
+                      </WithStyles(Button)>
+                    </WithStyles(DialogActions)>
+                  </WithStyles(Dialog)>
+                  <Unknown
+                    autoFocus={true}
+                    field="runName"
+                    instance={[Circular]}
+                    label="Run name"
+                    required={true}
+                  />
+                  <Unknown
+                    field="description"
+                    height="auto"
+                    instance={[Circular]}
+                    label="Description (optional)"
+                    multiline={true}
+                  />
+                  <div
+                    className="header"
+                  >
+                    Run parameters
+                  </div>
+                  <div>
+                    This pipeline has no parameters
+                  </div>
+                  <div
+                    className="flex"
+                  >
+                    <BusyButton
+                      busy={false}
+                      className="buttonAction"
+                      disabled={true}
+                      id="createNewRunBtn"
+                      onClick={[Function]}
+                      title="Create"
+                    />
+                    <WithStyles(Button)
+                      onClick={[Function]}
+                    >
+                      Cancel
+                    </WithStyles(Button)>
+                    <div
+                      style={
+                        Object {
+                          "color": "red",
+                        }
+                      }
+                    >
+                      Run name is required
+                    </div>
+                  </div>
+                </div>
+              </div>,
+              "_rendering": false,
+              "_updater": [Circular],
+            },
+          },
+          Symbol(enzyme.__setState__): [Function],
+        }
+      }
+      label="Run name"
+      required={true}
+    />
+    <Component
+      field="description"
+      height="auto"
+      instance={
+        NewRun {
+          "_isMounted": true,
+          "context": Object {},
+          "handleChange": [Function],
+          "props": Object {
+            "history": Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            },
+            "location": Object {
+              "pathname": "/runs/new",
+              "search": "?pipelineId=some-mock-pipeline-id",
+            },
+            "match": "",
+            "toolbarProps": Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            },
+            "updateBanner": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            },
+            "updateDialog": [MockFunction],
+            "updateSnackbar": [MockFunction],
+            "updateToolbar": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+          },
+          "refs": Object {},
+          "setState": [Function],
+          "state": Object {
+            "description": "",
+            "errorMessage": "Run name is required",
+            "experiment": undefined,
+            "experimentName": undefined,
+            "isBeingCreated": false,
+            "isFirstRunInExperiment": false,
+            "isRecurringRun": false,
+            "pipeline": Object {
+              "id": "some-mock-pipeline-id",
+              "name": "some mock pipeline name",
+            },
+            "pipelineName": "some mock pipeline name",
+            "pipelineSelectorOpen": false,
+            "runName": "",
+            "unconfirmedDialogPipelineId": "",
+          },
+          "updater": Updater {
+            "_callbacks": Array [],
+            "_renderer": ReactShallowRenderer {
+              "_context": Object {},
+              "_element": <NewRun
+                history={
+                  Object {
+                    "push": [MockFunction],
+                    "replace": [MockFunction],
+                  }
+                }
+                location={
+                  Object {
+                    "pathname": "/runs/new",
+                    "search": "?pipelineId=some-mock-pipeline-id",
+                  }
+                }
+                match=""
+                toolbarProps={
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  }
+                }
+                updateBanner={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {},
+                      ],
+                    ],
+                  }
+                }
+                updateDialog={[MockFunction]}
+                updateSnackbar={[MockFunction]}
+                updateToolbar={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                    ],
+                  }
+                }
+              />,
+              "_forcedUpdate": false,
+              "_instance": [Circular],
+              "_newState": Object {
+                "description": "",
+                "errorMessage": "Run name is required",
+                "experiment": undefined,
+                "experimentName": undefined,
+                "isBeingCreated": false,
+                "isFirstRunInExperiment": false,
+                "isRecurringRun": false,
+                "pipeline": Object {
+                  "id": "some-mock-pipeline-id",
+                  "name": "some mock pipeline name",
+                },
+                "pipelineName": "some mock pipeline name",
+                "pipelineSelectorOpen": false,
+                "runName": "",
+                "unconfirmedDialogPipelineId": "",
+              },
+              "_rendered": <div
+                className="page"
+              >
+                <div
+                  className="scrollContainer"
+                >
+                  <div
+                    className="header"
+                  >
+                    Run details
+                  </div>
+                  <Unknown
+                    InputProps={
+                      Object {
+                        "endAdornment": <WithStyles(InputAdornment)
+                          position="end"
+                        >
+                          <WithStyles(Button)
+                            color="secondary"
+                            id="choosePipelineBtn"
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "margin": 0,
+                                "padding": "3px 5px",
+                              }
+                            }
+                          >
+                            Choose
+                          </WithStyles(Button)>
+                        </WithStyles(InputAdornment)>,
+                        "readOnly": true,
+                      }
+                    }
+                    disabled={true}
+                    field="pipelineName"
+                    instance={[Circular]}
+                    label="Pipeline"
+                    required={true}
+                  />
+                  <WithStyles(Dialog)
+                    PaperProps={
+                      Object {
+                        "id": "pipelineSelectorDialog",
+                      }
+                    }
+                    classes={
+                      Object {
+                        "paper": "pipelineSelectorDialog",
+                      }
+                    }
+                    onClose={[Function]}
+                    open={false}
+                  >
+                    <WithStyles(DialogContent)>
+                      <PipelineSelector
+                        history={
+                          Object {
+                            "push": [MockFunction],
+                            "replace": [MockFunction],
+                          }
+                        }
+                        location={
+                          Object {
+                            "pathname": "/runs/new",
+                            "search": "?pipelineId=some-mock-pipeline-id",
+                          }
+                        }
+                        match=""
+                        pipelineSelectionChanged={[Function]}
+                        toolbarProps={
+                          Object {
+                            "actions": Array [],
+                            "breadcrumbs": Array [
+                              Object {
+                                "displayName": "Experiments",
+                                "href": "/experiments",
+                              },
+                              Object {
+                                "displayName": "Start a new run",
+                                "href": "",
+                              },
+                            ],
+                          }
+                        }
+                        updateBanner={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {},
+                              ],
+                            ],
+                          }
+                        }
+                        updateDialog={[MockFunction]}
+                        updateSnackbar={[MockFunction]}
+                        updateToolbar={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                            ],
+                          }
+                        }
+                      />
+                    </WithStyles(DialogContent)>
+                    <WithStyles(DialogActions)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        onClick={[Function]}
+                      >
+                        Cancel
+                      </WithStyles(Button)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        disabled={true}
+                        id="usePipelineBtn"
+                        onClick={[Function]}
+                      >
+                        Use this pipeline
+                      </WithStyles(Button)>
+                    </WithStyles(DialogActions)>
+                  </WithStyles(Dialog)>
+                  <Unknown
+                    autoFocus={true}
+                    field="runName"
+                    instance={[Circular]}
+                    label="Run name"
+                    required={true}
+                  />
+                  <Unknown
+                    field="description"
+                    height="auto"
+                    instance={[Circular]}
+                    label="Description (optional)"
+                    multiline={true}
+                  />
+                  <div
+                    className="header"
+                  >
+                    Run parameters
+                  </div>
+                  <div>
+                    This pipeline has no parameters
+                  </div>
+                  <div
+                    className="flex"
+                  >
+                    <BusyButton
+                      busy={false}
+                      className="buttonAction"
+                      disabled={true}
+                      id="createNewRunBtn"
+                      onClick={[Function]}
+                      title="Create"
+                    />
+                    <WithStyles(Button)
+                      onClick={[Function]}
+                    >
+                      Cancel
+                    </WithStyles(Button)>
+                    <div
+                      style={
+                        Object {
+                          "color": "red",
+                        }
+                      }
+                    >
+                      Run name is required
+                    </div>
+                  </div>
+                </div>
+              </div>,
+              "_rendering": false,
+              "_updater": [Circular],
+            },
+          },
+          Symbol(enzyme.__setState__): [Function],
+        }
+      }
+      label="Description (optional)"
+      multiline={true}
+    />
+    <div
+      className="header"
+    >
+      Run parameters
+    </div>
+    <div>
+      This pipeline has no parameters
+    </div>
+    <div
+      className="flex"
+    >
+      <BusyButton
+        busy={false}
+        className="buttonAction"
+        disabled={true}
+        id="createNewRunBtn"
+        onClick={[Function]}
+        title="Create"
+      />
+      <WithStyles(Button)
+        onClick={[Function]}
+      >
+        Cancel
+      </WithStyles(Button)>
+      <div
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+      >
+        Run name is required
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`NewRun renders the new run page 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="scrollContainer"
+  >
+    <div
+      className="header"
+    >
+      Run details
+    </div>
+    <Component
+      InputProps={
+        Object {
+          "endAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <WithStyles(Button)
+              color="secondary"
+              id="choosePipelineBtn"
+              onClick={[Function]}
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": "3px 5px",
+                }
+              }
+            >
+              Choose
+            </WithStyles(Button)>
+          </WithStyles(InputAdornment)>,
+          "readOnly": true,
+        }
+      }
+      disabled={true}
+      field="pipelineName"
+      instance={
+        NewRun {
+          "_isMounted": true,
+          "context": Object {},
+          "handleChange": [Function],
+          "props": Object {
+            "history": Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            },
+            "location": Object {
+              "pathname": "/runs/new",
+            },
+            "match": "",
+            "toolbarProps": Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            },
+            "updateBanner": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            },
+            "updateDialog": [MockFunction],
+            "updateSnackbar": [MockFunction],
+            "updateToolbar": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+          },
+          "refs": Object {},
+          "setState": [Function],
+          "state": Object {
+            "description": "",
+            "errorMessage": "A pipeline must be selected",
+            "experiment": undefined,
+            "experimentName": undefined,
+            "isBeingCreated": false,
+            "isFirstRunInExperiment": false,
+            "isRecurringRun": false,
+            "pipelineName": "",
+            "pipelineSelectorOpen": false,
+            "runName": "",
+            "unconfirmedDialogPipelineId": "",
+          },
+          "updater": Updater {
+            "_callbacks": Array [],
+            "_renderer": ReactShallowRenderer {
+              "_context": Object {},
+              "_element": <NewRun
+                history={
+                  Object {
+                    "push": [MockFunction],
+                    "replace": [MockFunction],
+                  }
+                }
+                location={
+                  Object {
+                    "pathname": "/runs/new",
+                  }
+                }
+                match=""
+                toolbarProps={
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  }
+                }
+                updateBanner={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {},
+                      ],
+                    ],
+                  }
+                }
+                updateDialog={[MockFunction]}
+                updateSnackbar={[MockFunction]}
+                updateToolbar={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                    ],
+                  }
+                }
+              />,
+              "_forcedUpdate": false,
+              "_instance": [Circular],
+              "_newState": Object {
+                "description": "",
+                "errorMessage": "A pipeline must be selected",
+                "experiment": undefined,
+                "experimentName": undefined,
+                "isBeingCreated": false,
+                "isFirstRunInExperiment": false,
+                "isRecurringRun": false,
+                "pipelineName": "",
+                "pipelineSelectorOpen": false,
+                "runName": "",
+                "unconfirmedDialogPipelineId": "",
+              },
+              "_rendered": <div
+                className="page"
+              >
+                <div
+                  className="scrollContainer"
+                >
+                  <div
+                    className="header"
+                  >
+                    Run details
+                  </div>
+                  <Unknown
+                    InputProps={
+                      Object {
+                        "endAdornment": <WithStyles(InputAdornment)
+                          position="end"
+                        >
+                          <WithStyles(Button)
+                            color="secondary"
+                            id="choosePipelineBtn"
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "margin": 0,
+                                "padding": "3px 5px",
+                              }
+                            }
+                          >
+                            Choose
+                          </WithStyles(Button)>
+                        </WithStyles(InputAdornment)>,
+                        "readOnly": true,
+                      }
+                    }
+                    disabled={true}
+                    field="pipelineName"
+                    instance={[Circular]}
+                    label="Pipeline"
+                    required={true}
+                  />
+                  <WithStyles(Dialog)
+                    PaperProps={
+                      Object {
+                        "id": "pipelineSelectorDialog",
+                      }
+                    }
+                    classes={
+                      Object {
+                        "paper": "pipelineSelectorDialog",
+                      }
+                    }
+                    onClose={[Function]}
+                    open={false}
+                  >
+                    <WithStyles(DialogContent)>
+                      <PipelineSelector
+                        history={
+                          Object {
+                            "push": [MockFunction],
+                            "replace": [MockFunction],
+                          }
+                        }
+                        location={
+                          Object {
+                            "pathname": "/runs/new",
+                          }
+                        }
+                        match=""
+                        pipelineSelectionChanged={[Function]}
+                        toolbarProps={
+                          Object {
+                            "actions": Array [],
+                            "breadcrumbs": Array [
+                              Object {
+                                "displayName": "Experiments",
+                                "href": "/experiments",
+                              },
+                              Object {
+                                "displayName": "Start a new run",
+                                "href": "",
+                              },
+                            ],
+                          }
+                        }
+                        updateBanner={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {},
+                              ],
+                            ],
+                          }
+                        }
+                        updateDialog={[MockFunction]}
+                        updateSnackbar={[MockFunction]}
+                        updateToolbar={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                            ],
+                          }
+                        }
+                      />
+                    </WithStyles(DialogContent)>
+                    <WithStyles(DialogActions)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        onClick={[Function]}
+                      >
+                        Cancel
+                      </WithStyles(Button)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        disabled={true}
+                        id="usePipelineBtn"
+                        onClick={[Function]}
+                      >
+                        Use this pipeline
+                      </WithStyles(Button)>
+                    </WithStyles(DialogActions)>
+                  </WithStyles(Dialog)>
+                  <Unknown
+                    autoFocus={true}
+                    field="runName"
+                    instance={[Circular]}
+                    label="Run name"
+                    required={true}
+                  />
+                  <Unknown
+                    field="description"
+                    height="auto"
+                    instance={[Circular]}
+                    label="Description (optional)"
+                    multiline={true}
+                  />
+                  <div
+                    className="header"
+                  >
+                    Run parameters
+                  </div>
+                  <div>
+                    Parameters will appear after you select a pipeline
+                  </div>
+                  <div
+                    className="flex"
+                  >
+                    <BusyButton
+                      busy={false}
+                      className="buttonAction"
+                      disabled={true}
+                      id="createNewRunBtn"
+                      onClick={[Function]}
+                      title="Create"
+                    />
+                    <WithStyles(Button)
+                      onClick={[Function]}
+                    >
+                      Cancel
+                    </WithStyles(Button)>
+                    <div
+                      style={
+                        Object {
+                          "color": "red",
+                        }
+                      }
+                    >
+                      A pipeline must be selected
+                    </div>
+                  </div>
+                </div>
+              </div>,
+              "_rendering": false,
+              "_updater": [Circular],
+            },
+          },
+          Symbol(enzyme.__setState__): [Function],
+        }
+      }
+      label="Pipeline"
+      required={true}
+    />
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "pipelineSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "pipelineSelectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <PipelineSelector
+          history={
+            Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            }
+          }
+          location={
+            Object {
+              "pathname": "/runs/new",
+            }
+          }
+          match=""
+          pipelineSelectionChanged={[Function]}
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={[MockFunction]}
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={true}
+          id="usePipelineBtn"
+          onClick={[Function]}
+        >
+          Use this pipeline
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <Component
+      autoFocus={true}
+      field="runName"
+      instance={
+        NewRun {
+          "_isMounted": true,
+          "context": Object {},
+          "handleChange": [Function],
+          "props": Object {
+            "history": Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            },
+            "location": Object {
+              "pathname": "/runs/new",
+            },
+            "match": "",
+            "toolbarProps": Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            },
+            "updateBanner": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            },
+            "updateDialog": [MockFunction],
+            "updateSnackbar": [MockFunction],
+            "updateToolbar": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+          },
+          "refs": Object {},
+          "setState": [Function],
+          "state": Object {
+            "description": "",
+            "errorMessage": "A pipeline must be selected",
+            "experiment": undefined,
+            "experimentName": undefined,
+            "isBeingCreated": false,
+            "isFirstRunInExperiment": false,
+            "isRecurringRun": false,
+            "pipelineName": "",
+            "pipelineSelectorOpen": false,
+            "runName": "",
+            "unconfirmedDialogPipelineId": "",
+          },
+          "updater": Updater {
+            "_callbacks": Array [],
+            "_renderer": ReactShallowRenderer {
+              "_context": Object {},
+              "_element": <NewRun
+                history={
+                  Object {
+                    "push": [MockFunction],
+                    "replace": [MockFunction],
+                  }
+                }
+                location={
+                  Object {
+                    "pathname": "/runs/new",
+                  }
+                }
+                match=""
+                toolbarProps={
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  }
+                }
+                updateBanner={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {},
+                      ],
+                    ],
+                  }
+                }
+                updateDialog={[MockFunction]}
+                updateSnackbar={[MockFunction]}
+                updateToolbar={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                    ],
+                  }
+                }
+              />,
+              "_forcedUpdate": false,
+              "_instance": [Circular],
+              "_newState": Object {
+                "description": "",
+                "errorMessage": "A pipeline must be selected",
+                "experiment": undefined,
+                "experimentName": undefined,
+                "isBeingCreated": false,
+                "isFirstRunInExperiment": false,
+                "isRecurringRun": false,
+                "pipelineName": "",
+                "pipelineSelectorOpen": false,
+                "runName": "",
+                "unconfirmedDialogPipelineId": "",
+              },
+              "_rendered": <div
+                className="page"
+              >
+                <div
+                  className="scrollContainer"
+                >
+                  <div
+                    className="header"
+                  >
+                    Run details
+                  </div>
+                  <Unknown
+                    InputProps={
+                      Object {
+                        "endAdornment": <WithStyles(InputAdornment)
+                          position="end"
+                        >
+                          <WithStyles(Button)
+                            color="secondary"
+                            id="choosePipelineBtn"
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "margin": 0,
+                                "padding": "3px 5px",
+                              }
+                            }
+                          >
+                            Choose
+                          </WithStyles(Button)>
+                        </WithStyles(InputAdornment)>,
+                        "readOnly": true,
+                      }
+                    }
+                    disabled={true}
+                    field="pipelineName"
+                    instance={[Circular]}
+                    label="Pipeline"
+                    required={true}
+                  />
+                  <WithStyles(Dialog)
+                    PaperProps={
+                      Object {
+                        "id": "pipelineSelectorDialog",
+                      }
+                    }
+                    classes={
+                      Object {
+                        "paper": "pipelineSelectorDialog",
+                      }
+                    }
+                    onClose={[Function]}
+                    open={false}
+                  >
+                    <WithStyles(DialogContent)>
+                      <PipelineSelector
+                        history={
+                          Object {
+                            "push": [MockFunction],
+                            "replace": [MockFunction],
+                          }
+                        }
+                        location={
+                          Object {
+                            "pathname": "/runs/new",
+                          }
+                        }
+                        match=""
+                        pipelineSelectionChanged={[Function]}
+                        toolbarProps={
+                          Object {
+                            "actions": Array [],
+                            "breadcrumbs": Array [
+                              Object {
+                                "displayName": "Experiments",
+                                "href": "/experiments",
+                              },
+                              Object {
+                                "displayName": "Start a new run",
+                                "href": "",
+                              },
+                            ],
+                          }
+                        }
+                        updateBanner={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {},
+                              ],
+                            ],
+                          }
+                        }
+                        updateDialog={[MockFunction]}
+                        updateSnackbar={[MockFunction]}
+                        updateToolbar={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                            ],
+                          }
+                        }
+                      />
+                    </WithStyles(DialogContent)>
+                    <WithStyles(DialogActions)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        onClick={[Function]}
+                      >
+                        Cancel
+                      </WithStyles(Button)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        disabled={true}
+                        id="usePipelineBtn"
+                        onClick={[Function]}
+                      >
+                        Use this pipeline
+                      </WithStyles(Button)>
+                    </WithStyles(DialogActions)>
+                  </WithStyles(Dialog)>
+                  <Unknown
+                    autoFocus={true}
+                    field="runName"
+                    instance={[Circular]}
+                    label="Run name"
+                    required={true}
+                  />
+                  <Unknown
+                    field="description"
+                    height="auto"
+                    instance={[Circular]}
+                    label="Description (optional)"
+                    multiline={true}
+                  />
+                  <div
+                    className="header"
+                  >
+                    Run parameters
+                  </div>
+                  <div>
+                    Parameters will appear after you select a pipeline
+                  </div>
+                  <div
+                    className="flex"
+                  >
+                    <BusyButton
+                      busy={false}
+                      className="buttonAction"
+                      disabled={true}
+                      id="createNewRunBtn"
+                      onClick={[Function]}
+                      title="Create"
+                    />
+                    <WithStyles(Button)
+                      onClick={[Function]}
+                    >
+                      Cancel
+                    </WithStyles(Button)>
+                    <div
+                      style={
+                        Object {
+                          "color": "red",
+                        }
+                      }
+                    >
+                      A pipeline must be selected
+                    </div>
+                  </div>
+                </div>
+              </div>,
+              "_rendering": false,
+              "_updater": [Circular],
+            },
+          },
+          Symbol(enzyme.__setState__): [Function],
+        }
+      }
+      label="Run name"
+      required={true}
+    />
+    <Component
+      field="description"
+      height="auto"
+      instance={
+        NewRun {
+          "_isMounted": true,
+          "context": Object {},
+          "handleChange": [Function],
+          "props": Object {
+            "history": Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            },
+            "location": Object {
+              "pathname": "/runs/new",
+            },
+            "match": "",
+            "toolbarProps": Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            },
+            "updateBanner": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            },
+            "updateDialog": [MockFunction],
+            "updateSnackbar": [MockFunction],
+            "updateToolbar": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+          },
+          "refs": Object {},
+          "setState": [Function],
+          "state": Object {
+            "description": "",
+            "errorMessage": "A pipeline must be selected",
+            "experiment": undefined,
+            "experimentName": undefined,
+            "isBeingCreated": false,
+            "isFirstRunInExperiment": false,
+            "isRecurringRun": false,
+            "pipelineName": "",
+            "pipelineSelectorOpen": false,
+            "runName": "",
+            "unconfirmedDialogPipelineId": "",
+          },
+          "updater": Updater {
+            "_callbacks": Array [],
+            "_renderer": ReactShallowRenderer {
+              "_context": Object {},
+              "_element": <NewRun
+                history={
+                  Object {
+                    "push": [MockFunction],
+                    "replace": [MockFunction],
+                  }
+                }
+                location={
+                  Object {
+                    "pathname": "/runs/new",
+                  }
+                }
+                match=""
+                toolbarProps={
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  }
+                }
+                updateBanner={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {},
+                      ],
+                    ],
+                  }
+                }
+                updateDialog={[MockFunction]}
+                updateSnackbar={[MockFunction]}
+                updateToolbar={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                    ],
+                  }
+                }
+              />,
+              "_forcedUpdate": false,
+              "_instance": [Circular],
+              "_newState": Object {
+                "description": "",
+                "errorMessage": "A pipeline must be selected",
+                "experiment": undefined,
+                "experimentName": undefined,
+                "isBeingCreated": false,
+                "isFirstRunInExperiment": false,
+                "isRecurringRun": false,
+                "pipelineName": "",
+                "pipelineSelectorOpen": false,
+                "runName": "",
+                "unconfirmedDialogPipelineId": "",
+              },
+              "_rendered": <div
+                className="page"
+              >
+                <div
+                  className="scrollContainer"
+                >
+                  <div
+                    className="header"
+                  >
+                    Run details
+                  </div>
+                  <Unknown
+                    InputProps={
+                      Object {
+                        "endAdornment": <WithStyles(InputAdornment)
+                          position="end"
+                        >
+                          <WithStyles(Button)
+                            color="secondary"
+                            id="choosePipelineBtn"
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "margin": 0,
+                                "padding": "3px 5px",
+                              }
+                            }
+                          >
+                            Choose
+                          </WithStyles(Button)>
+                        </WithStyles(InputAdornment)>,
+                        "readOnly": true,
+                      }
+                    }
+                    disabled={true}
+                    field="pipelineName"
+                    instance={[Circular]}
+                    label="Pipeline"
+                    required={true}
+                  />
+                  <WithStyles(Dialog)
+                    PaperProps={
+                      Object {
+                        "id": "pipelineSelectorDialog",
+                      }
+                    }
+                    classes={
+                      Object {
+                        "paper": "pipelineSelectorDialog",
+                      }
+                    }
+                    onClose={[Function]}
+                    open={false}
+                  >
+                    <WithStyles(DialogContent)>
+                      <PipelineSelector
+                        history={
+                          Object {
+                            "push": [MockFunction],
+                            "replace": [MockFunction],
+                          }
+                        }
+                        location={
+                          Object {
+                            "pathname": "/runs/new",
+                          }
+                        }
+                        match=""
+                        pipelineSelectionChanged={[Function]}
+                        toolbarProps={
+                          Object {
+                            "actions": Array [],
+                            "breadcrumbs": Array [
+                              Object {
+                                "displayName": "Experiments",
+                                "href": "/experiments",
+                              },
+                              Object {
+                                "displayName": "Start a new run",
+                                "href": "",
+                              },
+                            ],
+                          }
+                        }
+                        updateBanner={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {},
+                              ],
+                            ],
+                          }
+                        }
+                        updateDialog={[MockFunction]}
+                        updateSnackbar={[MockFunction]}
+                        updateToolbar={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                            ],
+                          }
+                        }
+                      />
+                    </WithStyles(DialogContent)>
+                    <WithStyles(DialogActions)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        onClick={[Function]}
+                      >
+                        Cancel
+                      </WithStyles(Button)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        disabled={true}
+                        id="usePipelineBtn"
+                        onClick={[Function]}
+                      >
+                        Use this pipeline
+                      </WithStyles(Button)>
+                    </WithStyles(DialogActions)>
+                  </WithStyles(Dialog)>
+                  <Unknown
+                    autoFocus={true}
+                    field="runName"
+                    instance={[Circular]}
+                    label="Run name"
+                    required={true}
+                  />
+                  <Unknown
+                    field="description"
+                    height="auto"
+                    instance={[Circular]}
+                    label="Description (optional)"
+                    multiline={true}
+                  />
+                  <div
+                    className="header"
+                  >
+                    Run parameters
+                  </div>
+                  <div>
+                    Parameters will appear after you select a pipeline
+                  </div>
+                  <div
+                    className="flex"
+                  >
+                    <BusyButton
+                      busy={false}
+                      className="buttonAction"
+                      disabled={true}
+                      id="createNewRunBtn"
+                      onClick={[Function]}
+                      title="Create"
+                    />
+                    <WithStyles(Button)
+                      onClick={[Function]}
+                    >
+                      Cancel
+                    </WithStyles(Button)>
+                    <div
+                      style={
+                        Object {
+                          "color": "red",
+                        }
+                      }
+                    >
+                      A pipeline must be selected
+                    </div>
+                  </div>
+                </div>
+              </div>,
+              "_rendering": false,
+              "_updater": [Circular],
+            },
+          },
+          Symbol(enzyme.__setState__): [Function],
+        }
+      }
+      label="Description (optional)"
+      multiline={true}
+    />
+    <div
+      className="header"
+    >
+      Run parameters
+    </div>
+    <div>
+      Parameters will appear after you select a pipeline
+    </div>
+    <div
+      className="flex"
+    >
+      <BusyButton
+        busy={false}
+        className="buttonAction"
+        disabled={true}
+        id="createNewRunBtn"
+        onClick={[Function]}
+        title="Create"
+      />
+      <WithStyles(Button)
+        onClick={[Function]}
+      >
+        Cancel
+      </WithStyles(Button)>
+      <div
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+      >
+        A pipeline must be selected
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`NewRun updates the run's state with the associated experiment if one is present in the query params 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="scrollContainer"
+  >
+    <div
+      className="header"
+    >
+      Run details
+    </div>
+    <Component
+      InputProps={
+        Object {
+          "endAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <WithStyles(Button)
+              color="secondary"
+              id="choosePipelineBtn"
+              onClick={[Function]}
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": "3px 5px",
+                }
+              }
+            >
+              Choose
+            </WithStyles(Button)>
+          </WithStyles(InputAdornment)>,
+          "readOnly": true,
+        }
+      }
+      disabled={true}
+      field="pipelineName"
+      instance={
+        NewRun {
+          "_isMounted": true,
+          "context": Object {},
+          "handleChange": [Function],
+          "props": Object {
+            "history": Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            },
+            "location": Object {
+              "pathname": "/runs/new",
+              "search": "?experimentId=some-mock-experiment-id",
+            },
+            "match": "",
+            "toolbarProps": Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            },
+            "updateBanner": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            },
+            "updateDialog": [MockFunction],
+            "updateSnackbar": [MockFunction],
+            "updateToolbar": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "some mock experiment name",
+                        "href": "/experiments/details/some-mock-experiment-id",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+          },
+          "refs": Object {},
+          "setState": [Function],
+          "state": Object {
+            "description": "",
+            "errorMessage": "A pipeline must be selected",
+            "experiment": Object {
+              "description": "mock experiment description",
+              "id": "some-mock-experiment-id",
+              "name": "some mock experiment name",
+            },
+            "experimentName": "some mock experiment name",
+            "isBeingCreated": false,
+            "isFirstRunInExperiment": false,
+            "isRecurringRun": false,
+            "pipelineName": "",
+            "pipelineSelectorOpen": false,
+            "runName": "",
+            "unconfirmedDialogPipelineId": "",
+          },
+          "updater": Updater {
+            "_callbacks": Array [],
+            "_renderer": ReactShallowRenderer {
+              "_context": Object {},
+              "_element": <NewRun
+                history={
+                  Object {
+                    "push": [MockFunction],
+                    "replace": [MockFunction],
+                  }
+                }
+                location={
+                  Object {
+                    "pathname": "/runs/new",
+                    "search": "?experimentId=some-mock-experiment-id",
+                  }
+                }
+                match=""
+                toolbarProps={
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  }
+                }
+                updateBanner={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {},
+                      ],
+                    ],
+                  }
+                }
+                updateDialog={[MockFunction]}
+                updateSnackbar={[MockFunction]}
+                updateToolbar={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "some mock experiment name",
+                              "href": "/experiments/details/some-mock-experiment-id",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                    ],
+                  }
+                }
+              />,
+              "_forcedUpdate": false,
+              "_instance": [Circular],
+              "_newState": Object {
+                "description": "",
+                "errorMessage": "A pipeline must be selected",
+                "experiment": Object {
+                  "description": "mock experiment description",
+                  "id": "some-mock-experiment-id",
+                  "name": "some mock experiment name",
+                },
+                "experimentName": "some mock experiment name",
+                "isBeingCreated": false,
+                "isFirstRunInExperiment": false,
+                "isRecurringRun": false,
+                "pipelineName": "",
+                "pipelineSelectorOpen": false,
+                "runName": "",
+                "unconfirmedDialogPipelineId": "",
+              },
+              "_rendered": <div
+                className="page"
+              >
+                <div
+                  className="scrollContainer"
+                >
+                  <div
+                    className="header"
+                  >
+                    Run details
+                  </div>
+                  <Unknown
+                    InputProps={
+                      Object {
+                        "endAdornment": <WithStyles(InputAdornment)
+                          position="end"
+                        >
+                          <WithStyles(Button)
+                            color="secondary"
+                            id="choosePipelineBtn"
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "margin": 0,
+                                "padding": "3px 5px",
+                              }
+                            }
+                          >
+                            Choose
+                          </WithStyles(Button)>
+                        </WithStyles(InputAdornment)>,
+                        "readOnly": true,
+                      }
+                    }
+                    disabled={true}
+                    field="pipelineName"
+                    instance={[Circular]}
+                    label="Pipeline"
+                    required={true}
+                  />
+                  <WithStyles(Dialog)
+                    PaperProps={
+                      Object {
+                        "id": "pipelineSelectorDialog",
+                      }
+                    }
+                    classes={
+                      Object {
+                        "paper": "pipelineSelectorDialog",
+                      }
+                    }
+                    onClose={[Function]}
+                    open={false}
+                  >
+                    <WithStyles(DialogContent)>
+                      <PipelineSelector
+                        history={
+                          Object {
+                            "push": [MockFunction],
+                            "replace": [MockFunction],
+                          }
+                        }
+                        location={
+                          Object {
+                            "pathname": "/runs/new",
+                            "search": "?experimentId=some-mock-experiment-id",
+                          }
+                        }
+                        match=""
+                        pipelineSelectionChanged={[Function]}
+                        toolbarProps={
+                          Object {
+                            "actions": Array [],
+                            "breadcrumbs": Array [
+                              Object {
+                                "displayName": "Experiments",
+                                "href": "/experiments",
+                              },
+                              Object {
+                                "displayName": "Start a new run",
+                                "href": "",
+                              },
+                            ],
+                          }
+                        }
+                        updateBanner={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {},
+                              ],
+                            ],
+                          }
+                        }
+                        updateDialog={[MockFunction]}
+                        updateSnackbar={[MockFunction]}
+                        updateToolbar={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "some mock experiment name",
+                                      "href": "/experiments/details/some-mock-experiment-id",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                            ],
+                          }
+                        }
+                      />
+                    </WithStyles(DialogContent)>
+                    <WithStyles(DialogActions)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        onClick={[Function]}
+                      >
+                        Cancel
+                      </WithStyles(Button)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        disabled={true}
+                        id="usePipelineBtn"
+                        onClick={[Function]}
+                      >
+                        Use this pipeline
+                      </WithStyles(Button)>
+                    </WithStyles(DialogActions)>
+                  </WithStyles(Dialog)>
+                  <Unknown
+                    autoFocus={true}
+                    field="runName"
+                    instance={[Circular]}
+                    label="Run name"
+                    required={true}
+                  />
+                  <Unknown
+                    field="description"
+                    height="auto"
+                    instance={[Circular]}
+                    label="Description (optional)"
+                    multiline={true}
+                  />
+                  <div>
+                    <div>
+                      This run will be associated with the following experiment
+                    </div>
+                    <Unknown
+                      disabled={true}
+                      field="experimentName"
+                      instance={[Circular]}
+                      label="Experiment"
+                    />
+                  </div>
+                  <div
+                    className="header"
+                  >
+                    Run parameters
+                  </div>
+                  <div>
+                    Parameters will appear after you select a pipeline
+                  </div>
+                  <div
+                    className="flex"
+                  >
+                    <BusyButton
+                      busy={false}
+                      className="buttonAction"
+                      disabled={true}
+                      id="createNewRunBtn"
+                      onClick={[Function]}
+                      title="Create"
+                    />
+                    <WithStyles(Button)
+                      onClick={[Function]}
+                    >
+                      Cancel
+                    </WithStyles(Button)>
+                    <div
+                      style={
+                        Object {
+                          "color": "red",
+                        }
+                      }
+                    >
+                      A pipeline must be selected
+                    </div>
+                  </div>
+                </div>
+              </div>,
+              "_rendering": false,
+              "_updater": [Circular],
+            },
+          },
+          Symbol(enzyme.__setState__): [Function],
+        }
+      }
+      label="Pipeline"
+      required={true}
+    />
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "pipelineSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "pipelineSelectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <PipelineSelector
+          history={
+            Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            }
+          }
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?experimentId=some-mock-experiment-id",
+            }
+          }
+          match=""
+          pipelineSelectionChanged={[Function]}
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={[MockFunction]}
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "some mock experiment name",
+                        "href": "/experiments/details/some-mock-experiment-id",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={true}
+          id="usePipelineBtn"
+          onClick={[Function]}
+        >
+          Use this pipeline
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <Component
+      autoFocus={true}
+      field="runName"
+      instance={
+        NewRun {
+          "_isMounted": true,
+          "context": Object {},
+          "handleChange": [Function],
+          "props": Object {
+            "history": Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            },
+            "location": Object {
+              "pathname": "/runs/new",
+              "search": "?experimentId=some-mock-experiment-id",
+            },
+            "match": "",
+            "toolbarProps": Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            },
+            "updateBanner": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            },
+            "updateDialog": [MockFunction],
+            "updateSnackbar": [MockFunction],
+            "updateToolbar": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "some mock experiment name",
+                        "href": "/experiments/details/some-mock-experiment-id",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+          },
+          "refs": Object {},
+          "setState": [Function],
+          "state": Object {
+            "description": "",
+            "errorMessage": "A pipeline must be selected",
+            "experiment": Object {
+              "description": "mock experiment description",
+              "id": "some-mock-experiment-id",
+              "name": "some mock experiment name",
+            },
+            "experimentName": "some mock experiment name",
+            "isBeingCreated": false,
+            "isFirstRunInExperiment": false,
+            "isRecurringRun": false,
+            "pipelineName": "",
+            "pipelineSelectorOpen": false,
+            "runName": "",
+            "unconfirmedDialogPipelineId": "",
+          },
+          "updater": Updater {
+            "_callbacks": Array [],
+            "_renderer": ReactShallowRenderer {
+              "_context": Object {},
+              "_element": <NewRun
+                history={
+                  Object {
+                    "push": [MockFunction],
+                    "replace": [MockFunction],
+                  }
+                }
+                location={
+                  Object {
+                    "pathname": "/runs/new",
+                    "search": "?experimentId=some-mock-experiment-id",
+                  }
+                }
+                match=""
+                toolbarProps={
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  }
+                }
+                updateBanner={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {},
+                      ],
+                    ],
+                  }
+                }
+                updateDialog={[MockFunction]}
+                updateSnackbar={[MockFunction]}
+                updateToolbar={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "some mock experiment name",
+                              "href": "/experiments/details/some-mock-experiment-id",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                    ],
+                  }
+                }
+              />,
+              "_forcedUpdate": false,
+              "_instance": [Circular],
+              "_newState": Object {
+                "description": "",
+                "errorMessage": "A pipeline must be selected",
+                "experiment": Object {
+                  "description": "mock experiment description",
+                  "id": "some-mock-experiment-id",
+                  "name": "some mock experiment name",
+                },
+                "experimentName": "some mock experiment name",
+                "isBeingCreated": false,
+                "isFirstRunInExperiment": false,
+                "isRecurringRun": false,
+                "pipelineName": "",
+                "pipelineSelectorOpen": false,
+                "runName": "",
+                "unconfirmedDialogPipelineId": "",
+              },
+              "_rendered": <div
+                className="page"
+              >
+                <div
+                  className="scrollContainer"
+                >
+                  <div
+                    className="header"
+                  >
+                    Run details
+                  </div>
+                  <Unknown
+                    InputProps={
+                      Object {
+                        "endAdornment": <WithStyles(InputAdornment)
+                          position="end"
+                        >
+                          <WithStyles(Button)
+                            color="secondary"
+                            id="choosePipelineBtn"
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "margin": 0,
+                                "padding": "3px 5px",
+                              }
+                            }
+                          >
+                            Choose
+                          </WithStyles(Button)>
+                        </WithStyles(InputAdornment)>,
+                        "readOnly": true,
+                      }
+                    }
+                    disabled={true}
+                    field="pipelineName"
+                    instance={[Circular]}
+                    label="Pipeline"
+                    required={true}
+                  />
+                  <WithStyles(Dialog)
+                    PaperProps={
+                      Object {
+                        "id": "pipelineSelectorDialog",
+                      }
+                    }
+                    classes={
+                      Object {
+                        "paper": "pipelineSelectorDialog",
+                      }
+                    }
+                    onClose={[Function]}
+                    open={false}
+                  >
+                    <WithStyles(DialogContent)>
+                      <PipelineSelector
+                        history={
+                          Object {
+                            "push": [MockFunction],
+                            "replace": [MockFunction],
+                          }
+                        }
+                        location={
+                          Object {
+                            "pathname": "/runs/new",
+                            "search": "?experimentId=some-mock-experiment-id",
+                          }
+                        }
+                        match=""
+                        pipelineSelectionChanged={[Function]}
+                        toolbarProps={
+                          Object {
+                            "actions": Array [],
+                            "breadcrumbs": Array [
+                              Object {
+                                "displayName": "Experiments",
+                                "href": "/experiments",
+                              },
+                              Object {
+                                "displayName": "Start a new run",
+                                "href": "",
+                              },
+                            ],
+                          }
+                        }
+                        updateBanner={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {},
+                              ],
+                            ],
+                          }
+                        }
+                        updateDialog={[MockFunction]}
+                        updateSnackbar={[MockFunction]}
+                        updateToolbar={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "some mock experiment name",
+                                      "href": "/experiments/details/some-mock-experiment-id",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                            ],
+                          }
+                        }
+                      />
+                    </WithStyles(DialogContent)>
+                    <WithStyles(DialogActions)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        onClick={[Function]}
+                      >
+                        Cancel
+                      </WithStyles(Button)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        disabled={true}
+                        id="usePipelineBtn"
+                        onClick={[Function]}
+                      >
+                        Use this pipeline
+                      </WithStyles(Button)>
+                    </WithStyles(DialogActions)>
+                  </WithStyles(Dialog)>
+                  <Unknown
+                    autoFocus={true}
+                    field="runName"
+                    instance={[Circular]}
+                    label="Run name"
+                    required={true}
+                  />
+                  <Unknown
+                    field="description"
+                    height="auto"
+                    instance={[Circular]}
+                    label="Description (optional)"
+                    multiline={true}
+                  />
+                  <div>
+                    <div>
+                      This run will be associated with the following experiment
+                    </div>
+                    <Unknown
+                      disabled={true}
+                      field="experimentName"
+                      instance={[Circular]}
+                      label="Experiment"
+                    />
+                  </div>
+                  <div
+                    className="header"
+                  >
+                    Run parameters
+                  </div>
+                  <div>
+                    Parameters will appear after you select a pipeline
+                  </div>
+                  <div
+                    className="flex"
+                  >
+                    <BusyButton
+                      busy={false}
+                      className="buttonAction"
+                      disabled={true}
+                      id="createNewRunBtn"
+                      onClick={[Function]}
+                      title="Create"
+                    />
+                    <WithStyles(Button)
+                      onClick={[Function]}
+                    >
+                      Cancel
+                    </WithStyles(Button)>
+                    <div
+                      style={
+                        Object {
+                          "color": "red",
+                        }
+                      }
+                    >
+                      A pipeline must be selected
+                    </div>
+                  </div>
+                </div>
+              </div>,
+              "_rendering": false,
+              "_updater": [Circular],
+            },
+          },
+          Symbol(enzyme.__setState__): [Function],
+        }
+      }
+      label="Run name"
+      required={true}
+    />
+    <Component
+      field="description"
+      height="auto"
+      instance={
+        NewRun {
+          "_isMounted": true,
+          "context": Object {},
+          "handleChange": [Function],
+          "props": Object {
+            "history": Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            },
+            "location": Object {
+              "pathname": "/runs/new",
+              "search": "?experimentId=some-mock-experiment-id",
+            },
+            "match": "",
+            "toolbarProps": Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            },
+            "updateBanner": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            },
+            "updateDialog": [MockFunction],
+            "updateSnackbar": [MockFunction],
+            "updateToolbar": [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "some mock experiment name",
+                        "href": "/experiments/details/some-mock-experiment-id",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+          },
+          "refs": Object {},
+          "setState": [Function],
+          "state": Object {
+            "description": "",
+            "errorMessage": "A pipeline must be selected",
+            "experiment": Object {
+              "description": "mock experiment description",
+              "id": "some-mock-experiment-id",
+              "name": "some mock experiment name",
+            },
+            "experimentName": "some mock experiment name",
+            "isBeingCreated": false,
+            "isFirstRunInExperiment": false,
+            "isRecurringRun": false,
+            "pipelineName": "",
+            "pipelineSelectorOpen": false,
+            "runName": "",
+            "unconfirmedDialogPipelineId": "",
+          },
+          "updater": Updater {
+            "_callbacks": Array [],
+            "_renderer": ReactShallowRenderer {
+              "_context": Object {},
+              "_element": <NewRun
+                history={
+                  Object {
+                    "push": [MockFunction],
+                    "replace": [MockFunction],
+                  }
+                }
+                location={
+                  Object {
+                    "pathname": "/runs/new",
+                    "search": "?experimentId=some-mock-experiment-id",
+                  }
+                }
+                match=""
+                toolbarProps={
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  }
+                }
+                updateBanner={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {},
+                      ],
+                    ],
+                  }
+                }
+                updateDialog={[MockFunction]}
+                updateSnackbar={[MockFunction]}
+                updateToolbar={
+                  [MockFunction] {
+                    "calls": Array [
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                      Array [
+                        Object {
+                          "actions": Array [],
+                          "breadcrumbs": Array [
+                            Object {
+                              "displayName": "Experiments",
+                              "href": "/experiments",
+                            },
+                            Object {
+                              "displayName": "some mock experiment name",
+                              "href": "/experiments/details/some-mock-experiment-id",
+                            },
+                            Object {
+                              "displayName": "Start a new run",
+                              "href": "",
+                            },
+                          ],
+                        },
+                      ],
+                    ],
+                  }
+                }
+              />,
+              "_forcedUpdate": false,
+              "_instance": [Circular],
+              "_newState": Object {
+                "description": "",
+                "errorMessage": "A pipeline must be selected",
+                "experiment": Object {
+                  "description": "mock experiment description",
+                  "id": "some-mock-experiment-id",
+                  "name": "some mock experiment name",
+                },
+                "experimentName": "some mock experiment name",
+                "isBeingCreated": false,
+                "isFirstRunInExperiment": false,
+                "isRecurringRun": false,
+                "pipelineName": "",
+                "pipelineSelectorOpen": false,
+                "runName": "",
+                "unconfirmedDialogPipelineId": "",
+              },
+              "_rendered": <div
+                className="page"
+              >
+                <div
+                  className="scrollContainer"
+                >
+                  <div
+                    className="header"
+                  >
+                    Run details
+                  </div>
+                  <Unknown
+                    InputProps={
+                      Object {
+                        "endAdornment": <WithStyles(InputAdornment)
+                          position="end"
+                        >
+                          <WithStyles(Button)
+                            color="secondary"
+                            id="choosePipelineBtn"
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "margin": 0,
+                                "padding": "3px 5px",
+                              }
+                            }
+                          >
+                            Choose
+                          </WithStyles(Button)>
+                        </WithStyles(InputAdornment)>,
+                        "readOnly": true,
+                      }
+                    }
+                    disabled={true}
+                    field="pipelineName"
+                    instance={[Circular]}
+                    label="Pipeline"
+                    required={true}
+                  />
+                  <WithStyles(Dialog)
+                    PaperProps={
+                      Object {
+                        "id": "pipelineSelectorDialog",
+                      }
+                    }
+                    classes={
+                      Object {
+                        "paper": "pipelineSelectorDialog",
+                      }
+                    }
+                    onClose={[Function]}
+                    open={false}
+                  >
+                    <WithStyles(DialogContent)>
+                      <PipelineSelector
+                        history={
+                          Object {
+                            "push": [MockFunction],
+                            "replace": [MockFunction],
+                          }
+                        }
+                        location={
+                          Object {
+                            "pathname": "/runs/new",
+                            "search": "?experimentId=some-mock-experiment-id",
+                          }
+                        }
+                        match=""
+                        pipelineSelectionChanged={[Function]}
+                        toolbarProps={
+                          Object {
+                            "actions": Array [],
+                            "breadcrumbs": Array [
+                              Object {
+                                "displayName": "Experiments",
+                                "href": "/experiments",
+                              },
+                              Object {
+                                "displayName": "Start a new run",
+                                "href": "",
+                              },
+                            ],
+                          }
+                        }
+                        updateBanner={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {},
+                              ],
+                            ],
+                          }
+                        }
+                        updateDialog={[MockFunction]}
+                        updateSnackbar={[MockFunction]}
+                        updateToolbar={
+                          [MockFunction] {
+                            "calls": Array [
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                              Array [
+                                Object {
+                                  "actions": Array [],
+                                  "breadcrumbs": Array [
+                                    Object {
+                                      "displayName": "Experiments",
+                                      "href": "/experiments",
+                                    },
+                                    Object {
+                                      "displayName": "some mock experiment name",
+                                      "href": "/experiments/details/some-mock-experiment-id",
+                                    },
+                                    Object {
+                                      "displayName": "Start a new run",
+                                      "href": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                            ],
+                          }
+                        }
+                      />
+                    </WithStyles(DialogContent)>
+                    <WithStyles(DialogActions)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        onClick={[Function]}
+                      >
+                        Cancel
+                      </WithStyles(Button)>
+                      <WithStyles(Button)
+                        color="secondary"
+                        disabled={true}
+                        id="usePipelineBtn"
+                        onClick={[Function]}
+                      >
+                        Use this pipeline
+                      </WithStyles(Button)>
+                    </WithStyles(DialogActions)>
+                  </WithStyles(Dialog)>
+                  <Unknown
+                    autoFocus={true}
+                    field="runName"
+                    instance={[Circular]}
+                    label="Run name"
+                    required={true}
+                  />
+                  <Unknown
+                    field="description"
+                    height="auto"
+                    instance={[Circular]}
+                    label="Description (optional)"
+                    multiline={true}
+                  />
+                  <div>
+                    <div>
+                      This run will be associated with the following experiment
+                    </div>
+                    <Unknown
+                      disabled={true}
+                      field="experimentName"
+                      instance={[Circular]}
+                      label="Experiment"
+                    />
+                  </div>
+                  <div
+                    className="header"
+                  >
+                    Run parameters
+                  </div>
+                  <div>
+                    Parameters will appear after you select a pipeline
+                  </div>
+                  <div
+                    className="flex"
+                  >
+                    <BusyButton
+                      busy={false}
+                      className="buttonAction"
+                      disabled={true}
+                      id="createNewRunBtn"
+                      onClick={[Function]}
+                      title="Create"
+                    />
+                    <WithStyles(Button)
+                      onClick={[Function]}
+                    >
+                      Cancel
+                    </WithStyles(Button)>
+                    <div
+                      style={
+                        Object {
+                          "color": "red",
+                        }
+                      }
+                    >
+                      A pipeline must be selected
+                    </div>
+                  </div>
+                </div>
+              </div>,
+              "_rendering": false,
+              "_updater": [Circular],
+            },
+          },
+          Symbol(enzyme.__setState__): [Function],
+        }
+      }
+      label="Description (optional)"
+      multiline={true}
+    />
+    <div>
+      <div>
+        This run will be associated with the following experiment
+      </div>
+      <Component
+        disabled={true}
+        field="experimentName"
+        instance={
+          NewRun {
+            "_isMounted": true,
+            "context": Object {},
+            "handleChange": [Function],
+            "props": Object {
+              "history": Object {
+                "push": [MockFunction],
+                "replace": [MockFunction],
+              },
+              "location": Object {
+                "pathname": "/runs/new",
+                "search": "?experimentId=some-mock-experiment-id",
+              },
+              "match": "",
+              "toolbarProps": Object {
+                "actions": Array [],
+                "breadcrumbs": Array [
+                  Object {
+                    "displayName": "Experiments",
+                    "href": "/experiments",
+                  },
+                  Object {
+                    "displayName": "Start a new run",
+                    "href": "",
+                  },
+                ],
+              },
+              "updateBanner": [MockFunction] {
+                "calls": Array [
+                  Array [
+                    Object {},
+                  ],
+                ],
+              },
+              "updateDialog": [MockFunction],
+              "updateSnackbar": [MockFunction],
+              "updateToolbar": [MockFunction] {
+                "calls": Array [
+                  Array [
+                    Object {
+                      "actions": Array [],
+                      "breadcrumbs": Array [
+                        Object {
+                          "displayName": "Experiments",
+                          "href": "/experiments",
+                        },
+                        Object {
+                          "displayName": "Start a new run",
+                          "href": "",
+                        },
+                      ],
+                    },
+                  ],
+                  Array [
+                    Object {
+                      "actions": Array [],
+                      "breadcrumbs": Array [
+                        Object {
+                          "displayName": "Experiments",
+                          "href": "/experiments",
+                        },
+                        Object {
+                          "displayName": "some mock experiment name",
+                          "href": "/experiments/details/some-mock-experiment-id",
+                        },
+                        Object {
+                          "displayName": "Start a new run",
+                          "href": "",
+                        },
+                      ],
+                    },
+                  ],
+                ],
+              },
+            },
+            "refs": Object {},
+            "setState": [Function],
+            "state": Object {
+              "description": "",
+              "errorMessage": "A pipeline must be selected",
+              "experiment": Object {
+                "description": "mock experiment description",
+                "id": "some-mock-experiment-id",
+                "name": "some mock experiment name",
+              },
+              "experimentName": "some mock experiment name",
+              "isBeingCreated": false,
+              "isFirstRunInExperiment": false,
+              "isRecurringRun": false,
+              "pipelineName": "",
+              "pipelineSelectorOpen": false,
+              "runName": "",
+              "unconfirmedDialogPipelineId": "",
+            },
+            "updater": Updater {
+              "_callbacks": Array [],
+              "_renderer": ReactShallowRenderer {
+                "_context": Object {},
+                "_element": <NewRun
+                  history={
+                    Object {
+                      "push": [MockFunction],
+                      "replace": [MockFunction],
+                    }
+                  }
+                  location={
+                    Object {
+                      "pathname": "/runs/new",
+                      "search": "?experimentId=some-mock-experiment-id",
+                    }
+                  }
+                  match=""
+                  toolbarProps={
+                    Object {
+                      "actions": Array [],
+                      "breadcrumbs": Array [
+                        Object {
+                          "displayName": "Experiments",
+                          "href": "/experiments",
+                        },
+                        Object {
+                          "displayName": "Start a new run",
+                          "href": "",
+                        },
+                      ],
+                    }
+                  }
+                  updateBanner={
+                    [MockFunction] {
+                      "calls": Array [
+                        Array [
+                          Object {},
+                        ],
+                      ],
+                    }
+                  }
+                  updateDialog={[MockFunction]}
+                  updateSnackbar={[MockFunction]}
+                  updateToolbar={
+                    [MockFunction] {
+                      "calls": Array [
+                        Array [
+                          Object {
+                            "actions": Array [],
+                            "breadcrumbs": Array [
+                              Object {
+                                "displayName": "Experiments",
+                                "href": "/experiments",
+                              },
+                              Object {
+                                "displayName": "Start a new run",
+                                "href": "",
+                              },
+                            ],
+                          },
+                        ],
+                        Array [
+                          Object {
+                            "actions": Array [],
+                            "breadcrumbs": Array [
+                              Object {
+                                "displayName": "Experiments",
+                                "href": "/experiments",
+                              },
+                              Object {
+                                "displayName": "some mock experiment name",
+                                "href": "/experiments/details/some-mock-experiment-id",
+                              },
+                              Object {
+                                "displayName": "Start a new run",
+                                "href": "",
+                              },
+                            ],
+                          },
+                        ],
+                      ],
+                    }
+                  }
+                />,
+                "_forcedUpdate": false,
+                "_instance": [Circular],
+                "_newState": Object {
+                  "description": "",
+                  "errorMessage": "A pipeline must be selected",
+                  "experiment": Object {
+                    "description": "mock experiment description",
+                    "id": "some-mock-experiment-id",
+                    "name": "some mock experiment name",
+                  },
+                  "experimentName": "some mock experiment name",
+                  "isBeingCreated": false,
+                  "isFirstRunInExperiment": false,
+                  "isRecurringRun": false,
+                  "pipelineName": "",
+                  "pipelineSelectorOpen": false,
+                  "runName": "",
+                  "unconfirmedDialogPipelineId": "",
+                },
+                "_rendered": <div
+                  className="page"
+                >
+                  <div
+                    className="scrollContainer"
+                  >
+                    <div
+                      className="header"
+                    >
+                      Run details
+                    </div>
+                    <Unknown
+                      InputProps={
+                        Object {
+                          "endAdornment": <WithStyles(InputAdornment)
+                            position="end"
+                          >
+                            <WithStyles(Button)
+                              color="secondary"
+                              id="choosePipelineBtn"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "margin": 0,
+                                  "padding": "3px 5px",
+                                }
+                              }
+                            >
+                              Choose
+                            </WithStyles(Button)>
+                          </WithStyles(InputAdornment)>,
+                          "readOnly": true,
+                        }
+                      }
+                      disabled={true}
+                      field="pipelineName"
+                      instance={[Circular]}
+                      label="Pipeline"
+                      required={true}
+                    />
+                    <WithStyles(Dialog)
+                      PaperProps={
+                        Object {
+                          "id": "pipelineSelectorDialog",
+                        }
+                      }
+                      classes={
+                        Object {
+                          "paper": "pipelineSelectorDialog",
+                        }
+                      }
+                      onClose={[Function]}
+                      open={false}
+                    >
+                      <WithStyles(DialogContent)>
+                        <PipelineSelector
+                          history={
+                            Object {
+                              "push": [MockFunction],
+                              "replace": [MockFunction],
+                            }
+                          }
+                          location={
+                            Object {
+                              "pathname": "/runs/new",
+                              "search": "?experimentId=some-mock-experiment-id",
+                            }
+                          }
+                          match=""
+                          pipelineSelectionChanged={[Function]}
+                          toolbarProps={
+                            Object {
+                              "actions": Array [],
+                              "breadcrumbs": Array [
+                                Object {
+                                  "displayName": "Experiments",
+                                  "href": "/experiments",
+                                },
+                                Object {
+                                  "displayName": "Start a new run",
+                                  "href": "",
+                                },
+                              ],
+                            }
+                          }
+                          updateBanner={
+                            [MockFunction] {
+                              "calls": Array [
+                                Array [
+                                  Object {},
+                                ],
+                              ],
+                            }
+                          }
+                          updateDialog={[MockFunction]}
+                          updateSnackbar={[MockFunction]}
+                          updateToolbar={
+                            [MockFunction] {
+                              "calls": Array [
+                                Array [
+                                  Object {
+                                    "actions": Array [],
+                                    "breadcrumbs": Array [
+                                      Object {
+                                        "displayName": "Experiments",
+                                        "href": "/experiments",
+                                      },
+                                      Object {
+                                        "displayName": "Start a new run",
+                                        "href": "",
+                                      },
+                                    ],
+                                  },
+                                ],
+                                Array [
+                                  Object {
+                                    "actions": Array [],
+                                    "breadcrumbs": Array [
+                                      Object {
+                                        "displayName": "Experiments",
+                                        "href": "/experiments",
+                                      },
+                                      Object {
+                                        "displayName": "some mock experiment name",
+                                        "href": "/experiments/details/some-mock-experiment-id",
+                                      },
+                                      Object {
+                                        "displayName": "Start a new run",
+                                        "href": "",
+                                      },
+                                    ],
+                                  },
+                                ],
+                              ],
+                            }
+                          }
+                        />
+                      </WithStyles(DialogContent)>
+                      <WithStyles(DialogActions)>
+                        <WithStyles(Button)
+                          color="secondary"
+                          onClick={[Function]}
+                        >
+                          Cancel
+                        </WithStyles(Button)>
+                        <WithStyles(Button)
+                          color="secondary"
+                          disabled={true}
+                          id="usePipelineBtn"
+                          onClick={[Function]}
+                        >
+                          Use this pipeline
+                        </WithStyles(Button)>
+                      </WithStyles(DialogActions)>
+                    </WithStyles(Dialog)>
+                    <Unknown
+                      autoFocus={true}
+                      field="runName"
+                      instance={[Circular]}
+                      label="Run name"
+                      required={true}
+                    />
+                    <Unknown
+                      field="description"
+                      height="auto"
+                      instance={[Circular]}
+                      label="Description (optional)"
+                      multiline={true}
+                    />
+                    <div>
+                      <div>
+                        This run will be associated with the following experiment
+                      </div>
+                      <Unknown
+                        disabled={true}
+                        field="experimentName"
+                        instance={[Circular]}
+                        label="Experiment"
+                      />
+                    </div>
+                    <div
+                      className="header"
+                    >
+                      Run parameters
+                    </div>
+                    <div>
+                      Parameters will appear after you select a pipeline
+                    </div>
+                    <div
+                      className="flex"
+                    >
+                      <BusyButton
+                        busy={false}
+                        className="buttonAction"
+                        disabled={true}
+                        id="createNewRunBtn"
+                        onClick={[Function]}
+                        title="Create"
+                      />
+                      <WithStyles(Button)
+                        onClick={[Function]}
+                      >
+                        Cancel
+                      </WithStyles(Button)>
+                      <div
+                        style={
+                          Object {
+                            "color": "red",
+                          }
+                        }
+                      >
+                        A pipeline must be selected
+                      </div>
+                    </div>
+                  </div>
+                </div>,
+                "_rendering": false,
+                "_updater": [Circular],
+              },
+            },
+            Symbol(enzyme.__setState__): [Function],
+          }
+        }
+        label="Experiment"
+      />
+    </div>
+    <div
+      className="header"
+    >
+      Run parameters
+    </div>
+    <div>
+      Parameters will appear after you select a pipeline
+    </div>
+    <div
+      className="flex"
+    >
+      <BusyButton
+        busy={false}
+        className="buttonAction"
+        disabled={true}
+        id="createNewRunBtn"
+        onClick={[Function]}
+        title="Create"
+      />
+      <WithStyles(Button)
+        onClick={[Function]}
+      >
+        Cancel
+      </WithStyles(Button)>
+      <div
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+      >
+        A pipeline must be selected
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -1,5 +1,436 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`NewRun changes the exit button's text if query params indicate this is the first run of an experiment 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="scrollContainer"
+  >
+    <div
+      className="header"
+    >
+      Run details
+    </div>
+    <Component
+      InputProps={
+        Object {
+          "endAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <WithStyles(Button)
+              color="secondary"
+              id="choosePipelineBtn"
+              onClick={[Function]}
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": "3px 5px",
+                }
+              }
+            >
+              Choose
+            </WithStyles(Button)>
+          </WithStyles(InputAdornment)>,
+          "readOnly": true,
+        }
+      }
+      disabled={true}
+      label="Pipeline"
+      required={true}
+      value=""
+    />
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "pipelineSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "pipelineSelectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <PipelineSelector
+          history={
+            Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            }
+          }
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?experimentId=some-mock-experiment-id&firstRunInExperiment=1",
+            }
+          }
+          match=""
+          pipelineSelectionChanged={[Function]}
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={[MockFunction]}
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "some mock experiment name",
+                        "href": "/experiments/details/some-mock-experiment-id",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          id="cancelPipelineSelectionBtn"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={true}
+          id="usePipelineBtn"
+          onClick={[Function]}
+        >
+          Use this pipeline
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <Component
+      autoFocus={true}
+      label="Run name"
+      onChange={[Function]}
+      required={true}
+      value=""
+    />
+    <Component
+      label="Description (optional)"
+      multiline={true}
+      onChange={[Function]}
+      value=""
+    />
+    <div>
+      <div>
+        This run will be associated with the following experiment
+      </div>
+      <Component
+        disabled={true}
+        label="Experiment"
+        onChange={[Function]}
+        value="some mock experiment name"
+      />
+    </div>
+    <div
+      className="header"
+    >
+      Run parameters
+    </div>
+    <div>
+      Parameters will appear after you select a pipeline
+    </div>
+    <div
+      className="flex"
+    >
+      <BusyButton
+        busy={false}
+        className="buttonAction"
+        disabled={true}
+        id="createNewRunBtn"
+        onClick={[Function]}
+        title="Create"
+      />
+      <WithStyles(Button)
+        id="exitNewRunPageBtn"
+        onClick={[Function]}
+      >
+        Skip this step
+      </WithStyles(Button)>
+      <div
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+      >
+        A pipeline must be selected
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`NewRun creating a new recurring run includes additional trigger input fields if run will be recurring 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="scrollContainer"
+  >
+    <div
+      className="header"
+    >
+      Run details
+    </div>
+    <Component
+      InputProps={
+        Object {
+          "endAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <WithStyles(Button)
+              color="secondary"
+              id="choosePipelineBtn"
+              onClick={[Function]}
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": "3px 5px",
+                }
+              }
+            >
+              Choose
+            </WithStyles(Button)>
+          </WithStyles(InputAdornment)>,
+          "readOnly": true,
+        }
+      }
+      disabled={true}
+      label="Pipeline"
+      required={true}
+      value=""
+    />
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "pipelineSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "pipelineSelectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <PipelineSelector
+          history={
+            Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            }
+          }
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?recurring=1",
+            }
+          }
+          match=""
+          pipelineSelectionChanged={[Function]}
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={[MockFunction]}
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a recurring run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          id="cancelPipelineSelectionBtn"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={true}
+          id="usePipelineBtn"
+          onClick={[Function]}
+        >
+          Use this pipeline
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <Component
+      autoFocus={true}
+      label="Run name"
+      onChange={[Function]}
+      required={true}
+      value=""
+    />
+    <Component
+      label="Description (optional)"
+      multiline={true}
+      onChange={[Function]}
+      value=""
+    />
+    <div
+      className="header"
+    >
+      Run trigger
+    </div>
+    <Trigger
+      onChange={[Function]}
+    />
+    <div
+      className="header"
+    >
+      Run parameters
+    </div>
+    <div>
+      Parameters will appear after you select a pipeline
+    </div>
+    <div
+      className="flex"
+    >
+      <BusyButton
+        busy={false}
+        className="buttonAction"
+        disabled={true}
+        id="createNewRunBtn"
+        onClick={[Function]}
+        title="Create"
+      />
+      <WithStyles(Button)
+        id="exitNewRunPageBtn"
+        onClick={[Function]}
+      >
+        Cancel
+      </WithStyles(Button)>
+      <div
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+      >
+        A pipeline must be selected
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`NewRun fetches the associated pipeline if one is present in the query params 1`] = `
 <div
   className="page"
@@ -36,408 +467,9 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
         }
       }
       disabled={true}
-      field="pipelineName"
-      instance={
-        NewRun {
-          "_isMounted": true,
-          "context": Object {},
-          "handleChange": [Function],
-          "props": Object {
-            "history": Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            },
-            "location": Object {
-              "pathname": "/runs/new",
-              "search": "?pipelineId=some-mock-pipeline-id",
-            },
-            "match": "",
-            "toolbarProps": Object {
-              "actions": Array [],
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
-              ],
-            },
-            "updateBanner": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {},
-                ],
-              ],
-            },
-            "updateDialog": [MockFunction],
-            "updateSnackbar": [MockFunction],
-            "updateToolbar": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-              ],
-            },
-          },
-          "refs": Object {},
-          "setState": [Function],
-          "state": Object {
-            "description": "",
-            "errorMessage": "Run name is required",
-            "experiment": undefined,
-            "experimentName": undefined,
-            "isBeingCreated": false,
-            "isFirstRunInExperiment": false,
-            "isRecurringRun": false,
-            "pipeline": Object {
-              "id": "some-mock-pipeline-id",
-              "name": "some mock pipeline name",
-            },
-            "pipelineName": "some mock pipeline name",
-            "pipelineSelectorOpen": false,
-            "runName": "",
-            "unconfirmedDialogPipelineId": "",
-          },
-          "updater": Updater {
-            "_callbacks": Array [],
-            "_renderer": ReactShallowRenderer {
-              "_context": Object {},
-              "_element": <NewRun
-                history={
-                  Object {
-                    "push": [MockFunction],
-                    "replace": [MockFunction],
-                  }
-                }
-                location={
-                  Object {
-                    "pathname": "/runs/new",
-                    "search": "?pipelineId=some-mock-pipeline-id",
-                  }
-                }
-                match=""
-                toolbarProps={
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  }
-                }
-                updateBanner={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {},
-                      ],
-                    ],
-                  }
-                }
-                updateDialog={[MockFunction]}
-                updateSnackbar={[MockFunction]}
-                updateToolbar={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                    ],
-                  }
-                }
-              />,
-              "_forcedUpdate": false,
-              "_instance": [Circular],
-              "_newState": Object {
-                "description": "",
-                "errorMessage": "Run name is required",
-                "experiment": undefined,
-                "experimentName": undefined,
-                "isBeingCreated": false,
-                "isFirstRunInExperiment": false,
-                "isRecurringRun": false,
-                "pipeline": Object {
-                  "id": "some-mock-pipeline-id",
-                  "name": "some mock pipeline name",
-                },
-                "pipelineName": "some mock pipeline name",
-                "pipelineSelectorOpen": false,
-                "runName": "",
-                "unconfirmedDialogPipelineId": "",
-              },
-              "_rendered": <div
-                className="page"
-              >
-                <div
-                  className="scrollContainer"
-                >
-                  <div
-                    className="header"
-                  >
-                    Run details
-                  </div>
-                  <Unknown
-                    InputProps={
-                      Object {
-                        "endAdornment": <WithStyles(InputAdornment)
-                          position="end"
-                        >
-                          <WithStyles(Button)
-                            color="secondary"
-                            id="choosePipelineBtn"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "margin": 0,
-                                "padding": "3px 5px",
-                              }
-                            }
-                          >
-                            Choose
-                          </WithStyles(Button)>
-                        </WithStyles(InputAdornment)>,
-                        "readOnly": true,
-                      }
-                    }
-                    disabled={true}
-                    field="pipelineName"
-                    instance={[Circular]}
-                    label="Pipeline"
-                    required={true}
-                  />
-                  <WithStyles(Dialog)
-                    PaperProps={
-                      Object {
-                        "id": "pipelineSelectorDialog",
-                      }
-                    }
-                    classes={
-                      Object {
-                        "paper": "pipelineSelectorDialog",
-                      }
-                    }
-                    onClose={[Function]}
-                    open={false}
-                  >
-                    <WithStyles(DialogContent)>
-                      <PipelineSelector
-                        history={
-                          Object {
-                            "push": [MockFunction],
-                            "replace": [MockFunction],
-                          }
-                        }
-                        location={
-                          Object {
-                            "pathname": "/runs/new",
-                            "search": "?pipelineId=some-mock-pipeline-id",
-                          }
-                        }
-                        match=""
-                        pipelineSelectionChanged={[Function]}
-                        toolbarProps={
-                          Object {
-                            "actions": Array [],
-                            "breadcrumbs": Array [
-                              Object {
-                                "displayName": "Experiments",
-                                "href": "/experiments",
-                              },
-                              Object {
-                                "displayName": "Start a new run",
-                                "href": "",
-                              },
-                            ],
-                          }
-                        }
-                        updateBanner={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {},
-                              ],
-                            ],
-                          }
-                        }
-                        updateDialog={[MockFunction]}
-                        updateSnackbar={[MockFunction]}
-                        updateToolbar={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                            ],
-                          }
-                        }
-                      />
-                    </WithStyles(DialogContent)>
-                    <WithStyles(DialogActions)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        onClick={[Function]}
-                      >
-                        Cancel
-                      </WithStyles(Button)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        disabled={true}
-                        id="usePipelineBtn"
-                        onClick={[Function]}
-                      >
-                        Use this pipeline
-                      </WithStyles(Button)>
-                    </WithStyles(DialogActions)>
-                  </WithStyles(Dialog)>
-                  <Unknown
-                    autoFocus={true}
-                    field="runName"
-                    instance={[Circular]}
-                    label="Run name"
-                    required={true}
-                  />
-                  <Unknown
-                    field="description"
-                    height="auto"
-                    instance={[Circular]}
-                    label="Description (optional)"
-                    multiline={true}
-                  />
-                  <div
-                    className="header"
-                  >
-                    Run parameters
-                  </div>
-                  <div>
-                    This pipeline has no parameters
-                  </div>
-                  <div
-                    className="flex"
-                  >
-                    <BusyButton
-                      busy={false}
-                      className="buttonAction"
-                      disabled={true}
-                      id="createNewRunBtn"
-                      onClick={[Function]}
-                      title="Create"
-                    />
-                    <WithStyles(Button)
-                      onClick={[Function]}
-                    >
-                      Cancel
-                    </WithStyles(Button)>
-                    <div
-                      style={
-                        Object {
-                          "color": "red",
-                        }
-                      }
-                    >
-                      Run name is required
-                    </div>
-                  </div>
-                </div>
-              </div>,
-              "_rendering": false,
-              "_updater": [Circular],
-            },
-          },
-          Symbol(enzyme.__setState__): [Function],
-        }
-      }
       label="Pipeline"
       required={true}
+      value="some mock pipeline name"
     />
     <WithStyles(Dialog)
       PaperProps={
@@ -536,6 +568,7 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
       <WithStyles(DialogActions)>
         <WithStyles(Button)
           color="secondary"
+          id="cancelPipelineSelectionBtn"
           onClick={[Function]}
         >
           Cancel
@@ -552,813 +585,16 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
     </WithStyles(Dialog)>
     <Component
       autoFocus={true}
-      field="runName"
-      instance={
-        NewRun {
-          "_isMounted": true,
-          "context": Object {},
-          "handleChange": [Function],
-          "props": Object {
-            "history": Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            },
-            "location": Object {
-              "pathname": "/runs/new",
-              "search": "?pipelineId=some-mock-pipeline-id",
-            },
-            "match": "",
-            "toolbarProps": Object {
-              "actions": Array [],
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
-              ],
-            },
-            "updateBanner": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {},
-                ],
-              ],
-            },
-            "updateDialog": [MockFunction],
-            "updateSnackbar": [MockFunction],
-            "updateToolbar": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-              ],
-            },
-          },
-          "refs": Object {},
-          "setState": [Function],
-          "state": Object {
-            "description": "",
-            "errorMessage": "Run name is required",
-            "experiment": undefined,
-            "experimentName": undefined,
-            "isBeingCreated": false,
-            "isFirstRunInExperiment": false,
-            "isRecurringRun": false,
-            "pipeline": Object {
-              "id": "some-mock-pipeline-id",
-              "name": "some mock pipeline name",
-            },
-            "pipelineName": "some mock pipeline name",
-            "pipelineSelectorOpen": false,
-            "runName": "",
-            "unconfirmedDialogPipelineId": "",
-          },
-          "updater": Updater {
-            "_callbacks": Array [],
-            "_renderer": ReactShallowRenderer {
-              "_context": Object {},
-              "_element": <NewRun
-                history={
-                  Object {
-                    "push": [MockFunction],
-                    "replace": [MockFunction],
-                  }
-                }
-                location={
-                  Object {
-                    "pathname": "/runs/new",
-                    "search": "?pipelineId=some-mock-pipeline-id",
-                  }
-                }
-                match=""
-                toolbarProps={
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  }
-                }
-                updateBanner={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {},
-                      ],
-                    ],
-                  }
-                }
-                updateDialog={[MockFunction]}
-                updateSnackbar={[MockFunction]}
-                updateToolbar={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                    ],
-                  }
-                }
-              />,
-              "_forcedUpdate": false,
-              "_instance": [Circular],
-              "_newState": Object {
-                "description": "",
-                "errorMessage": "Run name is required",
-                "experiment": undefined,
-                "experimentName": undefined,
-                "isBeingCreated": false,
-                "isFirstRunInExperiment": false,
-                "isRecurringRun": false,
-                "pipeline": Object {
-                  "id": "some-mock-pipeline-id",
-                  "name": "some mock pipeline name",
-                },
-                "pipelineName": "some mock pipeline name",
-                "pipelineSelectorOpen": false,
-                "runName": "",
-                "unconfirmedDialogPipelineId": "",
-              },
-              "_rendered": <div
-                className="page"
-              >
-                <div
-                  className="scrollContainer"
-                >
-                  <div
-                    className="header"
-                  >
-                    Run details
-                  </div>
-                  <Unknown
-                    InputProps={
-                      Object {
-                        "endAdornment": <WithStyles(InputAdornment)
-                          position="end"
-                        >
-                          <WithStyles(Button)
-                            color="secondary"
-                            id="choosePipelineBtn"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "margin": 0,
-                                "padding": "3px 5px",
-                              }
-                            }
-                          >
-                            Choose
-                          </WithStyles(Button)>
-                        </WithStyles(InputAdornment)>,
-                        "readOnly": true,
-                      }
-                    }
-                    disabled={true}
-                    field="pipelineName"
-                    instance={[Circular]}
-                    label="Pipeline"
-                    required={true}
-                  />
-                  <WithStyles(Dialog)
-                    PaperProps={
-                      Object {
-                        "id": "pipelineSelectorDialog",
-                      }
-                    }
-                    classes={
-                      Object {
-                        "paper": "pipelineSelectorDialog",
-                      }
-                    }
-                    onClose={[Function]}
-                    open={false}
-                  >
-                    <WithStyles(DialogContent)>
-                      <PipelineSelector
-                        history={
-                          Object {
-                            "push": [MockFunction],
-                            "replace": [MockFunction],
-                          }
-                        }
-                        location={
-                          Object {
-                            "pathname": "/runs/new",
-                            "search": "?pipelineId=some-mock-pipeline-id",
-                          }
-                        }
-                        match=""
-                        pipelineSelectionChanged={[Function]}
-                        toolbarProps={
-                          Object {
-                            "actions": Array [],
-                            "breadcrumbs": Array [
-                              Object {
-                                "displayName": "Experiments",
-                                "href": "/experiments",
-                              },
-                              Object {
-                                "displayName": "Start a new run",
-                                "href": "",
-                              },
-                            ],
-                          }
-                        }
-                        updateBanner={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {},
-                              ],
-                            ],
-                          }
-                        }
-                        updateDialog={[MockFunction]}
-                        updateSnackbar={[MockFunction]}
-                        updateToolbar={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                            ],
-                          }
-                        }
-                      />
-                    </WithStyles(DialogContent)>
-                    <WithStyles(DialogActions)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        onClick={[Function]}
-                      >
-                        Cancel
-                      </WithStyles(Button)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        disabled={true}
-                        id="usePipelineBtn"
-                        onClick={[Function]}
-                      >
-                        Use this pipeline
-                      </WithStyles(Button)>
-                    </WithStyles(DialogActions)>
-                  </WithStyles(Dialog)>
-                  <Unknown
-                    autoFocus={true}
-                    field="runName"
-                    instance={[Circular]}
-                    label="Run name"
-                    required={true}
-                  />
-                  <Unknown
-                    field="description"
-                    height="auto"
-                    instance={[Circular]}
-                    label="Description (optional)"
-                    multiline={true}
-                  />
-                  <div
-                    className="header"
-                  >
-                    Run parameters
-                  </div>
-                  <div>
-                    This pipeline has no parameters
-                  </div>
-                  <div
-                    className="flex"
-                  >
-                    <BusyButton
-                      busy={false}
-                      className="buttonAction"
-                      disabled={true}
-                      id="createNewRunBtn"
-                      onClick={[Function]}
-                      title="Create"
-                    />
-                    <WithStyles(Button)
-                      onClick={[Function]}
-                    >
-                      Cancel
-                    </WithStyles(Button)>
-                    <div
-                      style={
-                        Object {
-                          "color": "red",
-                        }
-                      }
-                    >
-                      Run name is required
-                    </div>
-                  </div>
-                </div>
-              </div>,
-              "_rendering": false,
-              "_updater": [Circular],
-            },
-          },
-          Symbol(enzyme.__setState__): [Function],
-        }
-      }
       label="Run name"
+      onChange={[Function]}
       required={true}
+      value=""
     />
     <Component
-      field="description"
-      height="auto"
-      instance={
-        NewRun {
-          "_isMounted": true,
-          "context": Object {},
-          "handleChange": [Function],
-          "props": Object {
-            "history": Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            },
-            "location": Object {
-              "pathname": "/runs/new",
-              "search": "?pipelineId=some-mock-pipeline-id",
-            },
-            "match": "",
-            "toolbarProps": Object {
-              "actions": Array [],
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
-              ],
-            },
-            "updateBanner": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {},
-                ],
-              ],
-            },
-            "updateDialog": [MockFunction],
-            "updateSnackbar": [MockFunction],
-            "updateToolbar": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-              ],
-            },
-          },
-          "refs": Object {},
-          "setState": [Function],
-          "state": Object {
-            "description": "",
-            "errorMessage": "Run name is required",
-            "experiment": undefined,
-            "experimentName": undefined,
-            "isBeingCreated": false,
-            "isFirstRunInExperiment": false,
-            "isRecurringRun": false,
-            "pipeline": Object {
-              "id": "some-mock-pipeline-id",
-              "name": "some mock pipeline name",
-            },
-            "pipelineName": "some mock pipeline name",
-            "pipelineSelectorOpen": false,
-            "runName": "",
-            "unconfirmedDialogPipelineId": "",
-          },
-          "updater": Updater {
-            "_callbacks": Array [],
-            "_renderer": ReactShallowRenderer {
-              "_context": Object {},
-              "_element": <NewRun
-                history={
-                  Object {
-                    "push": [MockFunction],
-                    "replace": [MockFunction],
-                  }
-                }
-                location={
-                  Object {
-                    "pathname": "/runs/new",
-                    "search": "?pipelineId=some-mock-pipeline-id",
-                  }
-                }
-                match=""
-                toolbarProps={
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  }
-                }
-                updateBanner={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {},
-                      ],
-                    ],
-                  }
-                }
-                updateDialog={[MockFunction]}
-                updateSnackbar={[MockFunction]}
-                updateToolbar={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                    ],
-                  }
-                }
-              />,
-              "_forcedUpdate": false,
-              "_instance": [Circular],
-              "_newState": Object {
-                "description": "",
-                "errorMessage": "Run name is required",
-                "experiment": undefined,
-                "experimentName": undefined,
-                "isBeingCreated": false,
-                "isFirstRunInExperiment": false,
-                "isRecurringRun": false,
-                "pipeline": Object {
-                  "id": "some-mock-pipeline-id",
-                  "name": "some mock pipeline name",
-                },
-                "pipelineName": "some mock pipeline name",
-                "pipelineSelectorOpen": false,
-                "runName": "",
-                "unconfirmedDialogPipelineId": "",
-              },
-              "_rendered": <div
-                className="page"
-              >
-                <div
-                  className="scrollContainer"
-                >
-                  <div
-                    className="header"
-                  >
-                    Run details
-                  </div>
-                  <Unknown
-                    InputProps={
-                      Object {
-                        "endAdornment": <WithStyles(InputAdornment)
-                          position="end"
-                        >
-                          <WithStyles(Button)
-                            color="secondary"
-                            id="choosePipelineBtn"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "margin": 0,
-                                "padding": "3px 5px",
-                              }
-                            }
-                          >
-                            Choose
-                          </WithStyles(Button)>
-                        </WithStyles(InputAdornment)>,
-                        "readOnly": true,
-                      }
-                    }
-                    disabled={true}
-                    field="pipelineName"
-                    instance={[Circular]}
-                    label="Pipeline"
-                    required={true}
-                  />
-                  <WithStyles(Dialog)
-                    PaperProps={
-                      Object {
-                        "id": "pipelineSelectorDialog",
-                      }
-                    }
-                    classes={
-                      Object {
-                        "paper": "pipelineSelectorDialog",
-                      }
-                    }
-                    onClose={[Function]}
-                    open={false}
-                  >
-                    <WithStyles(DialogContent)>
-                      <PipelineSelector
-                        history={
-                          Object {
-                            "push": [MockFunction],
-                            "replace": [MockFunction],
-                          }
-                        }
-                        location={
-                          Object {
-                            "pathname": "/runs/new",
-                            "search": "?pipelineId=some-mock-pipeline-id",
-                          }
-                        }
-                        match=""
-                        pipelineSelectionChanged={[Function]}
-                        toolbarProps={
-                          Object {
-                            "actions": Array [],
-                            "breadcrumbs": Array [
-                              Object {
-                                "displayName": "Experiments",
-                                "href": "/experiments",
-                              },
-                              Object {
-                                "displayName": "Start a new run",
-                                "href": "",
-                              },
-                            ],
-                          }
-                        }
-                        updateBanner={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {},
-                              ],
-                            ],
-                          }
-                        }
-                        updateDialog={[MockFunction]}
-                        updateSnackbar={[MockFunction]}
-                        updateToolbar={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                            ],
-                          }
-                        }
-                      />
-                    </WithStyles(DialogContent)>
-                    <WithStyles(DialogActions)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        onClick={[Function]}
-                      >
-                        Cancel
-                      </WithStyles(Button)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        disabled={true}
-                        id="usePipelineBtn"
-                        onClick={[Function]}
-                      >
-                        Use this pipeline
-                      </WithStyles(Button)>
-                    </WithStyles(DialogActions)>
-                  </WithStyles(Dialog)>
-                  <Unknown
-                    autoFocus={true}
-                    field="runName"
-                    instance={[Circular]}
-                    label="Run name"
-                    required={true}
-                  />
-                  <Unknown
-                    field="description"
-                    height="auto"
-                    instance={[Circular]}
-                    label="Description (optional)"
-                    multiline={true}
-                  />
-                  <div
-                    className="header"
-                  >
-                    Run parameters
-                  </div>
-                  <div>
-                    This pipeline has no parameters
-                  </div>
-                  <div
-                    className="flex"
-                  >
-                    <BusyButton
-                      busy={false}
-                      className="buttonAction"
-                      disabled={true}
-                      id="createNewRunBtn"
-                      onClick={[Function]}
-                      title="Create"
-                    />
-                    <WithStyles(Button)
-                      onClick={[Function]}
-                    >
-                      Cancel
-                    </WithStyles(Button)>
-                    <div
-                      style={
-                        Object {
-                          "color": "red",
-                        }
-                      }
-                    >
-                      Run name is required
-                    </div>
-                  </div>
-                </div>
-              </div>,
-              "_rendering": false,
-              "_updater": [Circular],
-            },
-          },
-          Symbol(enzyme.__setState__): [Function],
-        }
-      }
       label="Description (optional)"
       multiline={true}
+      onChange={[Function]}
+      value=""
     />
     <div
       className="header"
@@ -1380,6 +616,7 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
         title="Create"
       />
       <WithStyles(Button)
+        id="exitNewRunPageBtn"
         onClick={[Function]}
       >
         Cancel
@@ -1434,397 +671,9 @@ exports[`NewRun renders the new run page 1`] = `
         }
       }
       disabled={true}
-      field="pipelineName"
-      instance={
-        NewRun {
-          "_isMounted": true,
-          "context": Object {},
-          "handleChange": [Function],
-          "props": Object {
-            "history": Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            },
-            "location": Object {
-              "pathname": "/runs/new",
-            },
-            "match": "",
-            "toolbarProps": Object {
-              "actions": Array [],
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
-              ],
-            },
-            "updateBanner": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {},
-                ],
-              ],
-            },
-            "updateDialog": [MockFunction],
-            "updateSnackbar": [MockFunction],
-            "updateToolbar": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-              ],
-            },
-          },
-          "refs": Object {},
-          "setState": [Function],
-          "state": Object {
-            "description": "",
-            "errorMessage": "A pipeline must be selected",
-            "experiment": undefined,
-            "experimentName": undefined,
-            "isBeingCreated": false,
-            "isFirstRunInExperiment": false,
-            "isRecurringRun": false,
-            "pipelineName": "",
-            "pipelineSelectorOpen": false,
-            "runName": "",
-            "unconfirmedDialogPipelineId": "",
-          },
-          "updater": Updater {
-            "_callbacks": Array [],
-            "_renderer": ReactShallowRenderer {
-              "_context": Object {},
-              "_element": <NewRun
-                history={
-                  Object {
-                    "push": [MockFunction],
-                    "replace": [MockFunction],
-                  }
-                }
-                location={
-                  Object {
-                    "pathname": "/runs/new",
-                  }
-                }
-                match=""
-                toolbarProps={
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  }
-                }
-                updateBanner={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {},
-                      ],
-                    ],
-                  }
-                }
-                updateDialog={[MockFunction]}
-                updateSnackbar={[MockFunction]}
-                updateToolbar={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                    ],
-                  }
-                }
-              />,
-              "_forcedUpdate": false,
-              "_instance": [Circular],
-              "_newState": Object {
-                "description": "",
-                "errorMessage": "A pipeline must be selected",
-                "experiment": undefined,
-                "experimentName": undefined,
-                "isBeingCreated": false,
-                "isFirstRunInExperiment": false,
-                "isRecurringRun": false,
-                "pipelineName": "",
-                "pipelineSelectorOpen": false,
-                "runName": "",
-                "unconfirmedDialogPipelineId": "",
-              },
-              "_rendered": <div
-                className="page"
-              >
-                <div
-                  className="scrollContainer"
-                >
-                  <div
-                    className="header"
-                  >
-                    Run details
-                  </div>
-                  <Unknown
-                    InputProps={
-                      Object {
-                        "endAdornment": <WithStyles(InputAdornment)
-                          position="end"
-                        >
-                          <WithStyles(Button)
-                            color="secondary"
-                            id="choosePipelineBtn"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "margin": 0,
-                                "padding": "3px 5px",
-                              }
-                            }
-                          >
-                            Choose
-                          </WithStyles(Button)>
-                        </WithStyles(InputAdornment)>,
-                        "readOnly": true,
-                      }
-                    }
-                    disabled={true}
-                    field="pipelineName"
-                    instance={[Circular]}
-                    label="Pipeline"
-                    required={true}
-                  />
-                  <WithStyles(Dialog)
-                    PaperProps={
-                      Object {
-                        "id": "pipelineSelectorDialog",
-                      }
-                    }
-                    classes={
-                      Object {
-                        "paper": "pipelineSelectorDialog",
-                      }
-                    }
-                    onClose={[Function]}
-                    open={false}
-                  >
-                    <WithStyles(DialogContent)>
-                      <PipelineSelector
-                        history={
-                          Object {
-                            "push": [MockFunction],
-                            "replace": [MockFunction],
-                          }
-                        }
-                        location={
-                          Object {
-                            "pathname": "/runs/new",
-                          }
-                        }
-                        match=""
-                        pipelineSelectionChanged={[Function]}
-                        toolbarProps={
-                          Object {
-                            "actions": Array [],
-                            "breadcrumbs": Array [
-                              Object {
-                                "displayName": "Experiments",
-                                "href": "/experiments",
-                              },
-                              Object {
-                                "displayName": "Start a new run",
-                                "href": "",
-                              },
-                            ],
-                          }
-                        }
-                        updateBanner={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {},
-                              ],
-                            ],
-                          }
-                        }
-                        updateDialog={[MockFunction]}
-                        updateSnackbar={[MockFunction]}
-                        updateToolbar={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                            ],
-                          }
-                        }
-                      />
-                    </WithStyles(DialogContent)>
-                    <WithStyles(DialogActions)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        onClick={[Function]}
-                      >
-                        Cancel
-                      </WithStyles(Button)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        disabled={true}
-                        id="usePipelineBtn"
-                        onClick={[Function]}
-                      >
-                        Use this pipeline
-                      </WithStyles(Button)>
-                    </WithStyles(DialogActions)>
-                  </WithStyles(Dialog)>
-                  <Unknown
-                    autoFocus={true}
-                    field="runName"
-                    instance={[Circular]}
-                    label="Run name"
-                    required={true}
-                  />
-                  <Unknown
-                    field="description"
-                    height="auto"
-                    instance={[Circular]}
-                    label="Description (optional)"
-                    multiline={true}
-                  />
-                  <div
-                    className="header"
-                  >
-                    Run parameters
-                  </div>
-                  <div>
-                    Parameters will appear after you select a pipeline
-                  </div>
-                  <div
-                    className="flex"
-                  >
-                    <BusyButton
-                      busy={false}
-                      className="buttonAction"
-                      disabled={true}
-                      id="createNewRunBtn"
-                      onClick={[Function]}
-                      title="Create"
-                    />
-                    <WithStyles(Button)
-                      onClick={[Function]}
-                    >
-                      Cancel
-                    </WithStyles(Button)>
-                    <div
-                      style={
-                        Object {
-                          "color": "red",
-                        }
-                      }
-                    >
-                      A pipeline must be selected
-                    </div>
-                  </div>
-                </div>
-              </div>,
-              "_rendering": false,
-              "_updater": [Circular],
-            },
-          },
-          Symbol(enzyme.__setState__): [Function],
-        }
-      }
       label="Pipeline"
       required={true}
+      value=""
     />
     <WithStyles(Dialog)
       PaperProps={
@@ -1851,6 +700,7 @@ exports[`NewRun renders the new run page 1`] = `
           location={
             Object {
               "pathname": "/runs/new",
+              "search": "?experimentId=some-mock-experiment-id",
             }
           }
           match=""
@@ -1908,6 +758,10 @@ exports[`NewRun renders the new run page 1`] = `
                         "href": "/experiments",
                       },
                       Object {
+                        "displayName": "some mock experiment name",
+                        "href": "/experiments/details/some-mock-experiment-id",
+                      },
+                      Object {
                         "displayName": "Start a new run",
                         "href": "",
                       },
@@ -1922,6 +776,7 @@ exports[`NewRun renders the new run page 1`] = `
       <WithStyles(DialogActions)>
         <WithStyles(Button)
           color="secondary"
+          id="cancelPipelineSelectionBtn"
           onClick={[Function]}
         >
           Cancel
@@ -1938,792 +793,28 @@ exports[`NewRun renders the new run page 1`] = `
     </WithStyles(Dialog)>
     <Component
       autoFocus={true}
-      field="runName"
-      instance={
-        NewRun {
-          "_isMounted": true,
-          "context": Object {},
-          "handleChange": [Function],
-          "props": Object {
-            "history": Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            },
-            "location": Object {
-              "pathname": "/runs/new",
-            },
-            "match": "",
-            "toolbarProps": Object {
-              "actions": Array [],
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
-              ],
-            },
-            "updateBanner": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {},
-                ],
-              ],
-            },
-            "updateDialog": [MockFunction],
-            "updateSnackbar": [MockFunction],
-            "updateToolbar": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-              ],
-            },
-          },
-          "refs": Object {},
-          "setState": [Function],
-          "state": Object {
-            "description": "",
-            "errorMessage": "A pipeline must be selected",
-            "experiment": undefined,
-            "experimentName": undefined,
-            "isBeingCreated": false,
-            "isFirstRunInExperiment": false,
-            "isRecurringRun": false,
-            "pipelineName": "",
-            "pipelineSelectorOpen": false,
-            "runName": "",
-            "unconfirmedDialogPipelineId": "",
-          },
-          "updater": Updater {
-            "_callbacks": Array [],
-            "_renderer": ReactShallowRenderer {
-              "_context": Object {},
-              "_element": <NewRun
-                history={
-                  Object {
-                    "push": [MockFunction],
-                    "replace": [MockFunction],
-                  }
-                }
-                location={
-                  Object {
-                    "pathname": "/runs/new",
-                  }
-                }
-                match=""
-                toolbarProps={
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  }
-                }
-                updateBanner={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {},
-                      ],
-                    ],
-                  }
-                }
-                updateDialog={[MockFunction]}
-                updateSnackbar={[MockFunction]}
-                updateToolbar={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                    ],
-                  }
-                }
-              />,
-              "_forcedUpdate": false,
-              "_instance": [Circular],
-              "_newState": Object {
-                "description": "",
-                "errorMessage": "A pipeline must be selected",
-                "experiment": undefined,
-                "experimentName": undefined,
-                "isBeingCreated": false,
-                "isFirstRunInExperiment": false,
-                "isRecurringRun": false,
-                "pipelineName": "",
-                "pipelineSelectorOpen": false,
-                "runName": "",
-                "unconfirmedDialogPipelineId": "",
-              },
-              "_rendered": <div
-                className="page"
-              >
-                <div
-                  className="scrollContainer"
-                >
-                  <div
-                    className="header"
-                  >
-                    Run details
-                  </div>
-                  <Unknown
-                    InputProps={
-                      Object {
-                        "endAdornment": <WithStyles(InputAdornment)
-                          position="end"
-                        >
-                          <WithStyles(Button)
-                            color="secondary"
-                            id="choosePipelineBtn"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "margin": 0,
-                                "padding": "3px 5px",
-                              }
-                            }
-                          >
-                            Choose
-                          </WithStyles(Button)>
-                        </WithStyles(InputAdornment)>,
-                        "readOnly": true,
-                      }
-                    }
-                    disabled={true}
-                    field="pipelineName"
-                    instance={[Circular]}
-                    label="Pipeline"
-                    required={true}
-                  />
-                  <WithStyles(Dialog)
-                    PaperProps={
-                      Object {
-                        "id": "pipelineSelectorDialog",
-                      }
-                    }
-                    classes={
-                      Object {
-                        "paper": "pipelineSelectorDialog",
-                      }
-                    }
-                    onClose={[Function]}
-                    open={false}
-                  >
-                    <WithStyles(DialogContent)>
-                      <PipelineSelector
-                        history={
-                          Object {
-                            "push": [MockFunction],
-                            "replace": [MockFunction],
-                          }
-                        }
-                        location={
-                          Object {
-                            "pathname": "/runs/new",
-                          }
-                        }
-                        match=""
-                        pipelineSelectionChanged={[Function]}
-                        toolbarProps={
-                          Object {
-                            "actions": Array [],
-                            "breadcrumbs": Array [
-                              Object {
-                                "displayName": "Experiments",
-                                "href": "/experiments",
-                              },
-                              Object {
-                                "displayName": "Start a new run",
-                                "href": "",
-                              },
-                            ],
-                          }
-                        }
-                        updateBanner={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {},
-                              ],
-                            ],
-                          }
-                        }
-                        updateDialog={[MockFunction]}
-                        updateSnackbar={[MockFunction]}
-                        updateToolbar={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                            ],
-                          }
-                        }
-                      />
-                    </WithStyles(DialogContent)>
-                    <WithStyles(DialogActions)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        onClick={[Function]}
-                      >
-                        Cancel
-                      </WithStyles(Button)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        disabled={true}
-                        id="usePipelineBtn"
-                        onClick={[Function]}
-                      >
-                        Use this pipeline
-                      </WithStyles(Button)>
-                    </WithStyles(DialogActions)>
-                  </WithStyles(Dialog)>
-                  <Unknown
-                    autoFocus={true}
-                    field="runName"
-                    instance={[Circular]}
-                    label="Run name"
-                    required={true}
-                  />
-                  <Unknown
-                    field="description"
-                    height="auto"
-                    instance={[Circular]}
-                    label="Description (optional)"
-                    multiline={true}
-                  />
-                  <div
-                    className="header"
-                  >
-                    Run parameters
-                  </div>
-                  <div>
-                    Parameters will appear after you select a pipeline
-                  </div>
-                  <div
-                    className="flex"
-                  >
-                    <BusyButton
-                      busy={false}
-                      className="buttonAction"
-                      disabled={true}
-                      id="createNewRunBtn"
-                      onClick={[Function]}
-                      title="Create"
-                    />
-                    <WithStyles(Button)
-                      onClick={[Function]}
-                    >
-                      Cancel
-                    </WithStyles(Button)>
-                    <div
-                      style={
-                        Object {
-                          "color": "red",
-                        }
-                      }
-                    >
-                      A pipeline must be selected
-                    </div>
-                  </div>
-                </div>
-              </div>,
-              "_rendering": false,
-              "_updater": [Circular],
-            },
-          },
-          Symbol(enzyme.__setState__): [Function],
-        }
-      }
       label="Run name"
+      onChange={[Function]}
       required={true}
+      value=""
     />
     <Component
-      field="description"
-      height="auto"
-      instance={
-        NewRun {
-          "_isMounted": true,
-          "context": Object {},
-          "handleChange": [Function],
-          "props": Object {
-            "history": Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            },
-            "location": Object {
-              "pathname": "/runs/new",
-            },
-            "match": "",
-            "toolbarProps": Object {
-              "actions": Array [],
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
-              ],
-            },
-            "updateBanner": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {},
-                ],
-              ],
-            },
-            "updateDialog": [MockFunction],
-            "updateSnackbar": [MockFunction],
-            "updateToolbar": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-              ],
-            },
-          },
-          "refs": Object {},
-          "setState": [Function],
-          "state": Object {
-            "description": "",
-            "errorMessage": "A pipeline must be selected",
-            "experiment": undefined,
-            "experimentName": undefined,
-            "isBeingCreated": false,
-            "isFirstRunInExperiment": false,
-            "isRecurringRun": false,
-            "pipelineName": "",
-            "pipelineSelectorOpen": false,
-            "runName": "",
-            "unconfirmedDialogPipelineId": "",
-          },
-          "updater": Updater {
-            "_callbacks": Array [],
-            "_renderer": ReactShallowRenderer {
-              "_context": Object {},
-              "_element": <NewRun
-                history={
-                  Object {
-                    "push": [MockFunction],
-                    "replace": [MockFunction],
-                  }
-                }
-                location={
-                  Object {
-                    "pathname": "/runs/new",
-                  }
-                }
-                match=""
-                toolbarProps={
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  }
-                }
-                updateBanner={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {},
-                      ],
-                    ],
-                  }
-                }
-                updateDialog={[MockFunction]}
-                updateSnackbar={[MockFunction]}
-                updateToolbar={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                    ],
-                  }
-                }
-              />,
-              "_forcedUpdate": false,
-              "_instance": [Circular],
-              "_newState": Object {
-                "description": "",
-                "errorMessage": "A pipeline must be selected",
-                "experiment": undefined,
-                "experimentName": undefined,
-                "isBeingCreated": false,
-                "isFirstRunInExperiment": false,
-                "isRecurringRun": false,
-                "pipelineName": "",
-                "pipelineSelectorOpen": false,
-                "runName": "",
-                "unconfirmedDialogPipelineId": "",
-              },
-              "_rendered": <div
-                className="page"
-              >
-                <div
-                  className="scrollContainer"
-                >
-                  <div
-                    className="header"
-                  >
-                    Run details
-                  </div>
-                  <Unknown
-                    InputProps={
-                      Object {
-                        "endAdornment": <WithStyles(InputAdornment)
-                          position="end"
-                        >
-                          <WithStyles(Button)
-                            color="secondary"
-                            id="choosePipelineBtn"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "margin": 0,
-                                "padding": "3px 5px",
-                              }
-                            }
-                          >
-                            Choose
-                          </WithStyles(Button)>
-                        </WithStyles(InputAdornment)>,
-                        "readOnly": true,
-                      }
-                    }
-                    disabled={true}
-                    field="pipelineName"
-                    instance={[Circular]}
-                    label="Pipeline"
-                    required={true}
-                  />
-                  <WithStyles(Dialog)
-                    PaperProps={
-                      Object {
-                        "id": "pipelineSelectorDialog",
-                      }
-                    }
-                    classes={
-                      Object {
-                        "paper": "pipelineSelectorDialog",
-                      }
-                    }
-                    onClose={[Function]}
-                    open={false}
-                  >
-                    <WithStyles(DialogContent)>
-                      <PipelineSelector
-                        history={
-                          Object {
-                            "push": [MockFunction],
-                            "replace": [MockFunction],
-                          }
-                        }
-                        location={
-                          Object {
-                            "pathname": "/runs/new",
-                          }
-                        }
-                        match=""
-                        pipelineSelectionChanged={[Function]}
-                        toolbarProps={
-                          Object {
-                            "actions": Array [],
-                            "breadcrumbs": Array [
-                              Object {
-                                "displayName": "Experiments",
-                                "href": "/experiments",
-                              },
-                              Object {
-                                "displayName": "Start a new run",
-                                "href": "",
-                              },
-                            ],
-                          }
-                        }
-                        updateBanner={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {},
-                              ],
-                            ],
-                          }
-                        }
-                        updateDialog={[MockFunction]}
-                        updateSnackbar={[MockFunction]}
-                        updateToolbar={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                            ],
-                          }
-                        }
-                      />
-                    </WithStyles(DialogContent)>
-                    <WithStyles(DialogActions)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        onClick={[Function]}
-                      >
-                        Cancel
-                      </WithStyles(Button)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        disabled={true}
-                        id="usePipelineBtn"
-                        onClick={[Function]}
-                      >
-                        Use this pipeline
-                      </WithStyles(Button)>
-                    </WithStyles(DialogActions)>
-                  </WithStyles(Dialog)>
-                  <Unknown
-                    autoFocus={true}
-                    field="runName"
-                    instance={[Circular]}
-                    label="Run name"
-                    required={true}
-                  />
-                  <Unknown
-                    field="description"
-                    height="auto"
-                    instance={[Circular]}
-                    label="Description (optional)"
-                    multiline={true}
-                  />
-                  <div
-                    className="header"
-                  >
-                    Run parameters
-                  </div>
-                  <div>
-                    Parameters will appear after you select a pipeline
-                  </div>
-                  <div
-                    className="flex"
-                  >
-                    <BusyButton
-                      busy={false}
-                      className="buttonAction"
-                      disabled={true}
-                      id="createNewRunBtn"
-                      onClick={[Function]}
-                      title="Create"
-                    />
-                    <WithStyles(Button)
-                      onClick={[Function]}
-                    >
-                      Cancel
-                    </WithStyles(Button)>
-                    <div
-                      style={
-                        Object {
-                          "color": "red",
-                        }
-                      }
-                    >
-                      A pipeline must be selected
-                    </div>
-                  </div>
-                </div>
-              </div>,
-              "_rendering": false,
-              "_updater": [Circular],
-            },
-          },
-          Symbol(enzyme.__setState__): [Function],
-        }
-      }
       label="Description (optional)"
       multiline={true}
+      onChange={[Function]}
+      value=""
     />
+    <div>
+      <div>
+        This run will be associated with the following experiment
+      </div>
+      <Component
+        disabled={true}
+        label="Experiment"
+        onChange={[Function]}
+        value="some mock experiment name"
+      />
+    </div>
     <div
       className="header"
     >
@@ -2744,6 +835,7 @@ exports[`NewRun renders the new run page 1`] = `
         title="Create"
       />
       <WithStyles(Button)
+        id="exitNewRunPageBtn"
         onClick={[Function]}
       >
         Cancel
@@ -2798,431 +890,9 @@ exports[`NewRun updates the run's state with the associated experiment if one is
         }
       }
       disabled={true}
-      field="pipelineName"
-      instance={
-        NewRun {
-          "_isMounted": true,
-          "context": Object {},
-          "handleChange": [Function],
-          "props": Object {
-            "history": Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            },
-            "location": Object {
-              "pathname": "/runs/new",
-              "search": "?experimentId=some-mock-experiment-id",
-            },
-            "match": "",
-            "toolbarProps": Object {
-              "actions": Array [],
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
-              ],
-            },
-            "updateBanner": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {},
-                ],
-              ],
-            },
-            "updateDialog": [MockFunction],
-            "updateSnackbar": [MockFunction],
-            "updateToolbar": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "some mock experiment name",
-                        "href": "/experiments/details/some-mock-experiment-id",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-              ],
-            },
-          },
-          "refs": Object {},
-          "setState": [Function],
-          "state": Object {
-            "description": "",
-            "errorMessage": "A pipeline must be selected",
-            "experiment": Object {
-              "description": "mock experiment description",
-              "id": "some-mock-experiment-id",
-              "name": "some mock experiment name",
-            },
-            "experimentName": "some mock experiment name",
-            "isBeingCreated": false,
-            "isFirstRunInExperiment": false,
-            "isRecurringRun": false,
-            "pipelineName": "",
-            "pipelineSelectorOpen": false,
-            "runName": "",
-            "unconfirmedDialogPipelineId": "",
-          },
-          "updater": Updater {
-            "_callbacks": Array [],
-            "_renderer": ReactShallowRenderer {
-              "_context": Object {},
-              "_element": <NewRun
-                history={
-                  Object {
-                    "push": [MockFunction],
-                    "replace": [MockFunction],
-                  }
-                }
-                location={
-                  Object {
-                    "pathname": "/runs/new",
-                    "search": "?experimentId=some-mock-experiment-id",
-                  }
-                }
-                match=""
-                toolbarProps={
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  }
-                }
-                updateBanner={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {},
-                      ],
-                    ],
-                  }
-                }
-                updateDialog={[MockFunction]}
-                updateSnackbar={[MockFunction]}
-                updateToolbar={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "some mock experiment name",
-                              "href": "/experiments/details/some-mock-experiment-id",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                    ],
-                  }
-                }
-              />,
-              "_forcedUpdate": false,
-              "_instance": [Circular],
-              "_newState": Object {
-                "description": "",
-                "errorMessage": "A pipeline must be selected",
-                "experiment": Object {
-                  "description": "mock experiment description",
-                  "id": "some-mock-experiment-id",
-                  "name": "some mock experiment name",
-                },
-                "experimentName": "some mock experiment name",
-                "isBeingCreated": false,
-                "isFirstRunInExperiment": false,
-                "isRecurringRun": false,
-                "pipelineName": "",
-                "pipelineSelectorOpen": false,
-                "runName": "",
-                "unconfirmedDialogPipelineId": "",
-              },
-              "_rendered": <div
-                className="page"
-              >
-                <div
-                  className="scrollContainer"
-                >
-                  <div
-                    className="header"
-                  >
-                    Run details
-                  </div>
-                  <Unknown
-                    InputProps={
-                      Object {
-                        "endAdornment": <WithStyles(InputAdornment)
-                          position="end"
-                        >
-                          <WithStyles(Button)
-                            color="secondary"
-                            id="choosePipelineBtn"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "margin": 0,
-                                "padding": "3px 5px",
-                              }
-                            }
-                          >
-                            Choose
-                          </WithStyles(Button)>
-                        </WithStyles(InputAdornment)>,
-                        "readOnly": true,
-                      }
-                    }
-                    disabled={true}
-                    field="pipelineName"
-                    instance={[Circular]}
-                    label="Pipeline"
-                    required={true}
-                  />
-                  <WithStyles(Dialog)
-                    PaperProps={
-                      Object {
-                        "id": "pipelineSelectorDialog",
-                      }
-                    }
-                    classes={
-                      Object {
-                        "paper": "pipelineSelectorDialog",
-                      }
-                    }
-                    onClose={[Function]}
-                    open={false}
-                  >
-                    <WithStyles(DialogContent)>
-                      <PipelineSelector
-                        history={
-                          Object {
-                            "push": [MockFunction],
-                            "replace": [MockFunction],
-                          }
-                        }
-                        location={
-                          Object {
-                            "pathname": "/runs/new",
-                            "search": "?experimentId=some-mock-experiment-id",
-                          }
-                        }
-                        match=""
-                        pipelineSelectionChanged={[Function]}
-                        toolbarProps={
-                          Object {
-                            "actions": Array [],
-                            "breadcrumbs": Array [
-                              Object {
-                                "displayName": "Experiments",
-                                "href": "/experiments",
-                              },
-                              Object {
-                                "displayName": "Start a new run",
-                                "href": "",
-                              },
-                            ],
-                          }
-                        }
-                        updateBanner={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {},
-                              ],
-                            ],
-                          }
-                        }
-                        updateDialog={[MockFunction]}
-                        updateSnackbar={[MockFunction]}
-                        updateToolbar={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "some mock experiment name",
-                                      "href": "/experiments/details/some-mock-experiment-id",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                            ],
-                          }
-                        }
-                      />
-                    </WithStyles(DialogContent)>
-                    <WithStyles(DialogActions)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        onClick={[Function]}
-                      >
-                        Cancel
-                      </WithStyles(Button)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        disabled={true}
-                        id="usePipelineBtn"
-                        onClick={[Function]}
-                      >
-                        Use this pipeline
-                      </WithStyles(Button)>
-                    </WithStyles(DialogActions)>
-                  </WithStyles(Dialog)>
-                  <Unknown
-                    autoFocus={true}
-                    field="runName"
-                    instance={[Circular]}
-                    label="Run name"
-                    required={true}
-                  />
-                  <Unknown
-                    field="description"
-                    height="auto"
-                    instance={[Circular]}
-                    label="Description (optional)"
-                    multiline={true}
-                  />
-                  <div>
-                    <div>
-                      This run will be associated with the following experiment
-                    </div>
-                    <Unknown
-                      disabled={true}
-                      field="experimentName"
-                      instance={[Circular]}
-                      label="Experiment"
-                    />
-                  </div>
-                  <div
-                    className="header"
-                  >
-                    Run parameters
-                  </div>
-                  <div>
-                    Parameters will appear after you select a pipeline
-                  </div>
-                  <div
-                    className="flex"
-                  >
-                    <BusyButton
-                      busy={false}
-                      className="buttonAction"
-                      disabled={true}
-                      id="createNewRunBtn"
-                      onClick={[Function]}
-                      title="Create"
-                    />
-                    <WithStyles(Button)
-                      onClick={[Function]}
-                    >
-                      Cancel
-                    </WithStyles(Button)>
-                    <div
-                      style={
-                        Object {
-                          "color": "red",
-                        }
-                      }
-                    >
-                      A pipeline must be selected
-                    </div>
-                  </div>
-                </div>
-              </div>,
-              "_rendering": false,
-              "_updater": [Circular],
-            },
-          },
-          Symbol(enzyme.__setState__): [Function],
-        }
-      }
       label="Pipeline"
       required={true}
+      value=""
     />
     <WithStyles(Dialog)
       PaperProps={
@@ -3325,6 +995,7 @@ exports[`NewRun updates the run's state with the associated experiment if one is
       <WithStyles(DialogActions)>
         <WithStyles(Button)
           color="secondary"
+          id="cancelPipelineSelectionBtn"
           onClick={[Function]}
         >
           Cancel
@@ -3341,859 +1012,16 @@ exports[`NewRun updates the run's state with the associated experiment if one is
     </WithStyles(Dialog)>
     <Component
       autoFocus={true}
-      field="runName"
-      instance={
-        NewRun {
-          "_isMounted": true,
-          "context": Object {},
-          "handleChange": [Function],
-          "props": Object {
-            "history": Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            },
-            "location": Object {
-              "pathname": "/runs/new",
-              "search": "?experimentId=some-mock-experiment-id",
-            },
-            "match": "",
-            "toolbarProps": Object {
-              "actions": Array [],
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
-              ],
-            },
-            "updateBanner": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {},
-                ],
-              ],
-            },
-            "updateDialog": [MockFunction],
-            "updateSnackbar": [MockFunction],
-            "updateToolbar": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "some mock experiment name",
-                        "href": "/experiments/details/some-mock-experiment-id",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-              ],
-            },
-          },
-          "refs": Object {},
-          "setState": [Function],
-          "state": Object {
-            "description": "",
-            "errorMessage": "A pipeline must be selected",
-            "experiment": Object {
-              "description": "mock experiment description",
-              "id": "some-mock-experiment-id",
-              "name": "some mock experiment name",
-            },
-            "experimentName": "some mock experiment name",
-            "isBeingCreated": false,
-            "isFirstRunInExperiment": false,
-            "isRecurringRun": false,
-            "pipelineName": "",
-            "pipelineSelectorOpen": false,
-            "runName": "",
-            "unconfirmedDialogPipelineId": "",
-          },
-          "updater": Updater {
-            "_callbacks": Array [],
-            "_renderer": ReactShallowRenderer {
-              "_context": Object {},
-              "_element": <NewRun
-                history={
-                  Object {
-                    "push": [MockFunction],
-                    "replace": [MockFunction],
-                  }
-                }
-                location={
-                  Object {
-                    "pathname": "/runs/new",
-                    "search": "?experimentId=some-mock-experiment-id",
-                  }
-                }
-                match=""
-                toolbarProps={
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  }
-                }
-                updateBanner={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {},
-                      ],
-                    ],
-                  }
-                }
-                updateDialog={[MockFunction]}
-                updateSnackbar={[MockFunction]}
-                updateToolbar={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "some mock experiment name",
-                              "href": "/experiments/details/some-mock-experiment-id",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                    ],
-                  }
-                }
-              />,
-              "_forcedUpdate": false,
-              "_instance": [Circular],
-              "_newState": Object {
-                "description": "",
-                "errorMessage": "A pipeline must be selected",
-                "experiment": Object {
-                  "description": "mock experiment description",
-                  "id": "some-mock-experiment-id",
-                  "name": "some mock experiment name",
-                },
-                "experimentName": "some mock experiment name",
-                "isBeingCreated": false,
-                "isFirstRunInExperiment": false,
-                "isRecurringRun": false,
-                "pipelineName": "",
-                "pipelineSelectorOpen": false,
-                "runName": "",
-                "unconfirmedDialogPipelineId": "",
-              },
-              "_rendered": <div
-                className="page"
-              >
-                <div
-                  className="scrollContainer"
-                >
-                  <div
-                    className="header"
-                  >
-                    Run details
-                  </div>
-                  <Unknown
-                    InputProps={
-                      Object {
-                        "endAdornment": <WithStyles(InputAdornment)
-                          position="end"
-                        >
-                          <WithStyles(Button)
-                            color="secondary"
-                            id="choosePipelineBtn"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "margin": 0,
-                                "padding": "3px 5px",
-                              }
-                            }
-                          >
-                            Choose
-                          </WithStyles(Button)>
-                        </WithStyles(InputAdornment)>,
-                        "readOnly": true,
-                      }
-                    }
-                    disabled={true}
-                    field="pipelineName"
-                    instance={[Circular]}
-                    label="Pipeline"
-                    required={true}
-                  />
-                  <WithStyles(Dialog)
-                    PaperProps={
-                      Object {
-                        "id": "pipelineSelectorDialog",
-                      }
-                    }
-                    classes={
-                      Object {
-                        "paper": "pipelineSelectorDialog",
-                      }
-                    }
-                    onClose={[Function]}
-                    open={false}
-                  >
-                    <WithStyles(DialogContent)>
-                      <PipelineSelector
-                        history={
-                          Object {
-                            "push": [MockFunction],
-                            "replace": [MockFunction],
-                          }
-                        }
-                        location={
-                          Object {
-                            "pathname": "/runs/new",
-                            "search": "?experimentId=some-mock-experiment-id",
-                          }
-                        }
-                        match=""
-                        pipelineSelectionChanged={[Function]}
-                        toolbarProps={
-                          Object {
-                            "actions": Array [],
-                            "breadcrumbs": Array [
-                              Object {
-                                "displayName": "Experiments",
-                                "href": "/experiments",
-                              },
-                              Object {
-                                "displayName": "Start a new run",
-                                "href": "",
-                              },
-                            ],
-                          }
-                        }
-                        updateBanner={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {},
-                              ],
-                            ],
-                          }
-                        }
-                        updateDialog={[MockFunction]}
-                        updateSnackbar={[MockFunction]}
-                        updateToolbar={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "some mock experiment name",
-                                      "href": "/experiments/details/some-mock-experiment-id",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                            ],
-                          }
-                        }
-                      />
-                    </WithStyles(DialogContent)>
-                    <WithStyles(DialogActions)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        onClick={[Function]}
-                      >
-                        Cancel
-                      </WithStyles(Button)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        disabled={true}
-                        id="usePipelineBtn"
-                        onClick={[Function]}
-                      >
-                        Use this pipeline
-                      </WithStyles(Button)>
-                    </WithStyles(DialogActions)>
-                  </WithStyles(Dialog)>
-                  <Unknown
-                    autoFocus={true}
-                    field="runName"
-                    instance={[Circular]}
-                    label="Run name"
-                    required={true}
-                  />
-                  <Unknown
-                    field="description"
-                    height="auto"
-                    instance={[Circular]}
-                    label="Description (optional)"
-                    multiline={true}
-                  />
-                  <div>
-                    <div>
-                      This run will be associated with the following experiment
-                    </div>
-                    <Unknown
-                      disabled={true}
-                      field="experimentName"
-                      instance={[Circular]}
-                      label="Experiment"
-                    />
-                  </div>
-                  <div
-                    className="header"
-                  >
-                    Run parameters
-                  </div>
-                  <div>
-                    Parameters will appear after you select a pipeline
-                  </div>
-                  <div
-                    className="flex"
-                  >
-                    <BusyButton
-                      busy={false}
-                      className="buttonAction"
-                      disabled={true}
-                      id="createNewRunBtn"
-                      onClick={[Function]}
-                      title="Create"
-                    />
-                    <WithStyles(Button)
-                      onClick={[Function]}
-                    >
-                      Cancel
-                    </WithStyles(Button)>
-                    <div
-                      style={
-                        Object {
-                          "color": "red",
-                        }
-                      }
-                    >
-                      A pipeline must be selected
-                    </div>
-                  </div>
-                </div>
-              </div>,
-              "_rendering": false,
-              "_updater": [Circular],
-            },
-          },
-          Symbol(enzyme.__setState__): [Function],
-        }
-      }
       label="Run name"
+      onChange={[Function]}
       required={true}
+      value=""
     />
     <Component
-      field="description"
-      height="auto"
-      instance={
-        NewRun {
-          "_isMounted": true,
-          "context": Object {},
-          "handleChange": [Function],
-          "props": Object {
-            "history": Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            },
-            "location": Object {
-              "pathname": "/runs/new",
-              "search": "?experimentId=some-mock-experiment-id",
-            },
-            "match": "",
-            "toolbarProps": Object {
-              "actions": Array [],
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
-              ],
-            },
-            "updateBanner": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {},
-                ],
-              ],
-            },
-            "updateDialog": [MockFunction],
-            "updateSnackbar": [MockFunction],
-            "updateToolbar": [MockFunction] {
-              "calls": Array [
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-                Array [
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "some mock experiment name",
-                        "href": "/experiments/details/some-mock-experiment-id",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  },
-                ],
-              ],
-            },
-          },
-          "refs": Object {},
-          "setState": [Function],
-          "state": Object {
-            "description": "",
-            "errorMessage": "A pipeline must be selected",
-            "experiment": Object {
-              "description": "mock experiment description",
-              "id": "some-mock-experiment-id",
-              "name": "some mock experiment name",
-            },
-            "experimentName": "some mock experiment name",
-            "isBeingCreated": false,
-            "isFirstRunInExperiment": false,
-            "isRecurringRun": false,
-            "pipelineName": "",
-            "pipelineSelectorOpen": false,
-            "runName": "",
-            "unconfirmedDialogPipelineId": "",
-          },
-          "updater": Updater {
-            "_callbacks": Array [],
-            "_renderer": ReactShallowRenderer {
-              "_context": Object {},
-              "_element": <NewRun
-                history={
-                  Object {
-                    "push": [MockFunction],
-                    "replace": [MockFunction],
-                  }
-                }
-                location={
-                  Object {
-                    "pathname": "/runs/new",
-                    "search": "?experimentId=some-mock-experiment-id",
-                  }
-                }
-                match=""
-                toolbarProps={
-                  Object {
-                    "actions": Array [],
-                    "breadcrumbs": Array [
-                      Object {
-                        "displayName": "Experiments",
-                        "href": "/experiments",
-                      },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
-                    ],
-                  }
-                }
-                updateBanner={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {},
-                      ],
-                    ],
-                  }
-                }
-                updateDialog={[MockFunction]}
-                updateSnackbar={[MockFunction]}
-                updateToolbar={
-                  [MockFunction] {
-                    "calls": Array [
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                      Array [
-                        Object {
-                          "actions": Array [],
-                          "breadcrumbs": Array [
-                            Object {
-                              "displayName": "Experiments",
-                              "href": "/experiments",
-                            },
-                            Object {
-                              "displayName": "some mock experiment name",
-                              "href": "/experiments/details/some-mock-experiment-id",
-                            },
-                            Object {
-                              "displayName": "Start a new run",
-                              "href": "",
-                            },
-                          ],
-                        },
-                      ],
-                    ],
-                  }
-                }
-              />,
-              "_forcedUpdate": false,
-              "_instance": [Circular],
-              "_newState": Object {
-                "description": "",
-                "errorMessage": "A pipeline must be selected",
-                "experiment": Object {
-                  "description": "mock experiment description",
-                  "id": "some-mock-experiment-id",
-                  "name": "some mock experiment name",
-                },
-                "experimentName": "some mock experiment name",
-                "isBeingCreated": false,
-                "isFirstRunInExperiment": false,
-                "isRecurringRun": false,
-                "pipelineName": "",
-                "pipelineSelectorOpen": false,
-                "runName": "",
-                "unconfirmedDialogPipelineId": "",
-              },
-              "_rendered": <div
-                className="page"
-              >
-                <div
-                  className="scrollContainer"
-                >
-                  <div
-                    className="header"
-                  >
-                    Run details
-                  </div>
-                  <Unknown
-                    InputProps={
-                      Object {
-                        "endAdornment": <WithStyles(InputAdornment)
-                          position="end"
-                        >
-                          <WithStyles(Button)
-                            color="secondary"
-                            id="choosePipelineBtn"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "margin": 0,
-                                "padding": "3px 5px",
-                              }
-                            }
-                          >
-                            Choose
-                          </WithStyles(Button)>
-                        </WithStyles(InputAdornment)>,
-                        "readOnly": true,
-                      }
-                    }
-                    disabled={true}
-                    field="pipelineName"
-                    instance={[Circular]}
-                    label="Pipeline"
-                    required={true}
-                  />
-                  <WithStyles(Dialog)
-                    PaperProps={
-                      Object {
-                        "id": "pipelineSelectorDialog",
-                      }
-                    }
-                    classes={
-                      Object {
-                        "paper": "pipelineSelectorDialog",
-                      }
-                    }
-                    onClose={[Function]}
-                    open={false}
-                  >
-                    <WithStyles(DialogContent)>
-                      <PipelineSelector
-                        history={
-                          Object {
-                            "push": [MockFunction],
-                            "replace": [MockFunction],
-                          }
-                        }
-                        location={
-                          Object {
-                            "pathname": "/runs/new",
-                            "search": "?experimentId=some-mock-experiment-id",
-                          }
-                        }
-                        match=""
-                        pipelineSelectionChanged={[Function]}
-                        toolbarProps={
-                          Object {
-                            "actions": Array [],
-                            "breadcrumbs": Array [
-                              Object {
-                                "displayName": "Experiments",
-                                "href": "/experiments",
-                              },
-                              Object {
-                                "displayName": "Start a new run",
-                                "href": "",
-                              },
-                            ],
-                          }
-                        }
-                        updateBanner={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {},
-                              ],
-                            ],
-                          }
-                        }
-                        updateDialog={[MockFunction]}
-                        updateSnackbar={[MockFunction]}
-                        updateToolbar={
-                          [MockFunction] {
-                            "calls": Array [
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                              Array [
-                                Object {
-                                  "actions": Array [],
-                                  "breadcrumbs": Array [
-                                    Object {
-                                      "displayName": "Experiments",
-                                      "href": "/experiments",
-                                    },
-                                    Object {
-                                      "displayName": "some mock experiment name",
-                                      "href": "/experiments/details/some-mock-experiment-id",
-                                    },
-                                    Object {
-                                      "displayName": "Start a new run",
-                                      "href": "",
-                                    },
-                                  ],
-                                },
-                              ],
-                            ],
-                          }
-                        }
-                      />
-                    </WithStyles(DialogContent)>
-                    <WithStyles(DialogActions)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        onClick={[Function]}
-                      >
-                        Cancel
-                      </WithStyles(Button)>
-                      <WithStyles(Button)
-                        color="secondary"
-                        disabled={true}
-                        id="usePipelineBtn"
-                        onClick={[Function]}
-                      >
-                        Use this pipeline
-                      </WithStyles(Button)>
-                    </WithStyles(DialogActions)>
-                  </WithStyles(Dialog)>
-                  <Unknown
-                    autoFocus={true}
-                    field="runName"
-                    instance={[Circular]}
-                    label="Run name"
-                    required={true}
-                  />
-                  <Unknown
-                    field="description"
-                    height="auto"
-                    instance={[Circular]}
-                    label="Description (optional)"
-                    multiline={true}
-                  />
-                  <div>
-                    <div>
-                      This run will be associated with the following experiment
-                    </div>
-                    <Unknown
-                      disabled={true}
-                      field="experimentName"
-                      instance={[Circular]}
-                      label="Experiment"
-                    />
-                  </div>
-                  <div
-                    className="header"
-                  >
-                    Run parameters
-                  </div>
-                  <div>
-                    Parameters will appear after you select a pipeline
-                  </div>
-                  <div
-                    className="flex"
-                  >
-                    <BusyButton
-                      busy={false}
-                      className="buttonAction"
-                      disabled={true}
-                      id="createNewRunBtn"
-                      onClick={[Function]}
-                      title="Create"
-                    />
-                    <WithStyles(Button)
-                      onClick={[Function]}
-                    >
-                      Cancel
-                    </WithStyles(Button)>
-                    <div
-                      style={
-                        Object {
-                          "color": "red",
-                        }
-                      }
-                    >
-                      A pipeline must be selected
-                    </div>
-                  </div>
-                </div>
-              </div>,
-              "_rendering": false,
-              "_updater": [Circular],
-            },
-          },
-          Symbol(enzyme.__setState__): [Function],
-        }
-      }
       label="Description (optional)"
       multiline={true}
+      onChange={[Function]}
+      value=""
     />
     <div>
       <div>
@@ -4201,430 +1029,9 @@ exports[`NewRun updates the run's state with the associated experiment if one is
       </div>
       <Component
         disabled={true}
-        field="experimentName"
-        instance={
-          NewRun {
-            "_isMounted": true,
-            "context": Object {},
-            "handleChange": [Function],
-            "props": Object {
-              "history": Object {
-                "push": [MockFunction],
-                "replace": [MockFunction],
-              },
-              "location": Object {
-                "pathname": "/runs/new",
-                "search": "?experimentId=some-mock-experiment-id",
-              },
-              "match": "",
-              "toolbarProps": Object {
-                "actions": Array [],
-                "breadcrumbs": Array [
-                  Object {
-                    "displayName": "Experiments",
-                    "href": "/experiments",
-                  },
-                  Object {
-                    "displayName": "Start a new run",
-                    "href": "",
-                  },
-                ],
-              },
-              "updateBanner": [MockFunction] {
-                "calls": Array [
-                  Array [
-                    Object {},
-                  ],
-                ],
-              },
-              "updateDialog": [MockFunction],
-              "updateSnackbar": [MockFunction],
-              "updateToolbar": [MockFunction] {
-                "calls": Array [
-                  Array [
-                    Object {
-                      "actions": Array [],
-                      "breadcrumbs": Array [
-                        Object {
-                          "displayName": "Experiments",
-                          "href": "/experiments",
-                        },
-                        Object {
-                          "displayName": "Start a new run",
-                          "href": "",
-                        },
-                      ],
-                    },
-                  ],
-                  Array [
-                    Object {
-                      "actions": Array [],
-                      "breadcrumbs": Array [
-                        Object {
-                          "displayName": "Experiments",
-                          "href": "/experiments",
-                        },
-                        Object {
-                          "displayName": "some mock experiment name",
-                          "href": "/experiments/details/some-mock-experiment-id",
-                        },
-                        Object {
-                          "displayName": "Start a new run",
-                          "href": "",
-                        },
-                      ],
-                    },
-                  ],
-                ],
-              },
-            },
-            "refs": Object {},
-            "setState": [Function],
-            "state": Object {
-              "description": "",
-              "errorMessage": "A pipeline must be selected",
-              "experiment": Object {
-                "description": "mock experiment description",
-                "id": "some-mock-experiment-id",
-                "name": "some mock experiment name",
-              },
-              "experimentName": "some mock experiment name",
-              "isBeingCreated": false,
-              "isFirstRunInExperiment": false,
-              "isRecurringRun": false,
-              "pipelineName": "",
-              "pipelineSelectorOpen": false,
-              "runName": "",
-              "unconfirmedDialogPipelineId": "",
-            },
-            "updater": Updater {
-              "_callbacks": Array [],
-              "_renderer": ReactShallowRenderer {
-                "_context": Object {},
-                "_element": <NewRun
-                  history={
-                    Object {
-                      "push": [MockFunction],
-                      "replace": [MockFunction],
-                    }
-                  }
-                  location={
-                    Object {
-                      "pathname": "/runs/new",
-                      "search": "?experimentId=some-mock-experiment-id",
-                    }
-                  }
-                  match=""
-                  toolbarProps={
-                    Object {
-                      "actions": Array [],
-                      "breadcrumbs": Array [
-                        Object {
-                          "displayName": "Experiments",
-                          "href": "/experiments",
-                        },
-                        Object {
-                          "displayName": "Start a new run",
-                          "href": "",
-                        },
-                      ],
-                    }
-                  }
-                  updateBanner={
-                    [MockFunction] {
-                      "calls": Array [
-                        Array [
-                          Object {},
-                        ],
-                      ],
-                    }
-                  }
-                  updateDialog={[MockFunction]}
-                  updateSnackbar={[MockFunction]}
-                  updateToolbar={
-                    [MockFunction] {
-                      "calls": Array [
-                        Array [
-                          Object {
-                            "actions": Array [],
-                            "breadcrumbs": Array [
-                              Object {
-                                "displayName": "Experiments",
-                                "href": "/experiments",
-                              },
-                              Object {
-                                "displayName": "Start a new run",
-                                "href": "",
-                              },
-                            ],
-                          },
-                        ],
-                        Array [
-                          Object {
-                            "actions": Array [],
-                            "breadcrumbs": Array [
-                              Object {
-                                "displayName": "Experiments",
-                                "href": "/experiments",
-                              },
-                              Object {
-                                "displayName": "some mock experiment name",
-                                "href": "/experiments/details/some-mock-experiment-id",
-                              },
-                              Object {
-                                "displayName": "Start a new run",
-                                "href": "",
-                              },
-                            ],
-                          },
-                        ],
-                      ],
-                    }
-                  }
-                />,
-                "_forcedUpdate": false,
-                "_instance": [Circular],
-                "_newState": Object {
-                  "description": "",
-                  "errorMessage": "A pipeline must be selected",
-                  "experiment": Object {
-                    "description": "mock experiment description",
-                    "id": "some-mock-experiment-id",
-                    "name": "some mock experiment name",
-                  },
-                  "experimentName": "some mock experiment name",
-                  "isBeingCreated": false,
-                  "isFirstRunInExperiment": false,
-                  "isRecurringRun": false,
-                  "pipelineName": "",
-                  "pipelineSelectorOpen": false,
-                  "runName": "",
-                  "unconfirmedDialogPipelineId": "",
-                },
-                "_rendered": <div
-                  className="page"
-                >
-                  <div
-                    className="scrollContainer"
-                  >
-                    <div
-                      className="header"
-                    >
-                      Run details
-                    </div>
-                    <Unknown
-                      InputProps={
-                        Object {
-                          "endAdornment": <WithStyles(InputAdornment)
-                            position="end"
-                          >
-                            <WithStyles(Button)
-                              color="secondary"
-                              id="choosePipelineBtn"
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "margin": 0,
-                                  "padding": "3px 5px",
-                                }
-                              }
-                            >
-                              Choose
-                            </WithStyles(Button)>
-                          </WithStyles(InputAdornment)>,
-                          "readOnly": true,
-                        }
-                      }
-                      disabled={true}
-                      field="pipelineName"
-                      instance={[Circular]}
-                      label="Pipeline"
-                      required={true}
-                    />
-                    <WithStyles(Dialog)
-                      PaperProps={
-                        Object {
-                          "id": "pipelineSelectorDialog",
-                        }
-                      }
-                      classes={
-                        Object {
-                          "paper": "pipelineSelectorDialog",
-                        }
-                      }
-                      onClose={[Function]}
-                      open={false}
-                    >
-                      <WithStyles(DialogContent)>
-                        <PipelineSelector
-                          history={
-                            Object {
-                              "push": [MockFunction],
-                              "replace": [MockFunction],
-                            }
-                          }
-                          location={
-                            Object {
-                              "pathname": "/runs/new",
-                              "search": "?experimentId=some-mock-experiment-id",
-                            }
-                          }
-                          match=""
-                          pipelineSelectionChanged={[Function]}
-                          toolbarProps={
-                            Object {
-                              "actions": Array [],
-                              "breadcrumbs": Array [
-                                Object {
-                                  "displayName": "Experiments",
-                                  "href": "/experiments",
-                                },
-                                Object {
-                                  "displayName": "Start a new run",
-                                  "href": "",
-                                },
-                              ],
-                            }
-                          }
-                          updateBanner={
-                            [MockFunction] {
-                              "calls": Array [
-                                Array [
-                                  Object {},
-                                ],
-                              ],
-                            }
-                          }
-                          updateDialog={[MockFunction]}
-                          updateSnackbar={[MockFunction]}
-                          updateToolbar={
-                            [MockFunction] {
-                              "calls": Array [
-                                Array [
-                                  Object {
-                                    "actions": Array [],
-                                    "breadcrumbs": Array [
-                                      Object {
-                                        "displayName": "Experiments",
-                                        "href": "/experiments",
-                                      },
-                                      Object {
-                                        "displayName": "Start a new run",
-                                        "href": "",
-                                      },
-                                    ],
-                                  },
-                                ],
-                                Array [
-                                  Object {
-                                    "actions": Array [],
-                                    "breadcrumbs": Array [
-                                      Object {
-                                        "displayName": "Experiments",
-                                        "href": "/experiments",
-                                      },
-                                      Object {
-                                        "displayName": "some mock experiment name",
-                                        "href": "/experiments/details/some-mock-experiment-id",
-                                      },
-                                      Object {
-                                        "displayName": "Start a new run",
-                                        "href": "",
-                                      },
-                                    ],
-                                  },
-                                ],
-                              ],
-                            }
-                          }
-                        />
-                      </WithStyles(DialogContent)>
-                      <WithStyles(DialogActions)>
-                        <WithStyles(Button)
-                          color="secondary"
-                          onClick={[Function]}
-                        >
-                          Cancel
-                        </WithStyles(Button)>
-                        <WithStyles(Button)
-                          color="secondary"
-                          disabled={true}
-                          id="usePipelineBtn"
-                          onClick={[Function]}
-                        >
-                          Use this pipeline
-                        </WithStyles(Button)>
-                      </WithStyles(DialogActions)>
-                    </WithStyles(Dialog)>
-                    <Unknown
-                      autoFocus={true}
-                      field="runName"
-                      instance={[Circular]}
-                      label="Run name"
-                      required={true}
-                    />
-                    <Unknown
-                      field="description"
-                      height="auto"
-                      instance={[Circular]}
-                      label="Description (optional)"
-                      multiline={true}
-                    />
-                    <div>
-                      <div>
-                        This run will be associated with the following experiment
-                      </div>
-                      <Unknown
-                        disabled={true}
-                        field="experimentName"
-                        instance={[Circular]}
-                        label="Experiment"
-                      />
-                    </div>
-                    <div
-                      className="header"
-                    >
-                      Run parameters
-                    </div>
-                    <div>
-                      Parameters will appear after you select a pipeline
-                    </div>
-                    <div
-                      className="flex"
-                    >
-                      <BusyButton
-                        busy={false}
-                        className="buttonAction"
-                        disabled={true}
-                        id="createNewRunBtn"
-                        onClick={[Function]}
-                        title="Create"
-                      />
-                      <WithStyles(Button)
-                        onClick={[Function]}
-                      >
-                        Cancel
-                      </WithStyles(Button)>
-                      <div
-                        style={
-                          Object {
-                            "color": "red",
-                          }
-                        }
-                      >
-                        A pipeline must be selected
-                      </div>
-                    </div>
-                  </div>
-                </div>,
-                "_rendering": false,
-                "_updater": [Circular],
-              },
-            },
-            Symbol(enzyme.__setState__): [Function],
-          }
-        }
         label="Experiment"
+        onChange={[Function]}
+        value="some mock experiment name"
       />
     </div>
     <div
@@ -4647,6 +1054,7 @@ exports[`NewRun updates the run's state with the associated experiment if one is
         title="Create"
       />
       <WithStyles(Button)
+        id="exitNewRunPageBtn"
         onClick={[Function]}
       >
         Cancel

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -431,6 +431,954 @@ exports[`NewRun creating a new recurring run includes additional trigger input f
 </div>
 `;
 
+exports[`NewRun creating a new run updates the pipeline in state when a user fills in its params 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="scrollContainer"
+  >
+    <div
+      className="header"
+    >
+      Run details
+    </div>
+    <Component
+      InputProps={
+        Object {
+          "endAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <WithStyles(Button)
+              color="secondary"
+              id="choosePipelineBtn"
+              onClick={[Function]}
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": "3px 5px",
+                }
+              }
+            >
+              Choose
+            </WithStyles(Button)>
+          </WithStyles(InputAdornment)>,
+          "readOnly": true,
+        }
+      }
+      disabled={true}
+      label="Pipeline"
+      required={true}
+      value="some mock pipeline name"
+    />
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "pipelineSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "pipelineSelectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <PipelineSelector
+          history={
+            Object {
+              "push": [MockFunction] {
+                "calls": Array [
+                  Array [
+                    "/runs",
+                  ],
+                ],
+              },
+              "replace": [MockFunction],
+            }
+          }
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?pipelineId=some-mock-pipeline-id",
+            }
+          }
+          match=""
+          pipelineSelectionChanged={[Function]}
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "message": "Successfully created new Run: test run name",
+                    "open": true,
+                  },
+                ],
+              ],
+            }
+          }
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          id="cancelPipelineSelectionBtn"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={true}
+          id="usePipelineBtn"
+          onClick={[Function]}
+        >
+          Use this pipeline
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <Component
+      autoFocus={true}
+      label="Run name"
+      onChange={[Function]}
+      required={true}
+      value="test run name"
+    />
+    <Component
+      label="Description (optional)"
+      multiline={true}
+      onChange={[Function]}
+      value=""
+    />
+    <div
+      className="header"
+    >
+      Run parameters
+    </div>
+    <div>
+      Specify parameters required by the pipeline
+    </div>
+    <div>
+      <TextField
+        className="textField"
+        id="newRunPipelineParam0"
+        key="0"
+        label="param-1"
+        onChange={[Function]}
+        required={false}
+        select={false}
+        style={
+          Object {
+            "height": 40,
+            "maxWidth": 600,
+          }
+        }
+        value="test param value"
+        variant="outlined"
+      />
+      <TextField
+        className="textField"
+        id="newRunPipelineParam1"
+        key="1"
+        label="param-2"
+        onChange={[Function]}
+        required={false}
+        select={false}
+        style={
+          Object {
+            "height": 40,
+            "maxWidth": 600,
+          }
+        }
+        value="prefilled value"
+        variant="outlined"
+      />
+    </div>
+    <div
+      className="flex"
+    >
+      <BusyButton
+        busy={true}
+        className="buttonAction"
+        disabled={false}
+        id="createNewRunBtn"
+        onClick={[Function]}
+        title="Create"
+      />
+      <WithStyles(Button)
+        id="exitNewRunPageBtn"
+        onClick={[Function]}
+      >
+        Cancel
+      </WithStyles(Button)>
+      <div
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`NewRun creating a new run updates the pipeline params as user selects different pipelines 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="scrollContainer"
+  >
+    <div
+      className="header"
+    >
+      Run details
+    </div>
+    <Component
+      InputProps={
+        Object {
+          "endAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <WithStyles(Button)
+              color="secondary"
+              id="choosePipelineBtn"
+              onClick={[Function]}
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": "3px 5px",
+                }
+              }
+            >
+              Choose
+            </WithStyles(Button)>
+          </WithStyles(InputAdornment)>,
+          "readOnly": true,
+        }
+      }
+      disabled={true}
+      label="Pipeline"
+      required={true}
+      value=""
+    />
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "pipelineSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "pipelineSelectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <PipelineSelector
+          history={
+            Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            }
+          }
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?experimentId=some-mock-experiment-id",
+            }
+          }
+          match=""
+          pipelineSelectionChanged={[Function]}
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={[MockFunction]}
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "some mock experiment name",
+                        "href": "/experiments/details/some-mock-experiment-id",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          id="cancelPipelineSelectionBtn"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={true}
+          id="usePipelineBtn"
+          onClick={[Function]}
+        >
+          Use this pipeline
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <Component
+      autoFocus={true}
+      label="Run name"
+      onChange={[Function]}
+      required={true}
+      value=""
+    />
+    <Component
+      label="Description (optional)"
+      multiline={true}
+      onChange={[Function]}
+      value=""
+    />
+    <div>
+      <div>
+        This run will be associated with the following experiment
+      </div>
+      <Component
+        disabled={true}
+        label="Experiment"
+        onChange={[Function]}
+        value="some mock experiment name"
+      />
+    </div>
+    <div
+      className="header"
+    >
+      Run parameters
+    </div>
+    <div>
+      Parameters will appear after you select a pipeline
+    </div>
+    <div
+      className="flex"
+    >
+      <BusyButton
+        busy={false}
+        className="buttonAction"
+        disabled={true}
+        id="createNewRunBtn"
+        onClick={[Function]}
+        title="Create"
+      />
+      <WithStyles(Button)
+        id="exitNewRunPageBtn"
+        onClick={[Function]}
+      >
+        Cancel
+      </WithStyles(Button)>
+      <div
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+      >
+        A pipeline must be selected
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`NewRun creating a new run updates the pipeline params as user selects different pipelines 2`] = `
+<div
+  className="page"
+>
+  <div
+    className="scrollContainer"
+  >
+    <div
+      className="header"
+    >
+      Run details
+    </div>
+    <Component
+      InputProps={
+        Object {
+          "endAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <WithStyles(Button)
+              color="secondary"
+              id="choosePipelineBtn"
+              onClick={[Function]}
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": "3px 5px",
+                }
+              }
+            >
+              Choose
+            </WithStyles(Button)>
+          </WithStyles(InputAdornment)>,
+          "readOnly": true,
+        }
+      }
+      disabled={true}
+      label="Pipeline"
+      required={true}
+      value="some mock pipeline name"
+    />
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "pipelineSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "pipelineSelectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <PipelineSelector
+          history={
+            Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            }
+          }
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?experimentId=some-mock-experiment-id",
+            }
+          }
+          match=""
+          pipelineSelectionChanged={[Function]}
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={[MockFunction]}
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "some mock experiment name",
+                        "href": "/experiments/details/some-mock-experiment-id",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          id="cancelPipelineSelectionBtn"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={false}
+          id="usePipelineBtn"
+          onClick={[Function]}
+        >
+          Use this pipeline
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <Component
+      autoFocus={true}
+      label="Run name"
+      onChange={[Function]}
+      required={true}
+      value=""
+    />
+    <Component
+      label="Description (optional)"
+      multiline={true}
+      onChange={[Function]}
+      value=""
+    />
+    <div>
+      <div>
+        This run will be associated with the following experiment
+      </div>
+      <Component
+        disabled={true}
+        label="Experiment"
+        onChange={[Function]}
+        value="some mock experiment name"
+      />
+    </div>
+    <div
+      className="header"
+    >
+      Run parameters
+    </div>
+    <div>
+      Specify parameters required by the pipeline
+    </div>
+    <div>
+      <TextField
+        className="textField"
+        id="newRunPipelineParam0"
+        key="0"
+        label="param-1"
+        onChange={[Function]}
+        required={false}
+        select={false}
+        style={
+          Object {
+            "height": 40,
+            "maxWidth": 600,
+          }
+        }
+        value="prefilled value 1"
+        variant="outlined"
+      />
+      <TextField
+        className="textField"
+        id="newRunPipelineParam1"
+        key="1"
+        label="param-2"
+        onChange={[Function]}
+        required={false}
+        select={false}
+        style={
+          Object {
+            "height": 40,
+            "maxWidth": 600,
+          }
+        }
+        value="prefilled value 2"
+        variant="outlined"
+      />
+    </div>
+    <div
+      className="flex"
+    >
+      <BusyButton
+        busy={false}
+        className="buttonAction"
+        disabled={true}
+        id="createNewRunBtn"
+        onClick={[Function]}
+        title="Create"
+      />
+      <WithStyles(Button)
+        id="exitNewRunPageBtn"
+        onClick={[Function]}
+      >
+        Cancel
+      </WithStyles(Button)>
+      <div
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+      >
+        Run name is required
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`NewRun creating a new run updates the pipeline params as user selects different pipelines 3`] = `
+<div
+  className="page"
+>
+  <div
+    className="scrollContainer"
+  >
+    <div
+      className="header"
+    >
+      Run details
+    </div>
+    <Component
+      InputProps={
+        Object {
+          "endAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <WithStyles(Button)
+              color="secondary"
+              id="choosePipelineBtn"
+              onClick={[Function]}
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": "3px 5px",
+                }
+              }
+            >
+              Choose
+            </WithStyles(Button)>
+          </WithStyles(InputAdornment)>,
+          "readOnly": true,
+        }
+      }
+      disabled={true}
+      label="Pipeline"
+      required={true}
+      value="some mock pipeline name"
+    />
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "pipelineSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "pipelineSelectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <PipelineSelector
+          history={
+            Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            }
+          }
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?experimentId=some-mock-experiment-id",
+            }
+          }
+          match=""
+          pipelineSelectionChanged={[Function]}
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+                Object {
+                  "displayName": "Start a new run",
+                  "href": "",
+                },
+              ],
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={[MockFunction]}
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "some mock experiment name",
+                        "href": "/experiments/details/some-mock-experiment-id",
+                      },
+                      Object {
+                        "displayName": "Start a new run",
+                        "href": "",
+                      },
+                    ],
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          id="cancelPipelineSelectionBtn"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={false}
+          id="usePipelineBtn"
+          onClick={[Function]}
+        >
+          Use this pipeline
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <Component
+      autoFocus={true}
+      label="Run name"
+      onChange={[Function]}
+      required={true}
+      value=""
+    />
+    <Component
+      label="Description (optional)"
+      multiline={true}
+      onChange={[Function]}
+      value=""
+    />
+    <div>
+      <div>
+        This run will be associated with the following experiment
+      </div>
+      <Component
+        disabled={true}
+        label="Experiment"
+        onChange={[Function]}
+        value="some mock experiment name"
+      />
+    </div>
+    <div
+      className="header"
+    >
+      Run parameters
+    </div>
+    <div>
+      This pipeline has no parameters
+    </div>
+    <div
+      className="flex"
+    >
+      <BusyButton
+        busy={false}
+        className="buttonAction"
+        disabled={true}
+        id="createNewRunBtn"
+        onClick={[Function]}
+        title="Create"
+      />
+      <WithStyles(Button)
+        id="exitNewRunPageBtn"
+        onClick={[Function]}
+      >
+        Cancel
+      </WithStyles(Button)>
+      <div
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+      >
+        Run name is required
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`NewRun fetches the associated pipeline if one is present in the query params 1`] = `
 <div
   className="page"

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -95,7 +95,7 @@ describe('deploy helloworld sample run', () => {
     browser.keys(outputParameterValue);
 
     // Deploy
-    $('#createBtn').click();
+    $('#createNewRunBtn').click();
   });
 
   it('redirects back to experiment page', () => {


### PR DESCRIPTION
With this PR, the `NewRun` file has nearly complete coverage (by lines).

A little cleanup is done within the `NewExperiment` test as well.

The `_prepareFormFromClone()` function in `NewRun` did not actually change except that the wrapping if-block was changed to just return on the negative condition.

We no longer attempt to change the query params in  `handleChange` when the pipelineID changes as it only would be called during a clone flow, and there's no real reason to do it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/242)
<!-- Reviewable:end -->
