### PR TITLE
Stops k8s-helper from throwing error when a pod has no logs

### DIFF
--- a/frontend/server/k8s-helper.ts
+++ b/frontend/server/k8s-helper.ts
@@ -122,7 +122,8 @@ export function getPodLogs(podName: string): Promise<string> {
     throw new Error('Cannot access kubernetes API');
   }
   return (k8sV1Client.readNamespacedPodLog(podName, namespace, 'main') as any)
-    .then((response: any) => response.body.toString(), (error: any) => {
-      throw new Error(JSON.stringify(error.body));
-    });
+    .then(
+      (response: any) => (response && response.body) ? response.body.toString() : '',
+      (error: any) => { throw new Error(JSON.stringify(error.body)); }
+    );
 }


### PR DESCRIPTION
This will stop the errors, but we could potentially improve the experience further by replacing the `LogViewer` box with a simple message saying something like "This pod had no logs" or something.

Happy to go that route if people think that's useful.