### PR TITLE
Fixes await bug in create new run

### DIFF
--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -1021,8 +1021,6 @@ describe('NewRun', () => {
       await TestUtils.flushPromises();
 
       tree.find('#createNewRunBtn').simulate('click');
-      // The create APIs are called in a callback triggered by clicking 'Create', so we wait again
-      await TestUtils.flushPromises();
 
       expect(tree.state('isBeingCreated')).toBe(true);
     });

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -2298,7 +2298,7 @@ exports[`NewRun creating a new run copies pipeline from run in the create API ca
       className="flex"
     >
       <BusyButton
-        busy={true}
+        busy={false}
         className="buttonAction"
         disabled={false}
         id="createNewRunBtn"
@@ -2745,7 +2745,7 @@ exports[`NewRun creating a new run updates the pipeline in state when a user fil
       className="flex"
     >
       <BusyButton
-        busy={true}
+        busy={false}
         className="buttonAction"
         disabled={false}
         id="createNewRunBtn"


### PR DESCRIPTION
Previously, the `await` was not actually being applied to the API calls, so a run creation could fail, but the success snackbar would still be shown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/553)
<!-- Reviewable:end -->
