### PR TITLE
SDK/Component - Added the ComponentReference.spec property

### DIFF
--- a/sdk/python/kfp/components/_structures.py
+++ b/sdk/python/kfp/components/_structures.py
@@ -313,12 +313,13 @@ class ComponentReference(ModelBase):
         digest: Optional[str] = None,
         tag: Optional[str] = None,
         url: Optional[str] = None,
+        spec: Optional[ComponentSpec] = None,
     ):
         super().__init__(locals())
         self._post_init()
     
     def _post_init(self) -> None:
-        if not any([self.name, self.digest, self.tag, self.url]):
+        if not any([self.name, self.digest, self.tag, self.url, self.spec]):
             raise TypeError('Need at least one argument.')
 
 

--- a/sdk/python/tests/components/test_graph_components.py
+++ b/sdk/python/tests/components/test_graph_components.py
@@ -172,5 +172,33 @@ implementation:
 
 #TODO: Test task name conversion to Argo-compatible names
 
+
+    def test_handle_parsing_nested_graph_component(self):
+        component_text = '''\
+name: Top-level component
+implementation:
+  graph:
+    tasks:
+      task 1:
+        componentRef:
+          spec:
+            name: Nested component
+            inputs:
+            - {name: Input 1}
+            implementation:
+              container:
+                image: busybox
+                command:
+                - program.py
+                - {inputValue: Input 1}
+        arguments:
+          Input 1: 11
+'''
+        struct = load_yaml(component_text)
+        ComponentSpec.from_struct(struct)
+
+
+#TODO: Verify checking argument names against the component input names
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It can hold an inlined component spec instead of referring to an external component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/702)
<!-- Reviewable:end -->
