### PR TITLE
apiserver glog uses -alsologtostderr

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -57,4 +57,4 @@ RUN apk add ca-certificates
 EXPOSE 8888
 
 # Start the apiserver
-CMD apiserver --config=/config --sampleconfig=/config/sample_config.json
+CMD apiserver --config=/config --sampleconfig=/config/sample_config.json -alsologtostderr=true

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -108,7 +108,11 @@ See Ksonnet troubleshooting page [page](https://github.com/ksonnet/ksonnet/blob/
 
 API server logs are located at /tmp directory of the pod. To SSH into the pod, run:
 ```bash
-kubectl exec -it -n ${NAMESPACE} $(kubectl get pods -l app=ml-pipeline -o jsonpath='{.items[0].metadata.name}' -n ${NAMESPACE}) -- /bin/bash
+kubectl exec -it -n ${NAMESPACE} $(kubectl get pods -l app=ml-pipeline -o jsonpath='{.items[0].metadata.name}' -n ${NAMESPACE}) -- /bin/sh
+```
+or
+```bash
+kubectl logs -n ${NAMESPACE} $(kubectl get pods -l app=ml-pipeline -o jsonpath='{.items[0].metadata.name}' -n ${NAMESPACE})
 ```
 
 **Q: How to check my cluster status if I am using Minikube?**


### PR DESCRIPTION
To make "kubectl logs" work for apiserver, instead of sshing into the apiserver pod.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/859)
<!-- Reviewable:end -->
