### PR TITLE
remove jupyter hub link from UI

### DIFF
--- a/frontend/src/components/SideNav.test.tsx
+++ b/frontend/src/components/SideNav.test.tsx
@@ -338,14 +338,4 @@ describe('SideNav', () => {
     expect(tree.state('displayBuildInfo')).toBeUndefined();
     expect(consoleErrorSpy.mock.calls[0][0]).toBe('Failed to retrieve build info');
   });
-
-  it('logs an error if the call isJupyterHubAvailable fails', async () => {
-    TestUtils.makeErrorResponseOnce(checkHubSpy, 'Uh oh!');
-
-    tree = shallow(<SideNav page={RoutePage.PIPELINES} {...routerProps} />);
-    await TestUtils.flushPromises();
-
-    expect(tree.state('jupyterHubAvailable')).toEqual(false);
-    expect(consoleErrorSpy.mock.calls[0][0]).toBe('Failed to reach Jupyter Hub');
-  });
 });

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -195,6 +195,7 @@ export default class SideNav extends React.Component<SideNavProps, SideNavState>
 
     this.state = {
       collapsed,
+      // Set jupyterHubAvailable to false so UI don't show Jupyter Hub link
       jupyterHubAvailable: false,
       manualCollapseState: LocalStorage.hasKey(LocalStorageKey.navbarCollapsed),
     };
@@ -219,15 +220,7 @@ export default class SideNav extends React.Component<SideNavProps, SideNavState>
       logger.error('Failed to retrieve build info', err);
     }
 
-    // Verify Jupyter Hub is reachable
-    let jupyterHubAvailable = false;
-    try {
-      jupyterHubAvailable = await Apis.isJupyterHubAvailable();
-    } catch (err) {
-      logger.error('Failed to reach Jupyter Hub', err);
-    }
-
-    this.setStateSafe({ displayBuildInfo, jupyterHubAvailable });
+    this.setStateSafe({ displayBuildInfo});
   }
 
   public componentWillUnmount(): void {

--- a/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
@@ -74,42 +74,6 @@ exports[`SideNav populates the display build information using the response from
         </WithStyles(Button)>
       </Link>
     </WithStyles(Tooltip)>
-    <WithStyles(Tooltip)
-      disableFocusListener={true}
-      disableHoverListener={true}
-      disableTouchListener={true}
-      enterDelay={300}
-      placement="right-start"
-      title="Open Jupyter Notebook"
-    >
-      <a
-        className="unstyled"
-        href="/hub/"
-        id="jupyterhubBtn"
-        target="_blank"
-      >
-        <WithStyles(Button)
-          className="button"
-        >
-          <pure(CodeIcon)
-            style={
-              Object {
-                "height": 20,
-                "width": 20,
-              }
-            }
-          />
-          <span
-            className="label"
-          >
-            Notebooks
-          </span>
-          <pure(OpenInNewIcon)
-            className="openInNewTabIcon"
-          />
-        </WithStyles(Button)>
-      </a>
-    </WithStyles(Tooltip)>
     <hr
       className="separator"
     />


### PR DESCRIPTION
Set jupyterHubAvailable flag to always false so we don't show the link. 

/assign @rileyjbauer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1046)
<!-- Reviewable:end -->
