### PR TITLE
SDK - Removing unneeded uses of dsl.Pipeline

### DIFF
--- a/sdk/python/kfp/components/_dsl_bridge.py
+++ b/sdk/python/kfp/components/_dsl_bridge.py
@@ -129,16 +129,8 @@ def create_container_op_from_task(task_spec: TaskSpec):
     )
 
 
-_dummy_pipeline=None
-
 def _create_container_op_from_resolved_task(name:str, container_image:str, command=None, arguments=None, output_paths=None, env : Mapping[str, str]=None, component_spec=None):
     from .. import dsl
-    global _dummy_pipeline
-    need_dummy = dsl.Pipeline._default_pipeline is None
-    if need_dummy:
-        if _dummy_pipeline == None:
-            _dummy_pipeline = dsl.Pipeline('dummy pipeline')
-        _dummy_pipeline.__enter__()
 
     #Renaming outputs to conform with ContainerOp/Argo
     from ._naming import _sanitize_python_function_name, generate_unique_name_conversion_table
@@ -176,9 +168,6 @@ def _create_container_op_from_resolved_task(name:str, container_image:str, comma
             task.add_pod_annotation(key, value)
         for key, value in (component_spec.metadata.labels or {}).items():
             task.add_pod_label(key, value)
-
-    if need_dummy:
-        _dummy_pipeline.__exit__()
 
     return task
 

--- a/sdk/python/tests/components/test_components.py
+++ b/sdk/python/tests/components/test_components.py
@@ -522,9 +522,7 @@ implementation:
 '''
         task_factory1 = comp.load_component_from_text(component_text)
         
-        import kfp
-        with kfp.dsl.Pipeline('Dummy'): #Forcing the TaskSpec conversion to ContainerOp
-            task1 = task_factory1()
+        task1 = task_factory1()
         actual_env = {env_var.name: env_var.value for env_var in task1.container.env}
         expected_env = {'key1': 'value 1', 'key2': 'value 2'}
         self.assertDictEqual(expected_env, actual_env)

--- a/sdk/python/tests/dsl/aws_extensions_tests.py
+++ b/sdk/python/tests/dsl/aws_extensions_tests.py
@@ -26,7 +26,6 @@ class AwsExtensionTests(unittest.TestCase):
     assert spec.defaults[2] == 'AWS_SECRET_ACCESS_KEY'
 
   def test_use_aws_secret(self):
-    with Pipeline('somename') as p:
       op1 = ContainerOp(name='op1', image='image')
       op1 = op1.apply(use_aws_secret('myaws-secret', 'key_id', 'access_key'))
       assert len(op1.env_variables) == 2

--- a/sdk/python/tests/dsl/component_tests.py
+++ b/sdk/python/tests/dsl/component_tests.py
@@ -81,9 +81,8 @@ class TestPythonComponent(unittest.TestCase):
           }
       )
 
-    with Pipeline('pipeline') as p:
-      a = a_op(field_l=12)
-      b = b_op(field_x=a.outputs['field_n'], field_y=a.outputs['field_o'], field_z=a.outputs['field_m'])
+    a = a_op(field_l=12)
+    b = b_op(field_x=a.outputs['field_n'], field_y=a.outputs['field_o'], field_z=a.outputs['field_m'])
 
   def test_type_check_with_different_represenation(self):
     """Test type check at the decorator."""
@@ -123,9 +122,8 @@ class TestPythonComponent(unittest.TestCase):
           }
       )
 
-    with Pipeline('pipeline') as p:
-      a = a_op(field_l=12)
-      b = b_op(field_x=a.outputs['field_n'], field_y=a.outputs['field_o'], field_z=a.outputs['field_m'])
+    a = a_op(field_l=12)
+    b = b_op(field_x=a.outputs['field_n'], field_y=a.outputs['field_o'], field_z=a.outputs['field_m'])
 
   def test_type_check_with_inconsistent_types_property_value(self):
     """Test type check at the decorator."""
@@ -166,7 +164,6 @@ class TestPythonComponent(unittest.TestCase):
       )
 
     with self.assertRaises(InconsistentTypeException):
-      with Pipeline('pipeline') as p:
         a = a_op(field_l=12)
         b = b_op(field_x=a.outputs['field_n'], field_y=a.outputs['field_o'], field_z=a.outputs['field_m'])
 
@@ -209,7 +206,6 @@ class TestPythonComponent(unittest.TestCase):
       )
 
     with self.assertRaises(InconsistentTypeException):
-      with Pipeline('pipeline') as p:
         a = a_op(field_l=12)
         b = b_op(field_x=a.outputs['field_n'], field_y=a.outputs['field_o'], field_z=a.outputs['field_m'])
 
@@ -251,9 +247,8 @@ class TestPythonComponent(unittest.TestCase):
           }
       )
 
-    with Pipeline('pipeline') as p:
-      a = a_op(field_l=12)
-      b = b_op(field_x=a.outputs['field_n'], field_y=a.outputs['field_o'], field_z=a.outputs['field_m'])
+    a = a_op(field_l=12)
+    b = b_op(field_x=a.outputs['field_n'], field_y=a.outputs['field_o'], field_z=a.outputs['field_m'])
 
   def test_type_check_nonnamed_inputs(self):
     """Test type check at the decorator."""
@@ -293,9 +288,8 @@ class TestPythonComponent(unittest.TestCase):
           }
       )
 
-    with Pipeline('pipeline') as p:
-      a = a_op(field_l=12)
-      b = b_op(a.outputs['field_n'], field_z=a.outputs['field_m'], field_y=a.outputs['field_o'])
+    a = a_op(field_l=12)
+    b = b_op(a.outputs['field_n'], field_z=a.outputs['field_m'], field_y=a.outputs['field_o'])
 
   def test_type_check_with_inconsistent_types_disabled(self):
     """Test type check at the decorator."""
@@ -335,9 +329,8 @@ class TestPythonComponent(unittest.TestCase):
           }
       )
 
-    with Pipeline('pipeline') as p:
-      a = a_op(field_l=12)
-      b = b_op(field_x=a.outputs['field_n'], field_y=a.outputs['field_o'], field_z=a.outputs['field_m'])
+    a = a_op(field_l=12)
+    b = b_op(field_x=a.outputs['field_n'], field_y=a.outputs['field_o'], field_z=a.outputs['field_m'])
 
   def test_type_check_with_openapi_schema(self):
     """Test type check at the decorator."""
@@ -377,9 +370,8 @@ class TestPythonComponent(unittest.TestCase):
           }
       )
 
-    with Pipeline('pipeline') as p:
-      a = a_op(field_l=12)
-      b = b_op(field_x=a.outputs['field_n'], field_y=a.outputs['field_o'], field_z=a.outputs['field_m'])
+    a = a_op(field_l=12)
+    b = b_op(field_x=a.outputs['field_n'], field_y=a.outputs['field_o'], field_z=a.outputs['field_m'])
 
   def test_type_check_with_ignore_type(self):
     """Test type check at the decorator."""
@@ -419,11 +411,10 @@ class TestPythonComponent(unittest.TestCase):
           }
       )
 
-    with Pipeline('pipeline') as p:
-      a = a_op(field_l=12)
-      with self.assertRaises(InconsistentTypeException):
-        b = b_op(field_x=a.outputs['field_n'], field_y=a.outputs['field_o'], field_z=a.outputs['field_m'])
-      b = b_op(field_x=a.outputs['field_n'].ignore_type(), field_y=a.outputs['field_o'], field_z=a.outputs['field_m'])
+    a = a_op(field_l=12)
+    with self.assertRaises(InconsistentTypeException):
+      b = b_op(field_x=a.outputs['field_n'], field_y=a.outputs['field_o'], field_z=a.outputs['field_m'])
+    b = b_op(field_x=a.outputs['field_n'].ignore_type(), field_y=a.outputs['field_o'], field_z=a.outputs['field_m'])
 
 class TestGraphComponent(unittest.TestCase):
 

--- a/sdk/python/tests/dsl/container_op_tests.py
+++ b/sdk/python/tests/dsl/container_op_tests.py
@@ -36,7 +36,7 @@ class TestContainerOp(unittest.TestCase):
       
     self.assertCountEqual([x.name for x in op1.inputs], ['param1', 'param2'])
     self.assertCountEqual(list(op1.outputs.keys()), ['out1'])
-    self.assertCountEqual([x.op_name for x in op1.outputs.values()], ['op1'])
+    self.assertCountEqual([x.op_name for x in op1.outputs.values()], [op1.name])
     self.assertEqual(op1.output.name, 'out1')
     self.assertCountEqual([sidecar.name for sidecar in op1.sidecars], ['sidecar0', 'sidecar1', 'sidecar2'])
     self.assertCountEqual([sidecar.image for sidecar in op1.sidecars], ['image0', 'image1', 'image2'])

--- a/sdk/python/tests/dsl/container_op_tests.py
+++ b/sdk/python/tests/dsl/container_op_tests.py
@@ -24,16 +24,15 @@ class TestContainerOp(unittest.TestCase):
 
   def test_basic(self):
     """Test basic usage."""
-    with Pipeline('somename') as p:
-      param1 = PipelineParam('param1')
-      param2 = PipelineParam('param2')
-      op1 = (ContainerOp(name='op1', image='image',
-          arguments=['%s hello %s %s' % (param1, param2, param1)],
-          sidecars=[Sidecar(name='sidecar0', image='image0')],
-          container_kwargs={'env': [V1EnvVar(name='env1', value='value1')]},
-          file_outputs={'out1': '/tmp/b'})
-            .add_sidecar(Sidecar(name='sidecar1', image='image1'))
-            .add_sidecar(Sidecar(name='sidecar2', image='image2')))
+    param1 = PipelineParam('param1')
+    param2 = PipelineParam('param2')
+    op1 = (ContainerOp(name='op1', image='image',
+        arguments=['%s hello %s %s' % (param1, param2, param1)],
+        sidecars=[Sidecar(name='sidecar0', image='image0')],
+        container_kwargs={'env': [V1EnvVar(name='env1', value='value1')]},
+        file_outputs={'out1': '/tmp/b'})
+          .add_sidecar(Sidecar(name='sidecar1', image='image1'))
+          .add_sidecar(Sidecar(name='sidecar2', image='image2')))
       
     self.assertCountEqual([x.name for x in op1.inputs], ['param1', 'param2'])
     self.assertCountEqual(list(op1.outputs.keys()), ['out1'])
@@ -45,17 +44,15 @@ class TestContainerOp(unittest.TestCase):
 
   def test_after_op(self):
     """Test duplicate ops."""
-    with Pipeline('somename') as p:
-      op1 = ContainerOp(name='op1', image='image')
-      op2 = ContainerOp(name='op2', image='image')
-      op2.after(op1)
+    op1 = ContainerOp(name='op1', image='image')
+    op2 = ContainerOp(name='op2', image='image')
+    op2.after(op1)
     self.assertCountEqual(op2.dependent_names, [op1.name])
 
 
   def test_deprecation_warnings(self):
     """Test deprecation warnings."""
-    with Pipeline('somename') as p:
-      op = ContainerOp(name='op1', image='image')
+    op = ContainerOp(name='op1', image='image')
 
     with self.assertWarns(PendingDeprecationWarning):
       op.env_variables = [V1EnvVar(name="foo", value="bar")]

--- a/sdk/python/tests/dsl/test_azure_extensions.py
+++ b/sdk/python/tests/dsl/test_azure_extensions.py
@@ -24,17 +24,16 @@ class AzExtensionTests(unittest.TestCase):
         assert spec.defaults[0] == 'azcreds'
 
     def test_use_azure_secret(self):
-        with Pipeline('somename') as p:
-            op1 = ContainerOp(name='op1', image='image')
-            op1 = op1.apply(use_azure_secret('foo'))
-            assert len(op1.env_variables) == 4
-            
-            index = 0
-            for expected in ['AZ_SUBSCRIPTION_ID', 'AZ_TENANT_ID', 'AZ_CLIENT_ID', 'AZ_CLIENT_SECRET']:
-                assert op1.env_variables[index].name == expected
-                assert op1.env_variables[index].value_from.secret_key_ref.name == 'foo'
-                assert op1.env_variables[index].value_from.secret_key_ref.key == expected
-                index += 1
+        op1 = ContainerOp(name='op1', image='image')
+        op1 = op1.apply(use_azure_secret('foo'))
+        assert len(op1.env_variables) == 4
+        
+        index = 0
+        for expected in ['AZ_SUBSCRIPTION_ID', 'AZ_TENANT_ID', 'AZ_CLIENT_ID', 'AZ_CLIENT_SECRET']:
+            assert op1.env_variables[index].name == expected
+            assert op1.env_variables[index].value_from.secret_key_ref.name == 'foo'
+            assert op1.env_variables[index].value_from.secret_key_ref.key == expected
+            index += 1
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`dsl.Pipeline` is a private compiler context object that should not be used outside the compiler (and compiler tests).
This PR removes most of the unnecessary uses of `dsl.Pipeline`.
Please turn on "Hide whitespace changes" in diff settings when looking at the diff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1229)
<!-- Reviewable:end -->
