### PR TITLE
Testing - Clean up the Argo controller that was used to build images

### DIFF
--- a/test/install-argo.sh
+++ b/test/install-argo.sh
@@ -16,6 +16,7 @@
 
 set -ex
 
+# Tests work without these lines. TODO: Verify and remove these lines
 kubectl config set-context $(kubectl config current-context) --namespace=default
 echo "Add necessary cluster role bindings"
 ACCOUNT=$(gcloud info --format='value(config.account)')
@@ -28,8 +29,8 @@ mkdir -p ~/bin/
 export PATH=~/bin/:$PATH
 curl -sSL -o ~/bin/argo https://github.com/argoproj/argo/releases/download/$ARGO_VERSION/argo-linux-amd64
 chmod +x ~/bin/argo
-kubectl create ns argo
-kubectl apply -n argo -f https://raw.githubusercontent.com/argoproj/argo/$ARGO_VERSION/manifests/install.yaml
+#kubectl create ns argo
+#kubectl apply -n argo -f https://raw.githubusercontent.com/argoproj/argo/$ARGO_VERSION/manifests/install.yaml
 
 # Some workflows are deployed to the non-default namespace where the GCP credential secret is stored
 # In this case, the default service account in that namespace doesn't have enough permission

--- a/test/postsubmit-tests-with-pipeline-deployment.sh
+++ b/test/postsubmit-tests-with-pipeline-deployment.sh
@@ -70,10 +70,6 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 echo "postsubmit test starts"
 
 source "${DIR}/test-prep.sh"
-source "${DIR}/deploy-kubeflow.sh"
-
-# Install Argo
-source "${DIR}/install-argo.sh"
 
 ## Wait for the cloudbuild job to be started
 CLOUDBUILD_TIMEOUT_SECONDS=3600
@@ -117,6 +113,9 @@ elif [[ ${CLOUDBUILD_FINISHED} == TIMEOUT ]];then
   echo "Wait for cloudbuild job to finish, timeout exiting..."
   exit 1
 fi
+
+# Deploy Kubeflow
+source "${DIR}/deploy-kubeflow.sh"
 
 # Deploy the pipeline
 source ${DIR}/deploy-pipeline.sh --gcr_image_base_dir ${GCR_IMAGE_BASE_DIR} --gcr_image_tag ${PULL_BASE_SHA}

--- a/test/presubmit-tests-with-pipeline-deployment.sh
+++ b/test/presubmit-tests-with-pipeline-deployment.sh
@@ -70,20 +70,8 @@ source "${DIR}/test-prep.sh"
 # Deploy Kubeflow
 source "${DIR}/deploy-kubeflow.sh"
 
-# Install Argo CLI
-ARGO_VERSION=v2.2.0
-mkdir -p ~/bin/
-export PATH=~/bin/:$PATH
-curl -sSL -o ~/bin/argo https://github.com/argoproj/argo/releases/download/$ARGO_VERSION/argo-linux-amd64
-chmod +x ~/bin/argo
-
-# Add serviceaccount for test workflows
-# Some workflows are deployed to the non-default namespace where the GCP credential secret is stored
-# In this case, the default service account in that namespace doesn't have enough permission
-echo "add service account for running the test workflow"
-kubectl create serviceaccount test-runner -n ${NAMESPACE}
-kubectl create clusterrolebinding test-admin-binding --clusterrole=cluster-admin --serviceaccount=${NAMESPACE}:test-runner
-
+# Install Argo CLI and test-runner service account
+source "${DIR}/install-argo.sh"
 
 # Build Images
 echo "submitting argo workflow to build docker images for commit ${PULL_PULL_SHA}..."

--- a/test/presubmit-tests-with-pipeline-deployment.sh
+++ b/test/presubmit-tests-with-pipeline-deployment.sh
@@ -70,14 +70,14 @@ source "${DIR}/test-prep.sh"
 # Deploy Kubeflow
 source "${DIR}/deploy-kubeflow.sh"
 
-# Install Argo
-#source "${DIR}/install-argo.sh"
+# Install Argo CLI
 ARGO_VERSION=v2.2.0
 mkdir -p ~/bin/
 export PATH=~/bin/:$PATH
 curl -sSL -o ~/bin/argo https://github.com/argoproj/argo/releases/download/$ARGO_VERSION/argo-linux-amd64
 chmod +x ~/bin/argo
 
+# Add serviceaccount for test workflows
 # Some workflows are deployed to the non-default namespace where the GCP credential secret is stored
 # In this case, the default service account in that namespace doesn't have enough permission
 echo "add service account for running the test workflow"
@@ -100,9 +100,6 @@ ARGO_WORKFLOW=`argo submit ${DIR}/build_image.yaml \
 echo "build docker images workflow submitted successfully"
 source "${DIR}/check-argo-status.sh"
 echo "build docker images workflow completed"
-
-# Delete Argo that we used to build images
-#kubectl delete -n argo -f https://raw.githubusercontent.com/argoproj/argo/$ARGO_VERSION/manifests/install.yaml
 
 # Deploy the pipeline
 source ${DIR}/deploy-pipeline.sh --gcr_image_base_dir ${GCR_IMAGE_BASE_DIR}

--- a/test/presubmit-tests-with-pipeline-deployment.sh
+++ b/test/presubmit-tests-with-pipeline-deployment.sh
@@ -67,8 +67,16 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 echo "presubmit test starts"
 source "${DIR}/test-prep.sh"
 
+# Deploy Kubeflow
+source "${DIR}/deploy-kubeflow.sh"
+
 # Install Argo
-source "${DIR}/install-argo.sh"
+#source "${DIR}/install-argo.sh"
+ARGO_VERSION=v2.2.0
+mkdir -p ~/bin/
+export PATH=~/bin/:$PATH
+curl -sSL -o ~/bin/argo https://github.com/argoproj/argo/releases/download/$ARGO_VERSION/argo-linux-amd64
+chmod +x ~/bin/argo
 
 # Build Images
 echo "submitting argo workflow to build docker images for commit ${PULL_PULL_SHA}..."
@@ -87,10 +95,7 @@ source "${DIR}/check-argo-status.sh"
 echo "build docker images workflow completed"
 
 # Delete Argo that we used to build images
-kubectl delete -n argo -f https://raw.githubusercontent.com/argoproj/argo/$ARGO_VERSION/manifests/install.yaml
-
-# Deploy Kubeflow
-source "${DIR}/deploy-kubeflow.sh"
+#kubectl delete -n argo -f https://raw.githubusercontent.com/argoproj/argo/$ARGO_VERSION/manifests/install.yaml
 
 # Deploy the pipeline
 source ${DIR}/deploy-pipeline.sh --gcr_image_base_dir ${GCR_IMAGE_BASE_DIR}

--- a/test/presubmit-tests-with-pipeline-deployment.sh
+++ b/test/presubmit-tests-with-pipeline-deployment.sh
@@ -66,7 +66,6 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 
 echo "presubmit test starts"
 source "${DIR}/test-prep.sh"
-source "${DIR}/deploy-kubeflow.sh"
 
 # Install Argo
 source "${DIR}/install-argo.sh"
@@ -86,6 +85,12 @@ ARGO_WORKFLOW=`argo submit ${DIR}/build_image.yaml \
 echo "build docker images workflow submitted successfully"
 source "${DIR}/check-argo-status.sh"
 echo "build docker images workflow completed"
+
+# Delete Argo that we used to build images
+kubectl delete -n argo -f https://raw.githubusercontent.com/argoproj/argo/$ARGO_VERSION/manifests/install.yaml
+
+# Deploy Kubeflow
+source "${DIR}/deploy-kubeflow.sh"
 
 # Deploy the pipeline
 source ${DIR}/deploy-pipeline.sh --gcr_image_base_dir ${GCR_IMAGE_BASE_DIR}

--- a/test/presubmit-tests-with-pipeline-deployment.sh
+++ b/test/presubmit-tests-with-pipeline-deployment.sh
@@ -78,6 +78,13 @@ export PATH=~/bin/:$PATH
 curl -sSL -o ~/bin/argo https://github.com/argoproj/argo/releases/download/$ARGO_VERSION/argo-linux-amd64
 chmod +x ~/bin/argo
 
+# Some workflows are deployed to the non-default namespace where the GCP credential secret is stored
+# In this case, the default service account in that namespace doesn't have enough permission
+echo "add service account for running the test workflow"
+kubectl create serviceaccount test-runner -n ${NAMESPACE}
+kubectl create clusterrolebinding test-admin-binding --clusterrole=cluster-admin --serviceaccount=${NAMESPACE}:test-runner
+
+
 # Build Images
 echo "submitting argo workflow to build docker images for commit ${PULL_PULL_SHA}..."
 ARGO_WORKFLOW=`argo submit ${DIR}/build_image.yaml \


### PR DESCRIPTION
Currently we have two Argo installation in out test clusters with two controllers. The controllers have different configurations and are conflicting.
This PR cleans up one of the Argo installations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1311)
<!-- Reviewable:end -->
