### PR TITLE
Creates a default experiment at API server set up time

### DIFF
--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -200,7 +200,8 @@ func initDBClient(initConnectionTimeout time.Duration) *storage.DB {
 		&model.ResourceReference{},
 		&model.RunDetail{},
 		&model.RunMetric{},
-		&model.DBStatus{})
+		&model.DBStatus{},
+		&model.DefaultExperiment{})
 
 	if response.Error != nil {
 		glog.Fatalf("Failed to initialize the databases.")

--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -57,6 +57,7 @@ type ClientManager struct {
 	runStore               storage.RunStoreInterface
 	resourceReferenceStore storage.ResourceReferenceStoreInterface
 	dBStatusStore          storage.DBStatusStoreInterface
+	defaultExperimentStore storage.DefaultExperimentStoreInterface
 	objectStore            storage.ObjectStoreInterface
 	wfClient               workflowclient.WorkflowInterface
 	swfClient              scheduledworkflowclient.ScheduledWorkflowInterface
@@ -88,6 +89,10 @@ func (c *ClientManager) ResourceReferenceStore() storage.ResourceReferenceStoreI
 
 func (c *ClientManager) DBStatusStore() storage.DBStatusStoreInterface {
 	return c.dBStatusStore
+}
+
+func (c *ClientManager) DefaultExperimentStore() storage.DefaultExperimentStoreInterface {
+	return c.defaultExperimentStore
 }
 
 func (c *ClientManager) ObjectStore() storage.ObjectStoreInterface {
@@ -127,6 +132,7 @@ func (c *ClientManager) init() {
 	c.jobStore = storage.NewJobStore(db, c.time)
 	c.resourceReferenceStore = storage.NewResourceReferenceStore(db)
 	c.dBStatusStore = storage.NewDBStatusStore(db)
+	c.defaultExperimentStore = storage.NewDefaultExperimentStore(db)
 	c.objectStore = initMinioClient(getDurationConfig(initConnectionTimeout))
 
 	c.wfClient = client.CreateWorkflowClientOrFatal(

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -141,8 +141,9 @@ func registerHttpHandlerFromEndpoint(handler RegisterHttpHandlerFromEndpoint, se
 // Used to initialize the Experiment database with a default to be used for runs
 func createDefaultExperiment(resourceManager *resource.ResourceManager) error {
 	// First check that we don't already have a default experiment ID.
-	if storage.DefaultExperimentId != "" {
-		return util.NewCustomErrorf(util.CUSTOM_CODE_GENERIC, "Default experiment already exists! ID %v", storage.DefaultExperimentId)
+	if storage.DefaultExperimentId != "" || resourceManager.IsDefaultExperimentPresent() {
+		glog.Info("Default experiment already exists! ID: %v", storage.DefaultExperimentId)
+		return nil
 	}
 
 	defaultExperiment := &model.Experiment{Name: "Default", Description: "All runs created without specifying an experiment will be grouped here."}
@@ -151,6 +152,7 @@ func createDefaultExperiment(resourceManager *resource.ResourceManager) error {
 		return err
 	}
 
+	resourceManager.MarkDefaultExperimentPresent()
 	storage.DefaultExperimentId = experiment.UUID
 
 	return nil

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -138,27 +138,33 @@ func registerHttpHandlerFromEndpoint(handler RegisterHttpHandlerFromEndpoint, se
 
 // Used to initialize the Experiment database with a default to be used for runs
 func createDefaultExperiment(resourceManager *resource.ResourceManager) error {
-	// First check that we don't already have a default experiment ID.
+	// First check that we don't already have a default experiment ID in the DB.
 	defaultExperimentId, err := resourceManager.GetDefaultExperimentId()
 	if err != nil {
-		return err
+		return errors.New(fmt.Sprintf("Failed to check if default experiment exists. Err: %v", err.Error()))
 	}
 	if defaultExperimentId != "" {
 		glog.Info("Default experiment already exists! ID: %v", defaultExperimentId)
 		return nil
 	}
 
-	defaultExperiment := &model.Experiment{Name: "Default", Description: "All runs created without specifying an experiment will be grouped here."}
+	// Create default experiment
+	defaultExperiment := &model.Experiment{
+		Name: "Default",
+		Description: "All runs created without specifying an experiment will be grouped here."
+	}
 	experiment, err := resourceManager.CreateExperiment(defaultExperiment)
 	if err != nil {
-		return err
+		return errors.New(fmt.Sprintf("Failed to create default experiment. Err: %v", err.Error()))
 	}
 
+	// Set default experiment ID in the DB
 	err = resourceManager.SetDefaultExperimentId(experiment.UUID)
 	if err != nil {
-		return err
+		return errors.New(fmt.Sprintf("Failed to set default experiment ID. Err: %v", err.Error()))
 	}
 
+	glog.Info("Default experiment is set. ID is: %v", experiment.UUID)
 	return nil
 }
 

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -143,6 +143,7 @@ func createDefaultExperiment(resourceManager *resource.ResourceManager) error {
 	if err != nil {
 		return errors.New(fmt.Sprintf("Failed to check if default experiment exists. Err: %v", err.Error()))
 	}
+	// If default experiment ID is already present, don't fail, simply return.
 	if defaultExperimentId != "" {
 		glog.Info("Default experiment already exists! ID: %v", defaultExperimentId)
 		return nil
@@ -150,8 +151,8 @@ func createDefaultExperiment(resourceManager *resource.ResourceManager) error {
 
 	// Create default experiment
 	defaultExperiment := &model.Experiment{
-		Name: "Default",
-		Description: "All runs created without specifying an experiment will be grouped here."
+		Name:        "Default",
+		Description: "All runs created without specifying an experiment will be grouped here.",
 	}
 	experiment, err := resourceManager.CreateExperiment(defaultExperiment)
 	if err != nil {

--- a/backend/src/apiserver/model/BUILD.bazel
+++ b/backend/src/apiserver/model/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "db_status.go",
+        "default_experiment.go",
         "experiment.go",
         "job.go",
         "listable_model.go",

--- a/backend/src/apiserver/model/default_experiment.go
+++ b/backend/src/apiserver/model/default_experiment.go
@@ -1,0 +1,19 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+type DefaultExperiment struct {
+	DefaultExperimentId string `gorm:"column:DefaultExperimentId; not null"`
+}

--- a/backend/src/apiserver/resource/client_manager_fake.go
+++ b/backend/src/apiserver/resource/client_manager_fake.go
@@ -76,8 +76,8 @@ func NewFakeClientManager(time util.TimeInterface, uuid util.UUIDGeneratorInterf
 		defaultExperimentStore:      storage.NewDefaultExperimentStore(db),
 		objectStore:                 storage.NewFakeObjectStore(),
 		scheduledWorkflowClientFake: NewScheduledWorkflowClientFake(),
-		time: time,
-		uuid: uuid,
+		time:                        time,
+		uuid:                        uuid,
 	}, nil
 }
 

--- a/backend/src/apiserver/resource/client_manager_fake.go
+++ b/backend/src/apiserver/resource/client_manager_fake.go
@@ -38,6 +38,7 @@ type FakeClientManager struct {
 	runStore                    storage.RunStoreInterface
 	resourceReferenceStore      storage.ResourceReferenceStoreInterface
 	dBStatusStore               storage.DBStatusStoreInterface
+	defaultExperimentStore      storage.DefaultExperimentStoreInterface
 	objectStore                 storage.ObjectStoreInterface
 	workflowClientFake          *FakeWorkflowClient
 	scheduledWorkflowClientFake *FakeScheduledWorkflowClient
@@ -72,10 +73,11 @@ func NewFakeClientManager(time util.TimeInterface, uuid util.UUIDGeneratorInterf
 		workflowClientFake:          NewWorkflowClientFake(),
 		resourceReferenceStore:      storage.NewResourceReferenceStore(db),
 		dBStatusStore:               storage.NewDBStatusStore(db),
+		defaultExperimentStore:      storage.NewDefaultExperimentStore(db),
 		objectStore:                 storage.NewFakeObjectStore(),
 		scheduledWorkflowClientFake: NewScheduledWorkflowClientFake(),
-		time:                        time,
-		uuid:                        uuid,
+		time: time,
+		uuid: uuid,
 	}, nil
 }
 
@@ -142,6 +144,10 @@ func (f *FakeClientManager) ResourceReferenceStore() storage.ResourceReferenceSt
 
 func (f *FakeClientManager) DBStatusStore() storage.DBStatusStoreInterface {
 	return f.dBStatusStore
+}
+
+func (f *FakeClientManager) DefaultExperimentStore() storage.DefaultExperimentStoreInterface {
+	return f.defaultExperimentStore
 }
 
 func (f *FakeClientManager) ScheduledWorkflow() scheduledworkflowclient.ScheduledWorkflowInterface {

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -16,7 +16,6 @@ package resource
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -43,6 +43,7 @@ type ClientManagerInterface interface {
 	RunStore() storage.RunStoreInterface
 	ResourceReferenceStore() storage.ResourceReferenceStoreInterface
 	DBStatusStore() storage.DBStatusStoreInterface
+	DefaultExperimentStore() storage.DefaultExperimentStoreInterface
 	ObjectStore() storage.ObjectStoreInterface
 	Workflow() workflowclient.WorkflowInterface
 	ScheduledWorkflow() scheduledworkflowclient.ScheduledWorkflowInterface
@@ -57,6 +58,7 @@ type ResourceManager struct {
 	runStore                storage.RunStoreInterface
 	resourceReferenceStore  storage.ResourceReferenceStoreInterface
 	dBStatusStore           storage.DBStatusStoreInterface
+	defaultExperimentStore  storage.DefaultExperimentStoreInterface
 	objectStore             storage.ObjectStoreInterface
 	workflowClient          workflowclient.WorkflowInterface
 	scheduledWorkflowClient scheduledworkflowclient.ScheduledWorkflowInterface
@@ -72,11 +74,12 @@ func NewResourceManager(clientManager ClientManagerInterface) *ResourceManager {
 		runStore:                clientManager.RunStore(),
 		resourceReferenceStore:  clientManager.ResourceReferenceStore(),
 		dBStatusStore:           clientManager.DBStatusStore(),
+		defaultExperimentStore:  clientManager.DefaultExperimentStore(),
 		objectStore:             clientManager.ObjectStore(),
 		workflowClient:          clientManager.Workflow(),
 		scheduledWorkflowClient: clientManager.ScheduledWorkflow(),
-		time:                    clientManager.Time(),
-		uuid:                    clientManager.UUID(),
+		time: clientManager.Time(),
+		uuid: clientManager.UUID(),
 	}
 }
 
@@ -222,14 +225,19 @@ func (r *ResourceManager) CreateRun(apiRun *api.Run) (*model.RunDetail, error) {
 		}
 	}
 	if !hasExperiment {
+		// TODO: what should we do if defaultExperimentId is "" ?
+		defaultExperimentId, err := r.GetDefaultExperimentId()
+		if err != nil {
+			return nil, util.NewInternalServerError(err, "Failed to retrieve default experiment")
+		}
 		defaultExperimentRef := &api.ResourceReference{
-			Key: api.ResourceKey{
-				Id: storage.DefaultExperimentId,
+			Key: &api.ResourceKey{
+				Id:   defaultExperimentId,
 				Type: api.ResourceType_EXPERIMENT,
 			},
 			Relationship: api.Relationship_OWNER,
 		}
-		ref = append(ref, defaultExperimentRef)
+		apiRun.ResourceReferences = append(apiRun.ResourceReferences, defaultExperimentRef)
 	}
 
 	fmt.Printf("New run with references: %v", apiRun.ResourceReferences)
@@ -287,8 +295,8 @@ func (r *ResourceManager) ListJobs(filterContext *common.FilterContext,
 
 // TerminateWorkflow terminates a workflow by setting its activeDeadlineSeconds to 0
 func TerminateWorkflow(wfClient workflowclient.WorkflowInterface, name string) error {
-	patchObj := map[string]interface{} {
-		"spec": map[string]interface{} {
+	patchObj := map[string]interface{}{
+		"spec": map[string]interface{}{
 			"activeDeadlineSeconds": 0,
 		},
 	}
@@ -543,12 +551,12 @@ func (r *ResourceManager) ReadArtifact(runID string, nodeID string, artifactName
 	return r.objectStore.GetFile(artifactPath)
 }
 
-func (r *ResourceManager) IsDefaultExperimentPresent() (bool, error) {
-	return r.dBStatusStore.IsDefaultExperimentPresent()
+func (r *ResourceManager) GetDefaultExperimentId() (string, error) {
+	return r.defaultExperimentStore.GetDefaultExperimentId()
 }
 
-func (r *ResourceManager) MarkDefaultExperimentPresent() error {
-	return r.dBStatusStore.MarkDefaultExperimentPresent()
+func (r *ResourceManager) SetDefaultExperimentId(id string) error {
+	return r.defaultExperimentStore.SetDefaultExperimentId(id)
 }
 
 func (r *ResourceManager) HaveSamplesLoaded() (bool, error) {

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -78,8 +78,8 @@ func NewResourceManager(clientManager ClientManagerInterface) *ResourceManager {
 		objectStore:             clientManager.ObjectStore(),
 		workflowClient:          clientManager.Workflow(),
 		scheduledWorkflowClient: clientManager.ScheduledWorkflow(),
-		time:                    clientManager.Time(),
-		uuid:                    clientManager.UUID(),
+		time: clientManager.Time(),
+		uuid: clientManager.UUID(),
 	}
 }
 
@@ -217,29 +217,10 @@ func (r *ResourceManager) CreateRun(apiRun *api.Run) (*model.RunDetail, error) {
 		return nil, util.NewInternalServerError(err, "Failed to create a workflow for (%s)", workflow.Name)
 	}
 
-	hasExperiment := false
-	for _, ref := range apiRun.ResourceReferences {
-		if ref.Key.Type == api.ResourceType_EXPERIMENT && ref.Relationship == api.Relationship_OWNER {
-			hasExperiment = true
-			break
-		}
-	}
-	if !hasExperiment {
-		defaultExperimentId, err := r.GetDefaultExperimentId()
-		if err != nil {
-			return nil, util.NewInternalServerError(err, "Failed to retrieve default experiment")
-		}
-		if defaultExperimentId == "" {
-			return nil, util.NewInternalServerError(errors.New("Default experiment ID was empty"), "Default experiment was not set")
-		}
-		defaultExperimentRef := &api.ResourceReference{
-			Key: &api.ResourceKey{
-				Id:   defaultExperimentId,
-				Type: api.ResourceType_EXPERIMENT,
-			},
-			Relationship: api.Relationship_OWNER,
-		}
-		apiRun.ResourceReferences = append(apiRun.ResourceReferences, defaultExperimentRef)
+	// Add a reference to the default experiment if run does not already have a containing experiment
+	err = r.setExperimentIfNotPresent(apiRun)
+	if err != nil {
+		return nil, err
 	}
 
 	// Store run metadata into database
@@ -522,6 +503,36 @@ func (r *ResourceManager) getWorkflowSpecBytes(spec *api.PipelineSpec) ([]byte, 
 		return []byte(spec.GetWorkflowManifest()), nil
 	}
 	return nil, util.NewInvalidInputError("Please provide a valid pipeline spec")
+}
+
+// setDefaultExperimentIfNotPresent If the provided run does not include a reference to a containing
+// experiment, then we fetch the default experiment's ID and create a reference to that.
+func (r *ResourceManager) setExperimentIfNotPresent(apiRun *api.Run) error {
+	// First check if there is already a referenced experiment
+	for _, ref := range apiRun.ResourceReferences {
+		if ref.Key.Type == api.ResourceType_EXPERIMENT && ref.Relationship == api.Relationship_OWNER {
+			return nil
+		}
+	}
+
+	// Create reference to the default experiment
+	defaultExperimentId, err := r.GetDefaultExperimentId()
+	if err != nil {
+		return util.NewInternalServerError(err, "Failed to retrieve default experiment")
+	}
+	if defaultExperimentId == "" {
+		return util.NewInternalServerError(errors.New("Default experiment ID was empty"), "Default experiment was not set")
+	}
+	defaultExperimentRef := &api.ResourceReference{
+		Key: &api.ResourceKey{
+			Id:   defaultExperimentId,
+			Type: api.ResourceType_EXPERIMENT,
+		},
+		Relationship: api.Relationship_OWNER,
+	}
+	apiRun.ResourceReferences = append(apiRun.ResourceReferences, defaultExperimentRef)
+
+	return nil
 }
 
 func (r *ResourceManager) ReportMetric(metric *api.RunMetric, runUUID string) error {

--- a/backend/src/apiserver/server/run_server_test.go
+++ b/backend/src/apiserver/server/run_server_test.go
@@ -96,6 +96,12 @@ func TestListRun(t *testing.T) {
 			WorkflowManifest: testWorkflow2.ToStringForStore(),
 			Parameters:       []*api.Parameter{{Name: "param1", Value: "world"}},
 		},
+		ResourceReferences: []*api.ResourceReference{
+			{
+				Key:          &api.ResourceKey{Type: api.ResourceType_EXPERIMENT, Id: experiment.UUID},
+				Relationship: api.Relationship_OWNER,
+			},
+		},
 	}
 	_, err = server.CreateRun(nil, &api.CreateRunRequest{Run: run2})
 	assert.Nil(t, err)

--- a/backend/src/apiserver/storage/BUILD.bazel
+++ b/backend/src/apiserver/storage/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
     srcs = [
         "db_status_store_test.go",
         "db_test.go",
+        "default_experiment_store_test.go",
         "experiment_store_test.go",
         "job_store_test.go",
         "object_store_test.go",

--- a/backend/src/apiserver/storage/BUILD.bazel
+++ b/backend/src/apiserver/storage/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "db.go",
         "db_fake.go",
         "db_status_store.go",
+        "db_default_experiment_store.go",
         "experiment_store.go",
         "job_store.go",
         "minio_client.go",

--- a/backend/src/apiserver/storage/BUILD.bazel
+++ b/backend/src/apiserver/storage/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "db.go",
         "db_fake.go",
         "db_status_store.go",
-        "db_default_experiment_store.go",
+        "default_experiment_store.go",
         "experiment_store.go",
         "job_store.go",
         "minio_client.go",

--- a/backend/src/apiserver/storage/db_default_experiment_store.go
+++ b/backend/src/apiserver/storage/db_default_experiment_store.go
@@ -36,7 +36,7 @@ type DefaultExperimentStore struct {
 }
 
 func (s *DefaultExperimentStore) InitializeDefaultExperimentTable() error {
-	getDefaultExperimentSql, getDefaultExperimentArgs, err := sq.Select("*").From("default_experiment").ToSql()
+	getDefaultExperimentSql, getDefaultExperimentArgs, err := sq.Select("*").From("default_experiments").ToSql()
 	if err != nil {
 		return util.NewInternalServerError(err, "Error creating query to check default experiment.")
 	}
@@ -54,7 +54,7 @@ func (s *DefaultExperimentStore) InitializeDefaultExperimentTable() error {
 	// The table is not initialized
 	if !rows.Next() {
 		sql, args, queryErr := sq.
-			Insert("default_experiment").
+			Insert("default_experiments").
 			SetMap(defaultDBValue).
 			ToSql()
 
@@ -79,7 +79,7 @@ func (s *DefaultExperimentStore) InitializeDefaultExperimentTable() error {
 
 func (s *DefaultExperimentStore) SetDefaultExperimentId(id string) error {
 	sql, args, err := sq.
-		Update("default_experiment").
+		Update("default_experiments").
 		SetMap(sq.Eq{"DefaultExperimentId": id}).
 		ToSql()
 	if err != nil {
@@ -94,7 +94,7 @@ func (s *DefaultExperimentStore) SetDefaultExperimentId(id string) error {
 
 func (s *DefaultExperimentStore) GetDefaultExperimentId() (string, error) {
 	var defaultExperimentId string
-	sql, args, err := sq.Select("DefaultExperimentId").From("default_experiment").Where(sq.Eq{}).ToSql()
+	sql, args, err := sq.Select("DefaultExperimentId").From("default_experiments").Where(sq.Eq{}).ToSql()
 	if err != nil {
 		return "", util.NewInternalServerError(err, "Error creating query to get default experiment ID.")
 	}

--- a/backend/src/apiserver/storage/db_default_experiment_store.go
+++ b/backend/src/apiserver/storage/db_default_experiment_store.go
@@ -38,7 +38,7 @@ type DefaultExperimentStore struct {
 func (s *DefaultExperimentStore) InitializeDefaultExperimentTable() error {
 	getDefaultExperimentSql, getDefaultExperimentArgs, err := sq.Select("*").From("default_experiment").ToSql()
 	if err != nil {
-		return util.NewInternalServerError(err, "Error creating query to get default experiment ID.")
+		return util.NewInternalServerError(err, "Error creating query to check default experiment.")
 	}
 	tx, err := s.db.Begin()
 	if err != nil {

--- a/backend/src/apiserver/storage/db_default_experiment_store.go
+++ b/backend/src/apiserver/storage/db_default_experiment_store.go
@@ -1,0 +1,121 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	sq "github.com/Masterminds/squirrel"
+	"github.com/golang/glog"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+)
+
+var (
+	defaultDBValue = sq.Eq{"DefaultExperimentId": ""}
+)
+
+type DefaultExperimentStoreInterface interface {
+	GetDefaultExperimentId() (string, error)
+	SetDefaultExperimentId(id string) error
+}
+
+// Implementation of a DefaultExperimentStoreInterface. This stores the default experiment's ID, if
+// there is one.
+type DefaultExperimentStore struct {
+	db *DB
+}
+
+func (s *DefaultExperimentStore) InitializeDefaultExperimentTable() error {
+	getDefaultExperimentSql, getDefaultExperimentArgs, err := sq.Select("*").From("default_experiment").ToSql()
+	if err != nil {
+		return util.NewInternalServerError(err, "Error creating query to get default experiment ID.")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return util.NewInternalServerError(err, "Failed to create a new transaction to initialize default experiment table.")
+	}
+
+	rows, err := tx.Query(getDefaultExperimentSql, getDefaultExperimentArgs...)
+	if err != nil {
+		tx.Rollback()
+		return util.NewInternalServerError(err, "Failed to get default experiment.")
+	}
+
+	// The table is not initialized
+	if !rows.Next() {
+		sql, args, queryErr := sq.
+			Insert("default_experiment").
+			SetMap(defaultDBValue).
+			ToSql()
+
+		if queryErr != nil {
+			tx.Rollback()
+			return util.NewInternalServerError(queryErr, "Error creating query to initialize default experiment table.")
+		}
+
+		_, err = tx.Exec(sql, args...)
+		if err != nil {
+			tx.Rollback()
+			return util.NewInternalServerError(err, "Error initializing the default experiment table.")
+		}
+	}
+	err = tx.Commit()
+	if err != nil {
+		glog.Error("Failed to commit transaction to initialize default experiment table")
+		return util.NewInternalServerError(err, "Failed to initializing the default experiment table.")
+	}
+	return nil
+}
+
+func (s *DefaultExperimentStore) SetDefaultExperimentId(id string) error {
+	sql, args, err := sq.
+		Update("default_experiment").
+		SetMap(sq.Eq{"DefaultExperimentId": id}).
+		ToSql()
+	if err != nil {
+		return util.NewInternalServerError(err, "Error creating query to set default experiment ID.")
+	}
+	_, err = s.db.Exec(sql, args...)
+	if err != nil {
+		return util.NewInternalServerError(err, "Error setting default experiment ID.")
+	}
+	return nil
+}
+
+func (s *DefaultExperimentStore) GetDefaultExperimentId() (string, error) {
+	var defaultExperimentId string
+	sql, args, err := sq.Select("DefaultExperimentId").From("default_experiment").Where(sq.Eq{}).ToSql()
+	if err != nil {
+		return "", util.NewInternalServerError(err, "Error creating query to get default experiment ID.")
+	}
+	rows, err := s.db.Query(sql, args...)
+	if err != nil {
+		return "", util.NewInternalServerError(err, "Error when getting default experiment ID")
+	}
+	if rows.Next() {
+		err = rows.Scan(&defaultExperimentId)
+		if err != nil {
+			return "", util.NewInternalServerError(err, "Error when scanning row to find default experiment ID")
+		}
+		return defaultExperimentId, nil
+	}
+	return "", nil
+}
+
+// factory function for creating default experiment store
+func NewDefaultExperimentStore(db *DB) *DefaultExperimentStore {
+	s := &DefaultExperimentStore{db: db}
+	// Initialize default experiment table
+	s.InitializeDefaultExperimentTable()
+	return s
+}

--- a/backend/src/apiserver/storage/db_fake.go
+++ b/backend/src/apiserver/storage/db_fake.go
@@ -37,7 +37,8 @@ func NewFakeDb() (*DB, error) {
 		&model.ResourceReference{},
 		&model.RunDetail{},
 		&model.RunMetric{},
-		&model.DBStatus{})
+		&model.DBStatus{},
+		&model.DefaultExperiment{})
 
 	return NewDB(db.DB(), NewSQLiteDialect()), nil
 }

--- a/backend/src/apiserver/storage/db_status_store.go
+++ b/backend/src/apiserver/storage/db_status_store.go
@@ -36,16 +36,12 @@ type DBStatusStore struct {
 }
 
 func (s *DBStatusStore) InitializeDBStatusTable() error {
-	getDBStatusSql, getDBStatusArgs, err := sq.Select("*").From("db_statuses").ToSql()
-	if err != nil {
-		return util.NewInternalServerError(err, "Error creating query to get database status.")
-	}
 	tx, err := s.db.Begin()
 	if err != nil {
 		return util.NewInternalServerError(err, "Failed to create a new transaction to initialize database status.")
 	}
 
-	rows, err := tx.Query(getDBStatusSql, getDBStatusArgs...)
+	rows, err := tx.Query("SELECT * FROM db_statuses")
 	if err != nil {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to load database status.")

--- a/backend/src/apiserver/storage/db_status_store.go
+++ b/backend/src/apiserver/storage/db_status_store.go
@@ -21,11 +21,10 @@ import (
 )
 
 var (
-	defaultDBStatus = sq.Eq{"HaveSamplesLoaded": false, "IsDefaultExperimentPresent": false}
+	defaultDBStatus = sq.Eq{"HaveSamplesLoaded": false}
 )
 
 type DBStatusStoreInterface interface {
-	IsDefaultExperimentPresent() (bool, error)
 	HaveSamplesLoaded() (bool, error)
 	MarkSampleLoaded() error
 }
@@ -76,41 +75,6 @@ func (s *DBStatusStore) InitializeDBStatusTable() error {
 		return util.NewInternalServerError(err, "Failed to initializing the database status table.")
 	}
 	return nil
-}
-
-func (s *DBStatusStore) MarkDefaultExperimentPresent() error {
-	sql, args, err := sq.
-		Update("db_statuses").
-		SetMap(sq.Eq{"IsDefaultExperimentPresent": true}).
-		ToSql()
-	if err != nil {
-		return util.NewInternalServerError(err, "Error creating query to mark default experiment as present.")
-	}
-	_, err = s.db.Exec(sql, args...)
-	if err != nil {
-		return util.NewInternalServerError(err, "Error marking default experiment as present.")
-	}
-	return nil
-}
-
-func (s *DBStatusStore) IsDefaultExperimentPresent() (bool, error) {
-	var isDefaultExperimentPresent bool
-	sql, args, err := sq.Select("IsDefaultExperimentPresent").From("db_statuses").Where(sq.Eq{}).ToSql()
-	if err != nil {
-		return false, util.NewInternalServerError(err, "Error creating query to get default experiment status.")
-	}
-	rows, err := s.db.Query(sql, args...)
-	if err != nil {
-		return false, util.NewInternalServerError(err, "Error when getting default experiment status")
-	}
-	if rows.Next() {
-		err = rows.Scan(&isDefaultExperimentPresent)
-		if err != nil {
-			return false, util.NewInternalServerError(err, "Error when scanning row to find default experiment status")
-		}
-		return isDefaultExperimentPresent, nil
-	}
-	return false, nil
 }
 
 func (s *DBStatusStore) HaveSamplesLoaded() (bool, error) {

--- a/backend/src/apiserver/storage/db_status_store.go
+++ b/backend/src/apiserver/storage/db_status_store.go
@@ -79,7 +79,7 @@ func (s *DBStatusStore) InitializeDBStatusTable() error {
 
 func (s *DBStatusStore) HaveSamplesLoaded() (bool, error) {
 	var haveSamplesLoaded bool
-	sql, args, err := sq.Select("HaveSamplesLoaded").From("db_statuses").ToSql()
+	sql, args, err := sq.Select("*").From("db_statuses").ToSql()
 	if err != nil {
 		return false, util.NewInternalServerError(err, "Error creating query to get load sample status.")
 	}

--- a/backend/src/apiserver/storage/db_status_store_test.go
+++ b/backend/src/apiserver/storage/db_status_store_test.go
@@ -48,7 +48,7 @@ func TestMarkSampleLoaded(t *testing.T) {
 	// Initialize for the first time
 	err := dBStatusStore.InitializeDBStatusTable()
 	assert.Nil(t, err)
-	// Initialize again should be no-op and no error
+	// Mark the samples as loaded
 	err = dBStatusStore.MarkSampleLoaded()
 	assert.Nil(t, err)
 	haveSamplesLoaded, err := dBStatusStore.HaveSamplesLoaded()

--- a/backend/src/apiserver/storage/default_experiment_store.go
+++ b/backend/src/apiserver/storage/default_experiment_store.go
@@ -30,12 +30,12 @@ type DefaultExperimentStoreInterface interface {
 }
 
 // Implementation of a DefaultExperimentStoreInterface. This stores the default experiment's ID,
-// which is created as the API server is initialized.
+// which is created the first time the API server is initialized.
 type DefaultExperimentStore struct {
 	db *DB
 }
 
-func (s *DefaultExperimentStore) InitializeDefaultExperimentTable() error {
+func (s *DefaultExperimentStore) initializeDefaultExperimentTable() error {
 	// First check that the table is in fact empty
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -112,6 +112,6 @@ func (s *DefaultExperimentStore) GetDefaultExperimentId() (string, error) {
 func NewDefaultExperimentStore(db *DB) *DefaultExperimentStore {
 	s := &DefaultExperimentStore{db: db}
 	// Initialize default experiment table
-	s.InitializeDefaultExperimentTable()
+	s.initializeDefaultExperimentTable()
 	return s
 }

--- a/backend/src/apiserver/storage/default_experiment_store.go
+++ b/backend/src/apiserver/storage/default_experiment_store.go
@@ -29,8 +29,8 @@ type DefaultExperimentStoreInterface interface {
 	SetDefaultExperimentId(id string) error
 }
 
-// Implementation of a DefaultExperimentStoreInterface. This stores the default experiment's ID, if
-// there is one.
+// Implementation of a DefaultExperimentStoreInterface. This stores the default experiment's ID,
+// which is created as the API server is initialized.
 type DefaultExperimentStore struct {
 	db *DB
 }

--- a/backend/src/apiserver/storage/default_experiment_store.go
+++ b/backend/src/apiserver/storage/default_experiment_store.go
@@ -45,7 +45,6 @@ func (s *DefaultExperimentStore) InitializeDefaultExperimentTable() error {
 	if err != nil {
 		return util.NewInternalServerError(err, "Failed to create a new transaction to initialize default experiment table.")
 	}
-
 	rows, err := tx.Query(getDefaultExperimentSql, getDefaultExperimentArgs...)
 	if err != nil {
 		tx.Rollback()

--- a/backend/src/apiserver/storage/default_experiment_store.go
+++ b/backend/src/apiserver/storage/default_experiment_store.go
@@ -36,6 +36,7 @@ type DefaultExperimentStore struct {
 }
 
 func (s *DefaultExperimentStore) InitializeDefaultExperimentTable() error {
+	// First check that the table is in fact empty
 	getDefaultExperimentSql, getDefaultExperimentArgs, err := sq.Select("*").From("default_experiments").ToSql()
 	if err != nil {
 		return util.NewInternalServerError(err, "Error creating query to check default experiment.")
@@ -51,7 +52,7 @@ func (s *DefaultExperimentStore) InitializeDefaultExperimentTable() error {
 		return util.NewInternalServerError(err, "Failed to get default experiment.")
 	}
 
-	// The table is not initialized
+	// If the table is not initialized, then set the default value.
 	if !rows.Next() {
 		sql, args, queryErr := sq.
 			Insert("default_experiments").
@@ -94,7 +95,7 @@ func (s *DefaultExperimentStore) SetDefaultExperimentId(id string) error {
 
 func (s *DefaultExperimentStore) GetDefaultExperimentId() (string, error) {
 	var defaultExperimentId string
-	sql, args, err := sq.Select("DefaultExperimentId").From("default_experiments").Where(sq.Eq{}).ToSql()
+	sql, args, err := sq.Select("DefaultExperimentId").From("default_experiments").ToSql()
 	if err != nil {
 		return "", util.NewInternalServerError(err, "Error creating query to get default experiment ID.")
 	}

--- a/backend/src/apiserver/storage/default_experiment_store.go
+++ b/backend/src/apiserver/storage/default_experiment_store.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	defaultDBValue = sq.Eq{"DefaultExperimentId": ""}
+	defaultExperimentDBValue = sq.Eq{"DefaultExperimentId": ""}
 )
 
 type DefaultExperimentStoreInterface interface {
@@ -37,15 +37,11 @@ type DefaultExperimentStore struct {
 
 func (s *DefaultExperimentStore) InitializeDefaultExperimentTable() error {
 	// First check that the table is in fact empty
-	getDefaultExperimentSql, getDefaultExperimentArgs, err := sq.Select("*").From("default_experiments").ToSql()
-	if err != nil {
-		return util.NewInternalServerError(err, "Error creating query to check default experiment.")
-	}
 	tx, err := s.db.Begin()
 	if err != nil {
 		return util.NewInternalServerError(err, "Failed to create a new transaction to initialize default experiment table.")
 	}
-	rows, err := tx.Query(getDefaultExperimentSql, getDefaultExperimentArgs...)
+	rows, err := tx.Query("SELECT * FROM default_experiments")
 	if err != nil {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to get default experiment.")
@@ -55,7 +51,7 @@ func (s *DefaultExperimentStore) InitializeDefaultExperimentTable() error {
 	if !rows.Next() {
 		sql, args, queryErr := sq.
 			Insert("default_experiments").
-			SetMap(defaultDBValue).
+			SetMap(defaultExperimentDBValue).
 			ToSql()
 
 		if queryErr != nil {

--- a/backend/src/apiserver/storage/default_experiment_store_test.go
+++ b/backend/src/apiserver/storage/default_experiment_store_test.go
@@ -25,10 +25,10 @@ func TestInitializeDefaultExperimentTable(t *testing.T) {
 	defaultExperimentStore := NewDefaultExperimentStore(db)
 
 	// Initialize for the first time
-	err := defaultExperimentStore.InitializeDefaultExperimentTable()
+	err := defaultExperimentStore.initializeDefaultExperimentTable()
 	assert.Nil(t, err)
 	// Initialize again should be no-op and no error
-	err = defaultExperimentStore.InitializeDefaultExperimentTable()
+	err = defaultExperimentStore.initializeDefaultExperimentTable()
 	assert.Nil(t, err)
 	// Default experiment ID is empty after table initialization
 	defaultExperimentId, err := defaultExperimentStore.GetDefaultExperimentId()
@@ -37,7 +37,7 @@ func TestInitializeDefaultExperimentTable(t *testing.T) {
 
 	// Initializing the table with an invalid DB is an error
 	db.Close()
-	err = defaultExperimentStore.InitializeDefaultExperimentTable()
+	err = defaultExperimentStore.initializeDefaultExperimentTable()
 	assert.NotNil(t, err)
 }
 
@@ -46,7 +46,7 @@ func TestGetAndSetDefaultExperimentId(t *testing.T) {
 	defaultExperimentStore := NewDefaultExperimentStore(db)
 
 	// Initialize for the first time
-	err := defaultExperimentStore.InitializeDefaultExperimentTable()
+	err := defaultExperimentStore.initializeDefaultExperimentTable()
 	assert.Nil(t, err)
 	// Set the default experiment ID
 	err = defaultExperimentStore.SetDefaultExperimentId("test-ID")

--- a/backend/src/apiserver/storage/default_experiment_store_test.go
+++ b/backend/src/apiserver/storage/default_experiment_store_test.go
@@ -1,0 +1,68 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitializeDefaultExperimentTable(t *testing.T) {
+	db := NewFakeDbOrFatal()
+	defaultExperimentStore := NewDefaultExperimentStore(db)
+
+	// Initialize for the first time
+	err := defaultExperimentStore.InitializeDefaultExperimentTable()
+	assert.Nil(t, err)
+	// Initialize again should be no-op and no error
+	err = defaultExperimentStore.InitializeDefaultExperimentTable()
+	assert.Nil(t, err)
+	// Default experiment ID is empty after table initialization
+	defaultExperimentId, err := defaultExperimentStore.GetDefaultExperimentId()
+	assert.Nil(t, err)
+	assert.Equal(t, defaultExperimentId, "")
+
+	// Initializing the table with an invalid DB is an error
+	db.Close()
+	err = defaultExperimentStore.InitializeDefaultExperimentTable()
+	assert.NotNil(t, err)
+}
+
+func TestGetAndSetDefaultExperimentId(t *testing.T) {
+	db := NewFakeDbOrFatal()
+	defaultExperimentStore := NewDefaultExperimentStore(db)
+
+	// Initialize for the first time
+	err := defaultExperimentStore.InitializeDefaultExperimentTable()
+	assert.Nil(t, err)
+	// Set the default experiment ID
+	err = defaultExperimentStore.SetDefaultExperimentId("test-ID")
+	assert.Nil(t, err)
+	// Get the default experiment ID
+	defaultExperimentId, err := defaultExperimentStore.GetDefaultExperimentId()
+	assert.Nil(t, err)
+	assert.Equal(t, defaultExperimentId, "test-ID")
+	// Trying to set the default experiment ID again is an error
+	err = defaultExperimentStore.SetDefaultExperimentId("a-different-ID")
+	assert.NotNil(t, err)
+
+	// Setting or getting the default experiment ID with an invalid DB is an error
+	db.Close()
+	err = defaultExperimentStore.SetDefaultExperimentId("some-ID")
+	assert.NotNil(t, err)
+	_, err = defaultExperimentStore.GetDefaultExperimentId()
+	assert.NotNil(t, err)
+}

--- a/backend/src/apiserver/storage/object_store_util.go
+++ b/backend/src/apiserver/storage/object_store_util.go
@@ -20,9 +20,6 @@ const (
 	pipelineFolder = "pipelines"
 )
 
-// This variable holds the UUID of the default experiment.
-var DefaultExperimentId string
-
 // CreatePipelinePath creates object store path to a pipeline spec.
 func CreatePipelinePath(pipelineID string) string {
 	return path.Join(pipelineFolder, pipelineID)

--- a/backend/src/apiserver/storage/object_store_util.go
+++ b/backend/src/apiserver/storage/object_store_util.go
@@ -20,6 +20,9 @@ const (
 	pipelineFolder = "pipelines"
 )
 
+// This variable holds the UUID of the default experiment.
+var DefaultExperimentId string
+
 // CreatePipelinePath creates object store path to a pipeline spec.
 func CreatePipelinePath(pipelineID string) string {
 	return path.Join(pipelineFolder, pipelineID)

--- a/backend/src/common/util/error.go
+++ b/backend/src/common/util/error.go
@@ -144,6 +144,15 @@ func NewInternalServerError(err error, internalMessageFormat string,
 		codes.Internal)
 }
 
+func NewInternalServerError(err error, internalMessageFormat string,
+	a ...interface{}) *UserError {
+	internalMessage := fmt.Sprintf(internalMessageFormat, a...)
+	return newUserError(
+		errors.Wrapf(err, fmt.Sprintf("InternalServerError: %v", internalMessage)),
+		"Internal Server Error",
+		codes.Internal)
+}
+
 func NewResourceNotFoundError(resourceType string, resourceName string) *UserError {
 	externalMessage := fmt.Sprintf("%s %s not found.", resourceType, resourceName)
 	return newUserError(

--- a/backend/src/common/util/error.go
+++ b/backend/src/common/util/error.go
@@ -144,15 +144,6 @@ func NewInternalServerError(err error, internalMessageFormat string,
 		codes.Internal)
 }
 
-func NewInternalServerError(err error, internalMessageFormat string,
-	a ...interface{}) *UserError {
-	internalMessage := fmt.Sprintf(internalMessageFormat, a...)
-	return newUserError(
-		errors.Wrapf(err, fmt.Sprintf("InternalServerError: %v", internalMessage)),
-		"Internal Server Error",
-		codes.Internal)
-}
-
 func NewResourceNotFoundError(resourceType string, resourceName string) *UserError {
 	externalMessage := fmt.Sprintf("%s %s not found.", resourceType, resourceName)
 	return newUserError(

--- a/backend/test/initialization/BUILD.bazel
+++ b/backend/test/initialization/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "initialization_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//backend/api:go_default_library",
+        "//backend/api/go_http_client/experiment_client/experiment_service:go_default_library",
+        "//backend/src/common/client/api_server:go_default_library",
+        "//backend/test:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//suite:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["flags.go"],
+    importpath = "github.com/kubeflow/pipelines/backend/test/initialization",
+    visibility = ["//visibility:public"],
+)

--- a/backend/test/initialization/flags.go
+++ b/backend/test/initialization/flags.go
@@ -1,0 +1,9 @@
+package initialization
+
+import (
+	"flag"
+	"time"
+)
+
+var namespace = flag.String("namespace", "kubeflow", "The namespace ml pipeline deployed to")
+var initializeTimeout = flag.Duration("initializeTimeout", 2*time.Minute, "Duration to wait for test initialization")

--- a/backend/test/initialization/flags.go
+++ b/backend/test/initialization/flags.go
@@ -7,3 +7,4 @@ import (
 
 var namespace = flag.String("namespace", "kubeflow", "The namespace ml pipeline deployed to")
 var initializeTimeout = flag.Duration("initializeTimeout", 2*time.Minute, "Duration to wait for test initialization")
+var runIntegrationTests = flag.Bool("runIntegrationTests", false, "Whether to also run integration tests that call the service")

--- a/backend/test/initialization/initialization_test.go
+++ b/backend/test/initialization/initialization_test.go
@@ -19,6 +19,11 @@ type InitializationTest struct {
 
 // Check the namespace have ML job installed and ready
 func (s *InitializationTest) SetupTest() {
+	if !*runIntegrationTests {
+		s.T().SkipNow()
+		return
+	}
+
 	err := test.WaitForReady(*namespace, *initializeTimeout)
 	if err != nil {
 		glog.Exitf("Failed to initialize test. Error: %s", err.Error())

--- a/backend/test/initialization/initialization_test.go
+++ b/backend/test/initialization/initialization_test.go
@@ -26,13 +26,13 @@ func (s *InitializationTest) SetupTest() {
 
 	err := test.WaitForReady(*namespace, *initializeTimeout)
 	if err != nil {
-		glog.Exitf("Failed to initialize test. Error: %s", err.Error())
+		glog.Exitf("Failed to initialize test. Error: %v", err)
 	}
 	s.namespace = *namespace
 	clientConfig := test.GetClientConfig(*namespace)
 	s.experimentClient, err = api_server.NewExperimentClient(clientConfig, false)
 	if err != nil {
-		glog.Exitf("Failed to get experiment client. Error: %s", err.Error())
+		glog.Exitf("Failed to get experiment client. Error: %v", err)
 	}
 }
 

--- a/backend/test/initialization/initialization_test.go
+++ b/backend/test/initialization/initialization_test.go
@@ -1,0 +1,50 @@
+package initialization
+
+import (
+	"testing"
+
+	"github.com/golang/glog"
+	params "github.com/kubeflow/pipelines/backend/api/go_http_client/experiment_client/experiment_service"
+	"github.com/kubeflow/pipelines/backend/src/common/client/api_server"
+	"github.com/kubeflow/pipelines/backend/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type InitializationTest struct {
+	suite.Suite
+	namespace        string
+	experimentClient *api_server.ExperimentClient
+}
+
+// Check the namespace have ML job installed and ready
+func (s *InitializationTest) SetupTest() {
+	err := test.WaitForReady(*namespace, *initializeTimeout)
+	if err != nil {
+		glog.Exitf("Failed to initialize test. Error: %s", err.Error())
+	}
+	s.namespace = *namespace
+	clientConfig := test.GetClientConfig(*namespace)
+	s.experimentClient, err = api_server.NewExperimentClient(clientConfig, false)
+	if err != nil {
+		glog.Exitf("Failed to get experiment client. Error: %s", err.Error())
+	}
+}
+
+func (s *InitializationTest) TestInitialization() {
+	t := s.T()
+
+	/* ---------- Verify that only the default experiment exist ---------- */
+	experiments, totalSize, _, err := s.experimentClient.List(&params.ListExperimentParams{})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, totalSize)
+	assert.True(t, len(experiments) == 1)
+	assert.Equal(t, "Default", experiments[0].Name)
+
+	/* ---------- Clean up ---------- */
+	test.DeleteAllExperiments(s.experimentClient, t)
+}
+
+func TestInitialization(t *testing.T) {
+	suite.Run(t, new(InitializationTest))
+}

--- a/backend/test/initialization/initialization_test.go
+++ b/backend/test/initialization/initialization_test.go
@@ -39,7 +39,7 @@ func (s *InitializationTest) SetupTest() {
 func (s *InitializationTest) TestInitialization() {
 	t := s.T()
 
-	/* ---------- Verify that only the default experiment exist ---------- */
+	/* ---------- Verify that only the default experiment exists ---------- */
 	experiments, totalSize, _, err := s.experimentClient.List(&params.ListExperimentParams{})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, totalSize)

--- a/backend/test/integration/experiment_api_test.go
+++ b/backend/test/integration/experiment_api_test.go
@@ -30,13 +30,13 @@ func (s *ExperimentApiTest) SetupTest() {
 
 	err := test.WaitForReady(*namespace, *initializeTimeout)
 	if err != nil {
-		glog.Exitf("Failed to initialize test. Error: %s", err.Error())
+		glog.Exitf("Failed to initialize test. Error: %v", err)
 	}
 	s.namespace = *namespace
 	clientConfig := test.GetClientConfig(*namespace)
 	s.experimentClient, err = api_server.NewExperimentClient(clientConfig, false)
 	if err != nil {
-		glog.Exitf("Failed to get experiment client. Error: %s", err.Error())
+		glog.Exitf("Failed to get experiment client. Error: %v", err)
 	}
 }
 

--- a/backend/test/integration/experiment_api_test.go
+++ b/backend/test/integration/experiment_api_test.go
@@ -36,7 +36,7 @@ func (s *ExperimentApiTest) SetupTest() {
 	clientConfig := test.GetClientConfig(*namespace)
 	s.experimentClient, err = api_server.NewExperimentClient(clientConfig, false)
 	if err != nil {
-		glog.Exitf("Failed to get pipeline upload client. Error: %s", err.Error())
+		glog.Exitf("Failed to get experiment client. Error: %s", err.Error())
 	}
 }
 

--- a/test/api-integration-test/run_test.sh
+++ b/test/api-integration-test/run_test.sh
@@ -22,7 +22,7 @@ NAMESPACE=kubeflow
 usage()
 {
     echo "usage: run_test.sh
-    --results-gcs-dir GCS directory for the test results. Usually gs://<project-id>/<commit-sha>/api_integration_test
+    --results-gcs-dir GCS directory for the test results. Usually gs://<project-id>/<commit-sha>/backend_unit_test
     [--namespace      k8s namespace where ml-pipelines is deployed. The tests run against the instance in this namespace]
     [-h help]"
 }

--- a/test/e2e_test_gke_v2.yaml
+++ b/test/e2e_test_gke_v2.yaml
@@ -27,6 +27,8 @@ spec:
     - name: image-build-context-gcs-uri
     - name: target-image-prefix
     - name: test-results-gcs-dir
+    - name: initialization-test-image-suffix
+      value: initialization_test
     - name: api-integration-test-image-suffix
       value: api_integration_test
     - name: frontend-integration-tests-image-suffix
@@ -43,12 +45,23 @@ spec:
       parameters:
       - name: target-image-prefix
       - name: test-results-gcs-dir
+      - name: initialization-test-image-suffix
       - name: api-integration-test-image-suffix
       - name: frontend-integration-tests-image-suffix
       - name: basic-e2e-tests-image-suffix
       - name: namespace
     steps:
-    - - name: build-api-integration-test-image
+    - - name: build-initialization-test-image
+        template: build-image
+        arguments:
+          parameters:
+          - name: docker-path
+            value: .
+          - name: docker-file
+            value: test/initialization-test/Dockerfile
+          - name: image-name
+            value: "{{inputs.parameters.target-image-prefix}}{{inputs.parameters.initialization-test-image-suffix}}"
+      - name: build-api-integration-test-image
         template: build-image
         arguments:
           parameters:
@@ -76,6 +89,14 @@ spec:
             value: test/sample-test/Dockerfile
           - name: image-name
             value: "{{inputs.parameters.target-image-prefix}}{{inputs.parameters.basic-e2e-tests-image-suffix}}"
+    - - name: run-initialization-tests
+        template: run-initialization-tests
+        arguments:
+          parameters:
+          - name: test-results-gcs-dir
+            value: "{{inputs.parameters.test-results-gcs-dir}}"
+          - name: initialization-test-image
+            value: "{{inputs.parameters.target-image-prefix}}{{inputs.parameters.initialization-test-image-suffix}}"
     - - name: run-api-integration-tests
         template: run-api-integration-tests
         arguments:
@@ -209,6 +230,23 @@ spec:
       securityContext:
         privileged: true
       mirrorVolumeMounts: true
+
+  - name: run-initialization-tests
+    inputs:
+      parameters:
+      - name: test-results-gcs-dir
+      - name: initialization-test-image
+    container:
+      image: "{{inputs.parameters.initialization-test-image}}"
+      args: [
+        "--results-gcs-dir", "{{inputs.parameters.test-results-gcs-dir}}",
+      ]
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /secret/gcp-credentials/user-gcp-sa.json
+      volumeMounts:
+      - name: gcp-credentials
+        mountPath: /secret/gcp-credentials
 
   - name: run-api-integration-tests
     inputs:

--- a/test/initialization-test/Dockerfile
+++ b/test/initialization-test/Dockerfile
@@ -1,0 +1,18 @@
+# This image has the script to kick off the ML pipeline API integration test,
+# and upload the result to GCS
+
+FROM golang:1.11
+
+RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz
+RUN mkdir -p /usr/local/gcloud
+RUN tar -C /usr/local/gcloud -xf /tmp/google-cloud-sdk.tar.gz
+RUN /usr/local/gcloud/google-cloud-sdk/install.sh
+ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
+
+# install go-junit-report. It converts go test result to junit xml.
+RUN go get -u github.com/jstemmer/go-junit-report
+RUN go build github.com/jstemmer/go-junit-report
+
+COPY . /go/src/github.com/kubeflow/pipelines
+
+ENTRYPOINT ["/go/src/github.com/kubeflow/pipelines/test/initialization-test/run_test.sh"]

--- a/test/initialization-test/Dockerfile
+++ b/test/initialization-test/Dockerfile
@@ -1,4 +1,4 @@
-# This image has the script to kick off the ML pipeline API integration test,
+# This image has the script to kick off the ML pipeline initialization test,
 # and upload the result to GCS
 
 FROM golang:1.11

--- a/test/initialization-test/OWNERS
+++ b/test/initialization-test/OWNERS
@@ -1,6 +1,8 @@
 approvers:
   - vicaire
   - IronPan
+  - rileyjbauer
 reviewers:
   - vicaire
   - IronPan
+  - rileyjbauer

--- a/test/initialization-test/OWNERS
+++ b/test/initialization-test/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - vicaire
+  - IronPan
+reviewers:
+  - vicaire
+  - IronPan

--- a/test/initialization-test/run_test.sh
+++ b/test/initialization-test/run_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ NAMESPACE=kubeflow
 usage()
 {
     echo "usage: run_test.sh
-    --results-gcs-dir GCS directory for the test results. Usually gs://<project-id>/<commit-sha>/e2e_test
+    --results-gcs-dir GCS directory for the test results. Usually gs://<project-id>/<commit-sha>/initialization_test
     [--namespace      k8s namespace where ml-pipelines is deployed. The tests run against the instance in this namespace]
     [-h help]"
 }
@@ -49,37 +49,30 @@ if [ -z "$RESULTS_GCS_DIR" ]; then
     exit 1
 fi
 
-# Setup Google Cloud SDK, and use it to install kubectl so it gets the right context
-wget -nv https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip
-unzip -qq google-cloud-sdk.zip -d tools
-rm google-cloud-sdk.zip
-tools/google-cloud-sdk/install.sh --usage-reporting=false \
-  --path-update=false --bash-completion=false \
-  --disable-installation-options
-tools/google-cloud-sdk/bin/gcloud -q components install kubectl
-
 if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
-  tools/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
 fi
 
-npm install
+GITHUB_REPO=kubeflow/pipelines
+BASE_DIR=/go/src/github.com/${GITHUB_REPO}
+JUNIT_TEST_RESULT=junit_InitializationTestOutput.xml
+TEST_DIR=backend/test/initialization
 
-# Port forward the UI so tests can work against localhost
-POD=`/src/tools/google-cloud-sdk/bin/kubectl get pods -n ${NAMESPACE} -l app=ml-pipeline-ui -o jsonpath='{.items[0].metadata.name}'`
-/src/tools/google-cloud-sdk/bin/kubectl port-forward -n ${NAMESPACE} ${POD} 3000:3000 &
+cd "${BASE_DIR}/${TEST_DIR}"
 
-# Run Selenium server
-/opt/bin/entry_point.sh &
-./node_modules/.bin/wait-port 127.0.0.1:4444 -t 20000
-./node_modules/.bin/wait-port 127.0.0.1:3000 -t 20000
+# turn on go module
+export GO111MODULE=on
 
-export PIPELINE_OUTPUT=${RESULTS_GCS_DIR}/pipeline_output
-npm test
+echo "Run Initialization test..."
+TEST_RESULT=`go test -v ./... -namespace ${NAMESPACE} 2>&1`
 TEST_EXIT_CODE=$?
 
-JUNIT_TEST_RESULT=junit_FrontendIntegrationTestOutput.xml
+# Log the test result
+printf '%s\n' "$TEST_RESULT"
+# Convert test result to junit.xml
+printf '%s\n' "$TEST_RESULT" | go-junit-report > ${JUNIT_TEST_RESULT}
 
 echo "Copy test result to GCS ${RESULTS_GCS_DIR}/${JUNIT_TEST_RESULT}"
-tools/google-cloud-sdk/bin/gsutil cp ${JUNIT_TEST_RESULT} ${RESULTS_GCS_DIR}/${JUNIT_TEST_RESULT}
+gsutil cp ${JUNIT_TEST_RESULT} ${RESULTS_GCS_DIR}/${JUNIT_TEST_RESULT}
 
 exit $TEST_EXIT_CODE

--- a/test/initialization-test/run_test.sh
+++ b/test/initialization-test/run_test.sh
@@ -64,7 +64,7 @@ cd "${BASE_DIR}/${TEST_DIR}"
 export GO111MODULE=on
 
 echo "Run Initialization test..."
-TEST_RESULT=`go test -v ./... -namespace ${NAMESPACE} 2>&1`
+TEST_RESULT=`go test -v ./... -namespace ${NAMESPACE} -args -runIntegrationTests=true 2>&1`
 TEST_EXIT_CODE=$?
 
 # Log the test result


### PR DESCRIPTION
This experiment is named `Default` and is used whenever a `CreateRun` request is received without specifying a containing experiment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1089)
<!-- Reviewable:end -->
