### PR TITLE
Register proxy agent using the service account endpoint

### DIFF
--- a/proxy/attempt-register-vm-on-proxy.sh
+++ b/proxy/attempt-register-vm-on-proxy.sh
@@ -63,7 +63,7 @@ echo "Proxy URL from the config: ${PROXY_URL}"
 
 # Register the proxy agent
 VM_ID=$(curl -H 'Metadata-Flavor: Google' "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?format=full&audience=${PROXY_URL}/request-service-account-endpoint"  2>/dev/null)
-RESULT_JSON=$(curl -H "Authorization: Bearer $(gcloud auth print-access-token)" -H "X-Inverting-Proxy-VM-ID: ${VM_ID}" -d "" "${PROXY_URL}/request-endpoint" 2>/dev/null)
+RESULT_JSON=$(curl -H "Authorization: Bearer $(gcloud auth print-access-token)" -H "X-Inverting-Proxy-VM-ID: ${VM_ID}" -d "" "${PROXY_URL}/request-service-account-endpoint" 2>/dev/null)
 echo "Response from the registration server: ${RESULT_JSON}"
 
 HOSTNAME=$(echo "${RESULT_JSON}" | jq -r ".hostname")

--- a/proxy/attempt-register-vm-on-proxy.sh
+++ b/proxy/attempt-register-vm-on-proxy.sh
@@ -62,7 +62,7 @@ fi
 echo "Proxy URL from the config: ${PROXY_URL}"
 
 # Register the proxy agent
-VM_ID=$(curl -H 'Metadata-Flavor: Google' "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?format=full&audience=${PROXY_URL}/request-endpoint"  2>/dev/null)
+VM_ID=$(curl -H 'Metadata-Flavor: Google' "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?format=full&audience=${PROXY_URL}/request-service-account-endpoint"  2>/dev/null)
 RESULT_JSON=$(curl -H "Authorization: Bearer $(gcloud auth print-access-token)" -H "X-Inverting-Proxy-VM-ID: ${VM_ID}" -d "" "${PROXY_URL}/request-endpoint" 2>/dev/null)
 echo "Response from the registration server: ${RESULT_JSON}"
 


### PR DESCRIPTION
The proxy server now has a /request-service-account-endpoint that gives an endpoint for a service account. 
This endpoint will work with GKE, in case a VM dies and the agent failover to another VM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1043)
<!-- Reviewable:end -->
