### PR TITLE
mount gcp credentials for kaniko worker

### DIFF
--- a/sdk/python/kfp/compiler/_component_builder.py
+++ b/sdk/python/kfp/compiler/_component_builder.py
@@ -241,18 +241,36 @@ class ImageBuilder(object):
 
   def _generate_kaniko_spec(self, namespace, arc_dockerfile_name, gcs_path, target_image):
     """_generate_kaniko_yaml generates kaniko job yaml based on a template yaml """
-    content = {'apiVersion': 'v1',
-               'metadata': {
-                 'generateName': 'kaniko-',
-                 'namespace': 'default'},
-               'kind': 'Pod',
-               'spec': {
-                 'restartPolicy': 'Never',
-                 'containers': [
-                   {'name': 'kaniko',
-                    'args': ['--cache=true'],
-                    'image': 'gcr.io/kaniko-project/executor:v0.5.0'}],
-                 'serviceAccountName': 'default'}}
+    content = {
+      'apiVersion': 'v1',
+      'metadata': {
+        'generateName': 'kaniko-',
+        'namespace': 'kubeflow',
+      },
+      'kind': 'Pod',
+      'spec': {
+        'restartPolicy': 'Never',
+        'containers': [{
+          'name': 'kaniko',
+          'args': ['--cache=true'],
+          'image': 'gcr.io/kaniko-project/executor:v0.5.0',
+          'env': [{
+            'name': 'GOOGLE_APPLICATION_CREDENTIALS',
+            'value': '/secret/gcp-credentials/user-gcp-sa.json'
+          }],
+          'volumeMounts': [{
+            'mountPath': '/secret/gcp-credentials',
+            'name': 'gcp-credentials',
+          }],
+        }],
+        'volumes': [{
+          'name': 'gcp-credentials',
+          'secret': {
+            'secretName': 'user-gcp-sa',
+          },
+        }],
+        'serviceAccountName': 'default'}
+    }
 
     content['metadata']['namespace'] = namespace
     args = content['spec']['containers'][0]['args']

--- a/sdk/python/tests/compiler/testdata/kaniko.basic.yaml
+++ b/sdk/python/tests/compiler/testdata/kaniko.basic.yaml
@@ -28,3 +28,13 @@ spec:
                 "--dockerfile=dockerfile",
                 "--context=gs://mlpipeline/kaniko_build.tar.gz",
                 "--destination=gcr.io/mlpipeline/kaniko_image:latest"]
+    env:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /secret/gcp-credentials/user-gcp-sa.json
+    volumeMounts:
+    - mountPath: /secret/gcp-credentials
+      name: gcp-credentials
+  volumes:
+  - name: gcp-credentials
+    secret:
+      secretName: user-gcp-sa


### PR DESCRIPTION
Based on https://github.com/GoogleContainerTools/kaniko#kubernetes-secret this should work without additional setups. 

In future we should make the credential mounting configurable so it's not GCP specific.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/343)
<!-- Reviewable:end -->
