### PR TITLE
retry on create table in api server

### DIFF
--- a/backend/src/apiserver/config/config.json
+++ b/backend/src/apiserver/config/config.json
@@ -8,5 +8,5 @@
     "SecretAccessKey": "minio123",
     "BucketName": "mlpipeline"
   },
-  "InitConnectionTimeout": "3m"
+  "InitConnectionTimeout": "6m"
 }


### PR DESCRIPTION
The first time creating the table failed because service unavailable. Retry resolve the issue. 

F1221 08:21:25.810654       1 error.go:296] dial tcp 10.47.244.96:3306: connect: connection timed out
goroutine 1 [running]:
github.com/kubeflow/pipelines/vendor/github.com/golang/glog.stacks(0xc0006b6300, 0xc000400000, 0x66, 0x9b)
	/go/src/github.com/kubeflow/pipelines/vendor/github.com/golang/glog/glog.go:769 +0xd4
github.com/kubeflow/pipelines/vendor/github.com/golang/glog.(*loggingT).output(0x263bee0, 0xc000000003, 0xc0006ae790, 0x239a356, 0x8, 0x128, 0x0)
	/go/src/github.com/kubeflow/pipelines/vendor/github.com/golang/glog/glog.go:720 +0x329
github.com/kubeflow/pipelines/vendor/github.com/golang/glog.(*loggingT).printf(0x263bee0, 0xc000000003, 0x15d6c0d, 0x2, 0xc000543a60, 0x1, 0x1)
	/go/src/github.com/kubeflow/pipelines/vendor/github.com/golang/glog/glog.go:655 +0x14b
github.com/kubeflow/pipelines/vendor/github.com/golang/glog.Fatalf(0x15d6c0d, 0x2, 0xc000543a60, 0x1, 0x1)
	/go/src/github.com/kubeflow/pipelines/vendor/github.com/golang/glog/glog.go:1148 +0x67
github.com/kubeflow/pipelines/backend/src/common/util.TerminateIfError(0x1781280, 0xc0006ad540)
	/go/src/github.com/kubeflow/pipelines/backend/src/common/util/error.go:296 +0x79
main.initMysql(0xc0003eb798, 0x5, 0x53d1ac1000, 0x0, 0x0)
	/go/src/github.com/kubeflow/pipelines/backend/src/apiserver/client_manager.go:194 +0x2ed
main.initDBClient(0x53d1ac1000, 0x15)
	/go/src/github.com/kubeflow/pipelines/backend/src/apiserver/client_manager.go:137 +0x54c
main.(*ClientManager).init(0xc0001a3d50)
	/go/src/github.com/kubeflow/pipelines/backend/src/apiserver/client_manager.go:103 +0x80
main.newClientManager(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/go/src/github.com/kubeflow/pipelines/backend/src/apiserver/client_manager.go:232 +0x90
main.main()
	/go/src/github.com/kubeflow/pipelines/backend/src/apiserver/main.go:53 +0x88

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/582)
<!-- Reviewable:end -->
