### PR TITLE
Wait until logs appear right in e2e test

### DIFF
--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -165,9 +165,10 @@ describe('deploy helloworld sample run', () => {
   it('shows logs from node', () => {
     $('button=Logs').click();
     $('#logViewer').waitForVisible();
-    const logs = $('#logViewer').getText();
-    assert(logs.indexOf(outputParameterValue + ' from node: ') > -1,
-      'logs do not look right: ' + logs);
+    browser.waitUntil(() => {
+      const logs = $('#logViewer').getText();
+      return logs.indexOf(outputParameterValue + ' from node: ') > -1;
+    }, waitTimeout);
   });
   //TODO: enable this after we change the pipeline to a unique name such that deleting this
   // pipeline will not jeopardize the concurrent basic e2e tests.


### PR DESCRIPTION
Fixes #453.

The issue was that sometimes logs are grabbed too early, when they haven't been downloaded from the pod yet. This results in logs being just "1", which is the text of the line numbers gutter, which only has one line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/459)
<!-- Reviewable:end -->
