### PR TITLE
Adds metrics table to Compare page, creates Metric component

### DIFF
--- a/frontend/src/atoms/Metric.tsx
+++ b/frontend/src/atoms/Metric.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import { ApiRunMetric, RunMetricFormat } from '../apis/run';
+import { MetricMetadata } from '../lib/RunUtils';
+import { stylesheet } from 'typestyle';
+import { logger } from '../lib/Utils';
+import MetricUtils from '../lib/MetricUtils';
+
+const css = stylesheet({
+  metricContainer: {
+    background: '#f6f7f9',
+    marginLeft: 6,
+    marginRight: 10,
+  },
+  metricFill: {
+    background: '#cbf0f8',
+    boxSizing: 'border-box',
+    color: '#202124',
+    fontFamily: 'Roboto',
+    fontSize: 13,
+    textIndent: 6,
+  },
+});
+
+interface MetricProps {
+  metadata?: MetricMetadata;
+  metric?: ApiRunMetric;
+}
+
+class Metric extends React.PureComponent<MetricProps> {
+
+  public render(): JSX.Element {
+    const { metric, metadata } = this.props;
+    if (!metric || metric.number_value === undefined) {
+      return <div />;
+    }
+
+    const leftSpace = 6;
+    const displayString = MetricUtils.getMetricDisplayString(metric);
+    let width = '';
+
+    if (metric.format === RunMetricFormat.PERCENTAGE) {
+      width = `calc(${displayString})`;
+    } else {
+
+      // Non-percentage metrics must contain metadata
+      if (!metadata) {
+        return <div />;
+      }
+
+      if (metadata.maxValue === 0 && metadata.minValue === 0) {
+        return <div style={{ paddingLeft: leftSpace }}>{displayString}</div>;
+      }
+
+      if (metric.number_value - metadata.minValue < 0) {
+        logger.error(`Metric ${metadata.name}'s value:`
+          + ` (${metric.number_value}) was lower than the supposed minimum of`
+          + ` (${metadata.minValue})`);
+        return <div style={{ paddingLeft: leftSpace }}>{displayString}</div>;
+      }
+
+      if (metadata.maxValue - metric.number_value < 0) {
+        logger.error(`Metric ${metadata.name}'s value:`
+          + ` (${metric.number_value}) was greater than the supposed maximum of`
+          + ` (${metadata.maxValue})`);
+        return <div style={{ paddingLeft: leftSpace }}>{displayString}</div>;
+      }
+
+      const barWidth =
+        (metric.number_value - metadata.minValue)
+        / (metadata.maxValue - metadata.minValue)
+        * 100;
+
+      width = `calc(${barWidth}%)`;
+    }
+    return (
+      <div className={css.metricContainer}>
+        <div className={css.metricFill} style={{ width }}>
+          {displayString}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Metric;

--- a/frontend/src/components/Metric.test.tsx
+++ b/frontend/src/components/Metric.test.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import Metric from './Metric';
+import { ReactWrapper, ShallowWrapper, shallow } from 'enzyme';
+import { RunMetricFormat } from '../apis/run';
+
+describe('Metric', () => {
+  let tree: ShallowWrapper | ReactWrapper;
+
+  const onErrorSpy = jest.fn();
+
+  beforeEach(() => {
+    onErrorSpy.mockClear();
+  });
+
+  afterEach(async () => {
+    // unmount() should be called before resetAllMocks() in case any part of the unmount life cycle
+    // depends on mocks/spies
+    if (tree) {
+      await tree.unmount();
+    }
+    jest.resetAllMocks();
+  });
+
+  it('renders an empty metric when there is no metric', () => {
+    tree = shallow(<Metric />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders an empty metric when metric has no value', () => {
+    tree = shallow(<Metric metric={{}} />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders a metric when metric has value and percentage format', () => {
+    tree = shallow(<Metric metric={{ format: RunMetricFormat.PERCENTAGE, number_value: 0.54 }} />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders an empty metric when metric has no metadata and unspecified format', () => {
+    tree = shallow(<Metric metric={{ format: RunMetricFormat.UNSPECIFIED, number_value: 0.54 }} />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders an empty metric when metric has no metadata and raw format', () => {
+    tree = shallow(<Metric metric={{ format: RunMetricFormat.RAW, number_value: 0.54 }} />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders a metric when metric has max and min value of 0', () => {
+    tree = shallow(
+      <Metric
+        metadata={{ name: 'some metric', count: 1, maxValue: 0, minValue: 0 }}
+        metric={{ format: RunMetricFormat.RAW, number_value: 0.54 }}
+      />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders a metric and does not log an error when metric is between max and min value', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    tree = shallow(
+      <Metric
+        metadata={{ name: 'some metric', count: 1, maxValue: 1, minValue: 0 }}
+        metric={{ format: RunMetricFormat.RAW, number_value: 0.54 }}
+      />);
+    expect(consoleSpy).toHaveBeenCalledTimes(0);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders a metric and logs an error when metric has value less than min value', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    tree = shallow(
+      <Metric
+        metadata={{ name: 'some metric', count: 1, maxValue: 1, minValue: 0 }}
+        metric={{ format: RunMetricFormat.RAW, number_value: -0.54 }}
+      />);
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders a metric and logs an error when metric has value greater than max value', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    tree = shallow(
+      <Metric
+        metadata={{ name: 'some metric', count: 1, maxValue: 1, minValue: 0 }}
+        metric={{ format: RunMetricFormat.RAW, number_value: 2 }}
+      />);
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/frontend/src/components/Metric.tsx
+++ b/frontend/src/components/Metric.tsx
@@ -50,18 +50,18 @@ class Metric extends React.PureComponent<MetricProps> {
       return <div />;
     }
 
-    const leftSpace = 6;
     const displayString = MetricUtils.getMetricDisplayString(metric);
     let width = '';
 
     if (metric.format === RunMetricFormat.PERCENTAGE) {
       width = `calc(${displayString})`;
     } else {
-
       // Non-percentage metrics must contain metadata
       if (!metadata) {
         return <div />;
       }
+
+      const leftSpace = 6;
 
       if (metadata.maxValue === 0 && metadata.minValue === 0) {
         return <div style={{ paddingLeft: leftSpace }}>{displayString}</div>;

--- a/frontend/src/components/__snapshots__/Metric.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Metric.test.tsx.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Metric renders a metric and does not log an error when metric is between max and min value 1`] = `
+<div
+  className="metricContainer"
+>
+  <div
+    className="metricFill"
+    style={
+      Object {
+        "width": "calc(54%)",
+      }
+    }
+  >
+    0.540
+  </div>
+</div>
+`;
+
+exports[`Metric renders a metric and logs an error when metric has value greater than max value 1`] = `
+<div
+  style={
+    Object {
+      "paddingLeft": 6,
+    }
+  }
+>
+  2.000
+</div>
+`;
+
+exports[`Metric renders a metric and logs an error when metric has value less than min value 1`] = `
+<div
+  style={
+    Object {
+      "paddingLeft": 6,
+    }
+  }
+>
+  -0.540
+</div>
+`;
+
+exports[`Metric renders a metric when metric has max and min value of 0 1`] = `
+<div
+  style={
+    Object {
+      "paddingLeft": 6,
+    }
+  }
+>
+  0.540
+</div>
+`;
+
+exports[`Metric renders a metric when metric has value and percentage format 1`] = `
+<div
+  className="metricContainer"
+>
+  <div
+    className="metricFill"
+    style={
+      Object {
+        "width": "calc(54.000%)",
+      }
+    }
+  >
+    54.000%
+  </div>
+</div>
+`;
+
+exports[`Metric renders an empty metric when metric has no metadata and raw format 1`] = `<div />`;
+
+exports[`Metric renders an empty metric when metric has no metadata and unspecified format 1`] = `<div />`;
+
+exports[`Metric renders an empty metric when metric has no value 1`] = `<div />`;
+
+exports[`Metric renders an empty metric when there is no metric 1`] = `<div />`;

--- a/frontend/src/lib/CompareUtils.test.ts
+++ b/frontend/src/lib/CompareUtils.test.ts
@@ -15,7 +15,7 @@
  */
 
 import CompareUtils from './CompareUtils';
-import { ApiRun, ApiRunMetric } from '../apis/run';
+import { ApiRun } from '../apis/run';
 import { Workflow } from 'third_party/argo-ui/argo_template';
 
 describe('CompareUtils', () => {

--- a/frontend/src/lib/CompareUtils.test.ts
+++ b/frontend/src/lib/CompareUtils.test.ts
@@ -15,137 +15,232 @@
  */
 
 import CompareUtils from './CompareUtils';
+import { ApiRun, ApiRunMetric } from '../apis/run';
 import { Workflow } from 'third_party/argo-ui/argo_template';
 
 describe('CompareUtils', () => {
-  it('works with no runs', () => {
-    expect(CompareUtils.getParamsCompareProps([], [])).toEqual(
-      { rows: [], xLabels: [], yLabels: [] });
+
+  describe('getParamsCompareProps', () => {
+    it('works with no runs', () => {
+      expect(CompareUtils.getParamsCompareProps([], [])).toEqual(
+        { rows: [], xLabels: [], yLabels: [] });
+    });
+
+    it('works with one run', () => {
+      const runs = [{ run: { name: 'run1' } }];
+      const workflowObjects = [{
+        spec: {
+          arguments: {
+            parameters: [{
+              name: 'param1',
+              value: 'value1',
+            }],
+          },
+        },
+      } as Workflow];
+      expect(CompareUtils.getParamsCompareProps(runs, workflowObjects)).toEqual(
+        { rows: [['value1']], xLabels: ['run1'], yLabels: ['param1'] });
+    });
+
+    it('works with one run and several parameters', () => {
+      const runs = [{ run: { name: 'run1' } }];
+      const workflowObjects = [{
+        spec: {
+          arguments: {
+            parameters: [{
+              name: 'param1',
+              value: 'value1',
+            }, {
+              name: 'param2',
+              value: 'value2',
+            }, {
+              name: 'param3',
+              value: 'value3',
+            }],
+          },
+        },
+      } as Workflow];
+      expect(CompareUtils.getParamsCompareProps(runs, workflowObjects)).toEqual(
+        {
+          rows: [['value1'], ['value2'], ['value3']],
+          xLabels: ['run1'],
+          yLabels: ['param1', 'param2', 'param3'],
+        });
+    });
+
+    it('works with two runs and one parameter', () => {
+      const runs = [{ run: { name: 'run1' } }, { run: { name: 'run2' } }];
+      const workflowObjects = [{
+        spec: {
+          arguments: {
+            parameters: [{
+              name: 'param1',
+              value: 'value1',
+            }],
+          },
+        },
+      } as Workflow, {
+        spec: {
+          arguments: {
+            parameters: [{
+              name: 'param1',
+              value: 'value2',
+            }],
+          },
+        },
+      } as Workflow];
+      expect(CompareUtils.getParamsCompareProps(runs, workflowObjects)).toEqual(
+        {
+          rows: [['value1', 'value2']],
+          xLabels: ['run1', 'run2'],
+          yLabels: ['param1'],
+        });
+    });
+
+    it('sorts on parameter occurrence frequency', () => {
+      const runs = [{ run: { name: 'run1' } }, { run: { name: 'run2' } }, { run: { name: 'run3' } }];
+      const workflowObjects = [{
+        spec: {
+          arguments: {
+            parameters: [{
+              name: 'param1',
+              value: 'value1',
+            }, {
+              name: 'param2',
+              value: 'value2',
+            }, {
+              name: 'param3',
+              value: 'value3',
+            }],
+          },
+        },
+      } as Workflow, {
+        spec: {
+          arguments: {
+            parameters: [{
+              name: 'param2',
+              value: 'value4',
+            }, {
+              name: 'param3',
+              value: 'value5',
+            }],
+          },
+        },
+      } as Workflow, {
+        spec: {
+          arguments: {
+            parameters: [{
+              name: 'param3',
+              value: 'value6',
+            }, {
+              name: 'param4',
+              value: 'value7',
+            }],
+          },
+        },
+      } as Workflow];
+      expect(CompareUtils.getParamsCompareProps(runs, workflowObjects)).toEqual(
+        {
+          rows: [
+            ['value3', 'value5', 'value6'],
+            ['value2', 'value4', ''],
+            ['value1', '', ''],
+            ['', '', 'value7'],
+          ],
+          xLabels: ['run1', 'run2', 'run3'],
+          yLabels: ['param3', 'param2', 'param1', 'param4'],
+        });
+    });
   });
 
-  it('works with one run', () => {
-    const runs = [{ run: { name: 'run1' } }];
-    const workflowObjects = [{
-      spec: {
-        arguments: {
-          parameters: [{
-            name: 'param1',
-            value: 'value1',
-          }],
-        },
-      },
-    } as Workflow];
-    expect(CompareUtils.getParamsCompareProps(runs, workflowObjects)).toEqual(
-      { rows: [['value1']], xLabels: ['run1'], yLabels: ['param1'] });
-  });
+  describe('getMetricsCompareProps', () => {
+    it('returns empty props when passed no runs', () => {
+      expect(CompareUtils.getMetricsCompareProps([])).toEqual(
+        { rows: [], xLabels: [], yLabels: [] }
+      );
+    });
 
-  it('works with one run and several parameters', () => {
-    const runs = [{ run: { name: 'run1' } }];
-    const workflowObjects = [{
-      spec: {
-        arguments: {
-          parameters: [{
-            name: 'param1',
-            value: 'value1',
-          }, {
-            name: 'param2',
-            value: 'value2',
-          }, {
-            name: 'param3',
-            value: 'value3',
-          }],
-        },
-      },
-    } as Workflow];
-    expect(CompareUtils.getParamsCompareProps(runs, workflowObjects)).toEqual(
-      {
-        rows: [['value1'], ['value2'], ['value3']],
-        xLabels: ['run1'],
-        yLabels: ['param1', 'param2', 'param3'],
-      });
-  });
+    it('returns only x labels when passed a run with no metrics', () => {
+      const runs = [{ name: 'run1' } as ApiRun];
+      expect(CompareUtils.getMetricsCompareProps(runs)).toEqual(
+        { rows: [], xLabels: ['run1'], yLabels: [] }
+      );
+    });
 
-  it('works with two runs and one parameter', () => {
-    const runs = [{ run: { name: 'run1' } }, { run: { name: 'run2' } }];
-    const workflowObjects = [{
-      spec: {
-        arguments: {
-          parameters: [{
-            name: 'param1',
-            value: 'value1',
-          }],
-        },
-      },
-    } as Workflow, {
-      spec: {
-        arguments: {
-          parameters: [{
-            name: 'param1',
-            value: 'value2',
-          }],
-        },
-      },
-    } as Workflow];
-    expect(CompareUtils.getParamsCompareProps(runs, workflowObjects)).toEqual(
-      {
-        rows: [['value1', 'value2']],
-        xLabels: ['run1', 'run2'],
-        yLabels: ['param1'],
-      });
-  });
+    it('returns a row when passed a run with a metric', () => {
+      const runs = [
+        { name: 'run1', metrics: [{ name: 'some-metric', number_value: 0.33 }] } as ApiRun
+      ];
+      expect(CompareUtils.getMetricsCompareProps(runs)).toEqual(
+        { rows: [['0.330']], xLabels: ['run1'], yLabels: ['some-metric'] }
+      );
+    });
 
-  it('sorts on parameter occurrence frequency', () => {
-    const runs = [{ run: { name: 'run1' } }, { run: { name: 'run2' } }, { run: { name: 'run3' } }];
-    const workflowObjects = [{
-      spec: {
-        arguments: {
-          parameters: [{
-            name: 'param1',
-            value: 'value1',
-          }, {
-            name: 'param2',
-            value: 'value2',
-          }, {
-            name: 'param3',
-            value: 'value3',
-          }],
-        },
-      },
-    } as Workflow, {
-      spec: {
-        arguments: {
-          parameters: [{
-            name: 'param2',
-            value: 'value4',
-          }, {
-            name: 'param3',
-            value: 'value5',
-          }],
-        },
-      },
-    } as Workflow, {
-      spec: {
-        arguments: {
-          parameters: [{
-            name: 'param3',
-            value: 'value6',
-          }, {
-            name: 'param4',
-            value: 'value7',
-          }],
-        },
-      },
-    } as Workflow];
-    expect(CompareUtils.getParamsCompareProps(runs, workflowObjects)).toEqual(
-      {
-        rows: [
-          ['value3', 'value5', 'value6'],
-          ['value2', 'value4', ''],
-          ['value1', '', ''],
-          ['', '', 'value7'],
-        ],
-        xLabels: ['run1', 'run2', 'run3'],
-        yLabels: ['param3', 'param2', 'param1', 'param4'],
-      });
+    it('returns multiple rows when passed a run with multiple metrics', () => {
+      const runs = [
+        {
+          metrics: [
+            { name: 'some-metric', number_value: 0.33 },
+            { name: 'another-metric', number_value: 0.554 },
+          ],
+          name: 'run1',
+        } as ApiRun
+      ];
+      expect(CompareUtils.getMetricsCompareProps(runs)).toEqual(
+        {
+          rows: [['0.330'], ['0.554']],
+          xLabels: ['run1'],
+          yLabels: ['some-metric', 'another-metric'],
+        }
+      );
+    });
+
+    it('returns a row when passed multiple runs with the same metric', () => {
+      const runs = [
+        {
+          metrics: [
+            { name: 'some-metric', number_value: 0.33 },
+          ],
+          name: 'run1',
+        } as ApiRun,
+        {
+          metrics: [
+            { name: 'some-metric', number_value: 0.66 },
+          ],
+          name: 'run2',
+        } as ApiRun
+      ];
+      expect(CompareUtils.getMetricsCompareProps(runs)).toEqual(
+        {
+          rows: [['0.330', '0.660']],
+          xLabels: ['run1', 'run2'],
+          yLabels: ['some-metric'],
+        }
+      );
+    });
+
+    it('returns multiple rows when passed multiple runs with the different metrics', () => {
+      const runs = [
+        {
+          metrics: [
+            { name: 'some-metric', number_value: 0.33 },
+          ],
+          name: 'run1',
+        } as ApiRun,
+        {
+          metrics: [
+            { name: 'another-metric', number_value: 0.66 },
+          ],
+          name: 'run2',
+        } as ApiRun
+      ];
+      expect(CompareUtils.getMetricsCompareProps(runs)).toEqual(
+        {
+          rows: [['0.330', ''], ['', '0.660']],
+          xLabels: ['run1', 'run2'],
+          yLabels: ['some-metric', 'another-metric'],
+        }
+      );
+    });
   });
 });

--- a/frontend/src/lib/CompareUtils.ts
+++ b/frontend/src/lib/CompareUtils.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import { ApiRunDetail } from '../apis/run';
+import { ApiRunDetail, ApiRun } from '../apis/run';
 import { CompareTableProps } from '../components/CompareTable';
 import { Workflow } from 'third_party/argo-ui/argo_template';
 import { chain, flatten } from 'lodash';
 import WorkflowParser from './WorkflowParser';
 import { logger } from './Utils';
+import RunUtils from './RunUtils';
+import MetricUtils from './MetricUtils';
 
 export default class CompareUtils {
   /**
@@ -52,6 +54,37 @@ export default class CompareUtils {
           return param ? param.value || '' : '';
         });
     });
+
+    return { rows, xLabels, yLabels };
+  }
+
+  public static getMetricsCompareProps(runs: ApiRun[]): CompareTableProps {
+    const xLabels = runs.map(r => r.name!);
+
+    const metricMetadataMap = RunUtils.runsToMetricMetadataMap(runs);
+
+    const yLabels = Array.from(metricMetadataMap.keys());
+
+    // const yLabels = chain(flatten(workflowObjects
+    //   .map(w => WorkflowParser.getParameters(w))))
+    //   .countBy(p => p.name)                         // count by parameter name
+    //   .map((k, v) => ({ name: v, count: k }))       // convert to counter objects
+    //   .orderBy('count', 'desc')                     // sort on count field, descending
+    //   .map(o => o.name)
+    //   .value();
+
+    const rows =
+      yLabels.map(name =>
+        runs.map(r =>
+          MetricUtils.getMetricDisplayString((r.metrics || []).find(m => m.name === name))
+        )
+      );
+
+    // const rows: string[][] = [[]];
+
+    // const rows = runs.map(r => {
+
+    // });
 
     return { rows, xLabels, yLabels };
   }

--- a/frontend/src/lib/CompareUtils.ts
+++ b/frontend/src/lib/CompareUtils.ts
@@ -36,8 +36,6 @@ export default class CompareUtils {
       logger.error('Numbers of passed in runs and workflows do not match');
     }
 
-    const xLabels = runs.map(r => r.run!.name!);
-
     const yLabels = chain(flatten(workflowObjects
       .map(w => WorkflowParser.getParameters(w))))
       .countBy(p => p.name)                         // count by parameter name
@@ -55,23 +53,17 @@ export default class CompareUtils {
         });
     });
 
-    return { rows, xLabels, yLabels };
+    return {
+      rows,
+      xLabels: runs.map(r => r.run!.name!),
+      yLabels,
+    };
   }
 
   public static getMetricsCompareProps(runs: ApiRun[]): CompareTableProps {
-    const xLabels = runs.map(r => r.name!);
-
     const metricMetadataMap = RunUtils.runsToMetricMetadataMap(runs);
 
     const yLabels = Array.from(metricMetadataMap.keys());
-
-    // const yLabels = chain(flatten(workflowObjects
-    //   .map(w => WorkflowParser.getParameters(w))))
-    //   .countBy(p => p.name)                         // count by parameter name
-    //   .map((k, v) => ({ name: v, count: k }))       // convert to counter objects
-    //   .orderBy('count', 'desc')                     // sort on count field, descending
-    //   .map(o => o.name)
-    //   .value();
 
     const rows =
       yLabels.map(name =>
@@ -80,12 +72,10 @@ export default class CompareUtils {
         )
       );
 
-    // const rows: string[][] = [[]];
-
-    // const rows = runs.map(r => {
-
-    // });
-
-    return { rows, xLabels, yLabels };
+    return {
+      rows,
+      xLabels: runs.map(r => r.name!),
+      yLabels,
+    };
   }
 }

--- a/frontend/src/lib/MetricUtils.test.ts
+++ b/frontend/src/lib/MetricUtils.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MetricUtils from './MetricUtils';
+import { RunMetricFormat } from '../apis/run';
+
+describe('MetricUtils', () => {
+
+  describe('getMetricDisplayString', () => {
+
+    it('returns an empty string when no metric is provided', () => {
+      expect(MetricUtils.getMetricDisplayString()).toEqual('');
+    });
+
+    it('returns an empty string when metric has no number value', () => {
+      expect(MetricUtils.getMetricDisplayString({})).toEqual('');
+    });
+
+    it('returns a formatted string to three decimal places when metric has number value', () => {
+      expect(MetricUtils.getMetricDisplayString({ number_value: 0.1234 })).toEqual('0.123');
+    });
+
+    it('returns a formatted string to specified decimal places', () => {
+      expect(MetricUtils.getMetricDisplayString({ number_value: 0.1234 }, 2)).toEqual('0.12');
+    });
+
+    it('returns a formatted string when metric has format percentage and has number value', () => {
+      expect(MetricUtils.getMetricDisplayString({
+          format: RunMetricFormat.PERCENTAGE,
+          number_value: 0.12341234
+        })
+      ).toEqual('12.341%');
+    });
+
+    it('returns a formatted string to specified decimal places when metric has format percentage', () => {
+      expect(MetricUtils.getMetricDisplayString(
+        {
+          format: RunMetricFormat.PERCENTAGE,
+          number_value: 0.12341234
+        },
+        1)
+      ).toEqual('12.3%');
+    });
+  });
+
+});

--- a/frontend/src/lib/MetricUtils.ts
+++ b/frontend/src/lib/MetricUtils.ts
@@ -20,9 +20,11 @@ function getMetricDisplayString(metric?: ApiRunMetric, decimalPlaces = 3): strin
   if (!metric || metric.number_value === undefined) {
     return '';
   }
+
   if (metric.format === RunMetricFormat.PERCENTAGE) {
     return (metric.number_value * 100).toFixed(decimalPlaces) + '%';
   }
+
   return metric.number_value.toFixed(decimalPlaces);
 }
 

--- a/frontend/src/lib/MetricUtils.ts
+++ b/frontend/src/lib/MetricUtils.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiRunMetric, RunMetricFormat } from '../apis/run';
+
+function getMetricDisplayString(metric?: ApiRunMetric, decimalPlaces = 3): string {
+  if (!metric || metric.number_value === undefined) {
+    return '';
+  }
+  if (metric.format === RunMetricFormat.PERCENTAGE) {
+    return (metric.number_value * 100).toFixed(decimalPlaces) + '%';
+  }
+  return metric.number_value.toFixed(decimalPlaces);
+}
+
+export default {
+  getMetricDisplayString,
+};

--- a/frontend/src/pages/Compare.test.tsx
+++ b/frontend/src/pages/Compare.test.tsx
@@ -359,6 +359,7 @@ describe('Compare', () => {
     collapseBtn!.action();
 
     expect(tree.state('collapseSections')).toEqual({
+      'Metrics': true,
       'Parameters': true,
       'Run overview': true,
       'Table': true,
@@ -381,6 +382,7 @@ describe('Compare', () => {
     collapseBtn!.action();
 
     expect(tree.state('collapseSections')).toEqual({
+      'Metrics': true,
       'Parameters': true,
       'Run overview': true,
       'Table': true,

--- a/frontend/src/pages/Compare.test.tsx
+++ b/frontend/src/pages/Compare.test.tsx
@@ -293,6 +293,51 @@ describe('Compare', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('displays a run\'s metrics if the run has any', async () => {
+    const run = newMockRun('run-with-metrics');
+    run.run!.metrics = [
+      { name: 'some-metric', number_value: 0.33 },
+      { name: 'another-metric', number_value: 0.554 },
+    ];
+    runs.push(run);
+
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.runlist}=run-with-metrics`;
+
+    tree = shallow(<Compare {...props} />);
+    await TestUtils.flushPromises();
+    tree.update();
+
+    expect(tree.state('metricsCompareProps')).toEqual({
+      rows: [['0.330'], ['0.554']],
+      xLabels: ['test run run-with-metrics'],
+      yLabels: ['some-metric', 'another-metric']
+    });
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('displays metrics from multiple runs', async () => {
+    const run1 = newMockRun('run1');
+    run1.run!.metrics = [
+      { name: 'some-metric', number_value: 0.33 },
+      { name: 'another-metric', number_value: 0.554 },
+    ];
+    const run2 = newMockRun('run2');
+    run2.run!.metrics = [
+      { name: 'some-metric', number_value: 0.67 },
+    ];
+    runs.push(run1, run2);
+
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.runlist}=run1,run2`;
+
+    tree = shallow(<Compare {...props} />);
+    await TestUtils.flushPromises();
+    tree.update();
+
+    expect(tree).toMatchSnapshot();
+  });
+
   it('creates a map of viewers', async () => {
     // Simulate returning a tensorboard and table viewer
     outputArtifactLoaderSpy.mockImplementationOnce(() => [

--- a/frontend/src/pages/RunList.test.tsx
+++ b/frontend/src/pages/RunList.test.tsx
@@ -400,27 +400,6 @@ describe('RunList', () => {
     expect(getShallowInstance()._metricCustomRenderer({ value: { metric: {} }, id: 'run-id' })).toMatchSnapshot();
   });
 
-  it('renders a empty metric container when a metric has value of zero', () => {
-    expect(getShallowInstance()._metricCustomRenderer({ value: { metric: { number_value: 0 } }, id: 'run-id' })).toMatchSnapshot();
-  });
-
-  it('renders a metric container when a percentage metric has value of zero', () => {
-    expect(getShallowInstance()._metricCustomRenderer({
-      id: 'run-id',
-      value: { metric: { number_value: 0, format: RunMetricFormat.PERCENTAGE } },
-    })).toMatchSnapshot();
-  });
-
-  it('renders a metric container when a raw metric has value of zero', () => {
-    expect(getShallowInstance()._metricCustomRenderer({
-      id: 'run-id',
-      value: {
-        metadata: { maxValue: 10, minValue: 0 } as any,
-        metric: { number_value: 0, format: RunMetricFormat.RAW },
-      },
-    })).toMatchSnapshot();
-  });
-
   it('renders percentage metric', () => {
     expect(getShallowInstance()._metricCustomRenderer({
       id: 'run-id',
@@ -436,40 +415,6 @@ describe('RunList', () => {
         metric: { number_value: 55 } as ApiRunMetric,
       },
     })).toMatchSnapshot();
-  });
-
-  it('renders raw metric with zero max/min values', () => {
-    expect(getShallowInstance()._metricCustomRenderer({
-      id: 'run-id',
-      value: {
-        metadata: { count: 1, maxValue: 0, minValue: 0 } as MetricMetadata,
-        metric: { number_value: 15 } as ApiRunMetric,
-      },
-    })).toMatchSnapshot();
-  });
-
-  it('renders raw metric that is less than its min value, logs error to console', () => {
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-    expect(getShallowInstance()._metricCustomRenderer({
-      id: 'run-id',
-      value: {
-        metadata: { count: 1, maxValue: 100, minValue: 10 } as MetricMetadata,
-        metric: { number_value: 5 } as ApiRunMetric,
-      },
-    })).toMatchSnapshot();
-    expect(consoleSpy).toHaveBeenCalled();
-  });
-
-  it('renders raw metric that is greater than its max value, logs error to console', () => {
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-    expect(getShallowInstance()._metricCustomRenderer({
-      id: 'run-id',
-      value: {
-        metadata: { count: 1, maxValue: 100, minValue: 10 } as MetricMetadata,
-        metric: { number_value: 105 } as ApiRunMetric,
-      },
-    })).toMatchSnapshot();
-    expect(consoleSpy).toHaveBeenCalled();
   });
 
 });

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -16,8 +16,9 @@
 
 import * as React from 'react';
 import CustomTable, { Column, Row, CustomRendererProps } from '../components/CustomTable';
+import Metric from '../atoms/Metric';
 import RunUtils, { MetricMetadata } from '../../src/lib/RunUtils';
-import { ApiRun, ApiResourceType, RunMetricFormat, ApiRunMetric, RunStorageState, ApiRunDetail } from '../../src/apis/run';
+import { ApiRun, ApiResourceType, ApiRunMetric, RunStorageState, ApiRunDetail } from '../../src/apis/run';
 import { Apis, RunSortKeys, ListRequest } from '../lib/Apis';
 import { Link, RouteComponentProps } from 'react-router-dom';
 import { NodePhase } from '../lib/StatusUtils';
@@ -27,23 +28,6 @@ import { URLParser } from '../lib/URLParser';
 import { commonCss, color } from '../Css';
 import { formatDateString, logger, errorToMessage, getRunDuration } from '../lib/Utils';
 import { statusToIcon } from './Status';
-import { stylesheet } from 'typestyle';
-
-const css = stylesheet({
-  metricContainer: {
-    background: '#f6f7f9',
-    marginLeft: 6,
-    marginRight: 10,
-  },
-  metricFill: {
-    background: '#cbf0f8',
-    boxSizing: 'border-box',
-    color: '#202124',
-    fontFamily: 'Roboto',
-    fontSize: 13,
-    textIndent: 6,
-  },
-});
 
 interface ExperimentInfo {
   displayName?: string;
@@ -237,59 +221,11 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
 
   public _metricCustomRenderer: React.FC<CustomRendererProps<DisplayMetric>> = (props: CustomRendererProps<DisplayMetric>) => {
     const displayMetric = props.value;
-    if (!displayMetric || !displayMetric.metric ||
-      displayMetric.metric.number_value === undefined) {
+    if (!displayMetric) {
       return <div />;
     }
 
-    const leftSpace = 6;
-    let displayString = '';
-    let width = '';
-
-    if (displayMetric.metric.format === RunMetricFormat.PERCENTAGE) {
-      displayString = (displayMetric.metric.number_value * 100).toFixed(3) + '%';
-      width = `calc(${displayString})`;
-    } else {
-
-      // Non-percentage metrics must contain metadata
-      if (!displayMetric.metadata) {
-        return <div />;
-      }
-
-      displayString = displayMetric.metric.number_value.toFixed(3);
-
-      if (displayMetric.metadata.maxValue === 0 && displayMetric.metadata.minValue === 0) {
-        return <div style={{ paddingLeft: leftSpace }}>{displayString}</div>;
-      }
-
-      if (displayMetric.metric.number_value - displayMetric.metadata.minValue < 0) {
-        logger.error(`Run ${props.id}'s metric ${displayMetric.metadata.name}'s value:`
-          + ` (${displayMetric.metric.number_value}) was lower than the supposed minimum of`
-          + ` (${displayMetric.metadata.minValue})`);
-        return <div style={{ paddingLeft: leftSpace }}>{displayString}</div>;
-      }
-
-      if (displayMetric.metadata.maxValue - displayMetric.metric.number_value < 0) {
-        logger.error(`Run ${props.id}'s metric ${displayMetric.metadata.name}'s value:`
-          + ` (${displayMetric.metric.number_value}) was greater than the supposed maximum of`
-          + ` (${displayMetric.metadata.maxValue})`);
-        return <div style={{ paddingLeft: leftSpace }}>{displayString}</div>;
-      }
-
-      const barWidth =
-        (displayMetric.metric.number_value - displayMetric.metadata.minValue)
-        / (displayMetric.metadata.maxValue - displayMetric.metadata.minValue)
-        * 100;
-
-      width = `calc(${barWidth}%)`;
-    }
-    return (
-      <div className={css.metricContainer}>
-        <div className={css.metricFill} style={{ width }}>
-          {displayString}
-        </div>
-      </div>
-    );
+    return <Metric metric={displayMetric.metric} metadata={displayMetric.metadata} />;
   }
 
   protected async _loadRuns(request: ListRequest): Promise<string> {

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -16,7 +16,7 @@
 
 import * as React from 'react';
 import CustomTable, { Column, Row, CustomRendererProps } from '../components/CustomTable';
-import Metric from '../atoms/Metric';
+import Metric from '../components/Metric';
 import RunUtils, { MetricMetadata } from '../../src/lib/RunUtils';
 import { ApiRun, ApiResourceType, ApiRunMetric, RunStorageState, ApiRunDetail } from '../../src/apis/run';
 import { Apis, RunSortKeys, ListRequest } from '../lib/Apis';

--- a/frontend/src/pages/__snapshots__/Compare.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/Compare.test.tsx.snap
@@ -1415,6 +1415,190 @@ exports[`Compare renders a page with multiple runs 1`] = `
 </div>
 `;
 
+exports[`Compare renders a page with multiple runs 2`] = `
+<div
+  className="page"
+>
+  <CollapseButton
+    collapseSections={Object {}}
+    compareSetState={[Function]}
+    sectionName="Run overview"
+  />
+  <div
+    className="noShrink"
+  >
+    <RunList
+      disablePaging={true}
+      history={
+        Object {
+          "push": [MockFunction],
+        }
+      }
+      location={
+        Object {
+          "pathname": "/compare",
+          "search": "?runlist=mock-run-1-id,mock-run-2-id,mock-run-3-id",
+        }
+      }
+      match={Object {}}
+      onError={[Function]}
+      onSelectionChange={[Function]}
+      runIdListMask={
+        Array [
+          "mock-run-1-id",
+          "mock-run-2-id",
+          "mock-run-3-id",
+        ]
+      }
+      selectedIds={
+        Array [
+          "mock-run-1-id",
+          "mock-run-2-id",
+          "mock-run-3-id",
+        ]
+      }
+      toolbarProps={
+        Object {
+          "actions": Array [
+            Object {
+              "action": [Function],
+              "icon": [Function],
+              "id": "expandBtn",
+              "title": "Expand all",
+              "tooltip": "Expand all sections",
+            },
+            Object {
+              "action": [Function],
+              "icon": [Function],
+              "id": "collapseBtn",
+              "title": "Collapse all",
+              "tooltip": "Collapse all sections",
+            },
+            Object {
+              "action": [Function],
+              "id": "refreshBtn",
+              "title": "Refresh",
+              "tooltip": "Refresh the list",
+            },
+          ],
+          "breadcrumbs": Array [
+            Object {
+              "displayName": "Experiments",
+              "href": "/experiments",
+            },
+          ],
+          "pageTitle": "Compare runs",
+        }
+      }
+      updateBanner={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              Object {},
+            ],
+          ],
+        }
+      }
+      updateDialog={[MockFunction]}
+      updateSnackbar={[MockFunction]}
+      updateToolbar={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              Object {
+                "actions": Array [
+                  Object {
+                    "action": [Function],
+                    "icon": [Function],
+                    "id": "expandBtn",
+                    "title": "Expand all",
+                    "tooltip": "Expand all sections",
+                  },
+                  Object {
+                    "action": [Function],
+                    "icon": [Function],
+                    "id": "collapseBtn",
+                    "title": "Collapse all",
+                    "tooltip": "Collapse all sections",
+                  },
+                  Object {
+                    "action": [Function],
+                    "id": "refreshBtn",
+                    "title": "Refresh",
+                    "tooltip": "Refresh the list",
+                  },
+                ],
+                "breadcrumbs": Array [
+                  Object {
+                    "displayName": "Experiments",
+                    "href": "/experiments",
+                  },
+                ],
+                "pageTitle": "Compare runs",
+              },
+            ],
+          ],
+        }
+      }
+    />
+  </div>
+  <Component
+    orientation="vertical"
+  />
+  <CollapseButton
+    collapseSections={Object {}}
+    compareSetState={[Function]}
+    sectionName="Parameters"
+  />
+  <div
+    className="noShrink outputsRow"
+  >
+    <Component
+      orientation="vertical"
+    />
+    <CompareTable
+      rows={Array []}
+      xLabels={
+        Array [
+          "test run mock-run-1-id",
+          "test run mock-run-2-id",
+          "test run mock-run-3-id",
+        ]
+      }
+      yLabels={Array []}
+    />
+    <Component />
+  </div>
+  <CollapseButton
+    collapseSections={Object {}}
+    compareSetState={[Function]}
+    sectionName="Metrics"
+  />
+  <div
+    className="noShrink outputsRow"
+  >
+    <Component
+      orientation="vertical"
+    />
+    <CompareTable
+      rows={Array []}
+      xLabels={
+        Array [
+          "test run mock-run-1-id",
+          "test run mock-run-2-id",
+          "test run mock-run-3-id",
+        ]
+      }
+      yLabels={Array []}
+    />
+    <Component />
+  </div>
+  <Component
+    orientation="vertical"
+  />
+</div>
+`;
+
 exports[`Compare renders a page with no runs 1`] = `
 <div
   className="page"

--- a/frontend/src/pages/__snapshots__/Compare.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/Compare.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Compare collapses all sections 1`] = `
   <CollapseButton
     collapseSections={
       Object {
+        "Metrics": true,
         "Parameters": true,
         "Run overview": true,
         "Table": true,
@@ -22,6 +23,7 @@ exports[`Compare collapses all sections 1`] = `
   <CollapseButton
     collapseSections={
       Object {
+        "Metrics": true,
         "Parameters": true,
         "Run overview": true,
         "Table": true,
@@ -30,6 +32,19 @@ exports[`Compare collapses all sections 1`] = `
     }
     compareSetState={[Function]}
     sectionName="Parameters"
+  />
+  <CollapseButton
+    collapseSections={
+      Object {
+        "Metrics": true,
+        "Parameters": true,
+        "Run overview": true,
+        "Table": true,
+        "Tensorboard": true,
+      }
+    }
+    compareSetState={[Function]}
+    sectionName="Metrics"
   />
   <Component
     orientation="vertical"
@@ -40,6 +55,7 @@ exports[`Compare collapses all sections 1`] = `
     <CollapseButton
       collapseSections={
         Object {
+          "Metrics": true,
           "Parameters": true,
           "Run overview": true,
           "Table": true,
@@ -59,6 +75,7 @@ exports[`Compare collapses all sections 1`] = `
     <CollapseButton
       collapseSections={
         Object {
+          "Metrics": true,
           "Parameters": true,
           "Run overview": true,
           "Table": true,
@@ -130,6 +147,12 @@ exports[`Compare creates a map of viewers 1`] = `
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
+            Object {
+              "action": [Function],
+              "id": "refreshBtn",
+              "title": "Refresh",
+              "tooltip": "Refresh the list",
+            },
           ],
           "breadcrumbs": Array [
             Object {
@@ -171,6 +194,12 @@ exports[`Compare creates a map of viewers 1`] = `
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
                   },
+                  Object {
+                    "action": [Function],
+                    "id": "refreshBtn",
+                    "title": "Refresh",
+                    "tooltip": "Refresh the list",
+                  },
                 ],
                 "breadcrumbs": Array [
                   Object {
@@ -193,6 +222,28 @@ exports[`Compare creates a map of viewers 1`] = `
     collapseSections={Object {}}
     compareSetState={[Function]}
     sectionName="Parameters"
+  />
+  <div
+    className="noShrink outputsRow"
+  >
+    <Component
+      orientation="vertical"
+    />
+    <CompareTable
+      rows={Array []}
+      xLabels={
+        Array [
+          "test run run-with-workflow",
+        ]
+      }
+      yLabels={Array []}
+    />
+    <Component />
+  </div>
+  <CollapseButton
+    collapseSections={Object {}}
+    compareSetState={[Function]}
+    sectionName="Metrics"
   />
   <div
     className="noShrink outputsRow"
@@ -343,6 +394,12 @@ exports[`Compare creates an extra aggregation plot for compatible viewers 1`] = 
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
+            Object {
+              "action": [Function],
+              "id": "refreshBtn",
+              "title": "Refresh",
+              "tooltip": "Refresh the list",
+            },
           ],
           "breadcrumbs": Array [
             Object {
@@ -384,6 +441,12 @@ exports[`Compare creates an extra aggregation plot for compatible viewers 1`] = 
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
                   },
+                  Object {
+                    "action": [Function],
+                    "id": "refreshBtn",
+                    "title": "Refresh",
+                    "tooltip": "Refresh the list",
+                  },
                 ],
                 "breadcrumbs": Array [
                   Object {
@@ -406,6 +469,29 @@ exports[`Compare creates an extra aggregation plot for compatible viewers 1`] = 
     collapseSections={Object {}}
     compareSetState={[Function]}
     sectionName="Parameters"
+  />
+  <div
+    className="noShrink outputsRow"
+  >
+    <Component
+      orientation="vertical"
+    />
+    <CompareTable
+      rows={Array []}
+      xLabels={
+        Array [
+          "test run run1-id",
+          "test run run2-id",
+        ]
+      }
+      yLabels={Array []}
+    />
+    <Component />
+  </div>
+  <CollapseButton
+    collapseSections={Object {}}
+    compareSetState={[Function]}
+    sectionName="Metrics"
   />
   <div
     className="noShrink outputsRow"
@@ -608,6 +694,12 @@ exports[`Compare displays parameters from multiple runs 1`] = `
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
+            Object {
+              "action": [Function],
+              "id": "refreshBtn",
+              "title": "Refresh",
+              "tooltip": "Refresh the list",
+            },
           ],
           "breadcrumbs": Array [
             Object {
@@ -648,6 +740,12 @@ exports[`Compare displays parameters from multiple runs 1`] = `
                     "id": "collapseBtn",
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
+                  },
+                  Object {
+                    "action": [Function],
+                    "id": "refreshBtn",
+                    "title": "Refresh",
+                    "tooltip": "Refresh the list",
                   },
                 ],
                 "breadcrumbs": Array [
@@ -708,6 +806,29 @@ exports[`Compare displays parameters from multiple runs 1`] = `
           "r2-unique-param1",
         ]
       }
+    />
+    <Component />
+  </div>
+  <CollapseButton
+    collapseSections={Object {}}
+    compareSetState={[Function]}
+    sectionName="Metrics"
+  />
+  <div
+    className="noShrink outputsRow"
+  >
+    <Component
+      orientation="vertical"
+    />
+    <CompareTable
+      rows={Array []}
+      xLabels={
+        Array [
+          "test run run1",
+          "test run run2",
+        ]
+      }
+      yLabels={Array []}
     />
     <Component />
   </div>
@@ -772,6 +893,12 @@ exports[`Compare displays run's parameters if the run has any 1`] = `
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
+            Object {
+              "action": [Function],
+              "id": "refreshBtn",
+              "title": "Refresh",
+              "tooltip": "Refresh the list",
+            },
           ],
           "breadcrumbs": Array [
             Object {
@@ -812,6 +939,12 @@ exports[`Compare displays run's parameters if the run has any 1`] = `
                     "id": "collapseBtn",
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
+                  },
+                  Object {
+                    "action": [Function],
+                    "id": "refreshBtn",
+                    "title": "Refresh",
+                    "tooltip": "Refresh the list",
                   },
                 ],
                 "breadcrumbs": Array [
@@ -864,6 +997,28 @@ exports[`Compare displays run's parameters if the run has any 1`] = `
           "param2",
         ]
       }
+    />
+    <Component />
+  </div>
+  <CollapseButton
+    collapseSections={Object {}}
+    compareSetState={[Function]}
+    sectionName="Metrics"
+  />
+  <div
+    className="noShrink outputsRow"
+  >
+    <Component
+      orientation="vertical"
+    />
+    <CompareTable
+      rows={Array []}
+      xLabels={
+        Array [
+          "test run run-with-parameters",
+        ]
+      }
+      yLabels={Array []}
     />
     <Component />
   </div>
@@ -925,6 +1080,12 @@ exports[`Compare does not show viewers for deselected runs 1`] = `
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
+            Object {
+              "action": [Function],
+              "id": "refreshBtn",
+              "title": "Refresh",
+              "tooltip": "Refresh the list",
+            },
           ],
           "breadcrumbs": Array [
             Object {
@@ -966,6 +1127,12 @@ exports[`Compare does not show viewers for deselected runs 1`] = `
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
                   },
+                  Object {
+                    "action": [Function],
+                    "id": "refreshBtn",
+                    "title": "Refresh",
+                    "tooltip": "Refresh the list",
+                  },
                 ],
                 "breadcrumbs": Array [
                   Object {
@@ -988,6 +1155,24 @@ exports[`Compare does not show viewers for deselected runs 1`] = `
     collapseSections={Object {}}
     compareSetState={[Function]}
     sectionName="Parameters"
+  />
+  <div
+    className="noShrink outputsRow"
+  >
+    <Component
+      orientation="vertical"
+    />
+    <CompareTable
+      rows={Array []}
+      xLabels={Array []}
+      yLabels={Array []}
+    />
+    <Component />
+  </div>
+  <CollapseButton
+    collapseSections={Object {}}
+    compareSetState={[Function]}
+    sectionName="Metrics"
   />
   <div
     className="noShrink outputsRow"
@@ -1065,6 +1250,12 @@ exports[`Compare expands all sections if they were collapsed 1`] = `
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
+            Object {
+              "action": [Function],
+              "id": "refreshBtn",
+              "title": "Refresh",
+              "tooltip": "Refresh the list",
+            },
           ],
           "breadcrumbs": Array [
             Object {
@@ -1106,6 +1297,12 @@ exports[`Compare expands all sections if they were collapsed 1`] = `
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
                   },
+                  Object {
+                    "action": [Function],
+                    "id": "refreshBtn",
+                    "title": "Refresh",
+                    "tooltip": "Refresh the list",
+                  },
                 ],
                 "breadcrumbs": Array [
                   Object {
@@ -1128,6 +1325,29 @@ exports[`Compare expands all sections if they were collapsed 1`] = `
     collapseSections={Object {}}
     compareSetState={[Function]}
     sectionName="Parameters"
+  />
+  <div
+    className="noShrink outputsRow"
+  >
+    <Component
+      orientation="vertical"
+    />
+    <CompareTable
+      rows={Array []}
+      xLabels={
+        Array [
+          "test run run-with-workflow-1",
+          "test run run-with-workflow-2",
+        ]
+      }
+      yLabels={Array []}
+    />
+    <Component />
+  </div>
+  <CollapseButton
+    collapseSections={Object {}}
+    compareSetState={[Function]}
+    sectionName="Metrics"
   />
   <div
     className="noShrink outputsRow"
@@ -1268,154 +1488,6 @@ exports[`Compare expands all sections if they were collapsed 1`] = `
 `;
 
 exports[`Compare renders a page with multiple runs 1`] = `
-<div
-  className="page"
->
-  <CollapseButton
-    collapseSections={Object {}}
-    compareSetState={[Function]}
-    sectionName="Run overview"
-  />
-  <div
-    className="noShrink"
-  >
-    <RunList
-      disablePaging={true}
-      history={
-        Object {
-          "push": [MockFunction],
-        }
-      }
-      location={
-        Object {
-          "pathname": "/compare",
-          "search": "?runlist=mock-run-1-id,mock-run-2-id,mock-run-3-id",
-        }
-      }
-      match={Object {}}
-      onError={[Function]}
-      onSelectionChange={[Function]}
-      runIdListMask={
-        Array [
-          "mock-run-1-id",
-          "mock-run-2-id",
-          "mock-run-3-id",
-        ]
-      }
-      selectedIds={
-        Array [
-          "mock-run-1-id",
-          "mock-run-2-id",
-          "mock-run-3-id",
-        ]
-      }
-      toolbarProps={
-        Object {
-          "actions": Array [
-            Object {
-              "action": [Function],
-              "icon": [Function],
-              "id": "expandBtn",
-              "title": "Expand all",
-              "tooltip": "Expand all sections",
-            },
-            Object {
-              "action": [Function],
-              "icon": [Function],
-              "id": "collapseBtn",
-              "title": "Collapse all",
-              "tooltip": "Collapse all sections",
-            },
-          ],
-          "breadcrumbs": Array [
-            Object {
-              "displayName": "Experiments",
-              "href": "/experiments",
-            },
-          ],
-          "pageTitle": "Compare runs",
-        }
-      }
-      updateBanner={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Object {},
-            ],
-          ],
-        }
-      }
-      updateDialog={[MockFunction]}
-      updateSnackbar={[MockFunction]}
-      updateToolbar={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Object {
-                "actions": Array [
-                  Object {
-                    "action": [Function],
-                    "icon": [Function],
-                    "id": "expandBtn",
-                    "title": "Expand all",
-                    "tooltip": "Expand all sections",
-                  },
-                  Object {
-                    "action": [Function],
-                    "icon": [Function],
-                    "id": "collapseBtn",
-                    "title": "Collapse all",
-                    "tooltip": "Collapse all sections",
-                  },
-                ],
-                "breadcrumbs": Array [
-                  Object {
-                    "displayName": "Experiments",
-                    "href": "/experiments",
-                  },
-                ],
-                "pageTitle": "Compare runs",
-              },
-            ],
-          ],
-        }
-      }
-    />
-  </div>
-  <Component
-    orientation="vertical"
-  />
-  <CollapseButton
-    collapseSections={Object {}}
-    compareSetState={[Function]}
-    sectionName="Parameters"
-  />
-  <div
-    className="noShrink outputsRow"
-  >
-    <Component
-      orientation="vertical"
-    />
-    <CompareTable
-      rows={Array []}
-      xLabels={
-        Array [
-          "test run mock-run-1-id",
-          "test run mock-run-2-id",
-          "test run mock-run-3-id",
-        ]
-      }
-      yLabels={Array []}
-    />
-    <Component />
-  </div>
-  <Component
-    orientation="vertical"
-  />
-</div>
-`;
-
-exports[`Compare renders a page with multiple runs 2`] = `
 <div
   className="page"
 >
@@ -1646,6 +1718,12 @@ exports[`Compare renders a page with no runs 1`] = `
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
+            Object {
+              "action": [Function],
+              "id": "refreshBtn",
+              "title": "Refresh",
+              "tooltip": "Refresh the list",
+            },
           ],
           "breadcrumbs": Array [
             Object {
@@ -1687,6 +1765,12 @@ exports[`Compare renders a page with no runs 1`] = `
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
                   },
+                  Object {
+                    "action": [Function],
+                    "id": "refreshBtn",
+                    "title": "Refresh",
+                    "tooltip": "Refresh the list",
+                  },
                 ],
                 "breadcrumbs": Array [
                   Object {
@@ -1709,6 +1793,24 @@ exports[`Compare renders a page with no runs 1`] = `
     collapseSections={Object {}}
     compareSetState={[Function]}
     sectionName="Parameters"
+  />
+  <div
+    className="noShrink outputsRow"
+  >
+    <Component
+      orientation="vertical"
+    />
+    <CompareTable
+      rows={Array []}
+      xLabels={Array []}
+      yLabels={Array []}
+    />
+    <Component />
+  </div>
+  <CollapseButton
+    collapseSections={Object {}}
+    compareSetState={[Function]}
+    sectionName="Metrics"
   />
   <div
     className="noShrink outputsRow"

--- a/frontend/src/pages/__snapshots__/Compare.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/Compare.test.tsx.snap
@@ -637,6 +637,392 @@ exports[`Compare creates an extra aggregation plot for compatible viewers 1`] = 
 </div>
 `;
 
+exports[`Compare displays a run's metrics if the run has any 1`] = `
+<div
+  className="page"
+>
+  <CollapseButton
+    collapseSections={Object {}}
+    compareSetState={[Function]}
+    sectionName="Run overview"
+  />
+  <div
+    className="noShrink"
+  >
+    <RunList
+      disablePaging={true}
+      history={
+        Object {
+          "push": [MockFunction],
+        }
+      }
+      location={
+        Object {
+          "pathname": "/compare",
+          "search": "?runlist=run-with-metrics",
+        }
+      }
+      match={Object {}}
+      onError={[Function]}
+      onSelectionChange={[Function]}
+      runIdListMask={
+        Array [
+          "run-with-metrics",
+        ]
+      }
+      selectedIds={
+        Array [
+          "run-with-metrics",
+        ]
+      }
+      toolbarProps={
+        Object {
+          "actions": Array [
+            Object {
+              "action": [Function],
+              "icon": [Function],
+              "id": "expandBtn",
+              "title": "Expand all",
+              "tooltip": "Expand all sections",
+            },
+            Object {
+              "action": [Function],
+              "icon": [Function],
+              "id": "collapseBtn",
+              "title": "Collapse all",
+              "tooltip": "Collapse all sections",
+            },
+            Object {
+              "action": [Function],
+              "id": "refreshBtn",
+              "title": "Refresh",
+              "tooltip": "Refresh the list",
+            },
+          ],
+          "breadcrumbs": Array [
+            Object {
+              "displayName": "Experiments",
+              "href": "/experiments",
+            },
+          ],
+          "pageTitle": "Compare runs",
+        }
+      }
+      updateBanner={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              Object {},
+            ],
+          ],
+        }
+      }
+      updateDialog={[MockFunction]}
+      updateSnackbar={[MockFunction]}
+      updateToolbar={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              Object {
+                "actions": Array [
+                  Object {
+                    "action": [Function],
+                    "icon": [Function],
+                    "id": "expandBtn",
+                    "title": "Expand all",
+                    "tooltip": "Expand all sections",
+                  },
+                  Object {
+                    "action": [Function],
+                    "icon": [Function],
+                    "id": "collapseBtn",
+                    "title": "Collapse all",
+                    "tooltip": "Collapse all sections",
+                  },
+                  Object {
+                    "action": [Function],
+                    "id": "refreshBtn",
+                    "title": "Refresh",
+                    "tooltip": "Refresh the list",
+                  },
+                ],
+                "breadcrumbs": Array [
+                  Object {
+                    "displayName": "Experiments",
+                    "href": "/experiments",
+                  },
+                ],
+                "pageTitle": "Compare runs",
+              },
+            ],
+          ],
+        }
+      }
+    />
+  </div>
+  <Component
+    orientation="vertical"
+  />
+  <CollapseButton
+    collapseSections={Object {}}
+    compareSetState={[Function]}
+    sectionName="Parameters"
+  />
+  <div
+    className="noShrink outputsRow"
+  >
+    <Component
+      orientation="vertical"
+    />
+    <CompareTable
+      rows={Array []}
+      xLabels={
+        Array [
+          "test run run-with-metrics",
+        ]
+      }
+      yLabels={Array []}
+    />
+    <Component />
+  </div>
+  <CollapseButton
+    collapseSections={Object {}}
+    compareSetState={[Function]}
+    sectionName="Metrics"
+  />
+  <div
+    className="noShrink outputsRow"
+  >
+    <Component
+      orientation="vertical"
+    />
+    <CompareTable
+      rows={
+        Array [
+          Array [
+            "0.330",
+          ],
+          Array [
+            "0.554",
+          ],
+        ]
+      }
+      xLabels={
+        Array [
+          "test run run-with-metrics",
+        ]
+      }
+      yLabels={
+        Array [
+          "some-metric",
+          "another-metric",
+        ]
+      }
+    />
+    <Component />
+  </div>
+  <Component
+    orientation="vertical"
+  />
+</div>
+`;
+
+exports[`Compare displays metrics from multiple runs 1`] = `
+<div
+  className="page"
+>
+  <CollapseButton
+    collapseSections={Object {}}
+    compareSetState={[Function]}
+    sectionName="Run overview"
+  />
+  <div
+    className="noShrink"
+  >
+    <RunList
+      disablePaging={true}
+      history={
+        Object {
+          "push": [MockFunction],
+        }
+      }
+      location={
+        Object {
+          "pathname": "/compare",
+          "search": "?runlist=run1,run2",
+        }
+      }
+      match={Object {}}
+      onError={[Function]}
+      onSelectionChange={[Function]}
+      runIdListMask={
+        Array [
+          "run1",
+          "run2",
+        ]
+      }
+      selectedIds={
+        Array [
+          "run1",
+          "run2",
+        ]
+      }
+      toolbarProps={
+        Object {
+          "actions": Array [
+            Object {
+              "action": [Function],
+              "icon": [Function],
+              "id": "expandBtn",
+              "title": "Expand all",
+              "tooltip": "Expand all sections",
+            },
+            Object {
+              "action": [Function],
+              "icon": [Function],
+              "id": "collapseBtn",
+              "title": "Collapse all",
+              "tooltip": "Collapse all sections",
+            },
+            Object {
+              "action": [Function],
+              "id": "refreshBtn",
+              "title": "Refresh",
+              "tooltip": "Refresh the list",
+            },
+          ],
+          "breadcrumbs": Array [
+            Object {
+              "displayName": "Experiments",
+              "href": "/experiments",
+            },
+          ],
+          "pageTitle": "Compare runs",
+        }
+      }
+      updateBanner={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              Object {},
+            ],
+          ],
+        }
+      }
+      updateDialog={[MockFunction]}
+      updateSnackbar={[MockFunction]}
+      updateToolbar={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              Object {
+                "actions": Array [
+                  Object {
+                    "action": [Function],
+                    "icon": [Function],
+                    "id": "expandBtn",
+                    "title": "Expand all",
+                    "tooltip": "Expand all sections",
+                  },
+                  Object {
+                    "action": [Function],
+                    "icon": [Function],
+                    "id": "collapseBtn",
+                    "title": "Collapse all",
+                    "tooltip": "Collapse all sections",
+                  },
+                  Object {
+                    "action": [Function],
+                    "id": "refreshBtn",
+                    "title": "Refresh",
+                    "tooltip": "Refresh the list",
+                  },
+                ],
+                "breadcrumbs": Array [
+                  Object {
+                    "displayName": "Experiments",
+                    "href": "/experiments",
+                  },
+                ],
+                "pageTitle": "Compare runs",
+              },
+            ],
+          ],
+        }
+      }
+    />
+  </div>
+  <Component
+    orientation="vertical"
+  />
+  <CollapseButton
+    collapseSections={Object {}}
+    compareSetState={[Function]}
+    sectionName="Parameters"
+  />
+  <div
+    className="noShrink outputsRow"
+  >
+    <Component
+      orientation="vertical"
+    />
+    <CompareTable
+      rows={Array []}
+      xLabels={
+        Array [
+          "test run run1",
+          "test run run2",
+        ]
+      }
+      yLabels={Array []}
+    />
+    <Component />
+  </div>
+  <CollapseButton
+    collapseSections={Object {}}
+    compareSetState={[Function]}
+    sectionName="Metrics"
+  />
+  <div
+    className="noShrink outputsRow"
+  >
+    <Component
+      orientation="vertical"
+    />
+    <CompareTable
+      rows={
+        Array [
+          Array [
+            "0.330",
+            "0.670",
+          ],
+          Array [
+            "0.554",
+            "",
+          ],
+        ]
+      }
+      xLabels={
+        Array [
+          "test run run1",
+          "test run run2",
+        ]
+      }
+      yLabels={
+        Array [
+          "some-metric",
+          "another-metric",
+        ]
+      }
+    />
+    <Component />
+  </div>
+  <Component
+    orientation="vertical"
+  />
+</div>
+`;
+
 exports[`Compare displays parameters from multiple runs 1`] = `
 <div
   className="page"

--- a/frontend/src/pages/__snapshots__/RunList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunList.test.tsx.snap
@@ -6913,45 +6913,19 @@ exports[`RunList reloads the run when refresh is called 1`] = `
 </RunList>
 `;
 
-exports[`RunList renders a empty metric container when a metric has value of zero 1`] = `<div />`;
-
-exports[`RunList renders a metric container when a percentage metric has value of zero 1`] = `
-<div
-  className="metricContainer"
->
-  <div
-    className="metricFill"
-    style={
-      Object {
-        "width": "calc(0.000%)",
-      }
-    }
-  >
-    0.000%
-  </div>
-</div>
+exports[`RunList renders an empty metric when metric is empty 1`] = `
+<Metric
+  metadata={undefined}
+  metric={undefined}
+/>
 `;
 
-exports[`RunList renders a metric container when a raw metric has value of zero 1`] = `
-<div
-  className="metricContainer"
->
-  <div
-    className="metricFill"
-    style={
-      Object {
-        "width": "calc(0%)",
-      }
-    }
-  >
-    0.000
-  </div>
-</div>
+exports[`RunList renders an empty metric when metric value is empty 1`] = `
+<Metric
+  metadata={undefined}
+  metric={Object {}}
+/>
 `;
-
-exports[`RunList renders an empty metric when metric is empty 1`] = `<div />`;
-
-exports[`RunList renders an empty metric when metric value is empty 1`] = `<div />`;
 
 exports[`RunList renders an empty metric when there is no metric 1`] = `<div />`;
 
@@ -6987,20 +6961,15 @@ exports[`RunList renders no experiment name 1`] = `
 `;
 
 exports[`RunList renders percentage metric 1`] = `
-<div
-  className="metricContainer"
->
-  <div
-    className="metricFill"
-    style={
-      Object {
-        "width": "calc(30.000%)",
-      }
+<Metric
+  metadata={undefined}
+  metric={
+    Object {
+      "format": "PERCENTAGE",
+      "number_value": 0.3,
     }
-  >
-    30.000%
-  </div>
-</div>
+  }
+/>
 `;
 
 exports[`RunList renders pipeline name as link to its details page 1`] = `
@@ -7015,56 +6984,20 @@ exports[`RunList renders pipeline name as link to its details page 1`] = `
 `;
 
 exports[`RunList renders raw metric 1`] = `
-<div
-  className="metricContainer"
->
-  <div
-    className="metricFill"
-    style={
-      Object {
-        "width": "calc(50%)",
-      }
-    }
-  >
-    55.000
-  </div>
-</div>
-`;
-
-exports[`RunList renders raw metric that is greater than its max value, logs error to console 1`] = `
-<div
-  style={
+<Metric
+  metadata={
     Object {
-      "paddingLeft": 6,
+      "count": 1,
+      "maxValue": 100,
+      "minValue": 10,
     }
   }
->
-  105.000
-</div>
-`;
-
-exports[`RunList renders raw metric that is less than its min value, logs error to console 1`] = `
-<div
-  style={
+  metric={
     Object {
-      "paddingLeft": 6,
+      "number_value": 55,
     }
   }
->
-  5.000
-</div>
-`;
-
-exports[`RunList renders raw metric with zero max/min values 1`] = `
-<div
-  style={
-    Object {
-      "paddingLeft": 6,
-    }
-  }
->
-  15.000
-</div>
+/>
 `;
 
 exports[`RunList renders run name as link to its details page 1`] = `


### PR DESCRIPTION
The `CompareTable` is not sortable, which is not ideal for metrics. However, this isn't much of a problem if the number of runs being compared is small.
If we do want a sortable table, we'll have to decide if we want to build one that can sort along rows (rather than columns), or if we want to transpose the parameters and metrics tables on the compare page.

Fixes: #468

Initial table will look like this:
![image](https://user-images.githubusercontent.com/34456002/57891426-2fd73480-77f0-11e9-904b-5c17072659ab.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1284)
<!-- Reviewable:end -->
