### PR TITLE
SDK/Components - Command line args can only be strings or placeholders

### DIFF
--- a/sdk/python/kfp/components/_structures.py
+++ b/sdk/python/kfp/components/_structures.py
@@ -125,11 +125,14 @@ class OutputPathPlaceholder(ModelBase): #Non-standard attr names
         super().__init__(locals())
 
 
-CommandlineArgumentType = Optional[Union[
-    PrimitiveTypes, InputValuePlaceholder, InputPathPlaceholder, OutputPathPlaceholder,
+CommandlineArgumentType = Union[
+    str,
+    InputValuePlaceholder,
+    InputPathPlaceholder,
+    OutputPathPlaceholder,
     'ConcatPlaceholder',
     'IfPlaceholder',
-]]
+]
 
 
 class ConcatPlaceholder(ModelBase): #Non-standard attr names
@@ -479,6 +482,7 @@ class TaskSpec(ModelBase):
         k8s_pod_options: Optional[v1.PodArgoSubset] = None,
     ):
         super().__init__(locals())
+        #TODO: If component_ref is resolved to component spec, then check that the arguments correspond to the inputs
 
 
 class GraphSpec(ModelBase):

--- a/sdk/python/tests/components/test_components.py
+++ b/sdk/python/tests/components/test_components.py
@@ -227,65 +227,6 @@ implementation:
     def test_load_component_from_text_fail_on_none_arg(self):
         comp.load_component_from_text(None)
 
-    def test_command_yaml_types(self):
-        component_text = '''\
-implementation:
-  container:
-    image: busybox
-    args:
-      # Nulls:
-      - null #A null
-      - #Also a null
-      # Strings:
-      - "" #empty string
-      - "string"
-      # Booleans
-      - true
-      - True
-      - false
-      - FALSE
-      # Integers
-      - 0
-      - 0o7
-      - 0x3A
-      - -19
-      # Floats
-      - 0.
-      - -0.0
-      - .5
-      - +12e03
-      - -2E+05
-      # Infinite floats
-      - .inf
-      - -.Inf
-      - +.INF
-      - .NAN
-'''
-        task_factory1 = comp.load_component(text=component_text)
-        task = task_factory1()
-        self.assertEqual(task.arguments, [
-            #Nulls are skipped
-            '',
-            'string',
-            'True',
-            'True',
-            'False',
-            'False',
-            '0',
-            '0o7',
-            '58',
-            '-19',
-            '0.0',
-            '-0.0',
-            '0.5',
-            '+12e03',
-            '-2E+05',
-            'inf',
-            '-inf',
-            'inf',
-            'nan',
-        ])
-
     def test_input_value_resolving(self):
         component_text = '''\
 inputs:


### PR DESCRIPTION
Just replacing `PrimitiveTypes` with `str` and removing one test.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/711)
<!-- Reviewable:end -->
