### PR TITLE
Sets the background color for KFP pages

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -25,6 +25,7 @@ import { theme, fonts } from './Css';
 // TODO: license headers
 
 cssRule('html, body, #root', {
+  background: 'white',
   color: 'rgba(0, 0, 0, .66)',
   display: 'flex',
   fontFamily: fonts.main,


### PR DESCRIPTION
This will prevent the pages from appearing gray when viewed within the
iframe of the greater Kubeflow console.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1281)
<!-- Reviewable:end -->
