### PR TITLE
Add support for minio hosted artifacts

### DIFF
--- a/frontend/src/lib/WorkflowParser.test.ts
+++ b/frontend/src/lib/WorkflowParser.test.ts
@@ -505,6 +505,22 @@ describe('WorkflowParser', () => {
       });
     });
 
+    it('handles Minio bucket without key', () => {
+      expect(WorkflowParser.parseStoragePath('minio://testbucket/')).toEqual({
+        bucket: 'testbucket',
+        key: '',
+        source: StorageService.MINIO,
+      });
+    });
+
+    it('handles Minio bucket and key', () => {
+      expect(WorkflowParser.parseStoragePath('minio://testbucket/testkey')).toEqual({
+        bucket: 'testbucket',
+        key: 'testkey',
+        source: StorageService.MINIO,
+      });
+    });
+
     it('handles Minio bucket and multi-part key', () => {
       expect(WorkflowParser.parseStoragePath('minio://testbucket/test/key/path')).toEqual({
         bucket: 'testbucket',

--- a/frontend/src/lib/WorkflowParser.test.ts
+++ b/frontend/src/lib/WorkflowParser.test.ts
@@ -504,6 +504,14 @@ describe('WorkflowParser', () => {
         source: StorageService.GCS,
       });
     });
+
+    it('handles Minio bucket and multi-part key', () => {
+      expect(WorkflowParser.parseStoragePath('minio://testbucket/test/key/path')).toEqual({
+        bucket: 'testbucket',
+        key: 'test/key/path',
+        source: StorageService.MINIO,
+      });
+    });
   });
 
   describe('getOutboundNodes', () => {

--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -182,6 +182,13 @@ export default class WorkflowParser {
         key: pathParts.slice(1).join('/'),
         source: StorageService.GCS,
       };
+    } else if (strPath.startsWith('minio://')) {
+        const pathParts = strPath.substr('minio://'.length).split('/');
+        return {
+          bucket: pathParts[0],
+          key: pathParts.slice(1).join('/'),
+          source: StorageService.MINIO,
+        };
     } else {
       throw new Error('Unsupported storage path: ' + strPath);
     }


### PR DESCRIPTION
This adds support for artifact source urls that start with "minio://".  I have a custom pipeline step that needs to write HTML to the local minio store instead of gcs.  The artifacts API supports fetching urls from the local minio store, the url parser only supports "gs://".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/389)
<!-- Reviewable:end -->
