### PR TITLE
Sets 'Choose file' button width to avoid wrap

### DIFF
--- a/frontend/src/components/UploadPipelineDialog.tsx
+++ b/frontend/src/components/UploadPipelineDialog.tsx
@@ -126,7 +126,7 @@ class UploadPipelineDialog extends React.Component<UploadPipelineDialogProps, Up
                     endAdornment: (
                       <InputAdornment position='end'>
                         <Button color='secondary' onClick={() => this._dropzoneRef.current!.open()}
-                          style={{ padding: '3px 5px', margin: 0, minWidth: 90 }}>
+                          style={{ padding: '3px 5px', margin: 0, whiteSpace: 'nowrap' }}>
                           Choose file
                       </Button>
                       </InputAdornment>

--- a/frontend/src/components/UploadPipelineDialog.tsx
+++ b/frontend/src/components/UploadPipelineDialog.tsx
@@ -126,7 +126,7 @@ class UploadPipelineDialog extends React.Component<UploadPipelineDialogProps, Up
                     endAdornment: (
                       <InputAdornment position='end'>
                         <Button color='secondary' onClick={() => this._dropzoneRef.current!.open()}
-                          style={{ padding: '3px 5px', margin: 0 }}>
+                          style={{ padding: '3px 5px', margin: 0, minWidth: 90 }}>
                           Choose file
                       </Button>
                       </InputAdornment>

--- a/frontend/src/components/__snapshots__/UploadPipelineDialog.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/UploadPipelineDialog.test.tsx.snap
@@ -173,8 +173,8 @@ exports[`UploadPipelineDialog renders an active dropzone 1`] = `
                 style={
                   Object {
                     "margin": 0,
-                    "minWidth": 90,
                     "padding": "3px 5px",
+                    "whiteSpace": "nowrap",
                   }
                 }
               >
@@ -304,8 +304,8 @@ exports[`UploadPipelineDialog renders closed 1`] = `
                 style={
                   Object {
                     "margin": 0,
-                    "minWidth": 90,
                     "padding": "3px 5px",
+                    "whiteSpace": "nowrap",
                   }
                 }
               >
@@ -435,8 +435,8 @@ exports[`UploadPipelineDialog renders open 1`] = `
                 style={
                   Object {
                     "margin": 0,
-                    "minWidth": 90,
                     "padding": "3px 5px",
+                    "whiteSpace": "nowrap",
                   }
                 }
               >
@@ -566,8 +566,8 @@ exports[`UploadPipelineDialog renders with a selected file to upload 1`] = `
                 style={
                   Object {
                     "margin": 0,
-                    "minWidth": 90,
                     "padding": "3px 5px",
+                    "whiteSpace": "nowrap",
                   }
                 }
               >

--- a/frontend/src/components/__snapshots__/UploadPipelineDialog.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/UploadPipelineDialog.test.tsx.snap
@@ -173,6 +173,7 @@ exports[`UploadPipelineDialog renders an active dropzone 1`] = `
                 style={
                   Object {
                     "margin": 0,
+                    "minWidth": 90,
                     "padding": "3px 5px",
                   }
                 }
@@ -303,6 +304,7 @@ exports[`UploadPipelineDialog renders closed 1`] = `
                 style={
                   Object {
                     "margin": 0,
+                    "minWidth": 90,
                     "padding": "3px 5px",
                   }
                 }
@@ -433,6 +435,7 @@ exports[`UploadPipelineDialog renders open 1`] = `
                 style={
                   Object {
                     "margin": 0,
+                    "minWidth": 90,
                     "padding": "3px 5px",
                   }
                 }
@@ -563,6 +566,7 @@ exports[`UploadPipelineDialog renders with a selected file to upload 1`] = `
                 style={
                   Object {
                     "margin": 0,
+                    "minWidth": 90,
                     "padding": "3px 5px",
                   }
                 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/34456002/52879684-a80c5c00-3114-11e9-8aaa-78a76274c3e8.png)

After:
![image](https://user-images.githubusercontent.com/34456002/52879692-ac387980-3114-11e9-9267-3491cdeb98e9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/830)
<!-- Reviewable:end -->
