### PR TITLE
Tests - Stop repeating the logs three times

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -152,14 +152,14 @@ then
   gsutil cp -r "${TEST_RESULTS_GCS_DIR}"/* "${ARTIFACT_DIR}" || true
 fi
 
-ARGO_WORKFLOW_DETAILS=`argo get ${ARGO_WORKFLOW}`
-ARGO_WORKFLOW_LOGS=`argo logs -w ${ARGO_WORKFLOW}`
-
 if [[ $WORKFLOW_STATUS = *"${WORKFLOW_FAILED_KEYWORD}"* ]]; then
-  printf "The argo workflow failed.\n =========Argo Workflow=========\n${ARGO_WORKFLOW_DETAILS}\n==================\n"
-  printf "=========Argo Workflow Logs=========\n${ARGO_WORKFLOW_LOGS}\n==================\n"
+  echo "Test workflow failed."
+  echo "=========Argo Workflow Logs========="
+  argo logs -w ${ARGO_WORKFLOW}
+  echo "===================================="
+  argo get ${ARGO_WORKFLOW}
   exit 1
 else
-  printf ${ARGO_WORKFLOW_DETAILS}
+  argo get ${ARGO_WORKFLOW}
   exit 0
 fi


### PR DESCRIPTION
Since the script tracing is enabled, the logs are currently printed three times:
1. When they're assigned to the variable
2. When the printf command is traced
3. When the printf command executes

This makes the logs harder to understand.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/366)
<!-- Reviewable:end -->
