### PR TITLE
Correctly ignore src/apis when building frontend

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -32,7 +32,7 @@
     "node_modules",
     "scripts",
     "server",
-    "src/api",
+    "src/apis",
     "src/setupTests.ts",
     "third_party",
     "webpack"


### PR DESCRIPTION
Right now, the build fails if the generated Typescript definitions don't build according to our tsconfig file.
/area front-end
/assign @rileyjbauer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/654)
<!-- Reviewable:end -->
