### PR TITLE
SDK - Added support for raw input artifact argument values to ContainerOp

### DIFF
--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -130,21 +130,14 @@ def _parameters_to_json(params: List[dsl.PipelineParam]):
 def _inputs_to_json(
     inputs_params: List[dsl.PipelineParam],
     input_artifact_paths: Dict[str, str] = None,
-    input_artifact_arguments: Dict[str, str] = None,
 ):
     """Converts a list of PipelineParam into an argo `inputs` JSON obj."""
     parameters = _parameters_to_json(inputs_params)
 
     # Building the input artifacts section
-    # Only constant arguments are supported for now
-    # Constant arguments will be compiled as Argo's input artifact default values, not as real arguments until the artifact passing is implemented
     artifacts = []
     for name, path in (input_artifact_paths or {}).items():
         artifact = {'name': name, 'path': path}
-        if input_artifact_arguments:
-            argument = input_artifact_arguments.get(name, None)
-            if argument:
-                artifact['raw'] = {'data': str(argument)}
         artifacts.append(artifact)
     artifacts.sort(key=lambda x: x['name']) #Stabilizing the input artifact ordering
 
@@ -235,10 +228,7 @@ def _op_to_template(op: BaseOp):
         }
 
     # inputs
-    if isinstance(op, dsl.ContainerOp):
-        inputs = _inputs_to_json(processed_op.inputs, processed_op.input_artifact_paths, processed_op.input_artifact_arguments)
-    elif isinstance(op, dsl.ResourceOp):
-        inputs = _inputs_to_json(processed_op.inputs)
+    inputs = _inputs_to_json(processed_op.inputs, getattr(processed_op, 'input_artifact_paths', None))
     if inputs:
         template['inputs'] = inputs
 

--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -228,7 +228,8 @@ def _op_to_template(op: BaseOp):
         }
 
     # inputs
-    inputs = _inputs_to_json(processed_op.inputs, getattr(processed_op, 'input_artifact_paths', None))
+    input_artifact_paths = processed_op.input_artifact_paths if isinstance(processed_op, dsl.ContainerOp) else None
+    inputs = _inputs_to_json(processed_op.inputs, input_artifact_paths)
     if inputs:
         template['inputs'] = inputs
 

--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -130,7 +130,7 @@ def _parameters_to_json(params: List[dsl.PipelineParam]):
 def _inputs_to_json(
     inputs_params: List[dsl.PipelineParam],
     input_artifact_paths: Dict[str, str] = None,
-):
+) -> Dict[str, Dict]:
     """Converts a list of PipelineParam into an argo `inputs` JSON obj."""
     parameters = _parameters_to_json(inputs_params)
 

--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -127,11 +127,33 @@ def _parameters_to_json(params: List[dsl.PipelineParam]):
     return params
 
 
-# TODO: artifacts?
-def _inputs_to_json(inputs_params: List[dsl.PipelineParam], _artifacts=None):
+def _inputs_to_json(
+    inputs_params: List[dsl.PipelineParam],
+    input_artifact_paths: Dict[str, str] = None,
+    input_artifact_arguments: Dict[str, str] = None,
+):
     """Converts a list of PipelineParam into an argo `inputs` JSON obj."""
     parameters = _parameters_to_json(inputs_params)
-    return {'parameters': parameters} if parameters else None
+
+    # Building the input artifacts section
+    # Only constant arguments are supported for now
+    # Constant arguments will be compiled as Argo's input artifact default values, not as real arguments until the artifact passing is implemented
+    artifacts = []
+    for name, path in (input_artifact_paths or {}).items():
+        artifact = {'name': name, 'path': path}
+        if input_artifact_arguments:
+            argument = input_artifact_arguments.get(name, None)
+            if argument:
+                artifact['raw'] = {'data': str(argument)}
+        artifacts.append(artifact)
+    artifacts.sort(key=lambda x: x['name']) #Stabilizing the input artifact ordering
+
+    inputs_dict = {}
+    if parameters:
+        inputs_dict['parameters'] = parameters
+    if artifacts:
+        inputs_dict['artifacts'] = artifacts
+    return inputs_dict
 
 
 def _outputs_to_json(op: BaseOp,
@@ -213,7 +235,10 @@ def _op_to_template(op: BaseOp):
         }
 
     # inputs
-    inputs = _inputs_to_json(processed_op.inputs)
+    if isinstance(op, dsl.ContainerOp):
+        inputs = _inputs_to_json(processed_op.inputs, processed_op.input_artifact_paths, processed_op.input_artifact_arguments)
+    elif isinstance(op, dsl.ResourceOp):
+        inputs = _inputs_to_json(processed_op.inputs)
     if inputs:
         template['inputs'] = inputs
 

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -516,10 +516,9 @@ class Compiler(object):
         arguments.sort(key=lambda x: x['name'])
         task['arguments'] = {'parameters': arguments}
       
-      artifact_arguments = getattr(sub_group, 'artifact_arguments', None)
-      if artifact_arguments:
+      if isinstance(sub_group, dsl.ContainerOp) and sub_group.artifact_arguments:
         artifact_argument_structs = []
-        for input_name, argument in artifact_arguments.items():
+        for input_name, argument in sub_group.artifact_arguments.items():
           artifact_argument_dict = {'name': input_name}
           if isinstance(argument, str):
             artifact_argument_dict['raw'] = {'data': str(argument)}

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -515,6 +515,19 @@ class Compiler(object):
               })
         arguments.sort(key=lambda x: x['name'])
         task['arguments'] = {'parameters': arguments}
+      
+      artifact_arguments = getattr(sub_group, 'input_artifact_arguments', None)
+      if artifact_arguments:
+        artifact_argument_structs = []
+        for input_name, argument in artifact_arguments.items():
+          artifact_argument_dict = {'name': input_name}
+          if isinstance(argument, str):
+            artifact_argument_dict['raw'] = {'data': str(argument)}
+          else:
+            raise TypeError('Argument "{}" was passed to the artifact input "{}", but only constant strings are supported at this moment.'.format(str(argument), input_name))
+          artifact_argument_structs.append(artifact_argument_dict)
+        task.setdefault('arguments', {})['artifacts'] = artifact_argument_structs
+
       tasks.append(task)
     tasks.sort(key=lambda x: x['name'])
     template['dag'] = {'tasks': tasks}

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -516,7 +516,7 @@ class Compiler(object):
         arguments.sort(key=lambda x: x['name'])
         task['arguments'] = {'parameters': arguments}
       
-      artifact_arguments = getattr(sub_group, 'input_artifact_arguments', None)
+      artifact_arguments = getattr(sub_group, 'artifact_arguments', None)
       if artifact_arguments:
         artifact_argument_structs = []
         for input_name, argument in artifact_arguments.items():

--- a/sdk/python/kfp/components/_dsl_bridge.py
+++ b/sdk/python/kfp/components/_dsl_bridge.py
@@ -15,7 +15,7 @@
 from collections import OrderedDict
 from typing import Mapping
 from ._structures import ContainerImplementation, ConcatPlaceholder, IfPlaceholder, InputValuePlaceholder, InputPathPlaceholder, IsPresentPlaceholder, OutputPathPlaceholder, TaskSpec
-from ._components import _generate_output_file_name, _default_component_name
+from ._components import _generate_input_file_name, _generate_output_file_name, _default_component_name
 from kfp.dsl._metadata import ComponentMeta, ParameterMeta
 
 def create_container_op_from_task(task_spec: TaskSpec):
@@ -33,6 +33,9 @@ def create_container_op_from_task(task_spec: TaskSpec):
     for output in component_spec.outputs or []:
         if output.name in unconfigurable_output_paths:
             output_paths[output.name] = unconfigurable_output_paths[output.name]
+
+    input_paths = OrderedDict()
+    artifact_arguments = OrderedDict()
 
     def expand_command_part(arg): #input values with original names
         #(Union[str,Mapping[str, Any]]) -> Union[str,List[str]]
@@ -57,8 +60,10 @@ def create_container_op_from_task(task_spec: TaskSpec):
             input_name = arg.input_name
             input_value = argument_values.get(input_name, None)
             if input_value is not None:
-                raise ValueError('ContainerOp does not support input artifacts - input {}'.format(input_name))
-                #return input_value
+                input_path = _generate_input_file_name(input_name)
+                input_paths[input_name] = input_path
+                artifact_arguments[input_name] = input_value
+                return input_path
             else:
                 input_spec = inputs_dict[input_name]
                 if input_spec.optional:
@@ -123,13 +128,15 @@ def create_container_op_from_task(task_spec: TaskSpec):
         container_image=container_spec.image,
         command=expanded_command,
         arguments=expanded_args,
+        input_paths=input_paths,
         output_paths=output_paths,
+        artifact_arguments=artifact_arguments,
         env=container_spec.env,
         component_spec=component_spec,
     )
 
 
-def _create_container_op_from_resolved_task(name:str, container_image:str, command=None, arguments=None, output_paths=None, env : Mapping[str, str]=None, component_spec=None):
+def _create_container_op_from_resolved_task(name:str, container_image:str, command=None, arguments=None, input_paths=None, artifact_arguments=None, output_paths=None, env : Mapping[str, str]=None, component_spec=None):
     from .. import dsl
 
     #Renaming outputs to conform with ContainerOp/Argo
@@ -154,6 +161,7 @@ def _create_container_op_from_resolved_task(name:str, container_image:str, comma
         command=command,
         arguments=arguments,
         file_outputs=output_paths_for_container_op,
+        artifact_argument_paths=[dsl.InputArgumentPath(argument=artifact_arguments[input_name], input=input_name, path=path) for input_name, path in input_paths.items()],
     )
 
     task._set_metadata(component_meta)

--- a/sdk/python/kfp/dsl/__init__.py
+++ b/sdk/python/kfp/dsl/__init__.py
@@ -15,7 +15,7 @@
 
 from ._pipeline_param import PipelineParam, match_serialized_pipelineparam
 from ._pipeline import Pipeline, pipeline, get_pipeline_conf
-from ._container_op import ContainerOp, InputArtifactArgument, UserContainer, Sidecar
+from ._container_op import ContainerOp, InputArgumentPath, UserContainer, Sidecar
 from ._resource_op import ResourceOp
 from ._volume_op import (
     VolumeOp, VOLUME_MODE_RWO, VOLUME_MODE_RWM, VOLUME_MODE_ROM

--- a/sdk/python/kfp/dsl/__init__.py
+++ b/sdk/python/kfp/dsl/__init__.py
@@ -15,7 +15,7 @@
 
 from ._pipeline_param import PipelineParam, match_serialized_pipelineparam
 from ._pipeline import Pipeline, pipeline, get_pipeline_conf
-from ._container_op import ContainerOp, UserContainer, Sidecar
+from ._container_op import ContainerOp, InputArtifactArgument, UserContainer, Sidecar
 from ._resource_op import ResourceOp
 from ._volume_op import (
     VolumeOp, VOLUME_MODE_RWO, VOLUME_MODE_RWM, VOLUME_MODE_ROM

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -1077,7 +1077,7 @@ class ContainerOp(BaseOp):
 
         # attributes specific to `ContainerOp`
         self.input_artifact_paths = input_artifact_paths
-        self.input_artifact_arguments = artifact_arguments
+        self.artifact_arguments = artifact_arguments
         self.file_outputs = file_outputs
         self.output_artifact_paths = output_artifact_paths or {}
         self.artifact_location = artifact_location

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -961,6 +961,8 @@ class ContainerOp(BaseOp):
       init_containers: List[UserContainer] = None,
       sidecars: List[Sidecar] = None,
       container_kwargs: Dict = None,
+      input_artifact_paths: Dict[str, str] = None,
+      input_artifact_arguments: Dict[str, str] = None,
       file_outputs: Dict[str, str] = None,
       output_artifact_paths : Dict[str, str]=None,
       artifact_location: V1alpha1ArtifactLocation=None,
@@ -984,6 +986,10 @@ class ContainerOp(BaseOp):
                     together with the `main` container.
           container_kwargs: the dict of additional keyword arguments to pass to the
                             op's `Container` definition.
+          input_artifact_paths: Maps artifact input names to local file paths.
+              At pipeline run time, the value of the input artifact argument is saved to this local file.
+          input_artifact_arguments: Maps artifact input names to the artifact values.
+              At pipeline run time, the value of the input artifact argument is saved to a local file specified in the input_artifact_paths map.
           file_outputs: Maps output labels to local file paths. At pipeline run time,
               the value of a PipelineParam is saved to its corresponding local file. It's
               one way for outside world to receive outputs of the container.
@@ -1041,9 +1047,15 @@ class ContainerOp(BaseOp):
                 setattr(self, attr_to_proxy, _proxy(attr_to_proxy))
 
         # attributes specific to `ContainerOp`
+        self.input_artifact_paths = input_artifact_paths or {}
+        self.input_artifact_arguments = input_artifact_arguments or {}
         self.file_outputs = file_outputs
         self.output_artifact_paths = output_artifact_paths or {}
         self.artifact_location = artifact_location
+
+        for artifact_name, artifact_argument in self.input_artifact_arguments.items():
+            if not isinstance(artifact_argument, str):
+                raise TypeError('Argument "{}" was passed to the artifact input "{}", but only constant strings are supported at this moment.'.format(str(artifact_argument), artifact_name))
 
         self._metadata = None
 

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -968,7 +968,7 @@ class ContainerOp(BaseOp):
       init_containers: List[UserContainer] = None,
       sidecars: List[Sidecar] = None,
       container_kwargs: Dict = None,
-      artifact_argument_paths : List[InputArgumentPath] = None,
+      artifact_argument_paths: List[InputArgumentPath] = None,
       file_outputs: Dict[str, str] = None,
       output_artifact_paths : Dict[str, str]=None,
       artifact_location: V1alpha1ArtifactLocation=None,

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -903,7 +903,7 @@ class BaseOp(object):
 from ._pipeline_volume import PipelineVolume  # The import is here to prevent circular reference problems.
 
 
-class InputArtifactArgument:
+class InputArgumentPath:
     def __init__(self, argument, input=None, path=None):
         self.argument = argument
         self.input = input
@@ -968,7 +968,7 @@ class ContainerOp(BaseOp):
       init_containers: List[UserContainer] = None,
       sidecars: List[Sidecar] = None,
       container_kwargs: Dict = None,
-      input_artifact_arguments : List[InputArtifactArgument] = None,
+      artifact_argument_paths : List[InputArgumentPath] = None,
       file_outputs: Dict[str, str] = None,
       output_artifact_paths : Dict[str, str]=None,
       artifact_location: V1alpha1ArtifactLocation=None,
@@ -992,9 +992,10 @@ class ContainerOp(BaseOp):
                     together with the `main` container.
           container_kwargs: the dict of additional keyword arguments to pass to the
                             op's `Container` definition.
-          input_artifact_arguments: Maps artifact inputs to the artifact argument values and paths.
-              Only artifact argument value is required.
+          artifact_argument_paths: Optional. Maps input artifact arguments (values or references) to the local file paths where they'll be placed.
               At pipeline run time, the value of the artifact argument is saved to a local file with specified path.
+              This parameter is only needed when the input file paths are hard-coded in the program.
+              Otherwise it's better to pass input artifact placement paths by including artifact arguments in the command-line using the InputArgumentPath class instances.
           file_outputs: Maps output labels to local file paths. At pipeline run time,
               the value of a PipelineParam is saved to its corresponding local file. It's
               one way for outside world to receive outputs of the container.
@@ -1019,7 +1020,7 @@ class ContainerOp(BaseOp):
 
         def resolve_artifact_argument(artarg):
             from ..components._components import _generate_input_file_name
-            if not isinstance(artarg, InputArtifactArgument):
+            if not isinstance(artarg, InputArgumentPath):
                 return artarg
             input_name = getattr(artarg.input, 'name', artarg.input) or ('input-' + str(len(artifact_arguments)))
             input_path = artarg.path or _generate_input_file_name(input_name)
@@ -1030,7 +1031,7 @@ class ContainerOp(BaseOp):
             artifact_arguments[input_name] = artarg.argument
             return input_path
 
-        for artarg in input_artifact_arguments or []:
+        for artarg in artifact_argument_paths or []:
             resolve_artifact_argument(artarg)
 
         if isinstance(command, Sequence) and not isinstance(command, str):

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -702,3 +702,7 @@ implementation:
       self.assertIsNone(delete_op_template.get("successCondition"))
       self.assertIsNone(delete_op_template.get("failureCondition"))
       self.assertDictEqual(delete_op_template.get("outputs"), {})
+
+  def test_py_input_artifact_raw_value(self):
+    """Test pipeline input_artifact_raw_value."""
+    self._test_py_compile_yaml('input_artifact_raw_value')

--- a/sdk/python/tests/compiler/testdata/input_artifact_raw_value.py
+++ b/sdk/python/tests/compiler/testdata/input_artifact_raw_value.py
@@ -27,7 +27,7 @@ def component_with_inline_input_artifact(text: str):
     return dsl.ContainerOp(
         name='component_with_inline_input_artifact',
         image='alpine',
-        command=['cat', dsl.InputArtifactArgument(text, path='/tmp/inputs/text/data', input='text')], # path and input are optional
+        command=['cat', dsl.InputArgumentPath(text, path='/tmp/inputs/text/data', input='text')], # path and input are optional
     )
 
 
@@ -36,8 +36,8 @@ def component_with_input_artifact(text):
 
     return dsl.ContainerOp(
         name='component_with_input_artifact',
-        input_artifact_arguments=[
-            dsl.InputArtifactArgument(argument=text, path='/tmp/inputs/text/data', input='text'), # path and input are optional
+        artifact_argument_paths=[
+            dsl.InputArgumentPath(argument=text, path='/tmp/inputs/text/data', input='text'), # path and input are optional
         ],
         image='alpine',
         command=['cat', '/tmp/inputs/text/data'],
@@ -57,7 +57,7 @@ def component_with_input_artifact_value_from_file(file_path):
     name='Pipeline with artifact input raw argument value.',
     description='Pipeline shows how to define artifact inputs and pass raw artifacts to them.'
 )
-def retry_sample_pipeline():
+def input_artifact_pipeline():
     component_with_inline_input_artifact('Constant artifact value')
     component_with_input_artifact('Constant artifact value')
     component_with_hardcoded_input_artifact_value()
@@ -66,4 +66,4 @@ def retry_sample_pipeline():
     component_with_input_artifact_value_from_file(file_path)
 
 if __name__ == '__main__':
-    kfp.compiler.Compiler().compile(retry_sample_pipeline, __file__ + '.yaml')
+    kfp.compiler.Compiler().compile(input_artifact_pipeline, __file__ + '.yaml')

--- a/sdk/python/tests/compiler/testdata/input_artifact_raw_value.py
+++ b/sdk/python/tests/compiler/testdata/input_artifact_raw_value.py
@@ -19,18 +19,28 @@ from pathlib import Path
 
 sys.path.insert(0, __file__ + '/../../../../')
 
-import kfp.dsl as dsl
+import kfp
+from kfp import dsl
+
+
+def component_with_inline_input_artifact(text: str):
+    return dsl.ContainerOp(
+        name='component_with_inline_input_artifact',
+        image='alpine',
+        command=['cat', dsl.InputArtifactArgument(text, path='/tmp/inputs/text/data', input='text')], # path and input are optional
+    )
+
 
 def component_with_input_artifact(text):
     '''A component that passes text as input artifact'''
 
-    text_input_path = '/inputs/text/data'
     return dsl.ContainerOp(
         name='component_with_input_artifact',
-        input_artifact_paths={'text': text_input_path},
-        input_artifact_arguments={'text': text},
+        input_artifact_arguments=[
+            dsl.InputArtifactArgument(argument=text, path='/tmp/inputs/text/data', input='text'), # path and input are optional
+        ],
         image='alpine',
-        command=['cat', text_input_path],
+        command=['cat', '/tmp/inputs/text/data'],
     )
 
 def component_with_hardcoded_input_artifact_value():
@@ -43,18 +53,17 @@ def component_with_input_artifact_value_from_file(file_path):
     return component_with_input_artifact(Path(file_path).read_text())
 
 
-file_path = str(Path(__file__).parent.joinpath('input_artifact_raw_value.txt'))
-
-
 @dsl.pipeline(
-  name='Pipeline with artifact input raw argument value.',
-  description='Pipeline shows how to define artifact inputs and pass raw artifacts to them.'
+    name='Pipeline with artifact input raw argument value.',
+    description='Pipeline shows how to define artifact inputs and pass raw artifacts to them.'
 )
 def retry_sample_pipeline():
+    component_with_inline_input_artifact('Constant artifact value')
     component_with_input_artifact('Constant artifact value')
     component_with_hardcoded_input_artifact_value()
+
+    file_path = str(Path(__file__).parent.joinpath('input_artifact_raw_value.txt'))
     component_with_input_artifact_value_from_file(file_path)
 
 if __name__ == '__main__':
-    import kfp.compiler as compiler
-    compiler.Compiler().compile(retry_sample_pipeline, __file__ + '.tar.gz')
+    kfp.compiler.Compiler().compile(retry_sample_pipeline, __file__ + '.yaml')

--- a/sdk/python/tests/compiler/testdata/input_artifact_raw_value.py
+++ b/sdk/python/tests/compiler/testdata/input_artifact_raw_value.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, __file__ + '/../../../../')
+
+import kfp.dsl as dsl
+
+def component_with_input_artifact(text):
+    '''A component that passes text as input artifact'''
+
+    text_input_path = '/inputs/text/data'
+    return dsl.ContainerOp(
+        name='component_with_input_artifact',
+        input_artifact_paths={'text': text_input_path},
+        input_artifact_arguments={'text': text},
+        image='alpine',
+        command=['cat', text_input_path],
+    )
+
+def component_with_hardcoded_input_artifact_value():
+    '''A component that passes hard-coded text as input artifact'''
+    return component_with_input_artifact('hard-coded artifact value')
+
+
+def component_with_input_artifact_value_from_file(file_path):
+    '''A component that passes contents of a file as input artifact'''
+    return component_with_input_artifact(Path(file_path).read_text())
+
+
+file_path = str(Path(__file__).parent.joinpath('input_artifact_raw_value.txt'))
+
+
+@dsl.pipeline(
+  name='Pipeline with artifact input raw argument value.',
+  description='Pipeline shows how to define artifact inputs and pass raw artifacts to them.'
+)
+def retry_sample_pipeline():
+    component_with_input_artifact('Constant artifact value')
+    component_with_hardcoded_input_artifact_value()
+    component_with_input_artifact_value_from_file(file_path)
+
+if __name__ == '__main__':
+    import kfp.compiler as compiler
+    compiler.Compiler().compile(retry_sample_pipeline, __file__ + '.tar.gz')

--- a/sdk/python/tests/compiler/testdata/input_artifact_raw_value.txt
+++ b/sdk/python/tests/compiler/testdata/input_artifact_raw_value.txt
@@ -1,0 +1,1 @@
+Text from a file with hard-coded artifact value

--- a/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
+++ b/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
@@ -1,0 +1,81 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "Pipeline shows how to define artifact inputs and pass raw artifacts to them.", "name": "Pipeline with artifact input raw argument value."}'
+  generateName: pipeline-with-artifact-input-raw-argument-value-
+spec:
+  arguments:
+    parameters: []
+  entrypoint: pipeline-with-artifact-input-raw-argument-value
+  serviceAccountName: pipeline-runner
+  templates:
+  - container:
+      command:
+      - cat
+      - /inputs/text/data
+      image: alpine
+    inputs:
+      artifacts:
+      - name: text
+        path: /inputs/text/data
+        raw:
+          data: Constant artifact value
+    name: component-with-input-artifact
+    outputs:
+      artifacts:
+      - name: mlpipeline-ui-metadata
+        path: /mlpipeline-ui-metadata.json
+        optional: true
+      - name: mlpipeline-metrics
+        path: /mlpipeline-metrics.json
+        optional: true
+  - container:
+      command:
+      - cat
+      - /inputs/text/data
+      image: alpine
+    inputs:
+      artifacts:
+      - name: text
+        path: /inputs/text/data
+        raw:
+          data: hard-coded artifact value
+    name: component-with-input-artifact-2
+    outputs:
+      artifacts:
+      - name: mlpipeline-ui-metadata
+        path: /mlpipeline-ui-metadata.json
+        optional: true
+      - name: mlpipeline-metrics
+        path: /mlpipeline-metrics.json
+        optional: true
+  - container:
+      command:
+      - cat
+      - /inputs/text/data
+      image: alpine
+    inputs:
+      artifacts:
+      - name: text
+        path: /inputs/text/data
+        raw:
+          data: Text from a file with hard-coded artifact value
+    name: component-with-input-artifact-3
+    outputs:
+      artifacts:
+      - name: mlpipeline-ui-metadata
+        path: /mlpipeline-ui-metadata.json
+        optional: true
+      - name: mlpipeline-metrics
+        path: /mlpipeline-metrics.json
+        optional: true
+  - dag:
+      tasks:
+      - name: component-with-input-artifact
+        template: component-with-input-artifact
+      - name: component-with-input-artifact-2
+        template: component-with-input-artifact-2
+      - name: component-with-input-artifact-3
+        template: component-with-input-artifact-3
+    name: pipeline-with-artifact-input-raw-argument-value

--- a/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
+++ b/sdk/python/tests/compiler/testdata/input_artifact_raw_value.yaml
@@ -13,69 +13,103 @@ spec:
   - container:
       command:
       - cat
-      - /inputs/text/data
+      - /tmp/inputs/text/data
       image: alpine
     inputs:
       artifacts:
       - name: text
-        path: /inputs/text/data
-        raw:
-          data: Constant artifact value
+        path: /tmp/inputs/text/data
+    name: component-with-inline-input-artifact
+    outputs:
+      artifacts:
+      - name: mlpipeline-ui-metadata
+        optional: true
+        path: /mlpipeline-ui-metadata.json
+      - name: mlpipeline-metrics
+        optional: true
+        path: /mlpipeline-metrics.json
+  - container:
+      command:
+      - cat
+      - /tmp/inputs/text/data
+      image: alpine
+    inputs:
+      artifacts:
+      - name: text
+        path: /tmp/inputs/text/data
     name: component-with-input-artifact
     outputs:
       artifacts:
       - name: mlpipeline-ui-metadata
+        optional: true
         path: /mlpipeline-ui-metadata.json
-        optional: true
       - name: mlpipeline-metrics
-        path: /mlpipeline-metrics.json
         optional: true
+        path: /mlpipeline-metrics.json
   - container:
       command:
       - cat
-      - /inputs/text/data
+      - /tmp/inputs/text/data
       image: alpine
     inputs:
       artifacts:
       - name: text
-        path: /inputs/text/data
-        raw:
-          data: hard-coded artifact value
+        path: /tmp/inputs/text/data
     name: component-with-input-artifact-2
     outputs:
       artifacts:
       - name: mlpipeline-ui-metadata
+        optional: true
         path: /mlpipeline-ui-metadata.json
-        optional: true
       - name: mlpipeline-metrics
-        path: /mlpipeline-metrics.json
         optional: true
+        path: /mlpipeline-metrics.json
   - container:
       command:
       - cat
-      - /inputs/text/data
+      - /tmp/inputs/text/data
       image: alpine
     inputs:
       artifacts:
       - name: text
-        path: /inputs/text/data
-        raw:
-          data: Text from a file with hard-coded artifact value
+        path: /tmp/inputs/text/data
     name: component-with-input-artifact-3
     outputs:
       artifacts:
       - name: mlpipeline-ui-metadata
+        optional: true
         path: /mlpipeline-ui-metadata.json
-        optional: true
       - name: mlpipeline-metrics
-        path: /mlpipeline-metrics.json
         optional: true
+        path: /mlpipeline-metrics.json
   - dag:
       tasks:
-      - name: component-with-input-artifact
+      - arguments:
+          artifacts:
+          - name: text
+            raw:
+              data: Constant artifact value
+        name: component-with-inline-input-artifact
+        template: component-with-inline-input-artifact
+      - arguments:
+          artifacts:
+          - name: text
+            raw:
+              data: Constant artifact value
+        name: component-with-input-artifact
         template: component-with-input-artifact
-      - name: component-with-input-artifact-2
+      - arguments:
+          artifacts:
+          - name: text
+            raw:
+              data: hard-coded artifact value
+        name: component-with-input-artifact-2
         template: component-with-input-artifact-2
-      - name: component-with-input-artifact-3
+      - arguments:
+          artifacts:
+          - name: text
+            raw:
+              data: Text from a file with hard-coded artifact value
+        name: component-with-input-artifact-3
         template: component-with-input-artifact-3
     name: pipeline-with-artifact-input-raw-argument-value

--- a/sdk/python/tests/components/test_components.py
+++ b/sdk/python/tests/components/test_components.py
@@ -270,6 +270,23 @@ implementation:
         self.assertEqual(task1.arguments[0], '--output-data')
         self.assertTrue(task1.arguments[1].startswith('/'))
 
+    def test_input_path_placeholder_with_constant_argument(self):
+        component_text = '''\
+inputs:
+- {name: input 1}
+implementation:
+  container:
+    image: busybox
+    command:
+      - --input-data
+      - {inputPath: input 1}
+'''
+        task_factory1 = comp.load_component_from_text(component_text)
+        task1 = task_factory1('Text')
+
+        self.assertEqual(task1.command, ['--input-data', task1.input_artifact_paths['input 1']])
+        self.assertEqual(task1.artifact_arguments, {'input 1': 'Text'})
+
     def test_optional_inputs_reordering(self):
         '''Tests optional input reordering.
         In python signature, optional arguments must come after the required arguments.


### PR DESCRIPTION
Only constant string artifact arguments are supported for now. (no artifact passing yet.)

Usage:

```
def consumer_op(text):
    return dsl.ContainerOp(
        name='consumer',
        image='alpine',
        command=['cat', dsl.InputArtifactArgument(text)],
    )
```
 or

```
def consumer_op(text):
    return dsl.ContainerOp(
        name='consumer',
        image='alpine',
        command=['cat', '/tmp/inputs/text/data'],
        input_artifact_arguments=[
            dsl.InputArtifactArgument(argument=text, path='/tmp/inputs/text/data'), # path is optional
        ],
    )
```


Full artifact passing DSL:

```
# OP producing artifacts (already available)
def producer_op(text):
    return dsl.ContainerOp(
        name='producer',
        image='alpine',
        command=['sh', '-c', 'echo ' + text + ' > /tmp/output.txt'],
        output_artifact_paths={'text-artifact': '/tmp/output.txt'},
    )

# Op consuming artifacts (this PR)
def consumer_op(text_artifact):
    return dsl.ContainerOp(
        name='consumer',
        image='alpine',
        command=['cat', dsl.InputArtifactArgument(text)],
    )

# Pipeline with artifact passing (non in this PR)
@pipeline()
def my_pipeline():
    producer_task = producer_op('Hello world!')
    consumer_task = consumer_op(producer_task.outputs['text-artifact'])

```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/791)
<!-- Reviewable:end -->
