### PR TITLE
Removes unnecessary API calls

### DIFF
--- a/frontend/src/apis/run/api.ts
+++ b/frontend/src/apis/run/api.ts
@@ -341,6 +341,12 @@ export interface ApiRun {
      */
     scheduled_at?: Date;
     /**
+     * Output. When this run is finished.
+     * @type {Date}
+     * @memberof ApiRun
+     */
+    finished_at?: Date;
+    /**
      * 
      * @type {string}
      * @memberof ApiRun
@@ -445,7 +451,7 @@ export interface ApiStatus {
  */
 export interface ProtobufAny {
     /**
-     * A URL/resource name that uniquely identifies the type of the serialized protocol buffer message. This string must contain at least one \"/\" character. The last segment of the URL's path must represent the fully qualified name of the type (as in `path/google.protobuf.Duration`). The name should be in a canonical form (e.g., leading \".\" is not accepted).  In practice, teams usually precompile into the binary all types that they expect it to use in the context of Any. However, for URLs which use the scheme `http`, `https`, or no scheme, one can optionally set up a type server that maps type URLs to message definitions as follows:  * If no scheme is provided, `https` is assumed. * An HTTP GET on the URL must yield a [google.protobuf.Type][]   value in binary format, or produce an error. * Applications are allowed to cache lookup results based on the   URL, or have them precompiled into a binary to avoid any   lookup. Therefore, binary compatibility needs to be preserved   on changes to types. (Use versioned type names to manage   breaking changes.)  Note: this functionality is not currently available in the official protobuf release, and it is not used for type URLs beginning with type.googleapis.com.  Schemes other than `http`, `https` (or the empty scheme) might be used with implementation specific semantics.
+     * A URL/resource name that uniquely identifies the type of the serialized protocol buffer message. The last segment of the URL's path must represent the fully qualified name of the type (as in `path/google.protobuf.Duration`). The name should be in a canonical form (e.g., leading \".\" is not accepted).  In practice, teams usually precompile into the binary all types that they expect it to use in the context of Any. However, for URLs which use the scheme `http`, `https`, or no scheme, one can optionally set up a type server that maps type URLs to message definitions as follows:  * If no scheme is provided, `https` is assumed. * An HTTP GET on the URL must yield a [google.protobuf.Type][]   value in binary format, or produce an error. * Applications are allowed to cache lookup results based on the   URL, or have them precompiled into a binary to avoid any   lookup. Therefore, binary compatibility needs to be preserved   on changes to types. (Use versioned type names to manage   breaking changes.)  Note: this functionality is not currently available in the official protobuf release, and it is not used for type URLs beginning with type.googleapis.com.  Schemes other than `http`, `https` (or the empty scheme) might be used with implementation specific semantics.
      * @type {string}
      * @memberof ProtobufAny
      */

--- a/frontend/src/lib/Utils.test.ts
+++ b/frontend/src/lib/Utils.test.ts
@@ -18,7 +18,8 @@ import {
   logger,
   formatDateString,
   enabledDisplayString,
-  getRunTime,
+  getRunDuration,
+  getRunDurationFromWorkflow,
 } from './Utils';
 
 describe('Utils', () => {
@@ -77,99 +78,147 @@ describe('Utils', () => {
     });
   });
 
-  describe('getRunTime', () => {
+  describe('getRunDuration', () => {
+    it('handles no run', () => {
+      expect(getRunDuration()).toBe('-');
+    });
+
+    it('handles no status', () => {
+      const run = {} as any;
+      expect(getRunDuration(run)).toBe('-');
+    });
+
+    it('handles no created_at', () => {
+      const run = {
+        finished_at: 'some end',
+      } as any;
+      expect(getRunDuration(run)).toBe('-');
+    });
+
+    it('handles no finished_at', () => {
+      const run = {
+        created_at: 'some start',
+      } as any;
+      expect(getRunDuration(run)).toBe('-');
+    });
+
+    it('computes seconds', () => {
+      const run = {
+        created_at: new Date(2018, 1, 2, 3, 55, 30).toISOString(),
+        finished_at: new Date(2018, 1, 3, 3, 56, 25).toISOString(),
+      } as any;
+      expect(getRunDuration(run)).toBe('0:00:55');
+    });
+
+    it('computes minutes/seconds', () => {
+      const run = {
+        created_at: new Date(2018, 1, 2, 3, 55, 10).toISOString(),
+        finished_at: new Date(2018, 1, 3, 3, 59, 25).toISOString(),
+      } as any;
+      expect(getRunDuration(run)).toBe('0:04:15');
+    });
+
+    it('computes days/minutes/seconds', () => {
+      const run = {
+        created_at: new Date(2018, 1, 2, 3, 55, 10).toISOString(),
+        finished_at: new Date(2018, 1, 3, 4, 55, 10).toISOString(),
+      } as any;
+      expect(getRunDuration(run)).toBe('1:00:00');
+    });
+
+    it('computes padded days/minutes/seconds', () => {
+      const run = {
+        created_at: new Date(2018, 1, 2, 3, 55, 10).toISOString(),
+        finished_at: new Date(2018, 1, 3, 4, 56, 11).toISOString(),
+      } as any;
+      expect(getRunDuration(run)).toBe('1:01:01');
+    });
+
+    it('shows negative sign if start date is after end date', () => {
+      const run = {
+        created_at: new Date(2018, 1, 2, 3, 55, 13).toISOString(),
+        finished_at: new Date(2018, 1, 2, 3, 55, 11).toISOString(),
+      } as any;
+      expect(getRunDuration(run)).toBe('-0:00:02');
+    });
+  });
+
+  describe('getRunDurationFromWorkflow', () => {
     it('handles no workflow', () => {
-      expect(getRunTime()).toBe('-');
+      expect(getRunDurationFromWorkflow()).toBe('-');
     });
 
     it('handles no status', () => {
       const workflow = {} as any;
-      expect(getRunTime(workflow)).toBe('-');
-    });
-
-    it('handles no phase', () => {
-      const workflow = {
-        status: {
-          finishedAt: 'some end',
-          startedAt: 'some start',
-        }
-      } as any;
-      expect(getRunTime(workflow)).toBe('-');
+      expect(getRunDurationFromWorkflow(workflow)).toBe('-');
     });
 
     it('handles no start date', () => {
       const workflow = {
         status: {
           finishedAt: 'some end',
-          phase: 'Succeeded',
         }
       } as any;
-      expect(getRunTime(workflow)).toBe('-');
+      expect(getRunDurationFromWorkflow(workflow)).toBe('-');
     });
 
     it('handles no end date', () => {
       const workflow = {
         status: {
-          phase: 'Succeeded',
           startedAt: 'some end',
         }
       } as any;
-      expect(getRunTime(workflow)).toBe('-');
+      expect(getRunDurationFromWorkflow(workflow)).toBe('-');
     });
 
     it('computes seconds run time if status is provided', () => {
       const workflow = {
         status: {
           finishedAt: new Date(2018, 1, 3, 3, 56, 25).toISOString(),
-          phase: 'Succeeded',
           startedAt: new Date(2018, 1, 2, 3, 55, 30).toISOString(),
         }
       } as any;
-      expect(getRunTime(workflow)).toBe('0:00:55');
+      expect(getRunDurationFromWorkflow(workflow)).toBe('0:00:55');
     });
 
     it('computes minutes/seconds run time if status is provided', () => {
       const workflow = {
         status: {
           finishedAt: new Date(2018, 1, 3, 3, 59, 25).toISOString(),
-          phase: 'Succeeded',
           startedAt: new Date(2018, 1, 2, 3, 55, 10).toISOString(),
         }
       } as any;
-      expect(getRunTime(workflow)).toBe('0:04:15');
+      expect(getRunDurationFromWorkflow(workflow)).toBe('0:04:15');
     });
 
     it('computes days/minutes/seconds run time if status is provided', () => {
       const workflow = {
         status: {
           finishedAt: new Date(2018, 1, 3, 4, 55, 10).toISOString(),
-          phase: 'Succeeded',
           startedAt: new Date(2018, 1, 2, 3, 55, 10).toISOString(),
         }
       } as any;
-      expect(getRunTime(workflow)).toBe('1:00:00');
+      expect(getRunDurationFromWorkflow(workflow)).toBe('1:00:00');
     });
 
     it('computes padded days/minutes/seconds run time if status is provided', () => {
       const workflow = {
         status: {
           finishedAt: new Date(2018, 1, 3, 4, 56, 11).toISOString(),
-          phase: 'Succeeded',
           startedAt: new Date(2018, 1, 2, 3, 55, 10).toISOString(),
         }
       } as any;
-      expect(getRunTime(workflow)).toBe('1:01:01');
+      expect(getRunDurationFromWorkflow(workflow)).toBe('1:01:01');
     });
 
     it('shows negative sign if start date is after end date', () => {
       const workflow = {
         status: {
           finishedAt: new Date(2018, 1, 2, 3, 55, 11).toISOString(),
-          phase: 'Succeeded',
           startedAt: new Date(2018, 1, 2, 3, 55, 13).toISOString(),
         }
       } as any;
-      expect(getRunTime(workflow)).toBe('-0:00:02');
+      expect(getRunDurationFromWorkflow(workflow)).toBe('-0:00:02');
     });
   });
 });

--- a/frontend/src/lib/Utils.ts
+++ b/frontend/src/lib/Utils.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { Workflow } from '../../third_party/argo-ui/argo_template';
+import { ApiRun } from '../apis/run';
 import { ApiTrigger } from '../apis/job';
+import { Workflow } from '../../third_party/argo-ui/argo_template';
 import { isFunction } from 'lodash';
 
 export const logger = {
@@ -57,17 +58,8 @@ export function enabledDisplayString(trigger: ApiTrigger | undefined, enabled: b
   return '-';
 }
 
-export function getRunTime(workflow?: Workflow): string {
-  if (!workflow
-    || !workflow.status
-    || !workflow.status.phase
-    || !workflow.status.startedAt
-    || !workflow.status.finishedAt) {
-    return '-';
-  }
-
-  let diff = new Date(workflow.status.finishedAt).getTime()
-    - new Date(workflow.status.startedAt).getTime();
+function getDuration(start: Date, end: Date): string {
+  let diff = end.getTime() - start.getTime();
   const sign = diff < 0 ? '-' : '';
   if (diff < 0) {
     diff *= -1;
@@ -80,6 +72,28 @@ export function getRunTime(workflow?: Workflow): string {
   // Hours are the largest denomination, so we don't pad them
   const hours = Math.floor((diff / HOUR) % 24).toString();
   return `${sign}${hours}:${minutes}:${seconds}`;
+}
+
+export function getRunDuration(run?: ApiRun): string {
+  if (!run || !run.created_at || !run.finished_at) {
+    return '-';
+  }
+
+  // A bug in swagger-codegen causes the API to indicate that created_at and finished_at are Dates,
+  // as they should be, when in reality they are transferred as strings.
+  // See: https://github.com/swagger-api/swagger-codegen/issues/2776
+  return getDuration(new Date(run.created_at), new Date(run.finished_at));
+}
+
+export function getRunDurationFromWorkflow(workflow?: Workflow): string {
+  if (!workflow
+    || !workflow.status
+    || !workflow.status.startedAt
+    || !workflow.status.finishedAt) {
+    return '-';
+  }
+
+  return getDuration(new Date(workflow.status.startedAt), new Date(workflow.status.finishedAt));
 }
 
 export function s(items: any[] | number): string {

--- a/frontend/src/pages/ExperimentDetails.test.tsx
+++ b/frontend/src/pages/ExperimentDetails.test.tsx
@@ -335,7 +335,7 @@ describe('ExperimentDetails', () => {
       { id: 'run-1-id', name: 'run-1' },
       { id: 'run-2-id', name: 'run-2' },
     ];
-    listRunsSpy.mockImplementationOnce(() => ({ runs }));
+    listRunsSpy.mockImplementation(() => ({ runs }));
     await listRunsSpy;
 
     tree = TestUtils.mountWithRouter(<ExperimentDetails {...generateProps()} />);
@@ -383,7 +383,7 @@ describe('ExperimentDetails', () => {
 
   it('supports cloning a selected run', async () => {
     const runs = [{ id: 'run-1-id', name: 'run-1' }];
-    listRunsSpy.mockImplementationOnce(() => ({ runs }));
+    listRunsSpy.mockImplementation(() => ({ runs }));
     await listRunsSpy;
 
     tree = TestUtils.mountWithRouter(<ExperimentDetails {...generateProps()} />);

--- a/frontend/src/pages/ExperimentDetails.tsx
+++ b/frontend/src/pages/ExperimentDetails.tsx
@@ -197,7 +197,7 @@ class ExperimentDetails extends Page<{}, ExperimentDetailsState> {
             </div>
             <Toolbar {...this.state.runListToolbarProps} />
             <RunList onError={this.showPageError.bind(this)}
-              experimentIdMask={experiment.id} ref={this._runlistRef}
+              hideExperimentColumn={true} experimentIdMask={experiment.id} ref={this._runlistRef}
               selectedIds={this.state.selectedIds} storageState={RunStorageState.AVAILABLE}
               onSelectionChange={this._selectionChanged.bind(this)} {...this.props} />
 

--- a/frontend/src/pages/ExperimentList.test.tsx
+++ b/frontend/src/pages/ExperimentList.test.tsx
@@ -31,6 +31,8 @@ import { range } from 'lodash';
 describe('ExperimentList', () => {
   let tree: ShallowWrapper | ReactWrapper;
 
+  jest.spyOn(console, 'log').mockImplementation(() => null);
+
   const updateBannerSpy = jest.fn();
   const updateDialogSpy = jest.fn();
   const updateSnackbarSpy = jest.fn();
@@ -229,9 +231,9 @@ describe('ExperimentList', () => {
 
   it('renders a list of runs for given experiment', async () => {
     tree = shallow(<ExperimentList {...generateProps()} />);
-    tree.setState({ displayExperiments: [{ last5Runs: [{ id: 'run1id' }, { id: 'run2id' }] }] });
+    tree.setState({ displayExperiments: [{ id: 'experiment1', last5Runs: [{ id: 'run1id' }, { id: 'run2id' }] }] });
     const runListTree = (tree.instance() as any)._getExpandedExperimentComponent(0);
-    expect(runListTree.props.runIdListMask).toEqual(['run1id', 'run2id']);
+    expect(runListTree.props.experimentIdMask).toEqual('experiment1');
   });
 
   it('navigates to new experiment page when Create experiment button is clicked', async () => {

--- a/frontend/src/pages/ExperimentList.tsx
+++ b/frontend/src/pages/ExperimentList.tsx
@@ -210,8 +210,7 @@ class ExperimentList extends Page<{}, ExperimentListState> {
 
   private _getExpandedExperimentComponent(experimentIndex: number): JSX.Element {
     const experiment = this.state.displayExperiments[experimentIndex];
-    const runIds = (experiment.last5Runs || []).map((r) => r.id!);
-    return <RunList runIdListMask={runIds} onError={() => null} {...this.props}
+    return <RunList hideExperimentColumn={true} experimentIdMask={experiment.id} onError={() => null} {...this.props}
       disablePaging={true} selectedIds={this.state.selectedIds} noFilterBox={true}
       storageState={RunStorageState.AVAILABLE}
       onSelectionChange={this._selectionChanged.bind(this)} disableSorting={true} />;

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -43,7 +43,7 @@ import { classes, stylesheet } from 'typestyle';
 import { commonCss, padding, color, fonts, fontsize } from '../Css';
 import { componentMap } from '../components/viewers/ViewerContainer';
 import { flatten } from 'lodash';
-import { formatDateString, getRunTime, logger, errorToMessage } from '../lib/Utils';
+import { formatDateString, getRunDurationFromWorkflow, logger, errorToMessage } from '../lib/Utils';
 
 enum SidePaneTab {
   ARTIFACTS,
@@ -464,7 +464,7 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
       ['Created at', workflow.metadata ? formatDateString(workflow.metadata.creationTimestamp) : '-'],
       ['Started at', formatDateString(workflow.status.startedAt)],
       ['Finished at', formatDateString(workflow.status.finishedAt)],
-      ['Duration', getRunTime(workflow)],
+      ['Duration', getRunDurationFromWorkflow(workflow)],
     ];
   }
 

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -17,16 +17,15 @@
 import * as React from 'react';
 import CustomTable, { Column, Row, CustomRendererProps } from '../components/CustomTable';
 import RunUtils, { MetricMetadata } from '../../src/lib/RunUtils';
-import { ApiRunDetail, ApiRun, ApiResourceType, RunMetricFormat, ApiRunMetric, RunStorageState } from '../../src/apis/run';
+import { ApiRun, ApiResourceType, RunMetricFormat, ApiRunMetric, RunStorageState, ApiRunDetail } from '../../src/apis/run';
 import { Apis, RunSortKeys, ListRequest } from '../lib/Apis';
 import { Link, RouteComponentProps } from 'react-router-dom';
 import { NodePhase, statusToIcon } from './Status';
 import { PredicateOp, ApiFilter } from '../apis/filter';
 import { RoutePage, RouteParams, QUERY_PARAMS } from '../components/Router';
 import { URLParser } from '../lib/URLParser';
-import { Workflow } from '../../../frontend/third_party/argo-ui/argo_template';
 import { commonCss, color } from '../Css';
-import { getRunTime, formatDateString, logger, errorToMessage } from '../lib/Utils';
+import { formatDateString, logger, errorToMessage, getRunDuration } from '../lib/Utils';
 import { stylesheet } from 'typestyle';
 
 const css = stylesheet({
@@ -59,9 +58,8 @@ interface PipelineInfo {
 
 interface DisplayRun {
   experiment?: ExperimentInfo;
-  metadata: ApiRun;
+  run: ApiRun;
   pipeline?: PipelineInfo;
-  workflow?: Workflow;
   error?: string;
 }
 
@@ -75,6 +73,7 @@ export interface RunListProps extends RouteComponentProps {
   disableSelection?: boolean;
   disableSorting?: boolean;
   experimentIdMask?: string;
+  hideExperimentColumn?: boolean;
   noFilterBox?: boolean;
   onError: (message: string, error: Error) => void;
   onSelectionChange?: (selectedRunIds: string[]) => void;
@@ -112,10 +111,13 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
       },
       { customRenderer: this._statusCustomRenderer, flex: 0.5, label: 'Status' },
       { label: 'Duration', flex: 0.5 },
-      { customRenderer: this._experimentCustomRenderer, label: 'Experiment', flex: 1 },
       { customRenderer: this._pipelineCustomRenderer, label: 'Pipeline', flex: 1 },
       { label: 'Start time', flex: 1, sortKey: RunSortKeys.CREATED_AT },
     ];
+
+    if (!this.props.hideExperimentColumn) {
+      columns.splice(3, 0, { customRenderer: this._experimentCustomRenderer, label: 'Experiment', flex: 1 });
+    }
 
     if (metricMetadata.length) {
       // This is a column of empty cells with a left border to separate the metrics from the other
@@ -138,8 +140,8 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
     const rows: Row[] = this.state.runs.map(r => {
       const displayMetrics = metricMetadata.map(metadata => {
         const displayMetric: DisplayMetric = { metadata };
-        if (r.metadata.metrics) {
-          const foundMetric = r.metadata.metrics.find(m => m.name === metadata.name);
+        if (r.run.metrics) {
+          const foundMetric = r.run.metrics.find(m => m.name === metadata.name);
           if (foundMetric && foundMetric.number_value !== undefined) {
             displayMetric.metric = foundMetric;
           }
@@ -148,16 +150,18 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
       });
       const row = {
         error: r.error,
-        id: r.metadata.id!,
+        id: r.run.id!,
         otherFields: [
-          r.metadata!.name,
-          r.metadata.status || '-',
-          getRunTime(r.workflow),
-          r.experiment,
+          r.run!.name,
+          r.run.status || '-',
+          getRunDuration(r.run),
           r.pipeline,
-          formatDateString(r.metadata.created_at),
-        ]
+          formatDateString(r.run.created_at),
+        ] as any,
       };
+      if (!this.props.hideExperimentColumn) {
+        row.otherFields.splice(3, 0, r.experiment);
+      }
       if (displayMetrics.length) {
         row.otherFields.push(''); // Metric buffer column
         row.otherFields.push(...displayMetrics as any);
@@ -292,7 +296,10 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
     let nextPageToken = '';
 
     if (Array.isArray(this.props.runIdListMask)) {
-      displayRuns = this.props.runIdListMask.map(id => ({ metadata: { id } }));
+      displayRuns = this.props.runIdListMask.map(id => ({ run: { id } }));
+      // listRuns doesn't currently support batching by IDs, so in this case we retrieve each run
+      // individually.
+      await this._getAndSetRuns(displayRuns);
     } else {
       // Load all runs
       if (this.props.storageState) {
@@ -322,8 +329,9 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
           request.filter,
         );
 
-        displayRuns = (response.runs || []).map(r => ({ metadata: r }));
+        displayRuns = (response.runs || []).map(r => ({ run: r }));
         nextPageToken = response.next_page_token || '';
+
       } catch (err) {
         const error = new Error(await errorToMessage(err));
         this.props.onError('Error: failed to fetch runs.', error);
@@ -332,31 +340,28 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
       }
     }
 
-    await this._getAndSetMetadataAndWorkflows(displayRuns);
     await this._getAndSetPipelineNames(displayRuns);
-    await this._getAndSetExperimentNames(displayRuns);
+    if (!this.props.hideExperimentColumn) {
+      await this._getAndSetExperimentNames(displayRuns);
+    }
 
     this.setState({
-      metrics: RunUtils.extractMetricMetadata(displayRuns.map(r => r.metadata)),
+      metrics: RunUtils.extractMetricMetadata(displayRuns.map(r => r.run)),
       runs: displayRuns,
     });
     return nextPageToken;
   }
 
   /**
-   * For each DisplayRun, get its workflow spec and parse it into an object
+   * For each run ID, fetch its corresponding run, and set it in DisplayRuns
    */
-  private _getAndSetMetadataAndWorkflows(displayRuns: DisplayRun[]): Promise<DisplayRun[]> {
-    // Fetch and set the workflow details
+  private _getAndSetRuns(displayRuns: DisplayRun[]): Promise<DisplayRun[]> {
     return Promise.all(displayRuns.map(async displayRun => {
       let getRunResponse: ApiRunDetail;
       try {
-        getRunResponse = await Apis.runServiceApi.getRun(displayRun.metadata!.id!);
-        displayRun.metadata = getRunResponse.run!;
-        displayRun.workflow =
-          JSON.parse(getRunResponse.pipeline_runtime!.workflow_manifest || '{}');
+        getRunResponse = await Apis.runServiceApi.getRun(displayRun.run!.id!);
+        displayRun.run = getRunResponse.run!;
       } catch (err) {
-        // This could be an API exception, or a JSON parse exception.
         displayRun.error = await errorToMessage(err);
       }
       return displayRun;
@@ -371,7 +376,7 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
   private _getAndSetPipelineNames(displayRuns: DisplayRun[]): Promise<DisplayRun[]> {
     return Promise.all(
       displayRuns.map(async (displayRun) => {
-        const pipelineId = RunUtils.getPipelineId(displayRun.metadata);
+        const pipelineId = RunUtils.getPipelineId(displayRun.run);
         if (pipelineId) {
           try {
             const pipeline = await Apis.pipelineServiceApi.getPipeline(pipelineId);
@@ -380,7 +385,7 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
             // This could be an API exception, or a JSON parse exception.
             displayRun.error = 'Failed to get associated pipeline: ' + await errorToMessage(err);
           }
-        } else if (!!RunUtils.getPipelineSpec(displayRun.metadata)) {
+        } else if (!!RunUtils.getPipelineSpec(displayRun.run)) {
           displayRun.pipeline = { showLink: true };
         }
         return displayRun;
@@ -397,7 +402,7 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
   private _getAndSetExperimentNames(displayRuns: DisplayRun[]): Promise<DisplayRun[]> {
     return Promise.all(
       displayRuns.map(async (displayRun) => {
-        const experimentId = RunUtils.getFirstExperimentReferenceId(displayRun.metadata);
+        const experimentId = RunUtils.getFirstExperimentReferenceId(displayRun.run);
         if (experimentId) {
           try {
             // TODO: Experiment could be an optional field in state since whenever the RunList is

--- a/frontend/src/pages/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -131,6 +131,7 @@ exports[`ExperimentDetails fetches this experiment's recurring runs 1`] = `
     />
     <RunList
       experimentIdMask="some-mock-experiment-id"
+      hideExperimentColumn={true}
       history={
         Object {
           "push": [MockFunction],
@@ -484,6 +485,7 @@ exports[`ExperimentDetails removes all description text after second newline and
     />
     <RunList
       experimentIdMask="some-mock-experiment-id"
+      hideExperimentColumn={true}
       history={
         Object {
           "push": [MockFunction],
@@ -824,6 +826,7 @@ exports[`ExperimentDetails renders a page with no runs or recurring runs 1`] = `
     />
     <RunList
       experimentIdMask="some-mock-experiment-id"
+      hideExperimentColumn={true}
       history={
         Object {
           "push": [MockFunction],
@@ -1162,6 +1165,7 @@ exports[`ExperimentDetails uses an empty string if the experiment has no descrip
     />
     <RunList
       experimentIdMask="some-mock-experiment-id"
+      hideExperimentColumn={true}
       history={
         Object {
           "push": [MockFunction],

--- a/frontend/src/pages/__snapshots__/RunList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunList.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`RunList adds metrics columns 1`] = `
           "id": "testrun1",
           "otherFields": Array [
             "run with id: testrun1",
-            "-",
+            "Succeeded",
             "-",
             undefined,
             undefined,
@@ -100,7 +100,7 @@ exports[`RunList adds metrics columns 1`] = `
           "id": "testrun2",
           "otherFields": Array [
             "run with id: testrun2",
-            "-",
+            "Succeeded",
             "-",
             undefined,
             undefined,
@@ -243,10 +243,10 @@ exports[`RunList displays error in run row if it failed to parse (run list mask)
     rows={
       Array [
         Object {
-          "error": "Unexpected token b in JSON at position 0",
+          "error": "bad stuff happened",
           "id": "testrun1",
           "otherFields": Array [
-            "run with id: testrun1",
+            undefined,
             "-",
             "-",
             undefined,
@@ -255,71 +255,10 @@ exports[`RunList displays error in run row if it failed to parse (run list mask)
           ],
         },
         Object {
-          "error": "Unexpected token b in JSON at position 0",
+          "error": "Cannot read property 'run' of undefined",
           "id": "testrun2",
           "otherFields": Array [
-            "run with id: testrun2",
-            "-",
-            "-",
             undefined,
-            undefined,
-            "-",
-          ],
-        },
-      ]
-    }
-  />
-</div>
-`;
-
-exports[`RunList displays error in run row if it failed to parse 1`] = `
-<div>
-  <CustomTable
-    columns={
-      Array [
-        Object {
-          "customRenderer": [Function],
-          "flex": 2,
-          "label": "Run name",
-          "sortKey": "name",
-        },
-        Object {
-          "customRenderer": [Function],
-          "flex": 0.5,
-          "label": "Status",
-        },
-        Object {
-          "flex": 0.5,
-          "label": "Duration",
-        },
-        Object {
-          "customRenderer": [Function],
-          "flex": 1,
-          "label": "Experiment",
-        },
-        Object {
-          "customRenderer": [Function],
-          "flex": 1,
-          "label": "Pipeline",
-        },
-        Object {
-          "flex": 1,
-          "label": "Start time",
-          "sortKey": "created_at",
-        },
-      ]
-    }
-    emptyMessage="No available runs found."
-    filterLabel="Filter runs"
-    initialSortColumn="created_at"
-    reload={[Function]}
-    rows={
-      Array [
-        Object {
-          "error": "Unexpected token b in JSON at position 0",
-          "id": "testrun1",
-          "otherFields": Array [
-            "run with id: testrun1",
             "-",
             "-",
             undefined,
@@ -409,6 +348,61 @@ exports[`RunList handles no pipeline name 1`] = `
 >
   [View pipeline]
 </Link>
+`;
+
+exports[`RunList hides experiment name if instructed 1`] = `
+<div>
+  <CustomTable
+    columns={
+      Array [
+        Object {
+          "customRenderer": [Function],
+          "flex": 2,
+          "label": "Run name",
+          "sortKey": "name",
+        },
+        Object {
+          "customRenderer": [Function],
+          "flex": 0.5,
+          "label": "Status",
+        },
+        Object {
+          "flex": 0.5,
+          "label": "Duration",
+        },
+        Object {
+          "customRenderer": [Function],
+          "flex": 1,
+          "label": "Pipeline",
+        },
+        Object {
+          "flex": 1,
+          "label": "Start time",
+          "sortKey": "created_at",
+        },
+      ]
+    }
+    emptyMessage="No available runs found."
+    filterLabel="Filter runs"
+    initialSortColumn="created_at"
+    reload={[Function]}
+    rows={
+      Array [
+        Object {
+          "error": undefined,
+          "id": "testrun1",
+          "otherFields": Array [
+            "run with id: testrun1",
+            "-",
+            "-",
+            undefined,
+            "-",
+          ],
+        },
+      ]
+    }
+  />
+</div>
 `;
 
 exports[`RunList in archived state renders the empty experience 1`] = `
@@ -7333,11 +7327,11 @@ exports[`RunList shows run time for each run 1`] = `
           "id": "testrun1",
           "otherFields": Array [
             "run with id: testrun1",
-            "-",
+            "Succeeded",
             "1:01:01",
             undefined,
             undefined,
-            "-",
+            "1/2/2019, 12:34:56 PM",
           ],
         },
       ]


### PR DESCRIPTION
Updates frontend run API to match backend changes introduced in #1122 

From the ExperimentDetails and ExperimentList pages, calls to getRun and
getExperiment are removed.

From the RunList page, calls to getRun are removed.

Related to #149

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1144)
<!-- Reviewable:end -->
