### PR TITLE
Deflake frontend e2e test

### DIFF
--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -171,6 +171,7 @@ describe('deploy helloworld sample run', () => {
 
   it('opens the side panel when graph node is clicked', () => {
     $('.graphNode').click();
+    browser.pause(1000);
     $('button=Logs').waitForVisible();
   });
 


### PR DESCRIPTION
For some reason, clicking the logs tab immediately after opening the side pane doesn't register the click. This fix pauses for a second before clicking the tab.

Ran locally 10 times in a row successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/904)
<!-- Reviewable:end -->
