### PR TITLE
SDK/Components - Handling public GCS URIs in load_component_from_url

### DIFF
--- a/sdk/python/kfp/components/_components.py
+++ b/sdk/python/kfp/components/_components.py
@@ -76,6 +76,12 @@ def load_component_from_url(url):
     '''
     if url is None:
         raise TypeError
+
+    #Handling Google Cloud Storage URIs
+    if url.startswith('gs://'):
+        #Replacing the gs:// URI with https:// URI (works for public objects)
+        url = 'https://storage.googleapis.com/' + url[len('gs://'):]
+
     import requests
     resp = requests.get(url)
     resp.raise_for_status()


### PR DESCRIPTION
Adds support for handling public `gs://` links in `load_component_from_url`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1057)
<!-- Reviewable:end -->
