### PR TITLE
SDK - Simplified the @pipeline decorator

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -24,7 +24,7 @@ from .. import dsl
 from ._k8s_helper import K8sHelper
 from ._op_to_template import _op_to_template
 
-from ..dsl._metadata import TypeMeta, _create_pipeline_metadata_from_pipeline_func
+from ..dsl._metadata import TypeMeta, _extract_pipeline_metadata
 from ..dsl._ops_group import OpsGroup
 
 class Compiler(object):
@@ -575,7 +575,7 @@ class Compiler(object):
 
     # Create the arg list with no default values and call pipeline function.
     # Assign type information to the PipelineParam
-    pipeline_meta = _create_pipeline_metadata_from_pipeline_func(pipeline_func)
+    pipeline_meta = _extract_pipeline_metadata(pipeline_func)
     pipeline_name = K8sHelper.sanitize_k8s_name(pipeline_meta.name)
 
     args_list = []

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -24,7 +24,7 @@ from .. import dsl
 from ._k8s_helper import K8sHelper
 from ._op_to_template import _op_to_template
 
-from ..dsl._metadata import TypeMeta
+from ..dsl._metadata import TypeMeta, _create_pipeline_metadata_from_pipeline_func
 from ..dsl._ops_group import OpsGroup
 
 class Compiler(object):
@@ -573,16 +573,11 @@ class Compiler(object):
 
     argspec = inspect.getfullargspec(pipeline_func)
 
-    registered_pipeline_functions = dsl.Pipeline.get_pipeline_functions()
-    if pipeline_func not in registered_pipeline_functions:
-      raise ValueError('Please use a function with @dsl.pipeline decorator.')
-
-    pipeline_name = dsl.Pipeline.get_pipeline_functions()[pipeline_func].name
-    pipeline_name = K8sHelper.sanitize_k8s_name(pipeline_name)
-
     # Create the arg list with no default values and call pipeline function.
     # Assign type information to the PipelineParam
-    pipeline_meta = dsl.Pipeline.get_pipeline_functions()[pipeline_func]
+    pipeline_meta = _create_pipeline_metadata_from_pipeline_func(pipeline_func)
+    pipeline_name = K8sHelper.sanitize_k8s_name(pipeline_meta.name)
+
     args_list = []
     for arg_name in argspec.args:
       arg_type = TypeMeta()

--- a/sdk/python/kfp/compiler/main.py
+++ b/sdk/python/kfp/compiler/main.py
@@ -53,7 +53,7 @@ def parse_arguments():
 
 def _compile_pipeline_function(function_name, output_path, type_check):
 
-  pipeline_funcs = list(dsl.Pipeline.get_pipeline_functions().keys())
+  pipeline_funcs = dsl.Pipeline.get_pipeline_functions()
   if len(pipeline_funcs) == 0:
     raise ValueError('A function with @dsl.pipeline decorator is required in the py file.')
 

--- a/sdk/python/kfp/dsl/_metadata.py
+++ b/sdk/python/kfp/dsl/_metadata.py
@@ -152,3 +152,34 @@ def _annotation_to_typemeta(annotation):
   else:
     return TypeMeta()
   return arg_type
+
+def _create_pipeline_metadata_from_pipeline_func(func):
+  import inspect
+  fullargspec = inspect.getfullargspec(func)
+  args = fullargspec.args
+  annotations = fullargspec.annotations
+
+  # defaults
+  arg_defaults = {}
+  if fullargspec.defaults:
+    for arg, default in zip(reversed(fullargspec.args), reversed(fullargspec.defaults)):
+      arg_defaults[arg] = default
+
+  # Construct the PipelineMeta
+  pipeline_meta = PipelineMeta(
+    name=getattr(func, '_pipeline_name', func.__name__),
+    description=getattr(func, '_pipeline_description', func.__doc__)
+  )
+  # Inputs
+  for arg in args:
+    arg_type = TypeMeta()
+    arg_default = arg_defaults[arg] if arg in arg_defaults else None
+    if arg in annotations:
+      arg_type = _annotation_to_typemeta(annotations[arg])
+    pipeline_meta.inputs.append(ParameterMeta(name=arg, description='', param_type=arg_type, default=arg_default))
+
+  #TODO: add descriptions to the metadata
+  #docstring parser:
+  #  https://github.com/rr-/docstring_parser
+  #  https://github.com/terrencepreilly/darglint/blob/master/darglint/parse.py
+  return pipeline_meta

--- a/sdk/python/kfp/dsl/_metadata.py
+++ b/sdk/python/kfp/dsl/_metadata.py
@@ -153,7 +153,9 @@ def _annotation_to_typemeta(annotation):
     return TypeMeta()
   return arg_type
 
-def _create_pipeline_metadata_from_pipeline_func(func):
+def _extract_pipeline_metadata(func):
+  '''Creates pipeline metadata structure instance based on the function signature.'''
+
   import inspect
   fullargspec = inspect.getfullargspec(func)
   args = fullargspec.args

--- a/sdk/python/tests/dsl/pipeline_tests.py
+++ b/sdk/python/tests/dsl/pipeline_tests.py
@@ -14,7 +14,7 @@
 
 import kfp
 from kfp.dsl import Pipeline, PipelineParam, ContainerOp, pipeline
-from kfp.dsl._metadata import PipelineMeta, ParameterMeta, TypeMeta, _create_pipeline_metadata_from_pipeline_func
+from kfp.dsl._metadata import PipelineMeta, ParameterMeta, TypeMeta, _extract_pipeline_metadata
 from kfp.dsl.types import GCSPath, Integer
 import unittest
 
@@ -73,5 +73,5 @@ class TestPipeline(unittest.TestCase):
     golden_meta.inputs.append(ParameterMeta(name='a', description='', param_type=TypeMeta(name='Schema', properties={'file_type': 'csv'}), default='good'))
     golden_meta.inputs.append(ParameterMeta(name='b', description='', param_type=TypeMeta(name='Integer'), default=12))
 
-    pipeline_meta = _create_pipeline_metadata_from_pipeline_func(my_pipeline1)
+    pipeline_meta = _extract_pipeline_metadata(my_pipeline1)
     self.assertEqual(pipeline_meta, golden_meta)

--- a/sdk/python/tests/dsl/pipeline_tests.py
+++ b/sdk/python/tests/dsl/pipeline_tests.py
@@ -14,7 +14,7 @@
 
 import kfp
 from kfp.dsl import Pipeline, PipelineParam, ContainerOp, pipeline
-from kfp.dsl._metadata import PipelineMeta, ParameterMeta, TypeMeta
+from kfp.dsl._metadata import PipelineMeta, ParameterMeta, TypeMeta, _create_pipeline_metadata_from_pipeline_func
 from kfp.dsl.types import GCSPath, Integer
 import unittest
 
@@ -55,10 +55,10 @@ class TestPipeline(unittest.TestCase):
     def my_pipeline2():
       pass
     
-    self.assertEqual('p1', Pipeline.get_pipeline_functions()[my_pipeline1].name)
-    self.assertEqual('description1', Pipeline.get_pipeline_functions()[my_pipeline1].description)
-    self.assertEqual('p2', Pipeline.get_pipeline_functions()[my_pipeline2].name)
-    self.assertEqual('description2', Pipeline.get_pipeline_functions()[my_pipeline2].description)
+    self.assertEqual(my_pipeline1._pipeline_name, 'p1')
+    self.assertEqual(my_pipeline2._pipeline_name, 'p2')
+    self.assertEqual(my_pipeline1._pipeline_description, 'description1')
+    self.assertEqual(my_pipeline2._pipeline_description, 'description2')
 
   def test_decorator_metadata(self):
     """Test @pipeline decorator with metadata."""
@@ -73,5 +73,5 @@ class TestPipeline(unittest.TestCase):
     golden_meta.inputs.append(ParameterMeta(name='a', description='', param_type=TypeMeta(name='Schema', properties={'file_type': 'csv'}), default='good'))
     golden_meta.inputs.append(ParameterMeta(name='b', description='', param_type=TypeMeta(name='Integer'), default=12))
 
-    pipeline_meta = Pipeline.get_pipeline_functions()[my_pipeline1]
+    pipeline_meta = _create_pipeline_metadata_from_pipeline_func(my_pipeline1)
     self.assertEqual(pipeline_meta, golden_meta)


### PR DESCRIPTION
Moved metadata-related code to _metadata.
`Pipeline.get_pipeline_functions` now returns the list of pipeline functions.
Now the pipeline name, description and other metadata is passed directly with the pipeline instead of a using global variables.

(The global pipeline list is still used by the command-line compiler.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1120)
<!-- Reviewable:end -->
