### PR TITLE
delete the resnet image items

### DIFF
--- a/.cloudbuild.yaml
+++ b/.cloudbuild.yaml
@@ -189,11 +189,6 @@ images:
 - 'gcr.io/$PROJECT_ID/ml-pipeline-dataproc-transform:$COMMIT_SHA'
 - 'gcr.io/$PROJECT_ID/ml-pipeline-dataproc-train:$COMMIT_SHA'
 
-# Images for the ResNet CMLE sample  pipeline components
-- 'gcr.io/$PROJECT_ID/resnet-deploy:$COMMIT_SHA'
-- 'gcr.io/$PROJECT_ID/resnet-preprocess:$COMMIT_SHA'
-- 'gcr.io/$PROJECT_ID/resnet-train:$COMMIT_SHA'
-
 # Images for the GCP generic pipeline components
 - 'gcr.io/$PROJECT_ID/ml-pipeline-gcp:$COMMIT_SHA'
 


### PR DESCRIPTION
https://github.com/kubeflow/pipelines/pull/1124 deleted the image builds because resnet now uses the gcp components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1165)
<!-- Reviewable:end -->
