### PR TITLE
Return error when ml-metadata serialized format does not match expected format.

### DIFF
--- a/backend/src/apiserver/metadata/metadata_store.go
+++ b/backend/src/apiserver/metadata/metadata_store.go
@@ -101,6 +101,14 @@ func (a *artifactStruct) UnmarshalJSON(b []byte) error {
 		return errorF(err)
 	}
 
+	if _, ok := jsonMap["artifact_type"]; !ok {
+		return util.NewInvalidInputError("JSON Unmarshal failure: missing 'artifact_type' field")
+	}
+
+	if _, ok := jsonMap["artifact"]; !ok {
+		return util.NewInvalidInputError("JSON Unmarshal failure: missing 'artifact_type' field")
+	}
+
 	a.ArtifactType = &mlpb.ArtifactType{}
 	a.Artifact = &mlpb.Artifact{}
 

--- a/backend/src/apiserver/metadata/metadata_store_test.go
+++ b/backend/src/apiserver/metadata/metadata_store_test.go
@@ -124,6 +124,45 @@ func TestParseValidTFXMetadata(t *testing.T) {
 	}
 }
 
+func TestParseInvalidTFXMetadata(t *testing.T) {
+	tests := []struct {
+		desc  string
+		input string
+	}{
+		{
+			"no artifact type",
+			`[{
+			 	"artifact": {
+					"uri": "/location",
+					 "properties": {
+							 "state": {"stringValue": "complete"},
+							 "span": {"intValue": 10} }
+					}
+				}]`,
+		},
+		{
+			"no artifact",
+			`[{
+				"artifact_type": {
+					"name": "Artifact",
+					"properties": {"state": "STRING", "span": "INT" } },
+				}]`,
+		},
+		{
+			"empty string",
+			"",
+		},
+	}
+
+	for _, test := range tests {
+		_, err := parseTFXMetadata(test.input)
+		if err == nil {
+			t.Errorf("Test: %q", test.desc)
+			t.Errorf("parseTFXMetadata(%q)\nGot non-nil error. Want error.", test.input)
+		}
+	}
+}
+
 func fakeMLMDStore(t *testing.T) *mlmetadata.Store {
 	cfg := &mlpb.ConnectionConfig{
 		Config: &mlpb.ConnectionConfig_FakeDatabase{&mlpb.FakeDatabaseConfig{}},


### PR DESCRIPTION
Previously we assume the fields 'artifact_type' and 'artifact' always
exist. This change ensures we guard against the case when one or both of
these required fields aren't present. In those cases, referencing the missing field in the parse JSON map will result in a nil-pointer dereference error.

/assign @IronPan

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1192)
<!-- Reviewable:end -->
