### PR TITLE
SDK - Renamed ModelBase.from_struct/to_struct to from_dict/to_dict

### DIFF
--- a/sdk/python/kfp/compiler/_component_builder.py
+++ b/sdk/python/kfp/compiler/_component_builder.py
@@ -482,7 +482,7 @@ def _generate_pythonop(component_func, target_image, target_component_file=None)
   target_component_file = target_component_file or getattr(component_func, '_component_target_component_file', None)
   if target_component_file:
     from ..components._yaml_utils import dump_yaml
-    component_text = dump_yaml(component_spec.to_struct())
+    component_text = dump_yaml(component_spec.to_dict())
     Path(target_component_file).write_text(component_text)
 
   return _create_task_factory_from_component_spec(component_spec)

--- a/sdk/python/kfp/components/_components.py
+++ b/sdk/python/kfp/components/_components.py
@@ -153,7 +153,7 @@ def _create_task_factory_from_component_text(text_or_file, component_filename=No
 
 
 def _create_task_factory_from_component_dict(component_dict, component_filename=None, component_ref: ComponentReference = None):
-    component_spec = ComponentSpec.from_struct(component_dict)
+    component_spec = ComponentSpec.from_dict(component_dict)
     return _create_task_factory_from_component_spec(component_spec, component_filename, component_ref)
 
 

--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -225,7 +225,7 @@ for idx, filename in enumerate(_output_files):
 
 
 def _func_to_component_dict(func, extra_code='', base_image=_default_base_image):
-    return _func_to_component_spec(func, extra_code, base_image).to_struct()
+    return _func_to_component_spec(func, extra_code, base_image).to_dict()
 
 
 def func_to_component_text(func, extra_code='', base_image=_default_base_image):
@@ -309,9 +309,9 @@ def func_to_container_op(func, output_component_file=None, base_image=_default_b
 
     output_component_file = output_component_file or getattr(func, '_component_target_component_file', None)
     if output_component_file:
-        component_dict = component_spec.to_struct()
+        component_dict = component_spec.to_dict()
         component_yaml = dump_yaml(component_dict)
         Path(output_component_file).write_text(component_yaml)
-        #TODO: assert ComponentSpec.from_struct(load_yaml(output_component_file)) == component_spec
+        #TODO: assert ComponentSpec.from_dict(load_yaml(output_component_file)) == component_spec
 
     return _create_task_factory_from_component_spec(component_spec)

--- a/sdk/python/tests/components/test_graph_components.py
+++ b/sdk/python/tests/components/test_graph_components.py
@@ -82,7 +82,7 @@ implementation:
       graph out 2: {taskOutput: {taskId: task 1, outputName: out1 2}}
 '''
         struct = load_yaml(component_text)
-        ComponentSpec.from_struct(struct)
+        ComponentSpec.from_dict(struct)
 
     @unittest.expectedFailure
     def test_fail_on_cyclic_references(self):
@@ -100,7 +100,7 @@ implementation:
             in2 1: {taskOutput: {taskId: task 1, outputName: out1 1}}
 '''
         struct = load_yaml(component_text)
-        ComponentSpec.from_struct(struct)
+        ComponentSpec.from_dict(struct)
 
     def test_handle_parsing_predicates(self):
         component_text = '''\
@@ -127,7 +127,7 @@ implementation:
                             op2: 'head'
 '''
         struct = load_yaml(component_text)
-        ComponentSpec.from_struct(struct)
+        ComponentSpec.from_dict(struct)
 
     def test_handle_parsing_task_container_spec_options(self):
         component_text = '''\
@@ -144,7 +144,7 @@ implementation:
 
 '''
         struct = load_yaml(component_text)
-        component_spec = ComponentSpec.from_struct(struct)
+        component_spec = ComponentSpec.from_dict(struct)
         self.assertEqual(component_spec.implementation.graph.tasks['task 1'].k8s_container_options.resources.requests['memory'], '1024Mi')
 
 
@@ -166,7 +166,7 @@ implementation:
               emptyDir: {}
 '''
         struct = load_yaml(component_text)
-        component_spec = ComponentSpec.from_struct(struct)
+        component_spec = ComponentSpec.from_dict(struct)
         self.assertEqual(component_spec.implementation.graph.tasks['task 1'].k8s_pod_options.spec.volumes[0].name, 'workdir')
         self.assertTrue(component_spec.implementation.graph.tasks['task 1'].k8s_pod_options.spec.volumes[0].empty_dir is not None)
 

--- a/sdk/python/tests/components/test_structure_model_base.py
+++ b/sdk/python/tests/components/test_structure_model_base.py
@@ -129,105 +129,105 @@ class StructureModelBaseTestCase(unittest.TestCase):
         with self.assertRaises(TypeError):
             TestModel1(prop_0='', prop_5={'key 5': [val5]})
 
-    def test_handle_from_to_struct_for_simple_builtin(self):
+    def test_handle_from_to_dict_for_simple_builtin(self):
         struct0 = {'prop_0': 'value 0'}
-        obj0 = TestModel1.from_struct(struct0)
+        obj0 = TestModel1.from_dict(struct0)
         self.assertEqual(obj0.prop_0, 'value 0')
-        self.assertDictEqual(obj0.to_struct(), struct0)
+        self.assertDictEqual(obj0.to_dict(), struct0)
 
         with self.assertRaises(AttributeError): #TypeError:
-            TestModel1.from_struct(None)
+            TestModel1.from_dict(None)
 
         with self.assertRaises(AttributeError): #TypeError:
-            TestModel1.from_struct('')
+            TestModel1.from_dict('')
 
         with self.assertRaises(TypeError):
-            TestModel1.from_struct({})
+            TestModel1.from_dict({})
 
         with self.assertRaises(TypeError):
-            TestModel1.from_struct({'prop0': 'value 0'})
+            TestModel1.from_dict({'prop0': 'value 0'})
 
-    def test_handle_from_to_struct_for_optional_builtin(self):
+    def test_handle_from_to_dict_for_optional_builtin(self):
         struct11 = {'prop_0': '', 'prop1': 'value 1'}
-        obj11 = TestModel1.from_struct(struct11)
+        obj11 = TestModel1.from_dict(struct11)
         self.assertEqual(obj11.prop_1, struct11['prop1'])
-        self.assertDictEqual(obj11.to_struct(), struct11)
+        self.assertDictEqual(obj11.to_dict(), struct11)
 
         struct12 = {'prop_0': '', 'prop1': None}
-        obj12 = TestModel1.from_struct(struct12)
+        obj12 = TestModel1.from_dict(struct12)
         self.assertEqual(obj12.prop_1, None)
-        self.assertDictEqual(obj12.to_struct(), {'prop_0': ''})
+        self.assertDictEqual(obj12.to_dict(), {'prop_0': ''})
 
         with self.assertRaises(TypeError):
-            TestModel1.from_struct({'prop_0': '', 'prop 1': ''})
+            TestModel1.from_dict({'prop_0': '', 'prop 1': ''})
 
         with self.assertRaises(TypeError):
-            TestModel1.from_struct({'prop_0': '', 'prop1': 1})
+            TestModel1.from_dict({'prop_0': '', 'prop1': 1})
 
-    def test_handle_from_to_struct_for_union_builtin(self):
+    def test_handle_from_to_dict_for_union_builtin(self):
         struct21 = {'prop_0': '', 'prop 2': 'value 2'}
-        obj21 = TestModel1.from_struct(struct21)
+        obj21 = TestModel1.from_dict(struct21)
         self.assertEqual(obj21.prop_2,  struct21['prop 2'])
-        self.assertDictEqual(obj21.to_struct(), struct21)
+        self.assertDictEqual(obj21.to_dict(), struct21)
 
         struct22 = {'prop_0': '', 'prop 2': 22}
-        obj22 = TestModel1.from_struct(struct22)
+        obj22 = TestModel1.from_dict(struct22)
         self.assertEqual(obj22.prop_2, struct22['prop 2'])
-        self.assertDictEqual(obj22.to_struct(), struct22)
+        self.assertDictEqual(obj22.to_dict(), struct22)
 
         struct23 = {'prop_0': '', 'prop 2': True}
-        obj23 = TestModel1.from_struct(struct23)
+        obj23 = TestModel1.from_dict(struct23)
         self.assertEqual(obj23.prop_2, struct23['prop 2'])
-        self.assertDictEqual(obj23.to_struct(), struct23)
+        self.assertDictEqual(obj23.to_dict(), struct23)
         
         with self.assertRaises(TypeError):
-            TestModel1.from_struct({'prop_0': 'ZZZ', 'prop 2': None})
+            TestModel1.from_dict({'prop_0': 'ZZZ', 'prop 2': None})
 
         with self.assertRaises(TypeError):
-            TestModel1.from_struct({'prop_0': '', 'prop 2': 22.22})
+            TestModel1.from_dict({'prop_0': '', 'prop 2': 22.22})
 
-    def test_handle_from_to_struct_for_class(self):
+    def test_handle_from_to_dict_for_class(self):
         val3 = TestModel1(prop_0='value 0')
 
-        struct31 = {'prop_0': '', '@@': val3.to_struct()} #{'prop_0': '', '@@': TestModel1(prop_0='value 0')} is also valid for from_struct, but this cannot happen when parsing for real
-        obj31 = TestModel1.from_struct(struct31)
+        struct31 = {'prop_0': '', '@@': val3.to_dict()} #{'prop_0': '', '@@': TestModel1(prop_0='value 0')} is also valid for from_dict, but this cannot happen when parsing for real
+        obj31 = TestModel1.from_dict(struct31)
         self.assertEqual(obj31.prop_3, val3)
-        self.assertDictEqual(obj31.to_struct(), struct31)
+        self.assertDictEqual(obj31.to_dict(), struct31)
 
         with self.assertRaises(TypeError):
-            TestModel1.from_struct({'prop_0': '', '@@': 'value 3'})
+            TestModel1.from_dict({'prop_0': '', '@@': 'value 3'})
 
-    def test_handle_from_to_struct_for_dict_class(self):
+    def test_handle_from_to_dict_for_dict_class(self):
         val4 = TestModel1(prop_0='value 0')
 
-        struct41 = {'prop_0': '', 'prop_4': {'val 4': val4.to_struct()}}
-        obj41 = TestModel1.from_struct(struct41)
+        struct41 = {'prop_0': '', 'prop_4': {'val 4': val4.to_dict()}}
+        obj41 = TestModel1.from_dict(struct41)
         self.assertEqual(obj41.prop_4['val 4'], val4)
-        self.assertDictEqual(obj41.to_struct(), struct41)
+        self.assertDictEqual(obj41.to_dict(), struct41)
 
 
         with self.assertRaises(TypeError):
-            TestModel1.from_struct({'prop_0': '', 'prop_4': {44: val4.to_struct()}})
+            TestModel1.from_dict({'prop_0': '', 'prop_4': {44: val4.to_dict()}})
 
 
-    def test_handle_from_to_struct_for_union_dict_class(self):
+    def test_handle_from_to_dict_for_union_dict_class(self):
         val5 = TestModel1(prop_0='value 0')
 
-        struct51 = {'prop_0': '', 'prop_5': val5.to_struct()}
-        obj51 = TestModel1.from_struct(struct51)
+        struct51 = {'prop_0': '', 'prop_5': val5.to_dict()}
+        obj51 = TestModel1.from_dict(struct51)
         self.assertEqual(obj51.prop_5, val5)
-        self.assertDictEqual(obj51.to_struct(), struct51)
+        self.assertDictEqual(obj51.to_dict(), struct51)
 
-        struct52 = {'prop_0': '', 'prop_5': [val5.to_struct()]}
-        obj52 = TestModel1.from_struct(struct52)
+        struct52 = {'prop_0': '', 'prop_5': [val5.to_dict()]}
+        obj52 = TestModel1.from_dict(struct52)
         self.assertListEqual(obj52.prop_5, [val5])
-        self.assertDictEqual(obj52.to_struct(), struct52)
+        self.assertDictEqual(obj52.to_dict(), struct52)
 
         with self.assertRaises(TypeError):
-            TestModel1.from_struct({'prop_0': '', 'prop_5': {44: val5.to_struct()}})
+            TestModel1.from_dict({'prop_0': '', 'prop_5': {44: val5.to_dict()}})
 
         with self.assertRaises(TypeError):
-            TestModel1.from_struct({'prop_0': '', 'prop_5': [val5.to_struct(), None]})
+            TestModel1.from_dict({'prop_0': '', 'prop_5': [val5.to_dict(), None]})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a purely renaming PR.
`to_dict` is more common method name and these methods are already consuming/producing dicts anyway.

P.S. I'm not renaming some other stand-alone functions in that file since they're used with non-dict structures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1290)
<!-- Reviewable:end -->
