### PR TITLE
SDK - Fixed the non-string items in the command-line arguments

### DIFF
--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -72,10 +72,10 @@ def _proxy_container_op_props(cls: "ContainerOp"):
     return cls
 
 
-def as_string_list(list_or_str: Union[Any, Sequence[Any]], if_none: Optional[List] = None) -> List[str]:
+def as_string_list(list_or_str: Union[Any, Sequence[Any]]) -> List[str]:
     """Convert any value except None to a list if not already a list."""
     if list_or_str is None:
-        return if_none
+        return None
     if isinstance(list_or_str, Sequence) and not isinstance(list_or_str, str):
         list_value = list_or_str
     else:

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -72,7 +72,7 @@ def _proxy_container_op_props(cls: "ContainerOp"):
     return cls
 
 
-def as_string_list(list_or_str: Union[Any, Sequence[Any]]) -> List[str]:
+def as_string_list(list_or_str: Optional[Union[Any, Sequence[Any]]]) -> List[str]:
     """Convert any value except None to a list if not already a list."""
     if list_or_str is None:
         return None

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -14,7 +14,7 @@
 
 import re
 import warnings
-from typing import Any, Dict, List, TypeVar, Union, Callable
+from typing import Any, Dict, List, TypeVar, Union, Callable, Optional, Sequence
 from kubernetes.client.models import (
     V1Container, V1EnvVar, V1EnvFromSource, V1SecurityContext, V1Probe,
     V1ResourceRequirements, V1VolumeDevice, V1VolumeMount, V1ContainerPort,
@@ -72,11 +72,15 @@ def _proxy_container_op_props(cls: "ContainerOp"):
     return cls
 
 
-def as_list(value: Any, if_none: Union[None, List] = None) -> List:
+def as_string_list(list_or_str: Union[Any, Sequence[Any]], if_none: Optional[List] = None) -> List[str]:
     """Convert any value except None to a list if not already a list."""
-    if value is None:
+    if list_or_str is None:
         return if_none
-    return value if isinstance(value, list) else [value]
+    if isinstance(list_or_str, Sequence) and not isinstance(list_or_str, str):
+        list_value = list_or_str
+    else:
+        list_value = [list_or_str]
+    return [str(item) for item in list_value]
 
 
 def create_and_append(current_list: Union[List[T], None], item: T) -> List[T]:
@@ -596,8 +600,8 @@ class Sidecar(Container):
         super().__init__(
             name=name,
             image=image,
-            command=as_list(command),
-            args=as_list(args),
+            command=as_string_list(command),
+            args=as_string_list(args),
             **kwargs)
 
         self.mirror_volume_mounts = mirror_volume_mounts
@@ -884,8 +888,8 @@ class ContainerOp(BaseOp):
         self.attrs_with_pipelineparams = BaseOp.attrs_with_pipelineparams + ['_container'] #Copying the BaseOp class variable!
 
         # convert to list if not a list
-        command = as_list(command)
-        arguments = as_list(arguments)
+        command = as_string_list(command)
+        arguments = as_string_list(arguments)
 
         # `container` prop in `io.argoproj.workflow.v1alpha1.Template`
         container_kwargs = container_kwargs or {}
@@ -961,7 +965,7 @@ class ContainerOp(BaseOp):
 
     @command.setter
     def command(self, value):
-        self._container.command = as_list(value)
+        self._container.command = as_string_list(value)
 
     @property
     def arguments(self):
@@ -969,7 +973,7 @@ class ContainerOp(BaseOp):
 
     @arguments.setter
     def arguments(self, value):
-        self._container.args = as_list(value)
+        self._container.args = as_string_list(value)
 
     @property
     def container(self):


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/1121
When you pass non-string arguments to the ContainerOp.command, they're passed as such to the resulting Argo workflow which then cannot be loaded in back-end due to the item types.
This PR ensures the items are converted to string.

We should probably also stop supporting non-list command type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1197)
<!-- Reviewable:end -->
