### PR TITLE
Swagger - Specifying content types on the route level

### DIFF
--- a/backend/api/swagger/pipeline.upload.swagger.json
+++ b/backend/api/swagger/pipeline.upload.swagger.json
@@ -8,16 +8,16 @@
     "http",
     "https"
   ],
-  "consumes": [
-    "multipart/form-data"
-  ],
-  "produces": [
-    "application/json"
-  ],
   "paths": {
     "/apis/v1beta1/pipelines/upload": {
       "post": {
         "operationId": "UploadPipeline",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
         "responses": {
           "200": {
             "description": "",


### PR DESCRIPTION
The UploadPipeline route is unique in that it's uses `multipart/form-data` passing style. 
This PR moves that specification from global setting to the route level. This makes it easier to combine this route with other routes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1225)
<!-- Reviewable:end -->
