### PR TITLE
SDK - Configure artifact name and path separately (again)

### DIFF
--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -144,10 +144,10 @@ def _outputs_to_json(outputs: Dict[str, dsl.PipelineParam],
     return ret
 
 
-def _build_conventional_artifact(name):
+def _build_conventional_artifact(name, path):
     return {
         'name': name,
-        'path': '/' + name + '.json',
+        'path': path,
         's3': {
             # TODO: parameterize namespace for minio service
             'endpoint': 'minio-service.kubeflow:9000',
@@ -176,9 +176,13 @@ def _op_to_template(op: dsl.ContainerOp):
     processed_op = _process_container_ops(op)
 
     # default output artifacts
+    output_artifact_paths = {}
+    output_artifact_paths.setdefault('mlpipeline-ui-metadata', '/mlpipeline-ui-metadata.json')
+    output_artifact_paths.setdefault('mlpipeline-metrics', '/mlpipeline-metrics.json')
+
     output_artifacts = [
-        _build_conventional_artifact(name)
-        for name in ['mlpipeline-ui-metadata', 'mlpipeline-metrics']
+        _build_conventional_artifact(name, path)
+        for name, path in output_artifact_paths.items()
     ]
 
     # workflow template


### PR DESCRIPTION
Restoring the https://github.com/kubeflow/pipelines/pull/900 change that was overwritten by https://github.com/kubeflow/pipelines/pull/879

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1067)
<!-- Reviewable:end -->
