### PR TITLE
Tests - Fixed the argo submit failure not failing the script

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -123,7 +123,9 @@ ARGO_WORKFLOW=`argo submit $(dirname $0)/${WORKFLOW_FILE} \
 -p api-image="${GCR_IMAGE_BASE_DIR}/api" \
 -p frontend-image="${GCR_IMAGE_BASE_DIR}/frontend" \
 -p scheduledworkflow-image="${GCR_IMAGE_BASE_DIR}/scheduledworkflow" \
--p persistenceagent-image="${GCR_IMAGE_BASE_DIR}/persistenceagent" | awk '/Name:/{print $NF}'`
+-p persistenceagent-image="${GCR_IMAGE_BASE_DIR}/persistenceagent" \
+-o name
+`
 echo argo workflow submitted successfully
 
 echo "check status of argo workflow $ARGO_WORKFLOW...."


### PR DESCRIPTION
Removed pipe from argo submit.
Only the last pipe command affects the exit pipeline code unless `set -o pipefail` is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/324)
<!-- Reviewable:end -->
