### PR TITLE
switch set() to add() for better inheritance.

### DIFF
--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -58,9 +58,9 @@ class ContainerOp(object):
     self.memory_request = None
     self.cpu_limit = None
     self.cpu_request = None
-    self.volumes = None
-    self.volume_mounts = None
-    self.env_variables = None
+    self.volumes = []
+    self.volume_mounts = []
+    self.env_variables = []
 
     matches = []
     if arguments:
@@ -155,38 +155,38 @@ class ContainerOp(object):
     self._validate_cpu_string(cpu)
     self.cpu_limit = cpu
 
-  def set_volumes(self, volumes):
-    """Specifying what K8s volumes the container depends on
+  def add_volume(self, volume):
+    """Add K8s volume to the container
 
     Args:
-      volumes: a list of Kubernetes volumes
+      volume: Kubernetes volumes
       For detailed spec, check volume definition
       https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_volume.py
     """
 
-    self.volumes = volumes
+    self.volumes.append(volume)
 
-  def set_volume_mounts(self, volume_mounts):
-    """Specifying how volumes are mounted to the container
+  def add_volume_mount(self, volume_mount):
+    """Add volume to the container
 
     Args:
-      volume_mounts: a list of Kubernetes volume mounts
+      volume_mount: Kubernetes volume mount
       For detailed spec, check volume mount definition
       https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_volume_mount.py
     """
 
-    self.volume_mounts = volume_mounts
+    self.volume_mounts.append(volume_mount)
 
-  def set_env_variables(self, env_variables):
-    """Set environment variables available in the container.
+  def add_env_variable(self, env_variable):
+    """Add environment variable to the container.
 
     Args:
-      env_variables: a list of Kubernetes environment variable
+      env_variable: Kubernetes environment variable
       For detailed spec, check environment variable definition
       https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_env_var.py
     """
 
-    self.env_variables = env_variables
+    self.env_variables.append(env_variable)
 
   def __repr__(self):
       return str({self.__class__.__name__: self.__dict__})

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -37,12 +37,12 @@ class TestCompiler(unittest.TestCase):
       op = dsl.ContainerOp(name='echo', image='image', command=['sh', '-c'],
                            arguments=['echo %s %s | tee /tmp/message.txt' % (msg1, msg2)],
                            file_outputs={'merged': '/tmp/message.txt'})
-      op.set_volume_mounts([k8s_client.V1VolumeMount(
+      op.add_volume_mount(k8s_client.V1VolumeMount(
           mount_path='/secret/gcp-credentials',
-          name='gcp-credentials')])
-      op.set_env_variables([k8s_client.V1EnvVar(
+          name='gcp-credentials'))
+      op.add_env_variable(k8s_client.V1EnvVar(
           name='GOOGLE_APPLICATION_CREDENTIALS',
-          value='/secret/gcp-credentials/user-gcp-sa.json')])
+          value='/secret/gcp-credentials/user-gcp-sa.json'))
     golden_output = {
       'container': {
         'image': 'image',

--- a/sdk/python/tests/compiler/testdata/volume.py
+++ b/sdk/python/tests/compiler/testdata/volume.py
@@ -28,14 +28,15 @@ def volume_pipeline():
       command=['sh', '-c'],
       arguments=['ls | tee /tmp/results.txt'],
       file_outputs={'downloaded': '/tmp/results.txt'})
-  op1.set_volumes([k8s_client.V1Volume(name='gcp-credentials',
+  op1.add_volume(k8s_client.V1Volume(name='gcp-credentials',
                                        secret=k8s_client.V1SecretVolumeSource(
-                                           secret_name='user-gcp-sa'))])
-  op1.set_volume_mounts([k8s_client.V1VolumeMount(
-      mount_path='/secret/gcp-credentials', name='gcp-credentials')])
-  op1.set_env_variables([k8s_client.V1EnvVar(
+                                           secret_name='user-gcp-sa')))
+  op1.add_volume_mount(k8s_client.V1VolumeMount(
+      mount_path='/secret/gcp-credentials', name='gcp-credentials'))
+  op1.add_env_variable(k8s_client.V1EnvVar(
       name='GOOGLE_APPLICATION_CREDENTIALS',
-      value='/secret/gcp-credentials/user-gcp-sa.json')])
+      value='/secret/gcp-credentials/user-gcp-sa.json'))
+  op1.add_env_variable(k8s_client.V1EnvVar(name='Foo',value='bar'))
   op2 = dsl.ContainerOp(
       name='echo',
       image='library/bash',

--- a/sdk/python/tests/compiler/testdata/volume.yaml
+++ b/sdk/python/tests/compiler/testdata/volume.yaml
@@ -30,6 +30,8 @@ spec:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /secret/gcp-credentials/user-gcp-sa.json
+      - name: Foo
+        value: bar
       image: google/cloud-sdk
       volumeMounts:
       - mountPath: /secret/gcp-credentials


### PR DESCRIPTION
We will have a gcpOp that add some default volumes to the container, and we should allow upper level ops inheriting gcpOp to add more volumes, envs if they want. 

A concrete example is having a op that read a GCS data and push to github. In this case I want to mount both GCP secret volume and Git secret volume.

TODO: we can add a batch method to add a list of resources, but that's not must have right now. 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/312)
<!-- Reviewable:end -->
