### PR TITLE
Allow creating runs without experiments

### DIFF
--- a/frontend/src/components/CustomTable.tsx
+++ b/frontend/src/components/CustomTable.tsx
@@ -290,7 +290,7 @@ export default class CustomTable extends React.Component<CustomTableProps, Custo
         {/* Filter/Search bar */}
         {!this.props.noFilterBox && (
           <div>
-            <Input label={this.props.filterLabel || 'Filter'} height={48} maxWidth={'100%'}
+            <Input id='tableFilterBox' label={this.props.filterLabel || 'Filter'} height={48} maxWidth={'100%'}
               className={css.filterBox} InputLabelProps={{ classes: { root: css.noMargin }}}
               onChange={this.handleFilterChange} value={filterString}
               variant='outlined'

--- a/frontend/src/components/__snapshots__/CustomTable.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/CustomTable.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`CustomTable displays warning icon with tooltip if row has error 1`] = `
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -302,6 +303,7 @@ exports[`CustomTable renders a collapsed row 1`] = `
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -530,6 +532,7 @@ exports[`CustomTable renders a collapsed row when selection is disabled 1`] = `
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -744,6 +747,7 @@ exports[`CustomTable renders a table with sorting disabled 1`] = `
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -986,6 +990,7 @@ exports[`CustomTable renders an expanded row 1`] = `
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -1204,6 +1209,7 @@ exports[`CustomTable renders an expanded row with expanded component below it 1`
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -1439,6 +1445,7 @@ exports[`CustomTable renders columns with specified widths 1`] = `
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -1614,6 +1621,7 @@ exports[`CustomTable renders empty message on no rows 1`] = `
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -1751,6 +1759,7 @@ exports[`CustomTable renders new rows after clicking next page, and enables prev
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -1969,6 +1978,7 @@ exports[`CustomTable renders new rows after clicking previous page, and enables 
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -2229,6 +2239,7 @@ exports[`CustomTable renders some columns with descending sort order on first co
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -2405,6 +2416,7 @@ exports[`CustomTable renders some columns with equal widths without rows 1`] = `
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -2580,6 +2592,7 @@ exports[`CustomTable renders some rows 1`] = `
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -2840,6 +2853,7 @@ exports[`CustomTable renders some rows using a custom renderer 1`] = `
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -3104,6 +3118,7 @@ exports[`CustomTable renders with default filter label 1`] = `
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -3235,6 +3250,7 @@ exports[`CustomTable renders with provided filter label 1`] = `
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="test filter label"
       maxWidth="100%"
       onChange={[Function]}
@@ -3459,6 +3475,7 @@ exports[`CustomTable renders without rows or columns 1`] = `
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -3590,6 +3607,7 @@ exports[`CustomTable renders without the checkboxes if disableSelection is true 
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}
@@ -3824,6 +3842,7 @@ exports[`CustomTable updates the filter string in state when the filter box inpu
       }
       className="filterBox"
       height={48}
+      id="tableFilterBox"
       label="Filter"
       maxWidth="100%"
       onChange={[Function]}

--- a/frontend/src/lib/Buttons.ts
+++ b/frontend/src/lib/Buttons.ts
@@ -131,7 +131,7 @@ export default class Buttons {
       icon: AddIcon,
       id: 'newExperimentBtn',
       outlined: true,
-      title: 'Create an experiment',
+      title: 'Create experiment',
       tooltip: 'Create a new experiment',
     };
   }

--- a/frontend/src/pages/AllRunsList.tsx
+++ b/frontend/src/pages/AllRunsList.tsx
@@ -43,6 +43,7 @@ class AllRunsList extends Page<{}, AllRunsListState> {
     const buttons = new Buttons(this.props, this.refresh.bind(this));
     return {
       actions: [
+        buttons.newRun(),
         buttons.newExperiment(),
         buttons.compareRuns(() => this.state.selectedIds),
         buttons.cloneRun(() => this.state.selectedIds, false),
@@ -77,11 +78,11 @@ class AllRunsList extends Page<{}, AllRunsListState> {
   private _selectionChanged(selectedIds: string[]): void {
     const toolbarActions = [...this.props.toolbarProps.actions];
     // Compare runs button
-    toolbarActions[1].disabled = selectedIds.length <= 1 || selectedIds.length > 10;
+    toolbarActions[2].disabled = selectedIds.length <= 1 || selectedIds.length > 10;
     // Clone run button
-    toolbarActions[2].disabled = selectedIds.length !== 1;
+    toolbarActions[3].disabled = selectedIds.length !== 1;
     // Archive run button
-    toolbarActions[3].disabled = !selectedIds.length;
+    toolbarActions[4].disabled = !selectedIds.length;
     this.props.updateToolbar({ breadcrumbs: this.props.toolbarProps.breadcrumbs, actions: toolbarActions });
     this.setState({ selectedIds });
   }

--- a/frontend/src/pages/AllRunsList.tsx
+++ b/frontend/src/pages/AllRunsList.tsx
@@ -77,6 +77,8 @@ class AllRunsList extends Page<{}, AllRunsListState> {
 
   private _selectionChanged(selectedIds: string[]): void {
     const toolbarActions = [...this.props.toolbarProps.actions];
+    // TODO: keeping track of indices in the toolbarActions array is not ideal. This should be
+    // refactored so that individual buttons can be referenced with something other than indices.
     // Compare runs button
     toolbarActions[2].disabled = selectedIds.length <= 1 || selectedIds.length > 10;
     // Clone run button

--- a/frontend/src/pages/ExperimentList.test.tsx
+++ b/frontend/src/pages/ExperimentList.test.tsx
@@ -239,7 +239,7 @@ describe('ExperimentList', () => {
   it('navigates to new experiment page when Create experiment button is clicked', async () => {
     tree = TestUtils.mountWithRouter(<ExperimentList {...generateProps()} />);
     const createBtn = (tree.instance() as ExperimentList)
-      .getInitialToolbarState().actions.find(b => b.title === 'Create an experiment');
+      .getInitialToolbarState().actions.find(b => b.title === 'Create experiment');
     await createBtn!.action();
     expect(historyPushSpy).toHaveBeenLastCalledWith(RoutePage.NEW_EXPERIMENT);
   });
@@ -247,7 +247,7 @@ describe('ExperimentList', () => {
   it('always has new experiment button enabled', async () => {
     await mountWithNExperiments(1, 1);
     const calls = updateToolbarSpy.mock.calls[0];
-    expect(calls[0].actions.find((b: any) => b.title === 'Create an experiment')).not.toHaveProperty('disabled');
+    expect(calls[0].actions.find((b: any) => b.title === 'Create experiment')).not.toHaveProperty('disabled');
   });
 
   it('enables clone button when one run is selected', async () => {

--- a/frontend/src/pages/ExperimentList.tsx
+++ b/frontend/src/pages/ExperimentList.tsx
@@ -61,6 +61,7 @@ class ExperimentList extends Page<{}, ExperimentListState> {
     const buttons = new Buttons(this.props, this.refresh.bind(this));
     return {
       actions: [
+        buttons.newRun(),
         buttons.newExperiment(),
         buttons.compareRuns(() => this.state.selectedIds),
         buttons.cloneRun(() => this.state.selectedIds, false),
@@ -187,11 +188,11 @@ class ExperimentList extends Page<{}, ExperimentListState> {
   private _selectionChanged(selectedIds: string[]): void {
     const actions = produce(this.props.toolbarProps.actions, draft => {
       // Enable/Disable Run compare button
-      draft[1].disabled = selectedIds.length <= 1 || selectedIds.length > 10;
+      draft[2].disabled = selectedIds.length <= 1 || selectedIds.length > 10;
       // Enable/Disable Clone button
-      draft[2].disabled = selectedIds.length !== 1;
+      draft[3].disabled = selectedIds.length !== 1;
       // Archive run button
-      draft[3].disabled = !selectedIds.length;
+      draft[4].disabled = !selectedIds.length;
     });
     this.props.updateToolbar({ actions });
     this.setState({ selectedIds });

--- a/frontend/src/pages/PipelineDetails.test.tsx
+++ b/frontend/src/pages/PipelineDetails.test.tsx
@@ -325,7 +325,7 @@ describe('PipelineDetails', () => {
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
     const newExperimentBtn = instance.getInitialToolbarState().actions.find(
-      b => b.title === 'Create an experiment');
+      b => b.title === 'Create experiment');
     expect(newExperimentBtn).toBeDefined();
   });
 
@@ -379,7 +379,7 @@ describe('PipelineDetails', () => {
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
     const newExperimentBtn = instance.getInitialToolbarState().actions.find(
-      b => b.title === 'Create an experiment');
+      b => b.title === 'Create experiment');
     await newExperimentBtn!.action();
     expect(historyPushSpy).toHaveBeenCalledTimes(1);
     expect(historyPushSpy).toHaveBeenLastCalledWith(

--- a/frontend/src/pages/__snapshots__/AllRunsList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/AllRunsList.test.tsx.snap
@@ -22,9 +22,18 @@ exports[`AllRunsList renders all runs 1`] = `
           Object {
             "action": [Function],
             "icon": [Function],
+            "id": "createNewRunBtn",
+            "outlined": true,
+            "primary": true,
+            "title": "Create run",
+            "tooltip": "Create a new run",
+          },
+          Object {
+            "action": [Function],
+            "icon": [Function],
             "id": "newExperimentBtn",
             "outlined": true,
-            "title": "Create an experiment",
+            "title": "Create experiment",
             "tooltip": "Create a new experiment",
           },
           Object {

--- a/frontend/src/pages/__snapshots__/RunList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunList.test.tsx.snap
@@ -708,6 +708,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
             }
             className="filterBox"
             height={48}
+            id="tableFilterBox"
             label="Filter runs"
             maxWidth="100%"
             onChange={[Function]}
@@ -743,6 +744,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                 }
               }
               className="filterBox"
+              id="tableFilterBox"
               label="Filter runs"
               onChange={[Function]}
               required={false}
@@ -814,6 +816,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                           "root": "noMargin",
                         }
                       }
+                      htmlFor="tableFilterBox"
                     >
                       <WithFormControlContext(InputLabel)
                         classes={
@@ -831,6 +834,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                             "shrink": "MuiInputLabel-shrink-12",
                           }
                         }
+                        htmlFor="tableFilterBox"
                       >
                         <InputLabel
                           classes={
@@ -849,6 +853,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                             }
                           }
                           disableAnimation={false}
+                          htmlFor="tableFilterBox"
                           muiFormControl={
                             Object {
                               "adornedStart": true,
@@ -877,6 +882,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                               }
                             }
                             data-shrink={true}
+                            htmlFor="tableFilterBox"
                           >
                             <WithFormControlContext(FormLabel)
                               className="MuiInputLabel-root-5 noMargin MuiInputLabel-formControl-10 MuiInputLabel-animated-13 MuiInputLabel-shrink-12 MuiInputLabel-outlined-15"
@@ -892,6 +898,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                 }
                               }
                               data-shrink={true}
+                              htmlFor="tableFilterBox"
                             >
                               <FormLabel
                                 className="MuiInputLabel-root-5 noMargin MuiInputLabel-formControl-10 MuiInputLabel-animated-13 MuiInputLabel-shrink-12 MuiInputLabel-outlined-15"
@@ -908,6 +915,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                 }
                                 component="label"
                                 data-shrink={true}
+                                htmlFor="tableFilterBox"
                                 muiFormControl={
                                   Object {
                                     "adornedStart": true,
@@ -928,6 +936,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                 <label
                                   className="MuiFormLabel-root-16 MuiInputLabel-root-5 noMargin MuiInputLabel-formControl-10 MuiInputLabel-animated-13 MuiInputLabel-shrink-12 MuiInputLabel-outlined-15"
                                   data-shrink={true}
+                                  htmlFor="tableFilterBox"
                                 >
                                   Filter runs
                                 </label>
@@ -944,6 +953,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                           "root": "noLeftPadding",
                         }
                       }
+                      id="tableFilterBox"
                       labelWidth={0}
                       onChange={[Function]}
                       startAdornment={
@@ -980,6 +990,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                             "root": "MuiOutlinedInput-root-23 noLeftPadding",
                           }
                         }
+                        id="tableFilterBox"
                         labelWidth={0}
                         onChange={[Function]}
                         startAdornment={
@@ -1017,6 +1028,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                             }
                           }
                           fullWidth={false}
+                          id="tableFilterBox"
                           inputComponent="input"
                           multiline={false}
                           onChange={[Function]}
@@ -1061,6 +1073,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                               }
                             }
                             fullWidth={false}
+                            id="tableFilterBox"
                             inputComponent="input"
                             multiline={false}
                             onChange={[Function]}
@@ -1105,6 +1118,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                 }
                               }
                               fullWidth={false}
+                              id="tableFilterBox"
                               inputComponent="input"
                               muiFormControl={
                                 Object {
@@ -1652,6 +1666,7 @@ exports[`RunList reloads the run when refresh is called 1`] = `
                                   aria-invalid={false}
                                   className="MuiInputBase-input-46 MuiOutlinedInput-input-31 MuiInputBase-inputAdornedStart-51 MuiOutlinedInput-inputAdornedStart-34"
                                   disabled={false}
+                                  id="tableFilterBox"
                                   onBlur={[Function]}
                                   onChange={[Function]}
                                   onFocus={[Function]}

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -17,11 +17,11 @@ const URL = require('url').URL;
 
 const experimentName = 'helloworld-experiment-' + Date.now();
 const experimentDescription = 'hello world experiment description';
+const secondExperimentName = 'different-experiment-name-' + Date.now();
+const secondExperimentNameDescription = 'second experiment description';
 const pipelineName = 'helloworld-pipeline-' + Date.now();
 const runName = 'helloworld-' + Date.now();
 const runDescription = 'test run description ' + runName;
-const runWithoutExperimentName = 'helloworld-2-' + Date.now();
-const runWithoutExperimentDescription = 'test run without experiment description ' + runWithoutExperimentName;
 const waitTimeout = 5000;
 const outputParameterValue = 'Hello world in test'
 
@@ -192,62 +192,18 @@ describe('deploy helloworld sample run', () => {
     }, waitTimeout);
   });
 
-  it('creates a new run without selecting an experiment', () => {
-    $('#createNewRunBtn').waitForVisible();
-    $('#createNewRunBtn').click();
-
-    $('#choosePipelineBtn').waitForVisible();
-    $('#choosePipelineBtn').click();
-
-    $('.tableRow').waitForVisible();
-    $('.tableRow').click();
-
-    $('#usePipelineBtn').click();
-
-    $('#pipelineSelectorDialog').waitForVisible(waitTimeout, true);
-
-    browser.keys('Tab');
-    browser.keys(runWithoutExperimentName);
-
-    browser.keys('Tab');
-    browser.keys(runWithoutExperimentDescription);
-
-    // Skip over "choose experiment" button
-    browser.keys('Tab');
-
-    browser.keys('Tab');
-    browser.keys(outputParameterValue);
-
-    // Deploy
-    $('#startNewRunBtn').click();
-
-    browser.saveScreenshot('./new-run-screenshot.png');
-  });
-
-  it('redirects back to all runs page', () => {
-    browser.saveScreenshot('./redirect-screenshot.png');
-
+  it('creates a new experiment', () => {
+    $('#newExperimentBtn').click();
     browser.waitUntil(() => {
-      return (new URL(browser.getUrl())).hash === '#/runs';
-    }, waitTimeout, `URL was: ${new URL(browser.getUrl())}`);
+      return new URL(browser.getUrl()).hash.startsWith('#/experiments/new');
+    }, waitTimeout);
+
+    $('#experimentName').setValue(secondExperimentName);
+    $('#experimentDescription').setValue(secondExperimentNameDescription);
+
+    $('#createExperimentBtn').click();
   });
 
-  it('displays both runs in all runs page', () => {
-    let attempts = 30;
-    
-    // Wait for a reasonable amount of time until the run starts
-    while (attempts && $$('.tableRow').length !== 2) {
-      browser.pause(1000);
-      if (browser.isVisible('#refreshBtn')) {
-        $('#refreshBtn').click();
-      }
-      --attempts;
-    }
-    browser.saveScreenshot('./table-screenshot.png');
-    
-    assert(attempts, `waited for 30 seconds but table had ${$$('.tableRow').length} entries. URL was: ${browser.getUrl()}`);
-  });
-  
   it('navigates back to the experiment list', () => {
     $('button=Experiments').click();
     browser.waitUntil(() => {
@@ -255,7 +211,7 @@ describe('deploy helloworld sample run', () => {
     }, waitTimeout);
   });
 
-  it('displays both custom and default experiment in the list', () => {
+  it('displays both experiments in the list', () => {
     $('.tableRow').waitForVisible();
     const rows = $$('.tableRow').length;
     assert(rows === 2, 'there should now be two experiments in the table, instead there are: ' + rows);
@@ -272,6 +228,11 @@ describe('deploy helloworld sample run', () => {
     const rows = $$('.tableRow').length;
     assert(rows === 1, 'there should now be one experiment in the table, instead there are: ' + rows);
   });
+
+  // TODO: Add test for creating a run without an experiment. This will require changing the API
+  // initialization and integration tests to stop deleting the default experiment at the end of the
+  // suites. Otherwise, run creation here will fail with:
+  // 'Failed to store resource references to table for run [ID] : ResourceNotFoundError: [Default Experiment ID]'
 
   //TODO: enable this after we change the pipeline to a unique name such that deleting this
   // pipeline will not jeopardize the concurrent basic e2e tests.

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -229,9 +229,18 @@ describe('deploy helloworld sample run', () => {
   });
 
   it('displays both runs in all runs page', () => {
-    $('.tableRow').waitForVisible();
-    const rows = $$('.tableRow').length;
-    assert(rows === 2, 'there should now be two runs in the table, instead there are: ' + rows);
+    let attempts = 30;
+
+    // Wait for a reasonable amount of time until the run starts
+    while (attempts && $$('.tableRow').length !== 2) {
+      browser.pause(1000);
+      if (browser.isVisible('#refreshBtn')) {
+        $('#refreshBtn').click();
+      }
+      --attempts;
+    }
+
+    assert(attempts, `waited for 30 seconds but table had ${$$('.tableRow').length} entries. URL was: ${browser.getUrl()}`);
   });
 
   it('navigates back to the experiment list', () => {

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -224,7 +224,7 @@ describe('deploy helloworld sample run', () => {
 
   it('redirects back to all runs page', () => {
     browser.waitUntil(() => {
-      return new URL(browser.getUrl()).hash.startsWith('#/runs');
+      return new URL(browser.getUrl()).hash === '#/runs';
     }, waitTimeout);
   });
 

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -225,16 +225,16 @@ describe('deploy helloworld sample run', () => {
   });
 
   it('redirects back to all runs page', () => {
+    browser.saveScreenshot('./redirect-screenshot.png');
+
     browser.waitUntil(() => {
       return (new URL(browser.getUrl())).hash === '#/runs';
     }, waitTimeout, `URL was: ${new URL(browser.getUrl())}`);
-
-    browser.saveScreenshot('./redirect-screenshot.png');
   });
 
   it('displays both runs in all runs page', () => {
     let attempts = 30;
-
+    
     // Wait for a reasonable amount of time until the run starts
     while (attempts && $$('.tableRow').length !== 2) {
       browser.pause(1000);
@@ -243,10 +243,11 @@ describe('deploy helloworld sample run', () => {
       }
       --attempts;
     }
-
+    browser.saveScreenshot('./table-screenshot.png');
+    
     assert(attempts, `waited for 30 seconds but table had ${$$('.tableRow').length} entries. URL was: ${browser.getUrl()}`);
   });
-
+  
   it('navigates back to the experiment list', () => {
     $('button=Experiments').click();
     browser.waitUntil(() => {

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -224,8 +224,8 @@ describe('deploy helloworld sample run', () => {
 
   it('redirects back to all runs page', () => {
     browser.waitUntil(() => {
-      return new URL(browser.getUrl()).hash === '#/runs';
-    }, waitTimeout);
+      return (new URL(browser.getUrl())).hash === '#/runs';
+    }, waitTimeout, `URL was: ${new URL(browser.getUrl())}`);
   });
 
   it('displays both runs in all runs page', () => {

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -20,6 +20,8 @@ const experimentDescription = 'hello world experiment description';
 const pipelineName = 'helloworld-pipeline-' + Date.now();
 const runName = 'helloworld-' + Date.now();
 const runDescription = 'test run description ' + runName;
+const runWithoutExperimentName = 'helloworld-2-' + Date.now();
+const runWithoutExperimentDescription = 'test run without experiment description ' + runWithoutExperimentName;
 const waitTimeout = 5000;
 const outputParameterValue = 'Hello world in test'
 
@@ -182,6 +184,81 @@ describe('deploy helloworld sample run', () => {
       return logs.indexOf(outputParameterValue + ' from node: ') > -1;
     }, waitTimeout);
   });
+
+  it('navigates back to the experiment list', () => {
+    $('button=Experiments').click();
+    browser.waitUntil(() => {
+      return new URL(browser.getUrl()).hash.startsWith('#/experiments');
+    }, waitTimeout);
+  });
+
+  it('creates a new run without selecting an experiment', () => {
+    $('#createNewRunBtn').waitForVisible();
+    $('#createNewRunBtn').click();
+
+    $('#choosePipelineBtn').waitForVisible();
+    $('#choosePipelineBtn').click();
+
+    $('.tableRow').waitForVisible();
+    $('.tableRow').click();
+
+    $('#usePipelineBtn').click();
+
+    $('#pipelineSelectorDialog').waitForVisible(waitTimeout, true);
+
+    browser.keys('Tab');
+    browser.keys(runWithoutExperimentName);
+
+    browser.keys('Tab');
+    browser.keys(runWithoutExperimentDescription);
+
+    // Skip over "choose experiment" button
+    browser.keys('Tab');
+
+    browser.keys('Tab');
+    browser.keys(outputParameterValue);
+
+    // Deploy
+    $('#startNewRunBtn').click();
+  });
+
+  it('redirects back to all runs page', () => {
+    browser.waitUntil(() => {
+      return new URL(browser.getUrl()).hash.startsWith('#/runs');
+    }, waitTimeout);
+  });
+
+  it('displays both runs in all runs page', () => {
+    $('.tableRow').waitForVisible();
+    const rows = $$('.tableRow').length;
+    assert(rows === 2, 'there should now be two runs in the table, instead there are: ' + rows);
+  });
+
+  it('navigates back to the experiment list', () => {
+    $('button=Experiments').click();
+    browser.waitUntil(() => {
+      return new URL(browser.getUrl()).hash.startsWith('#/experiments');
+    }, waitTimeout);
+  });
+
+  it('displays both custom and default experiment experiment list page', () => {
+    $('.tableRow').waitForVisible();
+    const rows = $$('.tableRow').length;
+    assert(rows === 2, 'there should now be two experiments in the table, instead there are: ' + rows);
+  });
+
+  it('filters the experiment list', () => {
+    // Enter "hello" into filter bar
+    browser.click('#tableFilterBox');
+    browser.keys(experimentName.substring(0, 5));
+    // Wait for the list to refresh
+    browser.pause(2000);
+
+    $('.tableRow').waitForVisible();
+    const rows = $$('.tableRow').length;
+    assert(rows === 1, 'there should now be one experiment in the table, instead there are: ' + rows);
+  });
+
   //TODO: enable this after we change the pipeline to a unique name such that deleting this
   // pipeline will not jeopardize the concurrent basic e2e tests.
   // it('deletes the uploaded pipeline', () => {

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -220,12 +220,16 @@ describe('deploy helloworld sample run', () => {
 
     // Deploy
     $('#startNewRunBtn').click();
+
+    browser.saveScreenshot('./new-run-screenshot.png');
   });
 
   it('redirects back to all runs page', () => {
     browser.waitUntil(() => {
       return (new URL(browser.getUrl())).hash === '#/runs';
     }, waitTimeout, `URL was: ${new URL(browser.getUrl())}`);
+
+    browser.saveScreenshot('./redirect-screenshot.png');
   });
 
   it('displays both runs in all runs page', () => {

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -250,7 +250,7 @@ describe('deploy helloworld sample run', () => {
     }, waitTimeout);
   });
 
-  it('displays both custom and default experiment experiment list page', () => {
+  it('displays both custom and default experiment in the list', () => {
     $('.tableRow').waitForVisible();
     const rows = $$('.tableRow').length;
     assert(rows === 2, 'there should now be two experiments in the table, instead there are: ' + rows);

--- a/test/frontend-integration-test/run_test.sh
+++ b/test/frontend-integration-test/run_test.sh
@@ -74,8 +74,11 @@ POD=`/src/tools/google-cloud-sdk/bin/kubectl get pods -n ${NAMESPACE} -l app=ml-
 ./node_modules/.bin/wait-port 127.0.0.1:3000 -t 20000
 
 export PIPELINE_OUTPUT=${RESULTS_GCS_DIR}/pipeline_output
+# Don't exit early if 'npm test' fails
+set +e
 npm test
 TEST_EXIT_CODE=$?
+set -e
 
 JUNIT_TEST_RESULT=junit_FrontendIntegrationTestOutput.xml
 

--- a/test/frontend-integration-test/run_test.sh
+++ b/test/frontend-integration-test/run_test.sh
@@ -78,28 +78,6 @@ export PIPELINE_OUTPUT=${RESULTS_GCS_DIR}/pipeline_output
 set +e
 npm test
 TEST_EXIT_CODE=$?
-
-
-NEW_RUN_SCREENSHOT=new-run-screenshot.png
-REDIRECT_SCREENSHOT=redirect-screenshot.png
-TABLE_SCREENSHOT=table-screenshot.png
-
-echo 'new-run-screenshot'
-base64 ${NEW_RUN_SCREENSHOT}
-echo \"-----\"
-
-echo 'redirect-screenshot'
-base64 ${REDIRECT_SCREENSHOT}
-echo \"-----\"
-
-echo 'table-screenshot'
-base64 ${TABLE_SCREENSHOT}
-echo \"-----\"
-
-tools/google-cloud-sdk/bin/gsutil cp ${NEW_RUN_SCREENSHOT} ${RESULTS_GCS_DIR}/${NEW_RUN_SCREENSHOT}
-tools/google-cloud-sdk/bin/gsutil cp ${REDIRECT_SCREENSHOT} ${RESULTS_GCS_DIR}/${REDIRECT_SCREENSHOT}
-tools/google-cloud-sdk/bin/gsutil cp ${TABLE_SCREENSHOT} ${RESULTS_GCS_DIR}/${TABLE_SCREENSHOT}
-
 set -e
 
 JUNIT_TEST_RESULT=junit_FrontendIntegrationTestOutput.xml

--- a/test/frontend-integration-test/run_test.sh
+++ b/test/frontend-integration-test/run_test.sh
@@ -74,17 +74,21 @@ POD=`/src/tools/google-cloud-sdk/bin/kubectl get pods -n ${NAMESPACE} -l app=ml-
 ./node_modules/.bin/wait-port 127.0.0.1:3000 -t 20000
 
 export PIPELINE_OUTPUT=${RESULTS_GCS_DIR}/pipeline_output
+# Don't exit early if 'npm test' fails
+set +e
+npm test
+TEST_EXIT_CODE=$?
+set -e
+
+echo 'new-run-screenshot'
+base64 'new-run-screenshot.png'
+echo \"-----\"
+
+echo 'redirect-screenshot'
+base64 'redirect-screenshot.png'
+echo \"-----\"
 
 JUNIT_TEST_RESULT=junit_FrontendIntegrationTestOutput.xml
-
-# Don't exit early if 'npm test' fails
-TEST_RESULT=`npm test 2>&1`
-TEST_EXIT_CODE=$?
-
-# Log the test result
-printf '%s\n' "$TEST_RESULT"
-# Convert test result to junit.xml
-printf '%s\n' "$TEST_RESULT" | go-junit-report > ${JUNIT_TEST_RESULT}
 
 echo "Copy test result to GCS ${RESULTS_GCS_DIR}/${JUNIT_TEST_RESULT}"
 tools/google-cloud-sdk/bin/gsutil cp ${JUNIT_TEST_RESULT} ${RESULTS_GCS_DIR}/${JUNIT_TEST_RESULT}

--- a/test/frontend-integration-test/run_test.sh
+++ b/test/frontend-integration-test/run_test.sh
@@ -78,15 +78,29 @@ export PIPELINE_OUTPUT=${RESULTS_GCS_DIR}/pipeline_output
 set +e
 npm test
 TEST_EXIT_CODE=$?
-set -e
+
+
+NEW_RUN_SCREENSHOT=new-run-screenshot.png
+REDIRECT_SCREENSHOT=redirect-screenshot.png
+TABLE_SCREENSHOT=table-screenshot.png
 
 echo 'new-run-screenshot'
-base64 'new-run-screenshot.png'
+base64 ${NEW_RUN_SCREENSHOT}
 echo \"-----\"
 
 echo 'redirect-screenshot'
-base64 'redirect-screenshot.png'
+base64 ${REDIRECT_SCREENSHOT}
 echo \"-----\"
+
+echo 'table-screenshot'
+base64 ${TABLE_SCREENSHOT}
+echo \"-----\"
+
+tools/google-cloud-sdk/bin/gsutil cp ${NEW_RUN_SCREENSHOT} ${RESULTS_GCS_DIR}/${NEW_RUN_SCREENSHOT}
+tools/google-cloud-sdk/bin/gsutil cp ${REDIRECT_SCREENSHOT} ${RESULTS_GCS_DIR}/${REDIRECT_SCREENSHOT}
+tools/google-cloud-sdk/bin/gsutil cp ${TABLE_SCREENSHOT} ${RESULTS_GCS_DIR}/${TABLE_SCREENSHOT}
+
+set -e
 
 JUNIT_TEST_RESULT=junit_FrontendIntegrationTestOutput.xml
 

--- a/test/frontend-integration-test/run_test.sh
+++ b/test/frontend-integration-test/run_test.sh
@@ -74,13 +74,17 @@ POD=`/src/tools/google-cloud-sdk/bin/kubectl get pods -n ${NAMESPACE} -l app=ml-
 ./node_modules/.bin/wait-port 127.0.0.1:3000 -t 20000
 
 export PIPELINE_OUTPUT=${RESULTS_GCS_DIR}/pipeline_output
-# Don't exit early if 'npm test' fails
-set +e
-npm test
-TEST_EXIT_CODE=$?
-set -e
 
 JUNIT_TEST_RESULT=junit_FrontendIntegrationTestOutput.xml
+
+# Don't exit early if 'npm test' fails
+TEST_RESULT=`npm test 2>&1`
+TEST_EXIT_CODE=$?
+
+# Log the test result
+printf '%s\n' "$TEST_RESULT"
+# Convert test result to junit.xml
+printf '%s\n' "$TEST_RESULT" | go-junit-report > ${JUNIT_TEST_RESULT}
 
 echo "Copy test result to GCS ${RESULTS_GCS_DIR}/${JUNIT_TEST_RESULT}"
 tools/google-cloud-sdk/bin/gsutil cp ${JUNIT_TEST_RESULT} ${RESULTS_GCS_DIR}/${JUNIT_TEST_RESULT}


### PR DESCRIPTION
Following #1089, this PR adds `Create run` button to Experiment/All run list pages.

Also updates the frontend integration test to include creating a run without selecting an experiment, and filtering the experiment list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1175)
<!-- Reviewable:end -->
