### PR TITLE
Increase timeout waiting for test run to start

### DIFF
--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -105,7 +105,7 @@ describe('deploy helloworld sample run', () => {
   });
 
   it('finds the new run in the list of runs, navigates to it', () => {
-    $('.tableRow').waitForVisible(waitTimeout);
+    $('.tableRow').waitForVisible(3 * waitTimeout);
     assert.equal($$('.tableRow').length, 1, 'should only show one run');
 
     // Navigate to details of the deployed run by clicking its anchor element


### PR DESCRIPTION
I've seen a few frontend integration test failures timing out waiting for test runs to start. Let's see if this takes care of it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/392)
<!-- Reviewable:end -->
