### PR TITLE
First step to bring back CMLE sample.

### DIFF
--- a/components/resnet-cmle/resnet/resnet_model/trainer/resnet_main.py
+++ b/components/resnet-cmle/resnet/resnet_model/trainer/resnet_main.py
@@ -405,6 +405,7 @@ def main(unused_argv):
           per_host_input_for_training=tpu_config.InputPipelineConfig.PER_HOST_V2))  # pylint: disable=line-too-long
 
   resnet_classifier = tpu_estimator.TPUEstimator(
+      export_to_tpu=False,
       use_tpu=FLAGS.use_tpu,
       model_fn=resnet_model_fn,
       config=config,

--- a/sdk/python/kfp/gcp.py
+++ b/sdk/python/kfp/gcp.py
@@ -53,6 +53,12 @@ def use_gcp_secret(secret_name='user-gcp-sa', secret_file_path_in_volume='/user-
                         value=secret_volume_mount_path + secret_file_path_in_volume,
                     )
                 )
+                .add_env_variable(
+                    k8s_client.V1EnvVar(
+                        name='CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE',
+                        value=secret_volume_mount_path + secret_file_path_in_volume,
+                    )
+                )
         )
     
     return _use_gcp_secret

--- a/sdk/python/kfp/gcp.py
+++ b/sdk/python/kfp/gcp.py
@@ -59,6 +59,7 @@ def use_gcp_secret(secret_name='user-gcp-sa', secret_file_path_in_volume='/user-
                         value=secret_volume_mount_path + secret_file_path_in_volume,
                     )
                 ) # Set GCloud Credentials by using the env var override.
+                  # TODO: Is there a better way for GCloud to pick up the credential?
         )
     
     return _use_gcp_secret

--- a/sdk/python/kfp/gcp.py
+++ b/sdk/python/kfp/gcp.py
@@ -58,7 +58,7 @@ def use_gcp_secret(secret_name='user-gcp-sa', secret_file_path_in_volume='/user-
                         name='CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE',
                         value=secret_volume_mount_path + secret_file_path_in_volume,
                     )
-                )
+                ) # Set GCloud Credentials by using the env var override.
         )
     
     return _use_gcp_secret


### PR DESCRIPTION
Set GCP credential for gcloud. Do not export TPU Model because a) Serving does not need TPU. b) Workaround a CMLE 1.9 issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/599)
<!-- Reviewable:end -->
