### PR TITLE
Move e2e tests to us-east1

### DIFF
--- a/test/presubmit-tests-with-pipeline-deployment.sh
+++ b/test/presubmit-tests-with-pipeline-deployment.sh
@@ -71,7 +71,7 @@ echo "presubmit test starts"
 
 # activating the service account
 gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
-gcloud config set compute/zone us-west1-a
+gcloud config set compute/zone us-east1-a
 gcloud config set core/project ${PROJECT}
 
 #Uploading the source code to GCS:

--- a/test/presubmit-tests-with-pipeline-deployment.sh
+++ b/test/presubmit-tests-with-pipeline-deployment.sh
@@ -71,7 +71,7 @@ echo "presubmit test starts"
 
 # activating the service account
 gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
-gcloud config set compute/zone us-east1-a
+gcloud config set compute/zone us-east1-b
 gcloud config set core/project ${PROJECT}
 
 #Uploading the source code to GCS:


### PR DESCRIPTION
Copied from https://github.com/kubeflow/pipelines/pull/814

The original PR was blocked by github and travis integration bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/847)
<!-- Reviewable:end -->
