### PR TITLE
Improve docker image build perf by leveraging docker cache

### DIFF
--- a/components/bigquery/query/build_image.sh
+++ b/components/bigquery/query/build_image.sh
@@ -13,45 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-while getopts ":hp:t:i:" opt; do
-  case "${opt}" in
-    h) echo "-p: project name"
-        echo "-t: tag name"
-        echo "-i: image name. If provided, project name and tag name are not necessary"
-        exit
-      ;;
-    p) PROJECT_ID=${OPTARG}
-      ;;
-    t) TAG_NAME=${OPTARG}
-      ;;
-    i) IMAGE_NAME=${OPTARG}
-      ;;
-    \? ) echo "Usage: cmd [-p] project [-t] tag [-i] image"
-      exit
-      ;;
-  esac
-done
-
-LOCAL_IMAGE_NAME=ml-pipeline-bigquery-query
-
-if [ -z "${PROJECT_ID}" ]; then
-  PROJECT_ID=$(gcloud config config-helper --format "value(configuration.properties.core.project)")
-fi
-
-if [ -z "${TAG_NAME}" ]; then
-  TAG_NAME=$(date +v%Y%m%d)-$(git describe --tags --always --dirty)-$(git diff | shasum -a256 | cut -c -6)
-fi
-
 # build base image
 pushd ../base
 ./build_image.sh
 popd
 
-docker build -t ${LOCAL_IMAGE_NAME} .
-if [ -z "${IMAGE_NAME}" ]; then
-  docker tag ${LOCAL_IMAGE_NAME} gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-  docker push gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-else
-  docker tag ${LOCAL_IMAGE_NAME} "${IMAGE_NAME}"
-  docker push "${IMAGE_NAME}"
-fi
+../../build_image.sh -l ml-pipeline-bigquery-query "$@"

--- a/components/build_image.sh
+++ b/components/build_image.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -e
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+while getopts ":hp:t:i:l:" opt; do
+  case "${opt}" in
+    h) echo "-p: project name"
+        echo "-t: tag name"
+        echo "-i: image name. If provided, project name and tag name are not necessary"
+        echo "-l: local image name."
+        exit
+      ;;
+    p) PROJECT_ID=${OPTARG}
+      ;;
+    t) TAG_NAME=${OPTARG}
+      ;;
+    i) IMAGE_NAME=${OPTARG}
+      ;;
+    l) LOCAL_IMAGE_NAME=${OPTARG}
+      ;;
+    \? ) echo "Usage: cmd [-p] project [-t] tag [-i] image [-l] local image"
+      exit
+      ;;
+  esac
+done
+
+if [ -z "${PROJECT_ID}" ]; then
+  PROJECT_ID=$(gcloud config config-helper --format "value(configuration.properties.core.project)")
+fi
+
+if [ -z "${TAG_NAME}" ]; then
+  TAG_NAME=$(date +v%Y%m%d)-$(git describe --tags --always --dirty)-$(git diff | shasum -a256 | cut -c -6)
+fi
+
+if [ -z "${IMAGE_NAME}" ]; then
+  docker pull gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:latest || true
+fi
+
+docker build -t ${LOCAL_IMAGE_NAME} . --cache-from gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:latest
+if [ -z "${IMAGE_NAME}" ]; then
+  docker tag ${LOCAL_IMAGE_NAME} gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
+  docker tag ${LOCAL_IMAGE_NAME} gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:latest
+  docker push gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
+  docker push gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:latest
+else
+  docker tag ${LOCAL_IMAGE_NAME} "${IMAGE_NAME}"
+  docker push "${IMAGE_NAME}"
+fi

--- a/components/dataflow/predict/build_image.sh
+++ b/components/dataflow/predict/build_image.sh
@@ -13,45 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-while getopts ":hp:t:i:" opt; do
-  case "${opt}" in
-    h) echo "-p: project name"
-        echo "-t: tag name"
-        echo "-i: image name. If provided, project name and tag name are not necessary"
-        exit
-      ;;
-    p) PROJECT_ID=${OPTARG}
-      ;;
-    t) TAG_NAME=${OPTARG}
-      ;;
-    i) IMAGE_NAME=${OPTARG}
-      ;;
-    \? ) echo "Usage: cmd [-p] project [-t] tag [-i] image"
-      exit
-      ;;
-  esac
-done
-
-LOCAL_IMAGE_NAME=ml-pipeline-dataflow-tf-predict
-
-if [ -z "${PROJECT_ID}" ]; then
-  PROJECT_ID=$(gcloud config config-helper --format "value(configuration.properties.core.project)")
-fi
-
-if [ -z "${TAG_NAME}" ]; then
-  TAG_NAME=$(date +v%Y%m%d)-$(git describe --tags --always --dirty)-$(git diff | shasum -a256 | cut -c -6)
-fi
-
 # build base image
 pushd ../base
 ./build_image.sh
 popd
 
-docker build -t ${LOCAL_IMAGE_NAME} .
-if [ -z "${IMAGE_NAME}" ]; then
-  docker tag ${LOCAL_IMAGE_NAME} gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-  docker push gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-else
-  docker tag ${LOCAL_IMAGE_NAME} ${IMAGE_NAME}
-  docker push ${IMAGE_NAME}
-fi
+../../build_image.sh -l ml-pipeline-dataflow-tf-predict "$@"

--- a/components/dataflow/tfdv/build_image.sh
+++ b/components/dataflow/tfdv/build_image.sh
@@ -13,45 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-while getopts ":hp:t:i:" opt; do
-  case "${opt}" in
-    h) echo "-p: project name"
-        echo "-t: tag name"
-        echo "-i: image name. If provided, project name and tag name are not necessary"
-        exit
-      ;;
-    p) PROJECT_ID=${OPTARG}
-      ;;
-    t) TAG_NAME=${OPTARG}
-      ;;
-    i) IMAGE_NAME=${OPTARG}
-      ;;
-    \? ) echo "Usage: cmd [-p] project [-t] tag [-i] image"
-      exit
-      ;;
-  esac
-done
-
-LOCAL_IMAGE_NAME=ml-pipeline-dataflow-tfdv
-
-if [ -z "${PROJECT_ID}" ]; then
-  PROJECT_ID=$(gcloud config config-helper --format "value(configuration.properties.core.project)")
-fi
-
-if [ -z "${TAG_NAME}" ]; then
-  TAG_NAME=$(date +v%Y%m%d)-$(git describe --tags --always --dirty)-$(git diff | shasum -a256 | cut -c -6)
-fi
-
 # build base image
 pushd ../base
 ./build_image.sh
 popd
 
-docker build -t ${LOCAL_IMAGE_NAME} .
-if [ -z "${IMAGE_NAME}" ]; then
-  docker tag ${LOCAL_IMAGE_NAME} gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-  docker push gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-else
-  docker tag ${LOCAL_IMAGE_NAME} "${IMAGE_NAME}"
-  docker push "${IMAGE_NAME}"
-fi
+../../build_image.sh -l ml-pipeline-dataflow-tfdv "$@"

--- a/components/dataflow/tfma/build_image.sh
+++ b/components/dataflow/tfma/build_image.sh
@@ -13,45 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-while getopts ":hp:t:i:" opt; do
-  case "${opt}" in
-    h) echo "-p: project name"
-        echo "-t: tag name"
-        echo "-i: image name. If provided, project name and tag name are not necessary"
-        exit
-      ;;
-    p) PROJECT_ID=${OPTARG}
-      ;;
-    t) TAG_NAME=${OPTARG}
-      ;;
-    i) IMAGE_NAME=${OPTARG}
-      ;;
-    \? ) echo "Usage: cmd [-p] project [-t] tag [-i] image"
-      exit
-      ;;
-  esac
-done
-
-LOCAL_IMAGE_NAME=ml-pipeline-dataflow-tfma
-
-if [ -z "${PROJECT_ID}" ]; then
-  PROJECT_ID=$(gcloud config config-helper --format "value(configuration.properties.core.project)")
-fi
-
-if [ -z "${TAG_NAME}" ]; then
-  TAG_NAME=$(date +v%Y%m%d)-$(git describe --tags --always --dirty)-$(git diff | shasum -a256 | cut -c -6)
-fi
-
 # build base image
 pushd ../base
 ./build_image.sh
 popd
 
-docker build -t ${LOCAL_IMAGE_NAME} .
-if [ -z "${IMAGE_NAME}" ]; then
-  docker tag ${LOCAL_IMAGE_NAME} gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-  docker push gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-else
-  docker tag ${LOCAL_IMAGE_NAME} "${IMAGE_NAME}"
-  docker push "${IMAGE_NAME}"
-fi
+../../build_image.sh -l ml-pipeline-dataflow-tfma "$@"

--- a/components/dataflow/tft/build_image.sh
+++ b/components/dataflow/tft/build_image.sh
@@ -13,45 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-while getopts ":hp:t:i:" opt; do
-  case "${opt}" in
-    h) echo "-p: project name"
-        echo "-t: tag name"
-        echo "-i: image name. If provided, project name and tag name are not necessary"
-        exit
-      ;;
-    p) PROJECT_ID=${OPTARG}
-      ;;
-    t) TAG_NAME=${OPTARG}
-      ;;
-    i) IMAGE_NAME=${OPTARG}
-      ;;
-    \? ) echo "Usage: cmd [-p] project [-t] tag [-i] image"
-      exit
-      ;;
-  esac
-done
-
-LOCAL_IMAGE_NAME=ml-pipeline-dataflow-tft
-
-if [ -z "${PROJECT_ID}" ]; then
-  PROJECT_ID=$(gcloud config config-helper --format "value(configuration.properties.core.project)")
-fi
-
-if [ -z "${TAG_NAME}" ]; then
-  TAG_NAME=$(date +v%Y%m%d)-$(git describe --tags --always --dirty)-$(git diff | shasum -a256 | cut -c -6)
-fi
-
 # build base image
 pushd ../base
 ./build_image.sh
 popd
 
-docker build -t ${LOCAL_IMAGE_NAME} .
-if [ -z "${IMAGE_NAME}" ]; then
-  docker tag ${LOCAL_IMAGE_NAME} gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-  docker push gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-else
-  docker tag ${LOCAL_IMAGE_NAME} "${IMAGE_NAME}"
-  docker push "${IMAGE_NAME}"
-fi
+../../build_image.sh -l ml-pipeline-dataflow-tft "$@"

--- a/components/dataproc/analyze/build_image.sh
+++ b/components/dataproc/analyze/build_image.sh
@@ -13,45 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-while getopts ":hp:t:i:" opt; do
-  case "${opt}" in
-    h) echo "-p: project name"
-        echo "-t: tag name"
-        echo "-i: image name. If provided, project name and tag name are not necessary"
-        exit
-      ;;
-    p) PROJECT_ID=${OPTARG}
-      ;;
-    t) TAG_NAME=${OPTARG}
-      ;;
-    i) IMAGE_NAME=${OPTARG}
-      ;;
-    \? ) echo "Usage: cmd [-p] project [-t] tag [-i] image"
-      exit
-      ;;
-  esac
-done
-
-LOCAL_IMAGE_NAME=ml-pipeline-dataproc-analyze
-
-if [ -z "${PROJECT_ID}" ]; then
-  PROJECT_ID=$(gcloud config config-helper --format "value(configuration.properties.core.project)")
-fi
-
-if [ -z "${TAG_NAME}" ]; then
-  TAG_NAME=$(date +v%Y%m%d)-$(git describe --tags --always --dirty)-$(git diff | shasum -a256 | cut -c -6)
-fi
-
 # build base image
 pushd ../base
 ./build_image.sh
 popd
 
-docker build -t ${LOCAL_IMAGE_NAME} .
-if [ -z "${IMAGE_NAME}" ]; then
-  docker tag ${LOCAL_IMAGE_NAME} gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-  docker push gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-else
-  docker tag ${LOCAL_IMAGE_NAME} ${IMAGE_NAME}
-  docker push ${IMAGE_NAME}
-fi
+../../build_image.sh -l ml-pipeline-dataproc-analyze "$@"

--- a/components/dataproc/create_cluster/build_image.sh
+++ b/components/dataproc/create_cluster/build_image.sh
@@ -13,45 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-while getopts ":hp:t:i:" opt; do
-  case "${opt}" in
-    h) echo "-p: project name"
-        echo "-t: tag name"
-        echo "-i: image name. If provided, project name and tag name are not necessary"
-        exit
-      ;;
-    p) PROJECT_ID=${OPTARG}
-      ;;
-    t) TAG_NAME=${OPTARG}
-      ;;
-    i) IMAGE_NAME=${OPTARG}
-      ;;
-    \? ) echo "Usage: cmd [-p] project [-t] tag [-i] image"
-      exit
-      ;;
-  esac
-done
-
-LOCAL_IMAGE_NAME=ml-pipeline-dataproc-create-cluster
-
-if [ -z "${PROJECT_ID}" ]; then
-  PROJECT_ID=$(gcloud config config-helper --format "value(configuration.properties.core.project)")
-fi
-
-if [ -z "${TAG_NAME}" ]; then
-  TAG_NAME=$(date +v%Y%m%d)-$(git describe --tags --always --dirty)-$(git diff | shasum -a256 | cut -c -6)
-fi
-
 # build base image
 pushd ../base
 ./build_image.sh
 popd
 
-docker build -t ${LOCAL_IMAGE_NAME} .
-if [ -z "${IMAGE_NAME}" ]; then
-  docker tag ${LOCAL_IMAGE_NAME} gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-  docker push gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-else
-  docker tag ${LOCAL_IMAGE_NAME} ${IMAGE_NAME}
-  docker push ${IMAGE_NAME}
-fi
+../../build_image.sh -l ml-pipeline-dataproc-create-cluster "$@"

--- a/components/dataproc/delete_cluster/build_image.sh
+++ b/components/dataproc/delete_cluster/build_image.sh
@@ -13,45 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-while getopts ":hp:t:i:" opt; do
-  case "${opt}" in
-    h) echo "-p: project name"
-        echo "-t: tag name"
-        echo "-i: image name. If provided, project name and tag name are not necessary"
-        exit
-      ;;
-    p) PROJECT_ID=${OPTARG}
-      ;;
-    t) TAG_NAME=${OPTARG}
-      ;;
-    i) IMAGE_NAME=${OPTARG}
-      ;;
-    \? ) echo "Usage: cmd [-p] project [-t] tag [-i] image"
-      exit
-      ;;
-  esac
-done
-
-LOCAL_IMAGE_NAME=ml-pipeline-dataproc-delete-cluster
-
-if [ -z "${PROJECT_ID}" ]; then
-  PROJECT_ID=$(gcloud config config-helper --format "value(configuration.properties.core.project)")
-fi
-
-if [ -z "${TAG_NAME}" ]; then
-  TAG_NAME=$(date +v%Y%m%d)-$(git describe --tags --always --dirty)-$(git diff | shasum -a256 | cut -c -6)
-fi
-
 # build base image
 pushd ../base
 ./build_image.sh
 popd
 
-docker build -t ${LOCAL_IMAGE_NAME} .
-if [ -z "${IMAGE_NAME}" ]; then
-  docker tag ${LOCAL_IMAGE_NAME} gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-  docker push gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-else
-  docker tag ${LOCAL_IMAGE_NAME} ${IMAGE_NAME}
-  docker push ${IMAGE_NAME}
-fi
+../../build_image.sh -l ml-pipeline-dataproc-delete-cluster "$@"

--- a/components/dataproc/predict/build_image.sh
+++ b/components/dataproc/predict/build_image.sh
@@ -13,45 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-while getopts ":hp:t:i:" opt; do
-  case "${opt}" in
-    h) echo "-p: project name"
-        echo "-t: tag name"
-        echo "-i: image name. If provided, project name and tag name are not necessary"
-        exit
-      ;;
-    p) PROJECT_ID=${OPTARG}
-      ;;
-    t) TAG_NAME=${OPTARG}
-      ;;
-    i) IMAGE_NAME=${OPTARG}
-      ;;
-    \? ) echo "Usage: cmd [-p] project [-t] tag [-i] image"
-      exit
-      ;;
-  esac
-done
-
-LOCAL_IMAGE_NAME=ml-pipeline-dataproc-predict
-
-if [ -z "${PROJECT_ID}" ]; then
-  PROJECT_ID=$(gcloud config config-helper --format "value(configuration.properties.core.project)")
-fi
-
-if [ -z "${TAG_NAME}" ]; then
-  TAG_NAME=$(date +v%Y%m%d)-$(git describe --tags --always --dirty)-$(git diff | shasum -a256 | cut -c -6)
-fi
-
 # build base image
 pushd ../base
 ./build_image.sh
 popd
 
-docker build -t ${LOCAL_IMAGE_NAME} .
-if [ -z "${IMAGE_NAME}" ]; then
-  docker tag ${LOCAL_IMAGE_NAME} gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-  docker push gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-else
-  docker tag ${LOCAL_IMAGE_NAME} ${IMAGE_NAME}
-  docker push ${IMAGE_NAME}
-fi
+../../build_image.sh -l ml-pipeline-dataproc-predict "$@"

--- a/components/dataproc/train/build_image.sh
+++ b/components/dataproc/train/build_image.sh
@@ -13,45 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-while getopts ":hp:t:i:" opt; do
-  case "${opt}" in
-    h) echo "-p: project name"
-        echo "-t: tag name"
-        echo "-i: image name. If provided, project name and tag name are not necessary"
-        exit
-      ;;
-    p) PROJECT_ID=${OPTARG}
-      ;;
-    t) TAG_NAME=${OPTARG}
-      ;;
-    i) IMAGE_NAME=${OPTARG}
-      ;;
-    \? ) echo "Usage: cmd [-p] project [-t] tag [-i] image"
-      exit
-      ;;
-  esac
-done
-
-LOCAL_IMAGE_NAME=ml-pipeline-dataproc-train
-
-if [ -z "${PROJECT_ID}" ]; then
-  PROJECT_ID=$(gcloud config config-helper --format "value(configuration.properties.core.project)")
-fi
-
-if [ -z "${TAG_NAME}" ]; then
-  TAG_NAME=$(date +v%Y%m%d)-$(git describe --tags --always --dirty)-$(git diff | shasum -a256 | cut -c -6)
-fi
-
 # build base image
 pushd ../base
 ./build_image.sh
 popd
 
-docker build -t ${LOCAL_IMAGE_NAME} .
-if [ -z "${IMAGE_NAME}" ]; then
-  docker tag ${LOCAL_IMAGE_NAME} gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-  docker push gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-else
-  docker tag ${LOCAL_IMAGE_NAME} ${IMAGE_NAME}
-  docker push ${IMAGE_NAME}
-fi
+../../build_image.sh -l ml-pipeline-dataproc-train "$@"

--- a/components/dataproc/transform/build_image.sh
+++ b/components/dataproc/transform/build_image.sh
@@ -13,45 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-while getopts ":hp:t:i:" opt; do
-  case "${opt}" in
-    h) echo "-p: project name"
-        echo "-t: tag name"
-        echo "-i: image name. If provided, project name and tag name are not necessary"
-        exit
-      ;;
-    p) PROJECT_ID=${OPTARG}
-      ;;
-    t) TAG_NAME=${OPTARG}
-      ;;
-    i) IMAGE_NAME=${OPTARG}
-      ;;
-    \? ) echo "Usage: cmd [-p] project [-t] tag [-i] image"
-      exit
-      ;;
-  esac
-done
-
-LOCAL_IMAGE_NAME=ml-pipeline-dataproc-transform
-
-if [ -z "${PROJECT_ID}" ]; then
-  PROJECT_ID=$(gcloud config config-helper --format "value(configuration.properties.core.project)")
-fi
-
-if [ -z "${TAG_NAME}" ]; then
-  TAG_NAME=$(date +v%Y%m%d)-$(git describe --tags --always --dirty)-$(git diff | shasum -a256 | cut -c -6)
-fi
-
 # build base image
 pushd ../base
 ./build_image.sh
 popd
 
-docker build -t ${LOCAL_IMAGE_NAME} .
-if [ -z "${IMAGE_NAME}" ]; then
-  docker tag ${LOCAL_IMAGE_NAME} gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-  docker push gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-else
-  docker tag ${LOCAL_IMAGE_NAME} ${IMAGE_NAME}
-  docker push ${IMAGE_NAME}
-fi
+../../build_image.sh -l ml-pipeline-dataproc-transform "$@"

--- a/components/local/confusion_matrix/build_image.sh
+++ b/components/local/confusion_matrix/build_image.sh
@@ -13,45 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-while getopts ":hp:t:i:" opt; do
-  case "${opt}" in
-    h) echo "-p: project name"
-        echo "-t: tag name"
-        echo "-i: image name. If provided, project name and tag name are not necessary"
-        exit
-      ;;
-    p) PROJECT_ID=${OPTARG}
-      ;;
-    t) TAG_NAME=${OPTARG}
-      ;;
-    i) IMAGE_NAME=${OPTARG}
-      ;;
-    \? ) echo "Usage: cmd [-p] project [-t] tag [-i] image"
-      exit
-      ;;
-  esac
-done
-
-LOCAL_IMAGE_NAME=ml-pipeline-local-confusion-matrix
-
-if [ -z "${PROJECT_ID}" ]; then
-  PROJECT_ID=$(gcloud config config-helper --format "value(configuration.properties.core.project)")
-fi
-
-if [ -z "${TAG_NAME}" ]; then
-  TAG_NAME=$(date +v%Y%m%d)-$(git describe --tags --always --dirty)-$(git diff | shasum -a256 | cut -c -6)
-fi
-
 # build base image
 pushd ../base
 ./build_image.sh
 popd
 
-docker build -t ${LOCAL_IMAGE_NAME} .
-if [ -z "${IMAGE_NAME}" ]; then
-  docker tag ${LOCAL_IMAGE_NAME} gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-  docker push gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-else
-  docker tag ${LOCAL_IMAGE_NAME} "${IMAGE_NAME}"
-  docker push "${IMAGE_NAME}"
-fi
+../../build_image.sh -l ml-pipeline-local-confusion-matrix "$@"

--- a/components/local/roc/build_image.sh
+++ b/components/local/roc/build_image.sh
@@ -13,45 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-while getopts ":hp:t:i:" opt; do
-  case "${opt}" in
-    h) echo "-p: project name"
-        echo "-t: tag name"
-        echo "-i: image name. If provided, project name and tag name are not necessary"
-        exit
-      ;;
-    p) PROJECT_ID=${OPTARG}
-      ;;
-    t) TAG_NAME=${OPTARG}
-      ;;
-    i) IMAGE_NAME=${OPTARG}
-      ;;
-    \? ) echo "Usage: cmd [-p] project [-t] tag [-i] image"
-      exit
-      ;;
-  esac
-done
-
-LOCAL_IMAGE_NAME=ml-pipeline-local-roc
-
-if [ -z "${PROJECT_ID}" ]; then
-  PROJECT_ID=$(gcloud config config-helper --format "value(configuration.properties.core.project)")
-fi
-
-if [ -z "${TAG_NAME}" ]; then
-  TAG_NAME=$(date +v%Y%m%d)-$(git describe --tags --always --dirty)-$(git diff | shasum -a256 | cut -c -6)
-fi
-
 # build base image
 pushd ../base
 ./build_image.sh
 popd
 
-docker build -t ${LOCAL_IMAGE_NAME} .
-if [ -z "${IMAGE_NAME}" ]; then
-  docker tag ${LOCAL_IMAGE_NAME} gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-  docker push gcr.io/${PROJECT_ID}/${LOCAL_IMAGE_NAME}:${TAG_NAME}
-else
-  docker tag ${LOCAL_IMAGE_NAME} ${IMAGE_NAME}
-  docker push ${IMAGE_NAME}
-fi
+../../build_image.sh -l ml-pipeline-local-roc "$@"


### PR DESCRIPTION
The PR includes:
1. a shared build_image.sh file shared by multiple component build script
2. Supports optionally pull latest image and use it as cache to build new docker image

The PR only converts build scripts which follow the same pattern. If it proves to work, I will create another task to convert other components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/815)
<!-- Reviewable:end -->
