### PR TITLE
Add run status to page title

### DIFF
--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -99,7 +99,7 @@ class Router extends React.Component<{}, RouteComponentState> {
       updateBanner: this._updateBanner.bind(this),
       updateDialog: this._updateDialog.bind(this),
       updateSnackbar: this._updateSnackbar.bind(this),
-      updateToolbar: this._setToolbarActions.bind(this),
+      updateToolbar: this._updateToolbar.bind(this),
     };
 
     const routes: Array<{ path: string, Component: React.ComponentClass, view?: any }> = [
@@ -195,7 +195,8 @@ class Router extends React.Component<{}, RouteComponentState> {
     }
   }
 
-  private _setToolbarActions(toolbarProps: ToolbarProps): void {
+  private _updateToolbar(newToolbarProps: Partial<ToolbarProps>): void {
+    const toolbarProps = Object.assign(this.state.toolbarProps, newToolbarProps);
     this.setState({ toolbarProps });
   }
 

--- a/frontend/src/components/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar.test.tsx
@@ -87,7 +87,7 @@ describe('Toolbar', () => {
   });
 
   it('renders without actions, one breadcrumb, and a page name', () => {
-    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={[]} history={history}
+    const tree = shallow(<Toolbar breadcrumbs={[breadcrumbs[0]]} actions={[]} history={history}
       pageTitle='test page title' />);
     expect(tree).toMatchSnapshot();
   });

--- a/frontend/src/components/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar.test.tsx
@@ -62,6 +62,18 @@ describe('Toolbar', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders without breadcrumbs and a string page title', () => {
+    const tree = shallow(<Toolbar breadcrumbs={[]} actions={[actions[0]]} history={history}
+      pageTitle='test page title' />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders without breadcrumbs and a component page title', () => {
+    const tree = shallow(<Toolbar breadcrumbs={[]} actions={[actions[0]]} history={history}
+      pageTitle={<div id='myComponent'>test page title</div>} />);
+    expect(tree).toMatchSnapshot();
+  });
+
   it('renders without breadcrumbs and one action', () => {
     const tree = shallow(<Toolbar breadcrumbs={[]} actions={[actions[0]]} history={history}
       pageTitle='' />);

--- a/frontend/src/components/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar.test.tsx
@@ -115,7 +115,8 @@ describe('Toolbar', () => {
       tooltip: 'test tooltip',
     }];
 
-    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={outlinedActions} history={history} />);
+    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={outlinedActions} pageTitle=''
+      history={history} />);
     expect(tree).toMatchSnapshot();
   });
 
@@ -128,7 +129,8 @@ describe('Toolbar', () => {
       tooltip: 'test tooltip',
     }];
 
-    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={outlinedActions} history={history} />);
+    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={outlinedActions} pageTitle=''
+      history={history} />);
     expect(tree).toMatchSnapshot();
   });
 
@@ -142,13 +144,14 @@ describe('Toolbar', () => {
       tooltip: 'test tooltip',
     }];
 
-    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={outlinedActions} history={history} />);
+    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={outlinedActions} pageTitle=''
+      history={history} />);
     expect(tree).toMatchSnapshot();
   });
 
   it('renders with two breadcrumbs and two actions', () => {
-    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={actions} history={history}
-      pageTitle='' />);
+    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={actions} pageTitle=''
+      history={history} />);
     expect(tree).toMatchSnapshot();
   });
 });

--- a/frontend/src/components/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar.test.tsx
@@ -58,32 +58,37 @@ const history = createBrowserHistory({});
 
 describe('Toolbar', () => {
   it('renders nothing when there are no breadcrumbs or actions', () => {
-    const tree = shallow(<Toolbar breadcrumbs={[]} actions={[]} history={history} />);
+    const tree = shallow(<Toolbar breadcrumbs={[]} actions={[]} history={history} pageTitle='' />);
     expect(tree).toMatchSnapshot();
   });
 
   it('renders without breadcrumbs and one action', () => {
-    const tree = shallow(<Toolbar breadcrumbs={[]} actions={[actions[0]]} history={history} />);
+    const tree = shallow(<Toolbar breadcrumbs={[]} actions={[actions[0]]} history={history}
+      pageTitle='' />);
     expect(tree).toMatchSnapshot();
   });
 
   it('renders without actions and one breadcrumb', () => {
-    const tree = shallow(<Toolbar breadcrumbs={[breadcrumbs[0]]} actions={[]} history={history} />);
+    const tree = shallow(<Toolbar breadcrumbs={[breadcrumbs[0]]} actions={[]} history={history}
+      pageTitle='' />);
     expect(tree).toMatchSnapshot();
   });
 
   it('renders without actions, one breadcrumb, and a page name', () => {
-    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={[]} history={history} />);
+    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={[]} history={history}
+      pageTitle='test page title' />);
     expect(tree).toMatchSnapshot();
   });
 
   it('renders without breadcrumbs and two actions', () => {
-    const tree = shallow(<Toolbar breadcrumbs={[]} actions={actions} history={history} />);
+    const tree = shallow(<Toolbar breadcrumbs={[]} actions={actions} history={history}
+      pageTitle='' />);
     expect(tree).toMatchSnapshot();
   });
 
   it('fires the right action function when button is clicked', () => {
-    const tree = shallow(<Toolbar breadcrumbs={[]} actions={actions} history={history} />);
+    const tree = shallow(<Toolbar breadcrumbs={[]} actions={actions} history={history}
+      pageTitle='' />);
     tree.find('BusyButton').at(0).simulate('click');
     expect(action1).toHaveBeenCalled();
     action2.mockClear();
@@ -130,7 +135,8 @@ describe('Toolbar', () => {
   });
 
   it('renders with two breadcrumbs and two actions', () => {
-    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={actions} history={history} />);
+    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={actions} history={history}
+      pageTitle='' />);
     expect(tree).toMatchSnapshot();
   });
 });

--- a/frontend/src/components/Toolbar.tsx
+++ b/frontend/src/components/Toolbar.tsx
@@ -102,17 +102,17 @@ export interface ToolbarProps {
   actions: ToolbarActionConfig[];
   breadcrumbs: Breadcrumb[];
   history?: History;
+  pageTitle: string | JSX.Element;
+  pageTitleTooltip?: string;
   topLevelToolbar?: boolean;
 }
 
 class Toolbar extends React.Component<ToolbarProps> {
 
   public render(): JSX.Element | null {
-    const currentPage = this.props.breadcrumbs.length ?
-      this.props.breadcrumbs[this.props.breadcrumbs.length - 1].displayName : '';
-    const breadcrumbs = this.props.breadcrumbs.slice(0, this.props.breadcrumbs.length - 1);
+    const { breadcrumbs, pageTitle, pageTitleTooltip } = { ...this.props };
 
-    if (!this.props.actions.length && !this.props.breadcrumbs.length) {
+    if (!this.props.actions.length && !this.props.breadcrumbs.length && !this.props.pageTitle) {
       return null;
     }
 
@@ -143,8 +143,8 @@ class Toolbar extends React.Component<ToolbarProps> {
                 </IconButton>
               </Tooltip>}
             {/* Resource Name */}
-            <span className={classes(css.pageName, commonCss.ellipsis)} title={currentPage}>
-              {currentPage}
+            <span className={classes(css.pageName, commonCss.ellipsis)} title={pageTitleTooltip}>
+              {pageTitle}
             </span>
           </div>
         </div>

--- a/frontend/src/components/Toolbar.tsx
+++ b/frontend/src/components/Toolbar.tsx
@@ -157,7 +157,7 @@ class Toolbar extends React.Component<ToolbarProps> {
                 <BusyButton id={b.id} color='secondary' onClick={b.action} disabled={b.disabled}
                   title={b.title} icon={b.icon} busy={b.busy || false}
                   outlined={(b.outlined && !b.primary) || false}
-                  className={b.primary ? commonCss.buttonAction : ''}/>
+                  className={b.primary ? commonCss.buttonAction : ''} />
               </div>
             </Tooltip>
           ))}

--- a/frontend/src/components/__snapshots__/Toolbar.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Toolbar.test.tsx.snap
@@ -29,6 +29,22 @@ exports[`Toolbar renders outlined action buttons 1`] = `
           test display name
         </Link>
       </span>
+      <span
+        className="flex"
+        key="1"
+        title="test display name2"
+      >
+        <pure(ChevronRightIcon)
+          className="chevron"
+        />
+        <Link
+          className="unstyled ellipsis link"
+          replace={false}
+          to="/some/test/path2"
+        >
+          test display name2
+        </Link>
+      </span>
     </div>
     <div
       className="flex"
@@ -48,10 +64,7 @@ exports[`Toolbar renders outlined action buttons 1`] = `
       </WithStyles(Tooltip)>
       <span
         className="pageName ellipsis"
-        title="test display name2"
-      >
-        test display name2
-      </span>
+      />
     </div>
   </div>
   <div
@@ -181,6 +194,22 @@ exports[`Toolbar renders primary action buttons without outline, even if outline
           test display name
         </Link>
       </span>
+      <span
+        className="flex"
+        key="1"
+        title="test display name2"
+      >
+        <pure(ChevronRightIcon)
+          className="chevron"
+        />
+        <Link
+          className="unstyled ellipsis link"
+          replace={false}
+          to="/some/test/path2"
+        >
+          test display name2
+        </Link>
+      </span>
     </div>
     <div
       className="flex"
@@ -200,9 +229,8 @@ exports[`Toolbar renders primary action buttons without outline, even if outline
       </WithStyles(Tooltip)>
       <span
         className="pageName ellipsis"
-        title="test display name2"
       >
-        test display name2
+        test page title
       </span>
     </div>
   </div>
@@ -345,16 +373,40 @@ exports[`Toolbar renders without actions and one breadcrumb 1`] = `
   >
     <div
       className="breadcrumbs flex"
-    />
+    >
+      <span
+        className="flex"
+        key="0"
+        title="test display name"
+      >
+        <Link
+          className="unstyled ellipsis link"
+          replace={false}
+          to="/some/test/path"
+        >
+          test display name
+        </Link>
+      </span>
+    </div>
     <div
       className="flex"
     >
+      <WithStyles(Tooltip)
+        enterDelay={300}
+        title="Back"
+      >
+        <WithStyles(IconButton)
+          className="backLink"
+          onClick={[Function]}
+        >
+          <pure(ArrowBackIcon)
+            className="backIcon"
+          />
+        </WithStyles(IconButton)>
+      </WithStyles(Tooltip)>
       <span
         className="pageName ellipsis"
-        title="test display name"
-      >
-        test display name
-      </span>
+      />
     </div>
   </div>
   <div
@@ -421,6 +473,106 @@ exports[`Toolbar renders without actions, one breadcrumb, and a page name 1`] = 
 </div>
 `;
 
+exports[`Toolbar renders without breadcrumbs and a component page title 1`] = `
+<div
+  className="root topLevelToolbar"
+>
+  <div
+    style={
+      Object {
+        "minWidth": 100,
+      }
+    }
+  >
+    <div
+      className="breadcrumbs flex"
+    />
+    <div
+      className="flex"
+    >
+      <span
+        className="pageName ellipsis"
+      >
+        <div
+          id="myComponent"
+        >
+          test page title
+        </div>
+      </span>
+    </div>
+  </div>
+  <div
+    className="actions"
+  >
+    <WithStyles(Tooltip)
+      enterDelay={300}
+      key="0"
+      title="test tooltip"
+    >
+      <div>
+        <BusyButton
+          busy={false}
+          color="secondary"
+          icon={[Function]}
+          id="test id"
+          onClick={[MockFunction]}
+          outlined={false}
+          title="test title"
+        />
+      </div>
+    </WithStyles(Tooltip)>
+  </div>
+</div>
+`;
+
+exports[`Toolbar renders without breadcrumbs and a string page title 1`] = `
+<div
+  className="root topLevelToolbar"
+>
+  <div
+    style={
+      Object {
+        "minWidth": 100,
+      }
+    }
+  >
+    <div
+      className="breadcrumbs flex"
+    />
+    <div
+      className="flex"
+    >
+      <span
+        className="pageName ellipsis"
+      >
+        test page title
+      </span>
+    </div>
+  </div>
+  <div
+    className="actions"
+  >
+    <WithStyles(Tooltip)
+      enterDelay={300}
+      key="0"
+      title="test tooltip"
+    >
+      <div>
+        <BusyButton
+          busy={false}
+          color="secondary"
+          icon={[Function]}
+          id="test id"
+          onClick={[MockFunction]}
+          outlined={false}
+          title="test title"
+        />
+      </div>
+    </WithStyles(Tooltip)>
+  </div>
+</div>
+`;
+
 exports[`Toolbar renders without breadcrumbs and one action 1`] = `
 <div
   className="root topLevelToolbar"
@@ -440,7 +592,6 @@ exports[`Toolbar renders without breadcrumbs and one action 1`] = `
     >
       <span
         className="pageName ellipsis"
-        title=""
       />
     </div>
   </div>
@@ -488,7 +639,6 @@ exports[`Toolbar renders without breadcrumbs and two actions 1`] = `
     >
       <span
         className="pageName ellipsis"
-        title=""
       />
     </div>
   </div>

--- a/frontend/src/components/__snapshots__/Toolbar.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Toolbar.test.tsx.snap
@@ -118,6 +118,22 @@ exports[`Toolbar renders primary action buttons 1`] = `
           test display name
         </Link>
       </span>
+      <span
+        className="flex"
+        key="1"
+        title="test display name2"
+      >
+        <pure(ChevronRightIcon)
+          className="chevron"
+        />
+        <Link
+          className="unstyled ellipsis link"
+          replace={false}
+          to="/some/test/path2"
+        >
+          test display name2
+        </Link>
+      </span>
     </div>
     <div
       className="flex"
@@ -137,10 +153,7 @@ exports[`Toolbar renders primary action buttons 1`] = `
       </WithStyles(Tooltip)>
       <span
         className="pageName ellipsis"
-        title="test display name2"
-      >
-        test display name2
-      </span>
+      />
     </div>
   </div>
   <div
@@ -229,9 +242,7 @@ exports[`Toolbar renders primary action buttons without outline, even if outline
       </WithStyles(Tooltip)>
       <span
         className="pageName ellipsis"
-      >
-        test page title
-      </span>
+      />
     </div>
   </div>
   <div
@@ -285,6 +296,22 @@ exports[`Toolbar renders with two breadcrumbs and two actions 1`] = `
           test display name
         </Link>
       </span>
+      <span
+        className="flex"
+        key="1"
+        title="test display name2"
+      >
+        <pure(ChevronRightIcon)
+          className="chevron"
+        />
+        <Link
+          className="unstyled ellipsis link"
+          replace={false}
+          to="/some/test/path2"
+        >
+          test display name2
+        </Link>
+      </span>
     </div>
     <div
       className="flex"
@@ -304,10 +331,7 @@ exports[`Toolbar renders with two breadcrumbs and two actions 1`] = `
       </WithStyles(Tooltip)>
       <span
         className="pageName ellipsis"
-        title="test display name2"
-      >
-        test display name2
-      </span>
+      />
     </div>
   </div>
   <div
@@ -461,9 +485,8 @@ exports[`Toolbar renders without actions, one breadcrumb, and a page name 1`] = 
       </WithStyles(Tooltip)>
       <span
         className="pageName ellipsis"
-        title="test display name2"
       >
-        test display name2
+        test page title
       </span>
     </div>
   </div>
@@ -512,6 +535,7 @@ exports[`Toolbar renders without breadcrumbs and a component page title 1`] = `
       <div>
         <BusyButton
           busy={false}
+          className=""
           color="secondary"
           icon={[Function]}
           id="test id"
@@ -560,6 +584,7 @@ exports[`Toolbar renders without breadcrumbs and a string page title 1`] = `
       <div>
         <BusyButton
           busy={false}
+          className=""
           color="secondary"
           icon={[Function]}
           id="test id"

--- a/frontend/src/pages/404.tsx
+++ b/frontend/src/pages/404.tsx
@@ -20,7 +20,7 @@ import { ToolbarProps } from '../components/Toolbar';
 
 export default class Page404 extends Page<{}, {}> {
   public getInitialToolbarState(): ToolbarProps {
-    return { actions: [], breadcrumbs: [] };
+    return { actions: [], breadcrumbs: [], pageTitle: '' };
   }
 
   public async refresh(): Promise<void> {

--- a/frontend/src/pages/AllRunsList.tsx
+++ b/frontend/src/pages/AllRunsList.tsx
@@ -69,7 +69,8 @@ class AllRunsList extends Page<{}, AllRunsListState> {
         title: 'Refresh',
         tooltip: 'Refresh the list of runs',
       }],
-      breadcrumbs: [{ displayName: 'Experiments', href: '' }],
+      breadcrumbs: [],
+      pageTitle: 'Experiments',
     };
   }
 

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -96,10 +96,8 @@ class Compare extends Page<{}, CompareState> {
         title: 'Collapse all',
         tooltip: 'Collapse all sections',
       }],
-      breadcrumbs: [
-        { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
-        { displayName: 'Compare runs', href: '' },
-      ],
+      breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
+      pageTitle: 'Compare runs',
     };
   }
 

--- a/frontend/src/pages/ExperimentDetails.tsx
+++ b/frontend/src/pages/ExperimentDetails.tsx
@@ -257,7 +257,7 @@ class ExperimentDetails extends Page<{}, ExperimentDetailsState> {
 
     try {
       const experiment = await Apis.experimentServiceApi.getExperiment(experimentId);
-      const pageTitle = experiment && experiment.name ?
+      const pageTitle = (experiment && experiment.name) ?
         experiment.name : this.props.match.params[RouteParams.experimentId];
 
       this.props.updateToolbar({

--- a/frontend/src/pages/ExperimentDetails.tsx
+++ b/frontend/src/pages/ExperimentDetails.tsx
@@ -151,7 +151,8 @@ class ExperimentDetails extends Page<{}, ExperimentDetailsState> {
       recurringRunsManagerOpen: false,
       runListToolbarProps: {
         actions: this._runListToolbarActions,
-        breadcrumbs: [{ displayName: 'Runs', href: '' }],
+        breadcrumbs: [],
+        pageTitle: 'Runs',
         topLevelToolbar: false,
       },
       // TODO: remove
@@ -168,10 +169,8 @@ class ExperimentDetails extends Page<{}, ExperimentDetailsState> {
         title: 'Refresh',
         tooltip: 'Refresh',
       }],
-      breadcrumbs: [
-        { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
-        { displayName: this.props.match.params[RouteParams.experimentId], href: '' }
-      ],
+      breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
+      pageTitle: this.props.match.params[RouteParams.experimentId],
     };
   }
 
@@ -258,15 +257,14 @@ class ExperimentDetails extends Page<{}, ExperimentDetailsState> {
 
     try {
       const experiment = await Apis.experimentServiceApi.getExperiment(experimentId);
+      const pageTitle = experiment && experiment.name ?
+        experiment.name : this.props.match.params[RouteParams.experimentId];
 
       this.props.updateToolbar({
         actions: this.props.toolbarProps.actions,
-        breadcrumbs: [
-          { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
-          {
-            displayName: experiment && experiment.name ? experiment.name : this.props.match.params[RouteParams.experimentId],
-            href: ''
-          }],
+        breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
+        pageTitle,
+        pageTitleTooltip: pageTitle,
       });
 
       // TODO: get ALL jobs in the experiment
@@ -327,6 +325,7 @@ class ExperimentDetails extends Page<{}, ExperimentDetailsState> {
       runListToolbarProps: {
         actions: toolbarActions,
         breadcrumbs: this.state.runListToolbarProps.breadcrumbs,
+        pageTitle: this.state.runListToolbarProps.pageTitle,
         topLevelToolbar: this.state.runListToolbarProps.topLevelToolbar,
       },
       selectedRunIds

--- a/frontend/src/pages/ExperimentList.tsx
+++ b/frontend/src/pages/ExperimentList.tsx
@@ -86,7 +86,8 @@ class ExperimentList extends Page<{}, ExperimentListState> {
         title: 'Refresh',
         tooltip: 'Refresh the list of experiments',
       }],
-      breadcrumbs: [{ displayName: 'Experiments', href: '' }],
+      breadcrumbs: [],
+      pageTitle: 'Experiments',
     };
   }
 
@@ -206,7 +207,7 @@ class ExperimentList extends Page<{}, ExperimentListState> {
       // Enable/Disable Clone button
       draft[2].disabled = selectedRunIds.length !== 1;
     });
-    this.props.updateToolbar({ breadcrumbs: this.props.toolbarProps.breadcrumbs, actions });
+    this.props.updateToolbar({ actions });
     this.setState({ selectedRunIds });
   }
 

--- a/frontend/src/pages/ExperimentsAndRuns.tsx
+++ b/frontend/src/pages/ExperimentsAndRuns.tsx
@@ -40,7 +40,7 @@ interface ExperimentAndRunsState {
 class ExperimentsAndRuns extends Page<ExperimentAndRunsProps, ExperimentAndRunsState> {
 
   public getInitialToolbarState(): ToolbarProps {
-    return { actions: [], breadcrumbs: [] };
+    return { actions: [], breadcrumbs: [], pageTitle: '' };
   }
 
   public render(): JSX.Element {

--- a/frontend/src/pages/NewExperiment.test.tsx
+++ b/frontend/src/pages/NewExperiment.test.tsx
@@ -66,10 +66,8 @@ describe('NewExperiment', () => {
 
     expect(updateToolbarSpy).toHaveBeenCalledWith({
       actions: [],
-      breadcrumbs: [
-        { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
-        { displayName: 'New experiment', href: RoutePage.NEW_EXPERIMENT }
-      ],
+      breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
+      pageTitle: 'New experiment',
     });
     tree.unmount();
   });

--- a/frontend/src/pages/NewExperiment.tsx
+++ b/frontend/src/pages/NewExperiment.tsx
@@ -65,10 +65,8 @@ class NewExperiment extends Page<{}, NewExperimentState> {
   public getInitialToolbarState(): ToolbarProps {
     return {
       actions: [],
-      breadcrumbs: [
-        { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
-        { displayName: 'New experiment', href: RoutePage.NEW_EXPERIMENT }
-      ],
+      breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
+      pageTitle: 'New experiment',
     };
   }
 

--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -142,10 +142,8 @@ describe('NewRun', () => {
 
     expect(updateToolbarSpy).toHaveBeenLastCalledWith({
       actions: [],
-      breadcrumbs: [
-        { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
-        { displayName: 'Start a new run', href: '' }
-      ],
+      breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
+      pageTitle: 'Start a new run',
     });
     tree.unmount();
   });
@@ -239,8 +237,8 @@ describe('NewRun', () => {
           displayName: MOCK_EXPERIMENT.name,
           href: RoutePage.EXPERIMENT_DETAILS.replace(':' + RouteParams.experimentId, MOCK_EXPERIMENT.id!),
         },
-        { displayName: 'Start a new run', href: '' }
       ],
+      pageTitle: 'Start a new run',
     });
     tree.unmount();
   });
@@ -703,7 +701,7 @@ describe('NewRun', () => {
       const props = generateProps();
       props.location.search =
         `?${QUERY_PARAMS.experimentId}=${MOCK_EXPERIMENT.id}`
-          + `&${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}`;
+        + `&${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}`;
 
       const tree = shallow(<TestNewRun {...props} />);
       (tree.instance() as TestNewRun).handleChange('runName')({ target: { value: 'test run name' } });
@@ -953,10 +951,8 @@ describe('NewRun', () => {
 
       expect(updateToolbarSpy).toHaveBeenLastCalledWith({
         actions: [],
-        breadcrumbs: [
-          { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
-          { displayName: 'Start a recurring run', href: '' }
-        ],
+        breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
+        pageTitle: 'Start a recurring run',
       });
       tree.unmount();
     });
@@ -1022,9 +1018,9 @@ describe('NewRun', () => {
     it('displays an error message if periodic schedule end date/time is earlier than start date/time', async () => {
       const props = generateProps();
       props.location.search =
-      `?${QUERY_PARAMS.isRecurring}=1`
-      + `&${QUERY_PARAMS.experimentId}=${MOCK_EXPERIMENT.id}`
-      + `&${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}`;
+        `?${QUERY_PARAMS.isRecurring}=1`
+        + `&${QUERY_PARAMS.experimentId}=${MOCK_EXPERIMENT.id}`
+        + `&${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}`;
 
       const tree = shallow(<TestNewRun {...props} />);
       (tree.instance() as TestNewRun).handleChange('runName')({ target: { value: 'test run name' } });
@@ -1045,9 +1041,9 @@ describe('NewRun', () => {
     it('displays an error message if cron schedule end date/time is earlier than start date/time', async () => {
       const props = generateProps();
       props.location.search =
-      `?${QUERY_PARAMS.isRecurring}=1`
-      + `&${QUERY_PARAMS.experimentId}=${MOCK_EXPERIMENT.id}`
-      + `&${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}`;
+        `?${QUERY_PARAMS.isRecurring}=1`
+        + `&${QUERY_PARAMS.experimentId}=${MOCK_EXPERIMENT.id}`
+        + `&${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}`;
 
       const tree = shallow(<TestNewRun {...props} />);
       (tree.instance() as TestNewRun).handleChange('runName')({ target: { value: 'test run name' } });
@@ -1068,9 +1064,9 @@ describe('NewRun', () => {
     it('displays an error message if max concurrent runs is negative', async () => {
       const props = generateProps();
       props.location.search =
-      `?${QUERY_PARAMS.isRecurring}=1`
-      + `&${QUERY_PARAMS.experimentId}=${MOCK_EXPERIMENT.id}`
-      + `&${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}`;
+        `?${QUERY_PARAMS.isRecurring}=1`
+        + `&${QUERY_PARAMS.experimentId}=${MOCK_EXPERIMENT.id}`
+        + `&${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}`;
 
       const tree = shallow(<TestNewRun {...props} />);
       (tree.instance() as TestNewRun).handleChange('runName')({ target: { value: 'test run name' } });
@@ -1091,9 +1087,9 @@ describe('NewRun', () => {
     it('displays an error message if max concurrent runs is not a number', async () => {
       const props = generateProps();
       props.location.search =
-      `?${QUERY_PARAMS.isRecurring}=1`
-      + `&${QUERY_PARAMS.experimentId}=${MOCK_EXPERIMENT.id}`
-      + `&${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}`;
+        `?${QUERY_PARAMS.isRecurring}=1`
+        + `&${QUERY_PARAMS.experimentId}=${MOCK_EXPERIMENT.id}`
+        + `&${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}`;
 
       const tree = shallow(<TestNewRun {...props} />);
       (tree.instance() as TestNewRun).handleChange('runName')({ target: { value: 'test run name' } });

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -89,10 +89,8 @@ class NewRun extends Page<{}, NewRunState> {
   public getInitialToolbarState(): ToolbarProps {
     return {
       actions: [],
-      breadcrumbs: [
-        { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
-        { displayName: 'Start a new run', href: '' }
-      ]
+      breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
+      pageTitle: 'Start a new run',
     };
   }
 
@@ -268,11 +266,8 @@ class NewRun extends Page<{}, NewRunState> {
     }
 
     const isRecurringRun = urlParser.get(QUERY_PARAMS.isRecurring) === '1';
-    breadcrumbs.push({
-      displayName: isRecurringRun ? 'Start a recurring run' : 'Start a new run',
-      href: '',
-    });
-    this.props.updateToolbar({ actions: this.props.toolbarProps.actions, breadcrumbs });
+    const pageTitle = isRecurringRun ? 'Start a recurring run' : 'Start a new run';
+    this.props.updateToolbar({ actions: this.props.toolbarProps.actions, breadcrumbs, pageTitle });
 
     this.setState({
       experiment,

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -169,10 +169,8 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
         title: 'Delete',
         tooltip: 'Delete this pipeline',
       }],
-      breadcrumbs: [
-        { displayName: 'Pipelines', href: RoutePage.PIPELINES },
-        { displayName: this.props.match.params[RouteParams.pipelineId], href: '' }
-      ],
+      breadcrumbs: [{ displayName: 'Pipelines', href: RoutePage.PIPELINES }],
+      pageTitle: this.props.match.params[RouteParams.pipelineId],
     };
   }
 
@@ -295,14 +293,12 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
         await this.showPageError('Error: failed to generate Pipeline graph.', err);
       }
 
-      const breadcrumbs = [
-        { displayName: 'Pipelines', href: RoutePage.PIPELINES },
-        { displayName: pipeline.name!, href: '' },
-      ];
+      const breadcrumbs = [{ displayName: 'Pipelines', href: RoutePage.PIPELINES }];
+      const pageTitle = pipeline.name!;
 
       const toolbarActions = [...this.props.toolbarProps.actions];
       toolbarActions[0].disabled = false;
-      this.props.updateToolbar({ breadcrumbs, actions: toolbarActions });
+      this.props.updateToolbar({ breadcrumbs, actions: toolbarActions, pageTitle });
 
       this.setState({
         graph: g,

--- a/frontend/src/pages/PipelineList.tsx
+++ b/frontend/src/pages/PipelineList.tsx
@@ -77,7 +77,8 @@ class PipelineList extends Page<{}, PipelineListState> {
         title: 'Delete',
         tooltip: 'Delete',
       }],
-      breadcrumbs: [{ displayName: 'Pipelines', href: RoutePage.PIPELINES }],
+      breadcrumbs: [],
+      pageTitle: 'Pipelines',
     };
   }
 
@@ -148,7 +149,7 @@ class PipelineList extends Page<{}, PipelineListState> {
       // Delete pipeline
       draft[2].disabled = selectedIds.length < 1;
     });
-    this.props.updateToolbar({ breadcrumbs: this.props.toolbarProps.breadcrumbs, actions: toolbarActions });
+    this.props.updateToolbar({ actions: toolbarActions });
     this.setStateSafe({ selectedIds });
   }
 

--- a/frontend/src/pages/PipelineSelector.tsx
+++ b/frontend/src/pages/PipelineSelector.tsx
@@ -71,7 +71,7 @@ class PipelineSelector extends React.Component<PipelineSelectorProps, PipelineSe
 
     return (
       <React.Fragment>
-        <Toolbar actions={toolbarActions} breadcrumbs={[{ displayName: 'Choose a pipeline', href: '' }]} />
+        <Toolbar actions={toolbarActions} breadcrumbs={[]} pageTitle='Choose a pipeline' />
         <CustomTable columns={columns} rows={rows} selectedIds={selectedIds} useRadioButtons={true}
           updateSelection={this._pipelineSelectionChanged.bind(this)}
           initialSortColumn={PipelineSortKeys.CREATED_AT} ref={this._tableRef}

--- a/frontend/src/pages/RecurringRunDetails.test.tsx
+++ b/frontend/src/pages/RecurringRunDetails.test.tsx
@@ -130,10 +130,8 @@ describe('RecurringRunDetails', () => {
     const tree = shallow(<RecurringRunDetails {...generateProps()} />);
     await TestUtils.flushPromises();
     expect(updateToolbarSpy).toHaveBeenLastCalledWith(expect.objectContaining({
-      breadcrumbs: [
-        { displayName: 'All runs', href: RoutePage.RUNS },
-        { displayName: fullTestJob.name, href: '' },
-      ],
+      breadcrumbs: [{ displayName: 'All runs', href: RoutePage.RUNS }],
+      pageTitle: fullTestJob.name,
     }));
     tree.unmount();
   });
@@ -160,8 +158,8 @@ describe('RecurringRunDetails', () => {
           href: RoutePage.EXPERIMENT_DETAILS.replace(
             ':' + RouteParams.experimentId, 'test-experiment-id'),
         },
-        { displayName: fullTestJob.name, href: '' },
       ],
+      pageTitle: fullTestJob.name,
     }));
     tree.unmount();
   });

--- a/frontend/src/pages/RecurringRunDetails.tsx
+++ b/frontend/src/pages/RecurringRunDetails.tsx
@@ -77,6 +77,7 @@ class RecurringRunDetails extends Page<{}, RecurringRunConfigState> {
         tooltip: 'Delete this recurring run',
       }],
       breadcrumbs: [],
+      pageTitle: '',
     };
   }
 
@@ -192,16 +193,13 @@ class RecurringRunDetails extends Page<{}, RecurringRunConfigState> {
         { displayName: 'All runs', href: RoutePage.RUNS }
       );
     }
-    breadcrumbs.push({
-      displayName: run ? run.name! : runId,
-      href: '',
-    });
+    const pageTitle = run ? run.name! : runId;
 
     const toolbarActions = [...this.props.toolbarProps.actions];
     toolbarActions[1].disabled = !!run.enabled;
     toolbarActions[2].disabled = !run.enabled;
 
-    this.props.updateToolbar({ actions: toolbarActions, breadcrumbs });
+    this.props.updateToolbar({ actions: toolbarActions, breadcrumbs, pageTitle });
 
     this.setState({ run });
   }
@@ -230,7 +228,7 @@ class RecurringRunDetails extends Page<{}, RecurringRunConfigState> {
   }
 
   protected _updateToolbar(actions: ToolbarActionConfig[]): void {
-    this.props.updateToolbar({ breadcrumbs: this.props.toolbarProps.breadcrumbs, actions });
+    this.props.updateToolbar({ actions });
   }
 
   protected async _deleteDialogClosed(deleteConfirmed: boolean): Promise<void> {

--- a/frontend/src/pages/RecurringRunsManager.tsx
+++ b/frontend/src/pages/RecurringRunsManager.tsx
@@ -81,7 +81,7 @@ class RecurringRunsManager extends React.Component<RecurringRunListProps, Recurr
     });
 
     return (<React.Fragment>
-      <Toolbar actions={toolbarActions} breadcrumbs={[{ displayName: 'Recurring runs', href: '' }]} />
+      <Toolbar actions={toolbarActions} breadcrumbs={[]} pageTitle='Recurring runs' />
       <CustomTable columns={columns} rows={rows} ref={this._tableRef} selectedIds={selectedIds}
         updateSelection={ids => this.setState({ selectedIds: ids })} initialSortColumn={JobSortKeys.CREATED_AT}
         reload={this._loadRuns.bind(this)} emptyMessage={'No recurring runs found in this experiment.'}

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -32,7 +32,7 @@ import WorkflowParser from '../lib/WorkflowParser';
 import { ApiExperiment } from '../apis/experiment';
 import { ApiRun } from '../apis/run';
 import { Apis } from '../lib/Apis';
-import { NodePhase } from './Status';
+import { NodePhase, statusToIcon } from './Status';
 import { Page } from './Page';
 import { RoutePage, RouteParams } from '../components/Router';
 import { ToolbarProps } from 'src/components/Toolbar';
@@ -280,7 +280,7 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
         experiment = await Apis.experimentServiceApi.getExperiment(relatedExperimentId);
       }
       const workflow = JSON.parse(runDetail.pipeline_runtime!.workflow_manifest || '{}') as Workflow;
-      const runMetadata = runDetail.run;
+      const runMetadata = runDetail.run!;
 
       // Show workflow errors
       const workflowError = WorkflowParser.getWorkflowError(workflow);
@@ -308,10 +308,13 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
           { displayName: 'All runs', href: RoutePage.RUNS }
         );
       }
-      const pageTitle = runMetadata ? runMetadata.name! : this.props.runId!;
+      const pageTitle = <div className={commonCss.flex}>
+        {statusToIcon(runMetadata.status as NodePhase)}
+        <span style={{ marginLeft: 10 }}>{runMetadata.name!}</span>
+      </div>;
 
       // TODO: run status next to page name
-      this.props.updateToolbar({ breadcrumbs, pageTitle, pageTitleTooltip: pageTitle });
+      this.props.updateToolbar({ breadcrumbs, pageTitle, pageTitleTooltip: runMetadata.name });
 
       this.setState({
         experiment,

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -129,10 +129,8 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
         title: 'Refresh',
         tooltip: 'Refresh',
       }],
-      breadcrumbs: [
-        { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
-        { displayName: this.props.runId!, href: '' },
-      ],
+      breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
+      pageTitle: this.props.runId!,
     };
   }
 
@@ -310,13 +308,10 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
           { displayName: 'All runs', href: RoutePage.RUNS }
         );
       }
-      breadcrumbs.push({
-        displayName: runMetadata ? runMetadata.name! : this.props.runId!,
-        href: '',
-      });
+      const pageTitle = runMetadata ? runMetadata.name! : this.props.runId!;
 
       // TODO: run status next to page name
-      this.props.updateToolbar({ actions: this.props.toolbarProps.actions, breadcrumbs });
+      this.props.updateToolbar({ breadcrumbs, pageTitle, pageTitleTooltip: pageTitle });
 
       this.setState({
         experiment,

--- a/frontend/src/pages/Status.tsx
+++ b/frontend/src/pages/Status.tsx
@@ -76,7 +76,7 @@ export function statusToIcon(status: NodePhase): JSX.Element {
       logger.verbose('Unknown node phase:', status);
   }
 
-  return <Tooltip title={title}><span>
+  return <Tooltip title={title}><span style={{ height: 18 }}>
     <IconComponent style={{ color: iconColor, height: 18, width: 18 }} />
   </span></Tooltip>;
 }

--- a/frontend/src/pages/__snapshots__/AllRunsList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/AllRunsList.test.tsx.snap
@@ -56,12 +56,7 @@ exports[`AllRunsList disables clone button and enables compare button when multi
                   "tooltip": "Refresh the list of runs",
                 },
               ],
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "",
-                },
-              ],
+              "breadcrumbs": Array [],
             },
           ],
           Array [
@@ -98,12 +93,8 @@ exports[`AllRunsList disables clone button and enables compare button when multi
                   "tooltip": "Refresh the list of runs",
                 },
               ],
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "",
-                },
-              ],
+              "breadcrumbs": Array [],
+              "pageTitle": "Experiments",
             },
           ],
         ],
@@ -169,12 +160,7 @@ exports[`AllRunsList enables clone button when one run is selected 1`] = `
                   "tooltip": "Refresh the list of runs",
                 },
               ],
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "",
-                },
-              ],
+              "breadcrumbs": Array [],
             },
           ],
           Array [
@@ -211,12 +197,8 @@ exports[`AllRunsList enables clone button when one run is selected 1`] = `
                   "tooltip": "Refresh the list of runs",
                 },
               ],
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "",
-                },
-              ],
+              "breadcrumbs": Array [],
+              "pageTitle": "Experiments",
             },
           ],
         ],
@@ -275,12 +257,8 @@ exports[`AllRunsList renders all runs 1`] = `
             "tooltip": "Refresh the list of runs",
           },
         ],
-        "breadcrumbs": Array [
-          Object {
-            "displayName": "Experiments",
-            "href": "",
-          },
-        ],
+        "breadcrumbs": Array [],
+        "pageTitle": "Experiments",
       }
     }
     updateBanner={[MockFunction]}

--- a/frontend/src/pages/__snapshots__/ExperimentList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ExperimentList.test.tsx.snap
@@ -185,7 +185,13 @@ exports[`ExperimentList renders last 5 runs statuses 1`] = `
     <WithStyles(Tooltip)
       title="Executed successfully"
     >
-      <span>
+      <span
+        style={
+          Object {
+            "height": 18,
+          }
+        }
+      >
         <pure(CheckCircleIcon)
           style={
             Object {
@@ -209,7 +215,13 @@ exports[`ExperimentList renders last 5 runs statuses 1`] = `
     <WithStyles(Tooltip)
       title="Pending execution"
     >
-      <span>
+      <span
+        style={
+          Object {
+            "height": 18,
+          }
+        }
+      >
         <pure(ScheduleIcon)
           style={
             Object {
@@ -233,7 +245,13 @@ exports[`ExperimentList renders last 5 runs statuses 1`] = `
     <WithStyles(Tooltip)
       title="Resource failed to execute"
     >
-      <span>
+      <span
+        style={
+          Object {
+            "height": 18,
+          }
+        }
+      >
         <pure(ErrorIcon)
           style={
             Object {
@@ -257,7 +275,13 @@ exports[`ExperimentList renders last 5 runs statuses 1`] = `
     <WithStyles(Tooltip)
       title="Unknown status"
     >
-      <span>
+      <span
+        style={
+          Object {
+            "height": 18,
+          }
+        }
+      >
         <pure(HelpIcon)
           style={
             Object {
@@ -281,7 +305,13 @@ exports[`ExperimentList renders last 5 runs statuses 1`] = `
     <WithStyles(Tooltip)
       title="Executed successfully"
     >
-      <span>
+      <span
+        style={
+          Object {
+            "height": 18,
+          }
+        }
+      >
         <pure(CheckCircleIcon)
           style={
             Object {

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -78,11 +78,8 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
                   "displayName": "Experiments",
                   "href": "/experiments",
                 },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
               ],
+              "pageTitle": "Start a new run",
             }
           }
           updateBanner={
@@ -107,11 +104,8 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
                         "displayName": "Experiments",
                         "href": "/experiments",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
                 Array [
@@ -126,11 +120,8 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
                         "displayName": "some mock experiment name",
                         "href": "/experiments/details/some-mock-experiment-id",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
               ],
@@ -297,11 +288,8 @@ exports[`NewRun creating a new recurring run includes additional trigger input f
                   "displayName": "Experiments",
                   "href": "/experiments",
                 },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
               ],
+              "pageTitle": "Start a new run",
             }
           }
           updateBanner={
@@ -326,11 +314,8 @@ exports[`NewRun creating a new recurring run includes additional trigger input f
                         "displayName": "Experiments",
                         "href": "/experiments",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
                 Array [
@@ -341,11 +326,8 @@ exports[`NewRun creating a new recurring run includes additional trigger input f
                         "displayName": "Experiments",
                         "href": "/experiments",
                       },
-                      Object {
-                        "displayName": "Start a recurring run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a recurring run",
                   },
                 ],
               ],
@@ -515,11 +497,8 @@ exports[`NewRun creating a new run updates the pipeline in state when a user fil
                   "displayName": "Experiments",
                   "href": "/experiments",
                 },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
               ],
+              "pageTitle": "Start a new run",
             }
           }
           updateBanner={
@@ -555,11 +534,8 @@ exports[`NewRun creating a new run updates the pipeline in state when a user fil
                         "displayName": "Experiments",
                         "href": "/experiments",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
                 Array [
@@ -570,11 +546,8 @@ exports[`NewRun creating a new run updates the pipeline in state when a user fil
                         "displayName": "Experiments",
                         "href": "/experiments",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
               ],
@@ -764,11 +737,8 @@ exports[`NewRun creating a new run updates the pipeline params as user selects d
                   "displayName": "Experiments",
                   "href": "/experiments",
                 },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
               ],
+              "pageTitle": "Start a new run",
             }
           }
           updateBanner={
@@ -793,11 +763,8 @@ exports[`NewRun creating a new run updates the pipeline params as user selects d
                         "displayName": "Experiments",
                         "href": "/experiments",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
                 Array [
@@ -812,11 +779,8 @@ exports[`NewRun creating a new run updates the pipeline params as user selects d
                         "displayName": "some mock experiment name",
                         "href": "/experiments/details/some-mock-experiment-id",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
               ],
@@ -983,11 +947,8 @@ exports[`NewRun creating a new run updates the pipeline params as user selects d
                   "displayName": "Experiments",
                   "href": "/experiments",
                 },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
               ],
+              "pageTitle": "Start a new run",
             }
           }
           updateBanner={
@@ -1012,11 +973,8 @@ exports[`NewRun creating a new run updates the pipeline params as user selects d
                         "displayName": "Experiments",
                         "href": "/experiments",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
                 Array [
@@ -1031,11 +989,8 @@ exports[`NewRun creating a new run updates the pipeline params as user selects d
                         "displayName": "some mock experiment name",
                         "href": "/experiments/details/some-mock-experiment-id",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
               ],
@@ -1238,11 +1193,8 @@ exports[`NewRun creating a new run updates the pipeline params as user selects d
                   "displayName": "Experiments",
                   "href": "/experiments",
                 },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
               ],
+              "pageTitle": "Start a new run",
             }
           }
           updateBanner={
@@ -1267,11 +1219,8 @@ exports[`NewRun creating a new run updates the pipeline params as user selects d
                         "displayName": "Experiments",
                         "href": "/experiments",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
                 Array [
@@ -1286,11 +1235,8 @@ exports[`NewRun creating a new run updates the pipeline params as user selects d
                         "displayName": "some mock experiment name",
                         "href": "/experiments/details/some-mock-experiment-id",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
               ],
@@ -1457,11 +1403,8 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
                   "displayName": "Experiments",
                   "href": "/experiments",
                 },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
               ],
+              "pageTitle": "Start a new run",
             }
           }
           updateBanner={
@@ -1486,11 +1429,8 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
                         "displayName": "Experiments",
                         "href": "/experiments",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
                 Array [
@@ -1501,11 +1441,8 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
                         "displayName": "Experiments",
                         "href": "/experiments",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
               ],
@@ -1661,11 +1598,8 @@ exports[`NewRun renders the new run page 1`] = `
                   "displayName": "Experiments",
                   "href": "/experiments",
                 },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
               ],
+              "pageTitle": "Start a new run",
             }
           }
           updateBanner={
@@ -1690,11 +1624,8 @@ exports[`NewRun renders the new run page 1`] = `
                         "displayName": "Experiments",
                         "href": "/experiments",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
                 Array [
@@ -1709,11 +1640,8 @@ exports[`NewRun renders the new run page 1`] = `
                         "displayName": "some mock experiment name",
                         "href": "/experiments/details/some-mock-experiment-id",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
               ],
@@ -1880,11 +1808,8 @@ exports[`NewRun updates the run's state with the associated experiment if one is
                   "displayName": "Experiments",
                   "href": "/experiments",
                 },
-                Object {
-                  "displayName": "Start a new run",
-                  "href": "",
-                },
               ],
+              "pageTitle": "Start a new run",
             }
           }
           updateBanner={
@@ -1909,11 +1834,8 @@ exports[`NewRun updates the run's state with the associated experiment if one is
                         "displayName": "Experiments",
                         "href": "/experiments",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
                 Array [
@@ -1928,11 +1850,8 @@ exports[`NewRun updates the run's state with the associated experiment if one is
                         "displayName": "some mock experiment name",
                         "href": "/experiments/details/some-mock-experiment-id",
                       },
-                      Object {
-                        "displayName": "Start a new run",
-                        "href": "",
-                      },
                     ],
+                    "pageTitle": "Start a new run",
                   },
                 ],
               ],

--- a/frontend/src/pages/__snapshots__/RunList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunList.test.tsx.snap
@@ -7079,7 +7079,13 @@ exports[`RunList renders status as icon 1`] = `
   }
   title="Executed successfully"
 >
-  <span>
+  <span
+    style={
+      Object {
+        "height": 18,
+      }
+    }
+  >
     <pure(CheckCircleIcon)
       style={
         Object {

--- a/frontend/src/pages/__snapshots__/Status.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/Status.test.tsx.snap
@@ -279,7 +279,13 @@ exports[`Status handles an unknown phase 1`] = `
   }
   title="Unknown status"
 >
-  <span>
+  <span
+    style={
+      Object {
+        "height": 18,
+      }
+    }
+  >
     <pure(HelpIcon)
       style={
         Object {
@@ -572,7 +578,13 @@ exports[`Status renders an icon with tooltip for phase: ERROR 1`] = `
   }
   title="Error while running this resource"
 >
-  <span>
+  <span
+    style={
+      Object {
+        "height": 18,
+      }
+    }
+  >
     <pure(ErrorIcon)
       style={
         Object {
@@ -865,7 +877,13 @@ exports[`Status renders an icon with tooltip for phase: FAILED 1`] = `
   }
   title="Resource failed to execute"
 >
-  <span>
+  <span
+    style={
+      Object {
+        "height": 18,
+      }
+    }
+  >
     <pure(ErrorIcon)
       style={
         Object {
@@ -1158,7 +1176,13 @@ exports[`Status renders an icon with tooltip for phase: PENDING 1`] = `
   }
   title="Pending execution"
 >
-  <span>
+  <span
+    style={
+      Object {
+        "height": 18,
+      }
+    }
+  >
     <pure(ScheduleIcon)
       style={
         Object {
@@ -1451,7 +1475,13 @@ exports[`Status renders an icon with tooltip for phase: RUNNING 1`] = `
   }
   title="Running"
 >
-  <span>
+  <span
+    style={
+      Object {
+        "height": 18,
+      }
+    }
+  >
     <StatusRunning
       style={
         Object {
@@ -1744,7 +1774,13 @@ exports[`Status renders an icon with tooltip for phase: SKIPPED 1`] = `
   }
   title="Execution has been skipped for this resource"
 >
-  <span>
+  <span
+    style={
+      Object {
+        "height": 18,
+      }
+    }
+  >
     <pure(SkipNextIcon)
       style={
         Object {
@@ -2037,7 +2073,13 @@ exports[`Status renders an icon with tooltip for phase: SUCCEEDED 1`] = `
   }
   title="Executed successfully"
 >
-  <span>
+  <span
+    style={
+      Object {
+        "height": 18,
+      }
+    }
+  >
     <pure(CheckCircleIcon)
       style={
         Object {
@@ -2330,7 +2372,13 @@ exports[`Status renders an icon with tooltip for phase: UNKNOWN 1`] = `
   }
   title="Unknown status"
 >
-  <span>
+  <span
+    style={
+      Object {
+        "height": 18,
+      }
+    }
+  >
     <pure(HelpIcon)
       style={
         Object {


### PR DESCRIPTION
- Makes `updateToolbar` accept a partial object of toolbar props.
- Adds a `pageTitle` property to toolbar props that accepts a string or a component.
- Uses the property to display the status icon next to run name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/287)
<!-- Reviewable:end -->
