### PR TITLE
Expose service-type as parameter

### DIFF
--- a/components/kubeflow/deployer/component.yaml
+++ b/components/kubeflow/deployer/component.yaml
@@ -6,6 +6,7 @@ inputs:
   - {name: Namespace,     type: String, default: 'kubeflow',      description: 'Kubernetes namespace where the TS-serving service should be deployed.'}
   - {name: Server name,   type: String, default: 'model-server',  description: 'TF-serving server name to use when deploying.'}
   - {name: PVC name,      type: String, default: '' ,             description: 'Optional PersistentVolumeClaim to use.'}
+  - {name: Service Type,  type: String, default: '' ,             description: 'Optional Service type to use, two options: "ClusterIP"(default if not set) and "NodePort".'}
 #outputs:
 #  - {name: Endppoint URI, type: Serving URI,                      description: 'URI of the deployed prediction service..'}
 implementation:
@@ -18,4 +19,5 @@ implementation:
       --namespace,          {inputValue: Namespace},
       --server-name,        {inputValue: Server name},
       --pvc-name,           {inputValue: PVC name},
+      --service-type,       {inputValue: Service type},
     ]

--- a/components/kubeflow/deployer/src/deploy.sh
+++ b/components/kubeflow/deployer/src/deploy.sh
@@ -46,6 +46,11 @@ while (($#)); do
        PVC_NAME="$1"
        shift
        ;;
+     "--service-type")
+       shift
+       SERVICE_TYPE="$1"
+       shift
+       ;;
      *)
        echo "Unknown argument: '$1'"
        exit 1
@@ -99,6 +104,11 @@ ks pkg install kubeflow/tf-serving@${KUBEFLOW_VERSION}
 echo "Generating the TF Serving config..."
 ks generate tf-serving server --name="${SERVER_NAME}"
 ks param set server modelPath "${MODEL_EXPORT_PATH}"
+
+# service type: ClusterIP or NodePort
+if [ -n "${SERVICE_TYPE}" ];then
+  ks param set server serviceType "${SERVICE_TYPE}"
+fi
 
 # support local storage to deploy tf-serving.
 if [ -n "${PVC_NAME}" ];then


### PR DESCRIPTION
Expose the "service-type" parameter, then user can define it as "ClusterIP" or "NodePort"
I check the code of "kubeflow/kubeflow/tf-serving/", that model has already support that in v0.4.0, so we just need expose it, it could work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1136)
<!-- Reviewable:end -->
