### PR TITLE
Retaining the component url, digest or tag when loading

### DIFF
--- a/sdk/python/kfp/components/_component_store.py
+++ b/sdk/python/kfp/components/_component_store.py
@@ -5,6 +5,7 @@ __all__ = [
 from pathlib import Path
 import requests
 from . import _components as comp
+from ._structures import ComponentReference
 
 class ComponentStore:
     def __init__(self, local_search_paths=None, url_search_prefixes=None):
@@ -73,6 +74,7 @@ class ComponentStore:
             component_path = Path(local_search_path, path_suffix)
             tried_locations.append(str(component_path))
             if component_path.is_file():
+                component_ref = ComponentReference(name=name, digest=digest, tag=tag)
                 return comp.load_component_from_file(str(component_path))
 
         #Trying URL prefixes
@@ -85,6 +87,7 @@ class ComponentStore:
             except:
                 continue
             if response.content:
-                return comp._load_component_from_yaml_or_zip_bytes(response.content, url)
+                component_ref = ComponentReference(name=name, digest=digest, tag=tag, url=url)
+                return comp._load_component_from_yaml_or_zip_bytes(response.content, url, component_ref)
 
         raise RuntimeError('Component {} was not found. Tried the following locations:\n{}'.format(name, '\n'.join(tried_locations)))

--- a/sdk/python/kfp/components/_components.py
+++ b/sdk/python/kfp/components/_components.py
@@ -85,7 +85,8 @@ def load_component_from_url(url):
     import requests
     resp = requests.get(url)
     resp.raise_for_status()
-    return _load_component_from_yaml_or_zip_bytes(resp.content, url)
+    component_ref = ComponentReference(url=url)
+    return _load_component_from_yaml_or_zip_bytes(resp.content, url, component_ref)
 
 
 def load_component_from_file(filename):
@@ -124,13 +125,13 @@ def load_component_from_text(text):
 _COMPONENT_FILE_NAME_IN_ARCHIVE = 'component.yaml'
 
 
-def _load_component_from_yaml_or_zip_bytes(bytes, component_filename=None):
+def _load_component_from_yaml_or_zip_bytes(bytes, component_filename=None, component_ref: ComponentReference = None):
     import io
     component_stream = io.BytesIO(bytes)
-    return _load_component_from_yaml_or_zip_stream(component_stream, component_filename)
+    return _load_component_from_yaml_or_zip_stream(component_stream, component_filename, component_ref)
 
 
-def _load_component_from_yaml_or_zip_stream(stream, component_filename=None):
+def _load_component_from_yaml_or_zip_stream(stream, component_filename=None, component_ref: ComponentReference = None):
     '''Loads component from a stream and creates a task factory function.
     The stream can be YAML or a zip file with a component.yaml file inside.
     '''
@@ -140,20 +141,20 @@ def _load_component_from_yaml_or_zip_stream(stream, component_filename=None):
         stream.seek(0)
         with zipfile.ZipFile(stream) as zip_obj:
             with zip_obj.open(_COMPONENT_FILE_NAME_IN_ARCHIVE) as component_stream:
-                return _create_task_factory_from_component_text(component_stream, component_filename)
+                return _create_task_factory_from_component_text(component_stream, component_filename, component_ref)
     else:
         stream.seek(0)
-        return _create_task_factory_from_component_text(stream, component_filename)
+        return _create_task_factory_from_component_text(stream, component_filename, component_ref)
 
 
-def _create_task_factory_from_component_text(text_or_file, component_filename=None):
+def _create_task_factory_from_component_text(text_or_file, component_filename=None, component_ref: ComponentReference = None):
     component_dict = load_yaml(text_or_file)
-    return _create_task_factory_from_component_dict(component_dict, component_filename)
+    return _create_task_factory_from_component_dict(component_dict, component_filename, component_ref)
 
 
-def _create_task_factory_from_component_dict(component_dict, component_filename=None):
+def _create_task_factory_from_component_dict(component_dict, component_filename=None, component_ref: ComponentReference = None):
     component_spec = ComponentSpec.from_struct(component_dict)
-    return _create_task_factory_from_component_spec(component_spec, component_filename)
+    return _create_task_factory_from_component_spec(component_spec, component_filename, component_ref)
 
 
 _inputs_dir = '/inputs'


### PR DESCRIPTION
Currently this information is not passed through and is lost after loading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1090)
<!-- Reviewable:end -->
