### PR TITLE
Compare perf - pure components, disable ROC curve thumbnail animations

### DIFF
--- a/frontend/src/components/CompareTable.tsx
+++ b/frontend/src/components/CompareTable.tsx
@@ -55,39 +55,40 @@ export interface CompareTableProps {
   yLabels: string[];
 }
 
-// tslint:disable-next-line:variable-name
-const CompareTable = (compareProps: CompareTableProps) => {
-  const { rows, xLabels, yLabels } = compareProps;
-  if (rows.length !== yLabels.length) {
-    logger.error(
-      `Number of rows (${rows.length}) should match the number of Y labels (${yLabels.length}).`);
-  }
-  if (!rows || rows.length === 0) {
-    return null;
-  }
+class CompareTable extends React.PureComponent<CompareTableProps> {
+  public render(): JSX.Element | null {
+    const { rows, xLabels, yLabels } = this.props;
+    if (rows.length !== yLabels.length) {
+      logger.error(
+        `Number of rows (${rows.length}) should match the number of Y labels (${yLabels.length}).`);
+    }
+    if (!rows || rows.length === 0) {
+      return null;
+    }
 
-  return (
-    <table className={css.root}>
-      <tbody>
-        <tr className={css.row}>
-          <td className={css.labelCell} />
-          {/* X labels row */}
-          {xLabels.map((label, i) => (
-            <td key={i} className={classes(css.cell, css.labelCell)} title={label}>{label}</td>
-          ))}
-        </tr>
-        {rows.map((row, i) => (
-          <tr key={i} className={css.row}>
-            {/* Y label */}
-            <td className={classes(css.cell, css.labelCell)} title={yLabels[i]}>{yLabels[i]}</td>
-
-            {/* Row cells */}
-            {row.map((cell, j) => <td key={j} className={css.cell} title={cell}>{cell}</td>)}
+    return (
+      <table className={css.root}>
+        <tbody>
+          <tr className={css.row}>
+            <td className={css.labelCell} />
+            {/* X labels row */}
+            {xLabels.map((label, i) => (
+              <td key={i} className={classes(css.cell, css.labelCell)} title={label}>{label}</td>
+            ))}
           </tr>
-        ))}
-      </tbody>
-    </table>
-  );
-};
+          {rows.map((row, i) => (
+            <tr key={i} className={css.row}>
+              {/* Y label */}
+              <td className={classes(css.cell, css.labelCell)} title={yLabels[i]}>{yLabels[i]}</td>
+
+              {/* Row cells */}
+              {row.map((cell, j) => <td key={j} className={css.cell} title={cell}>{cell}</td>)}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+}
 
 export default CompareTable;

--- a/frontend/src/components/PlotCard.tsx
+++ b/frontend/src/components/PlotCard.tsx
@@ -99,6 +99,11 @@ class PlotCard extends React.Component<PlotCardProps, PlotCardState> {
     };
   }
 
+  public shouldComponentUpdate(nextProps: PlotCardProps, nextState: PlotCardState): boolean {
+    return JSON.stringify(nextProps) !== JSON.stringify(this.props) ||
+      nextState.fullscreenDialogOpen !== this.state.fullscreenDialogOpen;
+  }
+
   public render(): JSX.Element | null {
     const { title, configs, maxDimension, ...otherProps } = this.props;
 

--- a/frontend/src/components/viewers/ConfusionMatrix.tsx
+++ b/frontend/src/components/viewers/ConfusionMatrix.tsx
@@ -166,6 +166,8 @@ class ConfusionMatrix extends Viewer<ConfusionMatrixProps, ConfusionMatrixState>
   }
 
   public render(): JSX.Element | null {
+    // tslint:disable-next-line:no-console
+    console.log('confusion matrix render');
     if (!this._config) {
       return null;
     }

--- a/frontend/src/components/viewers/ConfusionMatrix.tsx
+++ b/frontend/src/components/viewers/ConfusionMatrix.tsx
@@ -166,8 +166,6 @@ class ConfusionMatrix extends Viewer<ConfusionMatrixProps, ConfusionMatrixState>
   }
 
   public render(): JSX.Element | null {
-    // tslint:disable-next-line:no-console
-    console.log('confusion matrix render');
     if (!this._config) {
       return null;
     }

--- a/frontend/src/components/viewers/ROCCurve.tsx
+++ b/frontend/src/components/viewers/ROCCurve.tsx
@@ -105,6 +105,8 @@ class ROCCurve extends Viewer<ROCCurveProps, ROCCurveState> {
   }
 
   public render(): JSX.Element {
+    // tslint:disable-next-line:no-console
+    console.log('roc curve render');
 
     const width = this.props.maxDimension || 800;
     const height = width * 0.65;

--- a/frontend/src/components/viewers/ROCCurve.tsx
+++ b/frontend/src/components/viewers/ROCCurve.tsx
@@ -105,9 +105,6 @@ class ROCCurve extends Viewer<ROCCurveProps, ROCCurveState> {
   }
 
   public render(): JSX.Element {
-    // tslint:disable-next-line:no-console
-    console.log('roc curve render');
-
     const width = this.props.maxDimension || 800;
     const height = width * 0.65;
     const isSmall = width < 600;

--- a/frontend/src/components/viewers/ROCCurve.tsx
+++ b/frontend/src/components/viewers/ROCCurve.tsx
@@ -106,8 +106,9 @@ class ROCCurve extends Viewer<ROCCurveProps, ROCCurveState> {
 
   public render(): JSX.Element {
 
-    const width = this.props.maxDimension || 600;
+    const width = this.props.maxDimension || 800;
     const height = width * 0.65;
+    const isSmall = width < 600;
     const datasets = this.props.configs.map(d => d.data);
     const numLines = datasets.length;
     const labels = this.props.configs.map((_, i) => `threshold (Series #${i})`);
@@ -116,7 +117,7 @@ class ROCCurve extends Viewer<ROCCurveProps, ROCCurveState> {
     const { hoveredValues, lastDrawLocation } = this.state;
 
     return <div>
-      <XYPlot width={width} height={height} animation={true}
+      <XYPlot width={width} height={height} animation={!isSmall}
         classes={{ root: css.root }}
         onMouseLeave={() => this.setState({ hoveredValues: new Array(numLines).fill('') })}
         xDomain={lastDrawLocation && [lastDrawLocation.left, lastDrawLocation.right]}>
@@ -136,21 +137,25 @@ class ROCCurve extends Viewer<ROCCurveProps, ROCCurveState> {
             strokeWidth={2} data={data} onNearestX={(d: any) => this._lineHovered(i, d)}
             curve='curveBasis' />)}
 
-        <Highlight onBrushEnd={(area: any) => this.setState({ lastDrawLocation: area })}
-          enableY={false} onDrag={(area: any) => this.setState({
-            lastDrawLocation: {
-              left: (lastDrawLocation ? lastDrawLocation.left : 0) - (area.right - area.left),
-              right: (lastDrawLocation ? lastDrawLocation.right : 0) - (area.right - area.left),
-            }
-          })} />
+        {!isSmall && (
+          <Highlight onBrushEnd={(area: any) => this.setState({ lastDrawLocation: area })}
+            enableY={false} onDrag={(area: any) => this.setState({
+              lastDrawLocation: {
+                left: (lastDrawLocation ? lastDrawLocation.left : 0) - (area.right - area.left),
+                right: (lastDrawLocation ? lastDrawLocation.right : 0) - (area.right - area.left),
+              }
+            })} />
+        )}
 
         {/* Hover effect to show labels */}
-        <Crosshair values={hoveredValues}>
-          <div className={css.crosshair}>
-            {hoveredValues.map((value, i) => (
-              <div key={i} className={css.crosshairLabel}>{`${labels[i]}: ${value.label}`}</div>))}
-          </div>
-        </Crosshair>
+        {!isSmall && (
+          <Crosshair values={hoveredValues}>
+            <div className={css.crosshair}>
+              {hoveredValues.map((value, i) => (
+                <div key={i} className={css.crosshairLabel}>{`${labels[i]}: ${value.label}`}</div>))}
+            </div>
+          </Crosshair>
+        )}
       </XYPlot>
 
       <div className={commonCss.flex}>

--- a/frontend/src/components/viewers/__snapshots__/ROCCurve.test.tsx.snap
+++ b/frontend/src/components/viewers/__snapshots__/ROCCurve.test.tsx.snap
@@ -10,9 +10,9 @@ exports[`ROCCurve does not break on empty data 1`] = `
         "root": "root",
       }
     }
-    height={390}
+    height={520}
     onMouseLeave={[Function]}
-    width={600}
+    width={800}
     xDomain={null}
   >
     <VerticalGridLines
@@ -519,9 +519,9 @@ exports[`ROCCurve does not break on no config 1`] = `
         "root": "root",
       }
     }
-    height={390}
+    height={520}
     onMouseLeave={[Function]}
-    width={600}
+    width={800}
     xDomain={null}
   >
     <VerticalGridLines
@@ -1003,9 +1003,9 @@ exports[`ROCCurve renders a simple ROC curve given one config 1`] = `
         "root": "root",
       }
     }
-    height={390}
+    height={520}
     onMouseLeave={[Function]}
-    width={600}
+    width={800}
     xDomain={null}
   >
     <VerticalGridLines
@@ -1540,9 +1540,9 @@ exports[`ROCCurve renders an ROC curve using three configs 1`] = `
         "root": "root",
       }
     }
-    height={390}
+    height={520}
     onMouseLeave={[Function]}
-    width={600}
+    width={800}
     xDomain={null}
   >
     <VerticalGridLines

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -117,7 +117,7 @@ class Compare extends Page<{}, CompareState> {
 
       {/* Overview section */}
       <CollapseButton sectionName={overviewSectionName} collapseSections={collapseSections}
-        compareSetState={this.setStateSafe.bind(this)}/>
+        compareSetState={this.setStateSafe.bind(this)} />
       {!collapseSections[overviewSectionName] && (
         <div className={commonCss.noShrink}>
           <RunList onError={this.showPageError.bind(this)} {...this.props}
@@ -130,7 +130,7 @@ class Compare extends Page<{}, CompareState> {
 
       {/* Parameters section */}
       <CollapseButton sectionName={paramsSectionName} collapseSections={collapseSections}
-        compareSetState={this.setStateSafe.bind(this)}/>
+        compareSetState={this.setStateSafe.bind(this)} />
       {!collapseSections[paramsSectionName] && (
         <div className={classes(commonCss.noShrink, css.outputsRow)}>
           <Separator orientation='vertical' />
@@ -213,9 +213,9 @@ class Compare extends Page<{}, CompareState> {
     }
 
     this.setStateSafe({
-      runs,	
-      selectedIds: runs.map(r => r.run!.id!),	
-      workflowObjects,	
+      runs,
+      selectedIds: runs.map(r => r.run!.id!),
+      workflowObjects,
     }, () => this._loadParameters());
 
     const outputPathsList = workflowObjects.map(

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -102,6 +102,8 @@ class Compare extends Page<{}, CompareState> {
   }
 
   public render(): JSX.Element {
+    // tslint:disable-next-line:no-console
+    console.log('compare page render');
     const { collapseSections, selectedIds, viewersMap } = this.state;
 
     const queryParamRunIds = new URLParser(this.props).get(QUERY_PARAMS.runlist);
@@ -212,11 +214,13 @@ class Compare extends Page<{}, CompareState> {
       return;
     }
 
+    const selectedIds = runs.map(r => r.run!.id!);
     this.setStateSafe({
       runs,
-      selectedIds: runs.map(r => r.run!.id!),
+      selectedIds,
       workflowObjects,
-    }, () => this._loadParameters());
+    });
+    this._loadParameters(selectedIds);
 
     const outputPathsList = workflowObjects.map(
       workflow => WorkflowParser.loadAllOutputPaths(workflow));
@@ -245,7 +249,8 @@ class Compare extends Page<{}, CompareState> {
   }
 
   protected _selectionChanged(selectedIds: string[]): void {
-    this.setState({ selectedIds }, () => this._loadParameters());
+    this.setState({ selectedIds });
+    this._loadParameters(selectedIds);
   }
 
   private _collapseAllSections(): void {
@@ -257,8 +262,8 @@ class Compare extends Page<{}, CompareState> {
     this.setState({ collapseSections });
   }
 
-  private _loadParameters(): void {
-    const { runs, selectedIds, workflowObjects } = this.state;
+  private _loadParameters(selectedIds: string[]): void {
+    const { runs, workflowObjects } = this.state;
 
     const selectedIndices = selectedIds.map(id => runs.findIndex(r => r.run!.id === id));
     const filteredRuns = runs.filter((_, i) => selectedIndices.indexOf(i) > -1);

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -102,8 +102,6 @@ class Compare extends Page<{}, CompareState> {
   }
 
   public render(): JSX.Element {
-    // tslint:disable-next-line:no-console
-    console.log('compare page render');
     const { collapseSections, selectedIds, viewersMap } = this.state;
 
     const queryParamRunIds = new URLParser(this.props).get(QUERY_PARAMS.runlist);
@@ -144,36 +142,38 @@ class Compare extends Page<{}, CompareState> {
       <Separator orientation='vertical' />
 
       {Array.from(viewersMap.keys()).map((viewerType, i) =>
-        <div key={i}>
-          <CollapseButton collapseSections={collapseSections}
-            compareSetState={this.setStateSafe.bind(this)}
-            sectionName={componentMap[viewerType].prototype.getDisplayName()} />
-          {!collapseSections[componentMap[viewerType].prototype.getDisplayName()] && (
-            <React.Fragment>
-              <div className={classes(commonCss.flex, css.outputsRow)}>
-                {/* If the component allows aggregation, add one more card for
+        !!runsPerViewerType(viewerType).length && (
+          <div key={i}>
+            <CollapseButton collapseSections={collapseSections}
+              compareSetState={this.setStateSafe.bind(this)}
+              sectionName={componentMap[viewerType].prototype.getDisplayName()} />
+            {!collapseSections[componentMap[viewerType].prototype.getDisplayName()] && (
+              <React.Fragment>
+                <div className={classes(commonCss.flex, css.outputsRow)}>
+                  {/* If the component allows aggregation, add one more card for
                 its aggregated view. Only do this if there is more than one
                 output, filtering out any unselected runs. */}
-                {(componentMap[viewerType].prototype.isAggregatable() && (
-                  runsPerViewerType(viewerType).length > 1) && (
-                    <PlotCard configs={
-                      runsPerViewerType(viewerType).map(t => t.config)} maxDimension={400}
-                      title='Aggregated view' />
-                  )
-                )}
+                  {(componentMap[viewerType].prototype.isAggregatable() && (
+                    runsPerViewerType(viewerType).length > 1) && (
+                      <PlotCard configs={
+                        runsPerViewerType(viewerType).map(t => t.config)} maxDimension={400}
+                        title='Aggregated view' />
+                    )
+                  )}
 
-                {runsPerViewerType(viewerType).map((taggedConfig, c) => (
-                  <PlotCard key={c} configs={[taggedConfig.config]} title={taggedConfig.runName}
-                    maxDimension={400} />
-                ))}
-                <Separator />
+                  {runsPerViewerType(viewerType).map((taggedConfig, c) => (
+                    <PlotCard key={c} configs={[taggedConfig.config]} title={taggedConfig.runName}
+                      maxDimension={400} />
+                  ))}
+                  <Separator />
 
-              </div>
-              <Hr />
-            </React.Fragment>
-          )}
-          <Separator orientation='vertical' />
-        </div>
+                </div>
+                <Hr />
+              </React.Fragment>
+            )}
+            <Separator orientation='vertical' />
+          </div>
+        )
       )}
     </div>);
   }

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -85,7 +85,7 @@ interface RunListState {
   runs: DisplayRun[];
 }
 
-class RunList extends React.Component<RunListProps, RunListState> {
+class RunList extends React.PureComponent<RunListProps, RunListState> {
   private _tableRef = React.createRef<CustomTable>();
 
   constructor(props: any) {

--- a/frontend/src/pages/__snapshots__/Compare.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/Compare.test.tsx.snap
@@ -1025,42 +1025,6 @@ exports[`Compare does not show viewers for deselected runs 1`] = `
   <Component
     orientation="vertical"
   />
-  <div
-    key="0"
-  >
-    <CollapseButton
-      collapseSections={Object {}}
-      compareSetState={[Function]}
-      sectionName="Tensorboard"
-    />
-    <div
-      className="flex outputsRow"
-    >
-      <Component />
-    </div>
-    <Component />
-    <Component
-      orientation="vertical"
-    />
-  </div>
-  <div
-    key="1"
-  >
-    <CollapseButton
-      collapseSections={Object {}}
-      compareSetState={[Function]}
-      sectionName="Table"
-    />
-    <div
-      className="flex outputsRow"
-    >
-      <Component />
-    </div>
-    <Component />
-    <Component
-      orientation="vertical"
-    />
-  </div>
 </div>
 `;
 


### PR DESCRIPTION
Fixes #597.

The main problem here was that the PlotCard component was not pure. This was causing all plots to re-render fully whenever state changes on the compare page, which happens on collapsing/expanding sections, and on selecting/deselecting runs.

Simply extending `PureComponent` doesn't work here, since it gets an array of objects, so shallow comparison always fails. Implementing `shouldComponentUpdate` to properly check fixes this.

This PR also disables animations in thumbnailed ROC curve, and turns RunList and CompareTable into pure components, which reduces the number of re-renders when collapsing all compare page sections from 280+ to about 50. Some of these are still because of some react-vis axis mutations that I do not understand, but it's quite a bit more usable.

Tip: turn off whitespace when viewing this change.

/area front-end
/assign @rileyjbauer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/598)
<!-- Reviewable:end -->
