### PR TITLE
Add -p to mkdir in quickstart

### DIFF
--- a/samples/notebooks/quickstart.ipynb
+++ b/samples/notebooks/quickstart.ipynb
@@ -52,7 +52,7 @@
    "source": [
     "# Install Pipeline SDK\n",
     "!pip3 install $KFP_PACKAGE --upgrade\n",
-    "!mkdir tmp/pipelines"
+    "!mkdir -p tmp/pipelines"
    ]
   },
   {


### PR DESCRIPTION
without this, the command `mkdir tmp/pipelines` fails and so does a later python cell that tries to use that directory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1299)
<!-- Reviewable:end -->
