### PR TITLE
update developer guide to renew deployment section

### DIFF
--- a/developer_guide.md
+++ b/developer_guide.md
@@ -4,34 +4,7 @@ This document describes the development guideline to contribute to ML pipeline p
 
 ## ML pipeline deployment
 
-The ML pipeline system uses [Ksonnet](https://ksonnet.io/) as part of the deployment process.
-Ksonnet provides the flexibility to generate Kubernetes manifests from parameterized templates and
-makes it easy to customize Kubernetes manifests for different use cases.
-The Ksonnet is wrapped in a customized bootstrap container so a user don't need to explicitly deal
-with Ksonnet to install ML pipeline.
-
-The docker container accepts various parameters to customize your deployment.
-- **--namespace** the namespace to deploy to
-- **--api_image** the API server image to use
-- **--ui_image** the webserver image to use
-- **--report_usage** whether to report usage for the deployment
-- **--uninstall** to uninstall everything.
-
-See [bootstrapper.yaml](https://github.com/kubeflow/pipelines/blob/master/bootstrapper.yaml) for examples on how to pass in parameter.
-
-Alternatively, you can use [deploy.sh](https://github.com/kubeflow/pipelines/blob/master/ml-pipeline/deploy.sh) if you want to interact with Ksonnet directly.
-To deploy, run the script locally.
-```bash
-$ ml-pipeline/deploy.sh
-```
-And you will se a Ksonnet [APP](https://ksonnet.io/docs/concepts#application) folder generated in your current path. If you want to update or delete the K8s resource created by the deployment, run
-```bash
-# Update
-$ cd ml-pipeline && ks apply default
-# Delete
-$ cd ml-pipeline && ks delete default
-```
-
+The Pipeline system is included in kubeflow. See [Getting Started Guide](https://www.kubeflow.org/docs/started/getting-started/) for how to deploy with Kubeflow.
 
 ## Build Image
 
@@ -80,15 +53,6 @@ Minikube can pick your local Docker image so you don't need to upload to remote 
 For example, to build API server image
 ```bash
 $ docker build -t ml-pipeline-api-server -f backend/Dockerfile .
-```
-
-### Update deployment image
-If your change updates deployment image (e.g. add new service account, change image version etc.),
-remember to update the deployment image as well, and use that image to create deployment job.
-```bash
-$ docker build -t gcr.io/<your-gcp-project>/bootstrapper ml-pipeline/
-$ gcloud auth configure-docker
-$ docker push gcr.io/<your-gcp-project>/bootstrapper
 ```
 
 ## Unit test


### PR DESCRIPTION
The old deployment way (bootstrapper.yaml/deploy.sh) has been removed, the pipeline is included in kubeflow now, but the developer guide is not updated accordingly. 

The PR to renew the deployment section.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/771)
<!-- Reviewable:end -->
