### PR TITLE
SDK/Components - Only convert TaskSpec to ContainerOp during compilation

### DIFF
--- a/sdk/python/kfp/components/_components.py
+++ b/sdk/python/kfp/components/_components.py
@@ -187,11 +187,6 @@ def _try_get_object_by_name(obj_name):
 _created_task_transformation_handler = []
 
 
-#TODO: Move to the dsl.Pipeline context class
-from . import _dsl_bridge
-_created_task_transformation_handler.append(_dsl_bridge.create_container_op_from_task)
-
-
 #TODO: Refactor the function to make it shorter
 def _create_task_factory_from_component_spec(component_spec:ComponentSpec, component_filename=None, component_ref: ComponentReference = None):
     name = component_spec.name or _default_component_name
@@ -215,7 +210,7 @@ def _create_task_factory_from_component_spec(component_spec:ComponentSpec, compo
 
     def create_task_from_component_and_arguments(pythonic_arguments):
         #Converting the argument names and not passing None arguments
-        valid_argument_types = (str, int, float, bool, GraphInputArgument, TaskOutputArgument, PipelineParam) #Hack for passed PipelineParams. TODO: Remove the hack once they're no longer passed here.
+        valid_argument_types = (str, GraphInputArgument, TaskOutputArgument, PipelineParam) #Hack for passed PipelineParams. TODO: Remove the hack once they're no longer passed here.
         arguments = {
             pythonic_name_to_input_name[k]: (v if isinstance(v, valid_argument_types) else str(v))
             for k, v in pythonic_arguments.items()

--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -144,10 +144,14 @@ class Pipeline():
       raise Exception('Nested pipelines are not allowed.')
 
     Pipeline._default_pipeline = self
+    from ..components import _components, _dsl_bridge
+    _components._created_task_transformation_handler.append(_dsl_bridge.create_container_op_from_task)
     return self
 
   def __exit__(self, *args):
     Pipeline._default_pipeline = None
+    from ..components import _components
+    _components._created_task_transformation_handler.pop()
         
   def add_op(self, op: _container_op.ContainerOp, define_only: bool):
     """Add a new operator.

--- a/sdk/python/tests/components/test_graph_components.py
+++ b/sdk/python/tests/components/test_graph_components.py
@@ -172,5 +172,16 @@ implementation:
 
 #TODO: Test task name conversion to Argo-compatible names
 
+    def test_handle_loading_graph_component_using_load_component(self):
+        component_text = '''\
+name: Graph component
+implementation:
+  graph:
+    tasks: {}
+'''
+        component = comp.load_component_from_text(component_text)
+        task = component()
+        self.assertEqual(task.component_ref._component_spec.name, 'Graph component')
+
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/tests/components/test_python_op.py
+++ b/sdk/python/tests/components/test_python_op.py
@@ -19,6 +19,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import kfp.components as comp
+from kfp import dsl
 
 def add_two_numbers(a: float, b: float) -> float:
     '''Returns sum of two arguments'''
@@ -46,7 +47,8 @@ class PythonOpTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temp_dir_name:
             with components_local_output_dir_context(temp_dir_name):
-                task = op(arg1, arg2)
+                with dsl.Pipeline('Test pipeline'):
+                    task = op(arg1, arg2)
 
             full_command = task.command + task.arguments
             process = subprocess.run(full_command)
@@ -66,7 +68,8 @@ class PythonOpTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temp_dir_name:
             with components_local_output_dir_context(temp_dir_name):
-                task = op(arg1, arg2)
+                with dsl.Pipeline('Test pipeline'):
+                    task = op(arg1, arg2)
 
             full_command = task.command + task.arguments
 


### PR DESCRIPTION
`dsl.Compiler` only works with `ContainerOp` instances, not `TaskSpec` instances, so we need to convert them during the `dsl.Compiler.compile()` compilation.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/712)
<!-- Reviewable:end -->
