### PR TITLE
add missing dependency in bazel BUILD

### DIFF
--- a/backend/src/apiserver/storage/BUILD.bazel
+++ b/backend/src/apiserver/storage/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "//backend/src/apiserver/model:go_default_library",
         "//backend/src/common/util:go_default_library",
         "//backend/src/crd/pkg/apis/scheduledworkflow/v1beta1:go_default_library",
+        "@com_github_masterminds_squirrel//:go_default_library",
         "@com_github_minio_minio_go//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",


### PR DESCRIPTION
caught this by running `bazel build //backend/...` from root

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/883)
<!-- Reviewable:end -->
