### PR TITLE
Fix PipelineParam pattern bug

### DIFF
--- a/sdk/python/kfp/dsl/_pipeline_param.py
+++ b/sdk/python/kfp/dsl/_pipeline_param.py
@@ -172,7 +172,7 @@ class PipelineParam(object):
     self.op_name = op_name if op_name else None
     self.value = value if value else None
     self.param_type = param_type
-    self.pattern = pattern
+    self.pattern = pattern or str(self)
 
   @property
   def full_name(self):

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -379,6 +379,10 @@ class TestCompiler(unittest.TestCase):
     """Test pipeline volumeop_sequential."""
     self._test_py_compile_yaml('volumeop_sequential')
 
+  def test_py_param_substitutions(self):
+    """Test pipeline param_substitutions."""
+    self._test_py_compile_yaml('param_substitutions')
+
   def test_type_checking_with_consistent_types(self):
     """Test type check pipeline parameters against component metadata."""
     @component

--- a/sdk/python/tests/compiler/testdata/param_substitutions.py
+++ b/sdk/python/tests/compiler/testdata/param_substitutions.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import kfp.dsl as dsl
+
+
+@dsl.pipeline(
+    name="Param Substitutions",
+    description="Test the same PipelineParam getting substituted in multiple "
+                "places"
+)
+def param_substitutions():
+    vop = dsl.VolumeOp(
+        name="create_volume",
+        resource_name="data",
+        size="1Gi"
+    )
+
+    op = dsl.ContainerOp(
+        name="cop",
+        image="image",
+        arguments=["--param", vop.output],
+        pvolumes={"/mnt": vop.volume}
+    )
+
+
+if __name__ == '__main__':
+    import kfp.compiler as compiler
+    compiler.Compiler().compile(param_substitutions, __file__ + '.tar.gz')

--- a/sdk/python/tests/compiler/testdata/param_substitutions.yaml
+++ b/sdk/python/tests/compiler/testdata/param_substitutions.yaml
@@ -1,0 +1,86 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: param-substitutions-
+spec:
+  arguments:
+    parameters: []
+  entrypoint: param-substitutions
+  serviceAccountName: pipeline-runner
+  templates:
+  - container:
+      args:
+      - --param
+      - '{{inputs.parameters.create-volume-name}}'
+      image: image
+      volumeMounts:
+      - mountPath: /mnt
+        name: create-volume
+    inputs:
+      parameters:
+      - name: create-volume-name
+    name: cop
+    outputs:
+      artifacts:
+      - name: mlpipeline-ui-metadata
+        optional: true
+        path: /mlpipeline-ui-metadata.json
+        s3:
+          accessKeySecret:
+            key: accesskey
+            name: mlpipeline-minio-artifact
+          bucket: mlpipeline
+          endpoint: minio-service.kubeflow:9000
+          insecure: true
+          key: runs/{{workflow.uid}}/{{pod.name}}/mlpipeline-ui-metadata.tgz
+          secretKeySecret:
+            key: secretkey
+            name: mlpipeline-minio-artifact
+      - name: mlpipeline-metrics
+        optional: true
+        path: /mlpipeline-metrics.json
+        s3:
+          accessKeySecret:
+            key: accesskey
+            name: mlpipeline-minio-artifact
+          bucket: mlpipeline
+          endpoint: minio-service.kubeflow:9000
+          insecure: true
+          key: runs/{{workflow.uid}}/{{pod.name}}/mlpipeline-metrics.tgz
+          secretKeySecret:
+            key: secretkey
+            name: mlpipeline-minio-artifact
+  - name: create-volume
+    outputs:
+      parameters:
+      - name: create-volume-manifest
+        valueFrom:
+          jsonPath: '{}'
+      - name: create-volume-name
+        valueFrom:
+          jsonPath: '{.metadata.name}'
+      - name: create-volume-size
+        valueFrom:
+          jsonPath: '{.status.capacity.storage}'
+    resource:
+      action: create
+      manifest: "apiVersion: v1\nkind: PersistentVolumeClaim\nmetadata:\n  name: '{{workflow.name}}-data'\n\
+        spec:\n  accessModes:\n  - ReadWriteMany\n  resources:\n    requests:\n  \
+        \    storage: 1Gi\n"
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: create-volume-name
+            value: '{{tasks.create-volume.outputs.parameters.create-volume-name}}'
+        dependencies:
+        - create-volume
+        name: cop
+        template: cop
+      - name: create-volume
+        template: create-volume
+    name: param-substitutions
+  volumes:
+  - name: create-volume
+    persistentVolumeClaim:
+      claimName: '{{inputs.parameters.create-volume-name}}'


### PR DESCRIPTION
If a `PipelineParam` was found twice in an Op, e.g. in `arguments` and in `volumes`, having different patterns (`None` vs anything) messed the `inputs` attribute (which uses `set()` on the extracted `PipelineParam`s).
The different `pattern`s may occur since `arguments` (as well as `command`) gets the `str()` representation of the `PipelineParam` **before** it gets sanitized.

I chose to generate a `pattern` in the constructor, if one is not provided.
Otherwise, we could use the `pattern` attribute in `__hash__` method, but it messes tests because it generally leads to duplicate entries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1300)
<!-- Reviewable:end -->
