### PR TITLE
SDK - Improve the python package build

### DIFF
--- a/sdk/python/build.sh
+++ b/sdk/python/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 #
 # Copyright 2018 Google LLC
 #
@@ -25,6 +25,13 @@
 #   apt-get install --no-install-recommends -y -q default-jdk
 #   wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar -O /tmp/swagger-codegen-cli.jar
 
+get_abs_filename() {
+  # $1 : relative filename
+  echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+
+target_archive_file=${1:-kfp.tar.gz}
+target_archive_file=$(get_abs_filename "$target_archive_file")
 
 DIR=$(mktemp -d)
 
@@ -42,5 +49,5 @@ cp ./setup.py $DIR
 # Build tarball package.
 cd $DIR
 python setup.py sdist --format=gztar
-cp $DIR/dist/*.tar.gz $1
+cp $DIR/dist/*.tar.gz "$target_archive_file"
 rm -rf $DIR


### PR DESCRIPTION
* Make the script fail on error.
* Support relative output paths: `./build.sh kfp.tar.gz`
* Support default output path (`./kfp.tar.gz`): `./build.sh`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/364)
<!-- Reviewable:end -->
