### PR TITLE
SDK - Made description and name parameters optional in the @pipeline decorator

### DIFF
--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -25,7 +25,7 @@ import sys
 _pipeline_decorator_handler = None
 
 
-def pipeline(name, description):
+def pipeline(name : str = None, description : str = None):
   """Decorator of pipeline functions.
 
   Usage:
@@ -39,8 +39,10 @@ def pipeline(name, description):
   ```
   """
   def _pipeline(func):
-    func._pipeline_name = name
-    func._pipeline_description = description
+    if name:
+      func._pipeline_name = name
+    if description:
+      func._pipeline_description = description
 
     if _pipeline_decorator_handler:
       return _pipeline_decorator_handler(func) or func


### PR DESCRIPTION
The explicit pipeline name and description are not really necessary since the name can be taken from the pipeline function name and the description - from the docstring.

The PR reduces the amount of boilerplate the pipeline creator needs to write to make a valid pipeline (that the command-line tools will recognize).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1335)
<!-- Reviewable:end -->
