### PR TITLE
Fixing comp names

### DIFF
--- a/components/ibm-components/commons/config/component.yaml
+++ b/components/ibm-components/commons/config/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Create secret - Kubernetes Cluster'
+name: 'Create Secret - Kubernetes Cluster'
 description: |
   Create secret to store pipeline credentials on Kubernetes Cluster
 inputs:

--- a/components/ibm-components/commons/config/component.yaml
+++ b/components/ibm-components/commons/config/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Kubernetes Cluster - Create secret'
+name: 'Create secret - Kubernetes Cluster'
 description: |
   Create secret to store pipeline credentials on Kubernetes Cluster
 inputs:

--- a/components/ibm-components/ffdl/serve/component.yaml
+++ b/components/ibm-components/ffdl/serve/component.yaml
@@ -10,11 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Seldon Core - Serve PyTorch Model'
+name: 'Serve PyTorch Model - Seldon Core'
 description: |
   Serve PyTorch Models remotely as web service using Seldon Core
 metadata:
-  labels: {platform: 'Open Source'}
+  labels: {platform: 'OpenSource'}
 inputs:
   - {name: model_id,            description: 'Required. Model training_id from Fabric for Deep Learning'}
   - {name: deployment_name,     description: 'Required. Deployment name for the seldon service'}

--- a/components/ibm-components/ffdl/train/component.yaml
+++ b/components/ibm-components/ffdl/train/component.yaml
@@ -10,11 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Fabric for Deep Learning - Train Model'
+name: 'Train Model - FfDL'
 description: |
   Train Machine Learning and Deep Learning Models remotely using Fabric for Deep Learning
 metadata:
-  labels: {platform: 'Open Source'}
+  labels: {platform: 'OpenSource'}
 inputs:
   - {name: model_def_file_path, description: 'Required. Path for model training code in object storage'}
   - {name: manifest_file_path,  description: 'Required. Path for model manifest definition in object storage'}

--- a/samples/ibm-samples/ffdl-seldon/ffdl_pipeline.py
+++ b/samples/ibm-samples/ffdl-seldon/ffdl_pipeline.py
@@ -27,7 +27,7 @@ def ffdlPipeline(
 ):
     """A pipeline for end to end machine learning workflow."""
     
-    get_configuration = configuration_op(
+    create_secrets = configuration_op(
                    token = GITHUB_TOKEN,
                    url = CONFIG_FILE_URL,
                    name = secret_name


### PR DESCRIPTION
Moving the verb in comp names before because of UI real estate, plus removing the space in metadata label value as Jupyter notebook driven pipelines are complaining about the space

metadata.labels: Invalid value: "Open Source": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue', or 'my_value', or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1239)
<!-- Reviewable:end -->
