### PR TITLE
Allow more flexible way to config the api server addr in persistence agent

### DIFF
--- a/backend/src/agent/persistence/client/pipeline_client.go
+++ b/backend/src/agent/persistence/client/pipeline_client.go
@@ -48,7 +48,6 @@ type PipelineClient struct {
 }
 
 func NewPipelineClient(
-	namespace string,
 	initializeTimeout time.Duration,
 	timeout time.Duration,
 	basePath string,

--- a/backend/src/agent/persistence/client/pipeline_client.go
+++ b/backend/src/agent/persistence/client/pipeline_client.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	addressTemp = "%s.%s.svc.cluster.local:%s"
+	addressTemp = "%s:%s"
 )
 
 type PipelineClientInterface interface {
@@ -55,8 +55,8 @@ func NewPipelineClient(
 	mlPipelineServiceName string,
 	mlPipelineServiceHttpPort string,
 	mlPipelineServiceGRPCPort string) (*PipelineClient, error) {
-	httpAddress := fmt.Sprintf(addressTemp, mlPipelineServiceName, namespace, mlPipelineServiceHttpPort)
-	grpcAddress := fmt.Sprintf(addressTemp, mlPipelineServiceName, namespace, mlPipelineServiceGRPCPort)
+	httpAddress := fmt.Sprintf(addressTemp, mlPipelineServiceName, mlPipelineServiceHttpPort)
+	grpcAddress := fmt.Sprintf(addressTemp, mlPipelineServiceName, mlPipelineServiceGRPCPort)
 	err := util.WaitForAPIAvailable(initializeTimeout, basePath, httpAddress)
 	if err != nil {
 		return nil, errors.Wrapf(err,

--- a/backend/src/agent/persistence/main.go
+++ b/backend/src/agent/persistence/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"flag"
-	"os"
 	"time"
 
 	workflowclientSet "github.com/argoproj/argo/pkg/client/clientset/versioned"
@@ -34,7 +33,6 @@ import (
 var (
 	masterURL                   string
 	kubeconfig                  string
-	namespace                   string
 	initializeTimeout           time.Duration
 	timeout                     time.Duration
 	mlPipelineAPIServerName     string
@@ -47,7 +45,6 @@ var (
 const (
 	kubeconfigFlagName                  = "kubeconfig"
 	masterFlagName                      = "master"
-	namespaceFlagName                   = "namespace"
 	initializationTimeoutFlagName       = "initializeTimeout"
 	timeoutFlagName                     = "timeout"
 	mlPipelineAPIServerBasePathFlagName = "mlPipelineAPIServerBasePath"
@@ -81,7 +78,6 @@ func main() {
 	workflowInformerFactory := workflowinformers.NewSharedInformerFactory(workflowClient, time.Second*30)
 
 	pipelineClient, err := client.NewPipelineClient(
-		namespace,
 		initializeTimeout,
 		timeout,
 		mlPipelineAPIServerBasePath,
@@ -109,7 +105,6 @@ func main() {
 func init() {
 	flag.StringVar(&kubeconfig, kubeconfigFlagName, "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, masterFlagName, "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
-	flag.StringVar(&namespace, namespaceFlagName, os.Getenv("POD_NAMESPACE"), "The namespace the ML pipeline API server is deployed to")
 	flag.DurationVar(&initializeTimeout, initializationTimeoutFlagName, 2*time.Minute, "Duration to wait for initialization of the ML pipeline API server.")
 	flag.DurationVar(&timeout, timeoutFlagName, 1*time.Minute, "Duration to wait for calls to complete.")
 	flag.StringVar(&mlPipelineAPIServerName, mlPipelineAPIServerNameFlagName, "ml-pipeline", "Name of the ML pipeline API server.")


### PR DESCRIPTION
In some clusters, service addr may not be formatted as "%s.%s.svc.cluster.local:%s". We need to a more flexible way to handle it. I checked approach in ml-pipeline-ui, which just make the entire FQDN configurable. But this change would bring incompatibility, as previously users may only config the service name while now need full name to make it work.

@IronPan thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/867)
<!-- Reviewable:end -->
