### PR TITLE
Adds a Tensorboard component for local environments

### DIFF
--- a/.cloudbuild.yaml
+++ b/.cloudbuild.yaml
@@ -139,6 +139,10 @@ steps:
   entrypoint: '/bin/bash'
   args: ['-c', 'cd /workspace/components/local/roc && ./build_image.sh -p $PROJECT_ID -t $COMMIT_SHA']
   id: 'buildROC'
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: '/bin/bash'
+  args: ['-c', 'cd /workspace/components/local/tensorboard && ./build_image.sh -p $PROJECT_ID -t $COMMIT_SHA']
+  id: 'buildTensorboard'
 
 # Build the tagged samples
 - name: 'debian'

--- a/components/local/tensorboard/Dockerfile
+++ b/components/local/tensorboard/Dockerfile
@@ -1,0 +1,11 @@
+FROM ml-pipeline-local-base
+
+RUN pip install numpy==1.15.0 \
+        tensorflow==1.11.0 \
+        tensorboard==1.11.0
+
+WORKDIR /ml
+
+EXPOSE 6006
+
+ENTRYPOINT [ "tensorboard" ]

--- a/components/local/tensorboard/README.md
+++ b/components/local/tensorboard/README.md
@@ -1,0 +1,34 @@
+# Pipeline Tensorboard Local Component
+
+For now, the output artifact cannot take inputs from the local file-system or Minio.
+This is crucial for on-prem / local setup.
+
+This is a workaround step until the features for the Output Artifact Viewer is finished.
+
+```python
+# Define the tensorboard step op
+def tensorboard_op(tensorboard_dir, step_name='tensorboard'):
+    return dsl.ContainerOp(
+        name = step_name,
+        image = 'gcr.io/ml-pipeline/ml-pipeline-local-tensorboard:latest',
+        arguments = [
+            '--logdir', tensorboard_dir,
+        ]
+    )
+
+# Define the volume, pvc, volume mount to be used for mounting TFEvents
+tensorboard_pvc = k8s_client.V1PersistentVolumeClaimVolumeSource(claim_name='tensorboard-pvc')
+tensorboard_volume = k8s_client.V1Volume(name='tensorboard', persistent_volume_claim=tensorboard_pvc)
+tensorboard_volume_mount = k8s_client.V1VolumeMount(mount_path='/mnt/tensorboard/', name='tensorboard')
+
+# Ensure tensorboard summaries are stored to this location from the training step
+# Or modify to match location of stored summaries
+tensorboard_dir = '/mnt/tensorboard/{{.workflow.name}}'
+
+# Create tensorboard step and attach volumes, volume mount
+tensorboard = bolts_tensorboard_op(tensorboard_dir)
+tensorboard.add_volume(tensorboard_volume)
+tensorboard.add_volume_mount(tensorboard_volume_mount)
+```
+
+`Port-forward to the 6006 port of the Tensorboard pod`

--- a/components/local/tensorboard/build_image.sh
+++ b/components/local/tensorboard/build_image.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -e
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+while getopts ":hp:t:i:" opt; do
+  case "${opt}" in
+    h) echo "-p: project name"
+        echo "-t: tag name"
+        echo "-i: image name. If provided, project name and tag name are not necessary"
+        exit
+      ;;
+    p) PROJECT_ID=${OPTARG}
+      ;;
+    t) TAG_NAME=${OPTARG}
+      ;;
+    i) IMAGE_NAME=${OPTARG}
+      ;;
+    \? ) echo "Usage: cmd [-p] project [-t] tag [-i] image"
+      exit
+      ;;
+  esac
+done
+
+LOCAL_IMAGE_NAME=ml-pipeline-local-tensorboard
+
+if [ -z "${PROJECT_ID}" ]; then
+  PROJECT_ID=$(gcloud config config-helper --format "value(configuration.properties.core.project)")
+fi
+
+if [ -z "${TAG_NAME}" ]; then
+  TAG_NAME=$(date +v%Y%m%d)-$(git describe --tags --always --dirty)-$(git diff | shasum -a256 | cut -c -6)
+fi
+
+# build base image
+pushd ../base
+./build_image.sh
+popd
+
+docker build -t ${LOCAL_IMAGE_NAME} .
+if [ -z "${IMAGE_NAME}" ]; then
+  docker tag ${LOCAL_IMAGE_NAME} gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
+  docker push gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
+else
+  docker tag ${LOCAL_IMAGE_NAME} ${IMAGE_NAME}
+  docker push ${IMAGE_NAME}
+fi


### PR DESCRIPTION
Right now, the Output Artifacts Viewer (Pipelines UI) only accepts GCS and Minio as the storage services [Source Code](https://github.com/kubeflow/pipelines/blob/master/frontend/src/lib/WorkflowParser.ts#L205).

However, Tensorboard cannot process links starting with `minio://` and as of now there's no way to read things off of the local filesystem through volumes and/or volume mounts.

This is a component that we have been using for our onprem demos, which we are working on open-sourcing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/792)
<!-- Reviewable:end -->
