### PR TITLE
Stabilized the artifact ordering during the compilation

### DIFF
--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import re
+from collections import OrderedDict
 from typing import Union, List, Any, Callable, TypeVar, Dict
 
 from ._k8s_helper import K8sHelper
@@ -176,7 +177,7 @@ def _op_to_template(op: dsl.ContainerOp):
     processed_op = _process_container_ops(op)
 
     # default output artifacts
-    output_artifact_paths = {}
+    output_artifact_paths = OrderedDict()
     output_artifact_paths.setdefault('mlpipeline-ui-metadata', '/mlpipeline-ui-metadata.json')
     output_artifact_paths.setdefault('mlpipeline-metrics', '/mlpipeline-metrics.json')
 


### PR DESCRIPTION
This change makes the order of output artifacts stable in Python 3.5.
The sample test seems to be relying on the artifact ordering (it tries to read the first artifact without looking at the name).
With this change the order is always the preserved and stable.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1097)
<!-- Reviewable:end -->
