### PR TITLE
Passing the annotations and labels to the ContainerOp

### DIFF
--- a/sdk/python/kfp/components/_dsl_bridge.py
+++ b/sdk/python/kfp/components/_dsl_bridge.py
@@ -170,7 +170,13 @@ def _create_container_op_from_resolved_task(name:str, container_image:str, comma
         from kubernetes import client as k8s_client
         for name, value in env.items():
             task.container.add_env_variable(k8s_client.V1EnvVar(name=name, value=value))
-  
+
+    if component_spec.metadata:
+        for key, value in (component_spec.metadata.annotations or {}).items():
+            task.add_pod_annotation(key, value)
+        for key, value in (component_spec.metadata.labels or {}).items():
+            task.add_pod_label(key, value)
+
     if need_dummy:
         _dummy_pipeline.__exit__()
 

--- a/sdk/python/tests/components/test_components.py
+++ b/sdk/python/tests/components/test_components.py
@@ -547,6 +547,23 @@ implementation:
         task2 = task_factory1('456')
         self.assertEqual(task2.arguments, ['456'])
 
+    def test_passing_component_metadata_to_container_op(self):
+        component_text = '''\
+metadata:
+  annotations:
+    key1: value1
+  labels:
+    key1: value1
+implementation:
+  container:
+    image: busybox
+'''
+        task_factory1 = comp.load_component_from_text(text=component_text)
+
+        task1 = task_factory1()
+        self.assertEqual(task1.pod_annotations['key1'], 'value1')
+        self.assertEqual(task1.pod_labels['key1'], 'value1')
+
     def test_type_compatibility_check_for_simple_types(self):
         component_a = '''\
 outputs:


### PR DESCRIPTION
Currently the annotations and labels are not passed from component to the `ContainerOp`. This PR fixes that.

Fixes https://github.com/kubeflow/pipelines/issues/1013

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1077)
<!-- Reviewable:end -->
