### PR TITLE
Properly alternate sorting in PagedTable between ascending and descending

### DIFF
--- a/frontend/src/components/viewers/PagedTable.test.tsx
+++ b/frontend/src/components/viewers/PagedTable.test.tsx
@@ -52,6 +52,15 @@ describe('PagedTable', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('sorts on first column ascending', () => {
+    const tree = shallow(<PagedTable configs={[{data, labels, type: PlotType.TABLE}]} />);
+    // Once for descending
+    tree.find('WithStyles(TableSortLabel)').at(0).simulate('click');
+    // Once for ascending
+    tree.find('WithStyles(TableSortLabel)').at(0).simulate('click');
+    expect(tree).toMatchSnapshot();
+  });
+
   it('returns a user friendly display name', () => {
     expect(PagedTable.prototype.getDisplayName()).toBe('Table');
   });

--- a/frontend/src/components/viewers/__snapshots__/PagedTable.test.tsx.snap
+++ b/frontend/src/components/viewers/__snapshots__/PagedTable.test.tsx.snap
@@ -292,6 +292,156 @@ exports[`PagedTable renders simple data without labels 1`] = `
 </div>
 `;
 
+exports[`PagedTable sorts on first column ascending 1`] = `
+<div
+  className="page"
+  style={
+    Object {
+      "width": "100%",
+    }
+  }
+>
+  <WithStyles(Table)
+    style={
+      Object {
+        "display": "block",
+        "overflow": "auto",
+      }
+    }
+  >
+    <WithStyles(TableHead)>
+      <WithStyles(TableRow)>
+        <WithStyles(TableCell)
+          className="columnName"
+          key="0"
+          sortDirection="asc"
+        >
+          <WithStyles(Tooltip)
+            enterDelay={300}
+            title="Sort"
+          >
+            <WithStyles(TableSortLabel)
+              active={true}
+              direction="asc"
+              onClick={[Function]}
+            >
+              field1
+            </WithStyles(TableSortLabel)>
+          </WithStyles(Tooltip)>
+        </WithStyles(TableCell)>
+        <WithStyles(TableCell)
+          className="columnName"
+          key="1"
+          sortDirection={false}
+        >
+          <WithStyles(Tooltip)
+            enterDelay={300}
+            title="Sort"
+          >
+            <WithStyles(TableSortLabel)
+              active={false}
+              direction="asc"
+              onClick={[Function]}
+            >
+              field2
+            </WithStyles(TableSortLabel)>
+          </WithStyles(Tooltip)>
+        </WithStyles(TableCell)>
+        <WithStyles(TableCell)
+          className="columnName"
+          key="2"
+          sortDirection={false}
+        >
+          <WithStyles(Tooltip)
+            enterDelay={300}
+            title="Sort"
+          >
+            <WithStyles(TableSortLabel)
+              active={false}
+              direction="asc"
+              onClick={[Function]}
+            >
+              field3
+            </WithStyles(TableSortLabel)>
+          </WithStyles(Tooltip)>
+        </WithStyles(TableCell)>
+      </WithStyles(TableRow)>
+    </WithStyles(TableHead)>
+    <WithStyles(TableBody)>
+      <WithStyles(TableRow)
+        className="row"
+        hover={true}
+        key="col1"
+        tabIndex={-1}
+      >
+        <WithStyles(TableCell)
+          className="cell"
+          key="0"
+        >
+          col1
+        </WithStyles(TableCell)>
+        <WithStyles(TableCell)
+          className="cell"
+          key="1"
+        >
+          col2
+        </WithStyles(TableCell)>
+        <WithStyles(TableCell)
+          className="cell"
+          key="2"
+        >
+          col3
+        </WithStyles(TableCell)>
+      </WithStyles(TableRow)>
+      <WithStyles(TableRow)
+        className="row"
+        hover={true}
+        key="col4"
+        tabIndex={-1}
+      >
+        <WithStyles(TableCell)
+          className="cell"
+          key="0"
+        >
+          col4
+        </WithStyles(TableCell)>
+        <WithStyles(TableCell)
+          className="cell"
+          key="1"
+        >
+          col5
+        </WithStyles(TableCell)>
+        <WithStyles(TableCell)
+          className="cell"
+          key="2"
+        >
+          col6
+        </WithStyles(TableCell)>
+      </WithStyles(TableRow)>
+      <WithStyles(TableRow)
+        style={
+          Object {
+            "height": 240,
+          }
+        }
+      >
+        <WithStyles(TableCell)
+          colSpan={6}
+        />
+      </WithStyles(TableRow)>
+    </WithStyles(TableBody)>
+  </WithStyles(Table)>
+  <WithStyles(TablePagination)
+    component="div"
+    count={2}
+    onChangePage={[Function]}
+    onChangeRowsPerPage={[Function]}
+    page={0}
+    rowsPerPage={10}
+  />
+</div>
+`;
+
 exports[`PagedTable sorts on first column descending 1`] = `
 <div
   className="page"


### PR DESCRIPTION
Also moves functions declared within `PagedTable.tsx` file into the class itself, and exposes header row and pagination controls when table is small.

Bug fix change is just line 147: `let order = SortOrder.ASC;`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1261)
<!-- Reviewable:end -->
