### PR TITLE
SDK/DSL/Compiler - Fixed compilation when using ContainerOp.after

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -551,6 +551,8 @@ class Compiler(object):
       if op.output is not None:
         op.output.name = K8sHelper.sanitize_k8s_name(op.output.name)
         op.output.op_name = K8sHelper.sanitize_k8s_name(op.output.op_name)
+      if op.dependent_op_names:
+        op.dependent_op_names = [K8sHelper.sanitize_k8s_name(name) for name in op.dependent_op_names]
       if op.file_outputs is not None:
         sanitized_file_outputs = {}
         for key in op.file_outputs.keys():

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -236,3 +236,17 @@ class TestCompiler(unittest.TestCase):
   def test_py_image_pull_secret(self):
     """Test pipeline imagepullsecret."""
     self._test_py_compile('imagepullsecret')
+
+  def test_compile_pipeline_with_after(self):
+    def op():
+      return dsl.ContainerOp(
+        name='Some component name',
+        image='image'
+      )
+
+    @dsl.pipeline(name='Pipeline', description='')
+    def pipeline():
+      task1 = op()
+      task2 = op().after(task1)
+    
+    compiler.Compiler()._compile(pipeline)


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/941
Also added tests for this case.

The issue was introduced in https://github.com/kubeflow/pipelines/pull/619 https://github.com/kubeflow/pipelines/pull/619/files#r245461691

There is another possible issue when sanitization function converts two different names to same name. This issue will be fixed later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/943)
<!-- Reviewable:end -->
