### PR TITLE
Components - Updating component versions in samples during release

### DIFF
--- a/components/release.sh
+++ b/components/release.sh
@@ -81,6 +81,19 @@ git add --all
 git commit --message "Updated component images to version $COMMIT_SHA"
 image_update_commit_sha=$(git rev-parse HEAD)
 
+# Updating the samples to use the updated components
+git diff HEAD~1 HEAD --name-only | while read component_file; do
+    echo $component_file
+    find components samples -type f | while read file; do
+      sed -i -E "s|(https://raw.githubusercontent.com/kubeflow/pipelines/)[^/]+(/$component_file)|\1${image_update_commit_sha}\2|g" "$file";
+    done
+done
+
+# Checking-in the component changes
+git add --all
+git commit --message "Updated components to version $image_update_commit_sha"
+component_update_commit_sha=$(git rev-parse HEAD)
+
 # Pushing the changes upstream
 read -p "Do you want to push the new branch to upstream to create a PR? [y|n]"
 if [ "$REPLY" != "y" ]; then


### PR DESCRIPTION
This PR builds on top of https://github.com/kubeflow/pipelines/pull/1172 to update all component references in samples after updating the images in the components.

Now both changes are done automatically and in the same release PR.

The script now does the following:

1. Checks out the clean repo
2. Updates container image versions
3. Commits the container image update
4. Updates component versions
5. Commits the component version update
6. Then it optionally pushes the changes to a new release branch
7. Opens the web-browser with a pull request page ready

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1283)
<!-- Reviewable:end -->
