### PR TITLE
Fixed small bug in DSL code that generates unique names for ops

### DIFF
--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -15,6 +15,7 @@
 
 from . import _container_op
 from . import _ops_group
+from ..components._naming import _make_name_unique_by_adding_index
 import sys
 
 
@@ -130,13 +131,8 @@ class Pipeline():
       op_name: a unique op name.
     """
 
-    op_name = op.human_name
     #If there is an existing op with this name then generate a new name.
-    if op_name in self.ops:
-      for i in range(2, sys.maxsize**10):
-        op_name = op_name + '-' + str(i)
-        if op_name not in self.ops:
-          break
+    op_name = _make_name_unique_by_adding_index(op.human_name, list(self.ops.keys()), ' ')
 
     self.ops[op_name] = op
     if not define_only:


### PR DESCRIPTION
Before the fix it would generate names as follows:
name
name-2
name-2-3
After the fix:
name
name-2
name-3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/923)
<!-- Reviewable:end -->
