### PR TITLE
SDK/Client - Removed import six

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-import six
 import time
 import logging
 import json
@@ -139,7 +138,7 @@ class Client(object):
 
     pipeline_obj = self._extract_pipeline_yaml(pipeline_package_path)
     pipeline_json_string = json.dumps(pipeline_obj)
-    api_params = [kfp_run.ApiParameter(name=k, value=str(v)) for k,v in six.iteritems(params)]
+    api_params = [kfp_run.ApiParameter(name=k, value=str(v)) for k,v in params.items()]
     key = kfp_run.models.ApiResourceKey(id=experiment_id,
                                         type=kfp_run.models.ApiResourceType.EXPERIMENT)
     reference = kfp_run.models.ApiResourceReference(key, kfp_run.models.ApiRelationship.OWNER)


### PR DESCRIPTION
We're only supporting Python 3.5+. We never supported Python 2.

The reason I want to remove `six` is because it's not a included in the standard package python image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/425)
<!-- Reviewable:end -->
