### PR TITLE
 SDK/Components - Refactoring: Improved container task resolution

### DIFF
--- a/sdk/python/kfp/components/_components.py
+++ b/sdk/python/kfp/components/_components.py
@@ -187,11 +187,6 @@ def _try_get_object_by_name(obj_name):
 _created_task_transformation_handler = []
 
 
-#TODO: Move to the dsl.Pipeline context class
-from . import _dsl_bridge
-_created_task_transformation_handler.append(_dsl_bridge.create_container_op_from_task)
-
-
 #TODO: Refactor the function to make it shorter
 def _create_task_factory_from_component_spec(component_spec:ComponentSpec, component_filename=None, component_ref: ComponentReference = None):
     name = component_spec.name or _default_component_name
@@ -215,7 +210,7 @@ def _create_task_factory_from_component_spec(component_spec:ComponentSpec, compo
 
     def create_task_from_component_and_arguments(pythonic_arguments):
         #Converting the argument names and not passing None arguments
-        valid_argument_types = (str, int, float, bool, GraphInputArgument, TaskOutputArgument, PipelineParam) #Hack for passed PipelineParams. TODO: Remove the hack once they're no longer passed here.
+        valid_argument_types = (str, GraphInputArgument, TaskOutputArgument, PipelineParam) #Hack for passed PipelineParams. TODO: Remove the hack once they're no longer passed here.
         arguments = {
             pythonic_name_to_input_name[k]: (v if isinstance(v, valid_argument_types) else str(v))
             for k, v in pythonic_arguments.items()

--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -144,10 +144,14 @@ class Pipeline():
       raise Exception('Nested pipelines are not allowed.')
 
     Pipeline._default_pipeline = self
+    from ..components import _components, _dsl_bridge
+    _components._created_task_transformation_handler.append(_dsl_bridge.create_container_op_from_task)
     return self
 
   def __exit__(self, *args):
     Pipeline._default_pipeline = None
+    from ..components import _components
+    _components._created_task_transformation_handler.pop()
         
   def add_op(self, op: _container_op.ContainerOp, define_only: bool):
     """Add a new operator.

--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -145,13 +145,15 @@ class Pipeline():
 
     Pipeline._default_pipeline = self
     from ..components import _components, _dsl_bridge
-    _components._created_task_transformation_handler.append(_dsl_bridge.create_container_op_from_task)
+    _components._created_task_transformation_handler.append(_dsl_bridge.resolve_container_task)
+    _dsl_bridge._created_resolved_container_task_transformation_handler.append(_dsl_bridge._create_container_op_from_resolved_task)
     return self
 
   def __exit__(self, *args):
     Pipeline._default_pipeline = None
-    from ..components import _components
+    from ..components import _components, _dsl_bridge
     _components._created_task_transformation_handler.pop()
+    _dsl_bridge._created_resolved_container_task_transformation_handler.pop()
         
   def add_op(self, op: _container_op.ContainerOp, define_only: bool):
     """Add a new operator.

--- a/sdk/python/tests/components/_contextmanagers.py
+++ b/sdk/python/tests/components/_contextmanagers.py
@@ -1,0 +1,24 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import contextmanager
+
+@contextmanager
+def resolve_container_task_context():
+    from kfp.components import _components, _dsl_bridge
+    try:
+        _components._created_task_transformation_handler.append(_dsl_bridge.resolve_container_task)
+        yield
+    finally:
+        _components._created_task_transformation_handler.pop()

--- a/sdk/python/tests/components/test_components.py
+++ b/sdk/python/tests/components/test_components.py
@@ -24,6 +24,8 @@ import kfp.components as comp
 from kfp.components._yaml_utils import load_yaml
 from kfp.dsl.types import InconsistentTypeException
 from kfp import dsl
+from ._contextmanagers import resolve_container_task_context
+
 
 class LoadComponentTestCase(unittest.TestCase):
     def _test_load_component_from_file(self, component_path: str):
@@ -250,7 +252,7 @@ implementation:
       - inputValue: Data
 '''
         task_factory1 = comp.load_component(text=component_text)
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task1 = task_factory1('some-data')
 
         self.assertEqual(task1.arguments, ['--data', 'some-data'])
@@ -267,7 +269,7 @@ implementation:
       - {outputPath: Data}
 '''
         task_factory1 = comp.load_component(text=component_text)
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task1 = task_factory1()
 
         self.assertEqual(len(task1.arguments), 2)
@@ -350,7 +352,7 @@ implementation:
       - z
 '''
         task_factory1 = comp.load_component_from_text(component_text)
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task1 = task_factory1()
 
         self.assertEqual(task1.command, ['a', 'z'])
@@ -369,7 +371,7 @@ implementation:
       - z
 '''
         task_factory1 = comp.load_component_from_text(component_text)
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task1 = task_factory1()
 
         self.assertEqual(task1.command, ['a', 'z'])
@@ -386,7 +388,7 @@ implementation:
       - concat: [{inputValue: In1}, {inputValue: In2}]
 '''
         task_factory1 = comp.load_component(text=component_text)
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task1 = task_factory1('some', 'data')
 
         self.assertEqual(task1.arguments, ['somedata'])
@@ -403,7 +405,7 @@ implementation:
           else: --false-arg
 '''
         task_factory1 = comp.load_component(text=component_text)
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task = task_factory1()
         self.assertEqual(task.arguments, ['--true-arg']) 
 
@@ -419,7 +421,7 @@ implementation:
           else: --false-arg
 '''
         task_factory1 = comp.load_component(text=component_text)
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task = task_factory1()
         self.assertEqual(task.arguments, ['--false-arg']) 
 
@@ -435,7 +437,7 @@ implementation:
           else: --false-arg
 '''
         task_factory1 = comp.load_component(text=component_text)
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task = task_factory1()
         self.assertEqual(task.arguments, ['--true-arg']) 
 
@@ -451,7 +453,7 @@ implementation:
           else: --false-arg
 '''
         task_factory1 = comp.load_component(text=component_text)
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task = task_factory1()
         self.assertEqual(task.arguments, ['--false-arg']) 
 
@@ -470,11 +472,11 @@ implementation:
 '''
         task_factory1 = comp.load_component(text=component_text)
 
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task_then = task_factory1('data')
         self.assertEqual(task_then.arguments, ['--in', 'data']) 
         
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task_else = task_factory1()
         self.assertEqual(task_else.arguments, [])
 
@@ -493,11 +495,11 @@ implementation:
 '''
         task_factory1 = comp.load_component(text=component_text)
 
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task_then = task_factory1('data')
         self.assertEqual(task_then.arguments, ['--in', 'data']) 
         
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task_else = task_factory1()
         self.assertEqual(task_else.arguments, ['--no-in'])
 
@@ -518,11 +520,11 @@ implementation:
 '''
         task_factory1 = comp.load_component(text=component_text)
 
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task_then = task_factory1(True, 'test_data.txt', 42)
         self.assertEqual(task_then.arguments, ['--test-data', 'test_data.txt', '--test-param1', '42'])
         
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task_else = task_factory1()
         self.assertEqual(task_else.arguments, [])
 
@@ -556,11 +558,11 @@ implementation:
 '''
         task_factory1 = comp.load_component_from_text(text=component_text)
 
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task1 = task_factory1()
         self.assertEqual(task1.arguments, ['123'])
 
-        with dsl.Pipeline('Test pipeline'):
+        with resolve_container_task_context():
             task2 = task_factory1('456')
         self.assertEqual(task2.arguments, ['456'])
 

--- a/sdk/python/tests/components/test_graph_components.py
+++ b/sdk/python/tests/components/test_graph_components.py
@@ -172,5 +172,16 @@ implementation:
 
 #TODO: Test task name conversion to Argo-compatible names
 
+    def test_handle_loading_graph_component_using_load_component(self):
+        component_text = '''\
+name: Graph component
+implementation:
+  graph:
+    tasks: {}
+'''
+        component = comp.load_component_from_text(component_text)
+        task = component()
+        self.assertEqual(task.component_ref._component_spec.name, 'Graph component')
+
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/tests/components/test_python_op.py
+++ b/sdk/python/tests/components/test_python_op.py
@@ -19,7 +19,8 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import kfp.components as comp
-from kfp import dsl
+from ._contextmanagers import resolve_container_task_context
+
 
 def add_two_numbers(a: float, b: float) -> float:
     '''Returns sum of two arguments'''
@@ -47,13 +48,13 @@ class PythonOpTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temp_dir_name:
             with components_local_output_dir_context(temp_dir_name):
-                with dsl.Pipeline('Test pipeline'):
+                with resolve_container_task_context():
                     task = op(arg1, arg2)
 
             full_command = task.command + task.arguments
             process = subprocess.run(full_command)
 
-            output_path = list(task.file_outputs.values())[0]
+            output_path = list(task.output_paths.values())[0]
             actual_str = Path(output_path).read_text()
 
         self.assertEqual(float(actual_str), float(expected_str))
@@ -68,14 +69,14 @@ class PythonOpTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temp_dir_name:
             with components_local_output_dir_context(temp_dir_name):
-                with dsl.Pipeline('Test pipeline'):
+                with resolve_container_task_context():
                     task = op(arg1, arg2)
 
             full_command = task.command + task.arguments
 
             process = subprocess.run(full_command)
 
-            (output_path1, output_path2) = (task.file_outputs[output_names[0]], task.file_outputs[output_names[1]])
+            (output_path1, output_path2) = (task.output_paths[output_names[0]], task.output_paths[output_names[1]])
             actual1_str = Path(output_path1).read_text()
             actual2_str = Path(output_path2).read_text()
 

--- a/sdk/python/tests/components/test_python_op.py
+++ b/sdk/python/tests/components/test_python_op.py
@@ -19,6 +19,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import kfp.components as comp
+from kfp import dsl
 
 def add_two_numbers(a: float, b: float) -> float:
     '''Returns sum of two arguments'''
@@ -46,7 +47,8 @@ class PythonOpTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temp_dir_name:
             with components_local_output_dir_context(temp_dir_name):
-                task = op(arg1, arg2)
+                with dsl.Pipeline('Test pipeline'):
+                    task = op(arg1, arg2)
 
             full_command = task.command + task.arguments
             process = subprocess.run(full_command)
@@ -66,7 +68,8 @@ class PythonOpTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temp_dir_name:
             with components_local_output_dir_context(temp_dir_name):
-                task = op(arg1, arg2)
+                with dsl.Pipeline('Test pipeline'):
+                    task = op(arg1, arg2)
 
             full_command = task.command + task.arguments
 


### PR DESCRIPTION
Added the ResolvedContainerTask class that holds the resolved container task properties (resolved command-line and input/output paths).
Renamed `_dsl_bridge.create_container_op_from_task` to `resolve_container_task`
Renamed `_dsl_bridge._task_object_factory` to `_dsl_bridge._created_resolved_container_task_transformation_handler`
Tests no longer need `dsl.Pipeline`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/713)
<!-- Reviewable:end -->
