### PR TITLE
Make Python Client robust to existing IPython installations

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -84,6 +84,9 @@ class Client(object):
     """Returns whether we are running in notebook."""
     try:
       import IPython
+      ipy = IPython.get_ipython()
+      if ipy is None:
+        raise ImportError("IPython installed but not running")
     except ImportError:
       return False
 

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -86,7 +86,7 @@ class Client(object):
       import IPython
       ipy = IPython.get_ipython()
       if ipy is None:
-        raise ImportError("IPython installed but not running")
+        return False
     except ImportError:
       return False
 


### PR DESCRIPTION
In the current implementation of `Client._is_ipython`, the only check performed is a simple attempted [import of the `IPython` package](https://github.com/kubeflow/pipelines/blob/master/sdk/python/kfp/_client.py#L85-L88
). However, this will fail in the case that the user (or container) has IPython installed, but the command is being executed from the normal Python interpreter.

This PR adds an extra call to `IPython.get_ipython`, which returns an instance of the running IPython kernel if any, and otherwise `None`. By raising an `ImportError` if `get_ipython` returns `None`, the existing logic kicks in and `Client._is_ipython` will return `False` as expected, whether IPython happens to be installed or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1186)
<!-- Reviewable:end -->
