### PR TITLE
Support rendering recursive static DAGs

### DIFF
--- a/frontend/mock-backend/fixed-data.ts
+++ b/frontend/mock-backend/fixed-data.ts
@@ -668,9 +668,11 @@ export const data = {
   runs,
 };
 
+// tslint:disable:object-literal-sort-keys
 export const namedPipelines = {
-  examplePipeline: pipelines[0],
-  examplePipeline2: pipelines[1],
+  unstructuredTextPipeline: pipelines[0],
+  imageClassificationPipeline: pipelines[1],
   noParamsPipeline: pipelines[2],
   undefinedParamsPipeline: pipelines[3],
 };
+// tslint:enable:object-literal-sort-keys

--- a/frontend/mock-backend/mock-api-middleware.ts
+++ b/frontend/mock-backend/mock-api-middleware.ts
@@ -478,9 +478,14 @@ export default (app: express.Application) => {
       res.status(404).send(`No pipeline was found with ID: ${req.params.pid}`);
       return;
     }
-    const filePath = req.params.pid === namedPipelines.noParamsPipeline.id
-      ? './mock-backend/mock-conditional-template.yaml'
-      : './mock-backend/mock-template.yaml';
+    let filePath = '';
+    if (req.params.pid === namedPipelines.noParamsPipeline.id) {
+      filePath = './mock-backend/mock-conditional-template.yaml';
+    } else if (req.params.pid === namedPipelines.unstructuredTextPipeline.id) {
+      filePath = './mock-backend/mock-recursive-template.yaml';
+    } else {
+      filePath = './mock-backend/mock-template.yaml';
+    }
     res.send(JSON.stringify({ template: fs.readFileSync(filePath, 'utf-8') }));
   });
 

--- a/frontend/mock-backend/mock-recursive-template.yaml
+++ b/frontend/mock-backend/mock-recursive-template.yaml
@@ -12,7 +12,7 @@ spec:
       - name: recurse-1
         template: recurse-1
       - name: leaf-1
-        template: leaf-2
+        template: leaf-1
     name: start
   - dag:
       tasks:
@@ -27,9 +27,18 @@ spec:
         template: start
       - name: leaf-2
         template: leaf-2
-      - name: leaf-3
-        template: leaf-2
+      - name: recurse-3
+        template: recurse-3
     name: recurse-2
+  - dag:
+      tasks:
+      - name: start
+        template: start
+      - name: recurse-1
+        template: recurse-1
+      - name: recurse-2
+        template: recurse-2
+    name: recurse-3
   - dag:
       tasks:
       - name: start
@@ -39,7 +48,5 @@ spec:
     name: leaf-1
   - container:
     name: leaf-2
-  - container:
-    name: leaf-3
   
   

--- a/frontend/mock-backend/mock-recursive-template.yaml
+++ b/frontend/mock-backend/mock-recursive-template.yaml
@@ -1,0 +1,45 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: entry-point-test-
+spec:
+  arguments:
+    parameters: []
+  entrypoint: entry-point-test
+  templates:
+  - dag:
+      tasks:
+      - name: recurse-1
+        template: recurse-1
+      - name: leaf-1
+        template: leaf-2
+    name: start
+  - dag:
+      tasks:
+      - name: start
+        template: start
+      - name: recurse-2
+        template: recurse-2
+    name: recurse-1
+  - dag:
+      tasks:
+      - name: start
+        template: start
+      - name: leaf-2
+        template: leaf-2
+      - name: leaf-3
+        template: leaf-2
+    name: recurse-2
+  - dag:
+      tasks:
+      - name: start
+        template: start
+    name: entry-point-test
+  - container:
+    name: leaf-1
+  - container:
+    name: leaf-2
+  - container:
+    name: leaf-3
+  
+  

--- a/frontend/src/lib/StaticGraphParser.ts
+++ b/frontend/src/lib/StaticGraphParser.ts
@@ -70,14 +70,6 @@ export function _populateInfoFromTemplate(info: SelectedNodeInfo, template?: Tem
   return info;
 }
 
-// function printMap(m: Map<string, string>): string {
-//   let s = '\n - ';
-//   m.forEach((v, k) => {
-//     s = s + k + ': ' + v + ',\n - ';
-//   });
-//   return s;
-// }
-
 /**
  * Recursively construct the static graph of the Pipeline.
  *

--- a/frontend/src/lib/StaticGraphParser.ts
+++ b/frontend/src/lib/StaticGraphParser.ts
@@ -127,8 +127,18 @@ function buildDag(
       }
 
       // Parent here will be the task that pointed to this DAG template.
-      // We do not set an edge if the task has dependencies because in that case it makes sense
-      // for incoming edges to only be drawn from its dependencies, not the DAG node itself
+      // Within a DAG template, tasks can have dependencies on one another, and long chains of
+      // dependencies can be present within a single DAG. In these cases, we choose not to draw an
+      // edge from the DAG node itself to these tasks with dependencies because such an edge would
+      // not be meaningful to the user. For example, consider a DAG A with two tasks, B and C, where
+      // task C depends on the output of task B. C is a task of A, but it's much more semantically
+      // important that C depends on B, so to avoid cluttering the graph, we simply omit the edge
+      // between A and C:
+      //      A                  A
+      //    /   \    becomes    /
+      //   B <-- C             B
+      //                      /
+      //                     C
       if (parentFullPath && !task.dependencies) {
         graph.setEdge(parentFullPath, nodeId);
       }
@@ -149,7 +159,7 @@ function buildDag(
         } else if (child.nodeType === 'container' ) {
           _populateInfoFromTemplate(info, child.template);
         } else {
-          logger.error(`Unknown nodetype: ${child.nodeType} on template: ${child.template}`);
+          throw new Error(`Unknown nodetype: ${child.nodeType} on workflow template: ${child.template}`);
         }
       }
 

--- a/frontend/src/lib/StaticGraphParser.ts
+++ b/frontend/src/lib/StaticGraphParser.ts
@@ -70,78 +70,103 @@ export function _populateInfoFromTemplate(info: SelectedNodeInfo, template?: Tem
   return info;
 }
 
+// function printMap(m: Map<string, string>): string {
+//   let s = '\n - ';
+//   m.forEach((v, k) => {
+//     s = s + k + ': ' + v + ',\n - ';
+//   });
+//   return s;
+// }
+
 /**
  * Recursively construct the static graph of the Pipeline.
  *
  * @param graph The dagre graph object
  * @param rootTemplateId The current template being explored at this level of recursion
  * @param templates An unchanging map of template name to template and type
- * @param parent The task that was being examined when the function recursed
+ * @param parentFullPath The task that was being examined when the function recursed. This string
+ * includes all of the nodes above it. For example, with a graph such as:
+ *     A
+ *    / \
+ *   B   C
+ *      / \
+ *     D   E
+ * where A and C are DAGs, the parentFullPath when rootTemplateId is C would be: /A/C
  */
 function buildDag(
-    graph: dagre.graphlib.Graph,
-    rootTemplateId: string,
-    templates: Map<string, { nodeType: nodeType, template: Template }>,
-    parent?: string): void {
+  graph: dagre.graphlib.Graph,
+  rootTemplateId: string,
+  templates: Map<string, { nodeType: nodeType, template: Template }>,
+  alreadyVisited: Map<string, string>,
+  parentFullPath: string): void {
 
   const root = templates.get(rootTemplateId);
 
   if (root && root.nodeType === 'dag') {
+    // Mark that we have visited this DAG, and save the original qualified path to it.
+    alreadyVisited.set(rootTemplateId, parentFullPath || '/' + rootTemplateId);
     const template = root.template;
 
     (template.dag.tasks || []).forEach((task) => {
 
-      const nodeId = (parent || '') + '/' + task.name;
+      const nodeId = parentFullPath + '/' + task.name;
 
       // If the user specifies an exit handler, then the compiler will wrap the entire Pipeline
       // within an additional DAG template prefixed with "exit-handler".
       // If this is the case, we simply treat it as the root of the graph and work from there
       if (task.name.startsWith('exit-handler')) {
-        buildDag(graph, task.template, templates);
-      } else {
-
-        // Parent here will be the task that pointed to this DAG template.
-        // We do not set an edge if the task has dependencies because in that case it makes sense
-        // for incoming edges to only be drawn from its dependencies, not the DAG node itself
-        if (parent && !task.dependencies) {
-          graph.setEdge(parent, nodeId);
-        }
-
-        // This object contains information about the node that we display to the user when they
-        // click on a node in the graph
-        const info = new SelectedNodeInfo();
-        if (task.when) {
-          info.condition = task.when;
-        }
-
-        // "Child" here is the template that this task points to. This template should either be a
-        // DAG, in which case we recurse, or a container which can be thought of as a leaf node
-        const child = templates.get(task.template);
-        if (child) {
-          if (child.nodeType === 'dag') {
-            buildDag(graph, task.template, templates, nodeId);
-          } else if (child.nodeType === 'container' ) {
-            _populateInfoFromTemplate(info, child.template);
-          } else {
-            logger.error(`Unknown nodetype: ${child.nodeType} on template: ${child.template}`);
-          }
-        }
-
-        graph.setNode(nodeId, {
-          bgColor: task.when ? 'cornsilk' : undefined,
-          height: Constants.NODE_HEIGHT,
-          info,
-          label: task.template,
-          width: Constants.NODE_WIDTH,
-        });
+        buildDag(graph, task.template, templates, alreadyVisited, '');
+        return;
       }
+
+      // If this task has already been visited, retrieve the qualified path name that was assigned
+      // to it, add an edge, and move on to the next task
+      if (alreadyVisited.has(task.name)) {
+        graph.setEdge(parentFullPath, alreadyVisited.get(task.name)!);
+        return;
+      }
+
+      // Parent here will be the task that pointed to this DAG template.
+      // We do not set an edge if the task has dependencies because in that case it makes sense
+      // for incoming edges to only be drawn from its dependencies, not the DAG node itself
+      if (parentFullPath && !task.dependencies) {
+        graph.setEdge(parentFullPath, nodeId);
+      }
+
+      // This object contains information about the node that we display to the user when they
+      // click on a node in the graph
+      const info = new SelectedNodeInfo();
+      if (task.when) {
+        info.condition = task.when;
+      }
+
+      // "Child" here is the template that this task points to. This template should either be a
+      // DAG, in which case we recurse, or a container which can be thought of as a leaf node
+      const child = templates.get(task.template);
+      if (child) {
+        if (child.nodeType === 'dag') {
+          buildDag(graph, task.template, templates, alreadyVisited, nodeId);
+        } else if (child.nodeType === 'container' ) {
+          _populateInfoFromTemplate(info, child.template);
+        } else {
+          logger.error(`Unknown nodetype: ${child.nodeType} on template: ${child.template}`);
+        }
+      }
+
+      graph.setNode(nodeId, {
+        bgColor: task.when ? 'cornsilk' : undefined,
+        height: Constants.NODE_HEIGHT,
+        info,
+        label: task.template,
+        width: Constants.NODE_WIDTH,
+      });
 
       // DAG tasks can indicate dependencies which are graphically shown as parents with edges
       // pointing to their children (the task(s)).
       // TODO: The addition of the parent prefix to the dependency here is only valid if nodes only
       // ever directly depend on their siblings. This is true now but may change in the future, and
       // this will need to be updated.
-      (task.dependencies || []).forEach((dep) => graph.setEdge((parent || '') + '/' + dep, nodeId));
+      (task.dependencies || []).forEach((dep) => graph.setEdge(parentFullPath + '/' + dep, nodeId));
     });
   }
 }
@@ -184,7 +209,7 @@ export function createGraph(workflow: Workflow): dagre.graphlib.Graph {
     }
   }
 
-  buildDag(graph, workflow.spec.entrypoint, templates);
+  buildDag(graph, workflow.spec.entrypoint, templates, new Map(), '');
 
   // DSL-compiled Pipelines will always include a DAG, so they should never reach this point.
   // It is, however, possible for users to upload manually constructed Pipelines, and extremely


### PR DESCRIPTION
With this change, `StaticGraphParser` no longer breaks when trying to lay out recursive pipelines.

This PR also adds a new mock template: `mock-recursive-template.yaml` which includes multiple instances of recursion.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/845)
<!-- Reviewable:end -->
