### PR TITLE
add sigint sigterm to the test

### DIFF
--- a/test/deploy-kubeflow.sh
+++ b/test/deploy-kubeflow.sh
@@ -54,7 +54,7 @@ function clean_up {
   # delete the storage
   gcloud deployment-manager --project=${PROJECT} deployments delete ${KFAPP}-storage --quiet
 }
-trap clean_up EXIT
+trap clean_up EXIT SIGINT SIGTERM
 
 ${KUBEFLOW_SRC}/scripts/kfctl.sh init ${KFAPP} --platform ${PLATFORM} --project ${PROJECT} --skipInitProject
 


### PR DESCRIPTION
We have cluster leaking, serviceaccount leaking, etc in the ml-pipeline-test. 
The reason is that when we push a new commit to the PR while the test is still running, our test infrastructure does not capture the signal and garbage collect the resources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/863)
<!-- Reviewable:end -->
