### PR TITLE
Improve dataflow job to use GCS to keep temp job states.

### DIFF
--- a/component_sdk/python/kfp_component/google/dataflow/_client.py
+++ b/component_sdk/python/kfp_component/google/dataflow/_client.py
@@ -30,22 +30,18 @@ class DataflowClient:
         ).execute()
 
     def get_job(self, project_id, job_id, location=None, view=None):
-        if not location:
-            location = 'us-central1'
         return self._df.projects().locations().jobs().get(
             projectId = project_id,
             jobId = job_id,
-            location = location,
+            location = self._get_location(location),
             view = view
         ).execute()
 
     def cancel_job(self, project_id, job_id, location):
-        if not location:
-            location = 'us-central1'
         return self._df.projects().locations().jobs().update(
             projectId = project_id,
             jobId = job_id,
-            location = location,
+            location = self._get_location(location),
             body = {
                 'requestedState': 'JOB_STATE_CANCELLED'
             }
@@ -60,3 +56,8 @@ class DataflowClient:
             pageSize = page_size,
             pageToken = page_token,
             location = location).execute()
+
+    def _get_location(self, location):
+        if not location:
+            location = 'us-central1'
+        return location

--- a/component_sdk/python/kfp_component/google/dataflow/_client.py
+++ b/component_sdk/python/kfp_component/google/dataflow/_client.py
@@ -30,7 +30,9 @@ class DataflowClient:
         ).execute()
 
     def get_job(self, project_id, job_id, location=None, view=None):
-        return self._df.projects().jobs().get(
+        if not location:
+            location = 'us-central1'
+        return self._df.projects().locations().jobs().get(
             projectId = project_id,
             jobId = job_id,
             location = location,
@@ -38,7 +40,9 @@ class DataflowClient:
         ).execute()
 
     def cancel_job(self, project_id, job_id, location):
-        return self._df.projects().jobs().update(
+        if not location:
+            location = 'us-central1'
+        return self._df.projects().locations().jobs().update(
             projectId = project_id,
             jobId = job_id,
             location = location,


### PR DESCRIPTION
The PR improves dataflow component so that it doesn't need to iterate through all dataflow job list before starting a job.

The fix is important as some beam code doesn't accept job name as command line arg and we cannot reliably depend on the job name to track job status. After the change, the intermediate states are kept in a staging_dir that user provided. The staging_dir is an optional input.

After the PR, I will update component.yaml, document and sample to reflect this interface change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/985)
<!-- Reviewable:end -->
