### PR TITLE
Removes link to Kubeflow privacy links as KFP no longer runs Spartakus

### DIFF
--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -137,21 +137,6 @@ export const css = stylesheet({
     marginLeft: 5,
     width: 12,
   },
-  privacyInfo: {
-    color: sideNavColors.fgDefault,
-    marginBottom: 6,
-    marginLeft: 30,
-  },
-  privacySeparator: {
-    background: sideNavColors.fgDefault,
-    borderRadius: 2,
-    display: 'inline-block',
-    height: 4,
-    marginBottom: 3,
-    marginLeft: 10,
-    marginRight: 10,
-    width: 4,
-  },
   root: {
     background: sideNavColors.bg,
     borderRight: `1px ${sideNavColors.sideNavBorder} solid`,
@@ -301,14 +286,6 @@ export default class SideNav extends React.Component<SideNavProps, SideNavState>
           </IconButton>
         </div>
         <div className={collapsed ? css.infoHidden : css.infoVisible}>
-          <div className={css.privacyInfo}>
-            <span>Privacy</span>
-            <span className={css.privacySeparator}/>
-            <a href='https://www.kubeflow.org/docs/guides/usage-reporting/'
-              className={classes(css.link, commonCss.unstyled)} target='_blank'>
-              Usage reporting
-            </a>
-          </div>
           {displayBuildInfo && (
             <Tooltip title={'Build date: ' + displayBuildInfo.date} enterDelay={300} placement={'top-start'}>
               <div className={css.buildInfo}>

--- a/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
@@ -126,23 +126,6 @@ exports[`SideNav populates the display build information using the response from
   <div
     className="infoVisible"
   >
-    <div
-      className="privacyInfo"
-    >
-      <span>
-        Privacy
-      </span>
-      <span
-        className="privacySeparator"
-      />
-      <a
-        className="link unstyled"
-        href="https://www.kubeflow.org/docs/guides/usage-reporting/"
-        target="_blank"
-      >
-        Usage reporting
-      </a>
-    </div>
     <WithStyles(Tooltip)
       enterDelay={300}
       placement="top-start"
@@ -292,25 +275,7 @@ exports[`SideNav renders Pipelines as active page 1`] = `
   </div>
   <div
     className="infoVisible"
-  >
-    <div
-      className="privacyInfo"
-    >
-      <span>
-        Privacy
-      </span>
-      <span
-        className="privacySeparator"
-      />
-      <a
-        className="link unstyled"
-        href="https://www.kubeflow.org/docs/guides/usage-reporting/"
-        target="_blank"
-      >
-        Usage reporting
-      </a>
-    </div>
-  </div>
+  />
 </div>
 `;
 
@@ -439,25 +404,7 @@ exports[`SideNav renders Pipelines as active when on PipelineDetails page 1`] = 
   </div>
   <div
     className="infoVisible"
-  >
-    <div
-      className="privacyInfo"
-    >
-      <span>
-        Privacy
-      </span>
-      <span
-        className="privacySeparator"
-      />
-      <a
-        className="link unstyled"
-        href="https://www.kubeflow.org/docs/guides/usage-reporting/"
-        target="_blank"
-      >
-        Usage reporting
-      </a>
-    </div>
-  </div>
+  />
 </div>
 `;
 
@@ -586,25 +533,7 @@ exports[`SideNav renders collapsed state 1`] = `
   </div>
   <div
     className="infoHidden"
-  >
-    <div
-      className="privacyInfo"
-    >
-      <span>
-        Privacy
-      </span>
-      <span
-        className="privacySeparator"
-      />
-      <a
-        className="link unstyled"
-        href="https://www.kubeflow.org/docs/guides/usage-reporting/"
-        target="_blank"
-      >
-        Usage reporting
-      </a>
-    </div>
-  </div>
+  />
 </div>
 `;
 
@@ -733,25 +662,7 @@ exports[`SideNav renders expanded state 1`] = `
   </div>
   <div
     className="infoVisible"
-  >
-    <div
-      className="privacyInfo"
-    >
-      <span>
-        Privacy
-      </span>
-      <span
-        className="privacySeparator"
-      />
-      <a
-        className="link unstyled"
-        href="https://www.kubeflow.org/docs/guides/usage-reporting/"
-        target="_blank"
-      >
-        Usage reporting
-      </a>
-    </div>
-  </div>
+  />
 </div>
 `;
 
@@ -880,25 +791,7 @@ exports[`SideNav renders experiments as active page 1`] = `
   </div>
   <div
     className="infoVisible"
-  >
-    <div
-      className="privacyInfo"
-    >
-      <span>
-        Privacy
-      </span>
-      <span
-        className="privacySeparator"
-      />
-      <a
-        className="link unstyled"
-        href="https://www.kubeflow.org/docs/guides/usage-reporting/"
-        target="_blank"
-      >
-        Usage reporting
-      </a>
-    </div>
-  </div>
+  />
 </div>
 `;
 
@@ -1027,25 +920,7 @@ exports[`SideNav renders experiments as active page when on AllRuns page 1`] = `
   </div>
   <div
     className="infoVisible"
-  >
-    <div
-      className="privacyInfo"
-    >
-      <span>
-        Privacy
-      </span>
-      <span
-        className="privacySeparator"
-      />
-      <a
-        className="link unstyled"
-        href="https://www.kubeflow.org/docs/guides/usage-reporting/"
-        target="_blank"
-      >
-        Usage reporting
-      </a>
-    </div>
-  </div>
+  />
 </div>
 `;
 
@@ -1174,25 +1049,7 @@ exports[`SideNav renders experiments as active page when on Compare page 1`] = `
   </div>
   <div
     className="infoVisible"
-  >
-    <div
-      className="privacyInfo"
-    >
-      <span>
-        Privacy
-      </span>
-      <span
-        className="privacySeparator"
-      />
-      <a
-        className="link unstyled"
-        href="https://www.kubeflow.org/docs/guides/usage-reporting/"
-        target="_blank"
-      >
-        Usage reporting
-      </a>
-    </div>
-  </div>
+  />
 </div>
 `;
 
@@ -1321,25 +1178,7 @@ exports[`SideNav renders experiments as active page when on NewExperiment page 1
   </div>
   <div
     className="infoVisible"
-  >
-    <div
-      className="privacyInfo"
-    >
-      <span>
-        Privacy
-      </span>
-      <span
-        className="privacySeparator"
-      />
-      <a
-        className="link unstyled"
-        href="https://www.kubeflow.org/docs/guides/usage-reporting/"
-        target="_blank"
-      >
-        Usage reporting
-      </a>
-    </div>
-  </div>
+  />
 </div>
 `;
 
@@ -1468,25 +1307,7 @@ exports[`SideNav renders experiments as active page when on NewRun page 1`] = `
   </div>
   <div
     className="infoVisible"
-  >
-    <div
-      className="privacyInfo"
-    >
-      <span>
-        Privacy
-      </span>
-      <span
-        className="privacySeparator"
-      />
-      <a
-        className="link unstyled"
-        href="https://www.kubeflow.org/docs/guides/usage-reporting/"
-        target="_blank"
-      >
-        Usage reporting
-      </a>
-    </div>
-  </div>
+  />
 </div>
 `;
 
@@ -1615,25 +1436,7 @@ exports[`SideNav renders experiments as active page when on RecurringRunDetails 
   </div>
   <div
     className="infoVisible"
-  >
-    <div
-      className="privacyInfo"
-    >
-      <span>
-        Privacy
-      </span>
-      <span
-        className="privacySeparator"
-      />
-      <a
-        className="link unstyled"
-        href="https://www.kubeflow.org/docs/guides/usage-reporting/"
-        target="_blank"
-      >
-        Usage reporting
-      </a>
-    </div>
-  </div>
+  />
 </div>
 `;
 
@@ -1762,25 +1565,7 @@ exports[`SideNav renders experiments as active page when on RunDetails page 1`] 
   </div>
   <div
     className="infoVisible"
-  >
-    <div
-      className="privacyInfo"
-    >
-      <span>
-        Privacy
-      </span>
-      <span
-        className="privacySeparator"
-      />
-      <a
-        className="link unstyled"
-        href="https://www.kubeflow.org/docs/guides/usage-reporting/"
-        target="_blank"
-      >
-        Usage reporting
-      </a>
-    </div>
-  </div>
+  />
 </div>
 `;
 
@@ -1909,25 +1694,7 @@ exports[`SideNav renders experiments as active when on ExperimentDetails page 1`
   </div>
   <div
     className="infoVisible"
-  >
-    <div
-      className="privacyInfo"
-    >
-      <span>
-        Privacy
-      </span>
-      <span
-        className="privacySeparator"
-      />
-      <a
-        className="link unstyled"
-        href="https://www.kubeflow.org/docs/guides/usage-reporting/"
-        target="_blank"
-      >
-        Usage reporting
-      </a>
-    </div>
-  </div>
+  />
 </div>
 `;
 
@@ -2092,24 +1859,6 @@ exports[`SideNav show jupyterhub link if accessible 1`] = `
   </div>
   <div
     className="infoVisible"
-  >
-    <div
-      className="privacyInfo"
-    >
-      <span>
-        Privacy
-      </span>
-      <span
-        className="privacySeparator"
-      />
-      <a
-        className="link unstyled"
-        href="https://www.kubeflow.org/docs/guides/usage-reporting/"
-        target="_blank"
-      >
-        Usage reporting
-      </a>
-    </div>
-  </div>
+  />
 </div>
 `;


### PR DESCRIPTION
Spartakus is now run by Kubeflow core, so it doesn't make sense for Kubeflow Pipelines to include a link to its documentation; the main Kubeflow UI will handle that.

Fixes: #1073 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1074)
<!-- Reviewable:end -->
