### PR TITLE
Enhance hard code for export dir in deploy component

### DIFF
--- a/components/kubeflow/deployer/src/deploy.sh
+++ b/components/kubeflow/deployer/src/deploy.sh
@@ -21,9 +21,9 @@ SERVER_NAME="${SERVER_NAME:-model-server}"
 
 while (($#)); do
    case $1 in
-     "--model-path")
+     "--model-export-path")
        shift
-       MODEL_PATH="$1"
+       MODEL_EXPORT_PATH="$1"
        shift
        ;;
      "--cluster-name")
@@ -53,12 +53,12 @@ while (($#)); do
    esac
 done
 
-if [ -z "${MODEL_PATH}" ]; then
+if [ -z "${MODEL_EXPORT_PATH}" ]; then
   echo "You must specify a path to the saved model"
   exit 1
 fi
 
-echo "Deploying the model '${MODEL_PATH}'"
+echo "Deploying the model '${MODEL_EXPORT_PATH}'"
 
 if [ -z "${CLUSTER_NAME}" ]; then
   CLUSTER_NAME=$(wget -q -O- --header="Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-name)
@@ -98,7 +98,7 @@ ks pkg install kubeflow/tf-serving@${KUBEFLOW_VERSION}
 
 echo "Generating the TF Serving config..."
 ks generate tf-serving server --name="${SERVER_NAME}"
-ks param set server modelPath "${MODEL_PATH}/export/export"
+ks param set server modelPath "${MODEL_EXPORT_PATH}"
 
 # support local storage to deploy tf-serving.
 if [ -n "${PVC_NAME}" ];then


### PR DESCRIPTION
While using deployer component to create a TF-Serving service, hit a issue that could not find base path for servable. Checked the details, that's caused by the export directory is hard code to `model_path/export/export` as below in [deploy.sh](https://github.com/kubeflow/pipelines/blob/master/components/kubeflow/deployer/src/deploy.sh#L101).

```
ks param set server modelPath "${MODEL_PATH}/export/export"
```
To let the deployer component to be reusable, we should enhance that because the model export path can be specified during tensorflow/estimator training from the offical [API](https://www.tensorflow.org/api_docs/python/tf/estimator/FinalExporter).

For the TFX taxi sample, the export path is specified `model_path/export/export` in training step, so update `taxi-cab-classification-pipeline.py` as well. Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/823)
<!-- Reviewable:end -->
