### PR TITLE
Add instruction on building viewer CRD controller image

### DIFF
--- a/developer_guide.md
+++ b/developer_guide.md
@@ -29,6 +29,15 @@ $ gcloud auth configure-docker
 $ docker push gcr.io/<your-gcp-project>/scheduledworkflow:latest
 ```
 
+To build the viewer CRD controller image and upload it to GCR:
+```bash
+# Run in the repository root directory
+$ docker build -t gcr.io/<your-gcp-project>/viewer-crd-controller:latest -f backend/Dockerfile.viewercontroller .
+# Push to GCR
+$ gcloud auth configure-docker
+$ docker push gcr.io/<your-gcp-project>/viewer-crd-controller:latest
+```
+
 To build the persistence agent image and upload it to GCR:
 ```bash
 # Run in the repository root directory


### PR DESCRIPTION
Instruction on building and pushing viewer CRD controller image is missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/981)
<!-- Reviewable:end -->
