### PR TITLE
SDK/DSL - ContainerOp.apply method now supports functions that do not return anything

### DIFF
--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -847,7 +847,7 @@ class ContainerOp(object):
               .set_memory_limit('2GB')
           )
         """
-        return mod_func(self)
+        return mod_func(self) or self
 
     def after(self, op):
         """Specify explicit dependency on another op."""


### PR DESCRIPTION
This change prevents errors in case the function does not return anything. Previously, the function had to always pass through the `ContainerOp` passed to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1226)
<!-- Reviewable:end -->
