### PR TITLE
Update swagger codegen version

### DIFF
--- a/.cloudbuild.yaml
+++ b/.cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
 # Build the Python SDK
 - name: 'debian'
   entrypoint: '/bin/bash'
-  args: ['-c', 'apt-get update -y; apt-get install --no-install-recommends -y -q default-jdk wget python python-setuptools; wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar -O /tmp/swagger-codegen-cli.jar;cd /workspace/sdk/python;./build.sh /workspace/kfp.tar.gz']
+  args: ['-c', 'apt-get update -y; apt-get install --no-install-recommends -y -q default-jdk wget python python-setuptools; wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.1/swagger-codegen-cli-2.4.1.jar -O /tmp/swagger-codegen-cli.jar;cd /workspace/sdk/python;./build.sh /workspace/kfp.tar.gz']
   id:   'preparePythonSDK'
 - name: 'gcr.io/cloud-builders/gsutil'
   args: ['cp', '/workspace/kfp.tar.gz', 'gs://$PROJECT_ID/builds/$COMMIT_SHA/kfp.tar.gz']

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
             - wget
       script:
         # DSL tests
-        - wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar -O /tmp/swagger-codegen-cli.jar
+        - wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.1/swagger-codegen-cli-2.4.1.jar -O /tmp/swagger-codegen-cli.jar
         - cd $TRAVIS_BUILD_DIR/sdk/python
         - ./build.sh /tmp/kfp.tar.gz
         - pip install /tmp/kfp.tar.gz

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -y && \
 
 RUN pip3 install setuptools==40.5.0
 
-RUN wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar -O /tmp/swagger-codegen-cli.jar
+RUN wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.1/swagger-codegen-cli-2.4.1.jar -O /tmp/swagger-codegen-cli.jar
 
 WORKDIR /go/src/github.com/kubeflow/pipelines
 COPY . .

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -5,8 +5,8 @@ You need `npm`, install dependencies using `npm install`.
 
 If you made any changes to protos (see backend/README), you'll need to
 regenerate the Typescript client library from swagger. We use
-swagger-codegen-cli@2.3.1, which you can get
-[here](http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar).
+swagger-codegen-cli@2.4.1, which you can get
+[here](http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.1/swagger-codegen-cli-2.4.1.jar).
 Make sure the jar file is somewhere on your path with the name
 swagger-codegen-cli.jar, then run `npm run apis`.
 

--- a/test/sample-test/Dockerfile
+++ b/test/sample-test/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -y && \
     apt-get install --no-install-recommends -y -q libssl-dev libffi-dev wget ssh
 
 # Install swagger codegen
-RUN wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar -O /tmp/swagger-codegen-cli.jar
+RUN wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.1/swagger-codegen-cli-2.4.1.jar -O /tmp/swagger-codegen-cli.jar
 
 RUN pip3 install wheel
 RUN pip3 install junit-xml


### PR DESCRIPTION
The old version had a bug (https://github.com/swagger-api/swagger-codegen/issues/8328) that are causing syntax error when running under python 3.7.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/839)
<!-- Reviewable:end -->
