### PR TITLE
Testing/Sample - Made checking confusion matrix data more robust

### DIFF
--- a/test/sample-test/run_kubeflow_test.py
+++ b/test/sample-test/run_kubeflow_test.py
@@ -14,6 +14,7 @@
 
 import argparse
 import os
+import io
 import json
 import tarfile
 from datetime import datetime
@@ -113,7 +114,7 @@ def main():
     assert len(file_handles) == 1
 
     with tar_handle.extractfile(file_handles[0]) as f:
-      cm_data = json.load(f)
+      cm_data = json.load(io.TextIOWrapper(f))
       utils.add_junit_test(test_cases, 'confusion matrix format', (len(cm_data['outputs'][0]['schema']) == 3), 'the column number of the confusion matrix output is not equal to three')
 
   ###### Delete Job ######

--- a/test/sample-test/run_kubeflow_test.py
+++ b/test/sample-test/run_kubeflow_test.py
@@ -107,14 +107,14 @@ def main():
   #   confusion matrix should show three columns for the flower data
   #     target, predicted, count
   cm_tar_path = './confusion_matrix.tar.gz'
-  cm_filename = 'mlpipeline-ui-metadata.json'
-  utils.get_artifact_in_minio(workflow_json, 'confusion-matrix', cm_tar_path)
-  tar_handler = tarfile.open(cm_tar_path)
-  tar_handler.extractall()
+  utils.get_artifact_in_minio(workflow_json, 'confusion-matrix', cm_tar_path, 'mlpipeline-ui-metadata')
+  with tarfile.open(cm_tar_path) as tar_handle:
+    file_handles = tar_handle.getmembers()
+    assert len(file_handles) == 1
 
-  with open(cm_filename, 'r') as f:
-    cm_data = json.load(f)
-    utils.add_junit_test(test_cases, 'confusion matrix format', (len(cm_data['outputs'][0]['schema']) == 3), 'the column number of the confusion matrix output is not equal to three')
+    with tar_handle.extractfile(file_handles[0]) as f:
+      cm_data = json.load(f)
+      utils.add_junit_test(test_cases, 'confusion matrix format', (len(cm_data['outputs'][0]['schema']) == 3), 'the column number of the confusion matrix output is not equal to three')
 
   ###### Delete Job ######
   #TODO: add deletion when the backend API offers the interface.

--- a/test/sample-test/run_xgboost_test.py
+++ b/test/sample-test/run_xgboost_test.py
@@ -109,14 +109,14 @@ def main():
   #   confusion matrix should show three columns for the flower data
   #     target, predicted, count
   cm_tar_path = './confusion_matrix.tar.gz'
-  cm_filename = 'mlpipeline-ui-metadata.json'
-  utils.get_artifact_in_minio(workflow_json, 'confusion-matrix', cm_tar_path)
-  tar_handler = tarfile.open(cm_tar_path)
-  tar_handler.extractall()
+  utils.get_artifact_in_minio(workflow_json, 'confusion-matrix', cm_tar_path, 'mlpipeline-ui-metadata')
+  with tarfile.open(cm_tar_path) as tar_handle:
+    file_handles = tar_handle.getmembers()
+    assert len(file_handles) == 1
 
-  with open(cm_filename, 'r') as f:
-    cm_data = f.read()
-    utils.add_junit_test(test_cases, 'confusion matrix format', (len(cm_data) > 0), 'the confusion matrix file is empty')
+    with tar_handle.extractfile(file_handles[0]) as f:
+      cm_data = f.read()
+      utils.add_junit_test(test_cases, 'confusion matrix format', (len(cm_data) > 0), 'the confusion matrix file is empty')
 
   ###### Delete Job ######
   #TODO: add deletion when the backend API offers the interface.


### PR DESCRIPTION
The sample tests no longer depend on particular  file names inside the archive. Now they only depend on the artifact name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1196)
<!-- Reviewable:end -->
