### PR TITLE
Manually delete service accounts after tests completed

### DIFF
--- a/proxy/attempt-register-vm-on-proxy.sh
+++ b/proxy/attempt-register-vm-on-proxy.sh
@@ -63,7 +63,7 @@ echo "Proxy URL from the config: ${PROXY_URL}"
 
 # Register the proxy agent
 VM_ID=$(curl -H 'Metadata-Flavor: Google' "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?format=full&audience=${PROXY_URL}/request-endpoint"  2>/dev/null)
-RESULT_JSON=$(curl -H "Authorization: Bearer $(gcloud auth print-access-token)" -H "X-Inverting-Proxy-VM-ID: ${VM_ID}" -d "" "${PROXY_URL}/request-endpoint" 2>/dev/null)
+RESULT_JSON=$(curl -H "Authorization: Bearer $(gcloud auth print-access-token)" -H "X-Inverting-Proxy-VM-ID: ${VM_ID}" -d "" "${PROXY_URL}/request-service-account-endpoint" 2>/dev/null)
 echo "Response from the registration server: ${RESULT_JSON}"
 
 HOSTNAME=$(echo "${RESULT_JSON}" | jq -r ".hostname")

--- a/proxy/attempt-register-vm-on-proxy.sh
+++ b/proxy/attempt-register-vm-on-proxy.sh
@@ -63,7 +63,7 @@ echo "Proxy URL from the config: ${PROXY_URL}"
 
 # Register the proxy agent
 VM_ID=$(curl -H 'Metadata-Flavor: Google' "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?format=full&audience=${PROXY_URL}/request-endpoint"  2>/dev/null)
-RESULT_JSON=$(curl -H "Authorization: Bearer $(gcloud auth print-access-token)" -H "X-Inverting-Proxy-VM-ID: ${VM_ID}" -d "" "${PROXY_URL}/request-service-account-endpoint" 2>/dev/null)
+RESULT_JSON=$(curl -H "Authorization: Bearer $(gcloud auth print-access-token)" -H "X-Inverting-Proxy-VM-ID: ${VM_ID}" -d "" "${PROXY_URL}/request-endpoint" 2>/dev/null)
 echo "Response from the registration server: ${RESULT_JSON}"
 
 HOSTNAME=$(echo "${RESULT_JSON}" | jq -r ".hostname")

--- a/test/deploy-kubeflow.sh
+++ b/test/deploy-kubeflow.sh
@@ -55,6 +55,9 @@ function clean_up {
   ${KUBEFLOW_SRC}/scripts/kfctl.sh delete all
   # delete the storage
   gcloud deployment-manager --project=${PROJECT} deployments delete ${KFAPP}-storage --quiet
+  gcloud iam service-accounts delete ${TEST_CLUSTER}-admin@ml-pipeline-test.iam.gserviceaccount.com --quiet
+  gcloud iam service-accounts delete ${TEST_CLUSTER}-vm@ml-pipeline-test.iam.gserviceaccount.com --quiet
+  gcloud iam service-accounts delete ${TEST_CLUSTER}-user@ml-pipeline-test.iam.gserviceaccount.com --quiet
 }
 trap clean_up EXIT SIGINT SIGTERM
 

--- a/test/deploy-kubeflow.sh
+++ b/test/deploy-kubeflow.sh
@@ -55,9 +55,9 @@ function clean_up {
   ${KUBEFLOW_SRC}/scripts/kfctl.sh delete all
   # delete the storage
   gcloud deployment-manager --project=${PROJECT} deployments delete ${KFAPP}-storage --quiet
-  gcloud iam service-accounts delete ${TEST_CLUSTER}-admin@ml-pipeline-test.iam.gserviceaccount.com --quiet
-  gcloud iam service-accounts delete ${TEST_CLUSTER}-vm@ml-pipeline-test.iam.gserviceaccount.com --quiet
-  gcloud iam service-accounts delete ${TEST_CLUSTER}-user@ml-pipeline-test.iam.gserviceaccount.com --quiet
+  gcloud iam --project=${PROJECT} service-accounts delete ${TEST_CLUSTER}-admin@ml-pipeline-test.iam.gserviceaccount.com --quiet
+  gcloud iam --project=${PROJECT} service-accounts delete ${TEST_CLUSTER}-vm@ml-pipeline-test.iam.gserviceaccount.com --quiet
+  gcloud iam --project=${PROJECT} service-accounts delete ${TEST_CLUSTER}-user@ml-pipeline-test.iam.gserviceaccount.com --quiet
 }
 trap clean_up EXIT SIGINT SIGTERM
 


### PR DESCRIPTION
Kubeflow kfctl will delete service account as part of deleting the cluster after v0.5. For now, we delete the account manually so we won't accumulate resources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1055)
<!-- Reviewable:end -->
