### PR TITLE
Fix Watson pipeline example 

### DIFF
--- a/components/ibm-components/commons/config/src/config.py
+++ b/components/ibm-components/commons/config/src/config.py
@@ -34,8 +34,12 @@ if __name__ == "__main__":
     secret_name = args.name
     if (not secret_name):
         secret_name = 'ai-pipeline-' + os.path.splitext(config_file)[0]
-    command = ['kubectl', 'delete', 'secret', secret_name]
-    subprocess.run(command, check=True)
+
+    try:
+        command = ['kubectl', 'delete', 'secret', secret_name]
+        subprocess.run(command, check=True)
+    except Exception as e:
+        print('No previous secret: ' + secret_name + '. Secret deletion is not performed.')
 
     # gather all secrets
     command = ['kubectl', 'create', 'secret', 'generic', secret_name]

--- a/components/ibm-components/ffdl/serve/component.yaml
+++ b/components/ibm-components/ffdl/serve/component.yaml
@@ -14,7 +14,7 @@ name: 'Seldon Core - Serve PyTorch Model'
 description: |
   Serve PyTorch Models remotely as web service using Seldon Core
 metadata:
-  labels: {platform: 'Open Source'}
+  annotations: {platform: 'Open Source'}
 inputs:
   - {name: model_id,            description: 'Required. Model training_id from Fabric for Deep Learning'}
   - {name: deployment_name,     description: 'Required. Deployment name for the seldon service'}

--- a/components/ibm-components/ffdl/train/component.yaml
+++ b/components/ibm-components/ffdl/train/component.yaml
@@ -14,7 +14,7 @@ name: 'Fabric for Deep Learning - Train Model'
 description: |
   Train Machine Learning and Deep Learning Models remotely using Fabric for Deep Learning
 metadata:
-  labels: {platform: 'Open Source'}
+  annotations: {platform: 'Open Source'}
 inputs:
   - {name: model_def_file_path, description: 'Required. Path for model training code in object storage'}
   - {name: manifest_file_path,  description: 'Required. Path for model manifest definition in object storage'}

--- a/components/ibm-components/watson/deploy/component.yaml
+++ b/components/ibm-components/watson/deploy/component.yaml
@@ -14,7 +14,7 @@ name: 'Deploy Model - Watson Machine Learning'
 description: |
   Deploy stored model on Watson Machine Learning as a web service.
 metadata:
-  labels: {platform: 'IBM-Watson-Machine-Learning'}
+  annotations: {platform: 'IBM Watson Machine Learning'}
 inputs:
   - {name: model_uid,       description: 'Required. UID for the stored model on Watson Machine Learning'}
   - {name: model_name,      description: 'Required. Model Name on Watson Machine Learning'}

--- a/components/ibm-components/watson/deploy/component.yaml
+++ b/components/ibm-components/watson/deploy/component.yaml
@@ -14,7 +14,7 @@ name: 'Deploy Model - Watson Machine Learning'
 description: |
   Deploy stored model on Watson Machine Learning as a web service.
 metadata:
-  labels: {platform: 'IBM Watson Machine Learning'}
+  labels: {platform: 'IBM-Watson-Machine-Learning'}
 inputs:
   - {name: model_uid,       description: 'Required. UID for the stored model on Watson Machine Learning'}
   - {name: model_name,      description: 'Required. Model Name on Watson Machine Learning'}

--- a/components/ibm-components/watson/manage/monitor_fairness/component.yaml
+++ b/components/ibm-components/watson/manage/monitor_fairness/component.yaml
@@ -14,7 +14,7 @@ name: 'Monitor Fairness - Watson OpenScale'
 description: |
   Enable model fairness monitoring on Watson OpenScale.
 metadata:
-  labels: {platform: 'IBM Watson OpenScale'}
+  labels: {platform: 'IBM-Watson-OpenScale'}
 inputs:
   - {name: model_name,            description: 'Deployed model name on OpenScale.', default: 'AIOS Spark German Risk Model - Final'}
   - {name: fairness_threshold,    description: 'Amount of threshold for fairness monitoring.', default: '0.95'}

--- a/components/ibm-components/watson/manage/monitor_fairness/component.yaml
+++ b/components/ibm-components/watson/manage/monitor_fairness/component.yaml
@@ -14,7 +14,7 @@ name: 'Monitor Fairness - Watson OpenScale'
 description: |
   Enable model fairness monitoring on Watson OpenScale.
 metadata:
-  labels: {platform: 'IBM-Watson-OpenScale'}
+  annotations: {platform: 'IBM Watson OpenScale'}
 inputs:
   - {name: model_name,            description: 'Deployed model name on OpenScale.', default: 'AIOS Spark German Risk Model - Final'}
   - {name: fairness_threshold,    description: 'Amount of threshold for fairness monitoring.', default: '0.95'}

--- a/components/ibm-components/watson/manage/monitor_quality/component.yaml
+++ b/components/ibm-components/watson/manage/monitor_quality/component.yaml
@@ -14,7 +14,7 @@ name: 'Monitor quality - Watson OpenScale'
 description: |
   Enable model quality monitoring on Watson OpenScale.
 metadata:
-  labels: {platform: 'IBM-Watson-OpenScale'}
+  annotations: {platform: 'IBM Watson OpenScale'}
 inputs:
   - {name: model_name,           description: 'Deployed model name on OpenScale.', default: 'AIOS Spark German Risk Model - Final'}
   - {name: problem_type,         description: 'Model problem type.', default: 'BINARY_CLASSIFICATION'}

--- a/components/ibm-components/watson/manage/monitor_quality/component.yaml
+++ b/components/ibm-components/watson/manage/monitor_quality/component.yaml
@@ -14,7 +14,7 @@ name: 'Monitor quality - Watson OpenScale'
 description: |
   Enable model quality monitoring on Watson OpenScale.
 metadata:
-  labels: {platform: 'IBM Watson OpenScale'}
+  labels: {platform: 'IBM-Watson-OpenScale'}
 inputs:
   - {name: model_name,           description: 'Deployed model name on OpenScale.', default: 'AIOS Spark German Risk Model - Final'}
   - {name: problem_type,         description: 'Model problem type.', default: 'BINARY_CLASSIFICATION'}

--- a/components/ibm-components/watson/manage/subscribe/component.yaml
+++ b/components/ibm-components/watson/manage/subscribe/component.yaml
@@ -14,7 +14,7 @@ name: 'Subscribe - Watson OpenScale'
 description: |
   Binding deployed models and subscribe them to Watson OpenScale service.
 metadata:
-  labels: {platform: 'IBM Watson OpenScale'}
+  labels: {platform: 'IBM-Watson-OpenScale'}
 inputs:
   - {name: model_name,    description: 'Deployed model name.', default: 'AIOS Spark German Risk Model - Final'}
   - {name: model_uid,     description: 'Deployed model uid.', default: 'dummy uid'}

--- a/components/ibm-components/watson/manage/subscribe/component.yaml
+++ b/components/ibm-components/watson/manage/subscribe/component.yaml
@@ -14,7 +14,7 @@ name: 'Subscribe - Watson OpenScale'
 description: |
   Binding deployed models and subscribe them to Watson OpenScale service.
 metadata:
-  labels: {platform: 'IBM-Watson-OpenScale'}
+  annotations: {platform: 'IBM Watson OpenScale'}
 inputs:
   - {name: model_name,    description: 'Deployed model name.', default: 'AIOS Spark German Risk Model - Final'}
   - {name: model_uid,     description: 'Deployed model uid.', default: 'dummy uid'}

--- a/components/ibm-components/watson/store/component.yaml
+++ b/components/ibm-components/watson/store/component.yaml
@@ -14,7 +14,7 @@ name: 'Store model - Watson Machine Learning'
 description: |
   Store and persistent trained model on Watson Machine Learning.
 metadata:
-  labels: {platform: 'IBM Watson Machine Learning'}
+  labels: {platform: 'IBM-Watson-Machine-Learning'}
 inputs:
   - {name: run_uid,        description: 'Required. UID for the Watson Machine Learning training-runs'}
   - {name: model_name,     description: 'Required. Model Name to store on Watson Machine Learning'}

--- a/components/ibm-components/watson/store/component.yaml
+++ b/components/ibm-components/watson/store/component.yaml
@@ -14,7 +14,7 @@ name: 'Store model - Watson Machine Learning'
 description: |
   Store and persistent trained model on Watson Machine Learning.
 metadata:
-  labels: {platform: 'IBM-Watson-Machine-Learning'}
+  annotations: {platform: 'IBM Watson Machine Learning'}
 inputs:
   - {name: run_uid,        description: 'Required. UID for the Watson Machine Learning training-runs'}
   - {name: model_name,     description: 'Required. Model Name to store on Watson Machine Learning'}

--- a/components/ibm-components/watson/train/component.yaml
+++ b/components/ibm-components/watson/train/component.yaml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Watson Machine Learning - Train Model'
+name: 'Train Model - Watson Machine Learning'
 description: |
   Train Machine Learning and Deep Learning Models in the Cloud using Watson Machine Learning
 metadata:

--- a/components/ibm-components/watson/train/component.yaml
+++ b/components/ibm-components/watson/train/component.yaml
@@ -10,21 +10,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Train Model - Watson Machine Learning'
+name: 'Watson Machine Learning - Train Model'
 description: |
   Train Machine Learning and Deep Learning Models in the Cloud using Watson Machine Learning
 metadata:
-  labels: {platform: 'IBM Watson Machine Learning'}
+  labels: {platform: 'IBM-Watson-Machine-Learning'}
 inputs:
   - {name: train_code,        description: 'Required. Code for training ML/DL models'}
   - {name: execution_command, description: 'Required. Execution command to start the model training.'}
-  - {name: config,            description: 'Required. Credential configfile is properly created.'}
+  - {name: config,            description: 'Required. Credential configfile is properly created.', default: 'secret_name'}
   - {name: framework,         description: 'ML/DL Model Framework', default: 'tensorflow'}
   - {name: framework_version, description: 'Model Framework version', default: '1.5'}
   - {name: runtime,           description: 'Model Code runtime language', default: 'python'}
   - {name: runtime_version,   description: 'Model Code runtime version', default: '3.5'}
   - {name: run_definition,    description: 'Name for the Watson Machine Learning training definition', default: 'python-tensorflow-definition'}
   - {name: run_name,          description: 'Name for the Watson Machine Learning training-runs', default: 'python-tensorflow-run'}
+  - {name: author_email,      description: 'Email of this training job author', default: 'author@ibm.com'}
 outputs:
   - {name: run_uid,           description: 'UID for the Watson Machine Learning training-runs'}
 implementation:
@@ -41,7 +42,8 @@ implementation:
       --runtime, {inputValue: runtime},
       --runtime-version, {inputValue: runtime_version},
       --run-definition, {inputValue: run_definition},
-      --run-name, {inputValue: run_name}
+      --run-name, {inputValue: run_name},
+      --author-email, {inputValue: author_email}
     ]
     fileOutputs:
       run_uid: /tmp/run_uid

--- a/components/ibm-components/watson/train/component.yaml
+++ b/components/ibm-components/watson/train/component.yaml
@@ -18,7 +18,7 @@ metadata:
 inputs:
   - {name: train_code,        description: 'Required. Code for training ML/DL models'}
   - {name: execution_command, description: 'Required. Execution command to start the model training.'}
-  - {name: config,            description: 'Required. Credential configfile is properly created.', default: 'secret_name'}
+  - {name: config,            description: 'Credential configfile is properly created.', default: 'secret_name'}
   - {name: framework,         description: 'ML/DL Model Framework', default: 'tensorflow'}
   - {name: framework_version, description: 'Model Framework version', default: '1.5'}
   - {name: runtime,           description: 'Model Code runtime language', default: 'python'}

--- a/components/ibm-components/watson/train/component.yaml
+++ b/components/ibm-components/watson/train/component.yaml
@@ -14,7 +14,7 @@ name: 'Train Model - Watson Machine Learning'
 description: |
   Train Machine Learning and Deep Learning Models in the Cloud using Watson Machine Learning
 metadata:
-  labels: {platform: 'IBM-Watson-Machine-Learning'}
+  annotations: {platform: 'IBM Watson Machine Learning'}
 inputs:
   - {name: train_code,        description: 'Required. Code for training ML/DL models'}
   - {name: execution_command, description: 'Required. Execution command to start the model training.'}

--- a/components/ibm-components/watson/train/src/wml-train.py
+++ b/components/ibm-components/watson/train/src/wml-train.py
@@ -31,6 +31,7 @@ def train(args):
     wml_runtime_version = args.runtime_version if args.runtime_version else '3.5'
     wml_run_definition = args.run_definition if args.run_definition else 'python-tensorflow-definition'
     wml_run_name = args.run_name if args.run_name else 'python-tensorflow-run'
+    wml_author_email = args.author_email if args.author_email else 'wzhuang@us.ibm.com'
 
     # retrieve credentials
     wml_url = getSecret("/app/secrets/wml_url")
@@ -43,9 +44,7 @@ def train(args):
     cos_endpoint = getSecret("/app/secrets/cos_endpoint")
     cos_access_key = getSecret("/app/secrets/cos_access_key")
     cos_secret_key = getSecret("/app/secrets/cos_secret_key")
-    
     cos_input_bucket = getSecret("/app/secrets/cos_input_bucket")
-
     cos_output_bucket = getSecret("/app/secrets/cos_output_bucket")
 
     # download model code
@@ -64,11 +63,11 @@ def train(args):
                        "instance_id": wml_instance_id
                       }
     client = WatsonMachineLearningAPIClient( wml_credentials )
-        
+
     # define the model
     metadata = {
         client.repository.DefinitionMetaNames.NAME              : wml_run_definition,
-        client.repository.DefinitionMetaNames.AUTHOR_EMAIL      : "wzhuang@us.ibm.com",
+        client.repository.DefinitionMetaNames.AUTHOR_EMAIL      : wml_author_email,
         client.repository.DefinitionMetaNames.FRAMEWORK_NAME    : wml_framework_name,
         client.repository.DefinitionMetaNames.FRAMEWORK_VERSION : wml_framework_version,
         client.repository.DefinitionMetaNames.RUNTIME_NAME      : wml_runtime_name,
@@ -83,7 +82,7 @@ def train(args):
     # define the run
     metadata = {
         client.training.ConfigurationMetaNames.NAME         : wml_run_name,
-        client.training.ConfigurationMetaNames.AUTHOR_EMAIL : "wzhuang@us.ibm.com",
+        client.training.ConfigurationMetaNames.AUTHOR_EMAIL : wml_author_email,
         client.training.ConfigurationMetaNames.TRAINING_DATA_REFERENCE : {
             "connection" : {
                 "endpoint_url"      : cos_endpoint,
@@ -137,8 +136,11 @@ if __name__ == "__main__":
     parser.add_argument('--runtime-version', type=str)
     parser.add_argument('--run-definition', type=str)
     parser.add_argument('--run-name', type=str)
-    parser.add_argument('--config', type=str)
+    parser.add_argument('--author-email', type=str)
+    parser.add_argument('--config', type=str, default="secret_name")
     args = parser.parse_args()
-    if (args.config != "created"):
+    # Check secret name is not empty
+    if (not args.config):
+        print("Secret for this pipeline is not properly created, exiting with status 1...")
         exit(1)
     train(args)

--- a/components/ibm-components/watson/train/src/wml-train.py
+++ b/components/ibm-components/watson/train/src/wml-train.py
@@ -31,7 +31,7 @@ def train(args):
     wml_runtime_version = args.runtime_version if args.runtime_version else '3.5'
     wml_run_definition = args.run_definition if args.run_definition else 'python-tensorflow-definition'
     wml_run_name = args.run_name if args.run_name else 'python-tensorflow-run'
-    wml_author_email = args.author_email if args.author_email else 'wzhuang@us.ibm.com'
+    wml_author_email = args.author_email if args.author_email else 'author@ibm.com'
 
     # retrieve credentials
     wml_url = getSecret("/app/secrets/wml_url")

--- a/samples/ibm-samples/watson/watson_train_serve_pipeline.py
+++ b/samples/ibm-samples/watson/watson_train_serve_pipeline.py
@@ -66,15 +66,15 @@ def kfp_wml_pipeline(
 
     # op3 - this operation stores the model trained above
     wml_store = store_op(
-                   run_uid=wml_train.output,
-                   model_name=model_name
+                   wml_train.output,
+                   model_name
                   ).apply(params.use_ai_pipeline_params(secret_name))
 
     # op4 - this operation deploys the model to a web service and run scoring with the payload in the cloud object store
     wml_deploy = deploy_op(
-                  model_uid=wml_store.output,
-                  model_name=model_name,
-                  scoring_payload=scoring_payload
+                  wml_store.output,
+                  model_name,
+                  scoring_payload
                  ).apply(params.use_ai_pipeline_params(secret_name))
 
 if __name__ == '__main__':

--- a/samples/ibm-samples/watson/watson_train_serve_pipeline.py
+++ b/samples/ibm-samples/watson/watson_train_serve_pipeline.py
@@ -10,9 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# place storing the configuration secrets
-GITHUB_TOKEN = ''
-CONFIG_FILE_URL = 'https://raw.githubusercontent.com/user-name/kfp-secrets/master/creds.ini'
 
 # generate default secret name
 import os
@@ -26,7 +23,7 @@ configuration_op = components.load_component_from_url('https://raw.githubusercon
 train_op = components.load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/watson/train/component.yaml')
 store_op = components.load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/watson/store/component.yaml')
 deploy_op = components.load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/watson/deploy/component.yaml')
-    
+
 # create pipelines
 
 @dsl.pipeline(
@@ -49,29 +46,35 @@ def kfp_wml_pipeline(
 ):
     # op1 - this operation will create the credentials as secrets to be used by other operations
     get_configuration = configuration_op(
-                   token = GITHUB_TOKEN,
-                   url = CONFIG_FILE_URL,
-                   name = secret_name
+                   token=GITHUB_TOKEN,
+                   url=CONFIG_FILE_URL,
+                   name=secret_name
     )
-    
+
     # op2 - this operation trains the model with the model codes and data saved in the cloud object store
     wml_train = train_op(
-                   get_configuration.output,
-                   train_code,
-                   execution_command
+                   config=get_configuration.output,
+                   train_code=train_code,
+                   execution_command=execution_command,
+                   framework=framework,
+                   framework_version=framework_version,
+                   runtime=runtime,
+                   runtime_version=runtime_version,
+                   run_definition=run_definition,
+                   run_name=run_name
                    ).apply(params.use_ai_pipeline_params(secret_name))
-    
+
     # op3 - this operation stores the model trained above
     wml_store = store_op(
-                   wml_train.output,
-                   model_name
+                   run_uid=wml_train.output,
+                   model_name=model_name
                   ).apply(params.use_ai_pipeline_params(secret_name))
-    
+
     # op4 - this operation deploys the model to a web service and run scoring with the payload in the cloud object store
     wml_deploy = deploy_op(
-                  wml_store.output,
-                  model_name,
-                  scoring_payload
+                  model_uid=wml_store.output,
+                  model_name=model_name,
+                  scoring_payload=scoring_payload
                  ).apply(params.use_ai_pipeline_params(secret_name))
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR contains the following fixes:
- In config component, add exception to `kubectl delete` when old secret is not present.
- Remove spaces in `metadata.labels` since Argo can't take labels with white space.
- Fix Watson train to not check on hard coded `created` text. Also parameterize author email field.
- Update Watson pipeline arguments to map with the correct component parameters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1246)
<!-- Reviewable:end -->
