### PR TITLE
Fix ROC Component

### DIFF
--- a/components/local/roc/src/roc.py
+++ b/components/local/roc/src/roc.py
@@ -50,6 +50,8 @@ def main(argv=None):
   names = [x['name'] for x in schema]
 
   trueclass = next((x for x in names if x.lower() == 'true'), None)
+  if trueclass is None:
+    raise ValueError('trueclass is not provided, and there is no "true" column.')
 
   dfs = []
   files = file_io.get_matching_files(args.predictions)

--- a/components/local/roc/src/roc.py
+++ b/components/local/roc/src/roc.py
@@ -32,11 +32,13 @@ from tensorflow.python.lib.io import file_io
 def main(argv=None):
   parser = argparse.ArgumentParser(description='ML Trainer')
   parser.add_argument('--predictions', type=str, help='GCS path of prediction file pattern.')
-  parser.add_argument('--trueclass', type=str, help='The name of the class as true value.')
+  parser.add_argument('--trueclass', type=str,
+                      help='The name of the class as true value. If missing, assuming it is ' +
+                           'binary classification and the true class is "True" (in any cases).')
   parser.add_argument('--target_lambda', type=str,
                       help='a lambda function as a string to determine positive or negative.' +
                            'For example, "lambda x: x[\'a\'] and x[\'b\']". If missing, ' +
-                           'trueclass must be set and input must have a "target" column.')
+                           'input must have a "target" column.')
   parser.add_argument('--output', type=str, help='GCS path of the output directory.')
   args = parser.parse_args()
 
@@ -46,6 +48,9 @@ def main(argv=None):
   schema_file = os.path.join(os.path.dirname(args.predictions), 'schema.json')
   schema = json.loads(file_io.read_file_to_string(schema_file))
   names = [x['name'] for x in schema]
+
+  trueclass = next((x for x in names if x.lower() == 'true'), None)
+
   dfs = []
   files = file_io.get_matching_files(args.predictions)
   for file in files:
@@ -56,9 +61,9 @@ def main(argv=None):
   if args.target_lambda:
     df['target'] = df.apply(eval(args.target_lambda), axis=1)
   else:
-    df['target'] = df['target'].apply(lambda x: 1 if x == args.trueclass else 0)
-  fpr, tpr, thresholds = roc_curve(df['target'], df[args.trueclass])
-  roc_auc = roc_auc_score(df['target'], df[args.trueclass])
+    df['target'] = df['target'].apply(lambda x: 1 if x == trueclass else 0)
+  fpr, tpr, thresholds = roc_curve(df['target'], df[trueclass])
+  roc_auc = roc_auc_score(df['target'], df[trueclass])
   df_roc = pd.DataFrame({'fpr': fpr, 'tpr': tpr, 'thresholds': thresholds})
   roc_file = os.path.join(args.output, 'roc.csv')
   with file_io.FileIO(roc_file, 'w') as f:


### PR DESCRIPTION
If it is a binary classification, which is usually the case when ROC is involved, we either expect a "trueclass" value to indicate the value of the true class, or expect the data is like:

predicted, target, true, false
false,true,0.1,0.9
...

in which there is a "true" column for the probability, and "true" is a predicted class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/559)
<!-- Reviewable:end -->
