### PR TITLE
Generate pipeline and job python client as part of SDK

### DIFF
--- a/sdk/python/build.sh
+++ b/sdk/python/build.sh
@@ -40,6 +40,12 @@ echo "{\"packageName\": \"kfp_experiment\"}" > /tmp/config.json
 java -jar /tmp/swagger-codegen-cli.jar generate -l python -i ../../backend/api/swagger/experiment.swagger.json -o $DIR -c /tmp/config.json
 echo "{\"packageName\": \"kfp_run\"}" > /tmp/config.json
 java -jar /tmp/swagger-codegen-cli.jar generate -l python -i ../../backend/api/swagger/run.swagger.json -o $DIR -c /tmp/config.json
+echo "{\"packageName\": \"kfp_pipeline\"}" > /tmp/config.json
+java -jar /tmp/swagger-codegen-cli.jar generate -l python -i ../../backend/api/swagger/pipeline.swagger.json -o $DIR -c /tmp/config.json
+echo "{\"packageName\": \"kfp_uploadpipeline\"}" > /tmp/config.json
+java -jar /tmp/swagger-codegen-cli.jar generate -l python -i ../../backend/api/swagger/pipeline.upload.swagger.json -o $DIR -c /tmp/config.json
+echo "{\"packageName\": \"kfp_job\"}" > /tmp/config.json
+java -jar /tmp/swagger-codegen-cli.jar generate -l python -i ../../backend/api/swagger/job.swagger.json -o $DIR -c /tmp/config.json
 rm /tmp/config.json
 
 # Merge generated code with the rest code (setup.py, seira_client, etc).


### PR DESCRIPTION
So people can use python to CRUD pipeline or job, from for example notebook.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/628)
<!-- Reviewable:end -->
