### PR TITLE
add job to load sample

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -62,4 +62,4 @@ RUN apk add ca-certificates
 EXPOSE 8888
 
 # Start the apiserver
-CMD apiserver --config=/config --sampleconfig=/config/sample_config.json
+CMD apiserver --config=/config

--- a/pipeline/pipeline/pipeline-apiserver.libsonnet
+++ b/pipeline/pipeline/pipeline-apiserver.libsonnet
@@ -5,6 +5,7 @@
     $.parts(namespace).role,
     $.parts(namespace).service,
     $.parts(namespace).deploy(apiImage),
+    $.parts(namespace).loadSampleJob(apiImage),
     $.parts(namespace).pipelineRunnerServiceAccount,
     $.parts(namespace).pipelineRunnerRole,
     $.parts(namespace).pipelineRunnerRoleBinding,
@@ -179,7 +180,7 @@
       },
     },  // deploy
 
-    job(image): {
+    loadSampleJob(image): {
       apiVersion: "batch/v1",
       kind: "Job",
       metadata: {
@@ -196,13 +197,16 @@
             image: image,
             imagePullPolicy: "Always",
             command: ["apiserver"],
-            args: ["--config", "/config", "--sampleconfig", "/config/sample_config.json"]
+            args: [
+              "--config", "/config",
+              "--sampleconfig", "/config/sample_config.json"
+            ]
             restartPolicy: "Never",
           },
         ],
         serviceAccountName: "ml-pipeline",
       },
-    }, // job
+    }, // loadSampleJob
 
     pipelineRunnerServiceAccount: {
       apiVersion: "v1",

--- a/pipeline/pipeline/pipeline-apiserver.libsonnet
+++ b/pipeline/pipeline/pipeline-apiserver.libsonnet
@@ -179,6 +179,31 @@
       },
     },  // deploy
 
+    job(image): {
+      apiVersion: "batch/v1",
+      kind: "Job",
+      metadata: {
+        labels: {
+          app: "ml-pipeline",
+        },
+        name: "ml-pipelines-load-samples",
+        namespace: namespace,
+      },
+      spec: {
+        containers: [
+          {
+            name: "ml-pipelines-load-samples",
+            image: image,
+            imagePullPolicy: "Always",
+            command: ["apiserver"],
+            args: ["--config", "/config", "--sampleconfig", "/config/sample_config.json"]
+            restartPolicy: "Never",
+          },
+        ],
+        serviceAccountName: "ml-pipeline",
+      },
+    }, // job
+
     pipelineRunnerServiceAccount: {
       apiVersion: "v1",
       kind: "ServiceAccount",

--- a/pipeline/pipeline/pipeline-apiserver.libsonnet
+++ b/pipeline/pipeline/pipeline-apiserver.libsonnet
@@ -184,27 +184,39 @@
       apiVersion: "batch/v1",
       kind: "Job",
       metadata: {
-        labels: {
-          app: "ml-pipeline",
-        },
         name: "ml-pipelines-load-samples",
         namespace: namespace,
       },
       spec: {
-        containers: [
-          {
-            name: "ml-pipelines-load-samples",
-            image: image,
-            imagePullPolicy: "Always",
-            command: ["apiserver"],
-            args: [
-              "--config", "/config",
-              "--sampleconfig", "/config/sample_config.json"
-            ]
+        template: {
+          spec: {
             restartPolicy: "Never",
+            containers: [
+              {
+                name: "ml-pipelines-load-samples",
+                image: image,
+                imagePullPolicy: "Always",
+                command: ["apiserver"],
+                args: [
+                  "--config=/config",
+                  "--sampleconfig=/config/sample_config.json"
+                ],
+                env: [
+                  {
+                    name: "POD_NAMESPACE",
+                    valueFrom: {
+                      fieldRef: {
+                        fieldPath: "metadata.namespace",
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            serviceAccountName: "ml-pipeline",
           },
-        ],
-        serviceAccountName: "ml-pipeline",
+        },
+        backoffLimit: 0
       },
     }, // loadSampleJob
 

--- a/test/presubmit-tests-with-pipeline-deployment.sh
+++ b/test/presubmit-tests-with-pipeline-deployment.sh
@@ -115,7 +115,7 @@ function clean_up {
   cd ${KFAPP}
   ${KUBEFLOW_SRC}/scripts/kfctl.sh delete all
 }
-trap clean_up EXIT
+# trap clean_up EXIT
 
 ${KUBEFLOW_SRC}/scripts/kfctl.sh init ${KFAPP} --platform gcp --project ${PROJECT} --skipInitProject
 

--- a/test/presubmit-tests-with-pipeline-deployment.sh
+++ b/test/presubmit-tests-with-pipeline-deployment.sh
@@ -115,7 +115,7 @@ function clean_up {
   cd ${KFAPP}
   ${KUBEFLOW_SRC}/scripts/kfctl.sh delete all
 }
-# trap clean_up EXIT
+trap clean_up EXIT
 
 ${KUBEFLOW_SRC}/scripts/kfctl.sh init ${KFAPP} --platform gcp --project ${PROJECT} --skipInitProject
 


### PR DESCRIPTION
Add a job to load sample to pipeline backend once. 
Reuse API server binary to load the samples since most code are shared. 
The corresponding kubeflow code change is here https://github.com/kubeflow/kubeflow/pull/2071

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/509)
<!-- Reviewable:end -->
