### PR TITLE
Allow creating runs with no experiments

### DIFF
--- a/backend/src/apiserver/server/run_server.go
+++ b/backend/src/apiserver/server/run_server.go
@@ -134,10 +134,6 @@ func (s *RunServer) validateCreateRunRequest(request *api.CreateRunRequest) erro
 	if run.Name == "" {
 		return util.NewInvalidInputError("The run name is empty. Please specify a valid name.")
 	}
-	// Run must be created under an experiment.
-	if err := ValidateExperimentResourceReference(s.resourceManager, run.ResourceReferences); err != nil {
-		return util.Wrap(err, "The run must have a valid experiment resource reference.")
-	}
 
 	if err := ValidatePipelineSpec(s.resourceManager, run.PipelineSpec); err != nil {
 		return util.Wrap(err, "The pipeline spec is invalid.")

--- a/backend/src/apiserver/server/run_server_test.go
+++ b/backend/src/apiserver/server/run_server_test.go
@@ -87,6 +87,22 @@ func TestValidateCreateRunRequest_EmptyName(t *testing.T) {
 	assert.Contains(t, err.Error(), "The run name is empty")
 }
 
+func TestValidateCreateRunRequest_NoExperiment(t *testing.T) {
+	clients, manager, _ := initWithExperiment(t)
+	defer clients.Close()
+	server := NewRunServer(manager)
+	run := &api.Run{
+		Name:               "123",
+		ResourceReferences: nil,
+		PipelineSpec: &api.PipelineSpec{
+			WorkflowManifest: testWorkflow.ToStringForStore(),
+			Parameters:       []*api.Parameter{{Name: "param1", Value: "world"}},
+		},
+	}
+	err := server.validateCreateRunRequest(&api.CreateRunRequest{Run: run})
+	assert.Nil(t, err)
+}
+
 func TestValidateCreateRunRequest_EmptyPipelineSpec(t *testing.T) {
 	clients, manager, _ := initWithExperiment(t)
 	defer clients.Close()


### PR DESCRIPTION
Removes the experiment reference validation, and adds a test. Fixes https://github.com/kubeflow/pipelines/issues/560.

/assign @IronPan 
/area back-end

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/572)
<!-- Reviewable:end -->
