### PR TITLE
Support cloning runs created with an embedded pipeline

### DIFF
--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -14,15 +14,18 @@
  * limitations under the License.
  */
 
+import * as JsYaml from 'js-yaml';
 import * as React from 'react';
 import BusyButton from '../atoms/BusyButton';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Input from '../atoms/Input';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import PipelineSelector from './PipelineSelector';
+import Radio from '@material-ui/core/Radio';
 import RunUtils from '../lib/RunUtils';
 import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import Trigger from '../components/Trigger';
@@ -42,6 +45,7 @@ import { commonCss, padding } from '../Css';
 import { logger, errorToMessage } from '../lib/Utils';
 
 interface NewRunState {
+  clonedRunPipeline?: ApiPipeline;
   description: string;
   errorMessage: string;
   experiment?: ApiExperiment;
@@ -58,6 +62,7 @@ interface NewRunState {
   pipelineName: string;
   pipelineSelectorOpen: boolean;
   runName: string;
+  selectPipelineFromClonedRun: boolean;
   trigger?: ApiTrigger;
   unconfirmedDialogPipelineId: string;
 }
@@ -82,6 +87,7 @@ class NewRun extends Page<{}, NewRunState> {
       pipelineName: '',
       pipelineSelectorOpen: false,
       runName: '',
+      selectPipelineFromClonedRun: false,
       unconfirmedDialogPipelineId: '',
     };
   }
@@ -96,6 +102,7 @@ class NewRun extends Page<{}, NewRunState> {
 
   public render(): JSX.Element {
     const {
+      clonedRunPipeline,
       description,
       errorMessage,
       experimentName,
@@ -105,6 +112,7 @@ class NewRun extends Page<{}, NewRunState> {
       pipelineName,
       pipelineSelectorOpen,
       runName,
+      selectPipelineFromClonedRun,
       unconfirmedDialogPipelineId,
     } = this.state;
 
@@ -114,19 +122,30 @@ class NewRun extends Page<{}, NewRunState> {
 
           <div className={commonCss.header}>Run details</div>
 
-          <Input value={pipelineName} required={true} label='Pipeline' disabled={true}
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position='end'>
-                  <Button color='secondary' id='choosePipelineBtn'
-                    onClick={() => this.setState({ pipelineSelectorOpen: true })}
-                    style={{ padding: '3px 5px', margin: 0 }}>
-                    Choose
+          {!!clonedRunPipeline && (<React.Fragment>
+            <FormControlLabel label='Use pipeline from cloned run' control={<Radio color='primary' />}
+              onChange={() => this.setStateSafe({ selectPipelineFromClonedRun: true })}
+              checked={selectPipelineFromClonedRun} />
+            <FormControlLabel label='Select a pipeline from list' control={<Radio color='primary' />}
+              onChange={() => this.setStateSafe({ selectPipelineFromClonedRun: false })}
+              checked={!selectPipelineFromClonedRun} />
+          </React.Fragment>)}
+
+          {!selectPipelineFromClonedRun && (
+            <Input value={pipelineName} required={true} label='Pipeline' disabled={true}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position='end'>
+                    <Button color='secondary' id='choosePipelineBtn'
+                      onClick={() => this.setState({ pipelineSelectorOpen: true })}
+                      style={{ padding: '3px 5px', margin: 0 }}>
+                      Choose
                 </Button>
-                </InputAdornment>
-              ),
-              readOnly: true,
-            }} />
+                  </InputAdornment>
+                ),
+                readOnly: true,
+              }} />
+          )}
 
           <Dialog open={pipelineSelectorOpen}
             classes={{ paper: css.pipelineSelectorDialog }}
@@ -317,26 +336,38 @@ class NewRun extends Page<{}, NewRunState> {
   }
 
   private async _prepareFormFromClone(originalRun: ApiRunDetail): Promise<void> {
-    const associatedPipelineId = RunUtils.getPipelineId(originalRun.run);
-    // TODO: Support runs without associated pipeline IDs (e.g. those created via notebooks)
-    if (!originalRun.run || !associatedPipelineId) {
-      logger.error('Original run did not have an associated pipeline ID');
+    if (!originalRun.run) {
+      logger.error('Could not get cloned run details');
       return;
     }
 
     let pipeline: ApiPipeline;
     let workflow: Workflow;
+    let clonedRunPipeline: ApiPipeline;
+    let selectPipelineFromClonedRun = false;
 
-    try {
-      pipeline = await Apis.pipelineServiceApi.getPipeline(associatedPipelineId);
-    } catch (err) {
-      await this.showPageError(
-        'Error: failed to find a pipeline corresponding to that of the original run:'
-        + ` ${originalRun.run.id}.`, err);
+    const referencePipelineId = RunUtils.getPipelineId(originalRun.run);
+    const embeddedPipelineSpec = RunUtils.getPipelineSpec(originalRun.run);
+    if (referencePipelineId) {
+      try {
+        pipeline = await Apis.pipelineServiceApi.getPipeline(referencePipelineId);
+      } catch (err) {
+        await this.showPageError('Could not get clone run\'s pipeline details', err);
+        return;
+      }
+    } else if (embeddedPipelineSpec) {
+      try {
+        pipeline = JsYaml.safeLoad(embeddedPipelineSpec);
+      } catch (err) {
+        await this.showPageError('Error: failed to read the clone run\'s pipeline definition.', err);
+      }
+      clonedRunPipeline = pipeline!;
+      selectPipelineFromClonedRun = true;
+    } else {
+      await this.showPageError('Could not find the cloned run\'s pipeline definition.');
       return;
     }
 
-    // TODO: Determine what is actually required from the pipeline if we have this manifest
     if (originalRun.pipeline_runtime!.workflow_manifest === undefined) {
       await this.showPageError(`Error: run ${originalRun.run.id} had no workflow manifest`);
       logger.error(originalRun.pipeline_runtime!.workflow_manifest);
@@ -351,12 +382,14 @@ class NewRun extends Page<{}, NewRunState> {
     }
 
     // Set pipeline parameter values from run's workflow
-    pipeline.parameters = WorkflowParser.getParameters(workflow);
+    pipeline!.parameters = WorkflowParser.getParameters(workflow);
 
     this.setState({
-      pipeline,
-      pipelineName: (pipeline && pipeline.name) || '',
-      runName: this._getCloneName(originalRun.run.name!)
+      clonedRunPipeline: clonedRunPipeline!,
+      pipeline: pipeline!,
+      pipelineName: (pipeline! && pipeline!.name) || '',
+      runName: this._getCloneName(originalRun.run.name!),
+      selectPipelineFromClonedRun,
     });
 
     this._validate();
@@ -446,7 +479,6 @@ class NewRun extends Page<{}, NewRunState> {
       return;
     }
     pipeline.parameters[index].value = value;
-    // TODO: is this doing anything?
     this.setState({ pipeline });
   }
 

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -352,7 +352,9 @@ class NewRun extends Page<{}, NewRunState> {
       try {
         pipeline = await Apis.pipelineServiceApi.getPipeline(referencePipelineId);
       } catch (err) {
-        await this.showPageError('Could not get clone run\'s pipeline details', err);
+        await this.showPageError(
+          'Error: failed to find a pipeline corresponding to that of the original run:'
+          + ` ${originalRun.run.id}.`, err);
         return;
       }
     } else if (embeddedPipelineSpec) {
@@ -360,6 +362,7 @@ class NewRun extends Page<{}, NewRunState> {
         pipeline = JsYaml.safeLoad(embeddedPipelineSpec);
       } catch (err) {
         await this.showPageError('Error: failed to read the clone run\'s pipeline definition.', err);
+        return;
       }
       clonedRunPipeline = pipeline!;
       usePipelineFromClonedRun = true;
@@ -433,7 +436,7 @@ class NewRun extends Page<{}, NewRunState> {
       pipeline_spec: {
         parameters: pipeline.parameters,
         pipeline_id: usePipelineFromClonedRun ? undefined : pipeline.id,
-        workflow_manifest: usePipelineFromClonedRun ? JsYaml.safeDump(clonedRunPipeline) : '',
+        workflow_manifest: usePipelineFromClonedRun ? JsYaml.safeDump(clonedRunPipeline) : undefined,
       },
       resource_references: references,
     };

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -210,6 +210,404 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
 </div>
 `;
 
+exports[`NewRun cloning from a run shows pipeline selector when switching from embedded pipeline to select pipeline 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="scrollContainer"
+  >
+    <div
+      className="header"
+    >
+      Run details
+    </div>
+    <WithStyles(FormControlLabel)
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Use pipeline from cloned run"
+      onChange={[Function]}
+    />
+    <WithStyles(FormControlLabel)
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Select a pipeline from list"
+      onChange={[Function]}
+    />
+    <Component
+      InputProps={
+        Object {
+          "endAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <WithStyles(Button)
+              color="secondary"
+              id="choosePipelineBtn"
+              onClick={[Function]}
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": "3px 5px",
+                }
+              }
+            >
+              Choose
+            </WithStyles(Button)>
+          </WithStyles(InputAdornment)>,
+          "readOnly": true,
+        }
+      }
+      disabled={true}
+      label="Pipeline"
+      required={true}
+      value=""
+    />
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "pipelineSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "pipelineSelectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <PipelineSelector
+          history={
+            Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            }
+          }
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?cloneFromRun=some-mock-run-id",
+            }
+          }
+          match=""
+          pipelineSelectionChanged={[Function]}
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+              ],
+              "pageTitle": "Start a new run",
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={[MockFunction]}
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                    ],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                    ],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          id="cancelPipelineSelectionBtn"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={true}
+          id="usePipelineBtn"
+          onClick={[Function]}
+        >
+          Use this pipeline
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <Component
+      autoFocus={true}
+      label="Run name"
+      onChange={[Function]}
+      required={true}
+      value="Clone of some mock run name"
+    />
+    <Component
+      label="Description (optional)"
+      multiline={true}
+      onChange={[Function]}
+      value=""
+    />
+    <div
+      className="header"
+    >
+      Run parameters
+    </div>
+    <div>
+      Parameters will appear after you select a pipeline
+    </div>
+    <div
+      className="flex"
+    >
+      <BusyButton
+        busy={false}
+        className="buttonAction"
+        disabled={false}
+        id="createNewRunBtn"
+        onClick={[Function]}
+        title="Create"
+      />
+      <WithStyles(Button)
+        id="exitNewRunPageBtn"
+        onClick={[Function]}
+      >
+        Cancel
+      </WithStyles(Button)>
+      <div
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`NewRun cloning from a run shows switching controls when run has embedded pipeline, selects that pipeline by default, and hides pipeline selector 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="scrollContainer"
+  >
+    <div
+      className="header"
+    >
+      Run details
+    </div>
+    <WithStyles(FormControlLabel)
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Use pipeline from cloned run"
+      onChange={[Function]}
+    />
+    <WithStyles(FormControlLabel)
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Select a pipeline from list"
+      onChange={[Function]}
+    />
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "pipelineSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "pipelineSelectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <PipelineSelector
+          history={
+            Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            }
+          }
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?cloneFromRun=some-mock-run-id",
+            }
+          }
+          match=""
+          pipelineSelectionChanged={[Function]}
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+              ],
+              "pageTitle": "Start a new run",
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={[MockFunction]}
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                    ],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                    ],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          id="cancelPipelineSelectionBtn"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={true}
+          id="usePipelineBtn"
+          onClick={[Function]}
+        >
+          Use this pipeline
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <Component
+      autoFocus={true}
+      label="Run name"
+      onChange={[Function]}
+      required={true}
+      value="Clone of some mock run name"
+    />
+    <Component
+      label="Description (optional)"
+      multiline={true}
+      onChange={[Function]}
+      value=""
+    />
+    <div
+      className="header"
+    >
+      Run parameters
+    </div>
+    <div>
+      This pipeline has no parameters
+    </div>
+    <div
+      className="flex"
+    >
+      <BusyButton
+        busy={false}
+        className="buttonAction"
+        disabled={false}
+        id="createNewRunBtn"
+        onClick={[Function]}
+        title="Create"
+      />
+      <WithStyles(Button)
+        id="exitNewRunPageBtn"
+        onClick={[Function]}
+      >
+        Cancel
+      </WithStyles(Button)>
+      <div
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`NewRun creating a new recurring run includes additional trigger input fields if run will be recurring 1`] = `
 <div
   className="page"
@@ -408,6 +806,208 @@ exports[`NewRun creating a new recurring run includes additional trigger input f
       >
         A pipeline must be selected
       </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`NewRun creating a new run copies pipeline from run in the create API call when cloning a run with embedded pipeline 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="scrollContainer"
+  >
+    <div
+      className="header"
+    >
+      Run details
+    </div>
+    <WithStyles(FormControlLabel)
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Use pipeline from cloned run"
+      onChange={[Function]}
+    />
+    <WithStyles(FormControlLabel)
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Select a pipeline from list"
+      onChange={[Function]}
+    />
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "pipelineSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "pipelineSelectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <PipelineSelector
+          history={
+            Object {
+              "push": [MockFunction] {
+                "calls": Array [
+                  Array [
+                    "/runs",
+                  ],
+                ],
+              },
+              "replace": [MockFunction],
+            }
+          }
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?cloneFromRun=some-mock-run-id",
+            }
+          }
+          match=""
+          pipelineSelectionChanged={[Function]}
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+              ],
+              "pageTitle": "Start a new run",
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "message": "Successfully created new Run: Clone of some mock run name",
+                    "open": true,
+                  },
+                ],
+              ],
+            }
+          }
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                    ],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                    ],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          id="cancelPipelineSelectionBtn"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={true}
+          id="usePipelineBtn"
+          onClick={[Function]}
+        >
+          Use this pipeline
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <Component
+      autoFocus={true}
+      label="Run name"
+      onChange={[Function]}
+      required={true}
+      value="Clone of some mock run name"
+    />
+    <Component
+      label="Description (optional)"
+      multiline={true}
+      onChange={[Function]}
+      value=""
+    />
+    <div
+      className="header"
+    >
+      Run parameters
+    </div>
+    <div>
+      This pipeline has no parameters
+    </div>
+    <div
+      className="flex"
+    >
+      <BusyButton
+        busy={true}
+        className="buttonAction"
+        disabled={false}
+        id="createNewRunBtn"
+        onClick={[Function]}
+        title="Create"
+      />
+      <WithStyles(Button)
+        id="exitNewRunPageBtn"
+        onClick={[Function]}
+      >
+        Cancel
+      </WithStyles(Button)>
+      <div
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+      />
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #75.

This PR adds cloning functionality in the `NewRun` component to support copying an embedded pipeline in the original run. When such a pipeline is found, switch controls show up (radio button group for now) to allow switching between the cloned run's pipeline, and choosing from the pipeline list.

![image](https://user-images.githubusercontent.com/1424661/49467434-5744c280-f7b7-11e8-8602-93f84317ac6e.png)

@ajayalfred can you take a look at this? I needed something working that is still usable, feel free to change the design. I won't block the PR on the potential redesign though, we can iterate on it later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/465)
<!-- Reviewable:end -->
