### PR TITLE
SDK - Simplified the @component decorator

### DIFF
--- a/sdk/python/kfp/dsl/_metadata.py
+++ b/sdk/python/kfp/dsl/_metadata.py
@@ -153,6 +153,49 @@ def _annotation_to_typemeta(annotation):
     return TypeMeta()
   return arg_type
 
+
+def _extract_component_metadata(func):
+  '''Creates component metadata structure instance based on the function signature.'''
+
+  import inspect
+  fullargspec = inspect.getfullargspec(func)
+  annotations = fullargspec.annotations
+
+  # defaults
+  arg_defaults = {}
+  if fullargspec.defaults:
+    for arg, default in zip(reversed(fullargspec.args), reversed(fullargspec.defaults)):
+      arg_defaults[arg] = default
+
+  # Inputs
+  inputs = []
+  for arg in fullargspec.args:
+    arg_type = TypeMeta()
+    arg_default = arg_defaults[arg] if arg in arg_defaults else None
+    if arg in annotations:
+      arg_type = _annotation_to_typemeta(annotations[arg])
+    inputs.append(ParameterMeta(name=arg, description='', param_type=arg_type, default=arg_default))
+  # Outputs
+  outputs = []
+  if 'return' in annotations:
+    for output in annotations['return']:
+      arg_type = _annotation_to_typemeta(annotations['return'][output])
+      outputs.append(ParameterMeta(name=output, description='', param_type=arg_type))
+
+  #TODO: add descriptions to the metadata
+  #docstring parser:
+  #  https://github.com/rr-/docstring_parser
+  #  https://github.com/terrencepreilly/darglint/blob/master/darglint/parse.py
+
+  # Construct the ComponentMeta
+  return ComponentMeta(
+    name=func.__name__,
+    description='',
+    inputs=inputs,
+    outputs=outputs,
+  )
+
+
 def _extract_pipeline_metadata(func):
   '''Creates pipeline metadata structure instance based on the function signature.'''
 


### PR DESCRIPTION
Moved metadata-related code to _metadata.py

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1166)
<!-- Reviewable:end -->
