### PR TITLE
Passing the environment variables to container op

### DIFF
--- a/sdk/python/tests/components/test_components.py
+++ b/sdk/python/tests/components/test_components.py
@@ -458,6 +458,24 @@ implementation:
         task_else = task_factory1()
         self.assertEqual(task_else.arguments, [])
 
+    def test_handling_env(self):
+        component_text = '''\
+implementation:
+  container:
+    image: busybox
+    env:
+      key1: value 1
+      key2: value 2
+'''
+        task_factory1 = comp.load_component_from_text(component_text)
+        
+        import kfp
+        with kfp.dsl.Pipeline('Dummy'): #Forcing the TaskSpec conversion to ContainerOp
+            task1 = task_factory1()
+        actual_env = {env_var.name: env_var.value for env_var in task1.env_variables}
+        expected_env = {'key1': 'value 1', 'key2': 'value 2'}
+        self.assertDictEqual(expected_env, actual_env)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Passing the environment variables to ContainerOp
When the DSL bridge code was written, ContainerOp did not support env, so we did not pass it. Now we're adding the passing code.
Added test that chacks that the env variables get to the ContainerOp.

The code is committed on top of https://github.com/kubeflow/pipelines/pull/712 and https://github.com/kubeflow/pipelines/pull/713, so see the last commit only: https://github.com/kubeflow/pipelines/commit/faebaf7dd3b602d90d8c445312c0033f9ad4f735

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/877)
<!-- Reviewable:end -->
