### PR TITLE
sample test image build failure

### DIFF
--- a/test/sample-test/Dockerfile
+++ b/test/sample-test/Dockerfile
@@ -3,7 +3,7 @@
 FROM google/cloud-sdk
 
 RUN apt-get update -y && \
-    apt-get install --no-install-recommends -y -q python3-pip default-jdk python3-setuptools && \
+    apt-get install --no-install-recommends -y -q python3-pip default-jdk python3-setuptools python3-dev && \
     apt-get install --no-install-recommends -y -q libssl-dev libffi-dev wget ssh
 
 # Install swagger codegen

--- a/test/sample-test/Dockerfile
+++ b/test/sample-test/Dockerfile
@@ -1,6 +1,6 @@
 # This image has the script to kick off the ML pipeline sample e2e test,
 
-FROM google/cloud-sdk
+FROM google/cloud-sdk:236.0.0
 
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y -q python3-pip default-jdk python3-setuptools python3-dev && \


### PR DESCRIPTION
lack of python3-dev package in the sample test image.
Reason: google/cloud-sdk base image is updated on Feb 26h, 2019.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/871)
<!-- Reviewable:end -->
