### PR TITLE
Fix corner case in scaling data when feature max is equal to feature min

### DIFF
--- a/components/dataproc/transform/src/transform_run.py
+++ b/components/dataproc/transform/src/transform_run.py
@@ -109,7 +109,7 @@ def make_process_rows_fn(
       if col in number_cols:
         v_max = stats['column_stats'][col]['max']
         v_min = stats['column_stats'][col]['min']
-        value = -1 + (col_value - v_min) * 2 / (v_max - v_min)
+        value = -1 + (col_value - v_min) * 2 / (v_max - v_min) if v_max != v_min else 0
         feature_indices.append(start_index)
         feature_values.append(value)
         start_index += 1


### PR DESCRIPTION
Ideally, we should use a threshold to check if v_max is equal to v_min(e.g. |v_max - v_min| > threshold). Also, it is not needed to scale values when using tree models. As a quick fix, let's make sure v_max is not equal to v_min. This could cause error in some situations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/667)
<!-- Reviewable:end -->
