### PR TITLE
Remove cops and rops pipeline attributes

### DIFF
--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -110,8 +110,6 @@ class Pipeline():
     """
     self.name = name
     self.ops = {}
-    self.cops = {}
-    self.rops = {}
     # Add the root group.
     self.groups = [_ops_group.OpsGroup('pipeline', name=name)]
     self.group_id = 0
@@ -148,10 +146,6 @@ class Pipeline():
     op_name = _make_name_unique_by_adding_index(op.human_name, list(self.ops.keys()), ' ')
 
     self.ops[op_name] = op
-    if isinstance(op, _container_op.ContainerOp):
-      self.cops[op_name] = op
-    elif isinstance(op, _resource_op.ResourceOp):
-      self.rops[op_name] = op
     if not define_only:
       self.groups[-1].ops.append(op)
 


### PR DESCRIPTION
* Remove the separated dictionaries for ContainerOps and ResourceOps
* Fix the sanitization performed by the compiler to iterate through ops
  dict and do type-check for the special fields file_outputs and
  attribute_outputs

~I found a bug which has to do with `PipelineParam` hashing.
`__hash__` method of `PipelineParam` now uses `pattern` attribute too.
If a `PipelineParam` was found twice in an Op, e.g. in `arguments` and in `volumes`, having different patterns messed the `inputs` attribute (which uses `set()` on the extracted `PipelineParam`s).~
I will open a separate PR for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1298)
<!-- Reviewable:end -->
