### PR TITLE
Moving the component 'verbs' ahead of 'product/project'

### DIFF
--- a/components/ibm-components/watson/deploy/component.yaml
+++ b/components/ibm-components/watson/deploy/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Watson Machine Learning - Deploy Model'
+name: 'Deploy Model - Watson Machine Learning'
 description: |
   Deploy stored model on Watson Machine Learning as a web service.
 metadata:

--- a/components/ibm-components/watson/manage/monitor_fairness/component.yaml
+++ b/components/ibm-components/watson/manage/monitor_fairness/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Watson OpenScale - Monitor Fairness'
+name: 'Monitor Fairness - Watson OpenScale'
 description: |
   Enable model fairness monitoring on Watson OpenScale.
 metadata:

--- a/components/ibm-components/watson/manage/monitor_quality/component.yaml
+++ b/components/ibm-components/watson/manage/monitor_quality/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Watson OpenScale - Monitor quality'
+name: 'Monitor quality - Watson OpenScale'
 description: |
   Enable model quality monitoring on Watson OpenScale.
 metadata:

--- a/components/ibm-components/watson/manage/subscribe/component.yaml
+++ b/components/ibm-components/watson/manage/subscribe/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Watson OpenScale - Subscribe'
+name: 'Subscribe - Watson OpenScale'
 description: |
   Binding deployed models and subscribe them to Watson OpenScale service.
 metadata:

--- a/components/ibm-components/watson/store/component.yaml
+++ b/components/ibm-components/watson/store/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Watson Machine Learning - Store model'
+name: 'Store model - Watson Machine Learning'
 description: |
   Store and persistent trained model on Watson Machine Learning.
 metadata:

--- a/components/ibm-components/watson/train/component.yaml
+++ b/components/ibm-components/watson/train/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Watson Machine Learning - Train Model'
+name: 'Train Model - Watson Machine Learning'
 description: |
   Train Machine Learning and Deep Learning Models in the Cloud using Watson Machine Learning
 metadata:

--- a/samples/ibm-samples/ffdl-seldon/ffdl_pipeline.py
+++ b/samples/ibm-samples/ffdl-seldon/ffdl_pipeline.py
@@ -6,12 +6,16 @@ import ai_pipeline_params as params
 # generate default secret name
 secret_name = 'kfp-creds'
 
-
+configuration_op = components.load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/commons/config/component.yaml')
+train_op = components.load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/ffdl/train/component.yaml')
+serve_op = components.load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/ffdl/serve/component.yaml')
+    
 # create pipeline
 @dsl.pipeline(
   name='FfDL pipeline',
   description='A pipeline for machine learning workflow using Fabric for Deep Learning and Seldon.'
 )
+
 def ffdlPipeline(
     GITHUB_TOKEN=dsl.PipelineParam(name='github-token',
                                    value=''),
@@ -29,10 +33,6 @@ def ffdlPipeline(
                                        value='gender_classification.py')
 ):
     """A pipeline for end to end machine learning workflow."""
-    
-    configuration_op = components.load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/785d474699cffb7463986b9abc4b1fbe03796cb6/components/ibm-components/commons/config/component.yaml')
-    train_op = components.load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/785d474699cffb7463986b9abc4b1fbe03796cb6/components/ibm-components/ffdl/train/component.yaml')
-    serve_op = components.load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/785d474699cffb7463986b9abc4b1fbe03796cb6/components/ibm-components/ffdl/serve/component.yaml')
     
     get_configuration = configuration_op(
                    token = GITHUB_TOKEN,


### PR DESCRIPTION
During run of pipelines, only first couple of words from comp names are displayed, and every step looks similar. So moving the verb ahead tells what each comp is doing in visual part

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1202)
<!-- Reviewable:end -->
