### PR TITLE
Add run termination controls to ui

### DIFF
--- a/backend/src/cmd/ml/cmd/run.go
+++ b/backend/src/cmd/ml/cmd/run.go
@@ -118,7 +118,7 @@ func NewRunTerminateCmd(root *RootCommand) *cobra.Command {
 			if err != nil {
 				return util.ExtractErrorForCLI(err, root.Debug())
 			}
-			PrettyPrintResult(root.Writer(), root.OutputFormat(), "Run was terminated successfully.")
+			PrettyPrintResult(root.Writer(), root.OutputFormat(), "Run has been scheduled for termination.")
 			return nil
 		},
 	}

--- a/frontend/src/Css.tsx
+++ b/frontend/src/Css.tsx
@@ -38,6 +38,7 @@ export const color = {
   strong: '#202124', // Google grey 900
   success: '#34a853',
   successWeak: '#e6f4ea', // Google green 50
+  terminate: '#80868b',
   theme: '#1a73e8',
   themeDarker: '#0b59dc',
   warningBg: '#f9f9e1',

--- a/frontend/src/Css.tsx
+++ b/frontend/src/Css.tsx
@@ -38,7 +38,7 @@ export const color = {
   strong: '#202124', // Google grey 900
   success: '#34a853',
   successWeak: '#e6f4ea', // Google green 50
-  terminate: '#80868b',
+  terminated: '#80868b',
   theme: '#1a73e8',
   themeDarker: '#0b59dc',
   warningBg: '#f9f9e1',

--- a/frontend/src/Css.tsx
+++ b/frontend/src/Css.tsx
@@ -42,6 +42,7 @@ export const color = {
   theme: '#1a73e8',
   themeDarker: '#0b59dc',
   warningBg: '#f9f9e1',
+  warningText: '#ee8100',
   weak: '#9aa0a6',
 };
 

--- a/frontend/src/apis/run/api.ts
+++ b/frontend/src/apis/run/api.ts
@@ -834,6 +834,42 @@ export const RunServiceApiFetchParamCreator = function (configuration?: Configur
         },
         /**
          * 
+         * @param {string} run_id 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        terminateRun(run_id: string, options: any = {}): FetchArgs {
+            // verify required parameter 'run_id' is not null or undefined
+            if (run_id === null || run_id === undefined) {
+                throw new RequiredError('run_id','Required parameter run_id was null or undefined when calling terminateRun.');
+            }
+            const localVarPath = `/apis/v1beta1/runs/{run_id}/terminate`
+                .replace(`{${"run_id"}}`, encodeURIComponent(String(run_id)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Bearer required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["authorization"] = localVarApiKeyValue;
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @param {string} id 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -1014,6 +1050,24 @@ export const RunServiceApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @param {string} run_id 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        terminateRun(run_id: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<any> {
+            const localVarFetchArgs = RunServiceApiFetchParamCreator(configuration).terminateRun(run_id, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
          * @param {string} id 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -1110,6 +1164,15 @@ export const RunServiceApiFactory = function (configuration?: Configuration, fet
          */
         reportRunMetrics(run_id: string, body: ApiReportRunMetricsRequest, options?: any) {
             return RunServiceApiFp(configuration).reportRunMetrics(run_id, body, options)(fetch, basePath);
+        },
+        /**
+         * 
+         * @param {string} run_id 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        terminateRun(run_id: string, options?: any) {
+            return RunServiceApiFp(configuration).terminateRun(run_id, options)(fetch, basePath);
         },
         /**
          * 
@@ -1214,6 +1277,17 @@ export class RunServiceApi extends BaseAPI {
      */
     public reportRunMetrics(run_id: string, body: ApiReportRunMetricsRequest, options?: any) {
         return RunServiceApiFp(this.configuration).reportRunMetrics(run_id, body, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @param {} run_id 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof RunServiceApi
+     */
+    public terminateRun(run_id: string, options?: any) {
+        return RunServiceApiFp(this.configuration).terminateRun(run_id, options)(this.fetch, this.basePath);
     }
 
     /**

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -91,7 +91,7 @@ class Banner extends React.Component<BannerProps, BannerState> {
         dialogTitle = 'An error occurred';
         break;
       case 'warning':
-        bannerModeCss = stylesheet({ mode: { backgroundColor: color.warningBg, color: color.errorText, } });
+        bannerModeCss = stylesheet({ mode: { backgroundColor: color.warningBg, color: color.warningText, } });
         bannerIcon = <WarningIcon className={css.icon} />;
         dialogTitle = 'Warning';
         break;

--- a/frontend/src/icons/statusTerminated.tsx
+++ b/frontend/src/icons/statusTerminated.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import { CSSProperties } from 'jss/css';
+export default class StatusRunning extends React.Component<{ style: CSSProperties }> {
+  public render(): JSX.Element {
+    const { style } = this.props;
+    return (
+      <svg width={style.width as string} height={style.height as string} viewBox='0 0 18 18'>
+        <g stroke='none' strokeWidth='1' fill='none' fillRule='evenodd'>
+          <g transform='translate(-1.000000, -1.000000)'>
+            <polygon points='0 0 18 0 18 18 0 18' />
+            <path d='M8.9925,1.5 C4.8525,1.5 1.5,4.86 1.5,9 C1.5,13.14 4.8525,16.5 8.9925,16.5
+              C13.14,16.5 16.5,13.14 16.5,9 C16.5,4.86 13.14,1.5 8.9925,1.5 Z M9,15 C5.685,15
+              3,12.315 3,9 C3,5.685 5.685,3 9,3 C12.315,3 15,5.685 15,9 C15,12.315 12.315,15 9,15 Z'
+              fill={style.color as string} fillRule='nonzero' />
+            <polygon fill={style.color as string} fillRule='nonzero'
+              points='6 6 12 6 12 12 6 12' />
+          </g>
+        </g>
+      </svg>
+    );
+  }
+}

--- a/frontend/src/lib/Buttons.ts
+++ b/frontend/src/lib/Buttons.ts
@@ -192,6 +192,18 @@ export default class Buttons {
     };
   }
 
+  public terminateRun(getSelectedIds: () => string[], useCurrentResource: boolean,
+      callback: (selectedIds: string[], success: boolean) => void): ToolbarActionConfig {
+    return {
+      action: () => this._terminateRun(getSelectedIds(), useCurrentResource, callback),
+      disabled: !useCurrentResource,
+      disabledTitle: useCurrentResource ? undefined : 'Select at least one run to terminate',
+      id: 'terminateRunBtn',
+      title: 'Terminate',
+      tooltip: 'Terminate execution of a run',
+    };
+  }
+
   public upload(action: () => void): ToolbarActionConfig {
     return {
       action,
@@ -263,6 +275,19 @@ export default class Buttons {
       callback,
       'Delete',
       'recurring run config',
+    );
+  }
+
+  private _terminateRun(ids: string[], useCurrentResource: boolean,
+    callback: (_: string[], success: boolean) => void): void {
+    this._dialogActionHandler(
+      ids,
+      'Do you want to terminate this run? This action cannot be undone.',
+      useCurrentResource,
+      id => Apis.runServiceApi.terminateRun(id),
+      callback,
+      'Terminate',
+      'run',
     );
   }
 

--- a/frontend/src/lib/Buttons.ts
+++ b/frontend/src/lib/Buttons.ts
@@ -282,7 +282,8 @@ export default class Buttons {
     callback: (_: string[], success: boolean) => void): void {
     this._dialogActionHandler(
       ids,
-      'Do you want to terminate this run? This action cannot be undone.',
+      'Do you want to terminate this run? This action cannot be undone. This will terminate any'
+      + ' running pods, but they will not be deleted.',
       useCurrentResource,
       id => Apis.runServiceApi.terminateRun(id),
       callback,

--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -75,11 +75,16 @@ export default class WorkflowParser {
         if (node.name === `${workflowName}.onExit`) {
           nodeLabel = `onExit - ${node.templateName}`;
         }
+        // Argo considers terminated runs as having "Failed", so we have to examine the failure message to
+        // determine why the run failed.
+        const phase = node.phase as NodePhase === NodePhase.FAILED && node.message === 'terminated'
+          ? NodePhase.TERMINATED
+          : node.phase as NodePhase;
         g.setNode(node.id, {
           height: Constants.NODE_HEIGHT,
-          icon: statusToIcon(node.phase as NodePhase, node.startedAt, node.finishedAt),
+          icon: statusToIcon(phase, node.startedAt, node.finishedAt),
           label: nodeLabel,
-          statusColoring: statusToBgColor(node.phase as NodePhase),
+          statusColoring: statusToBgColor(phase),
           width: Constants.NODE_WIDTH,
           ...node,
         });

--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -75,16 +75,11 @@ export default class WorkflowParser {
         if (node.name === `${workflowName}.onExit`) {
           nodeLabel = `onExit - ${node.templateName}`;
         }
-        // Argo considers terminated runs as having "Failed", so we have to examine the failure message to
-        // determine why the run failed.
-        const phase = node.phase as NodePhase === NodePhase.FAILED && node.message === 'terminated'
-          ? NodePhase.TERMINATED
-          : node.phase as NodePhase;
         g.setNode(node.id, {
           height: Constants.NODE_HEIGHT,
-          icon: statusToIcon(phase, node.startedAt, node.finishedAt),
+          icon: statusToIcon(node.phase as NodePhase, node.startedAt, node.finishedAt, node.message),
           label: nodeLabel,
-          statusColoring: statusToBgColor(phase),
+          statusColoring: statusToBgColor(node.phase as NodePhase, node.message),
           width: Constants.NODE_WIDTH,
           ...node,
         });

--- a/frontend/src/pages/Page.tsx
+++ b/frontend/src/pages/Page.tsx
@@ -49,6 +49,10 @@ export abstract class Page<P, S> extends React.Component<P & PageProps, S> {
     this._isMounted = false;
   }
 
+  public componentDidMount(): void {
+    this.clearBanner();
+  }
+
   public clearBanner(): void {
     this.props.updateBanner({});
   }

--- a/frontend/src/pages/RunDetails.test.tsx
+++ b/frontend/src/pages/RunDetails.test.tsx
@@ -120,19 +120,6 @@ describe('RunDetails', () => {
     expect(lastCall.pageTitle).toMatchSnapshot();
   });
 
-  it('has a refresh button, clicking it calls get run API again', async () => {
-    tree = shallow(<RunDetails {...generateProps()} />);
-    await getRunSpy;
-    await TestUtils.flushPromises();
-    const instance = tree.instance() as RunDetails;
-    const refreshBtn = instance.getInitialToolbarState().actions.find(
-      b => b.title === 'Refresh');
-    expect(refreshBtn).toBeDefined();
-    expect(getRunSpy).toHaveBeenCalledTimes(1);
-    await refreshBtn!.action();
-    expect(getRunSpy).toHaveBeenCalledTimes(2);
-  });
-
   it('has a clone button, clicking it navigates to new run page', async () => {
     tree = shallow(<RunDetails {...generateProps()} />);
     await getRunSpy;
@@ -555,7 +542,7 @@ describe('RunDetails', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('keeps side pane open and on same tab when refresh is clicked', async () => {
+  it('keeps side pane open and on same tab when page is refreshed', async () => {
     testRun.pipeline_runtime!.workflow_manifest = JSON.stringify({
       status: { nodes: { node1: { id: 'node1', }, }, },
     });
@@ -567,11 +554,8 @@ describe('RunDetails', () => {
     expect(tree.state('selectedNodeDetails')).toHaveProperty('id', 'node1');
     expect(tree.state('sidepanelSelectedTab')).toEqual(2);
 
-    const instance = tree.instance() as RunDetails;
-    const refreshBtn = instance.getInitialToolbarState().actions.find(
-      b => b.title === 'Refresh');
-    await refreshBtn!.action();
-    expect(getRunSpy).toHaveBeenCalledTimes(2);
+    await (tree.instance() as RunDetails).refresh();
+    expect (getRunSpy).toHaveBeenCalledTimes(2);
     expect(tree.state('selectedNodeDetails')).toHaveProperty('id', 'node1');
     expect(tree.state('sidepanelSelectedTab')).toEqual(2);
   });
@@ -593,10 +577,7 @@ describe('RunDetails', () => {
     expect(tree.state('selectedNodeDetails')).toHaveProperty('id', 'node1');
     expect(tree.state('sidepanelSelectedTab')).toEqual(2);
 
-    const instance = tree.instance() as RunDetails;
-    const refreshBtn = instance.getInitialToolbarState().actions.find(
-      b => b.title === 'Refresh');
-    await refreshBtn!.action();
+    await (tree.instance() as RunDetails).refresh();
     expect(getRunSpy).toHaveBeenCalledTimes(2);
     expect(tree.state('selectedNodeDetails')).toHaveProperty('id', 'node1');
     expect(tree.state('sidepanelSelectedTab')).toEqual(2);
@@ -619,10 +600,7 @@ describe('RunDetails', () => {
     expect(thirdCall.pageTitle).toMatchSnapshot();
 
     testRun.run!.status = 'Failed';
-    const instance = tree.instance() as RunDetails;
-    const refreshBtn = instance.getInitialToolbarState().actions.find(
-      b => b.title === 'Refresh');
-    await refreshBtn!.action();
+    await (tree.instance() as RunDetails).refresh();
     const fourthCall = updateToolbarSpy.mock.calls[3][0];
     expect(fourthCall.pageTitle).toMatchSnapshot();
   });
@@ -640,10 +618,7 @@ describe('RunDetails', () => {
     expect(tree.state('sidepanelSelectedTab')).toEqual(2);
 
     getPodLogsSpy.mockImplementationOnce(() => 'new test logs');
-    const instance = tree.instance() as RunDetails;
-    const refreshBtn = instance.getInitialToolbarState().actions.find(
-      b => b.title === 'Refresh');
-    await refreshBtn!.action();
+    await (tree.instance() as RunDetails).refresh();
     expect(tree).toMatchSnapshot();
   });
 
@@ -666,10 +641,7 @@ describe('RunDetails', () => {
     });
 
     testRun.run!.status = 'Failed';
-    const instance = tree.instance() as RunDetails;
-    const refreshBtn = instance.getInitialToolbarState().actions.find(
-      b => b.title === 'Refresh');
-    await refreshBtn!.action();
+    await (tree.instance() as RunDetails).refresh();
     expect(tree.state()).toMatchObject({
       logsBannerAdditionalInfo: '',
       logsBannerMessage: '',
@@ -690,10 +662,7 @@ describe('RunDetails', () => {
     testRun.pipeline_runtime!.workflow_manifest = JSON.stringify({
       status: { nodes: { node1: { id: 'node1', phase: 'Succeeded', message: 'some node message' } } },
     });
-    const instance = tree.instance() as RunDetails;
-    const refreshBtn = instance.getInitialToolbarState().actions.find(
-      b => b.title === 'Refresh');
-    await refreshBtn!.action();
+    await (tree.instance() as RunDetails).refresh();
     expect(tree.state('selectedNodeDetails')).toHaveProperty('phaseMessage',
       'This step is in Succeeded state with this message: some node message');
   });
@@ -713,10 +682,7 @@ describe('RunDetails', () => {
     testRun.pipeline_runtime!.workflow_manifest = JSON.stringify({
       status: { nodes: { node1: { id: 'node1' } } },
     });
-    const instance = tree.instance() as RunDetails;
-    const refreshBtn = instance.getInitialToolbarState().actions.find(
-      b => b.title === 'Refresh');
-    await refreshBtn!.action();
+    await (tree.instance() as RunDetails).refresh();
     expect(tree.state('selectedNodeDetails')).toHaveProperty('phaseMessage', undefined);
   });
 

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -140,7 +140,6 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
           true,
           () => this.refresh()
         ),
-        buttons.refresh(this.refresh.bind(this)),
       ],
       breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
       pageTitle: this.props.runId!,

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -304,6 +304,7 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
     this._stopAutoRefresh();
     window.removeEventListener('focus', this._onFocus);
     window.removeEventListener('blur', this._onBlur);
+    this.clearBanner();
   }
 
   public async refresh(): Promise<void> {

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -135,6 +135,11 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
     return {
       actions: [
         buttons.cloneRun(() => this.state.runMetadata ? [this.state.runMetadata!.id!] : [], true),
+        buttons.terminateRun(
+          () => this.state.runMetadata ? [this.state.runMetadata!.id!] : [],
+          true,
+          () => this.refresh()
+        ),
         buttons.refresh(this.refresh.bind(this)),
       ],
       breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
@@ -312,11 +317,13 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
 
     try {
       const runDetail = await Apis.runServiceApi.getRun(runId);
+
       const relatedExperimentId = RunUtils.getFirstExperimentReferenceId(runDetail.run);
       let experiment: ApiExperiment | undefined;
       if (relatedExperimentId) {
         experiment = await Apis.experimentServiceApi.getExperiment(relatedExperimentId);
       }
+
       const runMetadata = runDetail.run!;
 
       let runFinished = this.state.runFinished;
@@ -332,10 +339,19 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
       // Show workflow errors
       const workflowError = WorkflowParser.getWorkflowError(workflow);
       if (workflowError) {
-        this.showPageError(
-          `Error: found errors when executing run: ${runId}.`,
-          new Error(workflowError),
-        );
+        if (workflowError === 'terminated') {
+          this.props.updateBanner({
+            additionalInfo: `This run's workflow included the following message: ${workflowError}`,
+            message: 'This run was terminated',
+            mode: 'warning',
+            refresh: undefined,
+          });
+        } else {
+          this.showPageError(
+            `Error: found errors when executing run: ${runId}.`,
+            new Error(workflowError),
+          );
+        }
       }
 
       // Build runtime graph
@@ -374,6 +390,7 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
         buttons.restore(idGetter, true, () => this.refresh()) :
         buttons.archive(idGetter, true, () => this.refresh());
       actions.splice(2, 1, newButton);
+      actions[1].disabled = runMetadata.status as NodePhase === NodePhase.TERMINATING || runFinished;
       this.props.updateToolbar({ actions, breadcrumbs, pageTitle, pageTitleTooltip: runMetadata.name });
 
       this.setStateSafe({

--- a/frontend/src/pages/Status.tsx
+++ b/frontend/src/pages/Status.tsx
@@ -20,6 +20,8 @@ import PendingIcon from '@material-ui/icons/Schedule';
 import RunningIcon from '../icons/statusRunning';
 import SkippedIcon from '@material-ui/icons/SkipNext';
 import SuccessIcon from '@material-ui/icons/CheckCircle';
+import TerminatedIcon from '../icons/statusTerminated';
+import TerminatingIcon from '@material-ui/icons/NotInterested';
 import Tooltip from '@material-ui/core/Tooltip';
 import UnknownIcon from '@material-ui/icons/Help';
 import { color } from '../Css';
@@ -41,6 +43,8 @@ export enum NodePhase {
   RUNNING = 'Running',
   SKIPPED = 'Skipped',
   SUCCEEDED = 'Succeeded',
+  TERMINATING = 'Terminating',
+  TERMINATED = 'Terminated',
   UNKNOWN = 'Unknown',
 }
 
@@ -49,10 +53,12 @@ export function hasFinished(status?: NodePhase): boolean {
     case NodePhase.SUCCEEDED: // Fall through
     case NodePhase.FAILED: // Fall through
     case NodePhase.ERROR: // Fall through
-    case NodePhase.SKIPPED:
+    case NodePhase.SKIPPED: // Fall through
+    case NodePhase.TERMINATED:
       return true;
     case NodePhase.PENDING: // Fall through
     case NodePhase.RUNNING: // Fall through
+    case NodePhase.TERMINATING: // Fall through
     case NodePhase.UNKNOWN:
       return false;
     default:
@@ -70,10 +76,14 @@ export function statusToBgColor(status?: NodePhase): string {
       return statusBgColors.notStarted;
     case NodePhase.RUNNING:
       return statusBgColors.running;
-    case NodePhase.SKIPPED:
-      return statusBgColors.stopOrSkip;
     case NodePhase.SUCCEEDED:
       return statusBgColors.succeeded;
+    case NodePhase.SKIPPED:
+      // fall through
+    case NodePhase.TERMINATED:
+      // fall through
+    case NodePhase.TERMINATING:
+      return statusBgColors.stopOrSkip;
     case NodePhase.UNKNOWN:
       // fall through
     default:
@@ -116,6 +126,16 @@ export function statusToIcon(status?: NodePhase, startDate?: Date | string, endD
       IconComponent = SuccessIcon;
       iconColor = color.success;
       title = 'Executed successfully';
+      break;
+    case NodePhase.TERMINATED:
+      IconComponent = TerminatedIcon;
+      iconColor = color.terminate;
+      title = 'Manually terminated';
+      break;
+    case NodePhase.TERMINATING:
+      IconComponent = TerminatingIcon;
+      iconColor = color.terminate;
+      title = 'Run is terminating';
       break;
     case NodePhase.UNKNOWN:
       break;

--- a/frontend/src/pages/Status.tsx
+++ b/frontend/src/pages/Status.tsx
@@ -65,8 +65,8 @@ export function hasFinished(status?: NodePhase): boolean {
   }
 }
 
-export function statusToBgColor(status?: NodePhase, errorMessage?: string): string {
-  status = checkIfTerminated(status, errorMessage);
+export function statusToBgColor(status?: NodePhase, nodeMessage?: string): string {
+  status = checkIfTerminated(status, nodeMessage);
   switch (status) {
     case NodePhase.ERROR:
       // fall through
@@ -92,17 +92,17 @@ export function statusToBgColor(status?: NodePhase, errorMessage?: string): stri
   }
 }
 
-export function checkIfTerminated(status?: NodePhase, errorMessage?: string): NodePhase | undefined {
+export function checkIfTerminated(status?: NodePhase, nodeMessage?: string): NodePhase | undefined {
   // Argo considers terminated runs as having "Failed", so we have to examine the failure message to
   // determine why the run failed.
-  if (status === NodePhase.FAILED && errorMessage === 'terminated') {
+  if (status === NodePhase.FAILED && nodeMessage === 'terminated') {
     status = NodePhase.TERMINATED;
   }
   return status;
 }
 
-export function statusToIcon(status?: NodePhase, startDate?: Date | string, endDate?: Date | string, errorMessage?: string): JSX.Element {
-  status = checkIfTerminated(status, errorMessage);
+export function statusToIcon(status?: NodePhase, startDate?: Date | string, endDate?: Date | string, nodeMessage?: string): JSX.Element {
+  status = checkIfTerminated(status, nodeMessage);
   // tslint:disable-next-line:variable-name
   let IconComponent: any = UnknownIcon;
   let iconColor = color.inactive;
@@ -144,7 +144,7 @@ export function statusToIcon(status?: NodePhase, startDate?: Date | string, endD
       break;
     case NodePhase.TERMINATED:
       IconComponent = TerminatedIcon;
-      iconColor = color.terminate;
+      iconColor = color.terminated;
       title = 'Run was manually terminated';
       break;
     case NodePhase.UNKNOWN:

--- a/frontend/src/pages/__snapshots__/AllRunsList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/AllRunsList.test.tsx.snap
@@ -62,7 +62,15 @@ exports[`AllRunsList renders all runs 1`] = `
         "pageTitle": "Experiments",
       }
     }
-    updateBanner={[MockFunction]}
+    updateBanner={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            Object {},
+          ],
+        ],
+      }
+    }
     updateDialog={[MockFunction]}
     updateSnackbar={[MockFunction]}
     updateToolbar={[MockFunction]}

--- a/frontend/src/pages/__snapshots__/Archive.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/Archive.test.tsx.snap
@@ -38,7 +38,15 @@ exports[`Archive renders archived runs 1`] = `
         "pageTitle": "Archive",
       }
     }
-    updateBanner={[MockFunction]}
+    updateBanner={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            Object {},
+          ],
+        ],
+      }
+    }
     updateDialog={null}
     updateSnackbar={null}
     updateToolbar={

--- a/frontend/src/pages/__snapshots__/Status.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/Status.test.tsx.snap
@@ -5373,7 +5373,7 @@ exports[`Status statusToIcon renders an icon with tooltip for phase: TERMINATED 
   title={
     <div>
       <div>
-        Manually terminated
+        Run was manually terminated
       </div>
     </div>
   }
@@ -5799,10 +5799,10 @@ exports[`Status statusToIcon renders an icon with tooltip for phase: TERMINATING
       }
     }
   >
-    <pure(NotInterestedIcon)
+    <StatusRunning
       style={
         Object {
-          "color": "#80868b",
+          "color": "#4285f4",
           "height": 18,
           "width": 18,
         }

--- a/frontend/src/pages/__snapshots__/Status.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/Status.test.tsx.snap
@@ -4984,6 +4984,834 @@ exports[`Status statusToIcon renders an icon with tooltip for phase: SUCCEEDED 1
 </Tooltip>
 `;
 
+exports[`Status statusToIcon renders an icon with tooltip for phase: TERMINATED 1`] = `
+<Tooltip
+  TransitionComponent={[Function]}
+  classes={
+    Object {
+      "popper": "MuiTooltip-popper-1",
+      "popperInteractive": "MuiTooltip-popperInteractive-2",
+      "tooltip": "MuiTooltip-tooltip-3",
+      "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-8",
+      "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-5",
+      "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-6",
+      "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-7",
+      "touch": "MuiTooltip-touch-4",
+    }
+  }
+  disableFocusListener={false}
+  disableHoverListener={false}
+  disableTouchListener={false}
+  enterDelay={0}
+  enterTouchDelay={1000}
+  interactive={false}
+  leaveDelay={0}
+  leaveTouchDelay={1500}
+  placement="bottom"
+  theme={
+    Object {
+      "breakpoints": Object {
+        "between": [Function],
+        "down": [Function],
+        "keys": Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ],
+        "only": [Function],
+        "up": [Function],
+        "values": Object {
+          "lg": 1280,
+          "md": 960,
+          "sm": 600,
+          "xl": 1920,
+          "xs": 0,
+        },
+        "width": [Function],
+      },
+      "direction": "ltr",
+      "mixins": Object {
+        "gutters": [Function],
+        "toolbar": Object {
+          "@media (min-width:0px) and (orientation: landscape)": Object {
+            "minHeight": 48,
+          },
+          "@media (min-width:600px)": Object {
+            "minHeight": 64,
+          },
+          "minHeight": 56,
+        },
+      },
+      "overrides": Object {},
+      "palette": Object {
+        "action": Object {
+          "active": "rgba(0, 0, 0, 0.54)",
+          "disabled": "rgba(0, 0, 0, 0.26)",
+          "disabledBackground": "rgba(0, 0, 0, 0.12)",
+          "hover": "rgba(0, 0, 0, 0.08)",
+          "hoverOpacity": 0.08,
+          "selected": "rgba(0, 0, 0, 0.14)",
+        },
+        "augmentColor": [Function],
+        "background": Object {
+          "default": "#fafafa",
+          "paper": "#fff",
+        },
+        "common": Object {
+          "black": "#000",
+          "white": "#fff",
+        },
+        "contrastThreshold": 3,
+        "divider": "rgba(0, 0, 0, 0.12)",
+        "error": Object {
+          "contrastText": "#fff",
+          "dark": "#d32f2f",
+          "light": "#e57373",
+          "main": "#f44336",
+        },
+        "getContrastText": [Function],
+        "grey": Object {
+          "100": "#f5f5f5",
+          "200": "#eeeeee",
+          "300": "#e0e0e0",
+          "400": "#bdbdbd",
+          "50": "#fafafa",
+          "500": "#9e9e9e",
+          "600": "#757575",
+          "700": "#616161",
+          "800": "#424242",
+          "900": "#212121",
+          "A100": "#d5d5d5",
+          "A200": "#aaaaaa",
+          "A400": "#303030",
+          "A700": "#616161",
+        },
+        "primary": Object {
+          "contrastText": "#fff",
+          "dark": "#303f9f",
+          "light": "#7986cb",
+          "main": "#3f51b5",
+        },
+        "secondary": Object {
+          "contrastText": "#fff",
+          "dark": "#c51162",
+          "light": "#ff4081",
+          "main": "#f50057",
+        },
+        "text": Object {
+          "disabled": "rgba(0, 0, 0, 0.38)",
+          "hint": "rgba(0, 0, 0, 0.38)",
+          "primary": "rgba(0, 0, 0, 0.87)",
+          "secondary": "rgba(0, 0, 0, 0.54)",
+        },
+        "tonalOffset": 0.2,
+        "type": "light",
+      },
+      "props": Object {},
+      "shadows": Array [
+        "none",
+        "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+        "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+        "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+        "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+        "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+        "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+        "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+        "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+        "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+        "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+        "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+        "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+        "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+        "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+        "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+        "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+        "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+        "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+        "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+        "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+        "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+        "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+        "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+        "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+      ],
+      "shape": Object {
+        "borderRadius": 4,
+      },
+      "spacing": Object {
+        "unit": 8,
+      },
+      "transitions": Object {
+        "create": [Function],
+        "duration": Object {
+          "complex": 375,
+          "enteringScreen": 225,
+          "leavingScreen": 195,
+          "short": 250,
+          "shorter": 200,
+          "shortest": 150,
+          "standard": 300,
+        },
+        "easing": Object {
+          "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+          "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+          "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+          "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+        },
+        "getAutoHeightDuration": [Function],
+      },
+      "typography": Object {
+        "body1": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 400,
+          "lineHeight": "1.46429em",
+        },
+        "body1Next": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.00938em",
+          "lineHeight": 1.5,
+        },
+        "body2": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 500,
+          "lineHeight": "1.71429em",
+        },
+        "body2Next": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.01071em",
+          "lineHeight": 1.5,
+        },
+        "button": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 500,
+          "textTransform": "uppercase",
+        },
+        "buttonNext": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.02857em",
+          "lineHeight": 1.5,
+          "textTransform": "uppercase",
+        },
+        "caption": Object {
+          "color": "rgba(0, 0, 0, 0.54)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.75rem",
+          "fontWeight": 400,
+          "lineHeight": "1.375em",
+        },
+        "captionNext": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.75rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.03333em",
+          "lineHeight": 1.66,
+        },
+        "display1": Object {
+          "color": "rgba(0, 0, 0, 0.54)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "2.125rem",
+          "fontWeight": 400,
+          "lineHeight": "1.20588em",
+        },
+        "display2": Object {
+          "color": "rgba(0, 0, 0, 0.54)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "2.8125rem",
+          "fontWeight": 400,
+          "lineHeight": "1.13333em",
+          "marginLeft": "-.02em",
+        },
+        "display3": Object {
+          "color": "rgba(0, 0, 0, 0.54)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "3.5rem",
+          "fontWeight": 400,
+          "letterSpacing": "-.02em",
+          "lineHeight": "1.30357em",
+          "marginLeft": "-.02em",
+        },
+        "display4": Object {
+          "color": "rgba(0, 0, 0, 0.54)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "7rem",
+          "fontWeight": 300,
+          "letterSpacing": "-.04em",
+          "lineHeight": "1.14286em",
+          "marginLeft": "-.04em",
+        },
+        "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+        "fontSize": 14,
+        "fontWeightLight": 300,
+        "fontWeightMedium": 500,
+        "fontWeightRegular": 400,
+        "h1": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "6rem",
+          "fontWeight": 300,
+          "letterSpacing": "-0.01562em",
+          "lineHeight": 1,
+        },
+        "h2": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "3.75rem",
+          "fontWeight": 300,
+          "letterSpacing": "-0.00833em",
+          "lineHeight": 1,
+        },
+        "h3": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "3rem",
+          "fontWeight": 400,
+          "letterSpacing": "0em",
+          "lineHeight": 1.04,
+        },
+        "h4": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "2.125rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.00735em",
+          "lineHeight": 1.17,
+        },
+        "h5": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1.5rem",
+          "fontWeight": 400,
+          "letterSpacing": "0em",
+          "lineHeight": 1.33,
+        },
+        "h6": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1.25rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.0075em",
+          "lineHeight": 1.6,
+        },
+        "headline": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1.5rem",
+          "fontWeight": 400,
+          "lineHeight": "1.35417em",
+        },
+        "overline": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.75rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.08333em",
+          "lineHeight": 2.66,
+          "textTransform": "uppercase",
+        },
+        "pxToRem": [Function],
+        "round": [Function],
+        "subheading": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1rem",
+          "fontWeight": 400,
+          "lineHeight": "1.5em",
+        },
+        "subtitle1": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.00938em",
+          "lineHeight": 1.75,
+        },
+        "subtitle2": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.00714em",
+          "lineHeight": 1.57,
+        },
+        "title": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1.3125rem",
+          "fontWeight": 500,
+          "lineHeight": "1.16667em",
+        },
+        "useNextVariants": false,
+      },
+      "zIndex": Object {
+        "appBar": 1100,
+        "drawer": 1200,
+        "mobileStepper": 1000,
+        "modal": 1300,
+        "snackbar": 1400,
+        "tooltip": 1500,
+      },
+    }
+  }
+  title={
+    <div>
+      <div>
+        Manually terminated
+      </div>
+    </div>
+  }
+>
+  <span
+    style={
+      Object {
+        "height": 18,
+      }
+    }
+  >
+    <StatusRunning
+      style={
+        Object {
+          "color": "#80868b",
+          "height": 18,
+          "width": 18,
+        }
+      }
+    />
+  </span>
+</Tooltip>
+`;
+
+exports[`Status statusToIcon renders an icon with tooltip for phase: TERMINATING 1`] = `
+<Tooltip
+  TransitionComponent={[Function]}
+  classes={
+    Object {
+      "popper": "MuiTooltip-popper-1",
+      "popperInteractive": "MuiTooltip-popperInteractive-2",
+      "tooltip": "MuiTooltip-tooltip-3",
+      "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-8",
+      "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-5",
+      "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-6",
+      "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-7",
+      "touch": "MuiTooltip-touch-4",
+    }
+  }
+  disableFocusListener={false}
+  disableHoverListener={false}
+  disableTouchListener={false}
+  enterDelay={0}
+  enterTouchDelay={1000}
+  interactive={false}
+  leaveDelay={0}
+  leaveTouchDelay={1500}
+  placement="bottom"
+  theme={
+    Object {
+      "breakpoints": Object {
+        "between": [Function],
+        "down": [Function],
+        "keys": Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ],
+        "only": [Function],
+        "up": [Function],
+        "values": Object {
+          "lg": 1280,
+          "md": 960,
+          "sm": 600,
+          "xl": 1920,
+          "xs": 0,
+        },
+        "width": [Function],
+      },
+      "direction": "ltr",
+      "mixins": Object {
+        "gutters": [Function],
+        "toolbar": Object {
+          "@media (min-width:0px) and (orientation: landscape)": Object {
+            "minHeight": 48,
+          },
+          "@media (min-width:600px)": Object {
+            "minHeight": 64,
+          },
+          "minHeight": 56,
+        },
+      },
+      "overrides": Object {},
+      "palette": Object {
+        "action": Object {
+          "active": "rgba(0, 0, 0, 0.54)",
+          "disabled": "rgba(0, 0, 0, 0.26)",
+          "disabledBackground": "rgba(0, 0, 0, 0.12)",
+          "hover": "rgba(0, 0, 0, 0.08)",
+          "hoverOpacity": 0.08,
+          "selected": "rgba(0, 0, 0, 0.14)",
+        },
+        "augmentColor": [Function],
+        "background": Object {
+          "default": "#fafafa",
+          "paper": "#fff",
+        },
+        "common": Object {
+          "black": "#000",
+          "white": "#fff",
+        },
+        "contrastThreshold": 3,
+        "divider": "rgba(0, 0, 0, 0.12)",
+        "error": Object {
+          "contrastText": "#fff",
+          "dark": "#d32f2f",
+          "light": "#e57373",
+          "main": "#f44336",
+        },
+        "getContrastText": [Function],
+        "grey": Object {
+          "100": "#f5f5f5",
+          "200": "#eeeeee",
+          "300": "#e0e0e0",
+          "400": "#bdbdbd",
+          "50": "#fafafa",
+          "500": "#9e9e9e",
+          "600": "#757575",
+          "700": "#616161",
+          "800": "#424242",
+          "900": "#212121",
+          "A100": "#d5d5d5",
+          "A200": "#aaaaaa",
+          "A400": "#303030",
+          "A700": "#616161",
+        },
+        "primary": Object {
+          "contrastText": "#fff",
+          "dark": "#303f9f",
+          "light": "#7986cb",
+          "main": "#3f51b5",
+        },
+        "secondary": Object {
+          "contrastText": "#fff",
+          "dark": "#c51162",
+          "light": "#ff4081",
+          "main": "#f50057",
+        },
+        "text": Object {
+          "disabled": "rgba(0, 0, 0, 0.38)",
+          "hint": "rgba(0, 0, 0, 0.38)",
+          "primary": "rgba(0, 0, 0, 0.87)",
+          "secondary": "rgba(0, 0, 0, 0.54)",
+        },
+        "tonalOffset": 0.2,
+        "type": "light",
+      },
+      "props": Object {},
+      "shadows": Array [
+        "none",
+        "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+        "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+        "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+        "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+        "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+        "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+        "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+        "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+        "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+        "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+        "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+        "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+        "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+        "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+        "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+        "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+        "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+        "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+        "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+        "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+        "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+        "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+        "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+        "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+      ],
+      "shape": Object {
+        "borderRadius": 4,
+      },
+      "spacing": Object {
+        "unit": 8,
+      },
+      "transitions": Object {
+        "create": [Function],
+        "duration": Object {
+          "complex": 375,
+          "enteringScreen": 225,
+          "leavingScreen": 195,
+          "short": 250,
+          "shorter": 200,
+          "shortest": 150,
+          "standard": 300,
+        },
+        "easing": Object {
+          "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+          "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+          "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+          "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+        },
+        "getAutoHeightDuration": [Function],
+      },
+      "typography": Object {
+        "body1": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 400,
+          "lineHeight": "1.46429em",
+        },
+        "body1Next": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.00938em",
+          "lineHeight": 1.5,
+        },
+        "body2": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 500,
+          "lineHeight": "1.71429em",
+        },
+        "body2Next": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.01071em",
+          "lineHeight": 1.5,
+        },
+        "button": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 500,
+          "textTransform": "uppercase",
+        },
+        "buttonNext": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.02857em",
+          "lineHeight": 1.5,
+          "textTransform": "uppercase",
+        },
+        "caption": Object {
+          "color": "rgba(0, 0, 0, 0.54)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.75rem",
+          "fontWeight": 400,
+          "lineHeight": "1.375em",
+        },
+        "captionNext": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.75rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.03333em",
+          "lineHeight": 1.66,
+        },
+        "display1": Object {
+          "color": "rgba(0, 0, 0, 0.54)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "2.125rem",
+          "fontWeight": 400,
+          "lineHeight": "1.20588em",
+        },
+        "display2": Object {
+          "color": "rgba(0, 0, 0, 0.54)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "2.8125rem",
+          "fontWeight": 400,
+          "lineHeight": "1.13333em",
+          "marginLeft": "-.02em",
+        },
+        "display3": Object {
+          "color": "rgba(0, 0, 0, 0.54)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "3.5rem",
+          "fontWeight": 400,
+          "letterSpacing": "-.02em",
+          "lineHeight": "1.30357em",
+          "marginLeft": "-.02em",
+        },
+        "display4": Object {
+          "color": "rgba(0, 0, 0, 0.54)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "7rem",
+          "fontWeight": 300,
+          "letterSpacing": "-.04em",
+          "lineHeight": "1.14286em",
+          "marginLeft": "-.04em",
+        },
+        "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+        "fontSize": 14,
+        "fontWeightLight": 300,
+        "fontWeightMedium": 500,
+        "fontWeightRegular": 400,
+        "h1": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "6rem",
+          "fontWeight": 300,
+          "letterSpacing": "-0.01562em",
+          "lineHeight": 1,
+        },
+        "h2": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "3.75rem",
+          "fontWeight": 300,
+          "letterSpacing": "-0.00833em",
+          "lineHeight": 1,
+        },
+        "h3": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "3rem",
+          "fontWeight": 400,
+          "letterSpacing": "0em",
+          "lineHeight": 1.04,
+        },
+        "h4": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "2.125rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.00735em",
+          "lineHeight": 1.17,
+        },
+        "h5": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1.5rem",
+          "fontWeight": 400,
+          "letterSpacing": "0em",
+          "lineHeight": 1.33,
+        },
+        "h6": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1.25rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.0075em",
+          "lineHeight": 1.6,
+        },
+        "headline": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1.5rem",
+          "fontWeight": 400,
+          "lineHeight": "1.35417em",
+        },
+        "overline": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.75rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.08333em",
+          "lineHeight": 2.66,
+          "textTransform": "uppercase",
+        },
+        "pxToRem": [Function],
+        "round": [Function],
+        "subheading": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1rem",
+          "fontWeight": 400,
+          "lineHeight": "1.5em",
+        },
+        "subtitle1": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.00938em",
+          "lineHeight": 1.75,
+        },
+        "subtitle2": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.00714em",
+          "lineHeight": 1.57,
+        },
+        "title": Object {
+          "color": "rgba(0, 0, 0, 0.87)",
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1.3125rem",
+          "fontWeight": 500,
+          "lineHeight": "1.16667em",
+        },
+        "useNextVariants": false,
+      },
+      "zIndex": Object {
+        "appBar": 1100,
+        "drawer": 1200,
+        "mobileStepper": 1000,
+        "modal": 1300,
+        "snackbar": 1400,
+        "tooltip": 1500,
+      },
+    }
+  }
+  title={
+    <div>
+      <div>
+        Run is terminating
+      </div>
+    </div>
+  }
+>
+  <span
+    style={
+      Object {
+        "height": 18,
+      }
+    }
+  >
+    <pure(NotInterestedIcon)
+      style={
+        Object {
+          "color": "#80868b",
+          "height": 18,
+          "width": 18,
+        }
+      }
+    />
+  </span>
+</Tooltip>
+`;
+
 exports[`Status statusToIcon renders an icon with tooltip for phase: UNKNOWN 1`] = `
 <Tooltip
   TransitionComponent={[Function]}

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -139,7 +139,6 @@ describe('deploy helloworld sample run', () => {
     // Wait for a reasonable amount of time until the run is done
     while (attempts < maxAttempts && status.trim() !== 'Succeeded') {
       browser.pause(1000);
-      $('#refreshBtn').click();
       status = getValueFromDetailsTable('Status');
       attempts++;
     }

--- a/test/frontend-integration-test/tensorboard-example.spec.js
+++ b/test/frontend-integration-test/tensorboard-example.spec.js
@@ -116,7 +116,6 @@ describe('deploy tensorboard example run', () => {
     // Wait for a reasonable amount of time until the run is done
     while (attempts < maxAttempts && status.trim() !== 'Succeeded') {
       browser.pause(1000);
-      $('#refreshBtn').click();
       status = getValueFromDetailsTable('Status');
       attempts++;
     }


### PR DESCRIPTION
Adds a `Terminate` button to the run details page, allowing users to request that the pipeline execution be stopped:
![image](https://user-images.githubusercontent.com/34456002/54958302-82902080-4f12-11e9-9c61-4fce26c86f74.png)

This action is irreversible and the user is asked to confirm before the command is issued:
![image](https://user-images.githubusercontent.com/34456002/54956775-157a8c00-4f0e-11e9-922f-d6dff2026cc3.png)

Afterward, the `Terminate` button is disabled, and a warning banner is shown explaining that the run was terminated. The step that was executing when the pipeline terminated gets a special status icon indicating that it was stopped:
![image](https://user-images.githubusercontent.com/34456002/54956857-4eb2fc00-4f0e-11e9-8e21-1ab0f08f2a28.png)

If there were multiple steps running when the pipeline was terminated, each will show the stopped icon:
![image](https://user-images.githubusercontent.com/34456002/54957373-cd5c6900-4f0f-11e9-9e28-8a57630ab335.png)

The list pages will show terminated runs as `Failed`, and will not indicate that they are terminated due to #1040

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1039)
<!-- Reviewable:end -->