### PR TITLE
Cleanup pipeline bootstrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@ bower_components/
 
 # Build output
 dist
-ml-pipeline/ml-pipeline-app
-ml-pipeline/kf-app
 
 # Web server
 frontend/server/*.js


### PR DESCRIPTION
As pipeline bootstrapper has been removed in #739 , the gitignore file
and deployment guide should be updated as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/770)
<!-- Reviewable:end -->
