### PR TITLE
Tests - Updated image-builder Makefile

### DIFF
--- a/test/imagebuilder/Makefile
+++ b/test/imagebuilder/Makefile
@@ -14,26 +14,36 @@
 
 IMG = gcr.io/ml-pipeline-test/image-builder
 
-TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)-$(shell git diff | shasum -a256 | cut -c -6)
+# List any changed  files. We only include files in the notebooks directory.
+# because that is the code in the docker image.
+# In particular we exclude changes to the ksonnet configs.
+DIR := ${CURDIR}
+CHANGED_FILES := $(shell git diff-files --relative=$(DIR))
 
+GIT_VERSION := $(shell git describe --always)
+ifneq ($(strip $(CHANGED_FILES)),)
+GIT_VERSION := $(GIT_VERSION)-dirty-$(shell git diff | shasum -a256 | cut -c -6)
+endif
+
+TAG := $(shell date +v%Y%m%d)-$(GIT_VERSION)
 all: build
 
 # To build without the cache set the environment variable
 # export DOCKER_BUILD_OPTS=--no-cache
 build:
-	docker build ${DOCKER_BUILD_OPTS} -t $(IMG):$(TAG) .
-	@echo Built $(IMG):$(TAG)
+	docker build ${DOCKER_BUILD_OPTS} -t $(IMG):$(TAG) . \
+           --label=git-verions=$(GIT_VERSION)
+	docker tag $(IMG):$(TAG) $(IMG):latest
+	echo Built $(IMG):$(TAG)
+	echo Built $(IMG):latest
 
 # Build but don't attach the latest tag. This allows manual testing/inspection of the image
 # first.
 push: build
 	gcloud auth configure-docker
 	docker push $(IMG):$(TAG)
-	@echo Pushed $(IMG) with  :$(TAG) tags
-	# Tagging into a new project can be very slow but it appears to work.
-	gcloud container images add-tag --quiet $(IMG):$(TAG) $(IMG):$(TAG) --verbosity=info
-	echo created $(IMG):$(TAG)
+	echo Pushed $(IMG):$(TAG)
 
 push-latest: push
 	gcloud container images add-tag --quiet $(IMG):$(TAG) $(IMG):latest --verbosity=info
-	echo created $(IMG):latest
+	echo Updated $(IMG):latest


### PR DESCRIPTION
Just bringing it in line with Kubeflow original Makefiles. Nothing should change.

* No longer using `gcloud container images add-tag` after the push
* No longer adding `-dirty` if there are no changed files in the Docker context directory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/500)
<!-- Reviewable:end -->
