### PR TITLE
SDK - Update minimum Python version to 3.5.3

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -67,7 +67,7 @@ setup(
       'Topic :: Software Development :: Libraries',
       'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    python_requires='>=3.5',
+    python_requires='>=3.5.3',
     include_package_data=True,
     entry_points = {
       'console_scripts': [ 


### PR DESCRIPTION
This version has multiple bug fixes.
This seems to be the last release available for Debian 9.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/691)
<!-- Reviewable:end -->
