### PR TITLE
helper fn to add az secrets to container

### DIFF
--- a/sdk/python/kfp/az.py
+++ b/sdk/python/kfp/az.py
@@ -48,7 +48,7 @@ def use_az_secret(secret_name='azcreds'):
                         )
                     )
                 )
-                    .add_env_variable(
+                .add_env_variable(
                     k8s_client.V1EnvVar(
                         name='AZ_CLIENT_ID',
                         value_from=k8s_client.V1EnvVarSource(

--- a/sdk/python/kfp/az.py
+++ b/sdk/python/kfp/az.py
@@ -1,0 +1,75 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def use_az_secret(secret_name='azcreds'):
+    """An operator that configures the container to use Azure user credentials.
+
+        The azcreds secret is created as part of the kubeflow deployment that
+        stores the client ID and secrets for the kubeflow azure service principal.
+
+        With this service principal, the container has a range of Azure APIs to
+        access to. 
+    """
+
+    def _use_az_secret(task):
+        from kubernetes import client as k8s_client
+        return (
+            task            
+                .add_env_variable(
+                    k8s_client.V1EnvVar(
+                        name='AZ_SUBSCRIPTION_ID',
+                        value_from=k8s_client.V1EnvVarSource(
+                            secret_key_ref=k8s_client.V1SecretKeySelector(
+                                name=secret_name,
+                                key='AZ_SUBSCRIPTION_ID'
+                            )
+                        )
+                    )
+                )
+                .add_env_variable(
+                    k8s_client.V1EnvVar(
+                        name='AZ_TENANT_ID',
+                        value_from=k8s_client.V1EnvVarSource(
+                            secret_key_ref=k8s_client.V1SecretKeySelector(
+                                name=secret_name,
+                                key='AZ_TENANT_ID'
+                            )
+                        )
+                    )
+                )
+                    .add_env_variable(
+                    k8s_client.V1EnvVar(
+                        name='AZ_CLIENT_ID',
+                        value_from=k8s_client.V1EnvVarSource(
+                            secret_key_ref=k8s_client.V1SecretKeySelector(
+                                name=secret_name,
+                                key='AZ_CLIENT_ID'
+                            )
+                        )
+                    )
+                )
+                .add_env_variable(
+                    k8s_client.V1EnvVar(
+                        name='AZ_CLIENT_SECRET',
+                        value_from=k8s_client.V1EnvVarSource(
+                            secret_key_ref=k8s_client.V1SecretKeySelector(
+                                name=secret_name,
+                                key='AZ_CLIENT_SECRET'
+                            )
+                        )
+                    )
+                )
+        )
+    
+    return _use_az_secret

--- a/sdk/python/kfp/azure.py
+++ b/sdk/python/kfp/azure.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def use_az_secret(secret_name='azcreds'):
+def use_azure_secret(secret_name='azcreds'):
     """An operator that configures the container to use Azure user credentials.
 
         The azcreds secret is created as part of the kubeflow deployment that
@@ -22,7 +22,7 @@ def use_az_secret(secret_name='azcreds'):
         access to. 
     """
 
-    def _use_az_secret(task):
+    def _use_azure_secret(task):
         from kubernetes import client as k8s_client
         return (
             task            
@@ -72,4 +72,4 @@ def use_az_secret(secret_name='azcreds'):
                 )
         )
     
-    return _use_az_secret
+    return _use_azure_secret

--- a/sdk/python/tests/dsl/test_azure_extensions.py
+++ b/sdk/python/tests/dsl/test_azure_extensions.py
@@ -13,20 +13,20 @@
 # limitations under the License.
 
 from kfp.dsl import Pipeline, ContainerOp
-from kfp.az import use_az_secret
+from kfp.azure import use_azure_secret
 import unittest
 import inspect
 
 class AzExtensionTests(unittest.TestCase):
     def test_default_secret_name(self):
-        spec = inspect.getfullargspec(use_az_secret)
+        spec = inspect.getfullargspec(use_azure_secret)
         assert len(spec.defaults) == 1
         assert spec.defaults[0] == 'azcreds'
 
-    def test_use_az_secret(self):
+    def test_use_azure_secret(self):
         with Pipeline('somename') as p:
             op1 = ContainerOp(name='op1', image='image')
-            op1 = op1.apply(use_az_secret('foo'))
+            op1 = op1.apply(use_azure_secret('foo'))
             assert len(op1.env_variables) == 4
             
             index = 0

--- a/sdk/python/tests/dsl/test_azure_extensions.py
+++ b/sdk/python/tests/dsl/test_azure_extensions.py
@@ -1,0 +1,40 @@
+# Copyright 2019 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kfp.dsl import Pipeline, ContainerOp
+from kfp.az import use_az_secret
+import unittest
+import inspect
+
+class AzExtensionTests(unittest.TestCase):
+    def test_default_secret_name(self):
+        spec = inspect.getfullargspec(use_az_secret)
+        assert len(spec.defaults) == 1
+        assert spec.defaults[0] == 'azcreds'
+
+    def test_use_az_secret(self):
+        with Pipeline('somename') as p:
+            op1 = ContainerOp(name='op1', image='image')
+            op1 = op1.apply(use_az_secret('foo'))
+            assert len(op1.env_variables) == 4
+            
+            index = 0
+            for expected in ['AZ_SUBSCRIPTION_ID', 'AZ_TENANT_ID', 'AZ_CLIENT_ID', 'AZ_CLIENT_SECRET']:
+                assert op1.env_variables[index].name == expected
+                assert op1.env_variables[index].value_from.secret_key_ref.name == 'foo'
+                assert op1.env_variables[index].value_from.secret_key_ref.key == expected
+                index += 1
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Resolve #953 by adding a helper function to create environment variables based on the azure secret created during setup in https://github.com/kubeflow/kubeflow/pull/2676

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/954)
<!-- Reviewable:end -->
