### PR TITLE
Add platform params when installing kubeflow

### DIFF
--- a/pipeline/deploy.sh
+++ b/pipeline/deploy.sh
@@ -183,7 +183,7 @@ if [ "$WITH_KUBEFLOW" = true ]; then
   if [[ ${REPORT_USAGE} != "true" ]]; then
       (cd ${KUBEFLOW_REPO} && sed -i -e 's/--reportUsage\=true/--reportUsage\=false/g' scripts/util.sh)
   fi
-  (${KUBEFLOW_REPO}/scripts/kfctl.sh init ${KFAPP} --platform none)
+  (${KUBEFLOW_REPO}/scripts/kfctl.sh init ${KFAPP} --platform "$PLATFORM")
   (cd ${KFAPP} && ${KUBEFLOW_REPO}/scripts/kfctl.sh generate k8s && ${KUBEFLOW_REPO}/scripts/kfctl.sh apply k8s)
 fi
 


### PR DESCRIPTION
In China, the image from  `gcr.io` can not be download because of network. 
Kubeflow installation support different platform by ['PLATFORM' Params](https://github.com/kubeflow/kubeflow/blob/master/scripts/kfctl.sh#L44)
In `pipeline/deploy.sh` add platform params for installing kubeflow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/600)
<!-- Reviewable:end -->
