### PR TITLE
Frontend - Add support for artifacts stored in S3

### DIFF
--- a/frontend/server/server.ts
+++ b/frontend/server/server.ts
@@ -186,8 +186,8 @@ const artifactsHandler = async (req, res) => {
 
         try {
           let contents = '';
-          stream.pipe(new tar.Parse()).on('entry', (entry: Stream) => {
-            entry.on('data', (buffer) => contents += buffer.toString());
+          stream.on('data', (chunk) => {
+            contents = chunk.toString();
           });
 
           stream.on('end', () => {
@@ -197,10 +197,6 @@ const artifactsHandler = async (req, res) => {
           res.status(500).send(`Failed to get object in bucket ${bucket} at path ${key}: ${err}`);
         }
       });
-      break;
-    case 'local':
-      let contents = fs.readFileSync(key, 'utf-8')
-      res.send(contents)
       break;
 
     default:

--- a/frontend/server/server.ts
+++ b/frontend/server/server.ts
@@ -39,6 +39,12 @@ const minioClient = new MinioClient({
   useSSL: false,
 } as any);
 
+const s3Client = new MinioClient({
+  endPoint: 's3.amazonaws.com',
+  accessKey: process.env.AWS_ACCESS_KEY_ID,
+  secretKey: process.env.AWS_SECRET_ACCESS_KEY,
+} as any);
+
 const app = express() as Application;
 
 app.use(function (req, _, next) {
@@ -171,6 +177,32 @@ const artifactsHandler = async (req, res) => {
         }
       });
       break;
+    case 's3':
+      s3Client.getObject(bucket, key, (err, stream) => {
+        if (err) {
+          res.status(500).send(`Failed to get object in bucket ${bucket} at path ${key}: ${err}`);
+          return;
+        }
+
+        try {
+          let contents = '';
+          stream.pipe(new tar.Parse()).on('entry', (entry: Stream) => {
+            entry.on('data', (buffer) => contents += buffer.toString());
+          });
+
+          stream.on('end', () => {
+            res.send(contents);
+          });
+        } catch (err) {
+          res.status(500).send(`Failed to get object in bucket ${bucket} at path ${key}: ${err}`);
+        }
+      });
+      break;
+    case 'local':
+      let contents = fs.readFileSync(key, 'utf-8')
+      res.send(contents)
+      break;
+
     default:
       res.status(500).send('Unknown storage source: ' + source);
       return;

--- a/frontend/src/lib/WorkflowParser.test.ts
+++ b/frontend/src/lib/WorkflowParser.test.ts
@@ -686,6 +686,54 @@ describe('WorkflowParser', () => {
         source: StorageService.MINIO,
       });
     });
+
+    it('handles S3 bucket without key', () => {
+      expect(WorkflowParser.parseStoragePath('s3://testbucket/')).toEqual({
+        bucket: 'testbucket',
+        key: '',
+        source: StorageService.S3,
+      });
+    });
+
+    it('handles S3 bucket and key', () => {
+      expect(WorkflowParser.parseStoragePath('s3://testbucket/testkey')).toEqual({
+        bucket: 'testbucket',
+        key: 'testkey',
+        source: StorageService.S3,
+      });
+    });
+
+    it('handles S3 bucket and multi-part key', () => {
+      expect(WorkflowParser.parseStoragePath('s3://testbucket/test/key/path')).toEqual({
+        bucket: 'testbucket',
+        key: 'test/key/path',
+        source: StorageService.S3,
+      });
+    });
+
+    it('handles local file without directory', () => {
+      expect(WorkflowParser.parseStoragePath('/testbucket')).toEqual({
+        bucket: 'local',
+        key: '/testbucket',
+        source: StorageService.LOCAL,
+      });
+    });
+
+    it('handles local file with directory', () => {
+      expect(WorkflowParser.parseStoragePath('/testbucket/testkey')).toEqual({
+        bucket: 'local',
+        key: '/testbucket/testkey',
+        source: StorageService.LOCAL,
+      });
+    });
+
+    it('handles local file with multi-level directory', () => {
+      expect(WorkflowParser.parseStoragePath('/testbucket/test/key/path')).toEqual({
+        bucket: 'local',
+        key: '/testbucket/test/key/path',
+        source: StorageService.LOCAL,
+      });
+    });
   });
 
   describe('getOutboundNodes', () => {

--- a/frontend/src/lib/WorkflowParser.test.ts
+++ b/frontend/src/lib/WorkflowParser.test.ts
@@ -710,30 +710,6 @@ describe('WorkflowParser', () => {
         source: StorageService.S3,
       });
     });
-
-    it('handles local file without directory', () => {
-      expect(WorkflowParser.parseStoragePath('/testbucket')).toEqual({
-        bucket: 'local',
-        key: '/testbucket',
-        source: StorageService.LOCAL,
-      });
-    });
-
-    it('handles local file with directory', () => {
-      expect(WorkflowParser.parseStoragePath('/testbucket/testkey')).toEqual({
-        bucket: 'local',
-        key: '/testbucket/testkey',
-        source: StorageService.LOCAL,
-      });
-    });
-
-    it('handles local file with multi-level directory', () => {
-      expect(WorkflowParser.parseStoragePath('/testbucket/test/key/path')).toEqual({
-        bucket: 'local',
-        key: '/testbucket/test/key/path',
-        source: StorageService.LOCAL,
-      });
-    });
   });
 
   describe('getOutboundNodes', () => {

--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -25,6 +25,8 @@ import { Constants } from './Constants';
 export enum StorageService {
   GCS = 'gcs',
   MINIO = 'minio',
+  S3 = 's3',
+  LOCAL = 'local'
 }
 
 export interface StoragePath {
@@ -252,6 +254,19 @@ export default class WorkflowParser {
         bucket: pathParts[0],
         key: pathParts.slice(1).join('/'),
         source: StorageService.MINIO,
+      };
+    } else if (strPath.startsWith('s3://')) {
+      const pathParts = strPath.substr('s3://'.length).split('/');
+      return {
+        bucket: pathParts[0],
+        key: pathParts.slice(1).join('/'),
+        source: StorageService.S3,
+      };
+    } else if (strPath.startsWith('/')) {
+      return {
+        bucket: 'local',
+        key: strPath,
+        source: StorageService.LOCAL,
       };
     } else {
       throw new Error('Unsupported storage path: ' + strPath);

--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -208,7 +208,7 @@ export default class WorkflowParser {
         .filter((a) => a.name === 'mlpipeline-ui-metadata' && !!a.s3)
         .forEach((a) => {
           let source = StorageService.MINIO;
-          if (a.s3!.endpoint.indexOf('s3.amazonaws.com') >= 0){
+          if (a.s3!.endpoint && a.s3!.endpoint.indexOf('s3.amazonaws.com') >= 0){
             source = StorageService.S3;
           } else if (a.s3!.endpoint.indexOf('storage.googleapis.com') >= 0) {
             source = StorageService.GCS;

--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -206,19 +206,13 @@ export default class WorkflowParser {
     if (selectedWorkflowNode && selectedWorkflowNode.outputs) {
       (selectedWorkflowNode.outputs.artifacts || [])
         .filter((a) => a.name === 'mlpipeline-ui-metadata' && !!a.s3)
-        .forEach((a) => {
-          let source = StorageService.MINIO;
-          if (a.s3!.endpoint && a.s3!.endpoint.indexOf('s3.amazonaws.com') >= 0){
-            source = StorageService.S3;
-          } else if (a.s3!.endpoint.indexOf('storage.googleapis.com') >= 0) {
-            source = StorageService.GCS;
-          }
+        .forEach((a) =>
           outputPaths.push({
             bucket: a.s3!.bucket,
             key: a.s3!.key,
-            source: source!,
+            source: StorageService.MINIO,
           })
-        });
+        );
     }
 
     return outputPaths;


### PR DESCRIPTION
I was working on more storage options for artifacts. Original idea was to add local and s3 for no-prem and aws users. Notice local is a little bit tricky because pipeline-UI can not access PVC actively.  After some discussion, we think ViewerCRD or minio would be choice for on-prem users.

S3 parts, I notice @DmitryBe has some work https://github.com/kubeflow/pipelines/pull/767.  I can not reach out to him and wait for few days. I borrow some code snippet and reuse minio client in this PR. 

I will have some corresponding changes in kubeflow/kubeflow later to mount AWS credential to ui pod.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1278)
<!-- Reviewable:end -->
