### PR TITLE
RunDetails test suite, bug fixes

### DIFF
--- a/frontend/src/lib/OutputArtifactLoader.test.ts
+++ b/frontend/src/lib/OutputArtifactLoader.test.ts
@@ -18,7 +18,7 @@ import { Apis } from '../lib/Apis';
 import { ConfusionMatrixConfig } from '../components/viewers/ConfusionMatrix';
 import { PlotType } from '../components/viewers/Viewer';
 import { StoragePath, StorageService } from './WorkflowParser';
-import { loadOutputArtifacts, buildConfusionMatrixConfig, buildPagedTableConfig, buildTensorboardConfig, buildHtmlViewerConfig, buildRocCurveConfig } from './OutputArtifactLoader';
+import { OutputArtifactLoader } from './OutputArtifactLoader';
 import { PagedTableConfig } from '../components/viewers/PagedTable';
 import { TensorboardViewerConfig } from '../components/viewers/Tensorboard';
 import { HTMLViewerConfig } from '../components/viewers/HTMLViewer';
@@ -33,7 +33,7 @@ describe('OutputArtifactLoader', () => {
   describe('loadOutputArtifacts', () => {
     it('handles bad API call', async () => {
       jest.spyOn(Apis, 'readFile').mockImplementation(() => { throw new Error('bad call'); });
-      expect(await loadOutputArtifacts(storagePath)).toEqual([]);
+      expect(await OutputArtifactLoader.load(storagePath)).toEqual([]);
       expect(consoleSpy).toHaveBeenCalled();
 
       jest.spyOn(Apis, 'readFile').mockImplementation(() => fileToRead);
@@ -41,30 +41,30 @@ describe('OutputArtifactLoader', () => {
 
     it('handles an empty file', async () => {
       fileToRead = '';
-      expect(await loadOutputArtifacts(storagePath)).toEqual([]);
+      expect(await OutputArtifactLoader.load(storagePath)).toEqual([]);
     });
 
     it('handles bad json', async () => {
       fileToRead = 'bad json';
-      expect(await loadOutputArtifacts(storagePath)).toEqual([]);
+      expect(await OutputArtifactLoader.load(storagePath)).toEqual([]);
       expect(consoleSpy).toHaveBeenCalled();
     });
 
     it('handles an empty json', async () => {
       fileToRead = '{}';
-      expect(await loadOutputArtifacts(storagePath)).toEqual([]);
+      expect(await OutputArtifactLoader.load(storagePath)).toEqual([]);
       expect(consoleSpy).toHaveBeenCalled();
     });
 
     it('handles json with no "outputs" field', async () => {
       fileToRead = '{}';
-      expect(await loadOutputArtifacts(storagePath)).toEqual([]);
+      expect(await OutputArtifactLoader.load(storagePath)).toEqual([]);
       expect(consoleSpy).toHaveBeenCalled();
     });
 
     it('handles json with empty "outputs" array', async () => {
       fileToRead = '{"outputs": []}';
-      expect(await loadOutputArtifacts(storagePath)).toEqual([]);
+      expect(await OutputArtifactLoader.load(storagePath)).toEqual([]);
       expect(consoleSpy).toHaveBeenCalled();
     });
   });
@@ -72,25 +72,25 @@ describe('OutputArtifactLoader', () => {
   describe('buildConfusionMatrixConfig', () => {
     it('requires "source" metadata field', async () => {
       const metadata = { schema: 'schema', format: 'format' };
-      expect(buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
         'Malformed metadata, property "source" is required.');
     });
 
     it('requires "labels" metadata field', () => {
       const metadata = { source: 'source', schema: 'schema' };
-      expect(buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
         'Malformed metadata, property "labels" is required.');
     });
 
     it('requires "schema" metadata field', () => {
       const metadata = { source: 'source', labels: 'labels' };
-      expect(buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
         'Malformed metadata, property "schema" missing.');
     });
 
     it('handles empty schema', () => {
       const metadata = { source: 'gs://source', labels: ['labels'], schema: 'schema' };
-      expect(buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
         '"schema" must be an array of {"name": string, "type": string} objects');
     });
 
@@ -110,7 +110,7 @@ describe('OutputArtifactLoader', () => {
       field2,field1,0
       field2,field2,0
       `;
-      expect(buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
         'Each item in the "schema" array must contain a "name" field');
     });
 
@@ -126,7 +126,7 @@ describe('OutputArtifactLoader', () => {
         source: 'gs://path',
       };
       fileToRead = '';
-      expect(buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
         'Data dimensions 0 do not match the number of labels passed 2');
     });
 
@@ -147,7 +147,7 @@ describe('OutputArtifactLoader', () => {
       field2,field1,0
       field2,field2,0
       `;
-      const result = await buildConfusionMatrixConfig(metadata as any);
+      const result = await OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any);
       expect(result).toEqual({
         axes: ['field1', 'field2'],
         data: [[0, 0], [0, 0]],
@@ -160,25 +160,25 @@ describe('OutputArtifactLoader', () => {
   describe('buildPagedTableConfig', () => {
     it('requires "source" metadata field', () => {
       const metadata = { header: 'header', format: 'format' };
-      expect(buildPagedTableConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildPagedTableConfig(metadata as any)).rejects.toThrowError(
         'Malformed metadata, property "source" is required.');
     });
 
     it('requires "header" metadata field', () => {
       const metadata = { source: 'source', format: 'format' };
-      expect(buildPagedTableConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildPagedTableConfig(metadata as any)).rejects.toThrowError(
         'Malformed metadata, property "header" is required.');
     });
 
     it('requires "format" metadata field', () => {
       const metadata = { source: 'source', header: 'header' };
-      expect(buildPagedTableConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildPagedTableConfig(metadata as any)).rejects.toThrowError(
         'Malformed metadata, property "format" is required.');
     });
 
     it('requires only supports csv format', () => {
       const metadata = { source: 'source', header: 'header', format: 'json' };
-      expect(buildPagedTableConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildPagedTableConfig(metadata as any)).rejects.toThrowError(
         'Unsupported table format: json');
     });
 
@@ -194,7 +194,7 @@ describe('OutputArtifactLoader', () => {
       field2,field1,0
       field2,field2,0
       `;
-      const result = await buildPagedTableConfig(metadata as any);
+      const result = await OutputArtifactLoader.buildPagedTableConfig(metadata as any);
       expect(result).toEqual({
         data: [
           ['field1', 'field1', '0'],
@@ -211,13 +211,13 @@ describe('OutputArtifactLoader', () => {
   describe('buildTensorboardConfig', () => {
     it('requires "source" metadata field', () => {
       const metadata = { header: 'header', format: 'format' };
-      expect(buildTensorboardConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildTensorboardConfig(metadata as any)).rejects.toThrowError(
         'Malformed metadata, property "source" is required.');
     });
 
     it('returns a tensorboard config with basic metadata', async () => {
       const metadata = { source: 'gs://path' };
-      expect(await buildTensorboardConfig(metadata as any)).toEqual({
+      expect(await OutputArtifactLoader.buildTensorboardConfig(metadata as any)).toEqual({
         type: PlotType.TENSORBOARD,
         url: 'gs://path',
       } as TensorboardViewerConfig);
@@ -227,7 +227,7 @@ describe('OutputArtifactLoader', () => {
   describe('buildHtmlViewerConfig', () => {
     it('requires "source" metadata field', () => {
       const metadata = { header: 'header', format: 'format' };
-      expect(buildHtmlViewerConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildHtmlViewerConfig(metadata as any)).rejects.toThrowError(
         'Malformed metadata, property "source" is required.');
     });
 
@@ -236,7 +236,7 @@ describe('OutputArtifactLoader', () => {
       fileToRead = `<html><body>
         Hello World!
       </body></html>`;
-      expect(await buildHtmlViewerConfig(metadata as any)).toEqual({
+      expect(await OutputArtifactLoader.buildHtmlViewerConfig(metadata as any)).toEqual({
         htmlContent: fileToRead,
         type: PlotType.WEB_APP,
       } as HTMLViewerConfig);
@@ -246,31 +246,31 @@ describe('OutputArtifactLoader', () => {
   describe('buildRocCurveConfig', () => {
     it('requires "source" metadata field', () => {
       const metadata = { header: 'header', schema: 'schema' };
-      expect(buildRocCurveConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
         'Malformed metadata, property "source" is required.');
     });
 
     it('requires "schema" metadata field', () => {
       const metadata = { source: 'header' };
-      expect(buildRocCurveConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
         'Malformed metadata, property "schema" is required.');
     });
 
     it('throws for a non-array schema', () => {
       const metadata = { source: 'gs://path', schema: { field1: 'string' } };
-      expect(buildRocCurveConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
         'Malformed schema, must be an array of {"name": string, "type": string}');
     });
 
     it('requires "fpr" field in the schema', () => {
       const metadata = { source: 'gs://path', schema: [{ name: 'field1', type: 'string' }] };
-      expect(buildRocCurveConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
         'Malformed schema, expected to find a column named "fpr"');
     });
 
     it('requires "tpr" field in the schema', () => {
       const metadata = { source: 'gs://path', schema: [{ name: 'fpr', type: 'string' }] };
-      expect(buildRocCurveConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
         'Malformed schema, expected to find a column named "tpr"');
     });
 
@@ -285,7 +285,7 @@ describe('OutputArtifactLoader', () => {
         }],
         source: 'gs://path',
       };
-      expect(buildRocCurveConfig(metadata as any)).rejects.toThrowError(
+      expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
         'Malformed schema, expected to find a column named "threshold"');
     });
 
@@ -303,7 +303,7 @@ describe('OutputArtifactLoader', () => {
         3,4,5
         6,7,8
       `;
-      expect(await buildRocCurveConfig(metadata as any)).toEqual({
+      expect(await OutputArtifactLoader.buildRocCurveConfig(metadata as any)).toEqual({
         data: [
           { label: '2', x: 0, y: 1 },
           { label: '5', x: 3, y: 4 },
@@ -327,7 +327,7 @@ describe('OutputArtifactLoader', () => {
         3,4,5
         6,7,8
       `;
-      expect(await buildRocCurveConfig(metadata as any)).toEqual({
+      expect(await OutputArtifactLoader.buildRocCurveConfig(metadata as any)).toEqual({
         data: [
           { label: '0', x: 2, y: 1 },
           { label: '3', x: 5, y: 4 },
@@ -351,7 +351,7 @@ describe('OutputArtifactLoader', () => {
         3,4,5
         6,7,8
       `;
-      expect(await buildRocCurveConfig(metadata as any)).toEqual({
+      expect(await OutputArtifactLoader.buildRocCurveConfig(metadata as any)).toEqual({
         data: [
           { label: '2', x: 0, y: 1 },
           { label: '5', x: 3, y: 4 },

--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -41,189 +41,192 @@ export interface OutputMetadata {
   outputs: PlotMetadata[];
 }
 
-export async function loadOutputArtifacts(outputPath: StoragePath): Promise<ViewerConfig[]> {
-  let plotMetadataList: PlotMetadata[] = [];
-  try {
-    const metadataFile = await Apis.readFile(outputPath);
-    if (metadataFile) {
-      try {
-        plotMetadataList = (JSON.parse(metadataFile) as OutputMetadata).outputs;
-        if (plotMetadataList === undefined) {
-          throw new Error('"outputs" field required by not found on metadata file');
+export class OutputArtifactLoader {
+
+  public static async load(outputPath: StoragePath): Promise<ViewerConfig[]> {
+    let plotMetadataList: PlotMetadata[] = [];
+    try {
+      const metadataFile = await Apis.readFile(outputPath);
+      if (metadataFile) {
+        try {
+          plotMetadataList = (JSON.parse(metadataFile) as OutputMetadata).outputs;
+          if (plotMetadataList === undefined) {
+            throw new Error('"outputs" field required by not found on metadata file');
+          }
+        } catch (e) {
+          logger.error(`Could not parse metadata file at: ${outputPath.key}. Error: ${e}`);
+          return [];
         }
-      } catch (e) {
-        logger.error(`Could not parse metadata file at: ${outputPath.key}. Error: ${e}`);
-        return [];
       }
+    } catch (err) {
+      const errorMessage = await errorToMessage(err);
+      logger.error('Error loading run outputs:', errorMessage);
+      // TODO: error dialog
     }
-  } catch (err) {
-    const errorMessage = await errorToMessage(err);
-    logger.error('Error loading run outputs:', errorMessage);
-    // TODO: error dialog
+
+    const configs: Array<ViewerConfig | null> = await Promise.all(
+      plotMetadataList.map(async metadata => {
+        switch (metadata.type) {
+          case (PlotType.CONFUSION_MATRIX):
+            return await this.buildConfusionMatrixConfig(metadata);
+          case (PlotType.TABLE):
+            return await this.buildPagedTableConfig(metadata);
+          case (PlotType.TENSORBOARD):
+            return await this.buildTensorboardConfig(metadata);
+          case (PlotType.WEB_APP):
+            return await this.buildHtmlViewerConfig(metadata);
+          case (PlotType.ROC):
+            return await this.buildRocCurveConfig(metadata);
+          default:
+            logger.error('Unknown plot type: ' + metadata.type);
+            return null;
+        }
+      })
+    );
+
+    return configs.filter(c => !!c) as ViewerConfig[];
   }
 
-  const configs: Array<ViewerConfig | null> = await Promise.all(
-    plotMetadataList.map(async metadata => {
-      switch (metadata.type) {
-        case (PlotType.CONFUSION_MATRIX):
-          return await buildConfusionMatrixConfig(metadata);
-        case (PlotType.TABLE):
-          return await buildPagedTableConfig(metadata);
-        case (PlotType.TENSORBOARD):
-          return await buildTensorboardConfig(metadata);
-        case (PlotType.WEB_APP):
-          return await buildHtmlViewerConfig(metadata);
-        case (PlotType.ROC):
-          return await buildRocCurveConfig(metadata);
-        default:
-          logger.error('Unknown plot type: ' + metadata.type);
-          return null;
+  public static async buildConfusionMatrixConfig(metadata: PlotMetadata): Promise<ConfusionMatrixConfig> {
+    if (!metadata.source) {
+      throw new Error('Malformed metadata, property "source" is required.');
+    }
+    if (!metadata.labels) {
+      throw new Error('Malformed metadata, property "labels" is required.');
+    }
+    if (!metadata.schema) {
+      throw new Error('Malformed metadata, property "schema" missing.');
+    }
+    if (!Array.isArray(metadata.schema)) {
+      throw new Error('"schema" must be an array of {"name": string, "type": string} objects');
+    }
+
+    const path = WorkflowParser.parseStoragePath(metadata.source);
+    const csvRows = csvParseRows((await Apis.readFile(path)).trim());
+    const labels = metadata.labels;
+    const labelIndex: { [label: string]: number } = {};
+    let index = 0;
+    labels.forEach((l) => {
+      labelIndex[l] = index++;
+    });
+
+    if (labels.length ** 2 !== csvRows.length) {
+      throw new Error(
+        `Data dimensions ${csvRows.length} do not match the number of labels passed ${labels.length}`);
+    }
+
+    const data = Array.from(Array(labels.length), () => new Array(labels.length));
+    csvRows.forEach(([target, predicted, count]) => {
+      const i = labelIndex[target.trim()];
+      const j = labelIndex[predicted.trim()];
+      data[i][j] = Number.parseInt(count, 10);
+    });
+
+    const columnNames = metadata.schema.map((r) => {
+      if (!r.name) {
+        throw new Error('Each item in the "schema" array must contain a "name" field');
       }
-    })
-  );
+      return r.name;
+    });
+    const axes = [columnNames[0], columnNames[1]];
 
-  return configs.filter(c => !!c) as ViewerConfig[];
-}
-
-export async function buildConfusionMatrixConfig(metadata: PlotMetadata): Promise<ConfusionMatrixConfig> {
-  if (!metadata.source) {
-    throw new Error('Malformed metadata, property "source" is required.');
-  }
-  if (!metadata.labels) {
-    throw new Error('Malformed metadata, property "labels" is required.');
-  }
-  if (!metadata.schema) {
-    throw new Error('Malformed metadata, property "schema" missing.');
-  }
-  if (!Array.isArray(metadata.schema)) {
-    throw new Error('"schema" must be an array of {"name": string, "type": string} objects');
+    return {
+      axes,
+      data,
+      labels,
+      type: PlotType.CONFUSION_MATRIX,
+    };
   }
 
-  const path = WorkflowParser.parseStoragePath(metadata.source);
-  const csvRows = csvParseRows((await Apis.readFile(path)).trim());
-  const labels = metadata.labels;
-  const labelIndex: { [label: string]: number } = {};
-  let index = 0;
-  labels.forEach((l) => {
-    labelIndex[l] = index++;
-  });
-
-  if (labels.length ** 2 !== csvRows.length) {
-    throw new Error(
-      `Data dimensions ${csvRows.length} do not match the number of labels passed ${labels.length}`);
-  }
-
-  const data = Array.from(Array(labels.length), () => new Array(labels.length));
-  csvRows.forEach(([target, predicted, count]) => {
-    const i = labelIndex[target.trim()];
-    const j = labelIndex[predicted.trim()];
-    data[i][j] = Number.parseInt(count, 10);
-  });
-
-  const columnNames = metadata.schema.map((r) => {
-    if (!r.name) {
-      throw new Error('Each item in the "schema" array must contain a "name" field');
+  public static async buildPagedTableConfig(metadata: PlotMetadata): Promise<PagedTableConfig> {
+    if (!metadata.source) {
+      throw new Error('Malformed metadata, property "source" is required.');
     }
-    return r.name;
-  });
-  const axes = [columnNames[0], columnNames[1]];
+    if (!metadata.header) {
+      throw new Error('Malformed metadata, property "header" is required.');
+    }
+    if (!metadata.format) {
+      throw new Error('Malformed metadata, property "format" is required.');
+    }
+    let data: string[][] = [];
+    const labels = metadata.header || [];
 
-  return {
-    axes,
-    data,
-    labels,
-    type: PlotType.CONFUSION_MATRIX,
-  };
-}
+    switch (metadata.format) {
+      case 'csv':
+        const path = WorkflowParser.parseStoragePath(metadata.source);
+        data = csvParseRows((await Apis.readFile(path)).trim()).map(r => r.map(c => c.trim()));
+        break;
+      default:
+        throw new Error('Unsupported table format: ' + metadata.format);
+    }
 
-export async function buildPagedTableConfig(metadata: PlotMetadata): Promise<PagedTableConfig> {
-  if (!metadata.source) {
-    throw new Error('Malformed metadata, property "source" is required.');
-  }
-  if (!metadata.header) {
-    throw new Error('Malformed metadata, property "header" is required.');
-  }
-  if (!metadata.format) {
-    throw new Error('Malformed metadata, property "format" is required.');
-  }
-  let data: string[][] = [];
-  const labels = metadata.header || [];
-
-  switch (metadata.format) {
-    case 'csv':
-      const path = WorkflowParser.parseStoragePath(metadata.source);
-      data = csvParseRows((await Apis.readFile(path)).trim()).map(r => r.map(c => c.trim()));
-      break;
-    default:
-      throw new Error('Unsupported table format: ' + metadata.format);
+    return {
+      data,
+      labels,
+      type: PlotType.TABLE,
+    };
   }
 
-  return {
-    data,
-    labels,
-    type: PlotType.TABLE,
-  };
-}
-
-export async function buildTensorboardConfig(metadata: PlotMetadata): Promise<TensorboardViewerConfig> {
-  if (!metadata.source) {
-    throw new Error('Malformed metadata, property "source" is required.');
-  }
-  WorkflowParser.parseStoragePath(metadata.source);
-  return {
-    type: PlotType.TENSORBOARD,
-    url: metadata.source,
-  };
-}
-
-export async function buildHtmlViewerConfig(metadata: PlotMetadata): Promise<HTMLViewerConfig> {
-  if (!metadata.source) {
-    throw new Error('Malformed metadata, property "source" is required.');
-  }
-  const path = WorkflowParser.parseStoragePath(metadata.source);
-  const htmlContent = await Apis.readFile(path);
-
-  return {
-    htmlContent,
-    type: PlotType.WEB_APP,
-  };
-}
-
-export async function buildRocCurveConfig(metadata: PlotMetadata): Promise<ROCCurveConfig> {
-  if (!metadata.source) {
-    throw new Error('Malformed metadata, property "source" is required.');
-  }
-  if (!metadata.schema) {
-    throw new Error('Malformed metadata, property "schema" is required.');
-  }
-  if (!Array.isArray(metadata.schema)) {
-    throw new Error('Malformed schema, must be an array of {"name": string, "type": string}');
+  public static async buildTensorboardConfig(metadata: PlotMetadata): Promise<TensorboardViewerConfig> {
+    if (!metadata.source) {
+      throw new Error('Malformed metadata, property "source" is required.');
+    }
+    WorkflowParser.parseStoragePath(metadata.source);
+    return {
+      type: PlotType.TENSORBOARD,
+      url: metadata.source,
+    };
   }
 
-  const path = WorkflowParser.parseStoragePath(metadata.source);
-  const stringData = csvParseRows((await Apis.readFile(path)).trim());
+  public static async buildHtmlViewerConfig(metadata: PlotMetadata): Promise<HTMLViewerConfig> {
+    if (!metadata.source) {
+      throw new Error('Malformed metadata, property "source" is required.');
+    }
+    const path = WorkflowParser.parseStoragePath(metadata.source);
+    const htmlContent = await Apis.readFile(path);
 
-  const fprIndex = metadata.schema.findIndex(field => field.name === 'fpr');
-  if (fprIndex === -1) {
-    throw new Error('Malformed schema, expected to find a column named "fpr"');
-  }
-  const tprIndex = metadata.schema.findIndex(field => field.name === 'tpr');
-  if (tprIndex === -1) {
-    throw new Error('Malformed schema, expected to find a column named "tpr"');
-  }
-  const thresholdIndex = metadata.schema.findIndex(field => field.name.startsWith('threshold'));
-  if (thresholdIndex === -1) {
-    throw new Error('Malformed schema, expected to find a column named "threshold"');
+    return {
+      htmlContent,
+      type: PlotType.WEB_APP,
+    };
   }
 
-  const dataset = stringData.map(row => ({
-    label: row[thresholdIndex].trim(),
-    x: +row[fprIndex],
-    y: +row[tprIndex],
-  }));
+  public static async buildRocCurveConfig(metadata: PlotMetadata): Promise<ROCCurveConfig> {
+    if (!metadata.source) {
+      throw new Error('Malformed metadata, property "source" is required.');
+    }
+    if (!metadata.schema) {
+      throw new Error('Malformed metadata, property "schema" is required.');
+    }
+    if (!Array.isArray(metadata.schema)) {
+      throw new Error('Malformed schema, must be an array of {"name": string, "type": string}');
+    }
 
-  return {
-    data: dataset,
-    type: PlotType.ROC,
-  };
+    const path = WorkflowParser.parseStoragePath(metadata.source);
+    const stringData = csvParseRows((await Apis.readFile(path)).trim());
+
+    const fprIndex = metadata.schema.findIndex(field => field.name === 'fpr');
+    if (fprIndex === -1) {
+      throw new Error('Malformed schema, expected to find a column named "fpr"');
+    }
+    const tprIndex = metadata.schema.findIndex(field => field.name === 'tpr');
+    if (tprIndex === -1) {
+      throw new Error('Malformed schema, expected to find a column named "tpr"');
+    }
+    const thresholdIndex = metadata.schema.findIndex(field => field.name.startsWith('threshold'));
+    if (thresholdIndex === -1) {
+      throw new Error('Malformed schema, expected to find a column named "threshold"');
+    }
+
+    const dataset = stringData.map(row => ({
+      label: row[thresholdIndex].trim(),
+      x: +row[fprIndex],
+      y: +row[tprIndex],
+    }));
+
+    return {
+      data: dataset,
+      type: PlotType.ROC,
+    };
+  }
 }

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -36,7 +36,7 @@ import { Workflow } from '../../third_party/argo-ui/argo_template';
 import { classes, stylesheet } from 'typestyle';
 import { commonCss, padding } from '../Css';
 import { componentMap } from '../components/viewers/ViewerContainer';
-import { loadOutputArtifacts } from '../lib/OutputArtifactLoader';
+import { OutputArtifactLoader } from '../lib/OutputArtifactLoader';
 import { logger } from '../lib/Utils';
 
 const css = stylesheet({
@@ -225,7 +225,7 @@ class Compare extends Page<{}, CompareState> {
 
     await Promise.all(outputPathsList.map(async (pathList, i) => {
       for (const path of pathList) {
-        const configs = await loadOutputArtifacts(path);
+        const configs = await OutputArtifactLoader.load(path);
         configs.map(config => {
           const currentList: TaggedViewerConfig[] = viewersMap.get(config.type) || [];
           currentList.push({

--- a/frontend/src/pages/RunDetails.test.tsx
+++ b/frontend/src/pages/RunDetails.test.tsx
@@ -26,7 +26,6 @@ import { PlotType } from '../components/viewers/Viewer';
 import { QUERY_PARAMS } from '../lib/URLParser';
 import { RouteParams, RoutePage } from '../components/Router';
 import { Workflow } from 'third_party/argo-ui/argo_template';
-import { graphlib } from 'dagre';
 import { shallow } from 'enzyme';
 
 describe('RunDetails', () => {

--- a/frontend/src/pages/RunDetails.test.tsx
+++ b/frontend/src/pages/RunDetails.test.tsx
@@ -20,9 +20,12 @@ import TestUtils from '../TestUtils';
 import WorkflowParser from '../lib/WorkflowParser';
 import { ApiRunDetail, ApiResourceType } from '../apis/run';
 import { Apis } from '../lib/Apis';
+import { OutputArtifactLoader } from '../lib/OutputArtifactLoader';
 import { PageProps } from './Page';
+import { PlotType } from '../components/viewers/Viewer';
 import { QUERY_PARAMS } from '../lib/URLParser';
 import { RouteParams, RoutePage } from '../components/Router';
+import { Workflow } from 'third_party/argo-ui/argo_template';
 import { graphlib } from 'dagre';
 import { shallow } from 'enzyme';
 
@@ -71,6 +74,7 @@ describe('RunDetails', () => {
           parameters: [{ name: 'param1', value: 'value1' }],
           pipeline_id: 'some-pipeline-id',
         },
+        status: 'Succeeded',
       },
     };
     historyPushSpy.mockClear();
@@ -86,6 +90,25 @@ describe('RunDetails', () => {
     getPodLogsSpy.mockImplementation(() => new graphlib.Graph());
   });
 
+  it('shows success run status in page title', async () => {
+    const tree = shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    const lastCall = updateToolbarSpy.mock.calls[2][0];
+    expect(lastCall.pageTitle).toMatchSnapshot();
+    tree.unmount();
+  });
+
+  it('shows failure run status in page title', async () => {
+    testRun.run!.status = 'Failed';
+    const tree = shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    const lastCall = updateToolbarSpy.mock.calls[2][0];
+    expect(lastCall.pageTitle).toMatchSnapshot();
+    tree.unmount();
+  });
+
   it('has a refresh button, clicking it calls get run API again', async () => {
     const tree = shallow(<RunDetails {...generateProps()} />);
     await getRunSpy;
@@ -97,6 +120,7 @@ describe('RunDetails', () => {
     expect(getRunSpy).toHaveBeenCalledTimes(1);
     await refreshBtn!.action();
     expect(getRunSpy).toHaveBeenCalledTimes(2);
+    tree.unmount();
   });
 
   it('has a clone button, clicking it navigates to new run page', async () => {
@@ -111,31 +135,64 @@ describe('RunDetails', () => {
     expect(historyPushSpy).toHaveBeenCalledTimes(1);
     expect(historyPushSpy).toHaveBeenLastCalledWith(
       RoutePage.NEW_RUN + `?${QUERY_PARAMS.cloneFromRun}=${testRun.run!.id}`);
+    tree.unmount();
   });
 
   it('renders an empty run', async () => {
     const tree = shallow(<RunDetails {...generateProps()} />);
     await TestUtils.flushPromises();
     expect(tree).toMatchSnapshot();
+    tree.unmount();
   });
 
   it('calls the get run API once to load it', async () => {
-    shallow(<RunDetails {...generateProps()} />);
+    const tree = shallow(<RunDetails {...generateProps()} />);
     await getRunSpy;
     await TestUtils.flushPromises();
     expect(getRunSpy).toHaveBeenCalledTimes(1);
     expect(getRunSpy).toHaveBeenLastCalledWith(testRun.run!.id);
+    tree.unmount();
+  });
+
+  it('shows an error banner if get run API fails', async () => {
+    TestUtils.makeErrorResponseOnce(getRunSpy, 'woops');
+    const tree = shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    expect(updateBannerSpy).toHaveBeenCalledTimes(2); // Once initially to clear
+    expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+      additionalInfo: 'woops',
+      message: 'Error: failed to retrieve run: ' + testRun.run!.id + '. Click Details for more information.',
+      mode: 'error',
+    }));
+    tree.unmount();
+  });
+
+  it('shows an error banner if get experiment API fails', async () => {
+    testRun.run!.resource_references = [{ key: { id: 'experiment1', type: ApiResourceType.EXPERIMENT } }];
+    TestUtils.makeErrorResponseOnce(getExperimentSpy, 'woops');
+    const tree = shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    expect(updateBannerSpy).toHaveBeenCalledTimes(2); // Once initially to clear
+    expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+      additionalInfo: 'woops',
+      message: 'Error: failed to retrieve run: ' + testRun.run!.id + '. Click Details for more information.',
+      mode: 'error',
+    }));
+    tree.unmount();
   });
 
   it('calls the get experiment API once to load it if the run has its reference', async () => {
     testRun.run!.resource_references = [{ key: { id: 'experiment1', type: ApiResourceType.EXPERIMENT } }];
-    shallow(<RunDetails {...generateProps()} />);
+    const tree = shallow(<RunDetails {...generateProps()} />);
     await getRunSpy;
     await TestUtils.flushPromises();
     expect(getRunSpy).toHaveBeenCalledTimes(1);
     expect(getRunSpy).toHaveBeenLastCalledWith(testRun.run!.id);
     expect(getExperimentSpy).toHaveBeenCalledTimes(1);
     expect(getExperimentSpy).toHaveBeenLastCalledWith('experiment1');
+    tree.unmount();
   });
 
   it('shows workflow errors as page error', async () => {
@@ -151,5 +208,177 @@ describe('RunDetails', () => {
     }));
     tree.unmount();
   });
+
+  it('switches to config tab', async () => {
+    const tree = shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    tree.find('MD2Tabs').simulate('switch', 1);
+    expect(tree.state('selectedTab')).toBe(1);
+    expect(tree).toMatchSnapshot();
+    tree.unmount();
+  });
+
+  it('shows run config fields', async () => {
+    testRun.pipeline_runtime!.workflow_manifest = JSON.stringify({
+      metadata: {
+        creationTimestamp: new Date(2018, 6, 5, 4, 3, 2).toISOString(),
+      },
+      spec: {
+        arguments: {
+          parameters: [{
+            name: 'param1',
+            value: 'value1',
+          }, {
+            name: 'param2',
+            value: 'value2',
+          }],
+        },
+      },
+      status: {
+        finishedAt: new Date(2018, 6, 6, 5, 4, 3).toISOString(),
+        phase: 'Skipped',
+        startedAt: new Date(2018, 6, 5, 4, 3, 2).toISOString(),
+      },
+    } as Workflow);
+    const tree = shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    tree.find('MD2Tabs').simulate('switch', 1);
+    expect(tree.state('selectedTab')).toBe(1);
+    expect(tree).toMatchSnapshot();
+    tree.unmount();
+  });
+
+  it('shows run config fields - handles no description', async () => {
+    delete testRun.run!.description;
+    testRun.pipeline_runtime!.workflow_manifest = JSON.stringify({
+      metadata: {
+        creationTimestamp: new Date(2018, 6, 5, 4, 3, 2).toISOString(),
+      },
+      status: {
+        finishedAt: new Date(2018, 6, 6, 5, 4, 3).toISOString(),
+        phase: 'Skipped',
+        startedAt: new Date(2018, 6, 5, 4, 3, 2).toISOString(),
+      },
+    } as Workflow);
+    const tree = shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    tree.find('MD2Tabs').simulate('switch', 1);
+    expect(tree.state('selectedTab')).toBe(1);
+    expect(tree).toMatchSnapshot();
+    tree.unmount();
+  });
+
+  it('shows run config fields - handles no metadata', async () => {
+    testRun.pipeline_runtime!.workflow_manifest = JSON.stringify({
+      status: {
+        finishedAt: new Date(2018, 6, 6, 5, 4, 3).toISOString(),
+        phase: 'Skipped',
+        startedAt: new Date(2018, 6, 5, 4, 3, 2).toISOString(),
+      },
+    } as Workflow);
+    const tree = shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    tree.find('MD2Tabs').simulate('switch', 1);
+    expect(tree.state('selectedTab')).toBe(1);
+    expect(tree).toMatchSnapshot();
+    tree.unmount();
+  });
+
+  it('shows a one-node graph', async () => {
+    testRun.pipeline_runtime!.workflow_manifest = JSON.stringify({
+      status: {
+        nodes: {
+          node1: {
+            id: 'node1',
+            name: 'node1',
+            phase: 'Succeeded',
+          },
+        },
+      },
+    });
+    const tree = shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    expect(tree).toMatchSnapshot();
+    tree.unmount();
+  });
+
+  it('opens side panel when graph node is clicked', async () => {
+    testRun.pipeline_runtime!.workflow_manifest = JSON.stringify({
+      status: {
+        nodes: {
+          node1: {
+            id: 'node1',
+            name: 'node1',
+            phase: 'Succeeded',
+          },
+        },
+      },
+    });
+    const tree = shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    tree.find('Graph').simulate('click', 'node1');
+    expect(tree.state('selectedNodeDetails')).toHaveProperty('id', 'node1');
+    expect(tree).toMatchSnapshot();
+    tree.unmount();
+  });
+
+  it('shows clicked node message in side panel', async () => {
+    testRun.pipeline_runtime!.workflow_manifest = JSON.stringify({
+      status: {
+        nodes: {
+          node1: {
+            id: 'node1',
+            message: 'some test message',
+            name: 'node1',
+            phase: 'Succeeded',
+          },
+        },
+      },
+    });
+    const tree = shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    tree.find('Graph').simulate('click', 'node1');
+    expect(tree.state('selectedNodeDetails')).toHaveProperty('phaseMessage',
+      'This step is in ' + testRun.run!.status + ' state with this message: some test message');
+    expect(tree).toMatchSnapshot();
+    tree.unmount();
+  });
+
+  it('shows clicked node output in side pane', async () => {
+    testRun.pipeline_runtime!.workflow_manifest = JSON.stringify({
+      status: {
+        nodes: {
+          node1: {
+            id: 'node1',
+            message: 'some test message',
+            name: 'node1',
+            phase: 'Succeeded',
+          },
+        },
+      },
+    });
+    const parserSpy = jest.spyOn(WorkflowParser, 'loadNodeOutputPaths').mockImplementationOnce(() =>
+      [{ source: 'gcs', bucket: 'somebucket', key: 'somekey' }]);
+    const loaderSpy = jest.spyOn(OutputArtifactLoader, 'load').mockImplementationOnce(() =>
+      [{ type: PlotType.TENSORBOARD, url: 'some url' }]);
+    const tree = shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    tree.find('Graph').simulate('click', 'node1');
+    await parserSpy;
+    await loaderSpy;
+    expect(tree.state('selectedNodeDetails')).toHaveProperty('id', 'node1');
+    expect(tree).toMatchSnapshot();
+    tree.unmount();
+  });
+
+  // with side pane open, change workflows: nodes, status of open node, add message, remove message
 
 });

--- a/frontend/src/pages/RunDetails.test.tsx
+++ b/frontend/src/pages/RunDetails.test.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import RunDetails from './RunDetails';
+import TestUtils from '../TestUtils';
+import WorkflowParser from '../lib/WorkflowParser';
+import { ApiRunDetail, ApiResourceType } from '../apis/run';
+import { Apis } from '../lib/Apis';
+import { PageProps } from './Page';
+import { QUERY_PARAMS } from '../lib/URLParser';
+import { RouteParams, RoutePage } from '../components/Router';
+import { graphlib } from 'dagre';
+import { shallow } from 'enzyme';
+
+describe('RunDetails', () => {
+  const updateBannerSpy = jest.fn();
+  const updateDialogSpy = jest.fn();
+  const updateSnackbarSpy = jest.fn();
+  const updateToolbarSpy = jest.fn();
+  const historyPushSpy = jest.fn();
+  const getRunSpy = jest.spyOn(Apis.runServiceApi, 'getRun');
+  const getExperimentSpy = jest.spyOn(Apis.experimentServiceApi, 'getExperiment');
+  const getPodLogsSpy = jest.spyOn(Apis, 'getPodLogs');
+
+  let testRun: ApiRunDetail = {};
+
+  function generateProps(): PageProps {
+    const pageProps: PageProps = {
+      history: { push: historyPushSpy } as any,
+      location: '' as any,
+      match: { params: { [RouteParams.runId]: testRun.run!.id }, isExact: true, path: '', url: '' },
+      toolbarProps: { actions: [], breadcrumbs: [], pageTitle: '' },
+      updateBanner: updateBannerSpy,
+      updateDialog: updateDialogSpy,
+      updateSnackbar: updateSnackbarSpy,
+      updateToolbar: updateToolbarSpy,
+    };
+    return Object.assign(pageProps, {
+      toolbarProps: new RunDetails(pageProps).getInitialToolbarState(),
+    });
+  }
+
+  beforeAll(() => jest.spyOn(console, 'error').mockImplementation());
+  afterAll(() => jest.resetAllMocks());
+
+  beforeEach(() => {
+    testRun = {
+      pipeline_runtime: {
+        workflow_manifest: '{}',
+      },
+      run: {
+        created_at: new Date(2018, 8, 5, 4, 3, 2),
+        description: 'test run description',
+        id: 'test-run-id',
+        name: 'test run',
+        pipeline_spec: {
+          parameters: [{ name: 'param1', value: 'value1' }],
+          pipeline_id: 'some-pipeline-id',
+        },
+      },
+    };
+    historyPushSpy.mockClear();
+    updateBannerSpy.mockClear();
+    updateDialogSpy.mockClear();
+    updateSnackbarSpy.mockClear();
+    updateToolbarSpy.mockClear();
+    getRunSpy.mockReset();
+    getRunSpy.mockImplementation(() => Promise.resolve(testRun));
+    getExperimentSpy.mockClear();
+    getExperimentSpy.mockImplementation(() => Promise.resolve('{}'));
+    getPodLogsSpy.mockClear();
+    getPodLogsSpy.mockImplementation(() => new graphlib.Graph());
+  });
+
+  it('has a refresh button, clicking it calls get run API again', async () => {
+    const tree = shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    const instance = tree.instance() as RunDetails;
+    const refreshBtn = instance.getInitialToolbarState().actions.find(
+      b => b.title === 'Refresh');
+    expect(refreshBtn).toBeDefined();
+    expect(getRunSpy).toHaveBeenCalledTimes(1);
+    await refreshBtn!.action();
+    expect(getRunSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('has a clone button, clicking it navigates to new run page', async () => {
+    const tree = shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    const instance = tree.instance() as RunDetails;
+    const cloneBtn = instance.getInitialToolbarState().actions.find(
+      b => b.title === 'Clone');
+    expect(cloneBtn).toBeDefined();
+    await cloneBtn!.action();
+    expect(historyPushSpy).toHaveBeenCalledTimes(1);
+    expect(historyPushSpy).toHaveBeenLastCalledWith(
+      RoutePage.NEW_RUN + `?${QUERY_PARAMS.cloneFromRun}=${testRun.run!.id}`);
+  });
+
+  it('renders an empty run', async () => {
+    const tree = shallow(<RunDetails {...generateProps()} />);
+    await TestUtils.flushPromises();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('calls the get run API once to load it', async () => {
+    shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    expect(getRunSpy).toHaveBeenCalledTimes(1);
+    expect(getRunSpy).toHaveBeenLastCalledWith(testRun.run!.id);
+  });
+
+  it('calls the get experiment API once to load it if the run has its reference', async () => {
+    testRun.run!.resource_references = [{ key: { id: 'experiment1', type: ApiResourceType.EXPERIMENT } }];
+    shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    expect(getRunSpy).toHaveBeenCalledTimes(1);
+    expect(getRunSpy).toHaveBeenLastCalledWith(testRun.run!.id);
+    expect(getExperimentSpy).toHaveBeenCalledTimes(1);
+    expect(getExperimentSpy).toHaveBeenLastCalledWith('experiment1');
+  });
+
+  it('shows workflow errors as page error', async () => {
+    jest.spyOn(WorkflowParser, 'getWorkflowError').mockImplementationOnce(() => 'some error message');
+    const tree = shallow(<RunDetails {...generateProps()} />);
+    await getRunSpy;
+    await TestUtils.flushPromises();
+    expect(updateBannerSpy).toHaveBeenCalledTimes(2); // Once to clear on init, once for error
+    expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+      additionalInfo: 'some error message',
+      message: 'Error: found errors when executing run: ' + testRun.run!.id + '. Click Details for more information.',
+      mode: 'error',
+    }));
+    tree.unmount();
+  });
+
+});

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -39,7 +39,7 @@ import { Workflow } from '../../third_party/argo-ui/argo_template';
 import { commonCss, padding } from '../Css';
 import { componentMap } from '../components/viewers/ViewerContainer';
 import { formatDateString, getRunTime, logger, errorToMessage } from '../lib/Utils';
-import { loadOutputArtifacts } from '../lib/OutputArtifactLoader';
+import { OutputArtifactLoader } from '../lib/OutputArtifactLoader';
 import { classes } from 'typestyle';
 
 enum SidePaneTab {
@@ -117,10 +117,10 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
     return (
       <div className={classes(commonCss.page, padding(20, 't'))}>
 
-        {workflow && (
+        {!!workflow && (
           <div className={commonCss.page}>
             <MD2Tabs selectedTab={selectedTab} tabs={['Graph', 'Config']}
-              onSwitch={(tab: number) => this.setState({ selectedTab: tab })} />
+              onSwitch={(tab: number) => this.setStateSafe({ selectedTab: tab })} />
             <div className={commonCss.page}>
 
               {selectedTab === 0 && <div className={commonCss.page}>
@@ -129,7 +129,7 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
                     onClick={(id) => this._selectNode(id)} />
 
                   <SidePanel isBusy={this.state.sidepanelBusy} isOpen={!!selectedNodeDetails}
-                    onClose={() => this.setState({ selectedNodeDetails: null })} title={selectedNodeId}>
+                    onClose={() => this.setStateSafe({ selectedNodeDetails: null })} title={selectedNodeId}>
                     {!!selectedNodeDetails && (<React.Fragment>
                       {!!selectedNodeDetails.phaseMessage && (
                         <Banner mode='warning'
@@ -194,14 +194,7 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
               </div>}
 
               {selectedTab === 1 && <div className={padding()}>
-                <DetailsTable title='Run details' fields={[
-                  ['Status', workflow.status.phase],
-                  ['Description', runMetadata ? runMetadata!.description! : ''],
-                  ['Created at', formatDateString(workflow.metadata.creationTimestamp)],
-                  ['Started at', formatDateString(workflow.status.startedAt)],
-                  ['Finished at', formatDateString(workflow.status.finishedAt)],
-                  ['Duration', getRunTime(workflow)],
-                ]} />
+                <DetailsTable title='Run details' fields={this._getDetailsFields(workflow, runMetadata)} />
 
                 {workflowParameters && !!workflowParameters.length && (<div>
                   <DetailsTable title='Run parameters'
@@ -271,7 +264,7 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
       // TODO: run status next to page name
       this.props.updateToolbar({ breadcrumbs, pageTitle, pageTitleTooltip: runMetadata.name });
 
-      this.setState({
+      this.setStateSafe({
         experiment,
         graph,
         runMetadata,
@@ -288,8 +281,19 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
     this._loadSelectedNodeOutputs();
   }
 
+  private _getDetailsFields(workflow: Workflow, runMetadata?: ApiRun): string[][] {
+    return !workflow.status ? [] : [
+      ['Status', workflow.status.phase],
+      ['Description', runMetadata ? runMetadata!.description! : ''],
+      ['Created at', workflow.metadata ? formatDateString(workflow.metadata.creationTimestamp) : '-'],
+      ['Started at', formatDateString(workflow.status.startedAt)],
+      ['Finished at', formatDateString(workflow.status.finishedAt)],
+      ['Duration', getRunTime(workflow)],
+    ];
+  }
+
   private _selectNode(id: string): void {
-    this.setState({ selectedNodeDetails: { id } }, () =>
+    this.setStateSafe({ selectedNodeDetails: { id } }, () =>
       this._sidePaneTabSwitched(this.state.sidepanelSelectedTab));
   }
 
@@ -302,7 +306,7 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
         selectedNodeDetails.phaseMessage =
           `This step is in ${node.phase} state with this message: ` + node.message;
       }
-      this.setState({ selectedNodeDetails, sidepanelSelectedTab: tab });
+      this.setStateSafe({ selectedNodeDetails, sidepanelSelectedTab: tab });
 
       switch (tab) {
         case SidePaneTab.ARTIFACTS:
@@ -313,7 +317,7 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
             this._loadSelectedNodeLogs();
           } else {
             // Clear logs
-            this.setState({ logsBannerAdditionalInfo: '', logsBannerMessage: '' });
+            this.setStateSafe({ logsBannerAdditionalInfo: '', logsBannerMessage: '' });
           }
       }
     }
@@ -324,22 +328,23 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
     if (!selectedNodeDetails) {
       return;
     }
-    this.setState({ sidepanelBusy: true });
-    const workflow = this.state.workflow;
-    if (workflow && workflow.status && workflow.status.nodes) {
-      // Load runtime outputs from the selected Node
-      const outputPaths = WorkflowParser.loadNodeOutputPaths(workflow.status.nodes[selectedNodeDetails.id]);
+    this.setStateSafe({ sidepanelBusy: true }, async () => {
+      const workflow = this.state.workflow;
+      if (workflow && workflow.status && workflow.status.nodes) {
+        // Load runtime outputs from the selected Node
+        const outputPaths = WorkflowParser.loadNodeOutputPaths(workflow.status.nodes[selectedNodeDetails.id]);
 
-      // Load the viewer configurations from the output paths
-      let viewerConfigs: ViewerConfig[] = [];
-      for (const path of outputPaths) {
-        viewerConfigs = viewerConfigs.concat(await loadOutputArtifacts(path));
+        // Load the viewer configurations from the output paths
+        let viewerConfigs: ViewerConfig[] = [];
+        for (const path of outputPaths) {
+          viewerConfigs = viewerConfigs.concat(await OutputArtifactLoader.load(path));
+        }
+
+        selectedNodeDetails.viewerConfigs = viewerConfigs;
+        this.setStateSafe({ selectedNodeDetails });
       }
-
-      selectedNodeDetails.viewerConfigs = viewerConfigs;
-      this.setState({ selectedNodeDetails });
-    }
-    this.setState({ sidepanelBusy: false });
+      this.setStateSafe({ sidepanelBusy: false });
+    });
   }
 
   private async _loadSelectedNodeLogs(): Promise<void> {
@@ -347,14 +352,14 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
     if (!selectedNodeDetails) {
       return;
     }
-    this.setState({ sidepanelBusy: true });
+    this.setStateSafe({ sidepanelBusy: true });
     try {
       const logs = await Apis.getPodLogs(selectedNodeDetails.id);
       selectedNodeDetails.logs = logs;
-      this.setState({ selectedNodeDetails, logsBannerAdditionalInfo: '', logsBannerMessage: '' });
+      this.setStateSafe({ selectedNodeDetails, logsBannerAdditionalInfo: '', logsBannerMessage: '' });
     } catch (err) {
       const errorMessage = await errorToMessage(err);
-      this.setState({
+      this.setStateSafe({
         logsBannerAdditionalInfo: errorMessage,
         logsBannerMessage: 'Error: failed to retrieve logs.'
           + (errorMessage ? ' Click Details for more information.' : ''),
@@ -362,7 +367,7 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
       });
       logger.error('Error loading logs for node:', selectedNodeDetails.id);
     } finally {
-      this.setState({ sidepanelBusy: false });
+      this.setStateSafe({ sidepanelBusy: false });
     }
   }
 

--- a/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
@@ -1,5 +1,71 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RunDetails closes side panel when close button is clicked 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="page"
+  >
+    <MD2Tabs
+      onSwitch={[Function]}
+      selectedTab={0}
+      tabs={
+        Array [
+          "Graph",
+          "Config",
+        ]
+      }
+    />
+    <div
+      className="page"
+    >
+      <div
+        className="page"
+      >
+        <div
+          className="page"
+          style={
+            Object {
+              "overflow": "hidden",
+              "position": "relative",
+            }
+          }
+        >
+          <Graph
+            graph={
+              Graph {
+                "_defaultEdgeLabelFn": [Function],
+                "_defaultNodeLabelFn": [Function],
+                "_edgeLabels": Object {},
+                "_edgeObjs": Object {},
+                "_in": Object {},
+                "_isCompound": false,
+                "_isDirected": true,
+                "_isMultigraph": false,
+                "_label": Object {},
+                "_nodes": Object {},
+                "_out": Object {},
+                "_preds": Object {},
+                "_sucs": Object {},
+              }
+            }
+            onClick={[Function]}
+            selectedNodeId=""
+          />
+          <SidePanel
+            isBusy={false}
+            isOpen={false}
+            onClose={[Function]}
+            title=""
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`RunDetails does not load logs if clicked node status is skipped 1`] = `
 <div
   className="page"
@@ -95,6 +161,178 @@ exports[`RunDetails does not load logs if clicked node status is skipped 1`] = `
       </div>
     </div>
   </div>
+</div>
+`;
+
+exports[`RunDetails keeps side pane open and on same tab when logs change after refresh 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="page"
+  >
+    <MD2Tabs
+      onSwitch={[Function]}
+      selectedTab={0}
+      tabs={
+        Array [
+          "Graph",
+          "Config",
+        ]
+      }
+    />
+    <div
+      className="page"
+    >
+      <div
+        className="page"
+      >
+        <div
+          className="page"
+          style={
+            Object {
+              "overflow": "hidden",
+              "position": "relative",
+            }
+          }
+        >
+          <Graph
+            graph={
+              Graph {
+                "_defaultEdgeLabelFn": [Function],
+                "_defaultNodeLabelFn": [Function],
+                "_edgeLabels": Object {},
+                "_edgeObjs": Object {},
+                "_in": Object {},
+                "_isCompound": false,
+                "_isDirected": true,
+                "_isMultigraph": false,
+                "_label": Object {},
+                "_nodes": Object {},
+                "_out": Object {},
+                "_preds": Object {},
+                "_sucs": Object {},
+              }
+            }
+            onClick={[Function]}
+            selectedNodeId="node1"
+          />
+          <SidePanel
+            isBusy={false}
+            isOpen={true}
+            onClose={[Function]}
+            title="node1"
+          >
+            <div
+              className="page"
+            >
+              <MD2Tabs
+                onSwitch={[Function]}
+                selectedTab={2}
+                tabs={
+                  Array [
+                    "Artifacts",
+                    "Input/Output",
+                    "Logs",
+                  ]
+                }
+              />
+              <div
+                className="page"
+              >
+                <div
+                  className="page"
+                >
+                  <LogViewer
+                    classes="page"
+                    logLines={
+                      Array [
+                        "new test logs",
+                      ]
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </SidePanel>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RunDetails keeps side pane open and on same tab when run status changes, shows new status 1`] = `
+<div
+  className="flex"
+>
+  <WithStyles(Tooltip)
+    title="Executed successfully"
+  >
+    <span
+      style={
+        Object {
+          "height": 18,
+        }
+      }
+    >
+      <pure(CheckCircleIcon)
+        style={
+          Object {
+            "color": "#34a853",
+            "height": 18,
+            "width": 18,
+          }
+        }
+      />
+    </span>
+  </WithStyles(Tooltip)>
+  <span
+    style={
+      Object {
+        "marginLeft": 10,
+      }
+    }
+  >
+    test run
+  </span>
+</div>
+`;
+
+exports[`RunDetails keeps side pane open and on same tab when run status changes, shows new status 2`] = `
+<div
+  className="flex"
+>
+  <WithStyles(Tooltip)
+    title="Resource failed to execute"
+  >
+    <span
+      style={
+        Object {
+          "height": 18,
+        }
+      }
+    >
+      <pure(ErrorIcon)
+        style={
+          Object {
+            "color": "#D50000",
+            "height": 18,
+            "width": 18,
+          }
+        }
+      />
+    </span>
+  </WithStyles(Tooltip)>
+  <span
+    style={
+      Object {
+        "marginLeft": 10,
+      }
+    }
+  >
+    test run
+  </span>
 </div>
 `;
 

--- a/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
@@ -1,5 +1,94 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RunDetails opens side panel when graph node is clicked 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="page"
+  >
+    <MD2Tabs
+      onSwitch={[Function]}
+      selectedTab={0}
+      tabs={
+        Array [
+          "Graph",
+          "Config",
+        ]
+      }
+    />
+    <div
+      className="page"
+    >
+      <div
+        className="page"
+      >
+        <div
+          className="page"
+          style={
+            Object {
+              "overflow": "hidden",
+              "position": "relative",
+            }
+          }
+        >
+          <Graph
+            graph={
+              Graph {
+                "_defaultEdgeLabelFn": [Function],
+                "_defaultNodeLabelFn": [Function],
+                "_edgeLabels": Object {},
+                "_edgeObjs": Object {},
+                "_in": Object {},
+                "_isCompound": false,
+                "_isDirected": true,
+                "_isMultigraph": false,
+                "_label": Object {},
+                "_nodes": Object {},
+                "_out": Object {},
+                "_preds": Object {},
+                "_sucs": Object {},
+              }
+            }
+            onClick={[Function]}
+            selectedNodeId="node1"
+          />
+          <SidePanel
+            isBusy={false}
+            isOpen={true}
+            onClose={[Function]}
+            title="node1"
+          >
+            <div
+              className="page"
+            >
+              <MD2Tabs
+                onSwitch={[Function]}
+                selectedTab={0}
+                tabs={
+                  Array [
+                    "Artifacts",
+                    "Input/Output",
+                    "Logs",
+                  ]
+                }
+              />
+              <div
+                className="page"
+              >
+                <div
+                  className="page"
+                />
+              </div>
+            </div>
+          </SidePanel>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`RunDetails renders an empty run 1`] = `
 <div
   className="page"
@@ -32,6 +121,581 @@ exports[`RunDetails renders an empty run 1`] = `
         >
           No graph to show
         </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RunDetails shows a one-node graph 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="page"
+  >
+    <MD2Tabs
+      onSwitch={[Function]}
+      selectedTab={0}
+      tabs={
+        Array [
+          "Graph",
+          "Config",
+        ]
+      }
+    />
+    <div
+      className="page"
+    >
+      <div
+        className="page"
+      >
+        <div
+          className="page"
+          style={
+            Object {
+              "overflow": "hidden",
+              "position": "relative",
+            }
+          }
+        >
+          <Graph
+            graph={
+              Graph {
+                "_defaultEdgeLabelFn": [Function],
+                "_defaultNodeLabelFn": [Function],
+                "_edgeLabels": Object {},
+                "_edgeObjs": Object {},
+                "_in": Object {},
+                "_isCompound": false,
+                "_isDirected": true,
+                "_isMultigraph": false,
+                "_label": Object {},
+                "_nodes": Object {},
+                "_out": Object {},
+                "_preds": Object {},
+                "_sucs": Object {},
+              }
+            }
+            onClick={[Function]}
+            selectedNodeId=""
+          />
+          <SidePanel
+            isBusy={false}
+            isOpen={false}
+            onClose={[Function]}
+            title=""
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RunDetails shows clicked node message in side panel 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="page"
+  >
+    <MD2Tabs
+      onSwitch={[Function]}
+      selectedTab={0}
+      tabs={
+        Array [
+          "Graph",
+          "Config",
+        ]
+      }
+    />
+    <div
+      className="page"
+    >
+      <div
+        className="page"
+      >
+        <div
+          className="page"
+          style={
+            Object {
+              "overflow": "hidden",
+              "position": "relative",
+            }
+          }
+        >
+          <Graph
+            graph={
+              Graph {
+                "_defaultEdgeLabelFn": [Function],
+                "_defaultNodeLabelFn": [Function],
+                "_edgeLabels": Object {},
+                "_edgeObjs": Object {},
+                "_in": Object {},
+                "_isCompound": false,
+                "_isDirected": true,
+                "_isMultigraph": false,
+                "_label": Object {},
+                "_nodes": Object {},
+                "_out": Object {},
+                "_preds": Object {},
+                "_sucs": Object {},
+              }
+            }
+            onClick={[Function]}
+            selectedNodeId="node1"
+          />
+          <SidePanel
+            isBusy={false}
+            isOpen={true}
+            onClose={[Function]}
+            title="node1"
+          >
+            <Banner
+              message="This step is in Succeeded state with this message: some test message"
+              mode="warning"
+            />
+            <div
+              className="page"
+            >
+              <MD2Tabs
+                onSwitch={[Function]}
+                selectedTab={0}
+                tabs={
+                  Array [
+                    "Artifacts",
+                    "Input/Output",
+                    "Logs",
+                  ]
+                }
+              />
+              <div
+                className="page"
+              >
+                <div
+                  className="page"
+                />
+              </div>
+            </div>
+          </SidePanel>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RunDetails shows clicked node output in side pane 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="page"
+  >
+    <MD2Tabs
+      onSwitch={[Function]}
+      selectedTab={0}
+      tabs={
+        Array [
+          "Graph",
+          "Config",
+        ]
+      }
+    />
+    <div
+      className="page"
+    >
+      <div
+        className="page"
+      >
+        <div
+          className="page"
+          style={
+            Object {
+              "overflow": "hidden",
+              "position": "relative",
+            }
+          }
+        >
+          <Graph
+            graph={
+              Graph {
+                "_defaultEdgeLabelFn": [Function],
+                "_defaultNodeLabelFn": [Function],
+                "_edgeLabels": Object {},
+                "_edgeObjs": Object {},
+                "_in": Object {},
+                "_isCompound": false,
+                "_isDirected": true,
+                "_isMultigraph": false,
+                "_label": Object {},
+                "_nodes": Object {},
+                "_out": Object {},
+                "_preds": Object {},
+                "_sucs": Object {},
+              }
+            }
+            onClick={[Function]}
+            selectedNodeId="node1"
+          />
+          <SidePanel
+            isBusy={false}
+            isOpen={true}
+            onClose={[Function]}
+            title="node1"
+          >
+            <Banner
+              message="This step is in Succeeded state with this message: some test message"
+              mode="warning"
+            />
+            <div
+              className="page"
+            >
+              <MD2Tabs
+                onSwitch={[Function]}
+                selectedTab={0}
+                tabs={
+                  Array [
+                    "Artifacts",
+                    "Input/Output",
+                    "Logs",
+                  ]
+                }
+              />
+              <div
+                className="page"
+              >
+                <div
+                  className="page"
+                >
+                  <div
+                    className=""
+                    key="0"
+                  >
+                    <PlotCard
+                      configs={
+                        Array [
+                          Object {
+                            "type": "tensorboard",
+                            "url": "some url",
+                          },
+                        ]
+                      }
+                      maxDimension={500}
+                      title="Tensorboard"
+                    />
+                    <Component />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </SidePanel>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RunDetails shows failure run status in page title 1`] = `
+<div
+  className="flex"
+>
+  <WithStyles(Tooltip)
+    title="Resource failed to execute"
+  >
+    <span
+      style={
+        Object {
+          "height": 18,
+        }
+      }
+    >
+      <pure(ErrorIcon)
+        style={
+          Object {
+            "color": "#D50000",
+            "height": 18,
+            "width": 18,
+          }
+        }
+      />
+    </span>
+  </WithStyles(Tooltip)>
+  <span
+    style={
+      Object {
+        "marginLeft": 10,
+      }
+    }
+  >
+    test run
+  </span>
+</div>
+`;
+
+exports[`RunDetails shows run config fields - handles no description 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="page"
+  >
+    <MD2Tabs
+      onSwitch={[Function]}
+      selectedTab={1}
+      tabs={
+        Array [
+          "Graph",
+          "Config",
+        ]
+      }
+    />
+    <div
+      className="page"
+    >
+      <div
+        className=""
+      >
+        <Component
+          fields={
+            Array [
+              Array [
+                "Status",
+                "Skipped",
+              ],
+              Array [
+                "Description",
+                undefined,
+              ],
+              Array [
+                "Created at",
+                "7/5/2018, 4:03:02 AM",
+              ],
+              Array [
+                "Started at",
+                "7/5/2018, 4:03:02 AM",
+              ],
+              Array [
+                "Finished at",
+                "7/6/2018, 5:04:03 AM",
+              ],
+              Array [
+                "Duration",
+                "1:01:01",
+              ],
+            ]
+          }
+          title="Run details"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RunDetails shows run config fields - handles no metadata 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="page"
+  >
+    <MD2Tabs
+      onSwitch={[Function]}
+      selectedTab={1}
+      tabs={
+        Array [
+          "Graph",
+          "Config",
+        ]
+      }
+    />
+    <div
+      className="page"
+    >
+      <div
+        className=""
+      >
+        <Component
+          fields={
+            Array [
+              Array [
+                "Status",
+                "Skipped",
+              ],
+              Array [
+                "Description",
+                "test run description",
+              ],
+              Array [
+                "Created at",
+                "-",
+              ],
+              Array [
+                "Started at",
+                "7/5/2018, 4:03:02 AM",
+              ],
+              Array [
+                "Finished at",
+                "7/6/2018, 5:04:03 AM",
+              ],
+              Array [
+                "Duration",
+                "1:01:01",
+              ],
+            ]
+          }
+          title="Run details"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RunDetails shows run config fields 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="page"
+  >
+    <MD2Tabs
+      onSwitch={[Function]}
+      selectedTab={1}
+      tabs={
+        Array [
+          "Graph",
+          "Config",
+        ]
+      }
+    />
+    <div
+      className="page"
+    >
+      <div
+        className=""
+      >
+        <Component
+          fields={
+            Array [
+              Array [
+                "Status",
+                "Skipped",
+              ],
+              Array [
+                "Description",
+                "test run description",
+              ],
+              Array [
+                "Created at",
+                "7/5/2018, 4:03:02 AM",
+              ],
+              Array [
+                "Started at",
+                "7/5/2018, 4:03:02 AM",
+              ],
+              Array [
+                "Finished at",
+                "7/6/2018, 5:04:03 AM",
+              ],
+              Array [
+                "Duration",
+                "1:01:01",
+              ],
+            ]
+          }
+          title="Run details"
+        />
+        <div>
+          <Component
+            fields={
+              Array [
+                Array [
+                  "param1",
+                  "value1",
+                ],
+                Array [
+                  "param2",
+                  "value2",
+                ],
+              ]
+            }
+            title="Run parameters"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RunDetails shows success run status in page title 1`] = `
+<div
+  className="flex"
+>
+  <WithStyles(Tooltip)
+    title="Executed successfully"
+  >
+    <span
+      style={
+        Object {
+          "height": 18,
+        }
+      }
+    >
+      <pure(CheckCircleIcon)
+        style={
+          Object {
+            "color": "#34a853",
+            "height": 18,
+            "width": 18,
+          }
+        }
+      />
+    </span>
+  </WithStyles(Tooltip)>
+  <span
+    style={
+      Object {
+        "marginLeft": 10,
+      }
+    }
+  >
+    test run
+  </span>
+</div>
+`;
+
+exports[`RunDetails switches to config tab 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="page"
+  >
+    <MD2Tabs
+      onSwitch={[Function]}
+      selectedTab={1}
+      tabs={
+        Array [
+          "Graph",
+          "Config",
+        ]
+      }
+    />
+    <div
+      className="page"
+    >
+      <div
+        className=""
+      >
+        <Component
+          fields={Array []}
+          title="Run details"
+        />
       </div>
     </div>
   </div>

--- a/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
@@ -1,5 +1,201 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RunDetails does not load logs if clicked node status is skipped 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="page"
+  >
+    <MD2Tabs
+      onSwitch={[Function]}
+      selectedTab={0}
+      tabs={
+        Array [
+          "Graph",
+          "Config",
+        ]
+      }
+    />
+    <div
+      className="page"
+    >
+      <div
+        className="page"
+      >
+        <div
+          className="page"
+          style={
+            Object {
+              "overflow": "hidden",
+              "position": "relative",
+            }
+          }
+        >
+          <Graph
+            graph={
+              Graph {
+                "_defaultEdgeLabelFn": [Function],
+                "_defaultNodeLabelFn": [Function],
+                "_edgeLabels": Object {},
+                "_edgeObjs": Object {},
+                "_in": Object {},
+                "_isCompound": false,
+                "_isDirected": true,
+                "_isMultigraph": false,
+                "_label": Object {},
+                "_nodes": Object {},
+                "_out": Object {},
+                "_preds": Object {},
+                "_sucs": Object {},
+              }
+            }
+            onClick={[Function]}
+            selectedNodeId="node1"
+          />
+          <SidePanel
+            isBusy={false}
+            isOpen={true}
+            onClose={[Function]}
+            title="node1"
+          >
+            <div
+              className="page"
+            >
+              <MD2Tabs
+                onSwitch={[Function]}
+                selectedTab={2}
+                tabs={
+                  Array [
+                    "Artifacts",
+                    "Input/Output",
+                    "Logs",
+                  ]
+                }
+              />
+              <div
+                className="page"
+              >
+                <div
+                  className="page"
+                >
+                  <LogViewer
+                    classes="page"
+                    logLines={
+                      Array [
+                        "",
+                      ]
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </SidePanel>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RunDetails loads and shows logs in side pane 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="page"
+  >
+    <MD2Tabs
+      onSwitch={[Function]}
+      selectedTab={0}
+      tabs={
+        Array [
+          "Graph",
+          "Config",
+        ]
+      }
+    />
+    <div
+      className="page"
+    >
+      <div
+        className="page"
+      >
+        <div
+          className="page"
+          style={
+            Object {
+              "overflow": "hidden",
+              "position": "relative",
+            }
+          }
+        >
+          <Graph
+            graph={
+              Graph {
+                "_defaultEdgeLabelFn": [Function],
+                "_defaultNodeLabelFn": [Function],
+                "_edgeLabels": Object {},
+                "_edgeObjs": Object {},
+                "_in": Object {},
+                "_isCompound": false,
+                "_isDirected": true,
+                "_isMultigraph": false,
+                "_label": Object {},
+                "_nodes": Object {},
+                "_out": Object {},
+                "_preds": Object {},
+                "_sucs": Object {},
+              }
+            }
+            onClick={[Function]}
+            selectedNodeId="node1"
+          />
+          <SidePanel
+            isBusy={false}
+            isOpen={true}
+            onClose={[Function]}
+            title="node1"
+          >
+            <div
+              className="page"
+            >
+              <MD2Tabs
+                onSwitch={[Function]}
+                selectedTab={2}
+                tabs={
+                  Array [
+                    "Artifacts",
+                    "Input/Output",
+                    "Logs",
+                  ]
+                }
+              />
+              <div
+                className="page"
+              >
+                <div
+                  className="page"
+                >
+                  <LogViewer
+                    classes="page"
+                    logLines={
+                      Array [
+                        "test logs",
+                      ]
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </SidePanel>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`RunDetails opens side panel when graph node is clicked 1`] = `
 <div
   className="page"
@@ -345,10 +541,6 @@ exports[`RunDetails shows clicked node output in side pane 1`] = `
             onClose={[Function]}
             title="node1"
           >
-            <Banner
-              message="This step is in Succeeded state with this message: some test message"
-              mode="warning"
-            />
             <div
               className="page"
             >
@@ -387,6 +579,102 @@ exports[`RunDetails shows clicked node output in side pane 1`] = `
                     />
                     <Component />
                   </div>
+                </div>
+              </div>
+            </div>
+          </SidePanel>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RunDetails shows error banner atop logs area if fetching logs failed 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="page"
+  >
+    <MD2Tabs
+      onSwitch={[Function]}
+      selectedTab={0}
+      tabs={
+        Array [
+          "Graph",
+          "Config",
+        ]
+      }
+    />
+    <div
+      className="page"
+    >
+      <div
+        className="page"
+      >
+        <div
+          className="page"
+          style={
+            Object {
+              "overflow": "hidden",
+              "position": "relative",
+            }
+          }
+        >
+          <Graph
+            graph={
+              Graph {
+                "_defaultEdgeLabelFn": [Function],
+                "_defaultNodeLabelFn": [Function],
+                "_edgeLabels": Object {},
+                "_edgeObjs": Object {},
+                "_in": Object {},
+                "_isCompound": false,
+                "_isDirected": true,
+                "_isMultigraph": false,
+                "_label": Object {},
+                "_nodes": Object {},
+                "_out": Object {},
+                "_preds": Object {},
+                "_sucs": Object {},
+              }
+            }
+            onClick={[Function]}
+            selectedNodeId="node1"
+          />
+          <SidePanel
+            isBusy={false}
+            isOpen={true}
+            onClose={[Function]}
+            title="node1"
+          >
+            <div
+              className="page"
+            >
+              <MD2Tabs
+                onSwitch={[Function]}
+                selectedTab={2}
+                tabs={
+                  Array [
+                    "Artifacts",
+                    "Input/Output",
+                    "Logs",
+                  ]
+                }
+              />
+              <div
+                className="page"
+              >
+                <div
+                  className="page"
+                >
+                  <Banner
+                    additionalInfo="getting logs failed"
+                    message="Error: failed to retrieve logs. Click Details for more information."
+                    mode="error"
+                    refresh={[Function]}
+                  />
                 </div>
               </div>
             </div>
@@ -696,6 +984,224 @@ exports[`RunDetails switches to config tab 1`] = `
           fields={Array []}
           title="Run details"
         />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RunDetails switches to inputs/outputs tab in side pane 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="page"
+  >
+    <MD2Tabs
+      onSwitch={[Function]}
+      selectedTab={0}
+      tabs={
+        Array [
+          "Graph",
+          "Config",
+        ]
+      }
+    />
+    <div
+      className="page"
+    >
+      <div
+        className="page"
+      >
+        <div
+          className="page"
+          style={
+            Object {
+              "overflow": "hidden",
+              "position": "relative",
+            }
+          }
+        >
+          <Graph
+            graph={
+              Graph {
+                "_defaultEdgeLabelFn": [Function],
+                "_defaultNodeLabelFn": [Function],
+                "_edgeLabels": Object {},
+                "_edgeObjs": Object {},
+                "_in": Object {},
+                "_isCompound": false,
+                "_isDirected": true,
+                "_isMultigraph": false,
+                "_label": Object {},
+                "_nodes": Object {},
+                "_out": Object {},
+                "_preds": Object {},
+                "_sucs": Object {},
+              }
+            }
+            onClick={[Function]}
+            selectedNodeId="node1"
+          />
+          <SidePanel
+            isBusy={false}
+            isOpen={true}
+            onClose={[Function]}
+            title="node1"
+          >
+            <div
+              className="page"
+            >
+              <MD2Tabs
+                onSwitch={[Function]}
+                selectedTab={1}
+                tabs={
+                  Array [
+                    "Artifacts",
+                    "Input/Output",
+                    "Logs",
+                  ]
+                }
+              />
+              <div
+                className="page"
+              >
+                <div
+                  className=""
+                >
+                  <Component
+                    fields={
+                      Array [
+                        Array [
+                          "input1",
+                          "val1",
+                        ],
+                      ]
+                    }
+                    title="Input parameters"
+                  />
+                  <Component
+                    fields={
+                      Array [
+                        Array [
+                          "output1",
+                          "val1",
+                        ],
+                        Array [
+                          "output2",
+                          "value2",
+                        ],
+                      ]
+                    }
+                    title="Output parameters"
+                  />
+                </div>
+              </div>
+            </div>
+          </SidePanel>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RunDetails switches to logs tab in side pane 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="page"
+  >
+    <MD2Tabs
+      onSwitch={[Function]}
+      selectedTab={0}
+      tabs={
+        Array [
+          "Graph",
+          "Config",
+        ]
+      }
+    />
+    <div
+      className="page"
+    >
+      <div
+        className="page"
+      >
+        <div
+          className="page"
+          style={
+            Object {
+              "overflow": "hidden",
+              "position": "relative",
+            }
+          }
+        >
+          <Graph
+            graph={
+              Graph {
+                "_defaultEdgeLabelFn": [Function],
+                "_defaultNodeLabelFn": [Function],
+                "_edgeLabels": Object {},
+                "_edgeObjs": Object {},
+                "_in": Object {},
+                "_isCompound": false,
+                "_isDirected": true,
+                "_isMultigraph": false,
+                "_label": Object {},
+                "_nodes": Object {},
+                "_out": Object {},
+                "_preds": Object {},
+                "_sucs": Object {},
+              }
+            }
+            onClick={[Function]}
+            selectedNodeId="node1"
+          />
+          <SidePanel
+            isBusy={true}
+            isOpen={true}
+            onClose={[Function]}
+            title="node1"
+          >
+            <div
+              className="page"
+            >
+              <MD2Tabs
+                onSwitch={[Function]}
+                selectedTab={2}
+                tabs={
+                  Array [
+                    "Artifacts",
+                    "Input/Output",
+                    "Logs",
+                  ]
+                }
+              />
+              <WithStyles(CircularProgress)
+                className="absoluteCenter"
+                size={30}
+              />
+              <div
+                className="page"
+              >
+                <div
+                  className="page"
+                >
+                  <LogViewer
+                    classes="page"
+                    logLines={
+                      Array [
+                        "",
+                      ]
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </SidePanel>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RunDetails renders an empty run 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="page"
+  >
+    <MD2Tabs
+      onSwitch={[Function]}
+      selectedTab={0}
+      tabs={
+        Array [
+          "Graph",
+          "Config",
+        ]
+      }
+    />
+    <div
+      className="page"
+    >
+      <div
+        className="page"
+      >
+        <span
+          style={
+            Object {
+              "margin": "40px auto",
+            }
+          }
+        >
+          No graph to show
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Adds a comprehensive test suite for the RunDetails component, which caught a few bugs, also fixed here:
- Gracefully handle missing fields on the workflow object when displaying its config fields.
- Also parse out the selected node's message field when calling `load`, which is called on refresh.
- If the message field is gone after refresh, remove the banner.
- Wait for the side pane's busy state to be set before proceeding to unset it.

Fixes #383.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/394)
<!-- Reviewable:end -->
