### PR TITLE
Load sample when pipeline initially started

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -54,4 +54,4 @@ RUN apk add ca-certificates
 EXPOSE 8888
 
 # Start the apiserver
-CMD apiserver --config=/config
+CMD apiserver --config=/config --sampleconfig=/config/sample_config.json

--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -22,13 +22,13 @@ import (
 	workflowclient "github.com/argoproj/argo/pkg/client/clientset/versioned/typed/workflow/v1alpha1"
 	"github.com/cenkalti/backoff"
 	"github.com/golang/glog"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/storage"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	scheduledworkflowclient "github.com/kubeflow/pipelines/backend/src/crd/pkg/client/clientset/versioned/typed/scheduledworkflow/v1alpha1"
-	"github.com/jinzhu/gorm"
-	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	minio "github.com/minio/minio-go"
 )
 
@@ -50,6 +50,7 @@ type ClientManager struct {
 	jobStore               storage.JobStoreInterface
 	runStore               storage.RunStoreInterface
 	resourceReferenceStore storage.ResourceReferenceStoreInterface
+	systemInfoStore        storage.SystemInfoStoreInterface
 	objectStore            storage.ObjectStoreInterface
 	wfClient               workflowclient.WorkflowInterface
 	swfClient              scheduledworkflowclient.ScheduledWorkflowInterface
@@ -75,6 +76,10 @@ func (c *ClientManager) RunStore() storage.RunStoreInterface {
 
 func (c *ClientManager) ResourceReferenceStore() storage.ResourceReferenceStoreInterface {
 	return c.resourceReferenceStore
+}
+
+func (c *ClientManager) SystemInfoStore() storage.SystemInfoStoreInterface {
+	return c.systemInfoStore
 }
 
 func (c *ClientManager) ObjectStore() storage.ObjectStoreInterface {
@@ -114,6 +119,7 @@ func (c *ClientManager) init() {
 	c.jobStore = storage.NewJobStore(db, c.time)
 	c.runStore = storage.NewRunStore(db, c.time)
 	c.resourceReferenceStore = storage.NewResourceReferenceStore(db)
+	c.systemInfoStore = storage.NewSystemInfoStore(db)
 	c.objectStore = initMinioClient(getDurationConfig(initConnectionTimeout))
 
 	c.wfClient = client.CreateWorkflowClientOrFatal(
@@ -151,7 +157,8 @@ func initDBClient(initConnectionTimeout time.Duration) *storage.DB {
 		&model.Pipeline{},
 		&model.ResourceReference{},
 		&model.RunDetail{},
-		&model.RunMetric{})
+		&model.RunMetric{},
+		&model.SystemInfo{})
 
 	if response.Error != nil {
 		glog.Fatalf("Failed to initialize the databases.")

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -25,15 +25,16 @@ import (
 	"time"
 
 	"fmt"
+	"os"
+
 	"github.com/golang/glog"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/kubeflow/pipelines/backend/api/go_client"
+	api "github.com/kubeflow/pipelines/backend/api/go_client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/server"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
-	"os"
 )
 
 var (
@@ -52,15 +53,9 @@ func main() {
 	initConfig()
 	clientManager := newClientManager()
 	resourceManager := resource.NewResourceManager(&clientManager)
-
-	// If sample config path is not empty, this is a one time job to load samples to the system
-	// Load samples and terminate.
-	if *sampleConfigPath != "" {
-		err := loadSamples(resourceManager)
-		if err != nil {
-			glog.Fatalf("Failed to load samples. Err: %v", err.Error())
-		}
-		return
+	err := loadSamples(resourceManager)
+	if err != nil {
+		glog.Fatalf("Failed to load samples. Err: %v", err.Error())
 	}
 
 	go startRpcServer(resourceManager)
@@ -133,7 +128,14 @@ func registerHttpHandlerFromEndpoint(handler RegisterHttpHandlerFromEndpoint, se
 }
 
 // Preload a bunch of pipeline samples
+// Samples are only loaded once when the pipeline system is initially installed.
+// They won't be loaded when upgrade, to prevent them reappear if user explicitly delete the samples.
 func loadSamples(resourceManager *resource.ResourceManager) error {
+	// Check if sample has being loaded already and skip loading if true.
+	isSampleLoaded, err := resourceManager.IsSampleLoaded()
+	if err != nil || isSampleLoaded {
+		return err
+	}
 	configBytes, err := ioutil.ReadFile(*sampleConfigPath)
 	if err != nil {
 		return errors.New(fmt.Sprintf("Failed to read sample configurations file. Err: %v", err.Error()))
@@ -167,6 +169,11 @@ func loadSamples(resourceManager *resource.ResourceManager) error {
 		// Since the default sorting is by create time,
 		// Sleep one second makes sure the samples are showing up in the same order as they are added.
 		time.Sleep(1 * time.Second)
+	}
+	// Mark sample as loaded
+	err = resourceManager.MarkSampleLoaded()
+	if err != nil {
+		return err
 	}
 	glog.Info("All samples are loaded.")
 	return nil

--- a/backend/src/apiserver/model/system_info.go
+++ b/backend/src/apiserver/model/system_info.go
@@ -1,0 +1,19 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+type SystemInfo struct {
+	IsSampleLoaded bool `gorm:"column:IsSampleLoaded; not null"`
+}

--- a/backend/src/apiserver/resource/client_manager_fake.go
+++ b/backend/src/apiserver/resource/client_manager_fake.go
@@ -33,6 +33,7 @@ type FakeClientManager struct {
 	jobStore                    storage.JobStoreInterface
 	runStore                    storage.RunStoreInterface
 	resourceReferenceStore      storage.ResourceReferenceStoreInterface
+	systemInfoStore             storage.SystemInfoStoreInterface
 	objectStore                 storage.ObjectStoreInterface
 	workflowClientFake          *FakeWorkflowClient
 	scheduledWorkflowClientFake *FakeScheduledWorkflowClient
@@ -65,6 +66,7 @@ func NewFakeClientManager(time util.TimeInterface, uuid util.UUIDGeneratorInterf
 		runStore:                    storage.NewRunStore(db, time),
 		workflowClientFake:          NewWorkflowClientFake(),
 		resourceReferenceStore:      storage.NewResourceReferenceStore(db),
+		systemInfoStore:             storage.NewSystemInfoStore(db),
 		objectStore:                 storage.NewFakeObjectStore(),
 		scheduledWorkflowClientFake: NewScheduledWorkflowClientFake(),
 		time:                        time,
@@ -119,6 +121,10 @@ func (f *FakeClientManager) RunStore() storage.RunStoreInterface {
 
 func (f *FakeClientManager) ResourceReferenceStore() storage.ResourceReferenceStoreInterface {
 	return f.resourceReferenceStore
+}
+
+func (f *FakeClientManager) SystemInfoStore() storage.SystemInfoStoreInterface {
+	return f.systemInfoStore
 }
 
 func (f *FakeClientManager) ScheduledWorkflow() scheduledworkflowclient.ScheduledWorkflowInterface {

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -41,6 +41,7 @@ type ClientManagerInterface interface {
 	JobStore() storage.JobStoreInterface
 	RunStore() storage.RunStoreInterface
 	ResourceReferenceStore() storage.ResourceReferenceStoreInterface
+	SystemInfoStore() storage.SystemInfoStoreInterface
 	ObjectStore() storage.ObjectStoreInterface
 	Workflow() workflowclient.WorkflowInterface
 	ScheduledWorkflow() scheduledworkflowclient.ScheduledWorkflowInterface
@@ -54,6 +55,7 @@ type ResourceManager struct {
 	jobStore                storage.JobStoreInterface
 	runStore                storage.RunStoreInterface
 	resourceReferenceStore  storage.ResourceReferenceStoreInterface
+	systemInfoStore         storage.SystemInfoStoreInterface
 	objectStore             storage.ObjectStoreInterface
 	workflowClient          workflowclient.WorkflowInterface
 	scheduledWorkflowClient scheduledworkflowclient.ScheduledWorkflowInterface
@@ -68,6 +70,7 @@ func NewResourceManager(clientManager ClientManagerInterface) *ResourceManager {
 		jobStore:                clientManager.JobStore(),
 		runStore:                clientManager.RunStore(),
 		resourceReferenceStore:  clientManager.ResourceReferenceStore(),
+		systemInfoStore:         clientManager.SystemInfoStore(),
 		objectStore:             clientManager.ObjectStore(),
 		workflowClient:          clientManager.Workflow(),
 		scheduledWorkflowClient: clientManager.ScheduledWorkflow(),
@@ -478,4 +481,12 @@ func (r *ResourceManager) ReadArtifact(runID string, nodeID string, artifactName
 			"arifact", common.CreateArtifactPath(runID, nodeID, artifactName))
 	}
 	return r.objectStore.GetFile(artifactPath)
+}
+
+func (r *ResourceManager) IsSampleLoaded() (bool, error) {
+	return r.systemInfoStore.IsSampleLoaded()
+}
+
+func (r *ResourceManager) MarkSampleLoaded() error {
+	return r.MarkSampleLoaded()
 }

--- a/backend/src/apiserver/storage/db_fake.go
+++ b/backend/src/apiserver/storage/db_fake.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/jinzhu/gorm"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -36,7 +36,8 @@ func NewFakeDb() (*DB, error) {
 		&model.Pipeline{},
 		&model.ResourceReference{},
 		&model.RunDetail{},
-		&model.RunMetric{})
+		&model.RunMetric{},
+		&model.SystemInfo{})
 
 	return NewDB(db.DB(), NewSQLiteDialect()), nil
 }

--- a/backend/src/apiserver/storage/system_info_store.go
+++ b/backend/src/apiserver/storage/system_info_store.go
@@ -1,0 +1,113 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	sq "github.com/Masterminds/squirrel"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+)
+
+type SystemInfoStoreInterface interface {
+	IsSampleLoaded() (bool, error)
+	MarkSampleLoaded() error
+}
+
+type SystemInfoStore struct {
+	db *DB
+}
+
+func (s *SystemInfoStore) InitializeSystemInfoTable() error {
+	getSystemInfoSql, getSystemInfoArgs, err := sq.Select("*").From("system_infos").ToSql()
+	if err != nil {
+		return util.NewInternalServerError(err, "Error creating query to get system info.")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return util.NewInternalServerError(err, "Failed to create a new transaction to initialize system info.")
+	}
+
+	rows, err := tx.Query(getSystemInfoSql, getSystemInfoArgs...)
+	if err != nil {
+		tx.Rollback()
+		return util.NewInternalServerError(err, "Failed to get load sample status")
+	}
+
+	// The table is not initialized
+	if !rows.Next() {
+		sql, args, err := sq.
+			Insert("system_infos").
+			SetMap(sq.Eq{"IsSampleLoaded": false}).
+			ToSql()
+
+		if err != nil {
+			tx.Rollback()
+			return util.NewInternalServerError(err, "Error creating query to initialize system info table.")
+		}
+		_, err = tx.Exec(sql, args...)
+		if err != nil {
+			tx.Rollback()
+			return util.NewInternalServerError(err, "Error initializing the system info table.")
+		}
+	}
+	err = tx.Commit()
+	if err != nil {
+		tx.Rollback()
+		return util.NewInternalServerError(err, "Failed to initializing the system info table.")
+	}
+	return nil
+}
+
+func (s *SystemInfoStore) IsSampleLoaded() (bool, error) {
+	var isSampleLoaded bool
+	sql, args, err := sq.Select("*").From("system_infos").ToSql()
+	if err != nil {
+		return false, util.NewInternalServerError(err, "Error creating query to get load sample status.")
+	}
+	rows, err := s.db.Query(sql, args...)
+	if err != nil {
+		return false, util.NewInternalServerError(err, "Error when getting load sample status")
+	}
+	if rows.Next() {
+		err = rows.Scan(&isSampleLoaded)
+		if err != nil {
+			return false, util.NewInternalServerError(err, "Error when scanning row to load sample status")
+		}
+		return isSampleLoaded, nil
+	}
+	return false, nil
+}
+
+func (s *SystemInfoStore) MarkSampleLoaded() error {
+	sql, args, err := sq.
+		Update("system_infos").
+		SetMap(sq.Eq{"IsSampleLoaded": true}).
+		ToSql()
+	if err != nil {
+		return util.NewInternalServerError(err, "Error creating query to mark samples as loaded.")
+	}
+	_, err = s.db.Exec(sql, args...)
+	if err != nil {
+		return util.NewInternalServerError(err, "Error mark samples as loaded.")
+	}
+	return nil
+}
+
+// factory function for system info store
+func NewSystemInfoStore(db *DB) *SystemInfoStore {
+	s := &SystemInfoStore{db: db}
+	// Initialize system information table
+	s.InitializeSystemInfoTable()
+	return s
+}

--- a/backend/src/apiserver/storage/system_info_store_test.go
+++ b/backend/src/apiserver/storage/system_info_store_test.go
@@ -1,0 +1,61 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitializeSystemInfoTable(t *testing.T) {
+	db := NewFakeDbOrFatal()
+	defer db.Close()
+	systemInfoStore := NewSystemInfoStore(db)
+
+	// Initialize for the first time
+	err := systemInfoStore.InitializeSystemInfoTable()
+	assert.Nil(t, err)
+	// Initialize again should be no-op and no error
+	err = systemInfoStore.InitializeSystemInfoTable()
+	assert.Nil(t, err)
+	isSampleLoaded, err := systemInfoStore.IsSampleLoaded()
+	assert.Nil(t, err)
+	assert.False(t, isSampleLoaded)
+
+	db.Close()
+	err = systemInfoStore.InitializeSystemInfoTable()
+	assert.NotNil(t, err)
+}
+
+func TestMarkSampleLoaded(t *testing.T) {
+	db := NewFakeDbOrFatal()
+	defer db.Close()
+	systemInfoStore := NewSystemInfoStore(db)
+
+	// Initialize for the first time
+	err := systemInfoStore.InitializeSystemInfoTable()
+	assert.Nil(t, err)
+	// Initialize again should be no-op and no error
+	err = systemInfoStore.MarkSampleLoaded()
+	assert.Nil(t, err)
+	isSampleLoaded, err := systemInfoStore.IsSampleLoaded()
+	assert.Nil(t, err)
+	assert.True(t, isSampleLoaded)
+
+	db.Close()
+	err = systemInfoStore.MarkSampleLoaded()
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
Instead of using a K8s Job to load the sample, this change load the sample when pipeline backend is started and create a permanent system info table to store the state, so we don't load them again in case of pod failover or during upgrade. 

The K8s Job doesn't work well because it's immutable once created, ksonnet throw an error of "merging object with existing state failure" in case of upgrade. 

The system info table will potentially be useful in the future for storing the debugging information such as versions, upgrade history, DB version etc. 


