### PR TITLE
Adds a toggle between one-off and recurring runs to NewRun page

### DIFF
--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -26,17 +26,9 @@ import { ApiPipeline } from '../apis/pipeline';
 import { ApiResourceType, ApiRunDetail, ApiParameter, ApiRelationship } from '../apis/run';
 
 class TestNewRun extends NewRun {
-  public async _experimentSelectorClosed(confirmed: boolean): Promise<void> {
-    return await super._experimentSelectorClosed(confirmed);
-  }
-
-  public async _pipelineSelectorClosed(confirmed: boolean): Promise<void> {
-    return await super._pipelineSelectorClosed(confirmed);
-  }
-
-  public _updateRecurringRunState(isRecurringRun: boolean): void {
-    return super._updateRecurringRunState(isRecurringRun);
-  }
+  public _experimentSelectorClosed = super._experimentSelectorClosed;
+  public _pipelineSelectorClosed = super._pipelineSelectorClosed;
+  public _updateRecurringRunState = super._updateRecurringRunState;
 }
 
 describe('NewRun', () => {

--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -33,6 +33,10 @@ class TestNewRun extends NewRun {
   public async _pipelineSelectorClosed(confirmed: boolean): Promise<void> {
     return await super._pipelineSelectorClosed(confirmed);
   }
+
+  public _updateRecurringRunState(isRecurringRun: boolean): void {
+    return super._updateRecurringRunState(isRecurringRun);
+  }
 }
 
 describe('NewRun', () => {
@@ -189,6 +193,30 @@ describe('NewRun', () => {
     (tree.instance() as TestNewRun).handleChange('description')({ target: { value: 'run description' } });
 
     expect(tree.state()).toHaveProperty('description', 'run description');
+  });
+
+  it('changes title and form if the new run will recur, based on the radio buttons', async () => {
+    // Default props do not include isRecurring in query params
+    tree = shallow(<TestNewRun {...generateProps() as any} />);
+    await TestUtils.flushPromises();
+
+    (tree.instance() as TestNewRun)._updateRecurringRunState(true);
+    await TestUtils.flushPromises();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('changes title and form to default state if the new run is a one-off, based on the radio buttons', async () => {
+    // Modify props to set page to recurring run form
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.isRecurring}=1`;
+    tree = shallow(<TestNewRun {...props} />);
+    await TestUtils.flushPromises();
+
+    (tree.instance() as TestNewRun)._updateRecurringRunState(false);
+    await TestUtils.flushPromises();
+
+    expect(tree).toMatchSnapshot();
   });
 
   it('exits to the AllRuns page if there is no associated experiment', async () => {

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -444,7 +444,6 @@ class NewRun extends Page<{}, NewRunState> {
 
   protected _updateRecurringRunState(isRecurringRun: boolean): void {
     this.props.updateToolbar({
-      actions: this.props.toolbarProps.actions,
       pageTitle: isRecurringRun ? 'Start a recurring run' : 'Start a new run',
     });
     this.setStateSafe({ isRecurringRun });

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -144,9 +144,10 @@ class NewRun extends Page<{}, NewRunState> {
     } = this.state;
 
     const originalRunId = new URLParser(this.props).get(QUERY_PARAMS.cloneFromRun);
-    const pipelineDetailsUrl = originalRunId ?
-      RoutePage.PIPELINE_DETAILS.replace(':' + RouteParams.pipelineId + '?', '') +
-      new URLParser(this.props).build({ [QUERY_PARAMS.fromRunId]: originalRunId }) : '';
+    const pipelineDetailsUrl = originalRunId
+      ? RoutePage.PIPELINE_DETAILS.replace(':' + RouteParams.pipelineId + '?', '') +
+        new URLParser(this.props).build({ [QUERY_PARAMS.fromRunId]: originalRunId })
+      : '';
 
     return (
       <div className={classes(commonCss.page, padding(20, 'lr'))}>
@@ -247,8 +248,8 @@ class NewRun extends Page<{}, NewRunState> {
           </Dialog>
 
           {/* Run metadata inputs */}
-          <Input label='Run name' required={true} onChange={this.handleChange('runName')}
-            autoFocus={true} value={runName} variant='outlined' />
+          <Input label={isRecurringRun ? 'Recurring run config name' : 'Run name'} required={true}
+            onChange={this.handleChange('runName')} autoFocus={true} value={runName} variant='outlined' />
           <Input label='Description (optional)' multiline={true}
             onChange={this.handleChange('description')} value={description} variant='outlined' />
 
@@ -273,11 +274,11 @@ class NewRun extends Page<{}, NewRunState> {
 
           {/* One-off/Recurring Toggle */}
           <div className={commonCss.header}>Run Type</div>
-          <FormControlLabel label='One-off' control={<Radio color='primary' />}
-            onChange={() => this.updateRecurringRunState(false)}
+          <FormControlLabel id='oneOffToggle' label='One-off' control={<Radio color='primary' />}
+            onChange={() => this._updateRecurringRunState(false)}
             checked={!isRecurringRun} />
-          <FormControlLabel label='Recurring' control={<Radio color='primary' />}
-            onChange={() => this.updateRecurringRunState(true)}
+          <FormControlLabel label='Recurring' control={<Radio color='primary' id='recurringToggle' />}
+            onChange={() => this._updateRecurringRunState(true)}
             checked={isRecurringRun} />
 
           {/* Recurring run controls */}
@@ -326,14 +327,6 @@ class NewRun extends Page<{}, NewRunState> {
         </div>
       </div>
     );
-  }
-
-  public updateRecurringRunState(isRecurringRun: boolean): void {
-    this.props.updateToolbar({
-      actions: this.props.toolbarProps.actions,
-      pageTitle: isRecurringRun ? 'Start a recurring run' : 'Start a new run',
-    });
-    this.setStateSafe({ isRecurringRun });
   }
 
   public async refresh(): Promise<void> {
@@ -447,6 +440,14 @@ class NewRun extends Page<{}, NewRunState> {
       pipelineName: (pipeline && pipeline.name) || '',
       pipelineSelectorOpen: false
     }, () => this._validate());
+  }
+
+  protected _updateRecurringRunState(isRecurringRun: boolean): void {
+    this.props.updateToolbar({
+      actions: this.props.toolbarProps.actions,
+      pageTitle: isRecurringRun ? 'Start a recurring run' : 'Start a new run',
+    });
+    this.setStateSafe({ isRecurringRun });
   }
 
   private async _prepareFormFromEmbeddedPipeline(embeddedPipelineRunId: string): Promise<void> {

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -337,6 +337,31 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
     <div
       className="header"
     >
+      Run Type
+    </div>
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="One-off"
+      onChange={[Function]}
+    />
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Recurring"
+      onChange={[Function]}
+    />
+    <div
+      className="header"
+    >
       Run parameters
     </div>
     <div>
@@ -726,6 +751,31 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
       required={true}
       value="some mock experiment name"
       variant="outlined"
+    />
+    <div
+      className="header"
+    >
+      Run Type
+    </div>
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="One-off"
+      onChange={[Function]}
+    />
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Recurring"
+      onChange={[Function]}
     />
     <div
       className="header"
@@ -1141,6 +1191,31 @@ exports[`NewRun cloning from a run shows pipeline selector when switching from e
     <div
       className="header"
     >
+      Run Type
+    </div>
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="One-off"
+      onChange={[Function]}
+    />
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Recurring"
+      onChange={[Function]}
+    />
+    <div
+      className="header"
+    >
       Run parameters
     </div>
     <div>
@@ -1514,6 +1589,31 @@ exports[`NewRun cloning from a run shows switching controls when run has embedde
       required={true}
       value=""
       variant="outlined"
+    />
+    <div
+      className="header"
+    >
+      Run Type
+    </div>
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="One-off"
+      onChange={[Function]}
+    />
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Recurring"
+      onChange={[Function]}
     />
     <div
       className="header"
@@ -1897,6 +1997,31 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
       required={true}
       value=""
       variant="outlined"
+    />
+    <div
+      className="header"
+    >
+      Run Type
+    </div>
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="One-off"
+      onChange={[Function]}
+    />
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Recurring"
+      onChange={[Function]}
     />
     <div
       className="header"
@@ -2294,6 +2419,31 @@ exports[`NewRun renders the new run page 1`] = `
     <div
       className="header"
     >
+      Run Type
+    </div>
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="One-off"
+      onChange={[Function]}
+    />
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Recurring"
+      onChange={[Function]}
+    />
+    <div
+      className="header"
+    >
       Run parameters
     </div>
     <div>
@@ -2679,7 +2829,35 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
     <div
       className="header"
     >
+      Run Type
+    </div>
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="One-off"
+      onChange={[Function]}
+    />
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Recurring"
+      onChange={[Function]}
+    />
+    <div
+      className="header"
+    >
       Run trigger
+    </div>
+    <div>
+      Choose a method by which new runs will be triggered
     </div>
     <Trigger
       onChange={[Function]}
@@ -3096,6 +3274,31 @@ exports[`NewRun starting a new run copies pipeline from run in the start API cal
       required={true}
       value=""
       variant="outlined"
+    />
+    <div
+      className="header"
+    >
+      Run Type
+    </div>
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="One-off"
+      onChange={[Function]}
+    />
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Recurring"
+      onChange={[Function]}
     />
     <div
       className="header"
@@ -3517,6 +3720,31 @@ exports[`NewRun starting a new run updates the pipeline in state when a user fil
     <div
       className="header"
     >
+      Run Type
+    </div>
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="One-off"
+      onChange={[Function]}
+    />
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Recurring"
+      onChange={[Function]}
+    />
+    <div
+      className="header"
+    >
       Run parameters
     </div>
     <div>
@@ -3533,7 +3761,6 @@ exports[`NewRun starting a new run updates the pipeline in state when a user fil
         select={false}
         style={
           Object {
-            "height": 40,
             "maxWidth": 600,
           }
         }
@@ -3550,7 +3777,6 @@ exports[`NewRun starting a new run updates the pipeline in state when a user fil
         select={false}
         style={
           Object {
-            "height": 40,
             "maxWidth": 600,
           }
         }
@@ -3940,6 +4166,31 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
       required={true}
       value="some mock experiment name"
       variant="outlined"
+    />
+    <div
+      className="header"
+    >
+      Run Type
+    </div>
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="One-off"
+      onChange={[Function]}
+    />
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Recurring"
+      onChange={[Function]}
     />
     <div
       className="header"
@@ -4337,6 +4588,31 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
     <div
       className="header"
     >
+      Run Type
+    </div>
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="One-off"
+      onChange={[Function]}
+    />
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Recurring"
+      onChange={[Function]}
+    />
+    <div
+      className="header"
+    >
       Run parameters
     </div>
     <div>
@@ -4353,7 +4629,6 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
         select={false}
         style={
           Object {
-            "height": 40,
             "maxWidth": 600,
           }
         }
@@ -4370,7 +4645,6 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
         select={false}
         style={
           Object {
-            "height": 40,
             "maxWidth": 600,
           }
         }
@@ -4766,6 +5040,31 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
     <div
       className="header"
     >
+      Run Type
+    </div>
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="One-off"
+      onChange={[Function]}
+    />
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Recurring"
+      onChange={[Function]}
+    />
+    <div
+      className="header"
+    >
       Run parameters
     </div>
     <div>
@@ -5155,6 +5454,31 @@ exports[`NewRun updates the run's state with the associated experiment if one is
       required={true}
       value="some mock experiment name"
       variant="outlined"
+    />
+    <div
+      className="header"
+    >
+      Run Type
+    </div>
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="One-off"
+      onChange={[Function]}
+    />
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Recurring"
+      onChange={[Function]}
     />
     <div
       className="header"

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -973,7 +973,6 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
                     "pageTitle": "Start a recurring run",
                   },
                 ],
@@ -1109,7 +1108,6 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
                     "pageTitle": "Start a recurring run",
                   },
                 ],
@@ -1412,7 +1410,6 @@ exports[`NewRun changes title and form to default state if the new run is a one-
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
                     "pageTitle": "Start a new run",
                   },
                 ],
@@ -1544,7 +1541,6 @@ exports[`NewRun changes title and form to default state if the new run is a one-
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
                     "pageTitle": "Start a new run",
                   },
                 ],

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -346,6 +346,7 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
           color="primary"
         />
       }
+      id="oneOffToggle"
       label="One-off"
       onChange={[Function]}
     />
@@ -354,6 +355,7 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
       control={
         <WithStyles(Radio)
           color="primary"
+          id="recurringToggle"
         />
       }
       label="Recurring"
@@ -764,6 +766,7 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
           color="primary"
         />
       }
+      id="oneOffToggle"
       label="One-off"
       onChange={[Function]}
     />
@@ -772,6 +775,7 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
       control={
         <WithStyles(Radio)
           color="primary"
+          id="recurringToggle"
         />
       }
       label="Recurring"
@@ -801,6 +805,873 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
         onClick={[Function]}
       >
         Skip this step
+      </WithStyles(Button)>
+      <div
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+      >
+        A pipeline must be selected
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`NewRun changes title and form if the new run will recur, based on the radio buttons 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="scrollContainer"
+  >
+    <div
+      className="header"
+    >
+      Run details
+    </div>
+    <Component
+      InputProps={
+        Object {
+          "classes": Object {
+            "disabled": "nonEditableInput",
+          },
+          "endAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <WithStyles(Button)
+              color="secondary"
+              id="choosePipelineBtn"
+              onClick={[Function]}
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": "3px 5px",
+                }
+              }
+            >
+              Choose
+            </WithStyles(Button)>
+          </WithStyles(InputAdornment)>,
+          "readOnly": true,
+        }
+      }
+      disabled={true}
+      label="Pipeline"
+      required={true}
+      value=""
+      variant="outlined"
+    />
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "pipelineSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "selectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <ResourceSelector
+          columns={
+            Array [
+              Object {
+                "flex": 1,
+                "label": "Pipeline name",
+                "sortKey": "name",
+              },
+              Object {
+                "flex": 1.5,
+                "label": "Description",
+              },
+              Object {
+                "flex": 1,
+                "label": "Uploaded on",
+                "sortKey": "created_at",
+              },
+            ]
+          }
+          emptyMessage="No pipelines found. Upload a pipeline and then try again."
+          filterLabel="Filter pipelines"
+          history={
+            Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            }
+          }
+          initialSortColumn="created_at"
+          listApi={[Function]}
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?experimentId=some-mock-experiment-id",
+            }
+          }
+          match=""
+          selectionChanged={[Function]}
+          title="Choose a pipeline"
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+              ],
+              "pageTitle": "Start a new run",
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={[MockFunction]}
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                    ],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "some mock experiment name",
+                        "href": "/experiments/details/some-mock-experiment-id",
+                      },
+                    ],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "pageTitle": "Start a recurring run",
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          id="cancelPipelineSelectionBtn"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={true}
+          id="usePipelineBtn"
+          onClick={[Function]}
+        >
+          Use this pipeline
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "experimentSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "selectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <ResourceSelector
+          columns={
+            Array [
+              Object {
+                "flex": 1,
+                "label": "Experiment name",
+                "sortKey": "name",
+              },
+              Object {
+                "flex": 1.5,
+                "label": "Description",
+              },
+              Object {
+                "flex": 1,
+                "label": "Created at",
+                "sortKey": "created_at",
+              },
+            ]
+          }
+          emptyMessage="No experiments found. Create an experiment and then try again."
+          filterLabel="Filter experiments"
+          history={
+            Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            }
+          }
+          initialSortColumn="created_at"
+          listApi={[Function]}
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?experimentId=some-mock-experiment-id",
+            }
+          }
+          match=""
+          selectionChanged={[Function]}
+          title="Choose an experiment"
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+              ],
+              "pageTitle": "Start a new run",
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={[MockFunction]}
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                    ],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                      Object {
+                        "displayName": "some mock experiment name",
+                        "href": "/experiments/details/some-mock-experiment-id",
+                      },
+                    ],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "pageTitle": "Start a recurring run",
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          id="cancelExperimentSelectionBtn"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={true}
+          id="useExperimentBtn"
+          onClick={[Function]}
+        >
+          Use this experiment
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <Component
+      autoFocus={true}
+      label="Recurring run config name"
+      onChange={[Function]}
+      required={true}
+      value=""
+      variant="outlined"
+    />
+    <Component
+      label="Description (optional)"
+      multiline={true}
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+    <div>
+      This run will be associated with the following experiment
+    </div>
+    <Component
+      InputProps={
+        Object {
+          "classes": Object {
+            "disabled": "nonEditableInput",
+          },
+          "endAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <WithStyles(Button)
+              color="secondary"
+              id="chooseExperimentBtn"
+              onClick={[Function]}
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": "3px 5px",
+                }
+              }
+            >
+              Choose
+            </WithStyles(Button)>
+          </WithStyles(InputAdornment)>,
+          "readOnly": true,
+        }
+      }
+      disabled={true}
+      label="Experiment"
+      required={true}
+      value="some mock experiment name"
+      variant="outlined"
+    />
+    <div
+      className="header"
+    >
+      Run Type
+    </div>
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      id="oneOffToggle"
+      label="One-off"
+      onChange={[Function]}
+    />
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+          id="recurringToggle"
+        />
+      }
+      label="Recurring"
+      onChange={[Function]}
+    />
+    <div
+      className="header"
+    >
+      Run trigger
+    </div>
+    <div>
+      Choose a method by which new runs will be triggered
+    </div>
+    <Trigger
+      onChange={[Function]}
+    />
+    <div
+      className="header"
+    >
+      Run parameters
+    </div>
+    <div>
+      Parameters will appear after you select a pipeline
+    </div>
+    <div
+      className="flex"
+    >
+      <BusyButton
+        busy={false}
+        className="buttonAction"
+        disabled={true}
+        id="startNewRunBtn"
+        onClick={[Function]}
+        title="Start"
+      />
+      <WithStyles(Button)
+        id="exitNewRunPageBtn"
+        onClick={[Function]}
+      >
+        Cancel
+      </WithStyles(Button)>
+      <div
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+      >
+        A pipeline must be selected
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`NewRun changes title and form to default state if the new run is a one-off, based on the radio buttons 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="scrollContainer"
+  >
+    <div
+      className="header"
+    >
+      Run details
+    </div>
+    <Component
+      InputProps={
+        Object {
+          "classes": Object {
+            "disabled": "nonEditableInput",
+          },
+          "endAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <WithStyles(Button)
+              color="secondary"
+              id="choosePipelineBtn"
+              onClick={[Function]}
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": "3px 5px",
+                }
+              }
+            >
+              Choose
+            </WithStyles(Button)>
+          </WithStyles(InputAdornment)>,
+          "readOnly": true,
+        }
+      }
+      disabled={true}
+      label="Pipeline"
+      required={true}
+      value=""
+      variant="outlined"
+    />
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "pipelineSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "selectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <ResourceSelector
+          columns={
+            Array [
+              Object {
+                "flex": 1,
+                "label": "Pipeline name",
+                "sortKey": "name",
+              },
+              Object {
+                "flex": 1.5,
+                "label": "Description",
+              },
+              Object {
+                "flex": 1,
+                "label": "Uploaded on",
+                "sortKey": "created_at",
+              },
+            ]
+          }
+          emptyMessage="No pipelines found. Upload a pipeline and then try again."
+          filterLabel="Filter pipelines"
+          history={
+            Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            }
+          }
+          initialSortColumn="created_at"
+          listApi={[Function]}
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?recurring=1",
+            }
+          }
+          match=""
+          selectionChanged={[Function]}
+          title="Choose a pipeline"
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+              ],
+              "pageTitle": "Start a new run",
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={[MockFunction]}
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                    ],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                    ],
+                    "pageTitle": "Start a recurring run",
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          id="cancelPipelineSelectionBtn"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={true}
+          id="usePipelineBtn"
+          onClick={[Function]}
+        >
+          Use this pipeline
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "experimentSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "selectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <ResourceSelector
+          columns={
+            Array [
+              Object {
+                "flex": 1,
+                "label": "Experiment name",
+                "sortKey": "name",
+              },
+              Object {
+                "flex": 1.5,
+                "label": "Description",
+              },
+              Object {
+                "flex": 1,
+                "label": "Created at",
+                "sortKey": "created_at",
+              },
+            ]
+          }
+          emptyMessage="No experiments found. Create an experiment and then try again."
+          filterLabel="Filter experiments"
+          history={
+            Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            }
+          }
+          initialSortColumn="created_at"
+          listApi={[Function]}
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?recurring=1",
+            }
+          }
+          match=""
+          selectionChanged={[Function]}
+          title="Choose an experiment"
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+              ],
+              "pageTitle": "Start a new run",
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={[MockFunction]}
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                    ],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                    ],
+                    "pageTitle": "Start a recurring run",
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          id="cancelExperimentSelectionBtn"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={true}
+          id="useExperimentBtn"
+          onClick={[Function]}
+        >
+          Use this experiment
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <Component
+      autoFocus={true}
+      label="Run name"
+      onChange={[Function]}
+      required={true}
+      value=""
+      variant="outlined"
+    />
+    <Component
+      label="Description (optional)"
+      multiline={true}
+      onChange={[Function]}
+      value=""
+      variant="outlined"
+    />
+    <div>
+      This run will be associated with the following experiment
+    </div>
+    <Component
+      InputProps={
+        Object {
+          "classes": Object {
+            "disabled": "nonEditableInput",
+          },
+          "endAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <WithStyles(Button)
+              color="secondary"
+              id="chooseExperimentBtn"
+              onClick={[Function]}
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": "3px 5px",
+                }
+              }
+            >
+              Choose
+            </WithStyles(Button)>
+          </WithStyles(InputAdornment)>,
+          "readOnly": true,
+        }
+      }
+      disabled={true}
+      label="Experiment"
+      required={true}
+      value=""
+      variant="outlined"
+    />
+    <div
+      className="header"
+    >
+      Run Type
+    </div>
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      id="oneOffToggle"
+      label="One-off"
+      onChange={[Function]}
+    />
+    <WithStyles(WithFormControlContext(FormControlLabel))
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+          id="recurringToggle"
+        />
+      }
+      label="Recurring"
+      onChange={[Function]}
+    />
+    <div
+      className="header"
+    >
+      Run parameters
+    </div>
+    <div>
+      Parameters will appear after you select a pipeline
+    </div>
+    <div
+      className="flex"
+    >
+      <BusyButton
+        busy={false}
+        className="buttonAction"
+        disabled={true}
+        id="startNewRunBtn"
+        onClick={[Function]}
+        title="Start"
+      />
+      <WithStyles(Button)
+        id="exitNewRunPageBtn"
+        onClick={[Function]}
+      >
+        Cancel
       </WithStyles(Button)>
       <div
         style={
@@ -1200,6 +2071,7 @@ exports[`NewRun cloning from a run shows pipeline selector when switching from e
           color="primary"
         />
       }
+      id="oneOffToggle"
       label="One-off"
       onChange={[Function]}
     />
@@ -1208,6 +2080,7 @@ exports[`NewRun cloning from a run shows pipeline selector when switching from e
       control={
         <WithStyles(Radio)
           color="primary"
+          id="recurringToggle"
         />
       }
       label="Recurring"
@@ -1602,6 +2475,7 @@ exports[`NewRun cloning from a run shows switching controls when run has embedde
           color="primary"
         />
       }
+      id="oneOffToggle"
       label="One-off"
       onChange={[Function]}
     />
@@ -1610,6 +2484,7 @@ exports[`NewRun cloning from a run shows switching controls when run has embedde
       control={
         <WithStyles(Radio)
           color="primary"
+          id="recurringToggle"
         />
       }
       label="Recurring"
@@ -2010,6 +2885,7 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
           color="primary"
         />
       }
+      id="oneOffToggle"
       label="One-off"
       onChange={[Function]}
     />
@@ -2018,6 +2894,7 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
       control={
         <WithStyles(Radio)
           color="primary"
+          id="recurringToggle"
         />
       }
       label="Recurring"
@@ -2428,6 +3305,7 @@ exports[`NewRun renders the new run page 1`] = `
           color="primary"
         />
       }
+      id="oneOffToggle"
       label="One-off"
       onChange={[Function]}
     />
@@ -2436,6 +3314,7 @@ exports[`NewRun renders the new run page 1`] = `
       control={
         <WithStyles(Radio)
           color="primary"
+          id="recurringToggle"
         />
       }
       label="Recurring"
@@ -2778,7 +3657,7 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
     </WithStyles(Dialog)>
     <Component
       autoFocus={true}
-      label="Run name"
+      label="Recurring run config name"
       onChange={[Function]}
       required={true}
       value=""
@@ -2838,6 +3717,7 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
           color="primary"
         />
       }
+      id="oneOffToggle"
       label="One-off"
       onChange={[Function]}
     />
@@ -2846,6 +3726,7 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
       control={
         <WithStyles(Radio)
           color="primary"
+          id="recurringToggle"
         />
       }
       label="Recurring"
@@ -3287,6 +4168,7 @@ exports[`NewRun starting a new run copies pipeline from run in the start API cal
           color="primary"
         />
       }
+      id="oneOffToggle"
       label="One-off"
       onChange={[Function]}
     />
@@ -3295,6 +4177,7 @@ exports[`NewRun starting a new run copies pipeline from run in the start API cal
       control={
         <WithStyles(Radio)
           color="primary"
+          id="recurringToggle"
         />
       }
       label="Recurring"
@@ -3729,6 +4612,7 @@ exports[`NewRun starting a new run updates the pipeline in state when a user fil
           color="primary"
         />
       }
+      id="oneOffToggle"
       label="One-off"
       onChange={[Function]}
     />
@@ -3737,6 +4621,7 @@ exports[`NewRun starting a new run updates the pipeline in state when a user fil
       control={
         <WithStyles(Radio)
           color="primary"
+          id="recurringToggle"
         />
       }
       label="Recurring"
@@ -4179,6 +5064,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
           color="primary"
         />
       }
+      id="oneOffToggle"
       label="One-off"
       onChange={[Function]}
     />
@@ -4187,6 +5073,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
       control={
         <WithStyles(Radio)
           color="primary"
+          id="recurringToggle"
         />
       }
       label="Recurring"
@@ -4597,6 +5484,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
           color="primary"
         />
       }
+      id="oneOffToggle"
       label="One-off"
       onChange={[Function]}
     />
@@ -4605,6 +5493,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
       control={
         <WithStyles(Radio)
           color="primary"
+          id="recurringToggle"
         />
       }
       label="Recurring"
@@ -5049,6 +5938,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
           color="primary"
         />
       }
+      id="oneOffToggle"
       label="One-off"
       onChange={[Function]}
     />
@@ -5057,6 +5947,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
       control={
         <WithStyles(Radio)
           color="primary"
+          id="recurringToggle"
         />
       }
       label="Recurring"
@@ -5467,6 +6358,7 @@ exports[`NewRun updates the run's state with the associated experiment if one is
           color="primary"
         />
       }
+      id="oneOffToggle"
       label="One-off"
       onChange={[Function]}
     />
@@ -5475,6 +6367,7 @@ exports[`NewRun updates the run's state with the associated experiment if one is
       control={
         <WithStyles(Radio)
           color="primary"
+          id="recurringToggle"
         />
       }
       label="Recurring"

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -95,6 +95,8 @@ describe('deploy helloworld sample run', () => {
 
     // Skip over "choose experiment" button
     browser.keys('Tab');
+    // Skip over "Run Type" radio button
+    browser.keys('Tab');
 
     browser.keys('Tab');
     browser.keys(outputParameterValue);
@@ -213,6 +215,8 @@ describe('deploy helloworld sample run', () => {
     browser.keys(runWithoutExperimentDescription);
 
     // Skip over "choose experiment" button
+    browser.keys('Tab');
+    // Skip over "Run Type" radio button
     browser.keys('Tab');
 
     browser.keys('Tab');


### PR DESCRIPTION
Changes are mainly around lines 272 and 445 of `NewRun.tsx`.

Other changes, are primarily cleanup and tests.

Fixes #1217

Examples of the toggle:
One-off:
![image](https://user-images.githubusercontent.com/34456002/57107741-aac72800-6ce5-11e9-8bca-873906260cbc.png)

Recurring:
![image](https://user-images.githubusercontent.com/34456002/57107748-af8bdc00-6ce5-11e9-91ea-99a00666e69a.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1274)
<!-- Reviewable:end -->
