### PR TITLE
randomize the deployment name to avoid collision

### DIFF
--- a/samples/tfx/taxi-cab-classification-pipeline.py
+++ b/samples/tfx/taxi-cab-classification-pipeline.py
@@ -156,7 +156,7 @@ def taxi_cab_classification(
     steps=3000,
     analyze_slice_column='trip_start_hour'):
 
-  tf_server_name = 'taxi-cab-classification-model-{{workflow.name}}'
+  tf_server_name = 'taxi-cab-classification-model-{{workflow.uid}}'
   validation = dataflow_tf_data_validation_op(train, evaluation, column_names, 
       key_columns, project, mode, output
   ).apply(gcp.use_gcp_secret('user-gcp-sa'))


### PR DESCRIPTION
use the workflow UID instead of name to avoid name collision after the name is truncated inside the deployer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/704)
<!-- Reviewable:end -->
