### PR TITLE
use pending commit id for cluster and source code name

### DIFF
--- a/test/deploy-kubeflow.sh
+++ b/test/deploy-kubeflow.sh
@@ -17,7 +17,7 @@
 set -ex
 
 TEST_CLUSTER_PREFIX=${WORKFLOW_FILE%.*}
-TEST_CLUSTER=$(echo $TEST_CLUSTER_PREFIX | cut -d _ -f 1)-${PULL_BASE_SHA:0:7}-${RANDOM}
+TEST_CLUSTER=$(echo $TEST_CLUSTER_PREFIX | cut -d _ -f 1)-${PULL_PULL_SHA:0:7}-${RANDOM}
 # Install ksonnet
 KS_VERSION="0.13.0"
 

--- a/test/deploy-kubeflow.sh
+++ b/test/deploy-kubeflow.sh
@@ -18,6 +18,7 @@ set -ex
 
 TEST_CLUSTER_PREFIX=${WORKFLOW_FILE%.*}
 TEST_CLUSTER=$(echo $TEST_CLUSTER_PREFIX | cut -d _ -f 1)-${PULL_PULL_SHA:0:7}-${RANDOM}
+
 # Install ksonnet
 KS_VERSION="0.13.0"
 

--- a/test/test-prep.sh
+++ b/test/test-prep.sh
@@ -24,7 +24,7 @@ gcloud config set core/project ${PROJECT}
 #Uploading the source code to GCS:
 local_code_archive_file=$(mktemp)
 date_string=$(TZ=PST8PDT date +%Y-%m-%d_%H-%M-%S_%Z)
-code_archive_prefix="gs://${TEST_RESULT_BUCKET}/${PULL_BASE_SHA}/source_code"
+code_archive_prefix="gs://${TEST_RESULT_BUCKET}/${PULL_PULL_SHA}/source_code"
 remote_code_archive_uri="${code_archive_prefix}_${PULL_BASE_SHA}_${date_string}.tar.gz"
 
 tar -czf "$local_code_archive_file" .


### PR DESCRIPTION
this might be introduced by accident during the refactoring
https://github.com/kubeflow/pipelines/pull/613/files#diff-8020d71fc47e179d2ef2b0a1bb13edcbR34

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/994)
<!-- Reviewable:end -->
