### PR TITLE
Detecting file format using signature instead of file extension

### DIFF
--- a/backend/src/apiserver/server/test/malformed_zip2.zip
+++ b/backend/src/apiserver/server/test/malformed_zip2.zip
@@ -1,0 +1,1 @@
+PK I pretended to be a zip file

--- a/backend/src/apiserver/server/util_test.go
+++ b/backend/src/apiserver/server/util_test.go
@@ -100,6 +100,13 @@ func TestDecompressPipelineZip_MalformattedZip(t *testing.T) {
 	assert.Contains(t, err.Error(), "Not a valid zip file")
 }
 
+func TestDecompressPipelineZip_MalformedZip2(t *testing.T) {
+	zipByte, _ := ioutil.ReadFile("test/malformed_zip2.zip")
+	_, err := DecompressPipelineZip(zipByte)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Not a valid zip file")
+}
+
 func TestDecompressPipelineZip_NonYamlZip(t *testing.T) {
 	zipByte, _ := ioutil.ReadFile("test/non_yaml_zip/non_yaml_file.zip")
 	_, err := DecompressPipelineZip(zipByte)

--- a/backend/src/apiserver/server/util_test.go
+++ b/backend/src/apiserver/server/util_test.go
@@ -132,6 +132,15 @@ func TestReadPipelineFile_Zip(t *testing.T) {
 	assert.Equal(t, expectedPipelineFile, pipelineFile)
 }
 
+func TestReadPipelineFile_Zip_AnyExtension(t *testing.T) {
+	file, _ := os.Open("test/arguments_zip/arguments-parameters.zip")
+	pipelineFile, err := ReadPipelineFile("arguments-parameters.pipeline", file, MaxFileLength)
+	assert.Nil(t, err)
+
+	expectedPipelineFile, _ := ioutil.ReadFile("test/arguments-parameters.yaml")
+	assert.Equal(t, expectedPipelineFile, pipelineFile)
+}
+
 func TestReadPipelineFile_Tarball(t *testing.T) {
 	file, _ := os.Open("test/arguments_tarball/arguments.tar.gz")
 	pipelineFile, err := ReadPipelineFile("arguments.tar.gz", file, MaxFileLength)
@@ -141,9 +150,18 @@ func TestReadPipelineFile_Tarball(t *testing.T) {
 	assert.Equal(t, expectedPipelineFile, pipelineFile)
 }
 
+func TestReadPipelineFile_Tarball_AnyExtension(t *testing.T) {
+	file, _ := os.Open("test/arguments_tarball/arguments.tar.gz")
+	pipelineFile, err := ReadPipelineFile("arguments.pipeline", file, MaxFileLength)
+	assert.Nil(t, err)
+
+	expectedPipelineFile, _ := ioutil.ReadFile("test/arguments-parameters.yaml")
+	assert.Equal(t, expectedPipelineFile, pipelineFile)
+}
+
 func TestReadPipelineFile_UnknownFileFormat(t *testing.T) {
-	file, _ := os.Open("test/unknown_extension.foo")
-	_, err := ReadPipelineFile("unknown_extension.foo", file, MaxFileLength)
+	file, _ := os.Open("test/unknown_format.foo")
+	_, err := ReadPipelineFile("unknown_format.foo", file, MaxFileLength)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Unexpected pipeline file format")
 }


### PR DESCRIPTION
Currently the backend detects the pipeline payload type by looking at the file extension.
If we merge the https://github.com/kubeflow/pipelines/pull/855 PR, the DSL compiler will start produce files in ZIP format, but unless the pipeline author changes the code (which they realistically won't do), the file name and extension will remain the same: `.tar.gz`. This will cause the backend to stop accepting those compiled pipelines which will frustrate our users.

This PR replaces format checks based on file name with checks based on file signatures. This fixes the backwards compatibility problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/919)
<!-- Reviewable:end -->
