### PR TITLE
SDK/Components - Simplified _create_task_factory_from_component_spec function

### DIFF
--- a/sdk/python/kfp/components/_dsl_bridge.py
+++ b/sdk/python/kfp/components/_dsl_bridge.py
@@ -12,9 +12,120 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import OrderedDict
+from ._structures import ConcatPlaceholder, IfPlaceholder, InputValuePlaceholder, InputPathPlaceholder, IsPresentPlaceholder, OutputPathPlaceholder, TaskSpec
+from ._components import _generate_output_file_name, _default_component_name
+
+
+def create_container_op_from_task(task_spec: TaskSpec):
+    argument_values = task_spec.arguments
+    component_spec = task_spec.component_ref._component_spec
+
+    inputs_dict = {input_spec.name: input_spec for input_spec in component_spec.inputs or []}
+    container_spec = component_spec.implementation.container
+
+    output_paths = OrderedDict() #Preserving the order to make the kubernetes output names deterministic
+    unconfigurable_output_paths = container_spec.file_outputs or {}
+    for output in component_spec.outputs or []:
+        if output.name in unconfigurable_output_paths:
+            output_paths[output.name] = unconfigurable_output_paths[output.name]
+
+    def expand_command_part(arg): #input values with original names
+        #(Union[str,Mapping[str, Any]]) -> Union[str,List[str]]
+        if arg is None:
+            return None
+        if isinstance(arg, (str, int, float, bool)):
+            return str(arg)
+
+        if isinstance(arg, InputValuePlaceholder):
+            input_name = arg.input_name
+            input_value = argument_values.get(input_name, None)
+            if input_value is not None:
+                return str(input_value)
+            else:
+                input_spec = inputs_dict[input_name]
+                if input_spec.optional:
+                    return None
+                else:
+                    raise ValueError('No value provided for input {}'.format(input_name))
+
+        if isinstance(arg, InputPathPlaceholder):
+            input_name = arg.input_name
+            input_value = argument_values.get(input_name, None)
+            if input_value is not None:
+                raise ValueError('ContainerOp does not support input artifacts - input {}'.format(input_name))
+                #return input_value
+            else:
+                input_spec = inputs_dict[input_name]
+                if input_spec.optional:
+                    #Even when we support default values there is no need to check for a default here.
+                    #In current execution flow (called by python task factory), the missing argument would be replaced with the default value by python itself.
+                    return None
+                else:
+                    raise ValueError('No value provided for input {}'.format(input_name))
+
+        elif isinstance(arg, OutputPathPlaceholder):
+            output_name = arg.output_name
+            output_filename = _generate_output_file_name(output_name)
+            if arg.output_name in output_paths:
+                if output_paths[output_name] != output_filename:
+                    raise ValueError('Conflicting output files specified for port {}: {} and {}'.format(output_name, output_paths[output_name], output_filename))
+            else:
+                output_paths[output_name] = output_filename
+
+            return output_filename
+
+        elif isinstance(arg, ConcatPlaceholder):
+            expanded_argument_strings = expand_argument_list(arg.items)
+            return ''.join(expanded_argument_strings)
+
+        elif isinstance(arg, IfPlaceholder):
+            arg = arg.if_structure
+            condition_result = expand_command_part(arg.condition)
+            from distutils.util import strtobool
+            condition_result_bool = condition_result and strtobool(condition_result) #Python gotcha: bool('False') == True; Need to use strtobool; Also need to handle None and []
+            result_node = arg.then_value if condition_result_bool else arg.else_value
+            if result_node is None:
+                return []
+            if isinstance(result_node, list):
+                expanded_result = expand_argument_list(result_node)
+            else:
+                expanded_result = expand_command_part(result_node)
+            return expanded_result
+
+        elif isinstance(arg, IsPresentPlaceholder):
+            argument_is_present = argument_values.get(arg.input_name, None) is not None
+            return str(argument_is_present)
+        else:
+            raise TypeError('Unrecognized argument type: {}'.format(arg))
+    
+    def expand_argument_list(argument_list):
+        expanded_list = []
+        if argument_list is not None:
+            for part in argument_list:
+                expanded_part = expand_command_part(part)
+                if expanded_part is not None:
+                    if isinstance(expanded_part, list):
+                        expanded_list.extend(expanded_part)
+                    else:
+                        expanded_list.append(str(expanded_part))
+        return expanded_list
+
+    expanded_command = expand_argument_list(container_spec.command)
+    expanded_args = expand_argument_list(container_spec.args)
+
+    return _task_object_factory(
+        name=component_spec.name or _default_component_name,
+        container_image=container_spec.image,
+        command=expanded_command,
+        arguments=expanded_args,
+        output_paths=output_paths,
+    )
+
+
 _dummy_pipeline=None
 
-def _create_task_object(name:str, container_image:str, command=None, arguments=None, file_outputs=None):
+def _create_container_op_from_resolved_task(name:str, container_image:str, command=None, arguments=None, output_paths=None):
     from .. import dsl
     global _dummy_pipeline
     need_dummy = dsl.Pipeline._default_pipeline is None
@@ -23,12 +134,23 @@ def _create_task_object(name:str, container_image:str, command=None, arguments=N
             _dummy_pipeline = dsl.Pipeline('dummy pipeline')
         _dummy_pipeline.__enter__()
 
+    from ._components import _sanitize_kubernetes_resource_name, _make_name_unique_by_adding_index
+    output_name_to_kubernetes = {}
+    kubernetes_name_to_output_name = {}
+    for output_name in (output_paths or {}).keys():
+        kubernetes_name = _sanitize_kubernetes_resource_name(output_name)
+        kubernetes_name = _make_name_unique_by_adding_index(kubernetes_name, kubernetes_name_to_output_name, '-')
+        output_name_to_kubernetes[output_name] = kubernetes_name
+        kubernetes_name_to_output_name[kubernetes_name] = output_name
+    
+    output_paths_for_container_op = {output_name_to_kubernetes[name]: path for name, path in output_paths.items()}
+
     task = dsl.ContainerOp(
         name=name,
         image=container_image,
         command=command,
         arguments=arguments,
-        file_outputs=file_outputs,
+        file_outputs=output_paths_for_container_op,
     )
 
     if need_dummy:
@@ -37,4 +159,4 @@ def _create_task_object(name:str, container_image:str, command=None, arguments=N
     return task
 
 
-_task_object_factory=_create_task_object
+_task_object_factory=_create_container_op_from_resolved_task


### PR DESCRIPTION
Simple refactoring:

Most of the code was moved to `_dsl_bridge.create_container_op_from_task` and is less indented now.
* Renamed `_dsl_bridge._create_task_object` to `_create_container_op_from_resolved_task` and moved the output name sanitization there.
* Introduced the `_components._created_task_transformation_handler` handler that specifies the transformation function that is called when `TaskSpec` instance is created from `ComponentSpec`. Such transformation can for example convert `TaskSpec` to `ContainerOp`.

Rationale: When the pipeline author loads a component and uses it
```
train_test_op = load_component('TF - Train and evaluate')
...
train_test_task = train_test_op(train_data, test_data)
```
the `train_test_task` is not always container task. Sometimes it's a graph task. In this cases it should not be converted to `ContainerOp`. It should remain a `TaskSpec`. There are some other cases (e.g. creating graph components from a python pipeline function) where `TaskSpec` is needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/662)
<!-- Reviewable:end -->
