### PR TITLE
Add simple filtering by name to CustomTable

### DIFF
--- a/frontend/mock-backend/mock-api-middleware.ts
+++ b/frontend/mock-backend/mock-api-middleware.ts
@@ -412,14 +412,16 @@ export default (app: express.Application) => {
     ((filter && filter.predicates) || []).forEach(p => {
       resources = resources.filter(r => {
         switch(p.op) {
-          // case PredicateOp.CONTAINS
-          //   return r.name!.toLocaleLowerCase().indexOf(
-          //     decodeURIComponent(req.query.filter).toLocaleLowerCase()) > -1);
           case PredicateOp.EQUALS:
             if (p.key !== 'name') {
               throw new Error(`Key: ${p.key} is not yet supported by the mock API server`);
             }
-            return r.name!.toLocaleLowerCase() === (p.string_value || '').toLocaleLowerCase();
+            return r.name && r.name.toLocaleLowerCase() === (p.string_value || '').toLocaleLowerCase();
+          case PredicateOp.ISSUBSTRING:
+            if (p.key !== 'name') {
+              throw new Error(`Key: ${p.key} is not yet supported by the mock API server`);
+            }
+            return r.name && r.name.toLocaleLowerCase().includes((p.string_value || '').toLocaleLowerCase());
           case PredicateOp.NOTEQUALS:
             // Fall through
           case PredicateOp.GREATERTHAN:

--- a/frontend/mock-backend/mock-api-middleware.ts
+++ b/frontend/mock-backend/mock-api-middleware.ts
@@ -26,6 +26,7 @@ import { ApiRun, ApiListRunsResponse, ApiResourceType } from '../src/apis/run';
 import { ApiListExperimentsResponse, ApiExperiment } from '../src/apis/experiment';
 import RunUtils from '../src/lib/RunUtils';
 import { Response } from 'express-serve-static-core';
+import { ApiFilter, PredicateOp } from '../src/apis/filter/api';
 
 const rocMetadataJsonPath = './eval-output/metadata.json';
 const rocMetadataJsonPath2 = './eval-output/metadata2.json';
@@ -41,6 +42,15 @@ const helloWorldBigHtmlPath = './model-output/hello-world-big.html';
 const v1beta1Prefix = '/apis/v1beta1';
 
 let tensorboardPod = '';
+
+// This is a copy of the BaseResource defined within src/pages/ResourceSelector
+interface BaseResource {
+  id?: string;
+  created_at?: Date;
+  description?: string;
+  name?: string;
+  error?: string;
+}
 
 // tslint:disable-next-line:no-default-export
 export default (app: express.Application) => {
@@ -92,13 +102,8 @@ export default (app: express.Application) => {
     };
 
     let jobs: ApiJob[] = fixedData.jobs;
-    if (req.query.filter_by) {
-      // NOTE: We do not mock fuzzy matching. E.g. 'jb' doesn't match 'job'
-      // This may need to be updated when the backend implements filtering.
-      jobs = fixedData.jobs.filter((j) =>
-        j.name!.toLocaleLowerCase().indexOf(
-          decodeURIComponent(req.query.filter_by).toLocaleLowerCase()) > -1);
-
+    if (req.query.filter) {
+      jobs = filterResources(fixedData.jobs, req.query.filter);
     }
 
     const { desc, key } = getSortKeyAndOrder(ExperimentSortKeys.CREATED_AT, req.query.sort_by);
@@ -134,12 +139,8 @@ export default (app: express.Application) => {
     };
 
     let experiments: ApiExperiment[] = fixedData.experiments;
-    if (req.query.filterBy) {
-      // NOTE: We do not mock fuzzy matching. E.g. 'ep' doesn't match 'experiment'
-      experiments = fixedData.experiments.filter((exp) =>
-        exp.name!.toLocaleLowerCase().indexOf(
-          decodeURIComponent(req.query.filterBy).toLocaleLowerCase()) > -1);
-
+    if (req.query.filter) {
+      experiments = filterResources(fixedData.experiments, req.query.filter);
     }
 
     const { desc, key } = getSortKeyAndOrder(ExperimentSortKeys.NAME, req.query.sortBy);
@@ -272,11 +273,8 @@ export default (app: express.Application) => {
       return;
     }
 
-    if (req.query.filter_by) {
-      // NOTE: We do not mock fuzzy matching. E.g. 'jb' doesn't match 'job'
-      // This may need to be updated when the backend implements filtering.
-      runs = runs.filter((r) => r.name!.toLocaleLowerCase().indexOf(
-        decodeURIComponent(req.query.filter_by).toLocaleLowerCase()) > -1);
+    if (req.query.filter) {
+      runs = filterResources(runs, req.query.filter);
     }
 
     const { desc, key } = getSortKeyAndOrder(RunSortKeys.CREATED_AT, req.query.sort_by);
@@ -313,11 +311,8 @@ export default (app: express.Application) => {
 
     let runs: ApiRun[] = fixedData.runs.map((r) => r.run!);
 
-    if (req.query.filter_by) {
-      // NOTE: We do not mock fuzzy matching. E.g. 'rn' doesn't match 'run'
-      // This may need to be updated when the backend implements filtering.
-      runs = runs.filter((r) => r.name!.toLocaleLowerCase().indexOf(
-        decodeURIComponent(req.query.filter_by).toLocaleLowerCase()) > -1);
+    if (req.query.filter) {
+      runs = filterResources(runs, req.query.filter);
     }
 
     if (req.query['resource_reference_key.type'] === ApiResourceType.EXPERIMENT) {
@@ -409,6 +404,41 @@ export default (app: express.Application) => {
     }, 1000);
   });
 
+  function filterResources(resources: BaseResource[], filterString?: string): BaseResource[] {
+    if (!filterString) {
+      return resources;
+    }
+    const filter: ApiFilter = JSON.parse(decodeURIComponent(filterString));
+    ((filter && filter.predicates) || []).forEach(p => {
+      resources = resources.filter(r => {
+        switch(p.op) {
+          // case PredicateOp.CONTAINS
+          //   return r.name!.toLocaleLowerCase().indexOf(
+          //     decodeURIComponent(req.query.filter).toLocaleLowerCase()) > -1);
+          case PredicateOp.EQUALS:
+            if (p.key !== 'name') {
+              throw new Error(`Key: ${p.key} is not yet supported by the mock API server`);
+            }
+            return r.name!.toLocaleLowerCase() === (p.string_value || '').toLocaleLowerCase();
+          case PredicateOp.NOTEQUALS:
+            // Fall through
+          case PredicateOp.GREATERTHAN:
+            // Fall through
+          case PredicateOp.GREATERTHANEQUALS:
+            // Fall through
+          case PredicateOp.LESSTHAN:
+            // Fall through
+          case PredicateOp.LESSTHANEQUALS:
+            // Fall through
+            throw new Error(`Op: ${p.op} is not yet supported by the mock API server`);
+          default:
+            throw new Error(`Unknown Predicate op: ${p.op}`);
+        }
+      });
+    });
+    return resources;
+  }
+
   app.get(v1beta1Prefix + '/pipelines', (req, res) => {
     res.header('Content-Type', 'application/json');
     const response: ApiListPipelinesResponse = {
@@ -417,17 +447,11 @@ export default (app: express.Application) => {
     };
 
     let pipelines: ApiPipeline[] = fixedData.pipelines;
-    if (req.query.filter_by) {
-      // NOTE: We do not mock fuzzy matching. E.g. 'jb' doesn't match 'job'
-      // This may need to be updated depending on how the backend implements filtering.
-      pipelines = fixedData.pipelines.filter((p) =>
-        p.name!.toLocaleLowerCase().indexOf(
-          decodeURIComponent(req.query.filter_by).toLocaleLowerCase()) > -1);
-
+    if (req.query.filter) {
+      pipelines = filterResources(fixedData.pipelines, req.query.filter);
     }
 
     const { desc, key } = getSortKeyAndOrder(PipelineSortKeys.CREATED_AT, req.query.sort_by);
-
 
     pipelines.sort((a, b) => {
       let result = 1;

--- a/frontend/mock-backend/mock-api-middleware.ts
+++ b/frontend/mock-backend/mock-api-middleware.ts
@@ -15,18 +15,17 @@
 import * as express from 'express';
 import * as fs from 'fs';
 import * as _path from 'path';
-import proxyMiddleware from '../server/proxy-middleware';
-import { ExperimentSortKeys, RunSortKeys, PipelineSortKeys } from '../src/lib/Apis';
-
-import helloWorldRuntime from './integration-test-runtime';
-import { data as fixedData, namedPipelines } from './fixed-data';
-import { ApiPipeline, ApiListPipelinesResponse } from '../src/apis/pipeline';
-import { ApiListJobsResponse, ApiJob } from '../src/apis/job';
-import { ApiRun, ApiListRunsResponse, ApiResourceType } from '../src/apis/run';
-import { ApiListExperimentsResponse, ApiExperiment } from '../src/apis/experiment';
 import RunUtils from '../src/lib/RunUtils';
-import { Response } from 'express-serve-static-core';
+import helloWorldRuntime from './integration-test-runtime';
+import proxyMiddleware from '../server/proxy-middleware';
 import { ApiFilter, PredicateOp } from '../src/apis/filter/api';
+import { ApiListExperimentsResponse, ApiExperiment } from '../src/apis/experiment';
+import { ApiListJobsResponse, ApiJob } from '../src/apis/job';
+import { ApiListPipelinesResponse, ApiPipeline } from '../src/apis/pipeline';
+import { ApiListRunsResponse, ApiResourceType, ApiRun } from '../src/apis/run';
+import { ExperimentSortKeys, PipelineSortKeys, RunSortKeys } from '../src/lib/Apis';
+import { Response } from 'express-serve-static-core';
+import { data as fixedData, namedPipelines } from './fixed-data';
 
 const rocMetadataJsonPath = './eval-output/metadata.json';
 const rocMetadataJsonPath2 = './eval-output/metadata2.json';

--- a/frontend/src/apis/filter/api.ts
+++ b/frontend/src/apis/filter/api.ts
@@ -209,7 +209,8 @@ export enum PredicateOp {
     GREATERTHANEQUALS = <any> 'GREATER_THAN_EQUALS',
     LESSTHAN = <any> 'LESS_THAN',
     LESSTHANEQUALS = <any> 'LESS_THAN_EQUALS',
-    IN = <any> 'IN'
+    IN = <any> 'IN',
+    ISSUBSTRING = <any> 'IS_SUBSTRING'
 }
 
 

--- a/frontend/src/atoms/Input.tsx
+++ b/frontend/src/atoms/Input.tsx
@@ -20,16 +20,17 @@ import { commonCss } from '../Css';
 
 interface InputProps extends OutlinedTextFieldProps {
   height?: number | string;
+  maxWidth?: number | string;
   width?: number;
 }
 
 export default (props: InputProps) => {
-  const { height, variant, width, ...rest } = props;
+  const { height, maxWidth, variant, width, ...rest } = props;
   return (
     <TextField variant={variant} className={commonCss.textField} spellCheck={false}
         style={{
           height: !!props.multiline ? 'auto' : (height || 40),
-          maxWidth: 600,
+          maxWidth: maxWidth || 600,
           width: width || '100%' }}
         {...rest}>
       {props.children}

--- a/frontend/src/components/CustomTable.test.tsx
+++ b/frontend/src/components/CustomTable.test.tsx
@@ -15,10 +15,10 @@
  */
 
 import * as React from 'react';
-import CustomTable, { Column, Row, css, ExpandState } from './CustomTable';
+import CustomTable, { Column, ExpandState, Row, css } from './CustomTable';
 import TestUtils from '../TestUtils';
-import { shallow } from 'enzyme';
 import { PredicateOp } from '../apis/filter';
+import { shallow } from 'enzyme';
 
 const props = {
   columns: [],
@@ -291,7 +291,7 @@ describe('CustomTable', () => {
     expect(spy).toHaveBeenLastCalledWith(['row1']);
   });
 
-  it('does not add items to selection when multiple clicked', () => {
+  it('does not add items to selection when multiple rows are clicked', () => {
     // Keeping track of selection is the parent's job.
     const spy = jest.fn();
     const tree = shallow(<CustomTable {...props} rows={rows} columns={columns} updateSelection={spy} />);
@@ -300,7 +300,7 @@ describe('CustomTable', () => {
     expect(spy).toHaveBeenLastCalledWith(['row2']);
   });
 
-  it('passes both selectedIds and newly selected row when clicked', () => {
+  it('passes both selectedIds and the newly selected row to updateSelection when a row is clicked', () => {
     // Keeping track of selection is the parent's job.
     const selectedIds = ['previouslySelectedRow'];
     const spy = jest.fn();
@@ -539,7 +539,7 @@ describe('CustomTable', () => {
 
   it('updates the filter string in state when the filter box input changes', async () => {
     const tree = shallow(<CustomTable {...props} rows={rows} columns={columns} />);
-    (tree.instance() as CustomTable).handleChange('filterString')({ target: { value: 'test filter' } });
+    (tree.instance() as CustomTable).handleFilterChange({ target: { value: 'test filter' } });
     await TestUtils.flushPromises();
     expect(tree.state('filterString')).toEqual('test filter');
   });

--- a/frontend/src/components/CustomTable.test.tsx
+++ b/frontend/src/components/CustomTable.test.tsx
@@ -112,7 +112,13 @@ describe('CustomTable', () => {
   it('calls reload function with an empty page token to get rows', () => {
     const reload = jest.fn();
     shallow(<CustomTable {...props} reload={reload} />);
-    expect(reload).toHaveBeenLastCalledWith({ pageToken: '', pageSize: 10, orderAscending: false, sortBy: '' });
+    expect(reload).toHaveBeenLastCalledWith({
+      filter: '',
+      orderAscending: false,
+      pageSize: 10,
+      pageToken: '',
+      sortBy: '',
+    });
   });
 
   it('calls reload function with sort key of clicked column, while keeping same page', () => {
@@ -127,11 +133,21 @@ describe('CustomTable', () => {
     }];
     const reload = jest.fn();
     const tree = shallow(<CustomTable {...props} reload={reload} columns={testcolumns} />);
-    expect(reload).toHaveBeenLastCalledWith({ pageToken: '', pageSize: 10, sortBy: 'col1sortkey desc', orderAscending: false });
+    expect(reload).toHaveBeenLastCalledWith({
+      filter: '',
+      orderAscending: false,
+      pageSize: 10,
+      pageToken: '',
+      sortBy: 'col1sortkey desc',
+    });
 
     tree.find('WithStyles(TableSortLabel)').at(1).simulate('click');
     expect(reload).toHaveBeenLastCalledWith({
-      orderAscending: true, pageSize: 10, pageToken: '', sortBy: 'col2sortkey',
+      filter: '',
+      orderAscending: true,
+      pageSize: 10,
+      pageToken: '',
+      sortBy: 'col2sortkey',
     });
   });
 
@@ -147,16 +163,30 @@ describe('CustomTable', () => {
     }];
     const reload = jest.fn();
     const tree = shallow(<CustomTable {...props} reload={reload} columns={testcolumns} />);
-    expect(reload).toHaveBeenLastCalledWith({ pageToken: '', orderAscending: false, pageSize: 10, sortBy: 'col1sortkey desc' });
+    expect(reload).toHaveBeenLastCalledWith({
+      filter: '',
+      orderAscending: false,
+      pageSize: 10,
+      pageToken: '',
+      sortBy: 'col1sortkey desc',
+    });
 
     tree.find('WithStyles(TableSortLabel)').at(1).simulate('click');
     expect(reload).toHaveBeenLastCalledWith({
-      orderAscending: true, pageSize: 10, pageToken: '', sortBy: 'col2sortkey',
+      filter: '',
+      orderAscending: true,
+      pageSize: 10,
+      pageToken: '',
+      sortBy: 'col2sortkey',
     });
     tree.setProps({ sortBy: 'col1sortkey' });
     tree.find('WithStyles(TableSortLabel)').at(1).simulate('click');
     expect(reload).toHaveBeenLastCalledWith({
-      orderAscending: false, pageSize: 10, pageToken: '', sortBy: 'col2sortkey desc'
+      filter: '',
+      orderAscending: false,
+      pageSize: 10,
+      pageToken: '',
+      sortBy: 'col2sortkey desc',
     });
   });
 
@@ -170,10 +200,22 @@ describe('CustomTable', () => {
     }];
     const reload = jest.fn();
     const tree = shallow(<CustomTable {...props} reload={reload} columns={testcolumns} />);
-    expect(reload).toHaveBeenLastCalledWith({ pageToken: '', pageSize: 10, orderAscending: false, sortBy: '' });
+    expect(reload).toHaveBeenLastCalledWith({
+      filter: '',
+      orderAscending: false,
+      pageSize: 10,
+      pageToken: '',
+      sortBy: '',
+    });
 
     tree.find('WithStyles(TableSortLabel)').at(0).simulate('click');
-    expect(reload).toHaveBeenLastCalledWith({ pageToken: '', pageSize: 10, orderAscending: false, sortBy: '' });
+    expect(reload).toHaveBeenLastCalledWith({
+      filter: '',
+      orderAscending: false,
+      pageSize: 10,
+      pageToken: '',
+      sortBy: '',
+    });
   });
 
   it('logs error if row has more cells than columns', () => {
@@ -309,7 +351,13 @@ describe('CustomTable', () => {
     await TestUtils.flushPromises();
 
     tree.find('WithStyles(IconButton)').at(1).simulate('click');
-    expect(spy).toHaveBeenLastCalledWith({ pageToken: 'some token', pageSize: 10, orderAscending: false, sortBy: '' });
+    expect(spy).toHaveBeenLastCalledWith({
+      filter: '',
+      orderAscending: false,
+      pageSize: 10,
+      pageToken: 'some token',
+      sortBy: '',
+    });
   });
 
   it('renders new rows after clicking next page, and enables previous page button', async () => {
@@ -320,7 +368,13 @@ describe('CustomTable', () => {
 
     tree.find('WithStyles(IconButton)').at(1).simulate('click');
     await TestUtils.flushPromises();
-    expect(spy).toHaveBeenLastCalledWith({ pageToken: 'some token', pageSize: 10, sortBy: '', orderAscending: false });
+    expect(spy).toHaveBeenLastCalledWith({
+      filter: '',
+      orderAscending: false,
+      pageSize: 10,
+      pageToken: 'some token',
+      sortBy: '',
+    });
     expect(tree.state()).toHaveProperty('currentPage', 1);
     tree.setProps({ rows: [rows[1]] });
     expect(tree).toMatchSnapshot();
@@ -338,7 +392,13 @@ describe('CustomTable', () => {
 
     tree.find('WithStyles(IconButton)').at(0).simulate('click');
     await TestUtils.flushPromises();
-    expect(spy).toHaveBeenLastCalledWith({ pageToken: '', orderAscending: false, sortBy: '', pageSize: 10 });
+    expect(spy).toHaveBeenLastCalledWith({
+      filter: '',
+      orderAscending: false,
+      pageSize: 10,
+      pageToken: '',
+      sortBy: '',
+    });
 
     tree.setProps({ rows });
     expect(tree.find('WithStyles(IconButton)').at(0).prop('disabled')).toBeTruthy();
@@ -353,7 +413,13 @@ describe('CustomTable', () => {
 
     tree.find('.' + css.rowsPerPage).simulate('change', { target: { value: 1234 } });
     await TestUtils.flushPromises();
-    expect(spy).toHaveBeenLastCalledWith({ pageSize: 1234, pageToken: '', orderAscending: false, sortBy: '' });
+    expect(spy).toHaveBeenLastCalledWith({
+      filter: '',
+      orderAscending: false,
+      pageSize: 1234,
+      pageToken: '',
+      sortBy: '',
+    });
     expect(tree.state()).toHaveProperty('tokenList', ['', 'some token']);
   });
 
@@ -364,7 +430,13 @@ describe('CustomTable', () => {
 
     tree.find('.' + css.rowsPerPage).simulate('change', { target: { value: 1234 } });
     await reloadResult;
-    expect(spy).toHaveBeenLastCalledWith({ pageSize: 1234, pageToken: '', orderAscending: false, sortBy: '' });
+    expect(spy).toHaveBeenLastCalledWith({
+      filter: '',
+      orderAscending: false,
+      pageSize: 1234,
+      pageToken: '',
+      sortBy: '',
+    });
     expect(tree.state()).toHaveProperty('tokenList', ['']);
   });
 

--- a/frontend/src/components/CustomTable.test.tsx
+++ b/frontend/src/components/CustomTable.test.tsx
@@ -553,7 +553,7 @@ describe('CustomTable', () => {
     const expectedEncodedFilter = encodeURIComponent(JSON.stringify({
       predicates: [{
         key: 'name',
-        op: PredicateOp.EQUALS,
+        op: PredicateOp.ISSUBSTRING,
         string_value: 'test filter',
       }]
     }));

--- a/frontend/src/components/CustomTable.test.tsx
+++ b/frontend/src/components/CustomTable.test.tsx
@@ -542,6 +542,7 @@ describe('CustomTable', () => {
     (tree.instance() as CustomTable).handleFilterChange({ target: { value: 'test filter' } });
     await TestUtils.flushPromises();
     expect(tree.state('filterString')).toEqual('test filter');
+    expect(tree).toMatchSnapshot();
   });
 
   it('reloads the table with the encoded filter object', async () => {

--- a/frontend/src/components/CustomTable.tsx
+++ b/frontend/src/components/CustomTable.tsx
@@ -165,6 +165,9 @@ export const css = stylesheet({
   selectionToggle: {
     marginRight: 12,
   },
+  verticalAlignInitial: {
+    verticalAlign: 'initial',
+  },
 });
 
 interface CustomTableProps {
@@ -177,6 +180,7 @@ interface CustomTableProps {
   getExpandComponent?: (index: number) => React.ReactNode;
   initialSortColumn?: string;
   initialSortOrder?: 'asc' | 'desc';
+  noFilterBox?: boolean;
   reload: (request: ListRequest) => Promise<string>;
   rows: Row[];
   selectedIds?: string[];
@@ -277,22 +281,24 @@ export default class CustomTable extends React.Component<CustomTableProps, Custo
       <div className={commonCss.pageOverflowHidden}>
 
         {/* Filter/Search bar */}
-        <div>
-          <Input label={this.props.filterLabel || 'Filter'} height={48} maxWidth={'100%'}
-            className={css.filterBox} InputLabelProps={{ classes: { root: css.noMargin }}}
-            onChange={this.handleChange('filterString')} value={filterString}
-            InputProps={{
-              classes: {
-                notchedOutline: css.filterBorderRadius,
-                root: css.noLeftPadding,
-              },
-              startAdornment: (
-                <InputAdornment position='end'>
-                  <FilterIcon style={{ color: color.lowContrast, paddingRight: 16 }}/>
-                </InputAdornment>
-              )
-            }} />
-        </div>
+        {!this.props.noFilterBox && (
+          <div>
+            <Input label={this.props.filterLabel || 'Filter'} height={48} maxWidth={'100%'}
+              className={css.filterBox} InputLabelProps={{ classes: { root: css.noMargin }}}
+              onChange={this.handleChange('filterString')} value={filterString} variant='outlined'
+              InputProps={{
+                classes: {
+                  notchedOutline: css.filterBorderRadius,
+                  root: css.noLeftPadding,
+                },
+                startAdornment: (
+                  <InputAdornment position='end'>
+                    <FilterIcon style={{ color: color.lowContrast, paddingRight: 16 }}/>
+                  </InputAdornment>
+                )
+              }} />
+          </div>
+        )}
 
         {/* Header */}
         <div className={classes(
@@ -399,6 +405,7 @@ export default class CustomTable extends React.Component<CustomTableProps, Custo
           <div className={css.footer}>
             <span className={padding(10, 'r')}>Rows per page:</span>
             <TextField select={true} variant='standard' className={css.rowsPerPage}
+              classes={{ root: css.verticalAlignInitial }}
               InputProps={{ disableUnderline: true }} onChange={this._requestRowsPerPage.bind(this)}
               value={pageSize}>
               {[10, 20, 50, 100].map((size, i) => (
@@ -422,7 +429,7 @@ export default class CustomTable extends React.Component<CustomTableProps, Custo
   public async reload(loadRequest?: ListRequest): Promise<string> {
     // Override the current state with incoming request
     const request: ListRequest = Object.assign({
-      filterBy: this.state.filterStringEncoded,
+      filter: this.state.filterStringEncoded,
       orderAscending: this.state.sortOrder === 'asc',
       pageSize: this.state.pageSize,
       pageToken: this.state.tokenList[this.state.currentPage],

--- a/frontend/src/components/CustomTable.tsx
+++ b/frontend/src/components/CustomTable.tsx
@@ -480,8 +480,7 @@ export default class CustomTable extends React.Component<CustomTableProps, Custo
       predicates: [{
         // TODO: remove this hardcoding once more sophisticated filtering is supported
         key: 'name',
-        // TODO: change this to the substring match operator once it's supported
-        op: PredicateOp.EQUALS,
+        op: PredicateOp.ISSUBSTRING,
         string_value: filterString,
       }],
     };

--- a/frontend/src/components/CustomTable.tsx
+++ b/frontend/src/components/CustomTable.tsx
@@ -204,7 +204,7 @@ interface CustomTableState {
 export default class CustomTable extends React.Component<CustomTableProps, CustomTableState> {
   private _isMounted = true;
 
-  private _debouncedRequest =
+  private _debouncedFilterRequest =
     debounce((filterString: string) => this._requestFilter(filterString), 300);
 
   constructor(props: CustomTableProps) {
@@ -269,7 +269,7 @@ export default class CustomTable extends React.Component<CustomTableProps, Custo
 
   public componentWillUnmount(): void {
     this._isMounted = false;
-    this._debouncedRequest.cancel();
+    this._debouncedFilterRequest.cancel();
   }
 
   public render(): JSX.Element {
@@ -286,7 +286,8 @@ export default class CustomTable extends React.Component<CustomTableProps, Custo
           <div>
             <Input label={this.props.filterLabel || 'Filter'} height={48} maxWidth={'100%'}
               className={css.filterBox} InputLabelProps={{ classes: { root: css.noMargin }}}
-              onChange={this.handleChange('filterString')} value={filterString} variant='outlined'
+              onChange={this.handleFilterChange} value={filterString}
+              variant='outlined'
               InputProps={{
                 classes: {
                   notchedOutline: css.filterBorderRadius,
@@ -458,14 +459,13 @@ export default class CustomTable extends React.Component<CustomTableProps, Custo
     return result;
   }
 
-  public handleChange = (name: string) => (event: any) => {
+  public handleFilterChange = (event: any) => {
     const value = event.target.value;
-    this.setStateSafe({ [name]: value } as any,
-      async () => {
-        if (name === 'filterString') {
-          await this._debouncedRequest(value as string);
-        }
-      });
+    // Set state here so that the UI will be updated even if the actual filter request is debounced
+    this.setStateSafe(
+      { filterString: value } as any,
+      async () => await this._debouncedFilterRequest(value as string)
+    );
   }
 
   // Exposed for testing

--- a/frontend/src/components/__snapshots__/CustomTable.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/CustomTable.test.tsx.snap
@@ -4,6 +4,44 @@ exports[`CustomTable displays warning icon with tooltip if row has error 1`] = `
 <div
   className="pageOverflowHidden"
 >
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
   <div
     className="header"
   >
@@ -177,6 +215,11 @@ exports[`CustomTable displays warning icon with tooltip if row has error 1`] = `
         }
       }
       className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
       onChange={[Function]}
       required={false}
       select={true}
@@ -228,6 +271,44 @@ exports[`CustomTable renders a collapsed row 1`] = `
 <div
   className="pageOverflowHidden"
 >
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
   <div
     className="header"
   >
@@ -362,6 +443,11 @@ exports[`CustomTable renders a collapsed row 1`] = `
         }
       }
       className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
       onChange={[Function]}
       required={false}
       select={true}
@@ -413,6 +499,44 @@ exports[`CustomTable renders a collapsed row when selection is disabled 1`] = `
 <div
   className="pageOverflowHidden"
 >
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
   <div
     className="header"
   >
@@ -533,6 +657,11 @@ exports[`CustomTable renders a collapsed row when selection is disabled 1`] = `
         }
       }
       className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
       onChange={[Function]}
       required={false}
       select={true}
@@ -584,6 +713,44 @@ exports[`CustomTable renders a table with sorting disabled 1`] = `
 <div
   className="pageOverflowHidden"
 >
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
   <div
     className="header"
   >
@@ -732,6 +899,11 @@ exports[`CustomTable renders a table with sorting disabled 1`] = `
         }
       }
       className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
       onChange={[Function]}
       required={false}
       select={true}
@@ -783,6 +955,44 @@ exports[`CustomTable renders an expanded row 1`] = `
 <div
   className="pageOverflowHidden"
 >
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
   <div
     className="header"
   >
@@ -907,6 +1117,11 @@ exports[`CustomTable renders an expanded row 1`] = `
         }
       }
       className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
       onChange={[Function]}
       required={false}
       select={true}
@@ -958,6 +1173,44 @@ exports[`CustomTable renders an expanded row with expanded component below it 1`
 <div
   className="pageOverflowHidden"
 >
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
   <div
     className="header"
   >
@@ -1099,6 +1352,11 @@ exports[`CustomTable renders an expanded row with expanded component below it 1`
         }
       }
       className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
       onChange={[Function]}
       required={false}
       select={true}
@@ -1150,6 +1408,44 @@ exports[`CustomTable renders columns with specified widths 1`] = `
 <div
   className="pageOverflowHidden"
 >
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
   <div
     className="header"
   >
@@ -1231,6 +1527,11 @@ exports[`CustomTable renders columns with specified widths 1`] = `
         }
       }
       className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
       onChange={[Function]}
       required={false}
       select={true}
@@ -1282,6 +1583,44 @@ exports[`CustomTable renders empty message on no rows 1`] = `
 <div
   className="pageOverflowHidden"
 >
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
   <div
     className="header"
   >
@@ -1325,6 +1664,11 @@ exports[`CustomTable renders empty message on no rows 1`] = `
         }
       }
       className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
       onChange={[Function]}
       required={false}
       select={true}
@@ -1376,6 +1720,44 @@ exports[`CustomTable renders new rows after clicking next page, and enables prev
 <div
   className="pageOverflowHidden"
 >
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
   <div
     className="header"
   >
@@ -1500,6 +1882,11 @@ exports[`CustomTable renders new rows after clicking next page, and enables prev
         }
       }
       className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
       onChange={[Function]}
       required={false}
       select={true}
@@ -1551,6 +1938,44 @@ exports[`CustomTable renders new rows after clicking previous page, and enables 
 <div
   className="pageOverflowHidden"
 >
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
   <div
     className="header"
   >
@@ -1717,6 +2142,11 @@ exports[`CustomTable renders new rows after clicking previous page, and enables 
         }
       }
       className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
       onChange={[Function]}
       required={false}
       select={true}
@@ -1768,6 +2198,44 @@ exports[`CustomTable renders some columns with descending sort order on first co
 <div
   className="pageOverflowHidden"
 >
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
   <div
     className="header"
   >
@@ -1850,6 +2318,11 @@ exports[`CustomTable renders some columns with descending sort order on first co
         }
       }
       className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
       onChange={[Function]}
       required={false}
       select={true}
@@ -1901,6 +2374,44 @@ exports[`CustomTable renders some columns with equal widths without rows 1`] = `
 <div
   className="pageOverflowHidden"
 >
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
   <div
     className="header"
   >
@@ -1982,6 +2493,11 @@ exports[`CustomTable renders some columns with equal widths without rows 1`] = `
         }
       }
       className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
       onChange={[Function]}
       required={false}
       select={true}
@@ -2033,6 +2549,44 @@ exports[`CustomTable renders some rows 1`] = `
 <div
   className="pageOverflowHidden"
 >
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
   <div
     className="header"
   >
@@ -2199,6 +2753,11 @@ exports[`CustomTable renders some rows 1`] = `
         }
       }
       className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
       onChange={[Function]}
       required={false}
       select={true}
@@ -2250,6 +2809,44 @@ exports[`CustomTable renders some rows using a custom renderer 1`] = `
 <div
   className="pageOverflowHidden"
 >
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
   <div
     className="header"
   >
@@ -2420,6 +3017,11 @@ exports[`CustomTable renders some rows using a custom renderer 1`] = `
         }
       }
       className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
       onChange={[Function]}
       required={false}
       select={true}
@@ -2471,6 +3073,44 @@ exports[`CustomTable renders without rows or columns 1`] = `
 <div
   className="pageOverflowHidden"
 >
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
   <div
     className="header"
   >
@@ -2508,6 +3148,11 @@ exports[`CustomTable renders without rows or columns 1`] = `
         }
       }
       className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
       onChange={[Function]}
       required={false}
       select={true}
@@ -2559,6 +3204,44 @@ exports[`CustomTable renders without the checkboxes if disableSelection is true 
 <div
   className="pageOverflowHidden"
 >
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
   <div
     className="header"
   >
@@ -2699,6 +3382,11 @@ exports[`CustomTable renders without the checkboxes if disableSelection is true 
         }
       }
       className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
       onChange={[Function]}
       required={false}
       select={true}

--- a/frontend/src/components/__snapshots__/CustomTable.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/CustomTable.test.tsx.snap
@@ -3788,3 +3788,263 @@ exports[`CustomTable renders without the checkboxes if disableSelection is true 
   </div>
 </div>
 `;
+
+exports[`CustomTable updates the filter string in state when the filter box input changes 1`] = `
+<div
+  className="pageOverflowHidden"
+>
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value="test filter"
+      variant="outlined"
+    />
+  </div>
+  <div
+    className="header"
+  >
+    <div
+      className="columnName cell selectionToggle"
+    >
+      <WithStyles(Checkbox)
+        checked={false}
+        color="primary"
+        indeterminate={false}
+        onChange={[Function]}
+      />
+    </div>
+    <div
+      className="columnName"
+      key="0"
+      style={
+        Object {
+          "width": "50%",
+        }
+      }
+    >
+      <WithStyles(Tooltip)
+        enterDelay={300}
+        title="Cannot sort by this column"
+      >
+        <WithStyles(TableSortLabel)
+          active={false}
+          className="ellipsis"
+          onClick={[Function]}
+        >
+          col1
+        </WithStyles(TableSortLabel)>
+      </WithStyles(Tooltip)>
+    </div>
+    <div
+      className="columnName"
+      key="1"
+      style={
+        Object {
+          "width": "50%",
+        }
+      }
+    >
+      <WithStyles(Tooltip)
+        enterDelay={300}
+        title="Cannot sort by this column"
+      >
+        <WithStyles(TableSortLabel)
+          active={false}
+          className="ellipsis"
+          onClick={[Function]}
+        >
+          col2
+        </WithStyles(TableSortLabel)>
+      </WithStyles(Tooltip)>
+    </div>
+  </div>
+  <div
+    className="scrollContainer"
+    style={
+      Object {
+        "minHeight": 60,
+      }
+    }
+  >
+    <div
+      className="expandableContainer"
+      key="0"
+    >
+      <div
+        className="tableRow row"
+        onClick={[Function]}
+        role="checkbox"
+        tabIndex={-1}
+      >
+        <div
+          className="cell selectionToggle"
+        >
+          <WithStyles(Checkbox)
+            checked={false}
+            color="primary"
+          />
+        </div>
+        <div
+          className="cell"
+          key="0"
+          style={
+            Object {
+              "width": "50%",
+            }
+          }
+        >
+          cell1
+        </div>
+        <div
+          className="cell"
+          key="1"
+          style={
+            Object {
+              "width": "50%",
+            }
+          }
+        >
+          cell2
+        </div>
+      </div>
+    </div>
+    <div
+      className="expandableContainer"
+      key="1"
+    >
+      <div
+        className="tableRow row"
+        onClick={[Function]}
+        role="checkbox"
+        tabIndex={-1}
+      >
+        <div
+          className="cell selectionToggle"
+        >
+          <WithStyles(Checkbox)
+            checked={false}
+            color="primary"
+          />
+        </div>
+        <div
+          className="cell"
+          key="0"
+          style={
+            Object {
+              "width": "50%",
+            }
+          }
+        >
+          cell1
+        </div>
+        <div
+          className="cell"
+          key="1"
+          style={
+            Object {
+              "width": "50%",
+            }
+          }
+        >
+          cell2
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="footer"
+  >
+    <span
+      className=""
+    >
+      Rows per page:
+    </span>
+    <TextField
+      InputProps={
+        Object {
+          "disableUnderline": true,
+        }
+      }
+      className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
+      onChange={[Function]}
+      required={false}
+      select={true}
+      value={10}
+      variant="standard"
+    >
+      <WithStyles(MenuItem)
+        key="0"
+        value={10}
+      >
+        10
+      </WithStyles(MenuItem)>
+      <WithStyles(MenuItem)
+        key="1"
+        value={20}
+      >
+        20
+      </WithStyles(MenuItem)>
+      <WithStyles(MenuItem)
+        key="2"
+        value={50}
+      >
+        50
+      </WithStyles(MenuItem)>
+      <WithStyles(MenuItem)
+        key="3"
+        value={100}
+      >
+        100
+      </WithStyles(MenuItem)>
+    </TextField>
+    <WithStyles(IconButton)
+      disabled={true}
+      onClick={[Function]}
+    >
+      <pure(ChevronLeftIcon) />
+    </WithStyles(IconButton)>
+    <WithStyles(IconButton)
+      disabled={true}
+      onClick={[Function]}
+    >
+      <pure(ChevronRightIcon) />
+    </WithStyles(IconButton)>
+  </div>
+</div>
+`;

--- a/frontend/src/components/__snapshots__/CustomTable.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/CustomTable.test.tsx.snap
@@ -3069,6 +3069,361 @@ exports[`CustomTable renders some rows using a custom renderer 1`] = `
 </div>
 `;
 
+exports[`CustomTable renders with default filter label 1`] = `
+<div
+  className="pageOverflowHidden"
+>
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="Filter"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
+  <div
+    className="header"
+  >
+    <div
+      className="columnName cell selectionToggle"
+    >
+      <WithStyles(Checkbox)
+        checked={false}
+        color="primary"
+        indeterminate={false}
+        onChange={[Function]}
+      />
+    </div>
+  </div>
+  <div
+    className="scrollContainer"
+    style={
+      Object {
+        "minHeight": 60,
+      }
+    }
+  />
+  <div
+    className="footer"
+  >
+    <span
+      className=""
+    >
+      Rows per page:
+    </span>
+    <TextField
+      InputProps={
+        Object {
+          "disableUnderline": true,
+        }
+      }
+      className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
+      onChange={[Function]}
+      required={false}
+      select={true}
+      value={10}
+      variant="standard"
+    >
+      <WithStyles(MenuItem)
+        key="0"
+        value={10}
+      >
+        10
+      </WithStyles(MenuItem)>
+      <WithStyles(MenuItem)
+        key="1"
+        value={20}
+      >
+        20
+      </WithStyles(MenuItem)>
+      <WithStyles(MenuItem)
+        key="2"
+        value={50}
+      >
+        50
+      </WithStyles(MenuItem)>
+      <WithStyles(MenuItem)
+        key="3"
+        value={100}
+      >
+        100
+      </WithStyles(MenuItem)>
+    </TextField>
+    <WithStyles(IconButton)
+      disabled={true}
+      onClick={[Function]}
+    >
+      <pure(ChevronLeftIcon) />
+    </WithStyles(IconButton)>
+    <WithStyles(IconButton)
+      disabled={true}
+      onClick={[Function]}
+    >
+      <pure(ChevronRightIcon) />
+    </WithStyles(IconButton)>
+  </div>
+</div>
+`;
+
+exports[`CustomTable renders with provided filter label 1`] = `
+<div
+  className="pageOverflowHidden"
+>
+  <div>
+    <Component
+      InputLabelProps={
+        Object {
+          "classes": Object {
+            "root": "noMargin",
+          },
+        }
+      }
+      InputProps={
+        Object {
+          "classes": Object {
+            "notchedOutline": "filterBorderRadius",
+            "root": "noLeftPadding",
+          },
+          "startAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <pure(FilterListIcon)
+              style={
+                Object {
+                  "color": "#80868b",
+                  "paddingRight": 16,
+                }
+              }
+            />
+          </WithStyles(InputAdornment)>,
+        }
+      }
+      className="filterBox"
+      height={48}
+      label="test filter label"
+      maxWidth="100%"
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+  </div>
+  <div
+    className="header"
+  >
+    <div
+      className="columnName cell selectionToggle"
+    >
+      <WithStyles(Checkbox)
+        checked={false}
+        color="primary"
+        indeterminate={false}
+        onChange={[Function]}
+      />
+    </div>
+  </div>
+  <div
+    className="scrollContainer"
+    style={
+      Object {
+        "minHeight": 60,
+      }
+    }
+  />
+  <div
+    className="footer"
+  >
+    <span
+      className=""
+    >
+      Rows per page:
+    </span>
+    <TextField
+      InputProps={
+        Object {
+          "disableUnderline": true,
+        }
+      }
+      className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
+      onChange={[Function]}
+      required={false}
+      select={true}
+      value={10}
+      variant="standard"
+    >
+      <WithStyles(MenuItem)
+        key="0"
+        value={10}
+      >
+        10
+      </WithStyles(MenuItem)>
+      <WithStyles(MenuItem)
+        key="1"
+        value={20}
+      >
+        20
+      </WithStyles(MenuItem)>
+      <WithStyles(MenuItem)
+        key="2"
+        value={50}
+      >
+        50
+      </WithStyles(MenuItem)>
+      <WithStyles(MenuItem)
+        key="3"
+        value={100}
+      >
+        100
+      </WithStyles(MenuItem)>
+    </TextField>
+    <WithStyles(IconButton)
+      disabled={true}
+      onClick={[Function]}
+    >
+      <pure(ChevronLeftIcon) />
+    </WithStyles(IconButton)>
+    <WithStyles(IconButton)
+      disabled={true}
+      onClick={[Function]}
+    >
+      <pure(ChevronRightIcon) />
+    </WithStyles(IconButton)>
+  </div>
+</div>
+`;
+
+exports[`CustomTable renders without filter box 1`] = `
+<div
+  className="pageOverflowHidden"
+>
+  <div
+    className="header"
+  >
+    <div
+      className="columnName cell selectionToggle"
+    >
+      <WithStyles(Checkbox)
+        checked={false}
+        color="primary"
+        indeterminate={false}
+        onChange={[Function]}
+      />
+    </div>
+  </div>
+  <div
+    className="scrollContainer"
+    style={
+      Object {
+        "minHeight": 60,
+      }
+    }
+  />
+  <div
+    className="footer"
+  >
+    <span
+      className=""
+    >
+      Rows per page:
+    </span>
+    <TextField
+      InputProps={
+        Object {
+          "disableUnderline": true,
+        }
+      }
+      className="rowsPerPage"
+      classes={
+        Object {
+          "root": "verticalAlignInitial",
+        }
+      }
+      onChange={[Function]}
+      required={false}
+      select={true}
+      value={10}
+      variant="standard"
+    >
+      <WithStyles(MenuItem)
+        key="0"
+        value={10}
+      >
+        10
+      </WithStyles(MenuItem)>
+      <WithStyles(MenuItem)
+        key="1"
+        value={20}
+      >
+        20
+      </WithStyles(MenuItem)>
+      <WithStyles(MenuItem)
+        key="2"
+        value={50}
+      >
+        50
+      </WithStyles(MenuItem)>
+      <WithStyles(MenuItem)
+        key="3"
+        value={100}
+      >
+        100
+      </WithStyles(MenuItem)>
+    </TextField>
+    <WithStyles(IconButton)
+      disabled={true}
+      onClick={[Function]}
+    >
+      <pure(ChevronLeftIcon) />
+    </WithStyles(IconButton)>
+    <WithStyles(IconButton)
+      disabled={true}
+      onClick={[Function]}
+    >
+      <pure(ChevronRightIcon) />
+    </WithStyles(IconButton)>
+  </div>
+</div>
+`;
+
 exports[`CustomTable renders without rows or columns 1`] = `
 <div
   className="pageOverflowHidden"

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -22,7 +22,7 @@ import { StoragePath } from './WorkflowParser';
 const v1beta1Prefix = 'apis/v1beta1';
 
 export interface ListRequest {
-  filterBy?: string;
+  filter?: string;
   orderAscending?: boolean;
   pageSize?: number;
   pageToken?: string;

--- a/frontend/src/pages/ExperimentList.test.tsx
+++ b/frontend/src/pages/ExperimentList.test.tsx
@@ -126,7 +126,7 @@ describe('ExperimentList', () => {
 
   it('calls Apis to list experiments, sorted by creation time in descending order', async () => {
     const tree = await mountWithNExperiments(1, 1);
-    expect(listExperimentsSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc');
+    expect(listExperimentsSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '');
     expect(listRunsSpy).toHaveBeenLastCalledWith(undefined, 5, 'created_at desc',
       ApiResourceType.EXPERIMENT.toString(), 'test-experiment-id0');
     expect(tree.state()).toHaveProperty('displayExperiments', [{
@@ -146,7 +146,7 @@ describe('ExperimentList', () => {
     expect(refreshBtn).toBeDefined();
     await refreshBtn!.action();
     expect(listExperimentsSpy.mock.calls.length).toBe(2);
-    expect(listExperimentsSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc');
+    expect(listExperimentsSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '');
     expect(updateBannerSpy).toHaveBeenLastCalledWith({});
     tree.unmount();
   });
@@ -189,7 +189,7 @@ describe('ExperimentList', () => {
     TestUtils.makeErrorResponseOnce(listExperimentsSpy, 'bad stuff happened');
     await refreshBtn!.action();
     expect(listExperimentsSpy.mock.calls.length).toBe(2);
-    expect(listExperimentsSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc');
+    expect(listExperimentsSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '');
     expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
       additionalInfo: 'bad stuff happened',
       message: 'Error: failed to retrieve list of experiments. Click Details for more information.',

--- a/frontend/src/pages/ExperimentList.tsx
+++ b/frontend/src/pages/ExperimentList.tsx
@@ -125,6 +125,7 @@ class ExperimentList extends Page<{}, ExperimentListState> {
           disableSelection={true} initialSortColumn={ExperimentSortKeys.CREATED_AT}
           reload={this._reload.bind(this)} toggleExpansion={this._toggleRowExpand.bind(this)}
           getExpandComponent={this._getExpandedExperimentComponent.bind(this)}
+          filterLabel='Filter experiments'
           emptyMessage='No experiments found. Click "Create experiment" to start.' />
       </div>
     );
@@ -143,7 +144,7 @@ class ExperimentList extends Page<{}, ExperimentListState> {
     let displayExperiments: DisplayExperiment[];
     try {
       response = await Apis.experimentServiceApi.listExperiment(
-        request.pageToken, request.pageSize, request.sortBy);
+        request.pageToken, request.pageSize, request.sortBy, request.filter);
       displayExperiments = response.experiments || [];
       displayExperiments.forEach((exp) => exp.expandState = ExpandState.COLLAPSED);
     } catch (err) {

--- a/frontend/src/pages/ExperimentList.tsx
+++ b/frontend/src/pages/ExperimentList.tsx
@@ -242,7 +242,7 @@ class ExperimentList extends Page<{}, ExperimentListState> {
     const experiment = this.state.displayExperiments[experimentIndex];
     const runIds = (experiment.last5Runs || []).map((r) => r.id!);
     return <RunList runIdListMask={runIds} onError={() => null} {...this.props}
-      disablePaging={true} selectedIds={this.state.selectedRunIds}
+      disablePaging={true} selectedIds={this.state.selectedRunIds} noFilterBox={true}
       onSelectionChange={this._runSelectionChanged.bind(this)} disableSorting={true} />;
   }
 }

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -188,6 +188,7 @@ class NewRun extends Page<{}, NewRunState> {
             <DialogContent>
               <ResourceSelector {...this.props}
                 title='Choose a pipeline'
+                filterLabel='Filter pipelines'
                 listApi={async (...args) => {
                   const response = await Apis.pipelineServiceApi.listPipelines(...args);
                   return { resources: response.pipelines || [], nextPageToken: response.next_page_token || '' };
@@ -216,6 +217,7 @@ class NewRun extends Page<{}, NewRunState> {
             <DialogContent>
               <ResourceSelector {...this.props}
                 title='Choose an experiment'
+                filterLabel='Filter experiments'
                 listApi={async (...args) => {
                   const response = await Apis.experimentServiceApi.listExperiment(...args);
                   return { resources: response.experiments || [], nextPageToken: response.next_page_token || '' };

--- a/frontend/src/pages/PipelineList.test.tsx
+++ b/frontend/src/pages/PipelineList.test.tsx
@@ -121,7 +121,7 @@ describe('PipelineList', () => {
     listPipelinesSpy.mockImplementationOnce(() => ({ pipelines: [{ name: 'pipeline1' }] }));
     tree = TestUtils.mountWithRouter(<PipelineList {...generateProps()} />);
     await listPipelinesSpy;
-    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc');
+    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '');
     expect(tree.state()).toHaveProperty('pipelines', [{ name: 'pipeline1' }]);
   });
 
@@ -133,7 +133,7 @@ describe('PipelineList', () => {
     expect(refreshBtn).toBeDefined();
     await refreshBtn!.action();
     expect(listPipelinesSpy.mock.calls.length).toBe(2);
-    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc');
+    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '');
     expect(updateBannerSpy).toHaveBeenLastCalledWith({});
   });
 
@@ -157,7 +157,7 @@ describe('PipelineList', () => {
     TestUtils.makeErrorResponseOnce(listPipelinesSpy, 'bad stuff happened');
     await refreshBtn!.action();
     expect(listPipelinesSpy.mock.calls.length).toBe(2);
-    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc');
+    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '');
     expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
       additionalInfo: 'bad stuff happened',
       message: 'Error: failed to retrieve list of pipelines. Click Details for more information.',

--- a/frontend/src/pages/PipelineList.tsx
+++ b/frontend/src/pages/PipelineList.tsx
@@ -105,7 +105,7 @@ class PipelineList extends Page<{}, PipelineListState> {
       <div className={classes(commonCss.page, padding(20, 'lr'))}>
         <CustomTable ref={this._tableRef} columns={columns} rows={rows} initialSortColumn={PipelineSortKeys.CREATED_AT}
           updateSelection={this._selectionChanged.bind(this)} selectedIds={this.state.selectedIds}
-          reload={this._reload.bind(this)}
+          reload={this._reload.bind(this)} filterLabel='Filter pipelines'
           emptyMessage='No pipelines found. Click "Upload pipeline" to start.' />
 
         <UploadPipelineDialog open={this.state.uploadDialogOpen}
@@ -124,7 +124,7 @@ class PipelineList extends Page<{}, PipelineListState> {
     let response: ApiListPipelinesResponse | null = null;
     try {
       response = await Apis.pipelineServiceApi.listPipelines(
-        request.pageToken, request.pageSize, request.sortBy);
+        request.pageToken, request.pageSize, request.sortBy, request.filter);
       this.clearBanner();
     } catch (err) {
       await this.showPageError('Error: failed to retrieve list of pipelines.', err);

--- a/frontend/src/pages/RecurringRunsManager.test.tsx
+++ b/frontend/src/pages/RecurringRunsManager.test.tsx
@@ -89,7 +89,8 @@ describe('RecurringRunsManager', () => {
       undefined,
       undefined,
       ApiResourceType.EXPERIMENT,
-      'test-experiment');
+      'test-experiment',
+      undefined);
     expect(tree.state('runs')).toEqual(JOBS);
     expect(tree).toMatchSnapshot();
     tree.unmount();

--- a/frontend/src/pages/RecurringRunsManager.tsx
+++ b/frontend/src/pages/RecurringRunsManager.tsx
@@ -83,9 +83,10 @@ class RecurringRunsManager extends React.Component<RecurringRunListProps, Recurr
     return (<React.Fragment>
       <Toolbar actions={toolbarActions} breadcrumbs={[]} pageTitle='Recurring runs' />
       <CustomTable columns={columns} rows={rows} ref={this._tableRef} selectedIds={selectedIds}
-        updateSelection={ids => this.setState({ selectedIds: ids })} initialSortColumn={JobSortKeys.CREATED_AT}
-        reload={this._loadRuns.bind(this)} emptyMessage={'No recurring runs found in this experiment.'}
-        disableSelection={true} />
+        updateSelection={ids => this.setState({ selectedIds: ids })}
+        initialSortColumn={JobSortKeys.CREATED_AT} reload={this._loadRuns.bind(this)}
+        filterLabel='Filter recurring runs' disableSelection={true}
+        emptyMessage={'No recurring runs found in this experiment.'}/>
     </React.Fragment>);
   }
 
@@ -105,6 +106,7 @@ class RecurringRunsManager extends React.Component<RecurringRunListProps, Recurr
         request.sortBy,
         ApiResourceType.EXPERIMENT.toString(),
         this.props.experimentId,
+        request.filter,
       );
       runs = response.jobs || [];
       nextPageToken = response.next_page_token || '';

--- a/frontend/src/pages/ResourceSelector.test.tsx
+++ b/frontend/src/pages/ResourceSelector.test.tsx
@@ -97,7 +97,7 @@ describe('ResourceSelector', () => {
     await (tree.instance() as TestResourceSelector)._load({});
 
     expect(listResourceSpy).toHaveBeenCalledTimes(1);
-    expect(listResourceSpy).toHaveBeenLastCalledWith(undefined, undefined, undefined);
+    expect(listResourceSpy).toHaveBeenLastCalledWith(undefined, undefined, undefined, undefined);
     expect(tree.state('resources')).toEqual(RESOURCES);
     expect(tree).toMatchSnapshot();
   });

--- a/frontend/src/pages/ResourceSelector.test.tsx
+++ b/frontend/src/pages/ResourceSelector.test.tsx
@@ -68,6 +68,7 @@ describe('ResourceSelector', () => {
     return {
       columns: selectorColumns,
       emptyMessage: testEmptyMessage,
+      filterLabel: 'test filter label',
       history: {} as any,
       initialSortColumn: 'created_at',
       listApi: listResourceSpy as any,

--- a/frontend/src/pages/ResourceSelector.tsx
+++ b/frontend/src/pages/ResourceSelector.tsx
@@ -39,6 +39,7 @@ export interface ResourceSelectorProps extends RouteComponentProps {
   listApi: (...args: any[]) => Promise<BaseResponse>;
   columns: Column[];
   emptyMessage: string;
+  filterLabel: string;
   initialSortColumn: any;
   selectionChanged: (resource: BaseResource) => void;
   title: string;
@@ -68,13 +69,13 @@ class ResourceSelector extends React.Component<ResourceSelectorProps, ResourceSe
 
   public render(): JSX.Element {
     const { rows, selectedIds, toolbarActions } = this.state;
-    const { columns, title, emptyMessage, initialSortColumn } = this.props;
+    const { columns, title, filterLabel, emptyMessage, initialSortColumn } = this.props;
 
     return (
       <React.Fragment>
         <Toolbar actions={toolbarActions} breadcrumbs={[]} pageTitle={title} />
         <CustomTable columns={columns} rows={rows} selectedIds={selectedIds} useRadioButtons={true}
-          updateSelection={this._selectionChanged.bind(this)}
+          updateSelection={this._selectionChanged.bind(this)} filterLabel={filterLabel}
           initialSortColumn={initialSortColumn} reload={this._load.bind(this)}
           emptyMessage={emptyMessage} />
       </React.Fragment>
@@ -110,7 +111,7 @@ class ResourceSelector extends React.Component<ResourceSelectorProps, ResourceSe
     let nextPageToken = '';
     try {
       const response =
-        await this.props.listApi(request.pageToken, request.pageSize, request.sortBy);
+        await this.props.listApi(request.pageToken, request.pageSize, request.sortBy, request.filter);
 
       this.setStateSafe({
         resources: response.resources,

--- a/frontend/src/pages/RunList.test.tsx
+++ b/frontend/src/pages/RunList.test.tsx
@@ -85,7 +85,7 @@ describe('RunList', () => {
     const props = generateProps();
     const tree = shallow(<RunList {...props} />);
     await (tree.instance() as RunListTest)._loadRuns({});
-    expect(Apis.runServiceApi.listRuns).toHaveBeenLastCalledWith(undefined, undefined, undefined, undefined, undefined);
+    expect(Apis.runServiceApi.listRuns).toHaveBeenLastCalledWith(undefined, undefined, undefined, undefined, undefined, undefined);
     expect(props.onError).not.toHaveBeenCalled();
     expect(tree).toMatchSnapshot();
   });
@@ -97,7 +97,7 @@ describe('RunList', () => {
     await (tree.instance() as RunList).refresh();
     tree.update();
     expect(Apis.runServiceApi.listRuns).toHaveBeenCalledTimes(2);
-    expect(Apis.runServiceApi.listRuns).toHaveBeenLastCalledWith('', 10, RunSortKeys.CREATED_AT + ' desc', undefined, undefined);
+    expect(Apis.runServiceApi.listRuns).toHaveBeenLastCalledWith('', 10, RunSortKeys.CREATED_AT + ' desc', undefined, undefined, '');
     expect(props.onError).not.toHaveBeenCalled();
     expect(tree).toMatchSnapshot();
   });
@@ -187,7 +187,7 @@ describe('RunList', () => {
     await (tree.instance() as RunListTest)._loadRuns({});
     expect(props.onError).not.toHaveBeenCalled();
     expect(Apis.runServiceApi.listRuns).toHaveBeenLastCalledWith(
-      undefined, undefined, undefined, ApiResourceType.EXPERIMENT.toString(), 'experiment1');
+      undefined, undefined, undefined, ApiResourceType.EXPERIMENT.toString(), 'experiment1', undefined);
   });
 
   it('loads given list of runs only', async () => {

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -74,10 +74,11 @@ export interface RunListProps extends RouteComponentProps {
   disableSelection?: boolean;
   disableSorting?: boolean;
   experimentIdMask?: string;
-  runIdListMask?: string[];
+  noFilterBox?: boolean;
   onError: (message: string, error: Error) => void;
-  selectedIds?: string[];
   onSelectionChange?: (selectedRunIds: string[]) => void;
+  runIdListMask?: string[];
+  selectedIds?: string[];
 }
 
 interface RunListState {
@@ -164,10 +165,10 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
 
     return (<div>
       <CustomTable columns={columns} rows={rows} selectedIds={this.props.selectedIds}
-        initialSortColumn={RunSortKeys.CREATED_AT} ref={this._tableRef}
+        initialSortColumn={RunSortKeys.CREATED_AT} ref={this._tableRef} filterLabel='Filter runs'
         updateSelection={this.props.onSelectionChange} reload={this._loadRuns.bind(this)}
         disablePaging={this.props.disablePaging} disableSorting={this.props.disableSorting}
-        disableSelection={this.props.disableSelection} filterLabel='Filter runs'
+        disableSelection={this.props.disableSelection} noFilterBox={this.props.noFilterBox}
         emptyMessage={`No runs found${this.props.experimentIdMask ? ' for this experiment' : ''}.`}
       />
     </div>);

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -167,7 +167,7 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
         initialSortColumn={RunSortKeys.CREATED_AT} ref={this._tableRef}
         updateSelection={this.props.onSelectionChange} reload={this._loadRuns.bind(this)}
         disablePaging={this.props.disablePaging} disableSorting={this.props.disableSorting}
-        disableSelection={this.props.disableSelection}
+        disableSelection={this.props.disableSelection} filterLabel='Filter runs'
         emptyMessage={`No runs found${this.props.experimentIdMask ? ' for this experiment' : ''}.`}
       />
     </div>);
@@ -288,6 +288,7 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
           request.sortBy,
           this.props.experimentIdMask ? ApiResourceType.EXPERIMENT.toString() : undefined,
           this.props.experimentIdMask,
+          request.filter,
         );
 
         displayRuns = (response.runs || []).map(r => ({ metadata: r }));

--- a/frontend/src/pages/__snapshots__/ExperimentList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ExperimentList.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`ExperimentList renders a list of one experiment 1`] = `
     }
     disableSelection={true}
     emptyMessage="No experiments found. Click \\"Create experiment\\" to start."
+    filterLabel="Filter experiments"
     getExpandComponent={[Function]}
     initialSortColumn="created_at"
     reload={[Function]}
@@ -74,6 +75,7 @@ exports[`ExperimentList renders a list of one experiment with error 1`] = `
     }
     disableSelection={true}
     emptyMessage="No experiments found. Click \\"Create experiment\\" to start."
+    filterLabel="Filter experiments"
     getExpandComponent={[Function]}
     initialSortColumn="created_at"
     reload={[Function]}
@@ -109,6 +111,7 @@ exports[`ExperimentList renders a list of one experiment with no description 1`]
     }
     disableSelection={true}
     emptyMessage="No experiments found. Click \\"Create experiment\\" to start."
+    filterLabel="Filter experiments"
     getExpandComponent={[Function]}
     initialSortColumn="created_at"
     reload={[Function]}
@@ -144,6 +147,7 @@ exports[`ExperimentList renders an empty list with empty state message 1`] = `
     }
     disableSelection={true}
     emptyMessage="No experiments found. Click \\"Create experiment\\" to start."
+    filterLabel="Filter experiments"
     getExpandComponent={[Function]}
     initialSortColumn="created_at"
     reload={[Function]}

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -67,6 +67,7 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
             ]
           }
           emptyMessage="No pipelines found. Upload a pipeline and then try again."
+          filterLabel="Filter pipelines"
           history={
             Object {
               "push": [MockFunction],
@@ -192,6 +193,7 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
             ]
           }
           emptyMessage="No experiments found. Create an experiment and then try again."
+          filterLabel="Filter experiments"
           history={
             Object {
               "push": [MockFunction],
@@ -450,6 +452,7 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
             ]
           }
           emptyMessage="No pipelines found. Upload a pipeline and then try again."
+          filterLabel="Filter pipelines"
           history={
             Object {
               "push": [MockFunction],
@@ -579,6 +582,7 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
             ]
           }
           emptyMessage="No experiments found. Create an experiment and then try again."
+          filterLabel="Filter experiments"
           history={
             Object {
               "push": [MockFunction],
@@ -867,6 +871,7 @@ exports[`NewRun cloning from a run shows pipeline selector when switching from e
             ]
           }
           emptyMessage="No pipelines found. Upload a pipeline and then try again."
+          filterLabel="Filter pipelines"
           history={
             Object {
               "push": [MockFunction],
@@ -992,6 +997,7 @@ exports[`NewRun cloning from a run shows pipeline selector when switching from e
             ]
           }
           emptyMessage="No experiments found. Create an experiment and then try again."
+          filterLabel="Filter experiments"
           history={
             Object {
               "push": [MockFunction],
@@ -1242,6 +1248,7 @@ exports[`NewRun cloning from a run shows switching controls when run has embedde
             ]
           }
           emptyMessage="No pipelines found. Upload a pipeline and then try again."
+          filterLabel="Filter pipelines"
           history={
             Object {
               "push": [MockFunction],
@@ -1367,6 +1374,7 @@ exports[`NewRun cloning from a run shows switching controls when run has embedde
             ]
           }
           emptyMessage="No experiments found. Create an experiment and then try again."
+          filterLabel="Filter experiments"
           history={
             Object {
               "push": [MockFunction],
@@ -1623,6 +1631,7 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
             ]
           }
           emptyMessage="No pipelines found. Upload a pipeline and then try again."
+          filterLabel="Filter pipelines"
           history={
             Object {
               "push": [MockFunction],
@@ -1748,6 +1757,7 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
             ]
           }
           emptyMessage="No experiments found. Create an experiment and then try again."
+          filterLabel="Filter experiments"
           history={
             Object {
               "push": [MockFunction],
@@ -2006,6 +2016,7 @@ exports[`NewRun renders the new run page 1`] = `
             ]
           }
           emptyMessage="No pipelines found. Upload a pipeline and then try again."
+          filterLabel="Filter pipelines"
           history={
             Object {
               "push": [MockFunction],
@@ -2135,6 +2146,7 @@ exports[`NewRun renders the new run page 1`] = `
             ]
           }
           emptyMessage="No experiments found. Create an experiment and then try again."
+          filterLabel="Filter experiments"
           history={
             Object {
               "push": [MockFunction],
@@ -2397,6 +2409,7 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
             ]
           }
           emptyMessage="No pipelines found. Upload a pipeline and then try again."
+          filterLabel="Filter pipelines"
           history={
             Object {
               "push": [MockFunction],
@@ -2522,6 +2535,7 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
             ]
           }
           emptyMessage="No experiments found. Create an experiment and then try again."
+          filterLabel="Filter experiments"
           history={
             Object {
               "push": [MockFunction],
@@ -2782,6 +2796,7 @@ exports[`NewRun starting a new run copies pipeline from run in the start API cal
             ]
           }
           emptyMessage="No pipelines found. Upload a pipeline and then try again."
+          filterLabel="Filter pipelines"
           history={
             Object {
               "push": [MockFunction] {
@@ -2924,6 +2939,7 @@ exports[`NewRun starting a new run copies pipeline from run in the start API cal
             ]
           }
           emptyMessage="No experiments found. Create an experiment and then try again."
+          filterLabel="Filter experiments"
           history={
             Object {
               "push": [MockFunction] {
@@ -3197,6 +3213,7 @@ exports[`NewRun starting a new run updates the pipeline in state when a user fil
             ]
           }
           emptyMessage="No pipelines found. Upload a pipeline and then try again."
+          filterLabel="Filter pipelines"
           history={
             Object {
               "push": [MockFunction] {
@@ -3339,6 +3356,7 @@ exports[`NewRun starting a new run updates the pipeline in state when a user fil
             ]
           }
           emptyMessage="No experiments found. Create an experiment and then try again."
+          filterLabel="Filter experiments"
           history={
             Object {
               "push": [MockFunction] {
@@ -3648,6 +3666,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
             ]
           }
           emptyMessage="No pipelines found. Upload a pipeline and then try again."
+          filterLabel="Filter pipelines"
           history={
             Object {
               "push": [MockFunction],
@@ -3777,6 +3796,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
             ]
           }
           emptyMessage="No experiments found. Create an experiment and then try again."
+          filterLabel="Filter experiments"
           history={
             Object {
               "push": [MockFunction],
@@ -4039,6 +4059,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
             ]
           }
           emptyMessage="No pipelines found. Upload a pipeline and then try again."
+          filterLabel="Filter pipelines"
           history={
             Object {
               "push": [MockFunction],
@@ -4168,6 +4189,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
             ]
           }
           emptyMessage="No experiments found. Create an experiment and then try again."
+          filterLabel="Filter experiments"
           history={
             Object {
               "push": [MockFunction],
@@ -4466,6 +4488,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
             ]
           }
           emptyMessage="No pipelines found. Upload a pipeline and then try again."
+          filterLabel="Filter pipelines"
           history={
             Object {
               "push": [MockFunction],
@@ -4595,6 +4618,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
             ]
           }
           emptyMessage="No experiments found. Create an experiment and then try again."
+          filterLabel="Filter experiments"
           history={
             Object {
               "push": [MockFunction],
@@ -4857,6 +4881,7 @@ exports[`NewRun updates the run's state with the associated experiment if one is
             ]
           }
           emptyMessage="No pipelines found. Upload a pipeline and then try again."
+          filterLabel="Filter pipelines"
           history={
             Object {
               "push": [MockFunction],
@@ -4986,6 +5011,7 @@ exports[`NewRun updates the run's state with the associated experiment if one is
             ]
           }
           emptyMessage="No experiments found. Create an experiment and then try again."
+          filterLabel="Filter experiments"
           history={
             Object {
               "push": [MockFunction],

--- a/frontend/src/pages/__snapshots__/PipelineList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/PipelineList.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`PipelineList renders a list of one pipeline 1`] = `
       ]
     }
     emptyMessage="No pipelines found. Click \\"Upload pipeline\\" to start."
+    filterLabel="Filter pipelines"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={
@@ -74,6 +75,7 @@ exports[`PipelineList renders a list of one pipeline with error 1`] = `
       ]
     }
     emptyMessage="No pipelines found. Click \\"Upload pipeline\\" to start."
+    filterLabel="Filter pipelines"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={
@@ -123,6 +125,7 @@ exports[`PipelineList renders a list of one pipeline with no description or crea
       ]
     }
     emptyMessage="No pipelines found. Click \\"Upload pipeline\\" to start."
+    filterLabel="Filter pipelines"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={
@@ -172,6 +175,7 @@ exports[`PipelineList renders an empty list with empty state message 1`] = `
       ]
     }
     emptyMessage="No pipelines found. Click \\"Upload pipeline\\" to start."
+    filterLabel="Filter pipelines"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={Array []}

--- a/frontend/src/pages/__snapshots__/RecurringRunsManager.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RecurringRunsManager.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`RecurringRunsManager calls API to load recurring runs 1`] = `
     }
     disableSelection={true}
     emptyMessage="No recurring runs found in this experiment."
+    filterLabel="Filter recurring runs"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={
@@ -74,32 +75,32 @@ exports[`RecurringRunsManager reloads the list of runs after enable/disabling 1`
   className="root"
   classes={
     Object {
-      "colorInherit": "MuiButton-colorInherit-115",
-      "contained": "MuiButton-contained-105",
-      "containedPrimary": "MuiButton-containedPrimary-106",
-      "containedSecondary": "MuiButton-containedSecondary-107",
-      "disabled": "MuiButton-disabled-114",
-      "extendedFab": "MuiButton-extendedFab-112",
-      "fab": "MuiButton-fab-111",
-      "flat": "MuiButton-flat-99",
-      "flatPrimary": "MuiButton-flatPrimary-100",
-      "flatSecondary": "MuiButton-flatSecondary-101",
-      "focusVisible": "MuiButton-focusVisible-113",
-      "fullWidth": "MuiButton-fullWidth-119",
-      "label": "MuiButton-label-95",
-      "mini": "MuiButton-mini-116",
-      "outlined": "MuiButton-outlined-102",
-      "outlinedPrimary": "MuiButton-outlinedPrimary-103",
-      "outlinedSecondary": "MuiButton-outlinedSecondary-104",
-      "raised": "MuiButton-raised-108",
-      "raisedPrimary": "MuiButton-raisedPrimary-109",
-      "raisedSecondary": "MuiButton-raisedSecondary-110",
-      "root": "MuiButton-root-94",
-      "sizeLarge": "MuiButton-sizeLarge-118",
-      "sizeSmall": "MuiButton-sizeSmall-117",
-      "text": "MuiButton-text-96",
-      "textPrimary": "MuiButton-textPrimary-97",
-      "textSecondary": "MuiButton-textSecondary-98",
+      "colorInherit": "MuiButton-colorInherit-152",
+      "contained": "MuiButton-contained-142",
+      "containedPrimary": "MuiButton-containedPrimary-143",
+      "containedSecondary": "MuiButton-containedSecondary-144",
+      "disabled": "MuiButton-disabled-151",
+      "extendedFab": "MuiButton-extendedFab-149",
+      "fab": "MuiButton-fab-148",
+      "flat": "MuiButton-flat-136",
+      "flatPrimary": "MuiButton-flatPrimary-137",
+      "flatSecondary": "MuiButton-flatSecondary-138",
+      "focusVisible": "MuiButton-focusVisible-150",
+      "fullWidth": "MuiButton-fullWidth-156",
+      "label": "MuiButton-label-132",
+      "mini": "MuiButton-mini-153",
+      "outlined": "MuiButton-outlined-139",
+      "outlinedPrimary": "MuiButton-outlinedPrimary-140",
+      "outlinedSecondary": "MuiButton-outlinedSecondary-141",
+      "raised": "MuiButton-raised-145",
+      "raisedPrimary": "MuiButton-raisedPrimary-146",
+      "raisedSecondary": "MuiButton-raisedSecondary-147",
+      "root": "MuiButton-root-131",
+      "sizeLarge": "MuiButton-sizeLarge-155",
+      "sizeSmall": "MuiButton-sizeSmall-154",
+      "text": "MuiButton-text-133",
+      "textPrimary": "MuiButton-textPrimary-134",
+      "textSecondary": "MuiButton-textSecondary-135",
     }
   }
   color="primary"
@@ -114,22 +115,22 @@ exports[`RecurringRunsManager reloads the list of runs after enable/disabling 1`
   variant="text"
 >
   <WithStyles(ButtonBase)
-    className="MuiButton-root-94 MuiButton-text-96 MuiButton-textPrimary-97 MuiButton-flat-99 MuiButton-flatPrimary-100 root"
+    className="MuiButton-root-131 MuiButton-text-133 MuiButton-textPrimary-134 MuiButton-flat-136 MuiButton-flatPrimary-137 root"
     component="button"
     disabled={false}
     focusRipple={true}
-    focusVisibleClassName="MuiButton-focusVisible-113"
+    focusVisibleClassName="MuiButton-focusVisible-150"
     onClick={[Function]}
     type="button"
   >
     <ButtonBase
       centerRipple={false}
-      className="MuiButton-root-94 MuiButton-text-96 MuiButton-textPrimary-97 MuiButton-flat-99 MuiButton-flatPrimary-100 root"
+      className="MuiButton-root-131 MuiButton-text-133 MuiButton-textPrimary-134 MuiButton-flat-136 MuiButton-flatPrimary-137 root"
       classes={
         Object {
-          "disabled": "MuiButtonBase-disabled-15",
-          "focusVisible": "MuiButtonBase-focusVisible-16",
-          "root": "MuiButtonBase-root-14",
+          "disabled": "MuiButtonBase-disabled-82",
+          "focusVisible": "MuiButtonBase-focusVisible-83",
+          "root": "MuiButtonBase-root-81",
         }
       }
       component="button"
@@ -137,13 +138,13 @@ exports[`RecurringRunsManager reloads the list of runs after enable/disabling 1`
       disableTouchRipple={false}
       disabled={false}
       focusRipple={true}
-      focusVisibleClassName="MuiButton-focusVisible-113"
+      focusVisibleClassName="MuiButton-focusVisible-150"
       onClick={[Function]}
       tabIndex="0"
       type="button"
     >
       <button
-        className="MuiButtonBase-root-14 MuiButton-root-94 MuiButton-text-96 MuiButton-textPrimary-97 MuiButton-flat-99 MuiButton-flatPrimary-100 root"
+        className="MuiButtonBase-root-81 MuiButton-root-131 MuiButton-text-133 MuiButton-textPrimary-134 MuiButton-flat-136 MuiButton-flatPrimary-137 root"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -161,7 +162,7 @@ exports[`RecurringRunsManager reloads the list of runs after enable/disabling 1`
         type="button"
       >
         <span
-          className="MuiButton-label-95"
+          className="MuiButton-label-132"
         >
           <span>
             Enabled
@@ -179,25 +180,25 @@ exports[`RecurringRunsManager reloads the list of runs after enable/disabling 1`
               center={false}
               classes={
                 Object {
-                  "child": "MuiTouchRipple-child-91",
-                  "childLeaving": "MuiTouchRipple-childLeaving-92",
-                  "childPulsate": "MuiTouchRipple-childPulsate-93",
-                  "ripple": "MuiTouchRipple-ripple-88",
-                  "ripplePulsate": "MuiTouchRipple-ripplePulsate-90",
-                  "rippleVisible": "MuiTouchRipple-rippleVisible-89",
-                  "root": "MuiTouchRipple-root-87",
+                  "child": "MuiTouchRipple-child-128",
+                  "childLeaving": "MuiTouchRipple-childLeaving-129",
+                  "childPulsate": "MuiTouchRipple-childPulsate-130",
+                  "ripple": "MuiTouchRipple-ripple-125",
+                  "ripplePulsate": "MuiTouchRipple-ripplePulsate-127",
+                  "rippleVisible": "MuiTouchRipple-rippleVisible-126",
+                  "root": "MuiTouchRipple-root-124",
                 }
               }
             >
               <TransitionGroup
                 childFactory={[Function]}
-                className="MuiTouchRipple-root-87"
+                className="MuiTouchRipple-root-124"
                 component="span"
                 enter={true}
                 exit={true}
               >
                 <span
-                  className="MuiTouchRipple-root-87"
+                  className="MuiTouchRipple-root-124"
                 />
               </TransitionGroup>
             </TouchRipple>
@@ -214,32 +215,32 @@ exports[`RecurringRunsManager renders a disable button if the run is enabled, cl
   className="root"
   classes={
     Object {
-      "colorInherit": "MuiButton-colorInherit-115",
-      "contained": "MuiButton-contained-105",
-      "containedPrimary": "MuiButton-containedPrimary-106",
-      "containedSecondary": "MuiButton-containedSecondary-107",
-      "disabled": "MuiButton-disabled-114",
-      "extendedFab": "MuiButton-extendedFab-112",
-      "fab": "MuiButton-fab-111",
-      "flat": "MuiButton-flat-99",
-      "flatPrimary": "MuiButton-flatPrimary-100",
-      "flatSecondary": "MuiButton-flatSecondary-101",
-      "focusVisible": "MuiButton-focusVisible-113",
-      "fullWidth": "MuiButton-fullWidth-119",
-      "label": "MuiButton-label-95",
-      "mini": "MuiButton-mini-116",
-      "outlined": "MuiButton-outlined-102",
-      "outlinedPrimary": "MuiButton-outlinedPrimary-103",
-      "outlinedSecondary": "MuiButton-outlinedSecondary-104",
-      "raised": "MuiButton-raised-108",
-      "raisedPrimary": "MuiButton-raisedPrimary-109",
-      "raisedSecondary": "MuiButton-raisedSecondary-110",
-      "root": "MuiButton-root-94",
-      "sizeLarge": "MuiButton-sizeLarge-118",
-      "sizeSmall": "MuiButton-sizeSmall-117",
-      "text": "MuiButton-text-96",
-      "textPrimary": "MuiButton-textPrimary-97",
-      "textSecondary": "MuiButton-textSecondary-98",
+      "colorInherit": "MuiButton-colorInherit-152",
+      "contained": "MuiButton-contained-142",
+      "containedPrimary": "MuiButton-containedPrimary-143",
+      "containedSecondary": "MuiButton-containedSecondary-144",
+      "disabled": "MuiButton-disabled-151",
+      "extendedFab": "MuiButton-extendedFab-149",
+      "fab": "MuiButton-fab-148",
+      "flat": "MuiButton-flat-136",
+      "flatPrimary": "MuiButton-flatPrimary-137",
+      "flatSecondary": "MuiButton-flatSecondary-138",
+      "focusVisible": "MuiButton-focusVisible-150",
+      "fullWidth": "MuiButton-fullWidth-156",
+      "label": "MuiButton-label-132",
+      "mini": "MuiButton-mini-153",
+      "outlined": "MuiButton-outlined-139",
+      "outlinedPrimary": "MuiButton-outlinedPrimary-140",
+      "outlinedSecondary": "MuiButton-outlinedSecondary-141",
+      "raised": "MuiButton-raised-145",
+      "raisedPrimary": "MuiButton-raisedPrimary-146",
+      "raisedSecondary": "MuiButton-raisedSecondary-147",
+      "root": "MuiButton-root-131",
+      "sizeLarge": "MuiButton-sizeLarge-155",
+      "sizeSmall": "MuiButton-sizeSmall-154",
+      "text": "MuiButton-text-133",
+      "textPrimary": "MuiButton-textPrimary-134",
+      "textSecondary": "MuiButton-textSecondary-135",
     }
   }
   color="primary"
@@ -254,22 +255,22 @@ exports[`RecurringRunsManager renders a disable button if the run is enabled, cl
   variant="text"
 >
   <WithStyles(ButtonBase)
-    className="MuiButton-root-94 MuiButton-text-96 MuiButton-textPrimary-97 MuiButton-flat-99 MuiButton-flatPrimary-100 root"
+    className="MuiButton-root-131 MuiButton-text-133 MuiButton-textPrimary-134 MuiButton-flat-136 MuiButton-flatPrimary-137 root"
     component="button"
     disabled={false}
     focusRipple={true}
-    focusVisibleClassName="MuiButton-focusVisible-113"
+    focusVisibleClassName="MuiButton-focusVisible-150"
     onClick={[Function]}
     type="button"
   >
     <ButtonBase
       centerRipple={false}
-      className="MuiButton-root-94 MuiButton-text-96 MuiButton-textPrimary-97 MuiButton-flat-99 MuiButton-flatPrimary-100 root"
+      className="MuiButton-root-131 MuiButton-text-133 MuiButton-textPrimary-134 MuiButton-flat-136 MuiButton-flatPrimary-137 root"
       classes={
         Object {
-          "disabled": "MuiButtonBase-disabled-15",
-          "focusVisible": "MuiButtonBase-focusVisible-16",
-          "root": "MuiButtonBase-root-14",
+          "disabled": "MuiButtonBase-disabled-82",
+          "focusVisible": "MuiButtonBase-focusVisible-83",
+          "root": "MuiButtonBase-root-81",
         }
       }
       component="button"
@@ -277,13 +278,13 @@ exports[`RecurringRunsManager renders a disable button if the run is enabled, cl
       disableTouchRipple={false}
       disabled={false}
       focusRipple={true}
-      focusVisibleClassName="MuiButton-focusVisible-113"
+      focusVisibleClassName="MuiButton-focusVisible-150"
       onClick={[Function]}
       tabIndex="0"
       type="button"
     >
       <button
-        className="MuiButtonBase-root-14 MuiButton-root-94 MuiButton-text-96 MuiButton-textPrimary-97 MuiButton-flat-99 MuiButton-flatPrimary-100 root"
+        className="MuiButtonBase-root-81 MuiButton-root-131 MuiButton-text-133 MuiButton-textPrimary-134 MuiButton-flat-136 MuiButton-flatPrimary-137 root"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -301,7 +302,7 @@ exports[`RecurringRunsManager renders a disable button if the run is enabled, cl
         type="button"
       >
         <span
-          className="MuiButton-label-95"
+          className="MuiButton-label-132"
         >
           <span>
             Enabled
@@ -319,25 +320,25 @@ exports[`RecurringRunsManager renders a disable button if the run is enabled, cl
               center={false}
               classes={
                 Object {
-                  "child": "MuiTouchRipple-child-91",
-                  "childLeaving": "MuiTouchRipple-childLeaving-92",
-                  "childPulsate": "MuiTouchRipple-childPulsate-93",
-                  "ripple": "MuiTouchRipple-ripple-88",
-                  "ripplePulsate": "MuiTouchRipple-ripplePulsate-90",
-                  "rippleVisible": "MuiTouchRipple-rippleVisible-89",
-                  "root": "MuiTouchRipple-root-87",
+                  "child": "MuiTouchRipple-child-128",
+                  "childLeaving": "MuiTouchRipple-childLeaving-129",
+                  "childPulsate": "MuiTouchRipple-childPulsate-130",
+                  "ripple": "MuiTouchRipple-ripple-125",
+                  "ripplePulsate": "MuiTouchRipple-ripplePulsate-127",
+                  "rippleVisible": "MuiTouchRipple-rippleVisible-126",
+                  "root": "MuiTouchRipple-root-124",
                 }
               }
             >
               <TransitionGroup
                 childFactory={[Function]}
-                className="MuiTouchRipple-root-87"
+                className="MuiTouchRipple-root-124"
                 component="span"
                 enter={true}
                 exit={true}
               >
                 <span
-                  className="MuiTouchRipple-root-87"
+                  className="MuiTouchRipple-root-124"
                 />
               </TransitionGroup>
             </TouchRipple>
@@ -354,32 +355,32 @@ exports[`RecurringRunsManager renders an enable button if the run is disabled, c
   className="root"
   classes={
     Object {
-      "colorInherit": "MuiButton-colorInherit-115",
-      "contained": "MuiButton-contained-105",
-      "containedPrimary": "MuiButton-containedPrimary-106",
-      "containedSecondary": "MuiButton-containedSecondary-107",
-      "disabled": "MuiButton-disabled-114",
-      "extendedFab": "MuiButton-extendedFab-112",
-      "fab": "MuiButton-fab-111",
-      "flat": "MuiButton-flat-99",
-      "flatPrimary": "MuiButton-flatPrimary-100",
-      "flatSecondary": "MuiButton-flatSecondary-101",
-      "focusVisible": "MuiButton-focusVisible-113",
-      "fullWidth": "MuiButton-fullWidth-119",
-      "label": "MuiButton-label-95",
-      "mini": "MuiButton-mini-116",
-      "outlined": "MuiButton-outlined-102",
-      "outlinedPrimary": "MuiButton-outlinedPrimary-103",
-      "outlinedSecondary": "MuiButton-outlinedSecondary-104",
-      "raised": "MuiButton-raised-108",
-      "raisedPrimary": "MuiButton-raisedPrimary-109",
-      "raisedSecondary": "MuiButton-raisedSecondary-110",
-      "root": "MuiButton-root-94",
-      "sizeLarge": "MuiButton-sizeLarge-118",
-      "sizeSmall": "MuiButton-sizeSmall-117",
-      "text": "MuiButton-text-96",
-      "textPrimary": "MuiButton-textPrimary-97",
-      "textSecondary": "MuiButton-textSecondary-98",
+      "colorInherit": "MuiButton-colorInherit-152",
+      "contained": "MuiButton-contained-142",
+      "containedPrimary": "MuiButton-containedPrimary-143",
+      "containedSecondary": "MuiButton-containedSecondary-144",
+      "disabled": "MuiButton-disabled-151",
+      "extendedFab": "MuiButton-extendedFab-149",
+      "fab": "MuiButton-fab-148",
+      "flat": "MuiButton-flat-136",
+      "flatPrimary": "MuiButton-flatPrimary-137",
+      "flatSecondary": "MuiButton-flatSecondary-138",
+      "focusVisible": "MuiButton-focusVisible-150",
+      "fullWidth": "MuiButton-fullWidth-156",
+      "label": "MuiButton-label-132",
+      "mini": "MuiButton-mini-153",
+      "outlined": "MuiButton-outlined-139",
+      "outlinedPrimary": "MuiButton-outlinedPrimary-140",
+      "outlinedSecondary": "MuiButton-outlinedSecondary-141",
+      "raised": "MuiButton-raised-145",
+      "raisedPrimary": "MuiButton-raisedPrimary-146",
+      "raisedSecondary": "MuiButton-raisedSecondary-147",
+      "root": "MuiButton-root-131",
+      "sizeLarge": "MuiButton-sizeLarge-155",
+      "sizeSmall": "MuiButton-sizeSmall-154",
+      "text": "MuiButton-text-133",
+      "textPrimary": "MuiButton-textPrimary-134",
+      "textSecondary": "MuiButton-textSecondary-135",
     }
   }
   color="secondary"
@@ -394,22 +395,22 @@ exports[`RecurringRunsManager renders an enable button if the run is disabled, c
   variant="text"
 >
   <WithStyles(ButtonBase)
-    className="MuiButton-root-94 MuiButton-text-96 MuiButton-textSecondary-98 MuiButton-flat-99 MuiButton-flatSecondary-101 root"
+    className="MuiButton-root-131 MuiButton-text-133 MuiButton-textSecondary-135 MuiButton-flat-136 MuiButton-flatSecondary-138 root"
     component="button"
     disabled={false}
     focusRipple={true}
-    focusVisibleClassName="MuiButton-focusVisible-113"
+    focusVisibleClassName="MuiButton-focusVisible-150"
     onClick={[Function]}
     type="button"
   >
     <ButtonBase
       centerRipple={false}
-      className="MuiButton-root-94 MuiButton-text-96 MuiButton-textSecondary-98 MuiButton-flat-99 MuiButton-flatSecondary-101 root"
+      className="MuiButton-root-131 MuiButton-text-133 MuiButton-textSecondary-135 MuiButton-flat-136 MuiButton-flatSecondary-138 root"
       classes={
         Object {
-          "disabled": "MuiButtonBase-disabled-15",
-          "focusVisible": "MuiButtonBase-focusVisible-16",
-          "root": "MuiButtonBase-root-14",
+          "disabled": "MuiButtonBase-disabled-82",
+          "focusVisible": "MuiButtonBase-focusVisible-83",
+          "root": "MuiButtonBase-root-81",
         }
       }
       component="button"
@@ -417,13 +418,13 @@ exports[`RecurringRunsManager renders an enable button if the run is disabled, c
       disableTouchRipple={false}
       disabled={false}
       focusRipple={true}
-      focusVisibleClassName="MuiButton-focusVisible-113"
+      focusVisibleClassName="MuiButton-focusVisible-150"
       onClick={[Function]}
       tabIndex="0"
       type="button"
     >
       <button
-        className="MuiButtonBase-root-14 MuiButton-root-94 MuiButton-text-96 MuiButton-textSecondary-98 MuiButton-flat-99 MuiButton-flatSecondary-101 root"
+        className="MuiButtonBase-root-81 MuiButton-root-131 MuiButton-text-133 MuiButton-textSecondary-135 MuiButton-flat-136 MuiButton-flatSecondary-138 root"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -441,7 +442,7 @@ exports[`RecurringRunsManager renders an enable button if the run is disabled, c
         type="button"
       >
         <span
-          className="MuiButton-label-95"
+          className="MuiButton-label-132"
         >
           <span>
             Disabled
@@ -459,25 +460,25 @@ exports[`RecurringRunsManager renders an enable button if the run is disabled, c
               center={false}
               classes={
                 Object {
-                  "child": "MuiTouchRipple-child-91",
-                  "childLeaving": "MuiTouchRipple-childLeaving-92",
-                  "childPulsate": "MuiTouchRipple-childPulsate-93",
-                  "ripple": "MuiTouchRipple-ripple-88",
-                  "ripplePulsate": "MuiTouchRipple-ripplePulsate-90",
-                  "rippleVisible": "MuiTouchRipple-rippleVisible-89",
-                  "root": "MuiTouchRipple-root-87",
+                  "child": "MuiTouchRipple-child-128",
+                  "childLeaving": "MuiTouchRipple-childLeaving-129",
+                  "childPulsate": "MuiTouchRipple-childPulsate-130",
+                  "ripple": "MuiTouchRipple-ripple-125",
+                  "ripplePulsate": "MuiTouchRipple-ripplePulsate-127",
+                  "rippleVisible": "MuiTouchRipple-rippleVisible-126",
+                  "root": "MuiTouchRipple-root-124",
                 }
               }
             >
               <TransitionGroup
                 childFactory={[Function]}
-                className="MuiTouchRipple-root-87"
+                className="MuiTouchRipple-root-124"
                 component="span"
                 enter={true}
                 exit={true}
               >
                 <span
-                  className="MuiTouchRipple-root-87"
+                  className="MuiTouchRipple-root-124"
                 />
               </TransitionGroup>
             </TouchRipple>
@@ -494,32 +495,32 @@ exports[`RecurringRunsManager renders an enable button if the run's enabled fiel
   className="root"
   classes={
     Object {
-      "colorInherit": "MuiButton-colorInherit-115",
-      "contained": "MuiButton-contained-105",
-      "containedPrimary": "MuiButton-containedPrimary-106",
-      "containedSecondary": "MuiButton-containedSecondary-107",
-      "disabled": "MuiButton-disabled-114",
-      "extendedFab": "MuiButton-extendedFab-112",
-      "fab": "MuiButton-fab-111",
-      "flat": "MuiButton-flat-99",
-      "flatPrimary": "MuiButton-flatPrimary-100",
-      "flatSecondary": "MuiButton-flatSecondary-101",
-      "focusVisible": "MuiButton-focusVisible-113",
-      "fullWidth": "MuiButton-fullWidth-119",
-      "label": "MuiButton-label-95",
-      "mini": "MuiButton-mini-116",
-      "outlined": "MuiButton-outlined-102",
-      "outlinedPrimary": "MuiButton-outlinedPrimary-103",
-      "outlinedSecondary": "MuiButton-outlinedSecondary-104",
-      "raised": "MuiButton-raised-108",
-      "raisedPrimary": "MuiButton-raisedPrimary-109",
-      "raisedSecondary": "MuiButton-raisedSecondary-110",
-      "root": "MuiButton-root-94",
-      "sizeLarge": "MuiButton-sizeLarge-118",
-      "sizeSmall": "MuiButton-sizeSmall-117",
-      "text": "MuiButton-text-96",
-      "textPrimary": "MuiButton-textPrimary-97",
-      "textSecondary": "MuiButton-textSecondary-98",
+      "colorInherit": "MuiButton-colorInherit-152",
+      "contained": "MuiButton-contained-142",
+      "containedPrimary": "MuiButton-containedPrimary-143",
+      "containedSecondary": "MuiButton-containedSecondary-144",
+      "disabled": "MuiButton-disabled-151",
+      "extendedFab": "MuiButton-extendedFab-149",
+      "fab": "MuiButton-fab-148",
+      "flat": "MuiButton-flat-136",
+      "flatPrimary": "MuiButton-flatPrimary-137",
+      "flatSecondary": "MuiButton-flatSecondary-138",
+      "focusVisible": "MuiButton-focusVisible-150",
+      "fullWidth": "MuiButton-fullWidth-156",
+      "label": "MuiButton-label-132",
+      "mini": "MuiButton-mini-153",
+      "outlined": "MuiButton-outlined-139",
+      "outlinedPrimary": "MuiButton-outlinedPrimary-140",
+      "outlinedSecondary": "MuiButton-outlinedSecondary-141",
+      "raised": "MuiButton-raised-145",
+      "raisedPrimary": "MuiButton-raisedPrimary-146",
+      "raisedSecondary": "MuiButton-raisedSecondary-147",
+      "root": "MuiButton-root-131",
+      "sizeLarge": "MuiButton-sizeLarge-155",
+      "sizeSmall": "MuiButton-sizeSmall-154",
+      "text": "MuiButton-text-133",
+      "textPrimary": "MuiButton-textPrimary-134",
+      "textSecondary": "MuiButton-textSecondary-135",
     }
   }
   color="secondary"
@@ -534,22 +535,22 @@ exports[`RecurringRunsManager renders an enable button if the run's enabled fiel
   variant="text"
 >
   <WithStyles(ButtonBase)
-    className="MuiButton-root-94 MuiButton-text-96 MuiButton-textSecondary-98 MuiButton-flat-99 MuiButton-flatSecondary-101 root"
+    className="MuiButton-root-131 MuiButton-text-133 MuiButton-textSecondary-135 MuiButton-flat-136 MuiButton-flatSecondary-138 root"
     component="button"
     disabled={false}
     focusRipple={true}
-    focusVisibleClassName="MuiButton-focusVisible-113"
+    focusVisibleClassName="MuiButton-focusVisible-150"
     onClick={[Function]}
     type="button"
   >
     <ButtonBase
       centerRipple={false}
-      className="MuiButton-root-94 MuiButton-text-96 MuiButton-textSecondary-98 MuiButton-flat-99 MuiButton-flatSecondary-101 root"
+      className="MuiButton-root-131 MuiButton-text-133 MuiButton-textSecondary-135 MuiButton-flat-136 MuiButton-flatSecondary-138 root"
       classes={
         Object {
-          "disabled": "MuiButtonBase-disabled-15",
-          "focusVisible": "MuiButtonBase-focusVisible-16",
-          "root": "MuiButtonBase-root-14",
+          "disabled": "MuiButtonBase-disabled-82",
+          "focusVisible": "MuiButtonBase-focusVisible-83",
+          "root": "MuiButtonBase-root-81",
         }
       }
       component="button"
@@ -557,13 +558,13 @@ exports[`RecurringRunsManager renders an enable button if the run's enabled fiel
       disableTouchRipple={false}
       disabled={false}
       focusRipple={true}
-      focusVisibleClassName="MuiButton-focusVisible-113"
+      focusVisibleClassName="MuiButton-focusVisible-150"
       onClick={[Function]}
       tabIndex="0"
       type="button"
     >
       <button
-        className="MuiButtonBase-root-14 MuiButton-root-94 MuiButton-text-96 MuiButton-textSecondary-98 MuiButton-flat-99 MuiButton-flatSecondary-101 root"
+        className="MuiButtonBase-root-81 MuiButton-root-131 MuiButton-text-133 MuiButton-textSecondary-135 MuiButton-flat-136 MuiButton-flatSecondary-138 root"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -581,7 +582,7 @@ exports[`RecurringRunsManager renders an enable button if the run's enabled fiel
         type="button"
       >
         <span
-          className="MuiButton-label-95"
+          className="MuiButton-label-132"
         >
           <span>
             Disabled
@@ -599,25 +600,25 @@ exports[`RecurringRunsManager renders an enable button if the run's enabled fiel
               center={false}
               classes={
                 Object {
-                  "child": "MuiTouchRipple-child-91",
-                  "childLeaving": "MuiTouchRipple-childLeaving-92",
-                  "childPulsate": "MuiTouchRipple-childPulsate-93",
-                  "ripple": "MuiTouchRipple-ripple-88",
-                  "ripplePulsate": "MuiTouchRipple-ripplePulsate-90",
-                  "rippleVisible": "MuiTouchRipple-rippleVisible-89",
-                  "root": "MuiTouchRipple-root-87",
+                  "child": "MuiTouchRipple-child-128",
+                  "childLeaving": "MuiTouchRipple-childLeaving-129",
+                  "childPulsate": "MuiTouchRipple-childPulsate-130",
+                  "ripple": "MuiTouchRipple-ripple-125",
+                  "ripplePulsate": "MuiTouchRipple-ripplePulsate-127",
+                  "rippleVisible": "MuiTouchRipple-rippleVisible-126",
+                  "root": "MuiTouchRipple-root-124",
                 }
               }
             >
               <TransitionGroup
                 childFactory={[Function]}
-                className="MuiTouchRipple-root-87"
+                className="MuiTouchRipple-root-124"
                 component="span"
                 enter={true}
                 exit={true}
               >
                 <span
-                  className="MuiTouchRipple-root-87"
+                  className="MuiTouchRipple-root-124"
                 />
               </TransitionGroup>
             </TouchRipple>

--- a/frontend/src/pages/__snapshots__/ResourceSelector.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ResourceSelector.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`ResourceSelector displays resource selector 1`] = `
       ]
     }
     emptyMessage="Test - Sorry, no resources."
+    filterLabel="test filter label"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={

--- a/frontend/src/pages/__snapshots__/RunList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunList.test.tsx.snap
@@ -1314,7 +1314,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                             "fontSize": "0.875rem",
                                             "fontWeight": 500,
                                             "letterSpacing": "0.02857em",
-                                            "lineHeight": 1.3125,
+                                            "lineHeight": 1.5,
                                             "textTransform": "uppercase",
                                           },
                                           "caption": Object {

--- a/frontend/src/pages/__snapshots__/RunList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunList.test.tsx.snap
@@ -53,6 +53,7 @@ exports[`RunList adds metrics columns 1`] = `
       ]
     }
     emptyMessage="No runs found."
+    filterLabel="Filter runs"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={
@@ -175,6 +176,7 @@ exports[`RunList displays error in run row if experiment could not be fetched 1`
       ]
     }
     emptyMessage="No runs found."
+    filterLabel="Filter runs"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={
@@ -235,6 +237,7 @@ exports[`RunList displays error in run row if it failed to parse (run list mask)
       ]
     }
     emptyMessage="No runs found."
+    filterLabel="Filter runs"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={
@@ -307,6 +310,7 @@ exports[`RunList displays error in run row if it failed to parse 1`] = `
       ]
     }
     emptyMessage="No runs found."
+    filterLabel="Filter runs"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={
@@ -367,6 +371,7 @@ exports[`RunList displays error in run row if pipeline could not be fetched 1`] 
       ]
     }
     emptyMessage="No runs found."
+    filterLabel="Filter runs"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={
@@ -439,6 +444,7 @@ exports[`RunList loads multiple runs 1`] = `
       ]
     }
     emptyMessage="No runs found."
+    filterLabel="Filter runs"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={
@@ -547,6 +553,7 @@ exports[`RunList loads one run 1`] = `
       ]
     }
     emptyMessage="No runs found."
+    filterLabel="Filter runs"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={
@@ -617,6 +624,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
         ]
       }
       emptyMessage="No runs found."
+      filterLabel="Filter runs"
       initialSortColumn="created_at"
       reload={[Function]}
       rows={Array []}
@@ -624,6 +632,1000 @@ exports[`RunList reloads the run when refresh is called 1`] = `
       <div
         className="pageOverflowHidden"
       >
+        <div>
+          <Component
+            InputLabelProps={
+              Object {
+                "classes": Object {
+                  "root": "noMargin",
+                },
+              }
+            }
+            InputProps={
+              Object {
+                "classes": Object {
+                  "notchedOutline": "filterBorderRadius",
+                  "root": "noLeftPadding",
+                },
+                "startAdornment": <WithStyles(InputAdornment)
+                  position="end"
+                >
+                  <pure(FilterListIcon)
+                    style={
+                      Object {
+                        "color": "#80868b",
+                        "paddingRight": 16,
+                      }
+                    }
+                  />
+                </WithStyles(InputAdornment)>,
+              }
+            }
+            className="filterBox"
+            height={48}
+            label="Filter runs"
+            maxWidth="100%"
+            onChange={[Function]}
+            value=""
+            variant="outlined"
+          >
+            <TextField
+              InputLabelProps={
+                Object {
+                  "classes": Object {
+                    "root": "noMargin",
+                  },
+                }
+              }
+              InputProps={
+                Object {
+                  "classes": Object {
+                    "notchedOutline": "filterBorderRadius",
+                    "root": "noLeftPadding",
+                  },
+                  "startAdornment": <WithStyles(InputAdornment)
+                    position="end"
+                  >
+                    <pure(FilterListIcon)
+                      style={
+                        Object {
+                          "color": "#80868b",
+                          "paddingRight": 16,
+                        }
+                      }
+                    />
+                  </WithStyles(InputAdornment)>,
+                }
+              }
+              className="filterBox"
+              label="Filter runs"
+              onChange={[Function]}
+              required={false}
+              select={false}
+              spellCheck={false}
+              style={
+                Object {
+                  "height": 48,
+                  "maxWidth": "100%",
+                  "width": "100%",
+                }
+              }
+              value=""
+              variant="outlined"
+            >
+              <WithStyles(FormControl)
+                className="filterBox"
+                required={false}
+                spellCheck={false}
+                style={
+                  Object {
+                    "height": 48,
+                    "maxWidth": "100%",
+                    "width": "100%",
+                  }
+                }
+                variant="outlined"
+              >
+                <FormControl
+                  className="filterBox"
+                  classes={
+                    Object {
+                      "fullWidth": "MuiFormControl-fullWidth-4",
+                      "marginDense": "MuiFormControl-marginDense-3",
+                      "marginNormal": "MuiFormControl-marginNormal-2",
+                      "root": "MuiFormControl-root-1",
+                    }
+                  }
+                  component="div"
+                  disabled={false}
+                  error={false}
+                  fullWidth={false}
+                  margin="none"
+                  required={false}
+                  spellCheck={false}
+                  style={
+                    Object {
+                      "height": 48,
+                      "maxWidth": "100%",
+                      "width": "100%",
+                    }
+                  }
+                  variant="outlined"
+                >
+                  <div
+                    className="MuiFormControl-root-1 filterBox"
+                    spellCheck={false}
+                    style={
+                      Object {
+                        "height": 48,
+                        "maxWidth": "100%",
+                        "width": "100%",
+                      }
+                    }
+                  >
+                    <WithStyles(WithFormControlContext(InputLabel))
+                      classes={
+                        Object {
+                          "root": "noMargin",
+                        }
+                      }
+                    >
+                      <WithFormControlContext(InputLabel)
+                        classes={
+                          Object {
+                            "animated": "MuiInputLabel-animated-13",
+                            "disabled": "MuiInputLabel-disabled-7",
+                            "error": "MuiInputLabel-error-8",
+                            "filled": "MuiInputLabel-filled-14",
+                            "focused": "MuiInputLabel-focused-6",
+                            "formControl": "MuiInputLabel-formControl-10",
+                            "marginDense": "MuiInputLabel-marginDense-11",
+                            "outlined": "MuiInputLabel-outlined-15",
+                            "required": "MuiInputLabel-required-9",
+                            "root": "MuiInputLabel-root-5 noMargin",
+                            "shrink": "MuiInputLabel-shrink-12",
+                          }
+                        }
+                      >
+                        <InputLabel
+                          classes={
+                            Object {
+                              "animated": "MuiInputLabel-animated-13",
+                              "disabled": "MuiInputLabel-disabled-7",
+                              "error": "MuiInputLabel-error-8",
+                              "filled": "MuiInputLabel-filled-14",
+                              "focused": "MuiInputLabel-focused-6",
+                              "formControl": "MuiInputLabel-formControl-10",
+                              "marginDense": "MuiInputLabel-marginDense-11",
+                              "outlined": "MuiInputLabel-outlined-15",
+                              "required": "MuiInputLabel-required-9",
+                              "root": "MuiInputLabel-root-5 noMargin",
+                              "shrink": "MuiInputLabel-shrink-12",
+                            }
+                          }
+                          disableAnimation={false}
+                          muiFormControl={
+                            Object {
+                              "adornedStart": true,
+                              "disabled": false,
+                              "error": false,
+                              "filled": false,
+                              "focused": false,
+                              "margin": "none",
+                              "onBlur": [Function],
+                              "onEmpty": [Function],
+                              "onFilled": [Function],
+                              "onFocus": [Function],
+                              "required": false,
+                              "variant": "outlined",
+                            }
+                          }
+                        >
+                          <WithStyles(WithFormControlContext(FormLabel))
+                            className="MuiInputLabel-root-5 noMargin MuiInputLabel-formControl-10 MuiInputLabel-animated-13 MuiInputLabel-shrink-12 MuiInputLabel-outlined-15"
+                            classes={
+                              Object {
+                                "disabled": "MuiInputLabel-disabled-7",
+                                "error": "MuiInputLabel-error-8",
+                                "focused": "MuiInputLabel-focused-6",
+                                "required": "MuiInputLabel-required-9",
+                              }
+                            }
+                            data-shrink={true}
+                          >
+                            <WithFormControlContext(FormLabel)
+                              className="MuiInputLabel-root-5 noMargin MuiInputLabel-formControl-10 MuiInputLabel-animated-13 MuiInputLabel-shrink-12 MuiInputLabel-outlined-15"
+                              classes={
+                                Object {
+                                  "asterisk": "MuiFormLabel-asterisk-22",
+                                  "disabled": "MuiFormLabel-disabled-18 MuiInputLabel-disabled-7",
+                                  "error": "MuiFormLabel-error-19 MuiInputLabel-error-8",
+                                  "filled": "MuiFormLabel-filled-20",
+                                  "focused": "MuiFormLabel-focused-17 MuiInputLabel-focused-6",
+                                  "required": "MuiFormLabel-required-21 MuiInputLabel-required-9",
+                                  "root": "MuiFormLabel-root-16",
+                                }
+                              }
+                              data-shrink={true}
+                            >
+                              <FormLabel
+                                className="MuiInputLabel-root-5 noMargin MuiInputLabel-formControl-10 MuiInputLabel-animated-13 MuiInputLabel-shrink-12 MuiInputLabel-outlined-15"
+                                classes={
+                                  Object {
+                                    "asterisk": "MuiFormLabel-asterisk-22",
+                                    "disabled": "MuiFormLabel-disabled-18 MuiInputLabel-disabled-7",
+                                    "error": "MuiFormLabel-error-19 MuiInputLabel-error-8",
+                                    "filled": "MuiFormLabel-filled-20",
+                                    "focused": "MuiFormLabel-focused-17 MuiInputLabel-focused-6",
+                                    "required": "MuiFormLabel-required-21 MuiInputLabel-required-9",
+                                    "root": "MuiFormLabel-root-16",
+                                  }
+                                }
+                                component="label"
+                                data-shrink={true}
+                                muiFormControl={
+                                  Object {
+                                    "adornedStart": true,
+                                    "disabled": false,
+                                    "error": false,
+                                    "filled": false,
+                                    "focused": false,
+                                    "margin": "none",
+                                    "onBlur": [Function],
+                                    "onEmpty": [Function],
+                                    "onFilled": [Function],
+                                    "onFocus": [Function],
+                                    "required": false,
+                                    "variant": "outlined",
+                                  }
+                                }
+                              >
+                                <label
+                                  className="MuiFormLabel-root-16 MuiInputLabel-root-5 noMargin MuiInputLabel-formControl-10 MuiInputLabel-animated-13 MuiInputLabel-shrink-12 MuiInputLabel-outlined-15"
+                                  data-shrink={true}
+                                >
+                                  Filter runs
+                                </label>
+                              </FormLabel>
+                            </WithFormControlContext(FormLabel)>
+                          </WithStyles(WithFormControlContext(FormLabel))>
+                        </InputLabel>
+                      </WithFormControlContext(InputLabel)>
+                    </WithStyles(WithFormControlContext(InputLabel))>
+                    <WithStyles(OutlinedInput)
+                      classes={
+                        Object {
+                          "notchedOutline": "filterBorderRadius",
+                          "root": "noLeftPadding",
+                        }
+                      }
+                      labelWidth={0}
+                      onChange={[Function]}
+                      startAdornment={
+                        <WithStyles(InputAdornment)
+                          position="end"
+                        >
+                          <pure(FilterListIcon)
+                            style={
+                              Object {
+                                "color": "#80868b",
+                                "paddingRight": 16,
+                              }
+                            }
+                          />
+                        </WithStyles(InputAdornment)>
+                      }
+                      value=""
+                    >
+                      <OutlinedInput
+                        classes={
+                          Object {
+                            "adornedEnd": "MuiOutlinedInput-adornedEnd-27",
+                            "adornedStart": "MuiOutlinedInput-adornedStart-26",
+                            "disabled": "MuiOutlinedInput-disabled-25",
+                            "error": "MuiOutlinedInput-error-28",
+                            "focused": "MuiOutlinedInput-focused-24",
+                            "input": "MuiOutlinedInput-input-31",
+                            "inputAdornedEnd": "MuiOutlinedInput-inputAdornedEnd-35",
+                            "inputAdornedStart": "MuiOutlinedInput-inputAdornedStart-34",
+                            "inputMarginDense": "MuiOutlinedInput-inputMarginDense-32",
+                            "inputMultiline": "MuiOutlinedInput-inputMultiline-33",
+                            "multiline": "MuiOutlinedInput-multiline-29",
+                            "notchedOutline": "MuiOutlinedInput-notchedOutline-30 filterBorderRadius",
+                            "root": "MuiOutlinedInput-root-23 noLeftPadding",
+                          }
+                        }
+                        labelWidth={0}
+                        onChange={[Function]}
+                        startAdornment={
+                          <WithStyles(InputAdornment)
+                            position="end"
+                          >
+                            <pure(FilterListIcon)
+                              style={
+                                Object {
+                                  "color": "#80868b",
+                                  "paddingRight": 16,
+                                }
+                              }
+                            />
+                          </WithStyles(InputAdornment)>
+                        }
+                        value=""
+                      >
+                        <WithStyles(WithFormControlContext(InputBase))
+                          classes={
+                            Object {
+                              "adornedEnd": "MuiOutlinedInput-adornedEnd-27",
+                              "adornedStart": "MuiOutlinedInput-adornedStart-26",
+                              "disabled": "MuiOutlinedInput-disabled-25",
+                              "error": "MuiOutlinedInput-error-28",
+                              "focused": "MuiOutlinedInput-focused-24",
+                              "input": "MuiOutlinedInput-input-31",
+                              "inputAdornedEnd": "MuiOutlinedInput-inputAdornedEnd-35",
+                              "inputAdornedStart": "MuiOutlinedInput-inputAdornedStart-34",
+                              "inputMarginDense": "MuiOutlinedInput-inputMarginDense-32",
+                              "inputMultiline": "MuiOutlinedInput-inputMultiline-33",
+                              "multiline": "MuiOutlinedInput-multiline-29",
+                              "notchedOutline": null,
+                              "root": "MuiOutlinedInput-root-23 noLeftPadding",
+                            }
+                          }
+                          fullWidth={false}
+                          inputComponent="input"
+                          multiline={false}
+                          onChange={[Function]}
+                          renderPrefix={[Function]}
+                          startAdornment={
+                            <WithStyles(InputAdornment)
+                              position="end"
+                            >
+                              <pure(FilterListIcon)
+                                style={
+                                  Object {
+                                    "color": "#80868b",
+                                    "paddingRight": 16,
+                                  }
+                                }
+                              />
+                            </WithStyles(InputAdornment)>
+                          }
+                          type="text"
+                          value=""
+                        >
+                          <WithFormControlContext(InputBase)
+                            classes={
+                              Object {
+                                "adornedEnd": "MuiInputBase-adornedEnd-41 MuiOutlinedInput-adornedEnd-27",
+                                "adornedStart": "MuiInputBase-adornedStart-40 MuiOutlinedInput-adornedStart-26",
+                                "disabled": "MuiInputBase-disabled-39 MuiOutlinedInput-disabled-25",
+                                "error": "MuiInputBase-error-42 MuiOutlinedInput-error-28",
+                                "focused": "MuiInputBase-focused-38 MuiOutlinedInput-focused-24",
+                                "formControl": "MuiInputBase-formControl-37",
+                                "fullWidth": "MuiInputBase-fullWidth-45",
+                                "input": "MuiInputBase-input-46 MuiOutlinedInput-input-31",
+                                "inputAdornedEnd": "MuiInputBase-inputAdornedEnd-52 MuiOutlinedInput-inputAdornedEnd-35",
+                                "inputAdornedStart": "MuiInputBase-inputAdornedStart-51 MuiOutlinedInput-inputAdornedStart-34",
+                                "inputMarginDense": "MuiInputBase-inputMarginDense-47 MuiOutlinedInput-inputMarginDense-32",
+                                "inputMultiline": "MuiInputBase-inputMultiline-48 MuiOutlinedInput-inputMultiline-33",
+                                "inputType": "MuiInputBase-inputType-49",
+                                "inputTypeSearch": "MuiInputBase-inputTypeSearch-50",
+                                "marginDense": "MuiInputBase-marginDense-43",
+                                "multiline": "MuiInputBase-multiline-44 MuiOutlinedInput-multiline-29",
+                                "root": "MuiInputBase-root-36 MuiOutlinedInput-root-23 noLeftPadding",
+                              }
+                            }
+                            fullWidth={false}
+                            inputComponent="input"
+                            multiline={false}
+                            onChange={[Function]}
+                            renderPrefix={[Function]}
+                            startAdornment={
+                              <WithStyles(InputAdornment)
+                                position="end"
+                              >
+                                <pure(FilterListIcon)
+                                  style={
+                                    Object {
+                                      "color": "#80868b",
+                                      "paddingRight": 16,
+                                    }
+                                  }
+                                />
+                              </WithStyles(InputAdornment)>
+                            }
+                            type="text"
+                            value=""
+                          >
+                            <InputBase
+                              classes={
+                                Object {
+                                  "adornedEnd": "MuiInputBase-adornedEnd-41 MuiOutlinedInput-adornedEnd-27",
+                                  "adornedStart": "MuiInputBase-adornedStart-40 MuiOutlinedInput-adornedStart-26",
+                                  "disabled": "MuiInputBase-disabled-39 MuiOutlinedInput-disabled-25",
+                                  "error": "MuiInputBase-error-42 MuiOutlinedInput-error-28",
+                                  "focused": "MuiInputBase-focused-38 MuiOutlinedInput-focused-24",
+                                  "formControl": "MuiInputBase-formControl-37",
+                                  "fullWidth": "MuiInputBase-fullWidth-45",
+                                  "input": "MuiInputBase-input-46 MuiOutlinedInput-input-31",
+                                  "inputAdornedEnd": "MuiInputBase-inputAdornedEnd-52 MuiOutlinedInput-inputAdornedEnd-35",
+                                  "inputAdornedStart": "MuiInputBase-inputAdornedStart-51 MuiOutlinedInput-inputAdornedStart-34",
+                                  "inputMarginDense": "MuiInputBase-inputMarginDense-47 MuiOutlinedInput-inputMarginDense-32",
+                                  "inputMultiline": "MuiInputBase-inputMultiline-48 MuiOutlinedInput-inputMultiline-33",
+                                  "inputType": "MuiInputBase-inputType-49",
+                                  "inputTypeSearch": "MuiInputBase-inputTypeSearch-50",
+                                  "marginDense": "MuiInputBase-marginDense-43",
+                                  "multiline": "MuiInputBase-multiline-44 MuiOutlinedInput-multiline-29",
+                                  "root": "MuiInputBase-root-36 MuiOutlinedInput-root-23 noLeftPadding",
+                                }
+                              }
+                              fullWidth={false}
+                              inputComponent="input"
+                              muiFormControl={
+                                Object {
+                                  "adornedStart": true,
+                                  "disabled": false,
+                                  "error": false,
+                                  "filled": false,
+                                  "focused": false,
+                                  "margin": "none",
+                                  "onBlur": [Function],
+                                  "onEmpty": [Function],
+                                  "onFilled": [Function],
+                                  "onFocus": [Function],
+                                  "required": false,
+                                  "variant": "outlined",
+                                }
+                              }
+                              multiline={false}
+                              onChange={[Function]}
+                              renderPrefix={[Function]}
+                              startAdornment={
+                                <WithStyles(InputAdornment)
+                                  position="end"
+                                >
+                                  <pure(FilterListIcon)
+                                    style={
+                                      Object {
+                                        "color": "#80868b",
+                                        "paddingRight": 16,
+                                      }
+                                    }
+                                  />
+                                </WithStyles(InputAdornment)>
+                              }
+                              type="text"
+                              value=""
+                            >
+                              <div
+                                className="MuiInputBase-root-36 MuiOutlinedInput-root-23 noLeftPadding MuiInputBase-formControl-37 MuiInputBase-adornedStart-40 MuiOutlinedInput-adornedStart-26"
+                                onClick={[Function]}
+                              >
+                                <WithStyles(NotchedOutline)
+                                  className="MuiOutlinedInput-notchedOutline-30 filterBorderRadius"
+                                  labelWidth={0}
+                                  notched={true}
+                                >
+                                  <NotchedOutline
+                                    className="MuiOutlinedInput-notchedOutline-30 filterBorderRadius"
+                                    classes={
+                                      Object {
+                                        "legend": "MuiPrivateNotchedOutline-legend-54",
+                                        "root": "MuiPrivateNotchedOutline-root-53",
+                                      }
+                                    }
+                                    labelWidth={0}
+                                    notched={true}
+                                    theme={
+                                      Object {
+                                        "breakpoints": Object {
+                                          "between": [Function],
+                                          "down": [Function],
+                                          "keys": Array [
+                                            "xs",
+                                            "sm",
+                                            "md",
+                                            "lg",
+                                            "xl",
+                                          ],
+                                          "only": [Function],
+                                          "up": [Function],
+                                          "values": Object {
+                                            "lg": 1280,
+                                            "md": 960,
+                                            "sm": 600,
+                                            "xl": 1920,
+                                            "xs": 0,
+                                          },
+                                          "width": [Function],
+                                        },
+                                        "direction": "ltr",
+                                        "mixins": Object {
+                                          "gutters": [Function],
+                                          "toolbar": Object {
+                                            "@media (min-width:0px) and (orientation: landscape)": Object {
+                                              "minHeight": 48,
+                                            },
+                                            "@media (min-width:600px)": Object {
+                                              "minHeight": 64,
+                                            },
+                                            "minHeight": 56,
+                                          },
+                                        },
+                                        "overrides": Object {},
+                                        "palette": Object {
+                                          "action": Object {
+                                            "active": "rgba(0, 0, 0, 0.54)",
+                                            "disabled": "rgba(0, 0, 0, 0.26)",
+                                            "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                                            "hover": "rgba(0, 0, 0, 0.08)",
+                                            "hoverOpacity": 0.08,
+                                            "selected": "rgba(0, 0, 0, 0.14)",
+                                          },
+                                          "augmentColor": [Function],
+                                          "background": Object {
+                                            "default": "#fafafa",
+                                            "paper": "#fff",
+                                          },
+                                          "common": Object {
+                                            "black": "#000",
+                                            "white": "#fff",
+                                          },
+                                          "contrastThreshold": 3,
+                                          "divider": "rgba(0, 0, 0, 0.12)",
+                                          "error": Object {
+                                            "contrastText": "#fff",
+                                            "dark": "#d32f2f",
+                                            "light": "#e57373",
+                                            "main": "#f44336",
+                                          },
+                                          "getContrastText": [Function],
+                                          "grey": Object {
+                                            "100": "#f5f5f5",
+                                            "200": "#eeeeee",
+                                            "300": "#e0e0e0",
+                                            "400": "#bdbdbd",
+                                            "50": "#fafafa",
+                                            "500": "#9e9e9e",
+                                            "600": "#757575",
+                                            "700": "#616161",
+                                            "800": "#424242",
+                                            "900": "#212121",
+                                            "A100": "#d5d5d5",
+                                            "A200": "#aaaaaa",
+                                            "A400": "#303030",
+                                            "A700": "#616161",
+                                          },
+                                          "primary": Object {
+                                            "contrastText": "#fff",
+                                            "dark": "#303f9f",
+                                            "light": "#7986cb",
+                                            "main": "#3f51b5",
+                                          },
+                                          "secondary": Object {
+                                            "contrastText": "#fff",
+                                            "dark": "#c51162",
+                                            "light": "#ff4081",
+                                            "main": "#f50057",
+                                          },
+                                          "text": Object {
+                                            "disabled": "rgba(0, 0, 0, 0.38)",
+                                            "hint": "rgba(0, 0, 0, 0.38)",
+                                            "primary": "rgba(0, 0, 0, 0.87)",
+                                            "secondary": "rgba(0, 0, 0, 0.54)",
+                                          },
+                                          "tonalOffset": 0.2,
+                                          "type": "light",
+                                        },
+                                        "props": Object {},
+                                        "shadows": Array [
+                                          "none",
+                                          "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                                          "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                                          "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                                          "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                                          "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                                          "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                                          "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                                          "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                                          "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                                          "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                                          "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                                          "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                                          "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                                          "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                                          "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                                          "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                                          "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                                          "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                                          "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                                          "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                                          "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                                          "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                                          "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                                          "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+                                        ],
+                                        "shape": Object {
+                                          "borderRadius": 4,
+                                        },
+                                        "spacing": Object {
+                                          "unit": 8,
+                                        },
+                                        "transitions": Object {
+                                          "create": [Function],
+                                          "duration": Object {
+                                            "complex": 375,
+                                            "enteringScreen": 225,
+                                            "leavingScreen": 195,
+                                            "short": 250,
+                                            "shorter": 200,
+                                            "shortest": 150,
+                                            "standard": 300,
+                                          },
+                                          "easing": Object {
+                                            "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                                            "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                                            "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                                            "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                                          },
+                                          "getAutoHeightDuration": [Function],
+                                        },
+                                        "typography": Object {
+                                          "body1": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "0.875rem",
+                                            "fontWeight": 400,
+                                            "lineHeight": "1.46429em",
+                                          },
+                                          "body1Next": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "1rem",
+                                            "fontWeight": 400,
+                                            "letterSpacing": "0.00938em",
+                                            "lineHeight": 1.5,
+                                          },
+                                          "body2": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "0.875rem",
+                                            "fontWeight": 500,
+                                            "lineHeight": "1.71429em",
+                                          },
+                                          "body2Next": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "0.875rem",
+                                            "fontWeight": 400,
+                                            "letterSpacing": "0.01071em",
+                                            "lineHeight": 1.5,
+                                          },
+                                          "button": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "0.875rem",
+                                            "fontWeight": 500,
+                                            "textTransform": "uppercase",
+                                          },
+                                          "buttonNext": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "0.875rem",
+                                            "fontWeight": 500,
+                                            "letterSpacing": "0.02857em",
+                                            "lineHeight": 1.3125,
+                                            "textTransform": "uppercase",
+                                          },
+                                          "caption": Object {
+                                            "color": "rgba(0, 0, 0, 0.54)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "0.75rem",
+                                            "fontWeight": 400,
+                                            "lineHeight": "1.375em",
+                                          },
+                                          "captionNext": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "0.75rem",
+                                            "fontWeight": 400,
+                                            "letterSpacing": "0.03333em",
+                                            "lineHeight": 1.66,
+                                          },
+                                          "display1": Object {
+                                            "color": "rgba(0, 0, 0, 0.54)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "2.125rem",
+                                            "fontWeight": 400,
+                                            "lineHeight": "1.20588em",
+                                          },
+                                          "display2": Object {
+                                            "color": "rgba(0, 0, 0, 0.54)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "2.8125rem",
+                                            "fontWeight": 400,
+                                            "lineHeight": "1.13333em",
+                                            "marginLeft": "-.02em",
+                                          },
+                                          "display3": Object {
+                                            "color": "rgba(0, 0, 0, 0.54)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "3.5rem",
+                                            "fontWeight": 400,
+                                            "letterSpacing": "-.02em",
+                                            "lineHeight": "1.30357em",
+                                            "marginLeft": "-.02em",
+                                          },
+                                          "display4": Object {
+                                            "color": "rgba(0, 0, 0, 0.54)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "7rem",
+                                            "fontWeight": 300,
+                                            "letterSpacing": "-.04em",
+                                            "lineHeight": "1.14286em",
+                                            "marginLeft": "-.04em",
+                                          },
+                                          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                          "fontSize": 14,
+                                          "fontWeightLight": 300,
+                                          "fontWeightMedium": 500,
+                                          "fontWeightRegular": 400,
+                                          "h1": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "6rem",
+                                            "fontWeight": 300,
+                                            "letterSpacing": "-0.01562em",
+                                            "lineHeight": 1,
+                                          },
+                                          "h2": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "3.75rem",
+                                            "fontWeight": 300,
+                                            "letterSpacing": "-0.00833em",
+                                            "lineHeight": 1,
+                                          },
+                                          "h3": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "3rem",
+                                            "fontWeight": 400,
+                                            "letterSpacing": "0em",
+                                            "lineHeight": 1.04,
+                                          },
+                                          "h4": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "2.125rem",
+                                            "fontWeight": 400,
+                                            "letterSpacing": "0.00735em",
+                                            "lineHeight": 1.17,
+                                          },
+                                          "h5": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "1.5rem",
+                                            "fontWeight": 400,
+                                            "letterSpacing": "0em",
+                                            "lineHeight": 1.33,
+                                          },
+                                          "h6": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "1.25rem",
+                                            "fontWeight": 500,
+                                            "letterSpacing": "0.0075em",
+                                            "lineHeight": 1.6,
+                                          },
+                                          "headline": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "1.5rem",
+                                            "fontWeight": 400,
+                                            "lineHeight": "1.35417em",
+                                          },
+                                          "overline": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "0.75rem",
+                                            "fontWeight": 400,
+                                            "letterSpacing": "0.08333em",
+                                            "lineHeight": 2.66,
+                                            "textTransform": "uppercase",
+                                          },
+                                          "pxToRem": [Function],
+                                          "round": [Function],
+                                          "subheading": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "1rem",
+                                            "fontWeight": 400,
+                                            "lineHeight": "1.5em",
+                                          },
+                                          "subtitle1": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "1rem",
+                                            "fontWeight": 400,
+                                            "letterSpacing": "0.00938em",
+                                            "lineHeight": 1.75,
+                                          },
+                                          "subtitle2": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "0.875rem",
+                                            "fontWeight": 500,
+                                            "letterSpacing": "0.00714em",
+                                            "lineHeight": 1.57,
+                                          },
+                                          "title": Object {
+                                            "color": "rgba(0, 0, 0, 0.87)",
+                                            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                                            "fontSize": "1.3125rem",
+                                            "fontWeight": 500,
+                                            "lineHeight": "1.16667em",
+                                          },
+                                          "useNextVariants": false,
+                                        },
+                                        "zIndex": Object {
+                                          "appBar": 1100,
+                                          "drawer": 1200,
+                                          "mobileStepper": 1000,
+                                          "modal": 1300,
+                                          "snackbar": 1400,
+                                          "tooltip": 1500,
+                                        },
+                                      }
+                                    }
+                                  >
+                                    <fieldset
+                                      aria-hidden={true}
+                                      className="MuiPrivateNotchedOutline-root-53 MuiOutlinedInput-notchedOutline-30 filterBorderRadius"
+                                      style={
+                                        Object {
+                                          "paddingLeft": 8,
+                                        }
+                                      }
+                                    >
+                                      <legend
+                                        className="MuiPrivateNotchedOutline-legend-54"
+                                        style={
+                                          Object {
+                                            "width": 0,
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          dangerouslySetInnerHTML={
+                                            Object {
+                                              "__html": "&#8203;",
+                                            }
+                                          }
+                                        />
+                                      </legend>
+                                    </fieldset>
+                                  </NotchedOutline>
+                                </WithStyles(NotchedOutline)>
+                                <WithStyles(InputAdornment)
+                                  position="end"
+                                >
+                                  <InputAdornment
+                                    classes={
+                                      Object {
+                                        "filled": "MuiInputAdornment-filled-56",
+                                        "positionEnd": "MuiInputAdornment-positionEnd-58",
+                                        "positionStart": "MuiInputAdornment-positionStart-57",
+                                        "root": "MuiInputAdornment-root-55",
+                                      }
+                                    }
+                                    component="div"
+                                    disableTypography={false}
+                                    position="end"
+                                  >
+                                    <div
+                                      className="MuiInputAdornment-root-55 MuiInputAdornment-positionEnd-58"
+                                    >
+                                      <pure(FilterListIcon)
+                                        style={
+                                          Object {
+                                            "color": "#80868b",
+                                            "paddingRight": 16,
+                                          }
+                                        }
+                                      >
+                                        <FilterListIcon
+                                          style={
+                                            Object {
+                                              "color": "#80868b",
+                                              "paddingRight": 16,
+                                            }
+                                          }
+                                        >
+                                          <WithStyles(SvgIcon)
+                                            style={
+                                              Object {
+                                                "color": "#80868b",
+                                                "paddingRight": 16,
+                                              }
+                                            }
+                                          >
+                                            <SvgIcon
+                                              classes={
+                                                Object {
+                                                  "colorAction": "MuiSvgIcon-colorAction-62",
+                                                  "colorDisabled": "MuiSvgIcon-colorDisabled-64",
+                                                  "colorError": "MuiSvgIcon-colorError-63",
+                                                  "colorPrimary": "MuiSvgIcon-colorPrimary-60",
+                                                  "colorSecondary": "MuiSvgIcon-colorSecondary-61",
+                                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-65",
+                                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-67",
+                                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-66",
+                                                  "root": "MuiSvgIcon-root-59",
+                                                }
+                                              }
+                                              color="inherit"
+                                              component="svg"
+                                              fontSize="default"
+                                              style={
+                                                Object {
+                                                  "color": "#80868b",
+                                                  "paddingRight": 16,
+                                                }
+                                              }
+                                              viewBox="0 0 24 24"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                className="MuiSvgIcon-root-59"
+                                                focusable="false"
+                                                role="presentation"
+                                                style={
+                                                  Object {
+                                                    "color": "#80868b",
+                                                    "paddingRight": 16,
+                                                  }
+                                                }
+                                                viewBox="0 0 24 24"
+                                              >
+                                                <path
+                                                  d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+                                                />
+                                                <path
+                                                  d="M0 0h24v24H0z"
+                                                  fill="none"
+                                                />
+                                              </svg>
+                                            </SvgIcon>
+                                          </WithStyles(SvgIcon)>
+                                        </FilterListIcon>
+                                      </pure(FilterListIcon)>
+                                    </div>
+                                  </InputAdornment>
+                                </WithStyles(InputAdornment)>
+                                <input
+                                  aria-invalid={false}
+                                  className="MuiInputBase-input-46 MuiOutlinedInput-input-31 MuiInputBase-inputAdornedStart-51 MuiOutlinedInput-inputAdornedStart-34"
+                                  disabled={false}
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  required={false}
+                                  type="text"
+                                  value=""
+                                />
+                              </div>
+                            </InputBase>
+                          </WithFormControlContext(InputBase)>
+                        </WithStyles(WithFormControlContext(InputBase))>
+                      </OutlinedInput>
+                    </WithStyles(OutlinedInput)>
+                  </div>
+                </FormControl>
+              </WithStyles(FormControl)>
+            </TextField>
+          </Component>
+        </div>
         <div
           className="header"
         >
@@ -641,12 +1643,12 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                 checkedIcon={<pure(CheckBox) />}
                 classes={
                   Object {
-                    "checked": "MuiCheckbox-checked-2",
-                    "colorPrimary": "MuiCheckbox-colorPrimary-5",
-                    "colorSecondary": "MuiCheckbox-colorSecondary-6",
-                    "disabled": "MuiCheckbox-disabled-3",
-                    "indeterminate": "MuiCheckbox-indeterminate-4",
-                    "root": "MuiCheckbox-root-1",
+                    "checked": "MuiCheckbox-checked-69",
+                    "colorPrimary": "MuiCheckbox-colorPrimary-72",
+                    "colorSecondary": "MuiCheckbox-colorSecondary-73",
+                    "disabled": "MuiCheckbox-disabled-70",
+                    "indeterminate": "MuiCheckbox-indeterminate-71",
+                    "root": "MuiCheckbox-root-68",
                   }
                 }
                 color="primary"
@@ -661,9 +1663,9 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                   className=""
                   classes={
                     Object {
-                      "checked": "MuiCheckbox-checked-2",
-                      "disabled": "MuiCheckbox-disabled-3",
-                      "root": "MuiCheckbox-root-1 MuiCheckbox-colorPrimary-5",
+                      "checked": "MuiCheckbox-checked-69",
+                      "disabled": "MuiCheckbox-disabled-70",
+                      "root": "MuiCheckbox-root-68 MuiCheckbox-colorPrimary-72",
                     }
                   }
                   icon={<pure(CheckBoxOutlineBlank) />}
@@ -681,10 +1683,10 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                     className=""
                     classes={
                       Object {
-                        "checked": "MuiPrivateSwitchBase-checked-8 MuiCheckbox-checked-2",
-                        "disabled": "MuiPrivateSwitchBase-disabled-9 MuiCheckbox-disabled-3",
-                        "input": "MuiPrivateSwitchBase-input-10",
-                        "root": "MuiPrivateSwitchBase-root-7 MuiCheckbox-root-1 MuiCheckbox-colorPrimary-5",
+                        "checked": "MuiPrivateSwitchBase-checked-75 MuiCheckbox-checked-69",
+                        "disabled": "MuiPrivateSwitchBase-disabled-76 MuiCheckbox-disabled-70",
+                        "input": "MuiPrivateSwitchBase-input-77",
+                        "root": "MuiPrivateSwitchBase-root-74 MuiCheckbox-root-68 MuiCheckbox-colorPrimary-72",
                       }
                     }
                     icon={<pure(CheckBoxOutlineBlank) />}
@@ -702,10 +1704,10 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       className=""
                       classes={
                         Object {
-                          "checked": "MuiPrivateSwitchBase-checked-8 MuiCheckbox-checked-2",
-                          "disabled": "MuiPrivateSwitchBase-disabled-9 MuiCheckbox-disabled-3",
-                          "input": "MuiPrivateSwitchBase-input-10",
-                          "root": "MuiPrivateSwitchBase-root-7 MuiCheckbox-root-1 MuiCheckbox-colorPrimary-5",
+                          "checked": "MuiPrivateSwitchBase-checked-75 MuiCheckbox-checked-69",
+                          "disabled": "MuiPrivateSwitchBase-disabled-76 MuiCheckbox-disabled-70",
+                          "input": "MuiPrivateSwitchBase-input-77",
+                          "root": "MuiPrivateSwitchBase-root-74 MuiCheckbox-root-68 MuiCheckbox-colorPrimary-72",
                         }
                       }
                       icon={<pure(CheckBoxOutlineBlank) />}
@@ -718,22 +1720,22 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       type="checkbox"
                     >
                       <WithStyles(IconButton)
-                        className="MuiPrivateSwitchBase-root-7 MuiCheckbox-root-1 MuiCheckbox-colorPrimary-5"
+                        className="MuiPrivateSwitchBase-root-74 MuiCheckbox-root-68 MuiCheckbox-colorPrimary-72"
                         component="span"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         tabIndex={null}
                       >
                         <IconButton
-                          className="MuiPrivateSwitchBase-root-7 MuiCheckbox-root-1 MuiCheckbox-colorPrimary-5"
+                          className="MuiPrivateSwitchBase-root-74 MuiCheckbox-root-68 MuiCheckbox-colorPrimary-72"
                           classes={
                             Object {
-                              "colorInherit": "MuiIconButton-colorInherit-12",
-                              "colorPrimary": "MuiIconButton-colorPrimary-13",
-                              "colorSecondary": "MuiIconButton-colorSecondary-14",
-                              "disabled": "MuiIconButton-disabled-15",
-                              "label": "MuiIconButton-label-16",
-                              "root": "MuiIconButton-root-11",
+                              "colorInherit": "MuiIconButton-colorInherit-79",
+                              "colorPrimary": "MuiIconButton-colorPrimary-80",
+                              "colorSecondary": "MuiIconButton-colorSecondary-81",
+                              "disabled": "MuiIconButton-disabled-82",
+                              "label": "MuiIconButton-label-83",
+                              "root": "MuiIconButton-root-78",
                             }
                           }
                           color="default"
@@ -745,7 +1747,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                         >
                           <WithStyles(ButtonBase)
                             centerRipple={true}
-                            className="MuiIconButton-root-11 MuiPrivateSwitchBase-root-7 MuiCheckbox-root-1 MuiCheckbox-colorPrimary-5"
+                            className="MuiIconButton-root-78 MuiPrivateSwitchBase-root-74 MuiCheckbox-root-68 MuiCheckbox-colorPrimary-72"
                             component="span"
                             disabled={false}
                             focusRipple={true}
@@ -755,12 +1757,12 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                           >
                             <ButtonBase
                               centerRipple={true}
-                              className="MuiIconButton-root-11 MuiPrivateSwitchBase-root-7 MuiCheckbox-root-1 MuiCheckbox-colorPrimary-5"
+                              className="MuiIconButton-root-78 MuiPrivateSwitchBase-root-74 MuiCheckbox-root-68 MuiCheckbox-colorPrimary-72"
                               classes={
                                 Object {
-                                  "disabled": "MuiButtonBase-disabled-18",
-                                  "focusVisible": "MuiButtonBase-focusVisible-19",
-                                  "root": "MuiButtonBase-root-17",
+                                  "disabled": "MuiButtonBase-disabled-85",
+                                  "focusVisible": "MuiButtonBase-focusVisible-86",
+                                  "root": "MuiButtonBase-root-84",
                                 }
                               }
                               component="span"
@@ -774,7 +1776,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                               type="button"
                             >
                               <span
-                                className="MuiButtonBase-root-17 MuiIconButton-root-11 MuiPrivateSwitchBase-root-7 MuiCheckbox-root-1 MuiCheckbox-colorPrimary-5"
+                                className="MuiButtonBase-root-84 MuiIconButton-root-78 MuiPrivateSwitchBase-root-74 MuiCheckbox-root-68 MuiCheckbox-colorPrimary-72"
                                 onBlur={[Function]}
                                 onContextMenu={[Function]}
                                 onFocus={[Function]}
@@ -789,7 +1791,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                 tabIndex={null}
                               >
                                 <span
-                                  className="MuiIconButton-label-16"
+                                  className="MuiIconButton-label-83"
                                 >
                                   <pure(CheckBoxOutlineBlank)>
                                     <CheckBoxOutlineBlank>
@@ -797,15 +1799,15 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                         <SvgIcon
                                           classes={
                                             Object {
-                                              "colorAction": "MuiSvgIcon-colorAction-23",
-                                              "colorDisabled": "MuiSvgIcon-colorDisabled-25",
-                                              "colorError": "MuiSvgIcon-colorError-24",
-                                              "colorPrimary": "MuiSvgIcon-colorPrimary-21",
-                                              "colorSecondary": "MuiSvgIcon-colorSecondary-22",
-                                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-26",
-                                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-28",
-                                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-27",
-                                              "root": "MuiSvgIcon-root-20",
+                                              "colorAction": "MuiSvgIcon-colorAction-62",
+                                              "colorDisabled": "MuiSvgIcon-colorDisabled-64",
+                                              "colorError": "MuiSvgIcon-colorError-63",
+                                              "colorPrimary": "MuiSvgIcon-colorPrimary-60",
+                                              "colorSecondary": "MuiSvgIcon-colorSecondary-61",
+                                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-65",
+                                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-67",
+                                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-66",
+                                              "root": "MuiSvgIcon-root-59",
                                             }
                                           }
                                           color="inherit"
@@ -815,7 +1817,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                         >
                                           <svg
                                             aria-hidden="true"
-                                            className="MuiSvgIcon-root-20"
+                                            className="MuiSvgIcon-root-59"
                                             focusable="false"
                                             role="presentation"
                                             viewBox="0 0 24 24"
@@ -830,7 +1832,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                   </pure(CheckBoxOutlineBlank)>
                                   <input
                                     checked={false}
-                                    className="MuiPrivateSwitchBase-input-10"
+                                    className="MuiPrivateSwitchBase-input-77"
                                     data-indeterminate={false}
                                     onChange={[Function]}
                                     type="checkbox"
@@ -848,25 +1850,25 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                       center={true}
                                       classes={
                                         Object {
-                                          "child": "MuiTouchRipple-child-91",
-                                          "childLeaving": "MuiTouchRipple-childLeaving-92",
-                                          "childPulsate": "MuiTouchRipple-childPulsate-93",
-                                          "ripple": "MuiTouchRipple-ripple-88",
-                                          "ripplePulsate": "MuiTouchRipple-ripplePulsate-90",
-                                          "rippleVisible": "MuiTouchRipple-rippleVisible-89",
-                                          "root": "MuiTouchRipple-root-87",
+                                          "child": "MuiTouchRipple-child-128",
+                                          "childLeaving": "MuiTouchRipple-childLeaving-129",
+                                          "childPulsate": "MuiTouchRipple-childPulsate-130",
+                                          "ripple": "MuiTouchRipple-ripple-125",
+                                          "ripplePulsate": "MuiTouchRipple-ripplePulsate-127",
+                                          "rippleVisible": "MuiTouchRipple-rippleVisible-126",
+                                          "root": "MuiTouchRipple-root-124",
                                         }
                                       }
                                     >
                                       <TransitionGroup
                                         childFactory={[Function]}
-                                        className="MuiTouchRipple-root-87"
+                                        className="MuiTouchRipple-root-124"
                                         component="span"
                                         enter={true}
                                         exit={true}
                                       >
                                         <span
-                                          className="MuiTouchRipple-root-87"
+                                          className="MuiTouchRipple-root-124"
                                         />
                                       </TransitionGroup>
                                     </TouchRipple>
@@ -900,14 +1902,14 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                 TransitionComponent={[Function]}
                 classes={
                   Object {
-                    "popper": "MuiTooltip-popper-29",
-                    "popperInteractive": "MuiTooltip-popperInteractive-30",
-                    "tooltip": "MuiTooltip-tooltip-31",
-                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-36",
-                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-33",
-                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-34",
-                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-35",
-                    "touch": "MuiTooltip-touch-32",
+                    "popper": "MuiTooltip-popper-87",
+                    "popperInteractive": "MuiTooltip-popperInteractive-88",
+                    "tooltip": "MuiTooltip-tooltip-89",
+                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-94",
+                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-91",
+                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-92",
+                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-93",
+                    "touch": "MuiTooltip-touch-90",
                   }
                 }
                 disableFocusListener={false}
@@ -1307,11 +2309,11 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       className="ellipsis"
                       classes={
                         Object {
-                          "active": "MuiTableSortLabel-active-38",
-                          "icon": "MuiTableSortLabel-icon-39",
-                          "iconDirectionAsc": "MuiTableSortLabel-iconDirectionAsc-41",
-                          "iconDirectionDesc": "MuiTableSortLabel-iconDirectionDesc-40",
-                          "root": "MuiTableSortLabel-root-37",
+                          "active": "MuiTableSortLabel-active-96",
+                          "icon": "MuiTableSortLabel-icon-97",
+                          "iconDirectionAsc": "MuiTableSortLabel-iconDirectionAsc-99",
+                          "iconDirectionDesc": "MuiTableSortLabel-iconDirectionDesc-98",
+                          "root": "MuiTableSortLabel-root-95",
                         }
                       }
                       direction="desc"
@@ -1327,7 +2329,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                     >
                       <WithStyles(ButtonBase)
                         aria-describedby={null}
-                        className="MuiTableSortLabel-root-37 ellipsis"
+                        className="MuiTableSortLabel-root-95 ellipsis"
                         component="span"
                         disableRipple={true}
                         onBlur={[Function]}
@@ -1342,12 +2344,12 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                         <ButtonBase
                           aria-describedby={null}
                           centerRipple={false}
-                          className="MuiTableSortLabel-root-37 ellipsis"
+                          className="MuiTableSortLabel-root-95 ellipsis"
                           classes={
                             Object {
-                              "disabled": "MuiButtonBase-disabled-18",
-                              "focusVisible": "MuiButtonBase-focusVisible-19",
-                              "root": "MuiButtonBase-root-17",
+                              "disabled": "MuiButtonBase-disabled-85",
+                              "focusVisible": "MuiButtonBase-focusVisible-86",
+                              "root": "MuiButtonBase-root-84",
                             }
                           }
                           component="span"
@@ -1367,7 +2369,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                         >
                           <span
                             aria-describedby={null}
-                            className="MuiButtonBase-root-17 MuiTableSortLabel-root-37 ellipsis"
+                            className="MuiButtonBase-root-84 MuiTableSortLabel-root-95 ellipsis"
                             onBlur={[Function]}
                             onClick={[Function]}
                             onContextMenu={[Function]}
@@ -1387,27 +2389,27 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                           >
                             Run name
                             <pure(ArrowDownward)
-                              className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                              className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                             >
                               <ArrowDownward
-                                className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                               >
                                 <WithStyles(SvgIcon)
-                                  className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                  className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                 >
                                   <SvgIcon
-                                    className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                    className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                     classes={
                                       Object {
-                                        "colorAction": "MuiSvgIcon-colorAction-23",
-                                        "colorDisabled": "MuiSvgIcon-colorDisabled-25",
-                                        "colorError": "MuiSvgIcon-colorError-24",
-                                        "colorPrimary": "MuiSvgIcon-colorPrimary-21",
-                                        "colorSecondary": "MuiSvgIcon-colorSecondary-22",
-                                        "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-26",
-                                        "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-28",
-                                        "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-27",
-                                        "root": "MuiSvgIcon-root-20",
+                                        "colorAction": "MuiSvgIcon-colorAction-62",
+                                        "colorDisabled": "MuiSvgIcon-colorDisabled-64",
+                                        "colorError": "MuiSvgIcon-colorError-63",
+                                        "colorPrimary": "MuiSvgIcon-colorPrimary-60",
+                                        "colorSecondary": "MuiSvgIcon-colorSecondary-61",
+                                        "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-65",
+                                        "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-67",
+                                        "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-66",
+                                        "root": "MuiSvgIcon-root-59",
                                       }
                                     }
                                     color="inherit"
@@ -1417,7 +2419,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                   >
                                     <svg
                                       aria-hidden="true"
-                                      className="MuiSvgIcon-root-20 MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                      className="MuiSvgIcon-root-59 MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                       focusable="false"
                                       role="presentation"
                                       viewBox="0 0 24 24"
@@ -1439,7 +2441,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                 <Popper
                   anchorEl={
                     <span
-                      class="MuiButtonBase-root-17 MuiTableSortLabel-root-37 ellipsis"
+                      class="MuiButtonBase-root-84 MuiTableSortLabel-root-95 ellipsis"
                       role="button"
                       tabindex="0"
                       title="Sort"
@@ -1447,7 +2449,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       Run name
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root-20 MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                        class="MuiSvgIcon-root-59 MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                         focusable="false"
                         role="presentation"
                         viewBox="0 0 24 24"
@@ -1458,7 +2460,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       </svg>
                     </span>
                   }
-                  className="MuiTooltip-popper-29"
+                  className="MuiTooltip-popper-87"
                   disablePortal={false}
                   id={null}
                   open={false}
@@ -1485,14 +2487,14 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                 TransitionComponent={[Function]}
                 classes={
                   Object {
-                    "popper": "MuiTooltip-popper-29",
-                    "popperInteractive": "MuiTooltip-popperInteractive-30",
-                    "tooltip": "MuiTooltip-tooltip-31",
-                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-36",
-                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-33",
-                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-34",
-                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-35",
-                    "touch": "MuiTooltip-touch-32",
+                    "popper": "MuiTooltip-popper-87",
+                    "popperInteractive": "MuiTooltip-popperInteractive-88",
+                    "tooltip": "MuiTooltip-tooltip-89",
+                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-94",
+                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-91",
+                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-92",
+                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-93",
+                    "touch": "MuiTooltip-touch-90",
                   }
                 }
                 disableFocusListener={false}
@@ -1891,11 +2893,11 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       className="ellipsis"
                       classes={
                         Object {
-                          "active": "MuiTableSortLabel-active-38",
-                          "icon": "MuiTableSortLabel-icon-39",
-                          "iconDirectionAsc": "MuiTableSortLabel-iconDirectionAsc-41",
-                          "iconDirectionDesc": "MuiTableSortLabel-iconDirectionDesc-40",
-                          "root": "MuiTableSortLabel-root-37",
+                          "active": "MuiTableSortLabel-active-96",
+                          "icon": "MuiTableSortLabel-icon-97",
+                          "iconDirectionAsc": "MuiTableSortLabel-iconDirectionAsc-99",
+                          "iconDirectionDesc": "MuiTableSortLabel-iconDirectionDesc-98",
+                          "root": "MuiTableSortLabel-root-95",
                         }
                       }
                       direction="desc"
@@ -1911,7 +2913,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                     >
                       <WithStyles(ButtonBase)
                         aria-describedby={null}
-                        className="MuiTableSortLabel-root-37 ellipsis"
+                        className="MuiTableSortLabel-root-95 ellipsis"
                         component="span"
                         disableRipple={true}
                         onBlur={[Function]}
@@ -1926,12 +2928,12 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                         <ButtonBase
                           aria-describedby={null}
                           centerRipple={false}
-                          className="MuiTableSortLabel-root-37 ellipsis"
+                          className="MuiTableSortLabel-root-95 ellipsis"
                           classes={
                             Object {
-                              "disabled": "MuiButtonBase-disabled-18",
-                              "focusVisible": "MuiButtonBase-focusVisible-19",
-                              "root": "MuiButtonBase-root-17",
+                              "disabled": "MuiButtonBase-disabled-85",
+                              "focusVisible": "MuiButtonBase-focusVisible-86",
+                              "root": "MuiButtonBase-root-84",
                             }
                           }
                           component="span"
@@ -1951,7 +2953,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                         >
                           <span
                             aria-describedby={null}
-                            className="MuiButtonBase-root-17 MuiTableSortLabel-root-37 ellipsis"
+                            className="MuiButtonBase-root-84 MuiTableSortLabel-root-95 ellipsis"
                             onBlur={[Function]}
                             onClick={[Function]}
                             onContextMenu={[Function]}
@@ -1971,27 +2973,27 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                           >
                             Status
                             <pure(ArrowDownward)
-                              className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                              className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                             >
                               <ArrowDownward
-                                className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                               >
                                 <WithStyles(SvgIcon)
-                                  className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                  className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                 >
                                   <SvgIcon
-                                    className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                    className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                     classes={
                                       Object {
-                                        "colorAction": "MuiSvgIcon-colorAction-23",
-                                        "colorDisabled": "MuiSvgIcon-colorDisabled-25",
-                                        "colorError": "MuiSvgIcon-colorError-24",
-                                        "colorPrimary": "MuiSvgIcon-colorPrimary-21",
-                                        "colorSecondary": "MuiSvgIcon-colorSecondary-22",
-                                        "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-26",
-                                        "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-28",
-                                        "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-27",
-                                        "root": "MuiSvgIcon-root-20",
+                                        "colorAction": "MuiSvgIcon-colorAction-62",
+                                        "colorDisabled": "MuiSvgIcon-colorDisabled-64",
+                                        "colorError": "MuiSvgIcon-colorError-63",
+                                        "colorPrimary": "MuiSvgIcon-colorPrimary-60",
+                                        "colorSecondary": "MuiSvgIcon-colorSecondary-61",
+                                        "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-65",
+                                        "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-67",
+                                        "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-66",
+                                        "root": "MuiSvgIcon-root-59",
                                       }
                                     }
                                     color="inherit"
@@ -2001,7 +3003,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                   >
                                     <svg
                                       aria-hidden="true"
-                                      className="MuiSvgIcon-root-20 MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                      className="MuiSvgIcon-root-59 MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                       focusable="false"
                                       role="presentation"
                                       viewBox="0 0 24 24"
@@ -2023,7 +3025,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                 <Popper
                   anchorEl={
                     <span
-                      class="MuiButtonBase-root-17 MuiTableSortLabel-root-37 ellipsis"
+                      class="MuiButtonBase-root-84 MuiTableSortLabel-root-95 ellipsis"
                       role="button"
                       tabindex="0"
                       title="Cannot sort by this column"
@@ -2031,7 +3033,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       Status
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root-20 MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                        class="MuiSvgIcon-root-59 MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                         focusable="false"
                         role="presentation"
                         viewBox="0 0 24 24"
@@ -2042,7 +3044,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       </svg>
                     </span>
                   }
-                  className="MuiTooltip-popper-29"
+                  className="MuiTooltip-popper-87"
                   disablePortal={false}
                   id={null}
                   open={false}
@@ -2069,14 +3071,14 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                 TransitionComponent={[Function]}
                 classes={
                   Object {
-                    "popper": "MuiTooltip-popper-29",
-                    "popperInteractive": "MuiTooltip-popperInteractive-30",
-                    "tooltip": "MuiTooltip-tooltip-31",
-                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-36",
-                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-33",
-                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-34",
-                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-35",
-                    "touch": "MuiTooltip-touch-32",
+                    "popper": "MuiTooltip-popper-87",
+                    "popperInteractive": "MuiTooltip-popperInteractive-88",
+                    "tooltip": "MuiTooltip-tooltip-89",
+                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-94",
+                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-91",
+                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-92",
+                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-93",
+                    "touch": "MuiTooltip-touch-90",
                   }
                 }
                 disableFocusListener={false}
@@ -2475,11 +3477,11 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       className="ellipsis"
                       classes={
                         Object {
-                          "active": "MuiTableSortLabel-active-38",
-                          "icon": "MuiTableSortLabel-icon-39",
-                          "iconDirectionAsc": "MuiTableSortLabel-iconDirectionAsc-41",
-                          "iconDirectionDesc": "MuiTableSortLabel-iconDirectionDesc-40",
-                          "root": "MuiTableSortLabel-root-37",
+                          "active": "MuiTableSortLabel-active-96",
+                          "icon": "MuiTableSortLabel-icon-97",
+                          "iconDirectionAsc": "MuiTableSortLabel-iconDirectionAsc-99",
+                          "iconDirectionDesc": "MuiTableSortLabel-iconDirectionDesc-98",
+                          "root": "MuiTableSortLabel-root-95",
                         }
                       }
                       direction="desc"
@@ -2495,7 +3497,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                     >
                       <WithStyles(ButtonBase)
                         aria-describedby={null}
-                        className="MuiTableSortLabel-root-37 ellipsis"
+                        className="MuiTableSortLabel-root-95 ellipsis"
                         component="span"
                         disableRipple={true}
                         onBlur={[Function]}
@@ -2510,12 +3512,12 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                         <ButtonBase
                           aria-describedby={null}
                           centerRipple={false}
-                          className="MuiTableSortLabel-root-37 ellipsis"
+                          className="MuiTableSortLabel-root-95 ellipsis"
                           classes={
                             Object {
-                              "disabled": "MuiButtonBase-disabled-18",
-                              "focusVisible": "MuiButtonBase-focusVisible-19",
-                              "root": "MuiButtonBase-root-17",
+                              "disabled": "MuiButtonBase-disabled-85",
+                              "focusVisible": "MuiButtonBase-focusVisible-86",
+                              "root": "MuiButtonBase-root-84",
                             }
                           }
                           component="span"
@@ -2535,7 +3537,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                         >
                           <span
                             aria-describedby={null}
-                            className="MuiButtonBase-root-17 MuiTableSortLabel-root-37 ellipsis"
+                            className="MuiButtonBase-root-84 MuiTableSortLabel-root-95 ellipsis"
                             onBlur={[Function]}
                             onClick={[Function]}
                             onContextMenu={[Function]}
@@ -2555,27 +3557,27 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                           >
                             Duration
                             <pure(ArrowDownward)
-                              className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                              className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                             >
                               <ArrowDownward
-                                className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                               >
                                 <WithStyles(SvgIcon)
-                                  className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                  className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                 >
                                   <SvgIcon
-                                    className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                    className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                     classes={
                                       Object {
-                                        "colorAction": "MuiSvgIcon-colorAction-23",
-                                        "colorDisabled": "MuiSvgIcon-colorDisabled-25",
-                                        "colorError": "MuiSvgIcon-colorError-24",
-                                        "colorPrimary": "MuiSvgIcon-colorPrimary-21",
-                                        "colorSecondary": "MuiSvgIcon-colorSecondary-22",
-                                        "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-26",
-                                        "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-28",
-                                        "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-27",
-                                        "root": "MuiSvgIcon-root-20",
+                                        "colorAction": "MuiSvgIcon-colorAction-62",
+                                        "colorDisabled": "MuiSvgIcon-colorDisabled-64",
+                                        "colorError": "MuiSvgIcon-colorError-63",
+                                        "colorPrimary": "MuiSvgIcon-colorPrimary-60",
+                                        "colorSecondary": "MuiSvgIcon-colorSecondary-61",
+                                        "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-65",
+                                        "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-67",
+                                        "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-66",
+                                        "root": "MuiSvgIcon-root-59",
                                       }
                                     }
                                     color="inherit"
@@ -2585,7 +3587,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                   >
                                     <svg
                                       aria-hidden="true"
-                                      className="MuiSvgIcon-root-20 MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                      className="MuiSvgIcon-root-59 MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                       focusable="false"
                                       role="presentation"
                                       viewBox="0 0 24 24"
@@ -2607,7 +3609,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                 <Popper
                   anchorEl={
                     <span
-                      class="MuiButtonBase-root-17 MuiTableSortLabel-root-37 ellipsis"
+                      class="MuiButtonBase-root-84 MuiTableSortLabel-root-95 ellipsis"
                       role="button"
                       tabindex="0"
                       title="Cannot sort by this column"
@@ -2615,7 +3617,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       Duration
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root-20 MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                        class="MuiSvgIcon-root-59 MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                         focusable="false"
                         role="presentation"
                         viewBox="0 0 24 24"
@@ -2626,7 +3628,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       </svg>
                     </span>
                   }
-                  className="MuiTooltip-popper-29"
+                  className="MuiTooltip-popper-87"
                   disablePortal={false}
                   id={null}
                   open={false}
@@ -2653,14 +3655,14 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                 TransitionComponent={[Function]}
                 classes={
                   Object {
-                    "popper": "MuiTooltip-popper-29",
-                    "popperInteractive": "MuiTooltip-popperInteractive-30",
-                    "tooltip": "MuiTooltip-tooltip-31",
-                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-36",
-                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-33",
-                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-34",
-                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-35",
-                    "touch": "MuiTooltip-touch-32",
+                    "popper": "MuiTooltip-popper-87",
+                    "popperInteractive": "MuiTooltip-popperInteractive-88",
+                    "tooltip": "MuiTooltip-tooltip-89",
+                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-94",
+                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-91",
+                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-92",
+                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-93",
+                    "touch": "MuiTooltip-touch-90",
                   }
                 }
                 disableFocusListener={false}
@@ -3059,11 +4061,11 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       className="ellipsis"
                       classes={
                         Object {
-                          "active": "MuiTableSortLabel-active-38",
-                          "icon": "MuiTableSortLabel-icon-39",
-                          "iconDirectionAsc": "MuiTableSortLabel-iconDirectionAsc-41",
-                          "iconDirectionDesc": "MuiTableSortLabel-iconDirectionDesc-40",
-                          "root": "MuiTableSortLabel-root-37",
+                          "active": "MuiTableSortLabel-active-96",
+                          "icon": "MuiTableSortLabel-icon-97",
+                          "iconDirectionAsc": "MuiTableSortLabel-iconDirectionAsc-99",
+                          "iconDirectionDesc": "MuiTableSortLabel-iconDirectionDesc-98",
+                          "root": "MuiTableSortLabel-root-95",
                         }
                       }
                       direction="desc"
@@ -3079,7 +4081,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                     >
                       <WithStyles(ButtonBase)
                         aria-describedby={null}
-                        className="MuiTableSortLabel-root-37 ellipsis"
+                        className="MuiTableSortLabel-root-95 ellipsis"
                         component="span"
                         disableRipple={true}
                         onBlur={[Function]}
@@ -3094,12 +4096,12 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                         <ButtonBase
                           aria-describedby={null}
                           centerRipple={false}
-                          className="MuiTableSortLabel-root-37 ellipsis"
+                          className="MuiTableSortLabel-root-95 ellipsis"
                           classes={
                             Object {
-                              "disabled": "MuiButtonBase-disabled-18",
-                              "focusVisible": "MuiButtonBase-focusVisible-19",
-                              "root": "MuiButtonBase-root-17",
+                              "disabled": "MuiButtonBase-disabled-85",
+                              "focusVisible": "MuiButtonBase-focusVisible-86",
+                              "root": "MuiButtonBase-root-84",
                             }
                           }
                           component="span"
@@ -3119,7 +4121,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                         >
                           <span
                             aria-describedby={null}
-                            className="MuiButtonBase-root-17 MuiTableSortLabel-root-37 ellipsis"
+                            className="MuiButtonBase-root-84 MuiTableSortLabel-root-95 ellipsis"
                             onBlur={[Function]}
                             onClick={[Function]}
                             onContextMenu={[Function]}
@@ -3139,27 +4141,27 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                           >
                             Experiment
                             <pure(ArrowDownward)
-                              className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                              className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                             >
                               <ArrowDownward
-                                className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                               >
                                 <WithStyles(SvgIcon)
-                                  className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                  className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                 >
                                   <SvgIcon
-                                    className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                    className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                     classes={
                                       Object {
-                                        "colorAction": "MuiSvgIcon-colorAction-23",
-                                        "colorDisabled": "MuiSvgIcon-colorDisabled-25",
-                                        "colorError": "MuiSvgIcon-colorError-24",
-                                        "colorPrimary": "MuiSvgIcon-colorPrimary-21",
-                                        "colorSecondary": "MuiSvgIcon-colorSecondary-22",
-                                        "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-26",
-                                        "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-28",
-                                        "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-27",
-                                        "root": "MuiSvgIcon-root-20",
+                                        "colorAction": "MuiSvgIcon-colorAction-62",
+                                        "colorDisabled": "MuiSvgIcon-colorDisabled-64",
+                                        "colorError": "MuiSvgIcon-colorError-63",
+                                        "colorPrimary": "MuiSvgIcon-colorPrimary-60",
+                                        "colorSecondary": "MuiSvgIcon-colorSecondary-61",
+                                        "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-65",
+                                        "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-67",
+                                        "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-66",
+                                        "root": "MuiSvgIcon-root-59",
                                       }
                                     }
                                     color="inherit"
@@ -3169,7 +4171,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                   >
                                     <svg
                                       aria-hidden="true"
-                                      className="MuiSvgIcon-root-20 MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                      className="MuiSvgIcon-root-59 MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                       focusable="false"
                                       role="presentation"
                                       viewBox="0 0 24 24"
@@ -3191,7 +4193,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                 <Popper
                   anchorEl={
                     <span
-                      class="MuiButtonBase-root-17 MuiTableSortLabel-root-37 ellipsis"
+                      class="MuiButtonBase-root-84 MuiTableSortLabel-root-95 ellipsis"
                       role="button"
                       tabindex="0"
                       title="Cannot sort by this column"
@@ -3199,7 +4201,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       Experiment
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root-20 MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                        class="MuiSvgIcon-root-59 MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                         focusable="false"
                         role="presentation"
                         viewBox="0 0 24 24"
@@ -3210,7 +4212,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       </svg>
                     </span>
                   }
-                  className="MuiTooltip-popper-29"
+                  className="MuiTooltip-popper-87"
                   disablePortal={false}
                   id={null}
                   open={false}
@@ -3237,14 +4239,14 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                 TransitionComponent={[Function]}
                 classes={
                   Object {
-                    "popper": "MuiTooltip-popper-29",
-                    "popperInteractive": "MuiTooltip-popperInteractive-30",
-                    "tooltip": "MuiTooltip-tooltip-31",
-                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-36",
-                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-33",
-                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-34",
-                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-35",
-                    "touch": "MuiTooltip-touch-32",
+                    "popper": "MuiTooltip-popper-87",
+                    "popperInteractive": "MuiTooltip-popperInteractive-88",
+                    "tooltip": "MuiTooltip-tooltip-89",
+                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-94",
+                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-91",
+                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-92",
+                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-93",
+                    "touch": "MuiTooltip-touch-90",
                   }
                 }
                 disableFocusListener={false}
@@ -3643,11 +4645,11 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       className="ellipsis"
                       classes={
                         Object {
-                          "active": "MuiTableSortLabel-active-38",
-                          "icon": "MuiTableSortLabel-icon-39",
-                          "iconDirectionAsc": "MuiTableSortLabel-iconDirectionAsc-41",
-                          "iconDirectionDesc": "MuiTableSortLabel-iconDirectionDesc-40",
-                          "root": "MuiTableSortLabel-root-37",
+                          "active": "MuiTableSortLabel-active-96",
+                          "icon": "MuiTableSortLabel-icon-97",
+                          "iconDirectionAsc": "MuiTableSortLabel-iconDirectionAsc-99",
+                          "iconDirectionDesc": "MuiTableSortLabel-iconDirectionDesc-98",
+                          "root": "MuiTableSortLabel-root-95",
                         }
                       }
                       direction="desc"
@@ -3663,7 +4665,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                     >
                       <WithStyles(ButtonBase)
                         aria-describedby={null}
-                        className="MuiTableSortLabel-root-37 ellipsis"
+                        className="MuiTableSortLabel-root-95 ellipsis"
                         component="span"
                         disableRipple={true}
                         onBlur={[Function]}
@@ -3678,12 +4680,12 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                         <ButtonBase
                           aria-describedby={null}
                           centerRipple={false}
-                          className="MuiTableSortLabel-root-37 ellipsis"
+                          className="MuiTableSortLabel-root-95 ellipsis"
                           classes={
                             Object {
-                              "disabled": "MuiButtonBase-disabled-18",
-                              "focusVisible": "MuiButtonBase-focusVisible-19",
-                              "root": "MuiButtonBase-root-17",
+                              "disabled": "MuiButtonBase-disabled-85",
+                              "focusVisible": "MuiButtonBase-focusVisible-86",
+                              "root": "MuiButtonBase-root-84",
                             }
                           }
                           component="span"
@@ -3703,7 +4705,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                         >
                           <span
                             aria-describedby={null}
-                            className="MuiButtonBase-root-17 MuiTableSortLabel-root-37 ellipsis"
+                            className="MuiButtonBase-root-84 MuiTableSortLabel-root-95 ellipsis"
                             onBlur={[Function]}
                             onClick={[Function]}
                             onContextMenu={[Function]}
@@ -3723,27 +4725,27 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                           >
                             Pipeline
                             <pure(ArrowDownward)
-                              className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                              className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                             >
                               <ArrowDownward
-                                className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                               >
                                 <WithStyles(SvgIcon)
-                                  className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                  className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                 >
                                   <SvgIcon
-                                    className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                    className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                     classes={
                                       Object {
-                                        "colorAction": "MuiSvgIcon-colorAction-23",
-                                        "colorDisabled": "MuiSvgIcon-colorDisabled-25",
-                                        "colorError": "MuiSvgIcon-colorError-24",
-                                        "colorPrimary": "MuiSvgIcon-colorPrimary-21",
-                                        "colorSecondary": "MuiSvgIcon-colorSecondary-22",
-                                        "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-26",
-                                        "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-28",
-                                        "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-27",
-                                        "root": "MuiSvgIcon-root-20",
+                                        "colorAction": "MuiSvgIcon-colorAction-62",
+                                        "colorDisabled": "MuiSvgIcon-colorDisabled-64",
+                                        "colorError": "MuiSvgIcon-colorError-63",
+                                        "colorPrimary": "MuiSvgIcon-colorPrimary-60",
+                                        "colorSecondary": "MuiSvgIcon-colorSecondary-61",
+                                        "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-65",
+                                        "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-67",
+                                        "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-66",
+                                        "root": "MuiSvgIcon-root-59",
                                       }
                                     }
                                     color="inherit"
@@ -3753,7 +4755,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                   >
                                     <svg
                                       aria-hidden="true"
-                                      className="MuiSvgIcon-root-20 MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                      className="MuiSvgIcon-root-59 MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                       focusable="false"
                                       role="presentation"
                                       viewBox="0 0 24 24"
@@ -3775,7 +4777,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                 <Popper
                   anchorEl={
                     <span
-                      class="MuiButtonBase-root-17 MuiTableSortLabel-root-37 ellipsis"
+                      class="MuiButtonBase-root-84 MuiTableSortLabel-root-95 ellipsis"
                       role="button"
                       tabindex="0"
                       title="Cannot sort by this column"
@@ -3783,7 +4785,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       Pipeline
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root-20 MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                        class="MuiSvgIcon-root-59 MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                         focusable="false"
                         role="presentation"
                         viewBox="0 0 24 24"
@@ -3794,7 +4796,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       </svg>
                     </span>
                   }
-                  className="MuiTooltip-popper-29"
+                  className="MuiTooltip-popper-87"
                   disablePortal={false}
                   id={null}
                   open={false}
@@ -3821,14 +4823,14 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                 TransitionComponent={[Function]}
                 classes={
                   Object {
-                    "popper": "MuiTooltip-popper-29",
-                    "popperInteractive": "MuiTooltip-popperInteractive-30",
-                    "tooltip": "MuiTooltip-tooltip-31",
-                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-36",
-                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-33",
-                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-34",
-                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-35",
-                    "touch": "MuiTooltip-touch-32",
+                    "popper": "MuiTooltip-popper-87",
+                    "popperInteractive": "MuiTooltip-popperInteractive-88",
+                    "tooltip": "MuiTooltip-tooltip-89",
+                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-94",
+                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-91",
+                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-92",
+                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-93",
+                    "touch": "MuiTooltip-touch-90",
                   }
                 }
                 disableFocusListener={false}
@@ -4228,11 +5230,11 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       className="ellipsis"
                       classes={
                         Object {
-                          "active": "MuiTableSortLabel-active-38",
-                          "icon": "MuiTableSortLabel-icon-39",
-                          "iconDirectionAsc": "MuiTableSortLabel-iconDirectionAsc-41",
-                          "iconDirectionDesc": "MuiTableSortLabel-iconDirectionDesc-40",
-                          "root": "MuiTableSortLabel-root-37",
+                          "active": "MuiTableSortLabel-active-96",
+                          "icon": "MuiTableSortLabel-icon-97",
+                          "iconDirectionAsc": "MuiTableSortLabel-iconDirectionAsc-99",
+                          "iconDirectionDesc": "MuiTableSortLabel-iconDirectionDesc-98",
+                          "root": "MuiTableSortLabel-root-95",
                         }
                       }
                       direction="desc"
@@ -4248,7 +5250,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                     >
                       <WithStyles(ButtonBase)
                         aria-describedby={null}
-                        className="MuiTableSortLabel-root-37 MuiTableSortLabel-active-38 ellipsis"
+                        className="MuiTableSortLabel-root-95 MuiTableSortLabel-active-96 ellipsis"
                         component="span"
                         disableRipple={true}
                         onBlur={[Function]}
@@ -4263,12 +5265,12 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                         <ButtonBase
                           aria-describedby={null}
                           centerRipple={false}
-                          className="MuiTableSortLabel-root-37 MuiTableSortLabel-active-38 ellipsis"
+                          className="MuiTableSortLabel-root-95 MuiTableSortLabel-active-96 ellipsis"
                           classes={
                             Object {
-                              "disabled": "MuiButtonBase-disabled-18",
-                              "focusVisible": "MuiButtonBase-focusVisible-19",
-                              "root": "MuiButtonBase-root-17",
+                              "disabled": "MuiButtonBase-disabled-85",
+                              "focusVisible": "MuiButtonBase-focusVisible-86",
+                              "root": "MuiButtonBase-root-84",
                             }
                           }
                           component="span"
@@ -4288,7 +5290,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                         >
                           <span
                             aria-describedby={null}
-                            className="MuiButtonBase-root-17 MuiTableSortLabel-root-37 MuiTableSortLabel-active-38 ellipsis"
+                            className="MuiButtonBase-root-84 MuiTableSortLabel-root-95 MuiTableSortLabel-active-96 ellipsis"
                             onBlur={[Function]}
                             onClick={[Function]}
                             onContextMenu={[Function]}
@@ -4308,27 +5310,27 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                           >
                             Start time
                             <pure(ArrowDownward)
-                              className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                              className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                             >
                               <ArrowDownward
-                                className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                               >
                                 <WithStyles(SvgIcon)
-                                  className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                  className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                 >
                                   <SvgIcon
-                                    className="MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                    className="MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                     classes={
                                       Object {
-                                        "colorAction": "MuiSvgIcon-colorAction-23",
-                                        "colorDisabled": "MuiSvgIcon-colorDisabled-25",
-                                        "colorError": "MuiSvgIcon-colorError-24",
-                                        "colorPrimary": "MuiSvgIcon-colorPrimary-21",
-                                        "colorSecondary": "MuiSvgIcon-colorSecondary-22",
-                                        "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-26",
-                                        "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-28",
-                                        "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-27",
-                                        "root": "MuiSvgIcon-root-20",
+                                        "colorAction": "MuiSvgIcon-colorAction-62",
+                                        "colorDisabled": "MuiSvgIcon-colorDisabled-64",
+                                        "colorError": "MuiSvgIcon-colorError-63",
+                                        "colorPrimary": "MuiSvgIcon-colorPrimary-60",
+                                        "colorSecondary": "MuiSvgIcon-colorSecondary-61",
+                                        "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-65",
+                                        "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-67",
+                                        "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-66",
+                                        "root": "MuiSvgIcon-root-59",
                                       }
                                     }
                                     color="inherit"
@@ -4338,7 +5340,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                   >
                                     <svg
                                       aria-hidden="true"
-                                      className="MuiSvgIcon-root-20 MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                                      className="MuiSvgIcon-root-59 MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                                       focusable="false"
                                       role="presentation"
                                       viewBox="0 0 24 24"
@@ -4360,7 +5362,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                 <Popper
                   anchorEl={
                     <span
-                      class="MuiButtonBase-root-17 MuiTableSortLabel-root-37 MuiTableSortLabel-active-38 ellipsis"
+                      class="MuiButtonBase-root-84 MuiTableSortLabel-root-95 MuiTableSortLabel-active-96 ellipsis"
                       role="button"
                       tabindex="0"
                       title="Sort"
@@ -4368,7 +5370,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       Start time
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root-20 MuiTableSortLabel-icon-39 MuiTableSortLabel-iconDirectionDesc-40"
+                        class="MuiSvgIcon-root-59 MuiTableSortLabel-icon-97 MuiTableSortLabel-iconDirectionDesc-98"
                         focusable="false"
                         role="presentation"
                         viewBox="0 0 24 24"
@@ -4379,7 +5381,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                       </svg>
                     </span>
                   }
-                  className="MuiTooltip-popper-29"
+                  className="MuiTooltip-popper-87"
                   disablePortal={false}
                   id={null}
                   open={false}
@@ -4419,6 +5421,11 @@ exports[`RunList reloads the run when refresh is called 1`] = `
               }
             }
             className="rowsPerPage"
+            classes={
+              Object {
+                "root": "verticalAlignInitial",
+              }
+            }
             onChange={[Function]}
             required={false}
             select={true}
@@ -4427,6 +5434,11 @@ exports[`RunList reloads the run when refresh is called 1`] = `
           >
             <WithStyles(FormControl)
               className="rowsPerPage"
+              classes={
+                Object {
+                  "root": "verticalAlignInitial",
+                }
+              }
               required={false}
               variant="standard"
             >
@@ -4434,10 +5446,10 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                 className="rowsPerPage"
                 classes={
                   Object {
-                    "fullWidth": "MuiFormControl-fullWidth-45",
-                    "marginDense": "MuiFormControl-marginDense-44",
-                    "marginNormal": "MuiFormControl-marginNormal-43",
-                    "root": "MuiFormControl-root-42",
+                    "fullWidth": "MuiFormControl-fullWidth-4",
+                    "marginDense": "MuiFormControl-marginDense-3",
+                    "marginNormal": "MuiFormControl-marginNormal-2",
+                    "root": "MuiFormControl-root-1 verticalAlignInitial",
                   }
                 }
                 component="div"
@@ -4449,7 +5461,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                 variant="standard"
               >
                 <div
-                  className="MuiFormControl-root-42 rowsPerPage"
+                  className="MuiFormControl-root-1 verticalAlignInitial rowsPerPage"
                 >
                   <WithStyles(WithFormControlContext(Select))
                     input={
@@ -4479,13 +5491,13 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                     <WithFormControlContext(Select)
                       classes={
                         Object {
-                          "disabled": "MuiSelect-disabled-51",
-                          "filled": "MuiSelect-filled-48",
-                          "icon": "MuiSelect-icon-52",
-                          "outlined": "MuiSelect-outlined-49",
-                          "root": "MuiSelect-root-46",
-                          "select": "MuiSelect-select-47",
-                          "selectMenu": "MuiSelect-selectMenu-50",
+                          "disabled": "MuiSelect-disabled-105",
+                          "filled": "MuiSelect-filled-102",
+                          "icon": "MuiSelect-icon-106",
+                          "outlined": "MuiSelect-outlined-103",
+                          "root": "MuiSelect-root-100",
+                          "select": "MuiSelect-select-101",
+                          "selectMenu": "MuiSelect-selectMenu-104",
                         }
                       }
                       input={
@@ -4517,13 +5529,13 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                         autoWidth={false}
                         classes={
                           Object {
-                            "disabled": "MuiSelect-disabled-51",
-                            "filled": "MuiSelect-filled-48",
-                            "icon": "MuiSelect-icon-52",
-                            "outlined": "MuiSelect-outlined-49",
-                            "root": "MuiSelect-root-46",
-                            "select": "MuiSelect-select-47",
-                            "selectMenu": "MuiSelect-selectMenu-50",
+                            "disabled": "MuiSelect-disabled-105",
+                            "filled": "MuiSelect-filled-102",
+                            "icon": "MuiSelect-icon-106",
+                            "outlined": "MuiSelect-outlined-103",
+                            "root": "MuiSelect-root-100",
+                            "select": "MuiSelect-select-101",
+                            "selectMenu": "MuiSelect-selectMenu-104",
                           }
                         }
                         displayEmpty={false}
@@ -4601,13 +5613,13 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                 </WithStyles(MenuItem)>,
                               ],
                               "classes": Object {
-                                "disabled": "MuiSelect-disabled-51",
-                                "filled": "MuiSelect-filled-48",
-                                "icon": "MuiSelect-icon-52",
-                                "outlined": "MuiSelect-outlined-49",
-                                "root": "MuiSelect-root-46",
-                                "select": "MuiSelect-select-47",
-                                "selectMenu": "MuiSelect-selectMenu-50",
+                                "disabled": "MuiSelect-disabled-105",
+                                "filled": "MuiSelect-filled-102",
+                                "icon": "MuiSelect-icon-106",
+                                "outlined": "MuiSelect-outlined-103",
+                                "root": "MuiSelect-root-100",
+                                "select": "MuiSelect-select-101",
+                                "selectMenu": "MuiSelect-selectMenu-104",
                               },
                               "displayEmpty": false,
                               "multiple": false,
@@ -4625,19 +5637,19 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                           <Input
                             classes={
                               Object {
-                                "disabled": "MuiInput-disabled-56",
-                                "error": "MuiInput-error-58",
-                                "focused": "MuiInput-focused-55",
-                                "formControl": "MuiInput-formControl-54",
-                                "fullWidth": "MuiInput-fullWidth-60",
-                                "input": "MuiInput-input-61",
-                                "inputMarginDense": "MuiInput-inputMarginDense-62",
-                                "inputMultiline": "MuiInput-inputMultiline-63",
-                                "inputType": "MuiInput-inputType-64",
-                                "inputTypeSearch": "MuiInput-inputTypeSearch-65",
-                                "multiline": "MuiInput-multiline-59",
-                                "root": "MuiInput-root-53",
-                                "underline": "MuiInput-underline-57",
+                                "disabled": "MuiInput-disabled-110",
+                                "error": "MuiInput-error-112",
+                                "focused": "MuiInput-focused-109",
+                                "formControl": "MuiInput-formControl-108",
+                                "fullWidth": "MuiInput-fullWidth-114",
+                                "input": "MuiInput-input-115",
+                                "inputMarginDense": "MuiInput-inputMarginDense-116",
+                                "inputMultiline": "MuiInput-inputMultiline-117",
+                                "inputType": "MuiInput-inputType-118",
+                                "inputTypeSearch": "MuiInput-inputTypeSearch-119",
+                                "multiline": "MuiInput-multiline-113",
+                                "root": "MuiInput-root-107",
+                                "underline": "MuiInput-underline-111",
                               }
                             }
                             disableUnderline={true}
@@ -4671,13 +5683,13 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                   </WithStyles(MenuItem)>,
                                 ],
                                 "classes": Object {
-                                  "disabled": "MuiSelect-disabled-51",
-                                  "filled": "MuiSelect-filled-48",
-                                  "icon": "MuiSelect-icon-52",
-                                  "outlined": "MuiSelect-outlined-49",
-                                  "root": "MuiSelect-root-46",
-                                  "select": "MuiSelect-select-47",
-                                  "selectMenu": "MuiSelect-selectMenu-50",
+                                  "disabled": "MuiSelect-disabled-105",
+                                  "filled": "MuiSelect-filled-102",
+                                  "icon": "MuiSelect-icon-106",
+                                  "outlined": "MuiSelect-outlined-103",
+                                  "root": "MuiSelect-root-100",
+                                  "select": "MuiSelect-select-101",
+                                  "selectMenu": "MuiSelect-selectMenu-104",
                                 },
                                 "displayEmpty": false,
                                 "multiple": false,
@@ -4695,18 +5707,18 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                             <WithStyles(WithFormControlContext(InputBase))
                               classes={
                                 Object {
-                                  "disabled": "MuiInput-disabled-56",
-                                  "error": "MuiInput-error-58",
-                                  "focused": "MuiInput-focused-55",
-                                  "formControl": "MuiInput-formControl-54",
-                                  "fullWidth": "MuiInput-fullWidth-60",
-                                  "input": "MuiInput-input-61",
-                                  "inputMarginDense": "MuiInput-inputMarginDense-62",
-                                  "inputMultiline": "MuiInput-inputMultiline-63",
-                                  "inputType": "MuiInput-inputType-64",
-                                  "inputTypeSearch": "MuiInput-inputTypeSearch-65",
-                                  "multiline": "MuiInput-multiline-59",
-                                  "root": "MuiInput-root-53",
+                                  "disabled": "MuiInput-disabled-110",
+                                  "error": "MuiInput-error-112",
+                                  "focused": "MuiInput-focused-109",
+                                  "formControl": "MuiInput-formControl-108",
+                                  "fullWidth": "MuiInput-fullWidth-114",
+                                  "input": "MuiInput-input-115",
+                                  "inputMarginDense": "MuiInput-inputMarginDense-116",
+                                  "inputMultiline": "MuiInput-inputMultiline-117",
+                                  "inputType": "MuiInput-inputType-118",
+                                  "inputTypeSearch": "MuiInput-inputTypeSearch-119",
+                                  "multiline": "MuiInput-multiline-113",
+                                  "root": "MuiInput-root-107",
                                   "underline": null,
                                 }
                               }
@@ -4741,13 +5753,13 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                     </WithStyles(MenuItem)>,
                                   ],
                                   "classes": Object {
-                                    "disabled": "MuiSelect-disabled-51",
-                                    "filled": "MuiSelect-filled-48",
-                                    "icon": "MuiSelect-icon-52",
-                                    "outlined": "MuiSelect-outlined-49",
-                                    "root": "MuiSelect-root-46",
-                                    "select": "MuiSelect-select-47",
-                                    "selectMenu": "MuiSelect-selectMenu-50",
+                                    "disabled": "MuiSelect-disabled-105",
+                                    "filled": "MuiSelect-filled-102",
+                                    "icon": "MuiSelect-icon-106",
+                                    "outlined": "MuiSelect-outlined-103",
+                                    "root": "MuiSelect-root-100",
+                                    "select": "MuiSelect-select-101",
+                                    "selectMenu": "MuiSelect-selectMenu-104",
                                   },
                                   "displayEmpty": false,
                                   "multiple": false,
@@ -4767,23 +5779,23 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                               <WithFormControlContext(InputBase)
                                 classes={
                                   Object {
-                                    "adornedEnd": "MuiInputBase-adornedEnd-71",
-                                    "adornedStart": "MuiInputBase-adornedStart-70",
-                                    "disabled": "MuiInputBase-disabled-69 MuiInput-disabled-56",
-                                    "error": "MuiInputBase-error-72 MuiInput-error-58",
-                                    "focused": "MuiInputBase-focused-68 MuiInput-focused-55",
-                                    "formControl": "MuiInputBase-formControl-67 MuiInput-formControl-54",
-                                    "fullWidth": "MuiInputBase-fullWidth-75 MuiInput-fullWidth-60",
-                                    "input": "MuiInputBase-input-76 MuiInput-input-61",
-                                    "inputAdornedEnd": "MuiInputBase-inputAdornedEnd-82",
-                                    "inputAdornedStart": "MuiInputBase-inputAdornedStart-81",
-                                    "inputMarginDense": "MuiInputBase-inputMarginDense-77 MuiInput-inputMarginDense-62",
-                                    "inputMultiline": "MuiInputBase-inputMultiline-78 MuiInput-inputMultiline-63",
-                                    "inputType": "MuiInputBase-inputType-79 MuiInput-inputType-64",
-                                    "inputTypeSearch": "MuiInputBase-inputTypeSearch-80 MuiInput-inputTypeSearch-65",
-                                    "marginDense": "MuiInputBase-marginDense-73",
-                                    "multiline": "MuiInputBase-multiline-74 MuiInput-multiline-59",
-                                    "root": "MuiInputBase-root-66 MuiInput-root-53",
+                                    "adornedEnd": "MuiInputBase-adornedEnd-41",
+                                    "adornedStart": "MuiInputBase-adornedStart-40",
+                                    "disabled": "MuiInputBase-disabled-39 MuiInput-disabled-110",
+                                    "error": "MuiInputBase-error-42 MuiInput-error-112",
+                                    "focused": "MuiInputBase-focused-38 MuiInput-focused-109",
+                                    "formControl": "MuiInputBase-formControl-37 MuiInput-formControl-108",
+                                    "fullWidth": "MuiInputBase-fullWidth-45 MuiInput-fullWidth-114",
+                                    "input": "MuiInputBase-input-46 MuiInput-input-115",
+                                    "inputAdornedEnd": "MuiInputBase-inputAdornedEnd-52",
+                                    "inputAdornedStart": "MuiInputBase-inputAdornedStart-51",
+                                    "inputMarginDense": "MuiInputBase-inputMarginDense-47 MuiInput-inputMarginDense-116",
+                                    "inputMultiline": "MuiInputBase-inputMultiline-48 MuiInput-inputMultiline-117",
+                                    "inputType": "MuiInputBase-inputType-49 MuiInput-inputType-118",
+                                    "inputTypeSearch": "MuiInputBase-inputTypeSearch-50 MuiInput-inputTypeSearch-119",
+                                    "marginDense": "MuiInputBase-marginDense-43",
+                                    "multiline": "MuiInputBase-multiline-44 MuiInput-multiline-113",
+                                    "root": "MuiInputBase-root-36 MuiInput-root-107",
                                   }
                                 }
                                 fullWidth={false}
@@ -4817,13 +5829,13 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                       </WithStyles(MenuItem)>,
                                     ],
                                     "classes": Object {
-                                      "disabled": "MuiSelect-disabled-51",
-                                      "filled": "MuiSelect-filled-48",
-                                      "icon": "MuiSelect-icon-52",
-                                      "outlined": "MuiSelect-outlined-49",
-                                      "root": "MuiSelect-root-46",
-                                      "select": "MuiSelect-select-47",
-                                      "selectMenu": "MuiSelect-selectMenu-50",
+                                      "disabled": "MuiSelect-disabled-105",
+                                      "filled": "MuiSelect-filled-102",
+                                      "icon": "MuiSelect-icon-106",
+                                      "outlined": "MuiSelect-outlined-103",
+                                      "root": "MuiSelect-root-100",
+                                      "select": "MuiSelect-select-101",
+                                      "selectMenu": "MuiSelect-selectMenu-104",
                                     },
                                     "displayEmpty": false,
                                     "multiple": false,
@@ -4843,23 +5855,23 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                 <InputBase
                                   classes={
                                     Object {
-                                      "adornedEnd": "MuiInputBase-adornedEnd-71",
-                                      "adornedStart": "MuiInputBase-adornedStart-70",
-                                      "disabled": "MuiInputBase-disabled-69 MuiInput-disabled-56",
-                                      "error": "MuiInputBase-error-72 MuiInput-error-58",
-                                      "focused": "MuiInputBase-focused-68 MuiInput-focused-55",
-                                      "formControl": "MuiInputBase-formControl-67 MuiInput-formControl-54",
-                                      "fullWidth": "MuiInputBase-fullWidth-75 MuiInput-fullWidth-60",
-                                      "input": "MuiInputBase-input-76 MuiInput-input-61",
-                                      "inputAdornedEnd": "MuiInputBase-inputAdornedEnd-82",
-                                      "inputAdornedStart": "MuiInputBase-inputAdornedStart-81",
-                                      "inputMarginDense": "MuiInputBase-inputMarginDense-77 MuiInput-inputMarginDense-62",
-                                      "inputMultiline": "MuiInputBase-inputMultiline-78 MuiInput-inputMultiline-63",
-                                      "inputType": "MuiInputBase-inputType-79 MuiInput-inputType-64",
-                                      "inputTypeSearch": "MuiInputBase-inputTypeSearch-80 MuiInput-inputTypeSearch-65",
-                                      "marginDense": "MuiInputBase-marginDense-73",
-                                      "multiline": "MuiInputBase-multiline-74 MuiInput-multiline-59",
-                                      "root": "MuiInputBase-root-66 MuiInput-root-53",
+                                      "adornedEnd": "MuiInputBase-adornedEnd-41",
+                                      "adornedStart": "MuiInputBase-adornedStart-40",
+                                      "disabled": "MuiInputBase-disabled-39 MuiInput-disabled-110",
+                                      "error": "MuiInputBase-error-42 MuiInput-error-112",
+                                      "focused": "MuiInputBase-focused-38 MuiInput-focused-109",
+                                      "formControl": "MuiInputBase-formControl-37 MuiInput-formControl-108",
+                                      "fullWidth": "MuiInputBase-fullWidth-45 MuiInput-fullWidth-114",
+                                      "input": "MuiInputBase-input-46 MuiInput-input-115",
+                                      "inputAdornedEnd": "MuiInputBase-inputAdornedEnd-52",
+                                      "inputAdornedStart": "MuiInputBase-inputAdornedStart-51",
+                                      "inputMarginDense": "MuiInputBase-inputMarginDense-47 MuiInput-inputMarginDense-116",
+                                      "inputMultiline": "MuiInputBase-inputMultiline-48 MuiInput-inputMultiline-117",
+                                      "inputType": "MuiInputBase-inputType-49 MuiInput-inputType-118",
+                                      "inputTypeSearch": "MuiInputBase-inputTypeSearch-50 MuiInput-inputTypeSearch-119",
+                                      "marginDense": "MuiInputBase-marginDense-43",
+                                      "multiline": "MuiInputBase-multiline-44 MuiInput-multiline-113",
+                                      "root": "MuiInputBase-root-36 MuiInput-root-107",
                                     }
                                   }
                                   fullWidth={false}
@@ -4893,13 +5905,13 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                         </WithStyles(MenuItem)>,
                                       ],
                                       "classes": Object {
-                                        "disabled": "MuiSelect-disabled-51",
-                                        "filled": "MuiSelect-filled-48",
-                                        "icon": "MuiSelect-icon-52",
-                                        "outlined": "MuiSelect-outlined-49",
-                                        "root": "MuiSelect-root-46",
-                                        "select": "MuiSelect-select-47",
-                                        "selectMenu": "MuiSelect-selectMenu-50",
+                                        "disabled": "MuiSelect-disabled-105",
+                                        "filled": "MuiSelect-filled-102",
+                                        "icon": "MuiSelect-icon-106",
+                                        "outlined": "MuiSelect-outlined-103",
+                                        "root": "MuiSelect-root-100",
+                                        "select": "MuiSelect-select-101",
+                                        "selectMenu": "MuiSelect-selectMenu-104",
                                       },
                                       "displayEmpty": false,
                                       "multiple": false,
@@ -4933,23 +5945,23 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                   value={10}
                                 >
                                   <div
-                                    className="MuiInputBase-root-66 MuiInput-root-53 MuiInputBase-formControl-67 MuiInput-formControl-54"
+                                    className="MuiInputBase-root-36 MuiInput-root-107 MuiInputBase-formControl-37 MuiInput-formControl-108"
                                     onClick={[Function]}
                                   >
                                     <SelectInput
                                       IconComponent={[Function]}
                                       aria-invalid={false}
                                       autoWidth={false}
-                                      className="MuiInputBase-input-76 MuiInput-input-61"
+                                      className="MuiInputBase-input-46 MuiInput-input-115"
                                       classes={
                                         Object {
-                                          "disabled": "MuiSelect-disabled-51",
-                                          "filled": "MuiSelect-filled-48",
-                                          "icon": "MuiSelect-icon-52",
-                                          "outlined": "MuiSelect-outlined-49",
-                                          "root": "MuiSelect-root-46",
-                                          "select": "MuiSelect-select-47",
-                                          "selectMenu": "MuiSelect-selectMenu-50",
+                                          "disabled": "MuiSelect-disabled-105",
+                                          "filled": "MuiSelect-filled-102",
+                                          "icon": "MuiSelect-icon-106",
+                                          "outlined": "MuiSelect-outlined-103",
+                                          "root": "MuiSelect-root-100",
+                                          "select": "MuiSelect-select-101",
+                                          "selectMenu": "MuiSelect-selectMenu-104",
                                         }
                                       }
                                       disabled={false}
@@ -4964,12 +5976,12 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                       variant="standard"
                                     >
                                       <div
-                                        className="MuiSelect-root-46"
+                                        className="MuiSelect-root-100"
                                       >
                                         <div
                                           aria-haspopup="true"
                                           aria-pressed="false"
-                                          className="MuiSelect-select-47 MuiSelect-selectMenu-50 MuiInputBase-input-76 MuiInput-input-61"
+                                          className="MuiSelect-select-101 MuiSelect-selectMenu-104 MuiInputBase-input-46 MuiInput-input-115"
                                           onBlur={[Function]}
                                           onClick={[Function]}
                                           onFocus={[Function]}
@@ -4984,27 +5996,27 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                           value={10}
                                         />
                                         <pure(ArrowDropDown)
-                                          className="MuiSelect-icon-52"
+                                          className="MuiSelect-icon-106"
                                         >
                                           <ArrowDropDown
-                                            className="MuiSelect-icon-52"
+                                            className="MuiSelect-icon-106"
                                           >
                                             <WithStyles(SvgIcon)
-                                              className="MuiSelect-icon-52"
+                                              className="MuiSelect-icon-106"
                                             >
                                               <SvgIcon
-                                                className="MuiSelect-icon-52"
+                                                className="MuiSelect-icon-106"
                                                 classes={
                                                   Object {
-                                                    "colorAction": "MuiSvgIcon-colorAction-23",
-                                                    "colorDisabled": "MuiSvgIcon-colorDisabled-25",
-                                                    "colorError": "MuiSvgIcon-colorError-24",
-                                                    "colorPrimary": "MuiSvgIcon-colorPrimary-21",
-                                                    "colorSecondary": "MuiSvgIcon-colorSecondary-22",
-                                                    "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-26",
-                                                    "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-28",
-                                                    "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-27",
-                                                    "root": "MuiSvgIcon-root-20",
+                                                    "colorAction": "MuiSvgIcon-colorAction-62",
+                                                    "colorDisabled": "MuiSvgIcon-colorDisabled-64",
+                                                    "colorError": "MuiSvgIcon-colorError-63",
+                                                    "colorPrimary": "MuiSvgIcon-colorPrimary-60",
+                                                    "colorSecondary": "MuiSvgIcon-colorSecondary-61",
+                                                    "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-65",
+                                                    "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-67",
+                                                    "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-66",
+                                                    "root": "MuiSvgIcon-root-59",
                                                   }
                                                 }
                                                 color="inherit"
@@ -5014,7 +6026,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                               >
                                                 <svg
                                                   aria-hidden="true"
-                                                  className="MuiSvgIcon-root-20 MuiSelect-icon-52"
+                                                  className="MuiSvgIcon-root-59 MuiSelect-icon-106"
                                                   focusable="false"
                                                   role="presentation"
                                                   viewBox="0 0 24 24"
@@ -5044,7 +6056,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                             <div
                                               aria-haspopup="true"
                                               aria-pressed="false"
-                                              class="MuiSelect-select-47 MuiSelect-selectMenu-50 MuiInputBase-input-76 MuiInput-input-61"
+                                              class="MuiSelect-select-101 MuiSelect-selectMenu-104 MuiInputBase-input-46 MuiInput-input-115"
                                               role="button"
                                               tabindex="0"
                                             >
@@ -5072,7 +6084,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                               <div
                                                 aria-haspopup="true"
                                                 aria-pressed="false"
-                                                class="MuiSelect-select-47 MuiSelect-selectMenu-50 MuiInputBase-input-76 MuiInput-input-61"
+                                                class="MuiSelect-select-101 MuiSelect-selectMenu-104 MuiInputBase-input-46 MuiInput-input-115"
                                                 role="button"
                                                 tabindex="0"
                                               >
@@ -5081,7 +6093,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                             }
                                             classes={
                                               Object {
-                                                "paper": "MuiMenu-paper-83",
+                                                "paper": "MuiMenu-paper-120",
                                               }
                                             }
                                             disableAutoFocusItem={false}
@@ -5456,7 +6468,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                               PaperProps={
                                                 Object {
                                                   "classes": Object {
-                                                    "root": "MuiMenu-paper-83",
+                                                    "root": "MuiMenu-paper-120",
                                                   },
                                                   "style": Object {
                                                     "minWidth": null,
@@ -5467,7 +6479,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                                 <div
                                                   aria-haspopup="true"
                                                   aria-pressed="false"
-                                                  class="MuiSelect-select-47 MuiSelect-selectMenu-50 MuiInputBase-input-76 MuiInput-input-61"
+                                                  class="MuiSelect-select-101 MuiSelect-selectMenu-104 MuiInputBase-input-46 MuiInput-input-115"
                                                   role="button"
                                                   tabindex="0"
                                                 >
@@ -5497,7 +6509,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                                 PaperProps={
                                                   Object {
                                                     "classes": Object {
-                                                      "root": "MuiMenu-paper-83",
+                                                      "root": "MuiMenu-paper-120",
                                                     },
                                                     "style": Object {
                                                       "minWidth": null,
@@ -5509,7 +6521,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                                   <div
                                                     aria-haspopup="true"
                                                     aria-pressed="false"
-                                                    class="MuiSelect-select-47 MuiSelect-selectMenu-50 MuiInputBase-input-76 MuiInput-input-61"
+                                                    class="MuiSelect-select-101 MuiSelect-selectMenu-104 MuiInputBase-input-46 MuiInput-input-115"
                                                     role="button"
                                                     tabindex="0"
                                                   >
@@ -5525,7 +6537,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                                 anchorReference="anchorEl"
                                                 classes={
                                                   Object {
-                                                    "paper": "MuiPopover-paper-84",
+                                                    "paper": "MuiPopover-paper-121",
                                                   }
                                                 }
                                                 elevation={8}
@@ -5563,8 +6575,8 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                                     }
                                                     classes={
                                                       Object {
-                                                        "hidden": "MuiModal-hidden-86",
-                                                        "root": "MuiModal-root-85",
+                                                        "hidden": "MuiModal-hidden-123",
+                                                        "root": "MuiModal-root-122",
                                                       }
                                                     }
                                                     container={<body />}
@@ -5615,12 +6627,12 @@ exports[`RunList reloads the run when refresh is called 1`] = `
             <IconButton
               classes={
                 Object {
-                  "colorInherit": "MuiIconButton-colorInherit-12",
-                  "colorPrimary": "MuiIconButton-colorPrimary-13",
-                  "colorSecondary": "MuiIconButton-colorSecondary-14",
-                  "disabled": "MuiIconButton-disabled-15",
-                  "label": "MuiIconButton-label-16",
-                  "root": "MuiIconButton-root-11",
+                  "colorInherit": "MuiIconButton-colorInherit-79",
+                  "colorPrimary": "MuiIconButton-colorPrimary-80",
+                  "colorSecondary": "MuiIconButton-colorSecondary-81",
+                  "disabled": "MuiIconButton-disabled-82",
+                  "label": "MuiIconButton-label-83",
+                  "root": "MuiIconButton-root-78",
                 }
               }
               color="default"
@@ -5629,19 +6641,19 @@ exports[`RunList reloads the run when refresh is called 1`] = `
             >
               <WithStyles(ButtonBase)
                 centerRipple={true}
-                className="MuiIconButton-root-11 MuiIconButton-disabled-15"
+                className="MuiIconButton-root-78 MuiIconButton-disabled-82"
                 disabled={true}
                 focusRipple={true}
                 onClick={[Function]}
               >
                 <ButtonBase
                   centerRipple={true}
-                  className="MuiIconButton-root-11 MuiIconButton-disabled-15"
+                  className="MuiIconButton-root-78 MuiIconButton-disabled-82"
                   classes={
                     Object {
-                      "disabled": "MuiButtonBase-disabled-18",
-                      "focusVisible": "MuiButtonBase-focusVisible-19",
-                      "root": "MuiButtonBase-root-17",
+                      "disabled": "MuiButtonBase-disabled-85",
+                      "focusVisible": "MuiButtonBase-focusVisible-86",
+                      "root": "MuiButtonBase-root-84",
                     }
                   }
                   component="button"
@@ -5654,7 +6666,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                   type="button"
                 >
                   <button
-                    className="MuiButtonBase-root-17 MuiButtonBase-disabled-18 MuiIconButton-root-11 MuiIconButton-disabled-15"
+                    className="MuiButtonBase-root-84 MuiButtonBase-disabled-85 MuiIconButton-root-78 MuiIconButton-disabled-82"
                     disabled={true}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -5672,7 +6684,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                     type="button"
                   >
                     <span
-                      className="MuiIconButton-label-16"
+                      className="MuiIconButton-label-83"
                     >
                       <pure(ChevronLeftIcon)>
                         <ChevronLeftIcon>
@@ -5680,15 +6692,15 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                             <SvgIcon
                               classes={
                                 Object {
-                                  "colorAction": "MuiSvgIcon-colorAction-23",
-                                  "colorDisabled": "MuiSvgIcon-colorDisabled-25",
-                                  "colorError": "MuiSvgIcon-colorError-24",
-                                  "colorPrimary": "MuiSvgIcon-colorPrimary-21",
-                                  "colorSecondary": "MuiSvgIcon-colorSecondary-22",
-                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-26",
-                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-28",
-                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-27",
-                                  "root": "MuiSvgIcon-root-20",
+                                  "colorAction": "MuiSvgIcon-colorAction-62",
+                                  "colorDisabled": "MuiSvgIcon-colorDisabled-64",
+                                  "colorError": "MuiSvgIcon-colorError-63",
+                                  "colorPrimary": "MuiSvgIcon-colorPrimary-60",
+                                  "colorSecondary": "MuiSvgIcon-colorSecondary-61",
+                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-65",
+                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-67",
+                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-66",
+                                  "root": "MuiSvgIcon-root-59",
                                 }
                               }
                               color="inherit"
@@ -5698,7 +6710,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                className="MuiSvgIcon-root-20"
+                                className="MuiSvgIcon-root-59"
                                 focusable="false"
                                 role="presentation"
                                 viewBox="0 0 24 24"
@@ -5728,12 +6740,12 @@ exports[`RunList reloads the run when refresh is called 1`] = `
             <IconButton
               classes={
                 Object {
-                  "colorInherit": "MuiIconButton-colorInherit-12",
-                  "colorPrimary": "MuiIconButton-colorPrimary-13",
-                  "colorSecondary": "MuiIconButton-colorSecondary-14",
-                  "disabled": "MuiIconButton-disabled-15",
-                  "label": "MuiIconButton-label-16",
-                  "root": "MuiIconButton-root-11",
+                  "colorInherit": "MuiIconButton-colorInherit-79",
+                  "colorPrimary": "MuiIconButton-colorPrimary-80",
+                  "colorSecondary": "MuiIconButton-colorSecondary-81",
+                  "disabled": "MuiIconButton-disabled-82",
+                  "label": "MuiIconButton-label-83",
+                  "root": "MuiIconButton-root-78",
                 }
               }
               color="default"
@@ -5742,19 +6754,19 @@ exports[`RunList reloads the run when refresh is called 1`] = `
             >
               <WithStyles(ButtonBase)
                 centerRipple={true}
-                className="MuiIconButton-root-11 MuiIconButton-disabled-15"
+                className="MuiIconButton-root-78 MuiIconButton-disabled-82"
                 disabled={true}
                 focusRipple={true}
                 onClick={[Function]}
               >
                 <ButtonBase
                   centerRipple={true}
-                  className="MuiIconButton-root-11 MuiIconButton-disabled-15"
+                  className="MuiIconButton-root-78 MuiIconButton-disabled-82"
                   classes={
                     Object {
-                      "disabled": "MuiButtonBase-disabled-18",
-                      "focusVisible": "MuiButtonBase-focusVisible-19",
-                      "root": "MuiButtonBase-root-17",
+                      "disabled": "MuiButtonBase-disabled-85",
+                      "focusVisible": "MuiButtonBase-focusVisible-86",
+                      "root": "MuiButtonBase-root-84",
                     }
                   }
                   component="button"
@@ -5767,7 +6779,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                   type="button"
                 >
                   <button
-                    className="MuiButtonBase-root-17 MuiButtonBase-disabled-18 MuiIconButton-root-11 MuiIconButton-disabled-15"
+                    className="MuiButtonBase-root-84 MuiButtonBase-disabled-85 MuiIconButton-root-78 MuiIconButton-disabled-82"
                     disabled={true}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -5785,7 +6797,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                     type="button"
                   >
                     <span
-                      className="MuiIconButton-label-16"
+                      className="MuiIconButton-label-83"
                     >
                       <pure(ChevronRightIcon)>
                         <ChevronRightIcon>
@@ -5793,15 +6805,15 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                             <SvgIcon
                               classes={
                                 Object {
-                                  "colorAction": "MuiSvgIcon-colorAction-23",
-                                  "colorDisabled": "MuiSvgIcon-colorDisabled-25",
-                                  "colorError": "MuiSvgIcon-colorError-24",
-                                  "colorPrimary": "MuiSvgIcon-colorPrimary-21",
-                                  "colorSecondary": "MuiSvgIcon-colorSecondary-22",
-                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-26",
-                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-28",
-                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-27",
-                                  "root": "MuiSvgIcon-root-20",
+                                  "colorAction": "MuiSvgIcon-colorAction-62",
+                                  "colorDisabled": "MuiSvgIcon-colorDisabled-64",
+                                  "colorError": "MuiSvgIcon-colorError-63",
+                                  "colorPrimary": "MuiSvgIcon-colorPrimary-60",
+                                  "colorSecondary": "MuiSvgIcon-colorSecondary-61",
+                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-65",
+                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-67",
+                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-66",
+                                  "root": "MuiSvgIcon-root-59",
                                 }
                               }
                               color="inherit"
@@ -5811,7 +6823,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                             >
                               <svg
                                 aria-hidden="true"
-                                className="MuiSvgIcon-root-20"
+                                className="MuiSvgIcon-root-59"
                                 focusable="false"
                                 role="presentation"
                                 viewBox="0 0 24 24"
@@ -6026,14 +7038,14 @@ exports[`RunList renders status as icon 1`] = `
   TransitionComponent={[Function]}
   classes={
     Object {
-      "popper": "MuiTooltip-popper-29",
-      "popperInteractive": "MuiTooltip-popperInteractive-30",
-      "tooltip": "MuiTooltip-tooltip-31",
-      "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-36",
-      "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-33",
-      "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-34",
-      "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-35",
-      "touch": "MuiTooltip-touch-32",
+      "popper": "MuiTooltip-popper-87",
+      "popperInteractive": "MuiTooltip-popperInteractive-88",
+      "tooltip": "MuiTooltip-tooltip-89",
+      "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-94",
+      "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-91",
+      "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-92",
+      "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-93",
+      "touch": "MuiTooltip-touch-90",
     }
   }
   disableFocusListener={false}
@@ -6467,6 +7479,7 @@ exports[`RunList renders the empty experience 1`] = `
       ]
     }
     emptyMessage="No runs found."
+    filterLabel="Filter runs"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={Array []}
@@ -6529,6 +7542,7 @@ exports[`RunList shows experiment name 1`] = `
       ]
     }
     emptyMessage="No runs found."
+    filterLabel="Filter runs"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={
@@ -6592,6 +7606,7 @@ exports[`RunList shows pipeline name 1`] = `
       ]
     }
     emptyMessage="No runs found."
+    filterLabel="Filter runs"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={
@@ -6656,6 +7671,7 @@ exports[`RunList shows run time for each run 1`] = `
       ]
     }
     emptyMessage="No runs found."
+    filterLabel="Filter runs"
     initialSortColumn="created_at"
     reload={[Function]}
     rows={


### PR DESCRIPTION
All lists, excluding the "last 5 runs" within the experiment list, will now include a filter bar.

Initially, filtering will be limited to the "name" column for each resource and will look for matching substrings, so "xgb" and "oos" will both match "xgboost-1".

This PR partially addresses #257

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/656)
<!-- Reviewable:end -->
