### PR TITLE
Set run model default timestamp to 0

### DIFF
--- a/backend/src/apiserver/model/run.go
+++ b/backend/src/apiserver/model/run.go
@@ -20,10 +20,10 @@ type Run struct {
 	Name               string `gorm:"column:Name; not null;"`        /* The name of the K8s resource. Follow regex '[a-z0-9]([-a-z0-9]*[a-z0-9])?'*/
 	StorageState       string `gorm:"column:StorageState; not null;"`
 	Namespace          string `gorm:"column:Namespace; not null;"`
-	Description        string `gorm:"column:Description; not null"`
-	CreatedAtInSec     int64  `gorm:"column:CreatedAtInSec; not null"`
-	ScheduledAtInSec   int64  `gorm:"column:ScheduledAtInSec;"`
-	FinishedAtInSec    int64  `gorm:"column:FinishedAtInSec;"`
+	Description        string `gorm:"column:Description; not null;"`
+	CreatedAtInSec     int64  `gorm:"column:CreatedAtInSec; not null;"`
+	ScheduledAtInSec   int64  `gorm:"column:ScheduledAtInSec; default:0;"`
+	FinishedAtInSec    int64  `gorm:"column:FinishedAtInSec; default:0;"`
 	Conditions         string `gorm:"column:Conditions; not null"`
 	Metrics            []*RunMetric
 	ResourceReferences []*ResourceReference


### PR DESCRIPTION
Without setting to 0, the finished at field could be null if the argo workflow is already evicted from the cluster. 
This result in errors parsing the table. 

Alternatively we can use sql.NullInt64 type to parse the sql but that's less elegant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1140)
<!-- Reviewable:end -->
