### PR TITLE
SDK/Components - Renamed fileOutputs to unconfigurableOutputPaths in ContainerSpec

### DIFF
--- a/sdk/python/kfp/components/_dsl_bridge.py
+++ b/sdk/python/kfp/components/_dsl_bridge.py
@@ -25,7 +25,7 @@ def create_container_op_from_task(task_spec: TaskSpec):
     container_spec = component_spec.implementation.container
 
     output_paths = OrderedDict() #Preserving the order to make the kubernetes output names deterministic
-    unconfigurable_output_paths = container_spec.file_outputs or {}
+    unconfigurable_output_paths = container_spec.unconfigurable_output_paths or {}
     for output in component_spec.outputs or []:
         if output.name in unconfigurable_output_paths:
             output_paths[output.name] = unconfigurable_output_paths[output.name]

--- a/sdk/python/kfp/components/_structures.py
+++ b/sdk/python/kfp/components/_structures.py
@@ -190,7 +190,7 @@ class IfPlaceholder(ModelBase): #Non-standard attr names
 class ContainerSpec(ModelBase):
     '''Describes the container component implementation.'''
     _serialized_names = {
-        'file_outputs': 'fileOutputs', #TODO: rename to something like legacy_unconfigurable_output_paths
+        'unconfigurable_output_paths': 'unconfigurableOutputPaths', #TODO: rename to something like legacy_unconfigurable_output_paths
     }
 
     def __init__(self,
@@ -198,7 +198,7 @@ class ContainerSpec(ModelBase):
         command: Optional[List[CommandlineArgumentType]] = None,
         args: Optional[List[CommandlineArgumentType]] = None,
         env: Optional[Mapping[str, str]] = None,
-        file_outputs: Optional[Mapping[str, str]] = None, #TODO: rename to something like legacy_unconfigurable_output_paths
+        unconfigurable_output_paths: Optional[Mapping[str, str]] = None, #Deprecated. For legacy components only.
     ):
         super().__init__(locals())
 
@@ -258,8 +258,8 @@ class ComponentSpec(ModelBase):
         if isinstance(self.implementation, ContainerImplementation):
             container = self.implementation.container
 
-            if container.file_outputs:
-                for output_name, path in container.file_outputs.items():
+            if container.unconfigurable_output_paths:
+                for output_name, path in container.unconfigurable_output_paths.items():
                     if output_name not in self._outputs_dict:
                         raise TypeError('Unconfigurable output entry "{}" references non-existing output.'.format({output_name: path}))
 

--- a/sdk/python/kfp/components/_structures.py
+++ b/sdk/python/kfp/components/_structures.py
@@ -190,7 +190,7 @@ class IfPlaceholder(ModelBase): #Non-standard attr names
 class ContainerSpec(ModelBase):
     '''Describes the container component implementation.'''
     _serialized_names = {
-        'unconfigurable_output_paths': 'unconfigurableOutputPaths', #TODO: rename to something like legacy_unconfigurable_output_paths
+        'unconfigurable_output_paths': 'unconfigurableOutputPaths', #Deprecated and will be removed soon. For legacy components only.
     }
 
     def __init__(self,
@@ -200,6 +200,15 @@ class ContainerSpec(ModelBase):
         env: Optional[Mapping[str, str]] = None,
         unconfigurable_output_paths: Optional[Mapping[str, str]] = None, #Deprecated. For legacy components only.
     ):
+        '''
+        Arguments:
+
+        unconfigurable_output_paths: #Deprecated. For legacy components only.
+        #This feature is a workaround for cases when component code has some output file paths hardcoded (unconfigurable) instead of getting them from command-line. Thus the name - "unconfigurable output paths".
+        #The feature is current not used by any developer.
+        #The feature is only needed to support the current version of our sample components and will be #TODO: removed right after https://github.com/kubeflow/pipelines/pull/580 is completed.
+        #The feature is incompatible with most of the future storage and data management scenarios that need the paths to be set by the system and that cannot work with files written to the filesystem root (e.g. "/output.txt").
+        '''
         super().__init__(locals())
 
 

--- a/sdk/python/tests/components/test_components.py
+++ b/sdk/python/tests/components/test_components.py
@@ -141,14 +141,14 @@ implementation:
 '''
         task_factory1 = comp.load_component_from_text(component_text)
 
-    def test_handle_file_outputs_with_spaces(self):
+    def test_handle_output_names_with_spaces_in_unconfigurable_output_paths(self):
         component_text = '''\
 outputs:
 - {name: Output data}
 implementation:
   container:
     image: busybox
-    fileOutputs:
+    unconfigurableOutputPaths:
       Output data: /outputs/output-data
 '''
         task_factory1 = comp.load_component_from_text(component_text)
@@ -191,14 +191,27 @@ implementation:
         task_factory1 = comp.load_component_from_text(component_text)
 
     @unittest.expectedFailure
-    def test_fail_on_unknown_file_output(self):
+    def test_fail_on_unknown_output_in_output_path(self):
         component_text = '''\
 outputs:
 - {name: Data}
 implementation:
   container:
     image: busybox
-    fileOutputs:
+    command:
+        - {outputPath: Wrong output}
+'''
+        task_factory1 = comp.load_component_from_text(component_text)
+
+    @unittest.expectedFailure
+    def test_fail_on_unknown_output_in_unconfigurable_output_path(self):
+        component_text = '''\
+outputs:
+- {name: Data}
+implementation:
+  container:
+    image: busybox
+    unconfigurableOutputPaths:
         Wrong: '/outputs/output.txt'
 '''
         task_factory1 = comp.load_component_from_text(component_text)


### PR DESCRIPTION
This feature is deprecated and will only be supported until the existing legacy components are upgraded (See https://github.com/kubeflow/pipelines/pull/580)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/688)
<!-- Reviewable:end -->
