### PR TITLE
Clear default exp table on delete and create default exp on run create if none exists

### DIFF
--- a/backend/src/apiserver/storage/db_status_store.go
+++ b/backend/src/apiserver/storage/db_status_store.go
@@ -46,6 +46,7 @@ func (s *DBStatusStore) InitializeDBStatusTable() error {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to load database status.")
 	}
+	defer rows.Close()
 
 	// The table is not initialized
 	if !rows.Next() {
@@ -83,6 +84,7 @@ func (s *DBStatusStore) HaveSamplesLoaded() (bool, error) {
 	if err != nil {
 		return false, util.NewInternalServerError(err, "Error when getting load sample status")
 	}
+	defer rows.Close()
 	if rows.Next() {
 		err = rows.Scan(&haveSamplesLoaded)
 		if err != nil {

--- a/backend/src/apiserver/storage/default_experiment_store.go
+++ b/backend/src/apiserver/storage/default_experiment_store.go
@@ -48,6 +48,7 @@ func (s *DefaultExperimentStore) initializeDefaultExperimentTable() error {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to get default experiment.")
 	}
+	defer rows.Close()
 
 	// If the table is not initialized, then set the default value.
 	if !rows.Next() {
@@ -79,6 +80,7 @@ func (s *DefaultExperimentStore) SetDefaultExperimentId(id string) error {
 	sql, args, err := sq.
 		Update("default_experiments").
 		SetMap(sq.Eq{"DefaultExperimentId": id}).
+		Where(sq.Eq{"DefaultExperimentId": ""}).
 		ToSql()
 	if err != nil {
 		return util.NewInternalServerError(err, "Error creating query to set default experiment ID.")
@@ -96,10 +98,13 @@ func (s *DefaultExperimentStore) GetDefaultExperimentId() (string, error) {
 	if err != nil {
 		return "", util.NewInternalServerError(err, "Error creating query to get default experiment ID.")
 	}
+
 	rows, err := s.db.Query(sql, args...)
 	if err != nil {
 		return "", util.NewInternalServerError(err, "Error when getting default experiment ID")
 	}
+	defer rows.Close()
+
 	if rows.Next() {
 		err = rows.Scan(&defaultExperimentId)
 		if err != nil {

--- a/backend/src/apiserver/storage/default_experiment_store.go
+++ b/backend/src/apiserver/storage/default_experiment_store.go
@@ -15,6 +15,8 @@
 package storage
 
 import (
+	"database/sql"
+
 	sq "github.com/Masterminds/squirrel"
 	"github.com/golang/glog"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
@@ -106,6 +108,26 @@ func (s *DefaultExperimentStore) GetDefaultExperimentId() (string, error) {
 		return defaultExperimentId, nil
 	}
 	return "", nil
+}
+
+// Sets the default experiment ID stored in the DB to the empty string. This needs to happen if the
+// experiment is deleted via the normal delete experiment API so that the server knows to create a
+// new default.
+// This is always done alongside the deletion of the actual experiment itself, so a transaction is
+// needed as input.
+// Update is used instead of delete so that we don't need to first check that the experiment ID is
+// there.
+func (s *DefaultExperimentStore) ClearDefaultExperimentId(tx *sql.Tx, id string) error {
+	sql, args, err := sq.
+		Update("default_experiments").
+		SetMap(sq.Eq{"DefaultExperimentId": ""}).
+		Where(sq.Eq{"DefaultExperimentId": id}).
+		ToSql()
+	_, err = tx.Exec(sql, args...)
+	if err != nil {
+		return util.NewInternalServerError(err, "Failed to clear default experiment with ID: %s", id)
+	}
+	return nil
 }
 
 // factory function for creating default experiment store

--- a/backend/src/apiserver/storage/default_experiment_store.go
+++ b/backend/src/apiserver/storage/default_experiment_store.go
@@ -122,7 +122,7 @@ func (s *DefaultExperimentStore) GetDefaultExperimentId() (string, error) {
 // needed as input.
 // Update is used instead of delete so that we don't need to first check that the experiment ID is
 // there.
-func (s *DefaultExperimentStore) ClearDefaultExperimentId(tx *sql.Tx, id string) error {
+func (s *DefaultExperimentStore) UnsetDefaultExperimentIdIfIdMatches(tx *sql.Tx, id string) error {
 	sql, args, err := sq.
 		Update("default_experiments").
 		SetMap(sq.Eq{"DefaultExperimentId": ""}).

--- a/backend/src/apiserver/storage/default_experiment_store_test.go
+++ b/backend/src/apiserver/storage/default_experiment_store_test.go
@@ -70,7 +70,7 @@ func TestGetAndSetDefaultExperimentId(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestClearDefaultExperimentId(t *testing.T) {
+func TestUnsetDefaultExperimentIdIfIdMatches(t *testing.T) {
 	db := NewFakeDbOrFatal()
 	defaultExperimentStore := NewDefaultExperimentStore(db)
 
@@ -82,7 +82,7 @@ func TestClearDefaultExperimentId(t *testing.T) {
 	assert.Nil(t, err)
 	// Clear the default experiment ID. This requires a transaction.
 	tx, _ := db.Begin()
-	err = defaultExperimentStore.ClearDefaultExperimentId(tx, "test-ID")
+	err = defaultExperimentStore.UnsetDefaultExperimentIdIfIdMatches(tx, "test-ID")
 	assert.Nil(t, err)
 	err = tx.Commit()
 	assert.Nil(t, err)

--- a/backend/src/apiserver/storage/default_experiment_store_test.go
+++ b/backend/src/apiserver/storage/default_experiment_store_test.go
@@ -33,7 +33,7 @@ func TestInitializeDefaultExperimentTable(t *testing.T) {
 	// Default experiment ID is empty after table initialization
 	defaultExperimentId, err := defaultExperimentStore.GetDefaultExperimentId()
 	assert.Nil(t, err)
-	assert.Equal(t, defaultExperimentId, "")
+	assert.Equal(t, "", defaultExperimentId)
 
 	// Initializing the table with an invalid DB is an error
 	db.Close()
@@ -54,10 +54,13 @@ func TestGetAndSetDefaultExperimentId(t *testing.T) {
 	// Get the default experiment ID
 	defaultExperimentId, err := defaultExperimentStore.GetDefaultExperimentId()
 	assert.Nil(t, err)
-	assert.Equal(t, defaultExperimentId, "test-ID")
-	// Trying to set the default experiment ID again is an error
+	assert.Equal(t, "test-ID", defaultExperimentId)
+	// Trying to set the default experiment ID again is not an error, but the ID is not changed
 	err = defaultExperimentStore.SetDefaultExperimentId("a-different-ID")
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
+	defaultExperimentId, err = defaultExperimentStore.GetDefaultExperimentId()
+	assert.Nil(t, err)
+	assert.Equal(t, "test-ID", defaultExperimentId)
 
 	// Setting or getting the default experiment ID with an invalid DB is an error
 	db.Close()
@@ -65,4 +68,28 @@ func TestGetAndSetDefaultExperimentId(t *testing.T) {
 	assert.NotNil(t, err)
 	_, err = defaultExperimentStore.GetDefaultExperimentId()
 	assert.NotNil(t, err)
+}
+
+func TestClearDefaultExperimentId(t *testing.T) {
+	db := NewFakeDbOrFatal()
+	defaultExperimentStore := NewDefaultExperimentStore(db)
+
+	// Initialize for the first time
+	err := defaultExperimentStore.initializeDefaultExperimentTable()
+	assert.Nil(t, err)
+	// Set the default experiment ID
+	err = defaultExperimentStore.SetDefaultExperimentId("test-ID")
+	assert.Nil(t, err)
+	// Clear the default experiment ID. This requires a transaction.
+	tx, _ := db.Begin()
+	err = defaultExperimentStore.ClearDefaultExperimentId(tx, "test-ID")
+	assert.Nil(t, err)
+	err = tx.Commit()
+	assert.Nil(t, err)
+	// Get the default experiment ID
+	defaultExperimentId, err := defaultExperimentStore.GetDefaultExperimentId()
+	assert.Nil(t, err)
+	assert.Equal(t, "", defaultExperimentId)
+
+	db.Close()
 }

--- a/backend/src/apiserver/storage/experiment_store.go
+++ b/backend/src/apiserver/storage/experiment_store.go
@@ -61,12 +61,12 @@ func (s *ExperimentStore) ListExperiments(opts *list.Options) ([]*model.Experime
 		tx.Rollback()
 		return errorF(err)
 	}
+	defer rows.Close()
 	exps, err := s.scanRows(rows)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
-	rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {

--- a/backend/src/apiserver/storage/experiment_store.go
+++ b/backend/src/apiserver/storage/experiment_store.go
@@ -25,6 +25,7 @@ type ExperimentStore struct {
 	time                   util.TimeInterface
 	uuid                   util.UUIDGeneratorInterface
 	resourceReferenceStore *ResourceReferenceStore
+	defaultExperimentStore *DefaultExperimentStore
 }
 
 // Runs two SQL queries in a transaction to return a list of matching experiments, as well as their
@@ -178,7 +179,7 @@ func (s *ExperimentStore) DeleteExperiment(id string) error {
 		return util.NewInternalServerError(err,
 			"Failed to create query to delete experiment: %s", id)
 	}
-	// Use a transaction to make sure both experiment and its resource references are stored.
+	// Use a transaction to make sure both experiment and its resource references are deleted.
 	tx, err := s.db.Begin()
 	if err != nil {
 		return util.NewInternalServerError(err, "Failed to create a new transaction to delete experiment.")
@@ -187,6 +188,11 @@ func (s *ExperimentStore) DeleteExperiment(id string) error {
 	if err != nil {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to delete experiment %s from table", id)
+	}
+	err = s.defaultExperimentStore.ClearDefaultExperimentId(tx, id)
+	if err != nil {
+		tx.Rollback()
+		return util.NewInternalServerError(err, "Failed to clear default experiment ID for experiment %v ", id)
 	}
 	err = s.resourceReferenceStore.DeleteResourceReferences(tx, id, common.Run)
 	if err != nil {
@@ -202,5 +208,11 @@ func (s *ExperimentStore) DeleteExperiment(id string) error {
 
 // factory function for experiment store
 func NewExperimentStore(db *DB, time util.TimeInterface, uuid util.UUIDGeneratorInterface) *ExperimentStore {
-	return &ExperimentStore{db: db, time: time, uuid: uuid, resourceReferenceStore: NewResourceReferenceStore(db)}
+	return &ExperimentStore{
+		db:   db,
+		time: time,
+		uuid: uuid,
+		resourceReferenceStore: NewResourceReferenceStore(db),
+		defaultExperimentStore: NewDefaultExperimentStore(db),
+	}
 }

--- a/backend/src/apiserver/storage/experiment_store.go
+++ b/backend/src/apiserver/storage/experiment_store.go
@@ -61,12 +61,12 @@ func (s *ExperimentStore) ListExperiments(opts *list.Options) ([]*model.Experime
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer rows.Close()
 	exps, err := s.scanRows(rows)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
+	rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {

--- a/backend/src/apiserver/storage/experiment_store.go
+++ b/backend/src/apiserver/storage/experiment_store.go
@@ -189,7 +189,7 @@ func (s *ExperimentStore) DeleteExperiment(id string) error {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to delete experiment %s from table", id)
 	}
-	err = s.defaultExperimentStore.ClearDefaultExperimentId(tx, id)
+	err = s.defaultExperimentStore.UnsetDefaultExperimentIdIfIdMatches(tx, id)
 	if err != nil {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to clear default experiment ID for experiment %v ", id)

--- a/backend/src/apiserver/storage/job_store.go
+++ b/backend/src/apiserver/storage/job_store.go
@@ -77,12 +77,12 @@ func (s *JobStore) ListJobs(
 	if err != nil {
 		return errorF(err)
 	}
-	defer rows.Close()
 	jobs, err := s.scanRows(rows)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
+	rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {

--- a/backend/src/apiserver/storage/job_store.go
+++ b/backend/src/apiserver/storage/job_store.go
@@ -77,12 +77,12 @@ func (s *JobStore) ListJobs(
 	if err != nil {
 		return errorF(err)
 	}
+	defer rows.Close()
 	jobs, err := s.scanRows(rows)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
-	rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {
@@ -204,7 +204,7 @@ func (s *JobStore) scanRows(r *sql.Rows) ([]*model.Job, error) {
 				CronSchedule: model.CronSchedule{
 					CronScheduleStartTimeInSec: NullInt64ToPointer(cronScheduleStartTimeInSec),
 					CronScheduleEndTimeInSec:   NullInt64ToPointer(cronScheduleEndTimeInSec),
-					Cron:                       NullStringToPointer(cron),
+					Cron: NullStringToPointer(cron),
 				},
 				PeriodicSchedule: model.PeriodicSchedule{
 					PeriodicScheduleStartTimeInSec: NullInt64ToPointer(periodicScheduleStartTimeInSec),
@@ -384,8 +384,8 @@ func (s *JobStore) UpdateJob(swf *util.ScheduledWorkflow) error {
 // factory function for job store
 func NewJobStore(db *DB, time util.TimeInterface) *JobStore {
 	return &JobStore{
-		db:                     db,
+		db: db,
 		resourceReferenceStore: NewResourceReferenceStore(db),
-		time:                   time,
+		time: time,
 	}
 }

--- a/backend/src/apiserver/storage/pipeline_store.go
+++ b/backend/src/apiserver/storage/pipeline_store.go
@@ -78,12 +78,12 @@ func (s *PipelineStore) ListPipelines(opts *list.Options) ([]*model.Pipeline, in
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer rows.Close()
 	pipelines, err := s.scanRows(rows)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
+	rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {

--- a/backend/src/apiserver/storage/pipeline_store.go
+++ b/backend/src/apiserver/storage/pipeline_store.go
@@ -78,12 +78,12 @@ func (s *PipelineStore) ListPipelines(opts *list.Options) ([]*model.Pipeline, in
 		tx.Rollback()
 		return errorF(err)
 	}
+	defer rows.Close()
 	pipelines, err := s.scanRows(rows)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
-	rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -103,24 +103,24 @@ func (s *RunStore) ListRuns(
 	if err != nil {
 		return errorF(err)
 	}
+	defer rows.Close()
 	runDetails, err := s.scanRowsToRunDetails(rows)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
-	rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
+	defer sizeRow.Close()
 	total_size, err := list.ScanRowToTotalSize(sizeRow)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
-	sizeRow.Close()
 
 	err = tx.Commit()
 	if err != nil {
@@ -562,10 +562,10 @@ func (s *RunStore) toRunMetadatas(models []model.ListableDataModel) []model.Run 
 // used to record artifact metadata.
 func NewRunStore(db *DB, time util.TimeInterface, metadataStore *metadata.Store) *RunStore {
 	return &RunStore{
-		db:                     db,
+		db: db,
 		resourceReferenceStore: NewResourceReferenceStore(db),
-		time:                   time,
-		metadataStore:          metadataStore,
+		time:          time,
+		metadataStore: metadataStore,
 	}
 }
 

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -103,24 +103,24 @@ func (s *RunStore) ListRuns(
 	if err != nil {
 		return errorF(err)
 	}
-	defer rows.Close()
 	runDetails, err := s.scanRowsToRunDetails(rows)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
+	rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer sizeRow.Close()
 	total_size, err := list.ScanRowToTotalSize(sizeRow)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
+	sizeRow.Close()
 
 	err = tx.Commit()
 	if err != nil {


### PR DESCRIPTION
With this change, if the delete experiment API is called on the default
experiment, then the ID will also be removed from the default_experiments
table.

Additionally, if the default experiment doesn't exist and a new run is
created without an experiment, a new default experiment will be created,
and the run will be placed within this experiment.

This PR also fixes an issue in some of the backend store files where the connection to the database was not being closed. This wasn't much of an issue in production, but it appeared that in the test environment, only one connection was allowed, so failing to close the connection would cause subsequent queries to fail, claiming that the table no longer existed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1199)
<!-- Reviewable:end -->
