### PR TITLE
Added the component name to the docstring

### DIFF
--- a/sdk/python/kfp/components/_components.py
+++ b/sdk/python/kfp/components/_components.py
@@ -188,6 +188,8 @@ _created_task_transformation_handler.append(_dsl_bridge.create_container_op_from
 def _create_task_factory_from_component_spec(component_spec:ComponentSpec, component_filename=None, component_ref: ComponentReference = None):
     name = component_spec.name or _default_component_name
     description = component_spec.description
+    if component_spec.name:
+        description = component_spec.name + '\n' + description
     
     inputs_list = component_spec.inputs or [] #List[InputSpec]
     input_names = [input.name for input in inputs_list]

--- a/sdk/python/tests/components/test_components.py
+++ b/sdk/python/tests/components/test_components.py
@@ -31,7 +31,7 @@ class LoadComponentTestCase(unittest.TestCase):
         task1 = task_factory1(arg1, arg2)
 
         self.assertEqual(task1.human_name, 'Add')
-        self.assertEqual(task_factory1.__doc__.strip(), 'Returns sum of two arguments')
+        self.assertEqual(task_factory1.__doc__.strip(), 'Add\nReturns sum of two arguments')
         self.assertEqual(task1.image, 'python:3.5')
         self.assertEqual(task1.arguments[0], str(arg1))
         self.assertEqual(task1.arguments[1], str(arg2))
@@ -60,7 +60,7 @@ class LoadComponentTestCase(unittest.TestCase):
         component_text = resp.content
         component_dict = load_yaml(component_text)
         task_factory1 = comp.load_component_from_url(url)
-        assert task_factory1.__doc__ == component_dict['description']
+        assert task_factory1.__doc__ == component_dict['name'] + '\n' + component_dict['description']
 
         arg1 = 3
         arg2 = 5


### PR DESCRIPTION
The component name is now always included in the task factory function docstring.
The name is already used as the function name, but when someone assigns it to the variable, the variable name replaces the original name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/976)
<!-- Reviewable:end -->
