### PR TITLE
SDK/Components  - Added Json Schema spec for the component format

### DIFF
--- a/sdk/python/kfp/components/structures/components.json_schema.json
+++ b/sdk/python/kfp/components/structures/components.json_schema.json
@@ -8,7 +8,6 @@
     "TypeType": {
       "oneOf": [
         {"type": "string"},
-        {"type": "array", "items": {"$ref": "#/definitions/TypeType"}},
         {"type": "object", "additionalProperties": {"$ref": "#/definitions/TypeType"}}
       ]
     },

--- a/sdk/python/kfp/components/structures/components.json_schema.json
+++ b/sdk/python/kfp/components/structures/components.json_schema.json
@@ -5,10 +5,10 @@
   "$ref": "#/definitions/PipelineRunSpec",
 
   "definitions": {
-    "TypeType": {
+    "TypeSpecType": {
       "oneOf": [
         {"type": "string"},
-        {"type": "object", "additionalProperties": {"$ref": "#/definitions/TypeType"}}
+        {"type": "object", "additionalProperties": {"$ref": "#/definitions/TypeSpecType"}}
       ]
     },
 
@@ -18,7 +18,7 @@
       "required": ["name"],
       "properties": {
         "name": {"type": "string"},
-        "type": {"$ref": "#/definitions/TypeType"},
+        "type": {"$ref": "#/definitions/TypeSpecType"},
         "description": {"type": "string"},
         "default": {"type": "string"},
         "optional": {"type": "boolean", "default": false}
@@ -32,7 +32,7 @@
       "required": ["name"],
       "properties": {
         "name": {"type": "string"},
-        "type": {"$ref": "#/definitions/TypeType"},
+        "type": {"$ref": "#/definitions/TypeSpecType"},
         "description": {"type": "string"}
       },
       "additionalProperties": false

--- a/sdk/python/kfp/components/structures/components.json_schema.json
+++ b/sdk/python/kfp/components/structures/components.json_schema.json
@@ -334,16 +334,36 @@
       "additionalProperties": false
     },
 
-    "PodArgoSubset": {
-      "description": "Subset of io.k8s.api.core.v1.Pod structure supported by Argo",
+    "RetryStrategySpec": {
+      "description": "Optional configuration that specifies how the task should be retried if it fails.",
       "type": "object",
       "properties": {
-        "metadata": {"$ref": "#/definitions/ObjectMetaArgoSubset"},
-        "spec": {"$ref": "#/definitions/PodSpecArgoSubset"}
+        "maxRetries": {"type": "integer"}
       },
       "additionalProperties": false
     },
 
+    "KubernetesExecutionOptionsSpec": {
+      "description": "When running on Kubernetes, KubernetesExecutionOptionsSpec describes changes to the configuration of a Kubernetes Pod that will execute the task.",
+      "type": "object",
+      "properties": {
+        "metadata": {"$ref": "#/definitions/ObjectMetaArgoSubset"},
+        "mainContainer": {"$ref": "https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.11.2/_definitions.json#/definitions/io.k8s.api.core.v1.Container"},
+        "podSpec": {"$ref": "#/definitions/PodSpecArgoSubset"}
+      },
+      "additionalProperties": false
+    },
+
+    "ExecutionOptionsSpec": {
+      "description": "Optional configuration that specifies how the task should be executed. Can be used to set some platform-specific options.",
+      "type": "object",
+      "properties": {
+        "retryStrategy": {"$ref": "#/definitions/RetryStrategySpec"},
+        "kubernetesOptions": {"$ref": "#/definitions/KubernetesExecutionOptionsSpec"}
+      },
+      "additionalProperties": false
+    },
+    
     "TaskSpec": {
       "description": "'Task specification. Task is a configured component - a component supplied with arguments and other applied configuration changes.",
       "type": "object",
@@ -352,8 +372,7 @@
         "componentRef": {"$ref": "#/definitions/ComponentReference"},
         "arguments": {"type": "object", "additionalProperties": {"$ref": "#/definitions/ArgumentType"}},
         "isEnabled": {"$ref": "#/definitions/PredicateType"},
-        "k8sContainerOptions": {"$ref": "https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.11.2/_definitions.json#/definitions/io.k8s.api.core.v1.Container"},
-        "k8sPodOptions": {"$ref": "#/definitions/PodArgoSubset"}
+        "executionOptions": {"$ref": "#/definitions/ExecutionOptionsSpec"}
       },
       "additionalProperties": false
     },

--- a/sdk/python/kfp/components/structures/components.json_schema.json
+++ b/sdk/python/kfp/components/structures/components.json_schema.json
@@ -232,8 +232,13 @@
       "required": ["graphInput"],
       "properties": {
         "graphInput": {
-          "description": "Input name",
-          "type": "string"
+          "description": "References the input of the graph/pipeline.",
+          "type": "object",
+          "required": ["inputName"],
+          "properties": {
+            "inputName": {"type": "string"}
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/sdk/python/kfp/components/structures/components.json_schema.json
+++ b/sdk/python/kfp/components/structures/components.json_schema.json
@@ -8,7 +8,8 @@
     "TypeType": {
       "oneOf": [
         {"type": "string"},
-        {"type": "object", "additionalProperties": {"type": "string"}}
+        {"type": "array", "items": {"$ref": "#/definitions/TypeType"}},
+        {"type": "object", "additionalProperties": {"$ref": "#/definitions/TypeType"}}
       ]
     },
 
@@ -20,7 +21,8 @@
         "name": {"type": "string"},
         "type": {"$ref": "#/definitions/TypeType"},
         "description": {"type": "string"},
-        "default": {"type": "string"}
+        "default": {"type": "string"},
+        "optional": {"type": "boolean", "default": false}
       },
       "additionalProperties": false
     },
@@ -82,7 +84,8 @@
         {"$ref": "#/definitions/InputValuePlaceholder"},
         {"$ref": "#/definitions/InputPathPlaceholder"},
         {"$ref": "#/definitions/OutputPathPlaceholder"},
-        {"$ref": "#/definitions/ConcatPlaceholder"}
+        {"$ref": "#/definitions/ConcatPlaceholder"},
+        {"$ref": "#/definitions/IfPlaceholder"}
       ]
     },
 
@@ -98,6 +101,44 @@
         }
       },
       "additionalProperties": false
+    },
+
+    "IsPresentPlaceholder": {
+      "description": "Represents the command-line argument placeholder that will be replaced at run-time by a boolean value specifying whether the caller has passed an argument for the specified optional input.",
+      "type": "object",
+      "properties": {
+        "isPresent": {
+          "description": "Name of the input.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "IfConditionArgumentType": {
+      "oneOf": [
+        {"$ref": "#/definitions/IsPresentPlaceholder"},
+        {"type": "boolean"},
+        {"type": "string"},
+        {"$ref": "#/definitions/InputValuePlaceholder"}
+      ]
+    },
+
+    "IfPlaceholder": {
+      "description": "Represents the command-line argument placeholder that will be replaced at run-time by a boolean value specifying whether the caller has passed an argument for the specified optional input.",
+      "type": "object",
+      "required": ["if"],
+      "properties": {
+        "if" : {
+          "type": "object",
+          "required": ["cond", "then"],
+          "properties": {
+            "cond": {"$ref": "#/definitions/IfConditionArgumentType"},
+            "then": {"$ref": "#/definitions/CommandlineArgumentOrArrayType"},
+            "else": {"$ref": "#/definitions/CommandlineArgumentOrArrayType"}
+          }
+        }
+      }
     },
 
     "ContainerSpec": {
@@ -143,7 +184,8 @@
 
     "ImplementationType": {
       "oneOf": [
-        {"$ref": "#/definitions/ContainerImplementation"}
+        {"$ref": "#/definitions/ContainerImplementation"},
+        {"$ref": "#/definitions/GraphImplementation"}
       ]
     },
 
@@ -185,6 +227,19 @@
       "additionalProperties": false
     },
 
+    "GraphInputArgument": {
+      "description": "Represents the component argument value that comes from the graph component input.",
+      "type": "object",
+      "required": ["graphInput"],
+      "properties": {
+        "graphInput": {
+          "description": "Input name",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+
     "TaskOutputArgument": {
       "description": "Represents the component argument value that comes from the output of a sibling task.",
       "type": "object",
@@ -207,7 +262,46 @@
     "ArgumentType": {
       "oneOf": [
         {"type": "string"},
+        {"$ref": "#/definitions/GraphInputArgument"},
         {"$ref": "#/definitions/TaskOutputArgument"}
+      ]
+    },
+
+    "TwoArgumentOperands": {
+      "description": "Pair of operands for a binary operation.",
+      "type": "object",
+      "required": ["op1", "op2"],
+      "properties": {
+        "op1":  {"$ref": "#/definitions/ArgumentType"},
+        "op2":  {"$ref": "#/definitions/ArgumentType"}
+      },
+      "additionalProperties": false
+    },
+
+    "TwoLogicalOperands": {
+      "description": "Pair of operands for a binary logical operation.",
+      "type": "object",
+      "required": ["op1", "op2"],
+      "properties": {
+        "op1":  {"$ref": "#/definitions/PredicateType"},
+        "op2":  {"$ref": "#/definitions/PredicateType"}
+      },
+      "additionalProperties": false
+    },
+
+    "PredicateType": {
+      "oneOf": [
+        {"type": "object", "required": ["=="], "properties": {"==":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
+        {"type": "object", "required": ["!="], "properties": {"!=":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
+        {"type": "object", "required": [">"], "properties": {">":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
+        {"type": "object", "required": [">="], "properties": {">=":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
+        {"type": "object", "required": ["<"], "properties": {"<":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
+        {"type": "object", "required": ["<="], "properties": {"<=":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
+
+        {"type": "object", "required": ["and"], "properties": {"and":  {"$ref": "#/definitions/TwoLogicalOperands"}}},
+        {"type": "object", "required": ["or"], "properties": {"or":  {"$ref": "#/definitions/TwoLogicalOperands"}}},
+
+        {"type": "object", "required": ["not"], "properties": {"not":  {"$ref": "#/definitions/PredicateType"}}}
       ]
     },
 
@@ -251,8 +345,30 @@
       "properties": {
         "componentRef": {"$ref": "#/definitions/ComponentReference"},
         "arguments": {"type": "object", "additionalProperties": {"$ref": "#/definitions/ArgumentType"}},
+        "isEnabled": {"$ref": "#/definitions/PredicateType"},
         "k8sContainerOptions": {"$ref": "https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.11.2/_definitions.json#/definitions/io.k8s.api.core.v1.Container"},
         "k8sPodOptions": {"$ref": "#/definitions/PodArgoSubset"}
+      },
+      "additionalProperties": false
+    },
+
+    "GraphSpec": {
+      "description": "Describes the graph component implementation. It represents a graph of component tasks connected to the upstream sources of data using the argument specifications. It also describes the sources of graph output values.",
+      "type": "object",
+      "required": ["tasks"],
+      "properties": {
+        "tasks": {"type": "object", "additionalProperties": {"$ref": "#/definitions/TaskSpec"}},
+        "outputValues": {"type": "object", "additionalProperties": {"$ref": "#/definitions/TaskOutputArgument"}}
+      },
+      "additionalProperties": false
+    },
+
+    "GraphImplementation": {
+      "description": "Represents the graph component implementation.",
+      "type": "object",
+      "required": ["graph"],
+      "properties": {
+        "graph": {"$ref": "#/definitions/GraphSpec"}
       },
       "additionalProperties": false
     },

--- a/sdk/python/kfp/components/structures/components.json_schema.json
+++ b/sdk/python/kfp/components/structures/components.json_schema.json
@@ -236,7 +236,8 @@
           "type": "object",
           "required": ["inputName"],
           "properties": {
-            "inputName": {"type": "string"}
+            "inputName": {"type": "string"},
+            "type": {"$ref": "#/definitions/TypeSpecType"}
           },
           "additionalProperties": false
         }
@@ -255,7 +256,8 @@
           "required": ["taskId", "outputName"],
           "properties": {
             "taskId": {"type": "string"},
-            "outputName": {"type": "string"}
+            "outputName": {"type": "string"},
+            "type": {"$ref": "#/definitions/TypeSpecType"}
           },
           "additionalProperties": false
         }

--- a/sdk/python/kfp/components/structures/components.json_schema.json
+++ b/sdk/python/kfp/components/structures/components.json_schema.json
@@ -311,29 +311,6 @@
       ]
     },
 
-    "ObjectMetaArgoSubset": {
-      "description": "Subset of io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta structure supported by Argo",
-      "type": "object",
-      "properties": {
-        "annotations": {"type": "object", "additionalItems": {"type": "string"}},
-        "labels": {"type": "object", "additionalItems": {"type": "string"}}
-      },
-      "additionalProperties": false
-    },
-
-    "PodSpecArgoSubset": {
-      "description": "Subset of Kubernetes PodSpec structure supported by Argo",
-      "type": "object",
-      "properties": {
-        "activeDeadlineSeconds": {"type": "integer"},
-        "affinity": {"$ref": "https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.11.2/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity"},
-        "tolerations": {"type": "array", "items": {"$ref": "https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.11.2/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration"}},
-        "volumes": {"type": "array", "items": {"$ref": "https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.11.2/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"}},
-        "nodeSelector": {"type": "object", "additionalItems": {"type": "string"}}
-      },
-      "additionalProperties": false
-    },
-
     "RetryStrategySpec": {
       "description": "Optional configuration that specifies how the task should be retried if it fails.",
       "type": "object",
@@ -347,9 +324,9 @@
       "description": "When running on Kubernetes, KubernetesExecutionOptionsSpec describes changes to the configuration of a Kubernetes Pod that will execute the task.",
       "type": "object",
       "properties": {
-        "metadata": {"$ref": "#/definitions/ObjectMetaArgoSubset"},
-        "mainContainer": {"$ref": "https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.11.2/_definitions.json#/definitions/io.k8s.api.core.v1.Container"},
-        "podSpec": {"$ref": "#/definitions/PodSpecArgoSubset"}
+        "metadata": {"$ref": "#https://kubernetesjsonschema.dev/v1.14.0/_definitions.json/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},
+        "mainContainer": {"$ref": "https://kubernetesjsonschema.dev/v1.14.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container"},
+        "podSpec": {"$ref": "https://kubernetesjsonschema.dev/v1.14.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec"}
       },
       "additionalProperties": false
     },

--- a/sdk/python/kfp/components/structures/components.json_schema.json
+++ b/sdk/python/kfp/components/structures/components.json_schema.json
@@ -8,8 +8,7 @@
     "TypeType": {
       "oneOf": [
         {"type": "string"},
-        {"type": "array", "items": {"$ref": "#/definitions/TypeType"}},
-        {"type": "object", "additionalProperties": {"$ref": "#/definitions/TypeType"}}
+        {"type": "object", "additionalProperties": {"type": "string"}}
       ]
     },
 

--- a/sdk/python/kfp/components/structures/components.json_schema.json
+++ b/sdk/python/kfp/components/structures/components.json_schema.json
@@ -78,7 +78,7 @@
       "additionalProperties": false
     },
 
-    "CommandlineArgumentType": {
+    "StringOrPlaceholder": {
       "oneOf": [
         {"type": "string"},
         {"$ref": "#/definitions/InputValuePlaceholder"},
@@ -86,13 +86,6 @@
         {"$ref": "#/definitions/OutputPathPlaceholder"},
         {"$ref": "#/definitions/ConcatPlaceholder"},
         {"$ref": "#/definitions/IfPlaceholder"}
-      ]
-    },
-
-    "CommandlineArgumentOrArrayType": {
-      "oneOf": [
-        {"$ref": "#/definitions/CommandlineArgumentType"},
-        {"type": "array", "items": {"$ref": "#/definitions/CommandlineArgumentType"}}
       ]
     },
 
@@ -104,7 +97,7 @@
         "concat" : {
           "description": "Items to concatenate",
           "type": "array",
-          "items": {"$ref": "#/definitions/CommandlineArgumentType"}
+          "items": {"$ref": "#/definitions/StringOrPlaceholder"}
         }
       },
       "additionalProperties": false
@@ -154,22 +147,22 @@
       "properties": {
         "image": {
           "description": "Docker image name.",
-          "type": "string"
+          "$ref": "#/definitions/StringOrPlaceholder"
         },
         "command": {
           "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided.",
           "type": "array",
-          "items": {"$ref": "#/definitions/CommandlineArgumentType"}
+          "items": {"$ref": "#/definitions/StringOrPlaceholder"}
         },
         "args": {
           "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided.",
           "type": "array",
-          "items": {"$ref": "#/definitions/CommandlineArgumentType"}
+          "items": {"$ref": "#/definitions/StringOrPlaceholder"}
         },
         "env": {
           "description": "List of environment variables to set in the container.",
           "type": "object",
-          "additionalProperties": {"type": "string"}
+          "additionalProperties": {"$ref": "#/definitions/StringOrPlaceholder"}
         },
         "unconfigurableOutputPaths": {
           "description": "Legacy. Deprecated. Can be used to specify local output file paths for containers that do not allow setting the path of some output using command-line.",

--- a/sdk/python/kfp/components/structures/components.json_schema.json
+++ b/sdk/python/kfp/components/structures/components.json_schema.json
@@ -5,15 +5,6 @@
   "$ref": "#/definitions/PipelineRunSpec",
 
   "definitions": {
-    "PrimitiveTypes": {
-      "oneOf": [
-        {"type": "string"},
-        {"type": "integer"},
-        {"type": "number"},
-        {"type": "boolean"}
-      ]
-    },
-
     "TypeType": {
       "oneOf": [
         {"type": "string"},
@@ -30,7 +21,7 @@
         "name": {"type": "string"},
         "type": {"$ref": "#/definitions/TypeType"},
         "description": {"type": "string"},
-        "default": {"$ref": "#/definitions/PrimitiveTypes"},
+        "default": {"type": "string"},
         "optional": {"type": "boolean", "default": false}
       },
       "additionalProperties": false
@@ -89,7 +80,7 @@
 
     "CommandlineArgumentType": {
       "oneOf": [
-        {"$ref": "#/definitions/PrimitiveTypes"},
+        {"type": "string"},
         {"$ref": "#/definitions/InputValuePlaceholder"},
         {"$ref": "#/definitions/InputPathPlaceholder"},
         {"$ref": "#/definitions/OutputPathPlaceholder"},
@@ -277,7 +268,7 @@
 
     "ArgumentType": {
       "oneOf": [
-        {"$ref": "#/definitions/PrimitiveTypes"},
+        {"type": "string"},
         {"$ref": "#/definitions/GraphInputArgument"},
         {"$ref": "#/definitions/TaskOutputArgument"}
       ]

--- a/sdk/python/kfp/components/structures/components.json_schema.json
+++ b/sdk/python/kfp/components/structures/components.json_schema.json
@@ -1,0 +1,402 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "http://kubeflow.org/pipelines/components.json_schema.json",
+
+  "$ref": "#/definitions/PipelineRunSpec",
+
+  "definitions": {
+    "PrimitiveTypes": {
+      "oneOf": [
+        {"type": "string"},
+        {"type": "integer"},
+        {"type": "number"},
+        {"type": "boolean"}
+      ]
+    },
+
+    "TypeType": {
+      "oneOf": [
+        {"type": "string"},
+        {"type": "array", "items": {"$ref": "#/definitions/TypeType"}},
+        {"type": "object", "additionalProperties": {"$ref": "#/definitions/TypeType"}}
+      ]
+    },
+
+    "InputSpec": {
+      "description": "Describes the component input specification",
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"},
+        "type": {"$ref": "#/definitions/TypeType"},
+        "description": {"type": "string"},
+        "default": {"$ref": "#/definitions/PrimitiveTypes"},
+        "optional": {"type": "boolean", "default": false}
+      },
+      "additionalProperties": false
+    },
+
+    "OutputSpec": {
+      "description": "Describes the component output specification",
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {"type": "string"},
+        "type": {"$ref": "#/definitions/TypeType"},
+        "description": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+
+    "InputValuePlaceholder": {
+      "description": "Represents the command-line argument placeholder that will be replaced at run-time by the input argument value.",
+      "type": "object",
+      "required": ["inputValue"],
+      "properties": {
+        "inputValue" : {
+          "description": "Name of the input.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "InputPathPlaceholder": {
+      "description": "Represents the command-line argument placeholder that will be replaced at run-time by a local file path pointing to a file containing the input argument value.",
+      "type": "object",
+      "required": ["inputPath"],
+      "properties": {
+        "inputPath" : {
+          "description": "Name of the input.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "OutputPathPlaceholder": {
+      "description": "Represents the command-line argument placeholder that will be replaced at run-time by a local file path pointing to a file where the program should write its output data.",
+      "type": "object",
+      "required": ["outputPath"],
+      "properties": {
+        "outputPath" : {
+          "description": "Name of the output.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "CommandlineArgumentType": {
+      "oneOf": [
+        {"$ref": "#/definitions/PrimitiveTypes"},
+        {"$ref": "#/definitions/InputValuePlaceholder"},
+        {"$ref": "#/definitions/InputPathPlaceholder"},
+        {"$ref": "#/definitions/OutputPathPlaceholder"},
+        {"$ref": "#/definitions/ConcatPlaceholder"},
+        {"$ref": "#/definitions/IfPlaceholder"}
+      ]
+    },
+
+    "CommandlineArgumentOrArrayType": {
+      "oneOf": [
+        {"$ref": "#/definitions/CommandlineArgumentType"},
+        {"type": "array", "items": {"$ref": "#/definitions/CommandlineArgumentType"}}
+      ]
+    },
+
+    "ConcatPlaceholder": {
+      "description": "Represents the command-line argument placeholder that will be replaced at run-time by the concatenated values of its items.",
+      "type": "object",
+      "required": ["concat"],
+      "properties": {
+        "concat" : {
+          "description": "Items to concatenate",
+          "type": "array",
+          "items": {"$ref": "#/definitions/CommandlineArgumentType"}
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "IsPresentPlaceholder": {
+      "description": "Represents the command-line argument placeholder that will be replaced at run-time by a boolean value specifying whether the caller has passed an argument for the specified optional input.",
+      "type": "object",
+      "properties": {
+        "isPresent": {
+          "description": "Name of the input.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "IfConditionArgumentType": {
+      "oneOf": [
+        {"$ref": "#/definitions/IsPresentPlaceholder"},
+        {"type": "boolean"},
+        {"type": "string"},
+        {"$ref": "#/definitions/InputValuePlaceholder"}
+      ]
+    },
+
+    "IfPlaceholder": {
+      "description": "Represents the command-line argument placeholder that will be replaced at run-time by a boolean value specifying whether the caller has passed an argument for the specified optional input.",
+      "type": "object",
+      "required": ["if"],
+      "properties": {
+        "if" : {
+          "type": "object",
+          "required": ["cond", "then"],
+          "properties": {
+            "cond": {"$ref": "#/definitions/IfConditionArgumentType"},
+            "then": {"$ref": "#/definitions/CommandlineArgumentOrArrayType"},
+            "else": {"$ref": "#/definitions/CommandlineArgumentOrArrayType"}
+          }
+        }
+      }
+    },
+
+    "ContainerSpec": {
+      "type": "object",
+      "required": ["image"],
+      "properties": {
+        "image": {
+          "description": "Docker image name.",
+          "type": "string"
+        },
+        "command": {
+          "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided.",
+          "type": "array",
+          "items": {"$ref": "#/definitions/CommandlineArgumentType"}
+        },
+        "args": {
+          "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided.",
+          "type": "array",
+          "items": {"$ref": "#/definitions/CommandlineArgumentType"}
+        },
+        "env": {
+          "description": "List of environment variables to set in the container.",
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "unconfigurableOutputPaths": {
+          "description": "Legacy. Deprecated. Can be used to specify local output file paths for containers that do not allow setting the path of some output using command-line.",
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "ContainerImplementation": {
+      "description": "Represents the container component implementation.",
+      "type": "object",
+      "required": ["container"],
+      "properties": {
+        "container": {"$ref": "#/definitions/ContainerSpec"}
+      }
+    },
+
+    "ImplementationType": {
+      "oneOf": [
+        {"$ref": "#/definitions/ContainerImplementation"},
+        {"$ref": "#/definitions/GraphImplementation"}
+      ]
+    },
+
+    "SourceSpec": {
+      "description": "Specifies the location of the component source code.",
+      "type": "object",
+      "properties": {
+        "url": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+
+    "ComponentSpec": {
+      "description": "Component specification. Describes the metadata (name, description, source), the interface (inputs and outputs) and the implementation of the component.",
+      "type": "object",
+      "required": ["implementation"],
+      "properties": {
+        "name": {"type": "string"},
+        "description": {"type": "string"},
+        "source": {"$ref": "#/definitions/SourceSpec"},
+        "inputs": {"type": "array", "items": {"$ref": "#/definitions/InputSpec"}},
+        "outputs": {"type": "array", "items": {"$ref": "#/definitions/OutputSpec"}},
+        "implementation": {"$ref": "#/definitions/ImplementationType"},
+        "schemaVersion": {"type": "string", "default": "kubeflow.org/pipelines/component/v1"}
+      },
+      "additionalProperties": false
+    },
+
+    "ComponentReference": {
+      "description": "Component reference. Contains information that can be used to locate and load a component by name, digest or URL",
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"},
+        "digest": {"type": "string"},
+        "tag": {"type": "string"},
+        "url": {"type": "string"},
+        "spec": {"$ref": "#/definitions/ComponentSpec"}
+      },
+      "additionalProperties": false
+    },
+
+    "GraphInputArgument": {
+      "description": "Represents the component argument value that comes from the graph component input.",
+      "type": "object",
+      "required": ["graphInput"],
+      "properties": {
+        "graphInput": {
+          "description": "Input name",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "TaskOutputArgument": {
+      "description": "Represents the component argument value that comes from the output of a sibling task.",
+      "type": "object",
+      "required": ["taskOutput"],
+      "properties": {
+        "taskOutput": {
+          "description": "References the output of a sibling task.",
+          "type": "object",
+          "required": ["taskId", "outputName"],
+          "properties": {
+            "taskId": {"type": "string"},
+            "outputName": {"type": "string"}
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "ArgumentType": {
+      "oneOf": [
+        {"$ref": "#/definitions/PrimitiveTypes"},
+        {"$ref": "#/definitions/GraphInputArgument"},
+        {"$ref": "#/definitions/TaskOutputArgument"}
+      ]
+    },
+
+    "TwoArgumentOperands": {
+      "description": "Pair of operands for a binary operation.",
+      "type": "object",
+      "required": ["op1", "op2"],
+      "properties": {
+        "op1":  {"$ref": "#/definitions/ArgumentType"},
+        "op2":  {"$ref": "#/definitions/ArgumentType"}
+      },
+      "additionalProperties": false
+    },
+
+    "TwoLogicalOperands": {
+      "description": "Pair of operands for a binary logical operation.",
+      "type": "object",
+      "required": ["op1", "op2"],
+      "properties": {
+        "op1":  {"$ref": "#/definitions/PredicateType"},
+        "op2":  {"$ref": "#/definitions/PredicateType"}
+      },
+      "additionalProperties": false
+    },
+
+    "PredicateType": {
+      "oneOf": [
+        {"type": "object", "required": ["=="], "properties": {"==":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
+        {"type": "object", "required": ["!="], "properties": {"!=":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
+        {"type": "object", "required": [">"], "properties": {">":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
+        {"type": "object", "required": [">="], "properties": {">=":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
+        {"type": "object", "required": ["<"], "properties": {"<":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
+        {"type": "object", "required": ["<="], "properties": {"<=":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
+
+        {"type": "object", "required": ["and"], "properties": {"and":  {"$ref": "#/definitions/TwoLogicalOperands"}}},
+        {"type": "object", "required": ["or"], "properties": {"or":  {"$ref": "#/definitions/TwoLogicalOperands"}}},
+
+        {"type": "object", "required": ["not"], "properties": {"not":  {"$ref": "#/definitions/PredicateType"}}}
+      ]
+    },
+
+    "ObjectMetaArgoSubset": {
+      "description": "Subset of io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta structure supported by Argo",
+      "type": "object",
+      "properties": {
+        "annotations": {"type": "object", "additionalItems": {"type": "string"}},
+        "labels": {"type": "object", "additionalItems": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+
+    "PodSpecArgoSubset": {
+      "description": "Subset of Kubernetes PodSpec structure supported by Argo",
+      "type": "object",
+      "properties": {
+        "activeDeadlineSeconds": {"type": "integer"},
+        "affinity": {"$ref": "https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.11.2/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity"},
+        "tolerations": {"type": "array", "items": {"$ref": "https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.11.2/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration"}},
+        "volumes": {"type": "array", "items": {"$ref": "https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.11.2/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"}},
+        "nodeSelector": {"type": "object", "additionalItems": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+
+    "PodArgoSubset": {
+      "description": "Subset of io.k8s.api.core.v1.Pod structure supported by Argo",
+      "type": "object",
+      "properties": {
+        "metadata": {"$ref": "#/definitions/ObjectMetaArgoSubset"},
+        "spec": {"$ref": "#/definitions/PodSpecArgoSubset"}
+      },
+      "additionalProperties": false
+    },
+
+    "TaskSpec": {
+      "description": "'Task specification. Task is a configured component - a component supplied with arguments and other applied configuration changes.",
+      "type": "object",
+      "required": ["componentRef"],
+      "properties": {
+        "componentRef": {"$ref": "#/definitions/ComponentReference"},
+        "arguments": {"type": "object", "additionalProperties": {"$ref": "#/definitions/ArgumentType"}},
+        "isEnabled": {"$ref": "#/definitions/PredicateType"},
+        "k8sContainerOptions": {"$ref": "https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.11.2/_definitions.json#/definitions/io.k8s.api.core.v1.Container"},
+        "k8sPodOptions": {"$ref": "#/definitions/PodArgoSubset"}
+      },
+      "additionalProperties": false
+    },
+
+    "GraphSpec": {
+      "description": "Describes the graph component implementation. It represents a graph of component tasks connected to the upstream sources of data using the argument specifications. It also describes the sources of graph output values.",
+      "type": "object",
+      "required": ["tasks"],
+      "properties": {
+        "tasks": {"type": "object", "additionalProperties": {"$ref": "#/definitions/TaskSpec"}},
+        "outputValues": {"type": "object", "additionalProperties": {"$ref": "#/definitions/TaskOutputArgument"}}
+      },
+      "additionalProperties": false
+    },
+
+    "GraphImplementation": {
+      "description": "Represents the graph component implementation.",
+      "type": "object",
+      "required": ["graph"],
+      "properties": {
+        "graph": {"$ref": "#/definitions/GraphSpec"}
+      },
+      "additionalProperties": false
+    },
+
+    "PipelineRunSpec": {
+      "description": "The object that can be sent to the backend to start a new Run.",
+      "type": "object",
+      "required": ["rootTask"],
+      "properties": {
+        "rootTask": {"$ref": "#/definitions/TaskSpec"},
+        "onExitTask": {"$ref": "#/definitions/TaskSpec"}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/sdk/python/kfp/components/structures/components.json_schema.json
+++ b/sdk/python/kfp/components/structures/components.json_schema.json
@@ -211,44 +211,6 @@
       ]
     },
 
-    "TwoArgumentOperands": {
-      "description": "Pair of operands for a binary operation.",
-      "type": "object",
-      "required": ["op1", "op2"],
-      "properties": {
-        "op1":  {"$ref": "#/definitions/ArgumentType"},
-        "op2":  {"$ref": "#/definitions/ArgumentType"}
-      },
-      "additionalProperties": false
-    },
-
-    "TwoLogicalOperands": {
-      "description": "Pair of operands for a binary logical operation.",
-      "type": "object",
-      "required": ["op1", "op2"],
-      "properties": {
-        "op1":  {"$ref": "#/definitions/PredicateType"},
-        "op2":  {"$ref": "#/definitions/PredicateType"}
-      },
-      "additionalProperties": false
-    },
-
-    "PredicateType": {
-      "oneOf": [
-        {"type": "object", "required": ["=="], "properties": {"==":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
-        {"type": "object", "required": ["!="], "properties": {"!=":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
-        {"type": "object", "required": [">"], "properties": {">":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
-        {"type": "object", "required": [">="], "properties": {">=":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
-        {"type": "object", "required": ["<"], "properties": {"<":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
-        {"type": "object", "required": ["<="], "properties": {"<=":  {"$ref": "#/definitions/TwoArgumentOperands"}}},
-
-        {"type": "object", "required": ["and"], "properties": {"and":  {"$ref": "#/definitions/TwoLogicalOperands"}}},
-        {"type": "object", "required": ["or"], "properties": {"or":  {"$ref": "#/definitions/TwoLogicalOperands"}}},
-
-        {"type": "object", "required": ["not"], "properties": {"not":  {"$ref": "#/definitions/PredicateType"}}}
-      ]
-    },
-
     "ObjectMetaArgoSubset": {
       "description": "Subset of io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta structure supported by Argo",
       "type": "object",
@@ -289,7 +251,6 @@
       "properties": {
         "componentRef": {"$ref": "#/definitions/ComponentReference"},
         "arguments": {"type": "object", "additionalProperties": {"$ref": "#/definitions/ArgumentType"}},
-        "isEnabled": {"$ref": "#/definitions/PredicateType"},
         "k8sContainerOptions": {"$ref": "https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.11.2/_definitions.json#/definitions/io.k8s.api.core.v1.Container"},
         "k8sPodOptions": {"$ref": "#/definitions/PodArgoSubset"}
       },

--- a/sdk/python/kfp/components/structures/components.json_schema.json
+++ b/sdk/python/kfp/components/structures/components.json_schema.json
@@ -183,8 +183,7 @@
 
     "ImplementationType": {
       "oneOf": [
-        {"$ref": "#/definitions/ContainerImplementation"},
-        {"$ref": "#/definitions/GraphImplementation"}
+        {"$ref": "#/definitions/ContainerImplementation"}
       ]
     },
 
@@ -226,19 +225,6 @@
       "additionalProperties": false
     },
 
-    "GraphInputArgument": {
-      "description": "Represents the component argument value that comes from the graph component input.",
-      "type": "object",
-      "required": ["graphInput"],
-      "properties": {
-        "graphInput": {
-          "description": "Input name",
-          "type": "string"
-        }
-      },
-      "additionalProperties": false
-    },
-
     "TaskOutputArgument": {
       "description": "Represents the component argument value that comes from the output of a sibling task.",
       "type": "object",
@@ -261,7 +247,6 @@
     "ArgumentType": {
       "oneOf": [
         {"type": "string"},
-        {"$ref": "#/definitions/GraphInputArgument"},
         {"$ref": "#/definitions/TaskOutputArgument"}
       ]
     },
@@ -347,27 +332,6 @@
         "isEnabled": {"$ref": "#/definitions/PredicateType"},
         "k8sContainerOptions": {"$ref": "https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.11.2/_definitions.json#/definitions/io.k8s.api.core.v1.Container"},
         "k8sPodOptions": {"$ref": "#/definitions/PodArgoSubset"}
-      },
-      "additionalProperties": false
-    },
-
-    "GraphSpec": {
-      "description": "Describes the graph component implementation. It represents a graph of component tasks connected to the upstream sources of data using the argument specifications. It also describes the sources of graph output values.",
-      "type": "object",
-      "required": ["tasks"],
-      "properties": {
-        "tasks": {"type": "object", "additionalProperties": {"$ref": "#/definitions/TaskSpec"}},
-        "outputValues": {"type": "object", "additionalProperties": {"$ref": "#/definitions/TaskOutputArgument"}}
-      },
-      "additionalProperties": false
-    },
-
-    "GraphImplementation": {
-      "description": "Represents the graph component implementation.",
-      "type": "object",
-      "required": ["graph"],
-      "properties": {
-        "graph": {"$ref": "#/definitions/GraphSpec"}
       },
       "additionalProperties": false
     },

--- a/sdk/python/kfp/components/structures/components.json_schema.json
+++ b/sdk/python/kfp/components/structures/components.json_schema.json
@@ -20,8 +20,7 @@
         "name": {"type": "string"},
         "type": {"$ref": "#/definitions/TypeType"},
         "description": {"type": "string"},
-        "default": {"type": "string"},
-        "optional": {"type": "boolean", "default": false}
+        "default": {"type": "string"}
       },
       "additionalProperties": false
     },
@@ -83,8 +82,7 @@
         {"$ref": "#/definitions/InputValuePlaceholder"},
         {"$ref": "#/definitions/InputPathPlaceholder"},
         {"$ref": "#/definitions/OutputPathPlaceholder"},
-        {"$ref": "#/definitions/ConcatPlaceholder"},
-        {"$ref": "#/definitions/IfPlaceholder"}
+        {"$ref": "#/definitions/ConcatPlaceholder"}
       ]
     },
 
@@ -100,44 +98,6 @@
         }
       },
       "additionalProperties": false
-    },
-
-    "IsPresentPlaceholder": {
-      "description": "Represents the command-line argument placeholder that will be replaced at run-time by a boolean value specifying whether the caller has passed an argument for the specified optional input.",
-      "type": "object",
-      "properties": {
-        "isPresent": {
-          "description": "Name of the input.",
-          "type": "string"
-        }
-      },
-      "additionalProperties": false
-    },
-
-    "IfConditionArgumentType": {
-      "oneOf": [
-        {"$ref": "#/definitions/IsPresentPlaceholder"},
-        {"type": "boolean"},
-        {"type": "string"},
-        {"$ref": "#/definitions/InputValuePlaceholder"}
-      ]
-    },
-
-    "IfPlaceholder": {
-      "description": "Represents the command-line argument placeholder that will be replaced at run-time by a boolean value specifying whether the caller has passed an argument for the specified optional input.",
-      "type": "object",
-      "required": ["if"],
-      "properties": {
-        "if" : {
-          "type": "object",
-          "required": ["cond", "then"],
-          "properties": {
-            "cond": {"$ref": "#/definitions/IfConditionArgumentType"},
-            "then": {"$ref": "#/definitions/CommandlineArgumentOrArrayType"},
-            "else": {"$ref": "#/definitions/CommandlineArgumentOrArrayType"}
-          }
-        }
-      }
     },
 
     "ContainerSpec": {

--- a/sdk/python/kfp/components/structures/components.json_schema.json
+++ b/sdk/python/kfp/components/structures/components.json_schema.json
@@ -25,6 +25,7 @@
     "InputSpec": {
       "description": "Describes the component input specification",
       "type": "object",
+      "required": ["name"],
       "properties": {
         "name": {"type": "string"},
         "type": {"$ref": "#/definitions/TypeType"},

--- a/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
+++ b/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
@@ -56,7 +56,8 @@
                                     <oneOf>:
                                         string:
                                         <GraphInputArgument>:
-                                            graphInput: string
+                                            graphInput:
+                                                inputName: string
                                         <TaskOutputArgument>:
                                             taskOutput:
                                                 taskId: string

--- a/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
+++ b/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
@@ -58,10 +58,12 @@
                                         <GraphInputArgument>:
                                             graphInput:
                                                 inputName: string
+                                                type: TypeSpecType
                                         <TaskOutputArgument>:
                                             taskOutput:
                                                 taskId: string
                                                 outputName: string
+                                                type: TypeSpecType
                             isEnabled: PredicateType
                             k8sContainerOptions: io.k8s.api.core.v1.Container
                             k8sPodOptions: #PodArgoSubset

--- a/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
+++ b/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
@@ -10,6 +10,7 @@
             type: TypeType
             description: string
             default: string
+            optional: boolean
     outputs: #OutputSpec[]
         <OutputSpec[]>:
             name: string
@@ -31,33 +32,44 @@
                                 outputPath: string
                             <ConcatPlaceholder>:
                                 concat: StringOrPlaceholder[]
+                            <IfPlaceholder>:
+                                if:
+                                    cond: IfConditionArgumentType
+                                    then: StringOrPlaceholder[]
+                                    else: StringOrPlaceholder[]
                     args: StringOrPlaceholder[]
                     env: Map[str, StringOrPlaceholder]
                     unconfigurableOutputPaths: Map[str, str]
-
-<TaskSpec>:
-    componentRef: #ComponentReference
-        name: string
-        digest: string
-        tag: string
-        url: string
-        spec: ComponentSpec
-    arguments: #Map str -> ArgumentType
-        <Map str -> ArgumentType>:
-            <oneOf>:
-                string:
-                <TaskOutputArgument>:
-                    taskOutput:
-                        taskId: string
-                        outputName: string
-    k8sContainerOptions: io.k8s.api.core.v1.Container
-    k8sPodOptions: #PodArgoSubset
-        metadata: #ObjectMetaArgoSubset
-            annotations: Map str -> str
-            labels: Map str -> str
-        spec: #PodSpecArgoSubset
-            activeDeadlineSeconds: integer
-            affinity: io.k8s.api.core.v1.Affinity
-            tolerations: io.k8s.api.core.v1.Toleration[]
-            volumes: io.k8s.api.core.v1.Volume[]
-            nodeSelector: Map str -> str
+            <GraphImplementation>:
+                graph: #GraphSpec
+                    outputValues: Map str -> TaskOutputArgument
+                    tasks: #Map str -> TaskSpec
+                        <Map str -> TaskSpec>:
+                            componentRef: #ComponentReference
+                                name: string
+                                digest: string
+                                tag: string
+                                url: string
+                                spec: ComponentSpec
+                            arguments: #Map str -> ArgumentType
+                                <Map str -> ArgumentType>:
+                                    <oneOf>:
+                                        string:
+                                        <GraphInputArgument>:
+                                            graphInput: string
+                                        <TaskOutputArgument>:
+                                            taskOutput:
+                                                taskId: string
+                                                outputName: string
+                            isEnabled: PredicateType
+                            k8sContainerOptions: io.k8s.api.core.v1.Container
+                            k8sPodOptions: #PodArgoSubset
+                                metadata: #ObjectMetaArgoSubset
+                                    annotations: Map str -> str
+                                    labels: Map str -> str
+                                spec: #PodSpecArgoSubset
+                                    activeDeadlineSeconds: integer
+                                    affinity: io.k8s.api.core.v1.Affinity
+                                    tolerations: io.k8s.api.core.v1.Toleration[]
+                                    volumes: io.k8s.api.core.v1.Volume[]
+                                    nodeSelector: Map str -> str

--- a/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
+++ b/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
@@ -7,14 +7,14 @@
     inputs: #InputSpec[]
         <InputSpec[]>:
             name: string
-            type: TypeType
+            type: TypeSpecType
             description: string
             default: string
             optional: boolean
     outputs: #OutputSpec[]
         <OutputSpec[]>:
             name: string
-            type: TypeType
+            type: TypeSpecType
             description: string
     implementation: #ImplementationType
         <oneOf>:

--- a/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
+++ b/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
@@ -69,13 +69,6 @@
                                 retryStrategy: #RetryStrategySpec
                                     maxRetries: integer
                                 kubernetesOptions: #KubernetesExecutionOptionsSpec
-                                    metadata: #ObjectMetaArgoSubset
-                                        annotations: Map str -> str
-                                        labels: Map str -> str
+                                    metadata: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
                                     mainContainer: io.k8s.api.core.v1.Container
-                                    podSpec: #PodSpecArgoSubset
-                                        activeDeadlineSeconds: integer
-                                        affinity: io.k8s.api.core.v1.Affinity
-                                        tolerations: io.k8s.api.core.v1.Toleration[]
-                                        volumes: io.k8s.api.core.v1.Volume[]
-                                        nodeSelector: Map str -> str
+                                    podSpec: io.k8s.api.core.v1.PodSpec

--- a/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
+++ b/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
@@ -65,14 +65,17 @@
                                                 outputName: string
                                                 type: TypeSpecType
                             isEnabled: PredicateType
-                            k8sContainerOptions: io.k8s.api.core.v1.Container
-                            k8sPodOptions: #PodArgoSubset
-                                metadata: #ObjectMetaArgoSubset
-                                    annotations: Map str -> str
-                                    labels: Map str -> str
-                                spec: #PodSpecArgoSubset
-                                    activeDeadlineSeconds: integer
-                                    affinity: io.k8s.api.core.v1.Affinity
-                                    tolerations: io.k8s.api.core.v1.Toleration[]
-                                    volumes: io.k8s.api.core.v1.Volume[]
-                                    nodeSelector: Map str -> str
+                            executionOptions: #ExecutionOptionsSpec
+                                retryStrategy: #RetryStrategySpec
+                                    maxRetries: integer
+                                kubernetesOptions: #KubernetesExecutionOptionsSpec
+                                    metadata: #ObjectMetaArgoSubset
+                                        annotations: Map str -> str
+                                        labels: Map str -> str
+                                    mainContainer: io.k8s.api.core.v1.Container
+                                    podSpec: #PodSpecArgoSubset
+                                        activeDeadlineSeconds: integer
+                                        affinity: io.k8s.api.core.v1.Affinity
+                                        tolerations: io.k8s.api.core.v1.Toleration[]
+                                        volumes: io.k8s.api.core.v1.Volume[]
+                                        nodeSelector: Map str -> str

--- a/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
+++ b/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
@@ -10,7 +10,6 @@
             type: TypeType
             description: string
             default: string
-            optional: boolean
     outputs: #OutputSpec[]
         <OutputSpec[]>:
             name: string
@@ -32,11 +31,6 @@
                                 outputPath: string
                             <ConcatPlaceholder>:
                                 concat: StringOrPlaceholder[]
-                            <IfPlaceholder>:
-                                if:
-                                    cond: IfConditionArgumentType
-                                    then: StringOrPlaceholder[]
-                                    else: StringOrPlaceholder[]
                     args: StringOrPlaceholder[]
                     env: Map[str, StringOrPlaceholder]
                     unconfigurableOutputPaths: Map[str, str]

--- a/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
+++ b/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
@@ -9,7 +9,7 @@
             name: string
             type: TypeType
             description: string
-            default: PrimitiveTypes
+            default: string
             optional: boolean
     outputs: #OutputSpec[]
         <OutputSpec[]>:
@@ -23,8 +23,7 @@
                     image: string
                     command: #CommandlineArgumentType
                         <oneOf>:
-                            <PrimitiveTypes>:
-                                <oneOf>: string, integer, number, boolean
+                            string:
                             <InputValuePlaceholder>:
                                 inputValue: string
                             <InputPathPlaceholder>:
@@ -55,8 +54,7 @@
                             arguments: #Map str -> ArgumentType
                                 <Map str -> ArgumentType>:
                                     <oneOf>:
-                                        <PrimitiveTypes>:
-                                            oneOf: string, integer, number, boolean
+                                        string:
                                         <GraphInputArgument>:
                                             graphInput: string
                                         <TaskOutputArgument>:

--- a/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
+++ b/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
@@ -1,0 +1,77 @@
+<ComponentSpec>:
+    name: string
+    description: string
+    source: #SourceSpec
+        url: string
+    schemaVersion: string
+    inputs: #InputSpec[]
+        <InputSpec[]>:
+            name: string
+            type: TypeType
+            description: string
+            default: PrimitiveTypes
+            optional: boolean
+    outputs: #OutputSpec[]
+        <OutputSpec[]>:
+            name: string
+            type: TypeType
+            description: string
+    implementation: #ImplementationType
+        <oneOf>:
+            <ContainerImplementation>:
+                container: #ContainerSpec
+                    image: string
+                    command: #CommandlineArgumentType
+                        <oneOf>:
+                            <PrimitiveTypes>:
+                                <oneOf>: string, integer, number, boolean
+                            <InputValuePlaceholder>:
+                                inputValue: string
+                            <InputPathPlaceholder>:
+                                inputPath: string
+                            <OutputPathPlaceholder>:
+                                outputPath: string
+                            <ConcatPlaceholder>:
+                                concat: CommandlineArgumentType[]
+                            <IfPlaceholder>:
+                                if:
+                                    cond: IfConditionArgumentType
+                                    then: CommandlineArgumentType[]
+                                    else: CommandlineArgumentType[]
+                    args: CommandlineArgumentType
+                    env: Map[str, str]
+                    unconfigurableOutputPaths: Map[str, str]
+            <GraphImplementation>:
+                graph: #GraphSpec
+                    outputValues: Map str -> TaskOutputArgument
+                    tasks: #Map str -> TaskSpec
+                        <Map str -> TaskSpec>:
+                            componentRef: #ComponentReference
+                                name: string
+                                digest: string
+                                tag: string
+                                url: string
+                                spec: ComponentSpec
+                            arguments: #Map str -> ArgumentType
+                                <Map str -> ArgumentType>:
+                                    <oneOf>:
+                                        <PrimitiveTypes>:
+                                            oneOf: string, integer, number, boolean
+                                        <GraphInputArgument>:
+                                            graphInput: string
+                                        <TaskOutputArgument>:
+                                            taskOutput:
+                                                taskId: string
+                                                outputName: string
+                            isEnabled: PredicateType
+                            k8sContainerOptions: io.k8s.api.core.v1.Container
+                            k8sPodOptions: #PodArgoSubset
+                                metadata: #ObjectMetaArgoSubset
+                                    annotations: Map str -> str
+                                    labels: Map str -> str
+                                spec: #PodSpecArgoSubset
+                                    activeDeadlineSeconds: integer
+                                    affinity: io.k8s.api.core.v1.Affinity
+                                    tolerations: io.k8s.api.core.v1.Toleration[]
+                                    volumes: io.k8s.api.core.v1.Volume[]
+                                    nodeSelector: Map str -> str

--- a/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
+++ b/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
@@ -40,36 +40,31 @@
                     args: StringOrPlaceholder[]
                     env: Map[str, StringOrPlaceholder]
                     unconfigurableOutputPaths: Map[str, str]
-            <GraphImplementation>:
-                graph: #GraphSpec
-                    outputValues: Map str -> TaskOutputArgument
-                    tasks: #Map str -> TaskSpec
-                        <Map str -> TaskSpec>:
-                            componentRef: #ComponentReference
-                                name: string
-                                digest: string
-                                tag: string
-                                url: string
-                                spec: ComponentSpec
-                            arguments: #Map str -> ArgumentType
-                                <Map str -> ArgumentType>:
-                                    <oneOf>:
-                                        string:
-                                        <GraphInputArgument>:
-                                            graphInput: string
-                                        <TaskOutputArgument>:
-                                            taskOutput:
-                                                taskId: string
-                                                outputName: string
-                            isEnabled: PredicateType
-                            k8sContainerOptions: io.k8s.api.core.v1.Container
-                            k8sPodOptions: #PodArgoSubset
-                                metadata: #ObjectMetaArgoSubset
-                                    annotations: Map str -> str
-                                    labels: Map str -> str
-                                spec: #PodSpecArgoSubset
-                                    activeDeadlineSeconds: integer
-                                    affinity: io.k8s.api.core.v1.Affinity
-                                    tolerations: io.k8s.api.core.v1.Toleration[]
-                                    volumes: io.k8s.api.core.v1.Volume[]
-                                    nodeSelector: Map str -> str
+
+<TaskSpec>:
+    componentRef: #ComponentReference
+        name: string
+        digest: string
+        tag: string
+        url: string
+        spec: ComponentSpec
+    arguments: #Map str -> ArgumentType
+        <Map str -> ArgumentType>:
+            <oneOf>:
+                string:
+                <TaskOutputArgument>:
+                    taskOutput:
+                        taskId: string
+                        outputName: string
+    isEnabled: PredicateType
+    k8sContainerOptions: io.k8s.api.core.v1.Container
+    k8sPodOptions: #PodArgoSubset
+        metadata: #ObjectMetaArgoSubset
+            annotations: Map str -> str
+            labels: Map str -> str
+        spec: #PodSpecArgoSubset
+            activeDeadlineSeconds: integer
+            affinity: io.k8s.api.core.v1.Affinity
+            tolerations: io.k8s.api.core.v1.Toleration[]
+            volumes: io.k8s.api.core.v1.Volume[]
+            nodeSelector: Map str -> str

--- a/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
+++ b/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
@@ -50,7 +50,6 @@
                     taskOutput:
                         taskId: string
                         outputName: string
-    isEnabled: PredicateType
     k8sContainerOptions: io.k8s.api.core.v1.Container
     k8sPodOptions: #PodArgoSubset
         metadata: #ObjectMetaArgoSubset

--- a/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
+++ b/sdk/python/kfp/components/structures/components.json_schema.outline.yaml
@@ -20,8 +20,8 @@
         <oneOf>:
             <ContainerImplementation>:
                 container: #ContainerSpec
-                    image: string
-                    command: #CommandlineArgumentType
+                    image: StringOrPlaceholder
+                    command: #StringOrPlaceholder[]
                         <oneOf>:
                             string:
                             <InputValuePlaceholder>:
@@ -31,14 +31,14 @@
                             <OutputPathPlaceholder>:
                                 outputPath: string
                             <ConcatPlaceholder>:
-                                concat: CommandlineArgumentType[]
+                                concat: StringOrPlaceholder[]
                             <IfPlaceholder>:
                                 if:
                                     cond: IfConditionArgumentType
-                                    then: CommandlineArgumentType[]
-                                    else: CommandlineArgumentType[]
-                    args: CommandlineArgumentType
-                    env: Map[str, str]
+                                    then: StringOrPlaceholder[]
+                                    else: StringOrPlaceholder[]
+                    args: StringOrPlaceholder[]
+                    env: Map[str, StringOrPlaceholder]
                     unconfigurableOutputPaths: Map[str, str]
             <GraphImplementation>:
                 graph: #GraphSpec


### PR DESCRIPTION
See the much shorter outline of the schema: https://github.com/kubeflow/pipelines/blob/ae7cefede4cc005b5d2f443156450f317220a99e/sdk/python/kfp/components/structures/components.json_schema.outline.yaml

It's not an example. It's an outline. It's a component schema with sub-schemas inlined and without any extra info.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/669)
<!-- Reviewable:end -->
