### PR TITLE
extract the pipelineparam deserialize function

### DIFF
--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -65,7 +65,7 @@ class ContainerOp(object):
     self.pod_labels = {}
     self.num_retries = 0
 
-    self.argument_inputs = _extract_pipelineparams((command or []) + (arguments or []))
+    self.argument_inputs = _extract_pipelineparams([str(arg) for arg in (command or []) + (arguments or [])])
 
     self.file_outputs = file_outputs
     self.dependent_op_names = []

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -15,7 +15,7 @@
 
 from . import _pipeline
 from . import _pipeline_param
-from ._pipeline_param import _extract_pipeleineparam
+from ._pipeline_param import _extract_pipelineparam
 import re
 from typing import Dict
 
@@ -67,7 +67,7 @@ class ContainerOp(object):
 
     self.argument_inputs = []
     for arg in (command or []) + (arguments or []):
-      self.argument_inputs += _extract_pipeleineparam(str(arg))
+      self.argument_inputs += _extract_pipelineparam(str(arg))
 
     self.file_outputs = file_outputs
     self.dependent_op_names = []

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -15,6 +15,7 @@
 
 from . import _pipeline
 from . import _pipeline_param
+from ._pipeline_param import _extract_pipeleineparam
 import re
 from typing import Dict
 
@@ -64,13 +65,10 @@ class ContainerOp(object):
     self.pod_labels = {}
     self.num_retries = 0
 
-    matches = []
+    self.argument_inputs = []
     for arg in (command or []) + (arguments or []):
-      match = re.findall(r'{{pipelineparam:op=([\w\s_-]*);name=([\w\s_-]+);value=(.*?)}}', str(arg))
-      matches += match
+      self.argument_inputs += _extract_pipeleineparam(str(arg))
 
-    self.argument_inputs = [_pipeline_param.PipelineParam(x[1], x[0], x[2])
-                            for x in list(set(matches))]
     self.file_outputs = file_outputs
     self.dependent_op_names = []
 

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -15,7 +15,7 @@
 
 from . import _pipeline
 from . import _pipeline_param
-from ._pipeline_param import _extract_pipelineparam
+from ._pipeline_param import _extract_pipelineparams
 import re
 from typing import Dict
 
@@ -65,9 +65,7 @@ class ContainerOp(object):
     self.pod_labels = {}
     self.num_retries = 0
 
-    self.argument_inputs = []
-    for arg in (command or []) + (arguments or []):
-      self.argument_inputs += _extract_pipelineparam(str(arg))
+    self.argument_inputs = _extract_pipelineparams((command or []) + (arguments or []))
 
     self.file_outputs = file_outputs
     self.dependent_op_names = []

--- a/sdk/python/kfp/dsl/_pipeline_param.py
+++ b/sdk/python/kfp/dsl/_pipeline_param.py
@@ -34,7 +34,7 @@ def _extract_pipelineparams(payloads: str or list[str]):
     payloads = [payloads]
   matches = []
   for payload in payloads:
-    matches = re.findall(r'{{pipelineparam:op=([\w\s_-]*);name=([\w\s_-]+);value=(.*?)}}', payload)
+    matches += re.findall(r'{{pipelineparam:op=([\w\s_-]*);name=([\w\s_-]+);value=(.*?)}}', payload)
   return [PipelineParam(x[1], x[0], x[2]) for x in list(set(matches))]
 
 class PipelineParam(object):

--- a/sdk/python/kfp/dsl/_pipeline_param.py
+++ b/sdk/python/kfp/dsl/_pipeline_param.py
@@ -21,7 +21,7 @@ from collections import namedtuple
 # For now, this identifies a condition with only "==" operator supported.
 ConditionOperator = namedtuple('ConditionOperator', 'operator operand1 operand2')
 
-def _extract_pipeleineparam(payload: str):
+def _extract_pipelineparam(payload: str):
   """_extract_pipelineparam extract a list of PipelineParam instances from the payload string.
 
   Args:

--- a/sdk/python/kfp/dsl/_pipeline_param.py
+++ b/sdk/python/kfp/dsl/_pipeline_param.py
@@ -21,15 +21,20 @@ from collections import namedtuple
 # For now, this identifies a condition with only "==" operator supported.
 ConditionOperator = namedtuple('ConditionOperator', 'operator operand1 operand2')
 
-def _extract_pipelineparam(payload: str):
+def _extract_pipelineparams(payloads: str or list[str]):
   """_extract_pipelineparam extract a list of PipelineParam instances from the payload string.
+  Note: this function removes all duplicate matches.
 
   Args:
-    payload (str): a string that contains serialized pipelineparams
+    payload (str or list[str]): a string/a list of strings that contains serialized pipelineparams
   Return:
     List[PipelineParam]
   """
-  matches = re.findall(r'{{pipelineparam:op=([\w\s_-]*);name=([\w\s_-]+);value=(.*?)}}', payload)
+  if isinstance(payloads, str):
+    payloads = [payloads]
+  matches = []
+  for payload in payloads:
+    matches = re.findall(r'{{pipelineparam:op=([\w\s_-]*);name=([\w\s_-]+);value=(.*?)}}', payload)
   return [PipelineParam(x[1], x[0], x[2]) for x in list(set(matches))]
 
 class PipelineParam(object):

--- a/sdk/python/kfp/dsl/_pipeline_param.py
+++ b/sdk/python/kfp/dsl/_pipeline_param.py
@@ -21,6 +21,16 @@ from collections import namedtuple
 # For now, this identifies a condition with only "==" operator supported.
 ConditionOperator = namedtuple('ConditionOperator', 'operator operand1 operand2')
 
+def _extract_pipeleineparam(payload: str):
+  """_extract_pipelineparam extract a list of PipelineParam instances from the payload string.
+
+  Args:
+    payload (str): a string that contains serialized pipelineparams
+  Return:
+    List[PipelineParam]
+  """
+  matches = re.findall(r'{{pipelineparam:op=([\w\s_-]*);name=([\w\s_-]+);value=(.*?)}}', payload)
+  return [PipelineParam(x[1], x[0], x[2]) for x in list(set(matches))]
 
 class PipelineParam(object):
   """Representing a future value that is passed between pipeline components.

--- a/sdk/python/tests/dsl/pipeline_param_tests.py
+++ b/sdk/python/tests/dsl/pipeline_param_tests.py
@@ -14,7 +14,7 @@
 
 
 from kfp.dsl import PipelineParam
-from kfp.dsl._pipeline_param import _extract_pipelineparam
+from kfp.dsl._pipeline_param import _extract_pipelineparams
 import unittest
 
 
@@ -45,5 +45,5 @@ class TestPipelineParam(unittest.TestCase):
     p3 = PipelineParam(name='param3', value='value3')
     stuff_chars = ' between '
     payload = str(p1) + stuff_chars + str(p2) + stuff_chars + str(p3)
-    params = _extract_pipelineparam(payload)
+    params = _extract_pipelineparams(payload)
     self.assertListEqual([p1, p2, p3], params)

--- a/sdk/python/tests/dsl/pipeline_param_tests.py
+++ b/sdk/python/tests/dsl/pipeline_param_tests.py
@@ -14,6 +14,7 @@
 
 
 from kfp.dsl import PipelineParam
+from kfp.dsl._pipeline_param import _extract_pipeleineparam
 import unittest
 
 
@@ -35,3 +36,14 @@ class TestPipelineParam(unittest.TestCase):
 
     p = PipelineParam(name='param3', value='value3')
     self.assertEqual('{{pipelineparam:op=;name=param3;value=value3}}', str(p))
+
+  def test_extract_pipelineparam(self):
+    """Test _extract_pipeleineparam."""
+
+    p1 = PipelineParam(name='param1', op_name='op1')
+    p2 = PipelineParam(name='param2')
+    p3 = PipelineParam(name='param3', value='value3')
+    stuff_chars = ' between '
+    payload = str(p1) + stuff_chars + str(p2) + stuff_chars + str(p3)
+    params = _extract_pipeleineparam(payload)
+    self.assertListEqual([p1, p2, p3], params)

--- a/sdk/python/tests/dsl/pipeline_param_tests.py
+++ b/sdk/python/tests/dsl/pipeline_param_tests.py
@@ -14,7 +14,7 @@
 
 
 from kfp.dsl import PipelineParam
-from kfp.dsl._pipeline_param import _extract_pipeleineparam
+from kfp.dsl._pipeline_param import _extract_pipelineparam
 import unittest
 
 
@@ -45,5 +45,5 @@ class TestPipelineParam(unittest.TestCase):
     p3 = PipelineParam(name='param3', value='value3')
     stuff_chars = ' between '
     payload = str(p1) + stuff_chars + str(p2) + stuff_chars + str(p3)
-    params = _extract_pipeleineparam(payload)
+    params = _extract_pipelineparam(payload)
     self.assertListEqual([p1, p2, p3], params)

--- a/sdk/python/tests/dsl/pipeline_param_tests.py
+++ b/sdk/python/tests/dsl/pipeline_param_tests.py
@@ -47,3 +47,6 @@ class TestPipelineParam(unittest.TestCase):
     payload = str(p1) + stuff_chars + str(p2) + stuff_chars + str(p3)
     params = _extract_pipelineparams(payload)
     self.assertListEqual([p1, p2, p3], params)
+    payload = [str(p1) + stuff_chars + str(p2), str(p2) + stuff_chars + str(p3)]
+    params = _extract_pipelineparams(payload)
+    self.assertListEqual([p1, p2, p3], params)


### PR DESCRIPTION
Move the deserialize/matching function of the pipelineparam to the same class of PipelineParam such that future changes are much easier whenever we need to modify the pipelineparam.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/841)
<!-- Reviewable:end -->
