### PR TITLE
Return string from pod logs

### DIFF
--- a/frontend/server/k8s-helper.ts
+++ b/frontend/server/k8s-helper.ts
@@ -69,9 +69,9 @@ export async function newTensorboardPod(logdir: string): Promise<void> {
           name: 'gcp-credentials',
         }],
       }],
-      volumes:[{
+      volumes: [{
         name: 'gcp-credentials',
-        secret:{
+        secret: {
           secretName: 'user-gcp-sa',
         },
       }],
@@ -122,7 +122,7 @@ export function getPodLogs(podName: string): Promise<string> {
     throw new Error('Cannot access kubernetes API');
   }
   return (k8sV1Client.readNamespacedPodLog(podName, namespace, 'main') as any)
-    .then((response: any) => response.body, (error: any) => {
+    .then((response: any) => response.body.toString(), (error: any) => {
       throw new Error(JSON.stringify(error.body));
     });
 }


### PR DESCRIPTION
This fixes a bug where if logs only return a number, it's misinterpreted by express to be the status not the return content.
Fixes https://github.com/googleprivate/ml/issues/1390
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/476)
<!-- Reviewable:end -->
