### PR TITLE
Allow bigquery component to export to table only

### DIFF
--- a/component_sdk/python/tests/google/bigquery/test__query.py
+++ b/component_sdk/python/tests/google/bigquery/test__query.py
@@ -60,12 +60,14 @@ class TestQuery(unittest.TestCase):
         mock_client().extract_table.assert_called_with(
             mock_dataset.table('query_ctx1'),
             'gs://output/path')
-        self.assertEqual(2, mock_dump_json.call_count)
 
-    def test_query_dump_locally(self, mock_client,
+    def test_query_no_output_path(self, mock_client,
         mock_kfp_context, mock_dump_json, mock_display):
         mock_kfp_context().__enter__().context_id.return_value = 'ctx1'
         mock_client().get_job.side_effect = exceptions.NotFound('not found')
+        mock_dataset = bigquery.DatasetReference('project-1', 'dataset-1')
+        mock_client().dataset.return_value = mock_dataset
+        mock_client().get_dataset.return_value = bigquery.Dataset(mock_dataset)
         mock_response = {
             'configuration': {
                 'query': {
@@ -75,11 +77,21 @@ class TestQuery(unittest.TestCase):
         }
         mock_client().query.return_value.to_api_repr.return_value = mock_response
 
-        result = query('SELECT * FROM table_1', 'project-1')
+        result = query('SELECT * FROM table_1', 'project-1', 'dataset-1', 'table-1')
 
         self.assertEqual(mock_response, result)
         mock_client().create_dataset.assert_not_called()
-        mock_client().query.assert_called()
         mock_client().extract_table.assert_not_called()
-        self.assertEqual(3, mock_dump_json.call_count)
+
+        expected_job_config = bigquery.QueryJobConfig()
+        expected_job_config.create_disposition = bigquery.job.CreateDisposition.CREATE_IF_NEEDED
+        expected_job_config.write_disposition = bigquery.job.WriteDisposition.WRITE_TRUNCATE
+        expected_job_config.destination = mock_dataset.table('table-1')
+        mock_client().query.assert_called_with('SELECT * FROM table_1',mock.ANY,
+            job_id = 'query_ctx1')
+        actual_job_config = mock_client().query.call_args_list[0][0][1]
+        self.assertDictEqual(
+            expected_job_config.to_api_repr(),
+            actual_job_config.to_api_repr()
+        )
 


### PR DESCRIPTION
The PR includes changes:

* Removes the code to dump results to local disk, as there is no any requirement for it,
* Dumps dataset_id and table_id so it can be orchestrate in subsequent steps.
* Only set job_config default value if it's not provided. This gives user the chance to change it as needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1062)
<!-- Reviewable:end -->
