### PR TITLE
Fix typo in ContainerOp contructor's help string

### DIFF
--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -895,7 +895,7 @@ class ContainerOp(BaseOp):
           is_exit_handler: Whether it is used as an exit handler.
           pvolumes: Dictionary for the user to match a path on the op's fs with a
               V1Volume or it inherited type.
-              E.g {"/my/path": vol, "/mnt": other_op.volumes["/output"]}.
+              E.g {"/my/path": vol, "/mnt": other_op.pvolumes["/output"]}.
         """
 
         super().__init__(name=name, sidecars=sidecars, is_exit_handler=is_exit_handler)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1314)
<!-- Reviewable:end -->
