### PR TITLE
SDK/Components - Added /data to the generated file paths

### DIFF
--- a/sdk/python/kfp/components/_components.py
+++ b/sdk/python/kfp/components/_components.py
@@ -153,14 +153,15 @@ def _generate_unique_suffix(data):
 
 _inputs_dir = '/inputs'
 _outputs_dir = '/outputs'
+_single_io_file_name = 'data'
 
 
 def _generate_input_file_name(port_name):
-    return _inputs_dir + '/' + _sanitize_file_name(port_name)
+    return _inputs_dir + '/' + _sanitize_file_name(port_name) + '/' + _single_io_file_name
 
 
 def _generate_output_file_name(port_name):
-    return _outputs_dir + '/' + _sanitize_file_name(port_name)
+    return _outputs_dir + '/' + _sanitize_file_name(port_name) + '/' + _single_io_file_name
 
 
 def _try_get_object_by_name(obj_name):


### PR DESCRIPTION
This is needed for the future storage system based on volume mounts:
If outputs were written to files in the same dir (e.g. `/outputs/out1.txt` and `/outputs/out2.txt`), then we cannot separate them and mount to the downstream task containers independently.
Writing outputs to `/outputs/out1/data` and `/outputs/out2/data` solves this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/663)
<!-- Reviewable:end -->
