### PR TITLE
fix the e-2-e pipelines failing

### DIFF
--- a/test/deploy-kubeflow.sh
+++ b/test/deploy-kubeflow.sh
@@ -20,7 +20,7 @@ TEST_CLUSTER_PREFIX=${WORKFLOW_FILE%.*}
 TEST_CLUSTER=$(echo $TEST_CLUSTER_PREFIX | cut -d _ -f 1)-${PULL_PULL_SHA:0:7}-${RANDOM}
 
 # Install ksonnet
-KS_VERSION="0.13.0"
+KS_VERSION="0.13.1"
 
 curl -LO https://github.com/ksonnet/ksonnet/releases/download/v${KS_VERSION}/ks_${KS_VERSION}_linux_amd64.tar.gz
 tar -xzf ks_${KS_VERSION}_linux_amd64.tar.gz


### PR DESCRIPTION
The download link for version 0.13.1 is working, as opposed to 0.13.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1257)
<!-- Reviewable:end -->
