### PR TITLE
SDK - Fix obj name in K8s -> json conversion util

### DIFF
--- a/sdk/python/kfp/compiler/_k8s_helper.py
+++ b/sdk/python/kfp/compiler/_k8s_helper.py
@@ -159,7 +159,7 @@ class K8sHelper(object):
               for sub_obj in k8s_obj]
     elif isinstance(k8s_obj, tuple):
       return tuple(K8sHelper.convert_k8s_obj_to_json(sub_obj)
-                   for sub_obj in obj)
+                   for sub_obj in k8s_obj)
     elif isinstance(k8s_obj, (datetime, date)):
       return k8s_obj.isoformat()
     elif isinstance(k8s_obj, dsl.PipelineParam): 


### PR DESCRIPTION
It looks like this `obj` -> `k8s_obj` rename was missed during a refactor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1088)
<!-- Reviewable:end -->
