### PR TITLE
switch test to us-west1

### DIFF
--- a/test/presubmit-tests-with-pipeline-deployment.sh
+++ b/test/presubmit-tests-with-pipeline-deployment.sh
@@ -71,7 +71,7 @@ echo "presubmit test starts"
 
 # activating the service account
 gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
-gcloud config set compute/zone us-east1-b
+gcloud config set compute/zone us-west1-a
 gcloud config set core/project ${PROJECT}
 
 #Uploading the source code to GCS:

--- a/test/presubmit-tests-with-pipeline-deployment.sh
+++ b/test/presubmit-tests-with-pipeline-deployment.sh
@@ -71,7 +71,7 @@ echo "presubmit test starts"
 
 # activating the service account
 gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
-gcloud config set compute/zone us-central1-a
+gcloud config set compute/zone us-east1-b
 gcloud config set core/project ${PROJECT}
 
 #Uploading the source code to GCS:


### PR DESCRIPTION
us-central-1 has lots of stockout happening. switch zone for less flaky test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/808)
<!-- Reviewable:end -->
