### PR TITLE
Add Launcher module in component SDK

### DIFF
--- a/component_sdk/python/kfp_component/launcher/__init__.py
+++ b/component_sdk/python/kfp_component/launcher/__init__.py
@@ -12,4 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import launcher, core
+"""Entrypoint module to launch python module or file dynamically.
+
+This module makes it easier to build kfp component with python code 
+by defining a dynamic entrypoint and generate command line arg parser
+by python-fire module. It can be used as an entrypoint in the 
+container spec to run arbitary python module or code in the local 
+image.
+"""
+
+from .launcher import launch

--- a/component_sdk/python/kfp_component/launcher/__main__.py
+++ b/component_sdk/python/kfp_component/launcher/__main__.py
@@ -12,4 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import launcher, core
+import fire
+import importlib
+import sys
+import logging
+from .launcher import launch
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    fire.Fire(launch)
+
+if __name__ == '__main__':
+    main()

--- a/component_sdk/python/kfp_component/launcher/__main__.py
+++ b/component_sdk/python/kfp_component/launcher/__main__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import fire
 import importlib
 import sys
@@ -20,7 +21,14 @@ from .launcher import launch
 
 def main():
     logging.basicConfig(level=logging.INFO)
-    fire.Fire(launch)
+    parser = argparse.ArgumentParser(
+        prog='launcher',
+        description='Launch a python module or file.')
+    parser.add_argument('file_or_module', type=str,
+        help='Either a python file path or a module name.')
+    parser.add_argument('args', nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    launch(args.file_or_module, args.args)
 
 if __name__ == '__main__':
     main()

--- a/component_sdk/python/kfp_component/launcher/launcher.py
+++ b/component_sdk/python/kfp_component/launcher/launcher.py
@@ -1,0 +1,45 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import fire
+import importlib
+import sys
+import logging
+
+def launch(file_or_module, *args):
+    """Launches a python file or module as a command entrypoint.
+
+    Args:
+        file_or_module: it is either a file path to python file
+            a module path.
+        args: the args passed to the entrypoint function.
+
+    Returns:
+        The return value from the launched function.
+    """
+    try:
+        module = importlib.import_module(file_or_module)
+    except Exception:
+        try:
+            if sys.version_info.major > 2:
+                spec = importlib.util.spec_from_file_location('module', file_or_module)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+            else:
+                import imp
+                module = imp.load_source('module', file_or_module)
+        except Exception:
+            logging.error('Failed to find the module or file: {}'.format(file_or_module))
+            sys.exit(1)
+    return fire.Fire(module, command=args)

--- a/component_sdk/python/kfp_component/launcher/launcher.py
+++ b/component_sdk/python/kfp_component/launcher/launcher.py
@@ -17,7 +17,7 @@ import importlib
 import sys
 import logging
 
-def launch(file_or_module, *args):
+def launch(file_or_module, args):
     """Launches a python file or module as a command entrypoint.
 
     Args:
@@ -42,4 +42,4 @@ def launch(file_or_module, *args):
         except Exception:
             logging.error('Failed to find the module or file: {}'.format(file_or_module))
             sys.exit(1)
-    return fire.Fire(module, command=args)
+    return fire.Fire(module, command=args, name=module.__name__)

--- a/component_sdk/python/requirements.txt
+++ b/component_sdk/python/requirements.txt
@@ -1,2 +1,2 @@
-kubernetes
-fire
+kubernetes == 8.0.1
+fire == 0.1.3

--- a/component_sdk/python/requirements.txt
+++ b/component_sdk/python/requirements.txt
@@ -1,1 +1,2 @@
 kubernetes
+fire

--- a/component_sdk/python/run_test.sh
+++ b/component_sdk/python/run_test.sh
@@ -1,2 +1,2 @@
 pip install -U tox virtualenv
-tox
+tox "$@"

--- a/component_sdk/python/tests/launcher/__init__.py
+++ b/component_sdk/python/tests/launcher/__init__.py
@@ -11,5 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from . import launcher, core

--- a/component_sdk/python/tests/launcher/echo.py
+++ b/component_sdk/python/tests/launcher/echo.py
@@ -1,2 +1,16 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 def echo(message):
     return message

--- a/component_sdk/python/tests/launcher/echo.py
+++ b/component_sdk/python/tests/launcher/echo.py
@@ -1,0 +1,2 @@
+def echo(message):
+    return message

--- a/component_sdk/python/tests/launcher/test_launcher.py
+++ b/component_sdk/python/tests/launcher/test_launcher.py
@@ -12,4 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import launcher, core
+import mock
+import unittest
+import math
+import os
+
+from kfp_component.launcher import launch
+
+TEST_PY_FILE = os.path.join(os.path.dirname(__file__), 'echo.py')
+
+class LauncherTest(unittest.TestCase):
+
+    def test_launch_module_succeed(self):
+        self.assertEqual(math.pi, launch('math', 'pi'))
+
+    def test_launch_py_file_succeed(self):
+        self.assertEqual('hello', 
+            launch(TEST_PY_FILE, 'echo', 'hello'))

--- a/component_sdk/python/tests/launcher/test_launcher.py
+++ b/component_sdk/python/tests/launcher/test_launcher.py
@@ -28,4 +28,4 @@ class LauncherTest(unittest.TestCase):
 
     def test_launch_py_file_succeed(self):
         self.assertEqual('hello', 
-            launch(TEST_PY_FILE, 'echo', 'hello'))
+            launch(TEST_PY_FILE, ['echo', 'hello']))


### PR DESCRIPTION
Added a dynamic python fire launcher module which can be used as entrypoint to KFP components. 
This will be used by GCP component as a single entrypoint to run all gcp commands.

For example, in mlengine create job spec:
`python -m kfp_component.launcher kfp_component.google.ml_engine create_job --project <project> --job <job_payload>`

The same entrypoint can also be used to launch from arbitrary python file. After argo artifact raw content store is supported, user can directly put python function as a file in container and use the same entrypoint to launch it:
`python -m kfp_component.launcher /tmp/script.py my_func --param1 <p1> --param2 <p2>`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/769)
<!-- Reviewable:end -->
