### PR TITLE
Add component.yaml to every ibm-components

### DIFF
--- a/components/ibm-components/commons/config/component.yaml
+++ b/components/ibm-components/commons/config/component.yaml
@@ -1,0 +1,33 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Kubernetes Cluster: Create secret'
+description: |
+  Create secret to store pipeline credentials on Kubernetes Cluster
+inputs:
+  - {name: token,           description: 'Required. GitHub token for accessing private repository'}
+  - {name: url,             description: 'Required. GitHub raw path for accessing the credential file'}
+  - {name: name,            description: 'Required. Secret Name to be stored in Kubernetes'}
+outputs:
+  - {name: secret_name,     description: 'Kubernetes secret name'}
+implementation:
+  container:
+    image: docker.io/aipipeline/wml-config:latest
+    command: ['python3']
+    args: [
+      /app/config.py,
+      --token, {inputValue: token},
+      --url, {inputValue: url},
+      --name, {inputValue: name}
+    ]
+    fileOutputs:
+      secret_name: /tmp/ai-pipeline-creds

--- a/components/ibm-components/commons/config/component.yaml
+++ b/components/ibm-components/commons/config/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Kubernetes Cluster: Create secret'
+name: 'Kubernetes Cluster - Create secret'
 description: |
   Create secret to store pipeline credentials on Kubernetes Cluster
 inputs:

--- a/components/ibm-components/ffdl/serve/component.yaml
+++ b/components/ibm-components/ffdl/serve/component.yaml
@@ -10,9 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Seldon Core - Serve Model'
+name: 'Seldon Core - Serve PyTorch Model'
 description: |
-  Serve Machine Learning and Deep Learning Models remotely as web service using Seldon Core
+  Serve PyTorch Models remotely as web service using Seldon Core
 inputs:
   - {name: model_id,            description: 'Required. Model training_id from Fabric for Deep Learning'}
   - {name: deployment_name,     description: 'Required. Deployment name for the seldon service'}

--- a/components/ibm-components/ffdl/serve/component.yaml
+++ b/components/ibm-components/ffdl/serve/component.yaml
@@ -1,0 +1,37 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Seldon Core: Serve Model'
+description: |
+  Serve Machine Learning and Deep Learning Models remotely as web service using Seldon Core
+inputs:
+  - {name: model_id,            description: 'Required. Model training_id from Fabric for Deep Learning'}
+  - {name: deployment_name,     description: 'Required. Deployment name for the seldon service'}
+  - {name: model_class_name,    description: 'PyTorch model class name', default: 'ModelClass'}
+  - {name: model_class_file,    description: 'File that contains the PyTorch model class', default: 'model_class.py'}
+  - {name: serving_image,       description: 'Model serving images', default: 'aipipeline/seldon-pytorch:0.1'}
+outputs:
+  - {name: output,              description: 'Model Serving status'}
+implementation:
+  container:
+    image: docker.io/aipipeline/ffdl-serve:latest
+    command: ['python']
+    args: [
+      -u, serve.py,
+      --model_id, {inputValue: model_id},
+      --deployment_name, {inputValue: deployment_name},
+      --model_class_name, {inputValue: model_class_name},
+      --model_class_file, {inputValue: model_class_file},
+      --serving_image, {inputValue: serving_image}
+    ]
+    fileOutputs:
+      output: /tmp/deployment_result.txt

--- a/components/ibm-components/ffdl/serve/component.yaml
+++ b/components/ibm-components/ffdl/serve/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Seldon Core: Serve Model'
+name: 'Seldon Core - Serve Model'
 description: |
   Serve Machine Learning and Deep Learning Models remotely as web service using Seldon Core
 inputs:

--- a/components/ibm-components/ffdl/train/component.yaml
+++ b/components/ibm-components/ffdl/train/component.yaml
@@ -1,0 +1,31 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Fabric for Deep Learning: Train Model'
+description: |
+  Train Machine Learning and Deep Learning Models remotely using Fabric for Deep Learning
+inputs:
+  - {name: model_def_file_path, description: 'Required. Path for model training code in object storage'}
+  - {name: manifest_file_path,  description: 'Required. Path for model manifest definition in object storage'}
+outputs:
+  - {name: output,              description: 'Model training_id'}
+implementation:
+  container:
+    image: docker.io/aipipeline/ffdl-train:latest
+    command: ['python']
+    args: [
+      -u, train.py,
+      --model_def_file_path, {inputValue: model_def_file_path},
+      --manifest_file_path, {inputValue: manifest_file_path}
+    ]
+    fileOutputs:
+      output: /tmp/training_id.txt

--- a/components/ibm-components/ffdl/train/component.yaml
+++ b/components/ibm-components/ffdl/train/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Fabric for Deep Learning: Train Model'
+name: 'Fabric for Deep Learning - Train Model'
 description: |
   Train Machine Learning and Deep Learning Models remotely using Fabric for Deep Learning
 inputs:

--- a/components/ibm-components/watson/deploy/component.yaml
+++ b/components/ibm-components/watson/deploy/component.yaml
@@ -1,0 +1,33 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Watson Machine Learning: Deploy Model'
+description: |
+  Deploy stored model on Watson Machine Learning as a web service.
+inputs:
+  - {name: model_uid,       description: 'Required. UID for the Watson Machine Learning model'}
+  - {name: model_name,      description: 'Required. Model Name on Watson Machine Learning'}
+  - {name: scoring_payload, description: 'Required. Sample Payload file name in the object storage'}
+outputs:
+  - {name: output,          description: 'Link to the deployed model web service'}
+implementation:
+  container:
+    image: docker.io/aipipeline/wml-deploy:latest
+    command: ['python3']
+    args: [
+      /app/wml-deploy.py,
+      --model-uid, {inputValue: model_uid},
+      --model-name, {inputValue: model_name},
+      --scoring-payload, {inputValue: scoring_payload}
+    ]
+    fileOutputs:
+      output: /tmp/output

--- a/components/ibm-components/watson/deploy/component.yaml
+++ b/components/ibm-components/watson/deploy/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Watson Machine Learning: Deploy Model'
+name: 'Watson Machine Learning - Deploy Model'
 description: |
   Deploy stored model on Watson Machine Learning as a web service.
 inputs:

--- a/components/ibm-components/watson/manage/monitor_fairness/component.yaml
+++ b/components/ibm-components/watson/manage/monitor_fairness/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Watson OpenScale: Monitor Fairness'
+name: 'Watson OpenScale - Monitor Fairness'
 description: |
   Enable model fairness monitoring on Watson OpenScale.
 inputs:

--- a/components/ibm-components/watson/manage/monitor_fairness/component.yaml
+++ b/components/ibm-components/watson/manage/monitor_fairness/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Enable fairness monitoring on Watson OpenScale
+name: 'Watson OpenScale: Monitor Fairness'
 description: |
   Enable model fairness monitoring on Watson OpenScale.
 inputs:
@@ -22,6 +22,7 @@ inputs:
 implementation:
   container:
     image: docker.io/aipipeline/monitor_fairness:latest
+    command: ['python']
     args: [
       -u, monitor_fairness.py,
       --model_name, {inputValue: model_name},

--- a/components/ibm-components/watson/manage/monitor_quality/component.yaml
+++ b/components/ibm-components/watson/manage/monitor_quality/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Enable quality monitoring on Watson OpenScale
+name: 'Watson OpenScale: Monitor quality'
 description: |
   Enable model quality monitoring on Watson OpenScale.
 inputs:
@@ -21,6 +21,7 @@ inputs:
 implementation:
   container:
     image: docker.io/aipipeline/monitor_quality:latest
+    command: ['python']
     args: [
       -u, monitor_quality.py,
       --model_name, {inputValue: model_name},

--- a/components/ibm-components/watson/manage/monitor_quality/component.yaml
+++ b/components/ibm-components/watson/manage/monitor_quality/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Watson OpenScale: Monitor quality'
+name: 'Watson OpenScale - Monitor quality'
 description: |
   Enable model quality monitoring on Watson OpenScale.
 inputs:

--- a/components/ibm-components/watson/manage/subscribe/component.yaml
+++ b/components/ibm-components/watson/manage/subscribe/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Subscribe Watson OpenScale
+name: 'Watson OpenScale: Subscribe'
 description: |
   Binding deployed models and subscribe them to Watson OpenScale service.
 inputs:
@@ -23,6 +23,7 @@ outputs:
 implementation:
   container:
     image: docker.io/aipipeline/subscribe:latest
+    command: ['python']
     args: [
       -u, subscribe.py,
       --model_name, {inputValue: model_name},
@@ -31,4 +32,4 @@ implementation:
       --label_column, {inputValue: label_column}
     ]
     fileOutputs:
-      job_id: /tmp/model_name.txt
+      model_name: /tmp/model_name.txt

--- a/components/ibm-components/watson/manage/subscribe/component.yaml
+++ b/components/ibm-components/watson/manage/subscribe/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Watson OpenScale: Subscribe'
+name: 'Watson OpenScale - Subscribe'
 description: |
   Binding deployed models and subscribe them to Watson OpenScale service.
 inputs:

--- a/components/ibm-components/watson/store/component.yaml
+++ b/components/ibm-components/watson/store/component.yaml
@@ -1,0 +1,31 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Watson Machine Learning: Store model'
+description: |
+  Store and persistent trained model on Watson Machine Learning.
+inputs:
+  - {name: run_uid,        description: 'Required. UID for the Watson Machine Learning training-runs'}
+  - {name: model_name,     description: 'Required. Model Name to store on Watson Machine Learning'}
+outputs:
+  - {name: model_uid,      description: 'UID for the stored model on Watson Machine Learning'}
+implementation:
+  container:
+    image: docker.io/aipipeline/wml-store:latest
+    command: ['python3']
+    args: [
+      /app/wml-store.py,
+      --run-uid, {inputValue: run_uid},
+      --model-name, {inputValue: model_name}
+    ]
+    fileOutputs:
+      model_uid: /tmp/model_uid

--- a/components/ibm-components/watson/store/component.yaml
+++ b/components/ibm-components/watson/store/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Watson Machine Learning: Store model'
+name: 'Watson Machine Learning - Store model'
 description: |
   Store and persistent trained model on Watson Machine Learning.
 inputs:

--- a/components/ibm-components/watson/train/component.yaml
+++ b/components/ibm-components/watson/train/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Watson Machine Learning: Train Model'
+name: 'Watson Machine Learning - Train Model'
 description: |
   Train Machine Learning and Deep Learning Models in the Cloud using Watson Machine Learning
 inputs:

--- a/components/ibm-components/watson/train/component.yaml
+++ b/components/ibm-components/watson/train/component.yaml
@@ -1,0 +1,45 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Watson Machine Learning: Train Model'
+description: |
+  Train Machine Learning and Deep Learning Models in the Cloud using Watson Machine Learning
+inputs:
+  - {name: train_code,        description: 'Required. Code for training ML/DL models'}
+  - {name: execution_command, description: 'Required. Execution command to start the model training.'}
+  - {name: config,            description: 'Required. Credential configfile is properly created.'}
+  - {name: framework,         description: 'ML/DL Model Framework', default: 'tensorflow'}
+  - {name: framework_version, description: 'Model Framework version', default: '1.5'}
+  - {name: runtime,           description: 'Model Code runtime language', default: 'python'}
+  - {name: runtime_version,   description: 'Model Code runtime version', default: '3.5'}
+  - {name: run_definition,    description: 'Name for the Watson Machine Learning training definition', default: 'python-tensorflow-definition'}
+  - {name: run_name,          description: 'Name for the Watson Machine Learning training-runs', default: 'python-tensorflow-run'}
+outputs:
+  - {name: run_uid,           description: 'UID for the Watson Machine Learning training-runs'}
+implementation:
+  container:
+    image: docker.io/aipipeline/wml-train:latest
+    command: ['python3']
+    args: [
+      /app/wml-train.py,
+      --config, {inputValue: config},
+      --train-code, {inputValue: train_code},
+      --execution-command, {inputValue: execution_command},
+      --framework, {inputValue: framework},
+      --framework-version, {inputValue: framework_version},
+      --runtime, {inputValue: runtime},
+      --runtime-version, {inputValue: runtime_version},
+      --run-definition, {inputValue: run_definition},
+      --run-name, {inputValue: run_name}
+    ]
+    fileOutputs:
+      run_uid: /tmp/run_uid


### PR DESCRIPTION
Add component.yaml to every ibm-components, so users can have a better idea about each component and able to load components with `kfp.components`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/984)
<!-- Reviewable:end -->
