### PR TITLE
Backend - Marking auto-added artifacts as optional

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -955,3 +955,9 @@ go_repository(
     importpath = "k8s.io/klog",
     tag = "v0.1.0",
 )
+
+go_repository(
+    name = "com_github_gorilla_websocket",
+    importpath = "github.com/gorilla/websocket",
+    tag = "v1.2.0",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,7 +50,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
 go_repository(
     name = "google_ml_metadata",
-    commit = "becc26ab61f82bfe7c812894f56f597949ce0fdc",
+    commit = "0fb82dc56ff7",
     importpath = "github.com/google/ml-metadata",
 )
 
@@ -770,7 +770,7 @@ go_repository(
 
 go_repository(
     name = "org_golang_google_genproto",
-    commit = "bd91e49a0898",
+    commit = "ae2f86662275",
     importpath = "google.golang.org/genproto",
 )
 
@@ -924,4 +924,34 @@ go_repository(
     name = "org_golang_x_arch",
     commit = "5a4828bb7045",
     importpath = "golang.org/x/arch",
+)
+
+go_repository(
+    name = "com_github_docker_distribution",
+    importpath = "github.com/docker/distribution",
+    tag = "v2.7.0",
+)
+
+go_repository(
+    name = "com_github_opencontainers_go_digest",
+    importpath = "github.com/opencontainers/go-digest",
+    tag = "v1.0.0-rc1",
+)
+
+go_repository(
+    name = "io_k8s_apiextensions_apiserver",
+    commit = "e7617803aceb",
+    importpath = "k8s.io/apiextensions-apiserver",
+)
+
+go_repository(
+    name = "io_k8s_apiserver",
+    commit = "d55c9aeff1eb",
+    importpath = "k8s.io/apiserver",
+)
+
+go_repository(
+    name = "io_k8s_klog",
+    importpath = "k8s.io/klog",
+    tag = "v0.1.0",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -159,7 +159,7 @@ go_repository(
 go_repository(
     name = "com_github_argoproj_argo",
     importpath = "github.com/argoproj/argo",
-    tag = "v2.3.0-rc2",
+    tag = "v2.3.0-rc3",
 )
 
 go_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -159,7 +159,7 @@ go_repository(
 go_repository(
     name = "com_github_argoproj_argo",
     importpath = "github.com/argoproj/argo",
-    tag = "v2.2.0",
+    tag = "v2.3.0-rc2",
 )
 
 go_repository(

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -215,7 +215,7 @@ func (r *ResourceManager) CreateRun(apiRun *api.Run) (*model.RunDetail, error) {
 	for templateIdx, template := range workflow.Workflow.Spec.Templates {
 		for artIdx, artifact := range template.Outputs.Artifacts {
 			if artifact.Name == "mlpipeline-ui-metadata" || artifact.Name == "mlpipeline-metrics" {
-				workflow.Workflow.Spec.Templates[templateIdx].Outputs.Artifacts[artIdx].Optional = True
+				workflow.Workflow.Spec.Templates[templateIdx].Outputs.Artifacts[artIdx].Optional = true
 			}
 		}
 	}

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -78,8 +78,8 @@ func NewResourceManager(clientManager ClientManagerInterface) *ResourceManager {
 		objectStore:             clientManager.ObjectStore(),
 		workflowClient:          clientManager.Workflow(),
 		scheduledWorkflowClient: clientManager.ScheduledWorkflow(),
-		time: clientManager.Time(),
-		uuid: clientManager.UUID(),
+		time:                    clientManager.Time(),
+		uuid:                    clientManager.UUID(),
 	}
 }
 
@@ -211,7 +211,9 @@ func (r *ResourceManager) CreateRun(apiRun *api.Run) (*model.RunDetail, error) {
 	// Append provided parameter
 	workflow.OverrideParameters(parameters)
 
-	// Mark auto-added artifacts as optional. Otherwise workflows fail in Argo 2.3. Proper fix: Fix the components to explicitly declare the artifacts where needed. Fix the compiler to stop auto-adding atrifacts to all tasks.
+	// Marking auto-added artifacts as optional. Otherwise most older workflows will start failing after upgrade to Argo 2.3.
+	// TODO: Fix the components to explicitly declare the artifacts they really output.
+	// TODO: Change the compiler to stop auto-adding those two atrifacts to all tasks.
 	for templateIdx, template := range workflow.Workflow.Spec.Templates {
 		for artIdx, artifact := range template.Outputs.Artifacts {
 			if artifact.Name == "mlpipeline-ui-metadata" || artifact.Name == "mlpipeline-metrics" {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/Masterminds/squirrel v0.0.0-20190107164353-fa735ea14f09
 	github.com/VividCortex/mysqlerr v0.0.0-20170204212430-6c6b55f8796f
-	github.com/argoproj/argo v2.3.0-rc2+incompatible
+	github.com/argoproj/argo v2.3.0-rc3+incompatible
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/denisenkom/go-mssqldb v0.0.0-20181014144952-4e0d7dc8888f // indirect
 	github.com/docker/distribution v2.7.0+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/Masterminds/squirrel v0.0.0-20190107164353-fa735ea14f09
 	github.com/VividCortex/mysqlerr v0.0.0-20170204212430-6c6b55f8796f
-	github.com/argoproj/argo v2.2.0+incompatible
+	github.com/argoproj/argo v2.3.0-rc2+incompatible
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/denisenkom/go-mssqldb v0.0.0-20181014144952-4e0d7dc8888f // indirect
 	github.com/docker/distribution v2.7.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,9 @@ github.com/VividCortex/mysqlerr v0.0.0-20170204212430-6c6b55f8796f/go.mod h1:f3H
 github.com/argoproj/argo v2.2.0+incompatible h1:2CfmV2Ov7qGM7p2Jo0YkyD2SuuDNopbp426NdNrWJmc=
 github.com/argoproj/argo v2.2.0+incompatible/go.mod h1:KJ0MB+tuhtAklR4jkPM10mIZXfRA0peTYJ1sLUnFLVU=
 github.com/argoproj/argo v2.2.1+incompatible h1:FAXd83gaZZhkFvqsc24g1BSf79WZaFS7btcKePH5t4o=
+github.com/argoproj/argo v2.2.1+incompatible/go.mod h1:KJ0MB+tuhtAklR4jkPM10mIZXfRA0peTYJ1sLUnFLVU=
+github.com/argoproj/argo v2.3.0-rc2+incompatible h1:3HIZzFnr9pNouyVij/9uS4JIiM1ANmM+9RlMEO2O5+g=
+github.com/argoproj/argo v2.3.0-rc2+incompatible/go.mod h1:KJ0MB+tuhtAklR4jkPM10mIZXfRA0peTYJ1sLUnFLVU=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf h1:eg0MeVzsP1G42dRafH3vf+al2vQIJU0YHX+1Tw87oco=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=


### PR DESCRIPTION
This PR is implementing part of the https://github.com/kubeflow/pipelines/issues/1250 plan.

Problem:
DSL-compiler has been auto-adding two artifacts to all pipeline tasks (including ones that do not actually outputs those artifacts). All out existing compiled pipelines have this problem.
Argo 2.3 makes missing output artifacts a reason for task failure.
The workaround for the existing pipelines is for backend to mark those two artifacts as optional.

P.S.
The `optional` property is only available starting with Argo 2.3, so I'm bumping the Argo version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1289)
<!-- Reviewable:end -->
