### PR TITLE
Update TFX Pipeline Example Readme

### DIFF
--- a/samples/tfx-oss/README.md
+++ b/samples/tfx-oss/README.md
@@ -4,7 +4,7 @@ This sample walks through running [TFX](https://github.com/tensorflow/tfx) [Taxi
 
 ## Overview
 
-This pipeline demonstrates the TFX capablities at scale. The pipeline uses a public BigQuery dataset and uses GCP services to preprpocess data (Dataflow) and train the model (Cloud ML Engine). The model is then deployed to Cloud ML Engine Prediction service.
+This pipeline demonstrates the TFX capabilities at scale. The pipeline uses a public BigQuery dataset and uses GCP services to preprocess data (Dataflow) and train the model (Cloud ML Engine). The model is then deployed to Cloud ML Engine Prediction service.
 
 
 ## Setup
@@ -44,7 +44,7 @@ gfile.Copy('tfx/examples/chicago_taxi_pipeline/taxi_utils.py', 'gs://<my bucket>
 
 Modify the pipeline configuration file at 
 ```
-tfx/examples/chicago_taxi_pipeline/taxi_pipeline_kubeflow_large.py
+tfx/examples/chicago_taxi_pipeline/taxi_pipeline_kubeflow.py
 ```
 Configure 
 - Set `_input_bucket` to the GCS directory where you've copied taxi_utils.py. I.e. gs://<my bucket>/<path>/
@@ -54,7 +54,7 @@ Configure
 
 ## Compile and run the pipeline
 ```
-python tfx/examples/chicago_taxi_pipeline/taxi_pipeline_kubeflow_large.py
+python tfx/examples/chicago_taxi_pipeline/taxi_pipeline_kubeflow.py
 ```
-This will generate a file named chicago_taxi_pipeline_kubeflow_large.tar.gz 
-Upload this file to the Pipelines Cluster and crate a run.
+This will generate a file named chicago_taxi_pipeline_kubeflow.tar.gz
+Upload this file to the Pipelines Cluster and create a run.


### PR DESCRIPTION
In the tfx repo, taxi_pipeline_kubeflow_large.py has been renamed to [taxi_pipeline_kubeflow.py][1]. This commit updates the readme to reflect that change and also fixes a few minor typos.

[1]: https://github.com/tensorflow/tfx/blob/master/examples/chicago_taxi_pipeline/taxi_pipeline_kubeflow.py

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1011)
<!-- Reviewable:end -->
