### PR TITLE
Extend e2e-tests: Add resources tests

### DIFF
--- a/samples/resourceops/volumeop_sequential.py
+++ b/samples/resourceops/volumeop_sequential.py
@@ -25,7 +25,7 @@ def volumeop_sequential():
         name="mypvc",
         resource_name="newpvc",
         size="10Gi",
-        modes=dsl.VOLUME_MODE_RWM
+        modes=dsl.VOLUME_MODE_RWO
     )
 
     step1 = dsl.ContainerOp(

--- a/test/deploy-kubeflow.sh
+++ b/test/deploy-kubeflow.sh
@@ -56,4 +56,11 @@ ${KUBEFLOW_SRC}/scripts/kfctl.sh apply platform
 ${KUBEFLOW_SRC}/scripts/kfctl.sh generate k8s
 ${KUBEFLOW_SRC}/scripts/kfctl.sh apply k8s
 
+pushd ks_app
+ks param set argo workflowControllerImage argoproj/workflow-controller:v2.3.0-rc3
+ks param set argo executorImage argoproj/argoexec:v2.3.0-rc3
+ks param set argo uiImage argoproj/argoui:v2.3.0-rc3
+ks apply default -c argo
+popd
+
 gcloud container clusters get-credentials ${TEST_CLUSTER}

--- a/test/deploy-kubeflow.sh
+++ b/test/deploy-kubeflow.sh
@@ -56,11 +56,4 @@ ${KUBEFLOW_SRC}/scripts/kfctl.sh apply platform
 ${KUBEFLOW_SRC}/scripts/kfctl.sh generate k8s
 ${KUBEFLOW_SRC}/scripts/kfctl.sh apply k8s
 
-pushd ks_app
-ks param set argo workflowControllerImage argoproj/workflow-controller:v2.3.0-rc3
-ks param set argo executorImage argoproj/argoexec:v2.3.0-rc3
-ks param set argo uiImage argoproj/argoui:v2.3.0-rc3
-ks apply default -c argo
-popd
-
 gcloud container clusters get-credentials ${TEST_CLUSTER}

--- a/test/e2e_test_gke_v2.yaml
+++ b/test/e2e_test_gke_v2.yaml
@@ -188,6 +188,18 @@ spec:
               value: "{{inputs.parameters.namespace}}"
             - name: test-name
               value: "recursion"
+      - name: run-resources-tests
+        template: run-basic-e2e-tests
+        arguments:
+          parameters:
+            - name: test-results-gcs-dir
+              value: "{{inputs.parameters.test-results-gcs-dir}}"
+            - name: sample-tests-image
+              value: "{{inputs.parameters.target-image-prefix}}{{inputs.parameters.basic-e2e-tests-image-suffix}}"
+            - name: namespace
+              value: "{{inputs.parameters.namespace}}"
+            - name: test-name
+              value: "resources"
 
   # Build and push image
   - name: build-image

--- a/test/install-argo.sh
+++ b/test/install-argo.sh
@@ -24,7 +24,7 @@ kubectl create clusterrolebinding PROW_BINDING --clusterrole=cluster-admin --use
 kubectl create clusterrolebinding DEFAULT_BINDING --clusterrole=cluster-admin --serviceaccount=default:default
 
 echo "install argo"
-ARGO_VERSION=v2.3.0-rc3
+ARGO_VERSION=v2.3.0
 mkdir -p ~/bin/
 export PATH=~/bin/:$PATH
 curl -sSL -o ~/bin/argo https://github.com/argoproj/argo/releases/download/$ARGO_VERSION/argo-linux-amd64

--- a/test/install-argo.sh
+++ b/test/install-argo.sh
@@ -24,7 +24,7 @@ kubectl create clusterrolebinding PROW_BINDING --clusterrole=cluster-admin --use
 kubectl create clusterrolebinding DEFAULT_BINDING --clusterrole=cluster-admin --serviceaccount=default:default
 
 echo "install argo"
-ARGO_VERSION=v2.2.0
+ARGO_VERSION=v2.3.0-rc3
 mkdir -p ~/bin/
 export PATH=~/bin/:$PATH
 curl -sSL -o ~/bin/argo https://github.com/argoproj/argo/releases/download/$ARGO_VERSION/argo-linux-amd64

--- a/test/sample-test/run_basic_test.py
+++ b/test/sample-test/run_basic_test.py
@@ -18,6 +18,7 @@ import os
 from datetime import datetime
 from kfp import Client
 import utils
+import json
 
 ###### Input/Output Instruction ######
 # input: yaml
@@ -49,6 +50,10 @@ def parse_arguments():
                       type=str,
                       default='kubeflow',
                       help="namespace of the deployed pipeline system. Default: kubeflow")
+  parser.add_argument('--params',
+                      type=str,
+                      default='{}',
+                      help="Parameters to pass to the pipeline (as JSON string). Default: {}")
   args = parser.parse_args()
   return args
 
@@ -76,7 +81,7 @@ def main():
 
   ###### Create Job ######
   job_name = args.testname +'_sample'
-  params = {}
+  params = json.loads(args.params)
   response = client.run_pipeline(experiment_id, job_name, args.input, params)
   run_id = response.id
   utils.add_junit_test(test_cases, 'create pipeline run', True)

--- a/test/sample-test/run_test.sh
+++ b/test/sample-test/run_test.sh
@@ -269,11 +269,11 @@ elif [ "$TEST_NAME" == "resources" ]; then
 #  SAMPLE_RESOURCEOP_TEST_OUTPUT=${RESULTS_GCS_DIR}
 #
 #  # Compile samples
-#  cd ${BASE_DIR}/samples/resourceops
+#  cd ${BASE_DIR}/samples/basic
 #  dsl-compile --py resourceop_basic.py --output resourceop_basic.tar.gz
 #
 #  cd "${TEST_DIR}"
-#  python3 run_basic_test.py --input ${BASE_DIR}/samples/resourceops/resourceop_basic.tar.gz --result $SAMPLE_RESOURCEOP_TEST_RESULT --output $SAMPLE_RESOURCEOP_TEST_OUTPUT --testname resource --namespace ${NAMESPACE} --params '{"username": "test", "password": "test123"}'
+#  python3 run_basic_test.py --input ${BASE_DIR}/samples/basic/resourceop_basic.tar.gz --result $SAMPLE_RESOURCEOP_TEST_RESULT --output $SAMPLE_RESOURCEOP_TEST_OUTPUT --testname resource --namespace ${NAMESPACE} --params '{"username": "test", "password": "test123"}'
 #
 #  echo "Copy the test results to GCS ${RESULTS_GCS_DIR}/"
 #  gsutil cp ${SAMPLE_RESOURCEOP_TEST_RESULT} ${RESULTS_GCS_DIR}/${SAMPLE_RESOURCEOP_TEST_RESULT}
@@ -283,11 +283,11 @@ elif [ "$TEST_NAME" == "resources" ]; then
   SAMPLE_VOLUMEOP_TEST_OUTPUT=${RESULTS_GCS_DIR}
 
   # Compile samples
-  cd ${BASE_DIR}/samples/resourceops
+  cd ${BASE_DIR}/samples/volumes
   dsl-compile --py volumeop_sequential.py --output volumeop_sequential.tar.gz
 
   cd "${TEST_DIR}"
-  python3 run_basic_test.py --input ${BASE_DIR}/samples/resourceops/volumeop_sequential.tar.gz --result $SAMPLE_VOLUMEOP_TEST_RESULT --output $SAMPLE_VOLUMEOP_TEST_OUTPUT --testname resource --namespace ${NAMESPACE}
+  python3 run_basic_test.py --input ${BASE_DIR}/samples/volumes/volumeop_sequential.tar.gz --result $SAMPLE_VOLUMEOP_TEST_RESULT --output $SAMPLE_VOLUMEOP_TEST_OUTPUT --testname resource --namespace ${NAMESPACE}
 
   echo "Copy the test results to GCS ${RESULTS_GCS_DIR}/"
   gsutil cp ${SAMPLE_VOLUMEOP_TEST_RESULT} ${RESULTS_GCS_DIR}/${SAMPLE_VOLUMEOP_TEST_RESULT}

--- a/test/sample-test/run_test.sh
+++ b/test/sample-test/run_test.sh
@@ -264,19 +264,19 @@ elif [ "$TEST_NAME" == "recursion" ]; then
   echo "Copy the test results to GCS ${RESULTS_GCS_DIR}/"
   gsutil cp ${SAMPLE_RECURSION_TEST_RESULT} ${RESULTS_GCS_DIR}/${SAMPLE_RECURSION_TEST_RESULT}
 elif [ "$TEST_NAME" == "resources" ]; then
-  # ResourceOp
-  SAMPLE_RESOURCEOP_TEST_RESULT=junit_SampleResourceOpOutput.xml
-  SAMPLE_RESOURCEOP_TEST_OUTPUT=${RESULTS_GCS_DIR}
-
-  # Compile samples
-  cd ${BASE_DIR}/samples/resourceops
-  dsl-compile --py resourceop_basic.py --output resourceop_basic.tar.gz
-
-  cd "${TEST_DIR}"
-  python3 run_basic_test.py --input ${BASE_DIR}/samples/resourceops/resourceop_basic.tar.gz --result $SAMPLE_RESOURCEOP_TEST_RESULT --output $SAMPLE_RESOURCEOP_TEST_OUTPUT --testname resource --namespace ${NAMESPACE} --params '{"username": "test", "password": "test123"}'
-
-  echo "Copy the test results to GCS ${RESULTS_GCS_DIR}/"
-  gsutil cp ${SAMPLE_RESOURCEOP_TEST_RESULT} ${RESULTS_GCS_DIR}/${SAMPLE_RESOURCEOP_TEST_RESULT}
+#  # ResourceOp
+#  SAMPLE_RESOURCEOP_TEST_RESULT=junit_SampleResourceOpOutput.xml
+#  SAMPLE_RESOURCEOP_TEST_OUTPUT=${RESULTS_GCS_DIR}
+#
+#  # Compile samples
+#  cd ${BASE_DIR}/samples/resourceops
+#  dsl-compile --py resourceop_basic.py --output resourceop_basic.tar.gz
+#
+#  cd "${TEST_DIR}"
+#  python3 run_basic_test.py --input ${BASE_DIR}/samples/resourceops/resourceop_basic.tar.gz --result $SAMPLE_RESOURCEOP_TEST_RESULT --output $SAMPLE_RESOURCEOP_TEST_OUTPUT --testname resource --namespace ${NAMESPACE} --params '{"username": "test", "password": "test123"}'
+#
+#  echo "Copy the test results to GCS ${RESULTS_GCS_DIR}/"
+#  gsutil cp ${SAMPLE_RESOURCEOP_TEST_RESULT} ${RESULTS_GCS_DIR}/${SAMPLE_RESOURCEOP_TEST_RESULT}
 
   # VolumeOpSequential
   SAMPLE_VOLUMEOP_TEST_RESULT=junit_SampleVolumeOpOutput.xml

--- a/test/sample-test/run_test.sh
+++ b/test/sample-test/run_test.sh
@@ -263,6 +263,34 @@ elif [ "$TEST_NAME" == "recursion" ]; then
 
   echo "Copy the test results to GCS ${RESULTS_GCS_DIR}/"
   gsutil cp ${SAMPLE_RECURSION_TEST_RESULT} ${RESULTS_GCS_DIR}/${SAMPLE_RECURSION_TEST_RESULT}
+elif [ "$TEST_NAME" == "resources" ]; then
+  # ResourceOp
+  SAMPLE_RESOURCEOP_TEST_RESULT=junit_SampleResourceOpOutput.xml
+  SAMPLE_RESOURCEOP_TEST_OUTPUT=${RESULTS_GCS_DIR}
+
+  # Compile samples
+  cd ${BASE_DIR}/samples/resourceops
+  dsl-compile --py resourceop_basic.py --output resourceop_basic.tar.gz
+
+  cd "${TEST_DIR}"
+  python3 run_basic_test.py --input ${BASE_DIR}/samples/resourceops/resourceop_basic.tar.gz --result $SAMPLE_RESOURCEOP_TEST_RESULT --output $SAMPLE_RESOURCEOP_TEST_OUTPUT --testname resource --namespace ${NAMESPACE} --params '{"username": "test", "password": "test123"}'
+
+  echo "Copy the test results to GCS ${RESULTS_GCS_DIR}/"
+  gsutil cp ${SAMPLE_RESOURCEOP_TEST_RESULT} ${RESULTS_GCS_DIR}/${SAMPLE_RESOURCEOP_TEST_RESULT}
+
+  # VolumeOpSequential
+  SAMPLE_VOLUMEOP_TEST_RESULT=junit_SampleVolumeOpOutput.xml
+  SAMPLE_VOLUMEOP_TEST_OUTPUT=${RESULTS_GCS_DIR}
+
+  # Compile samples
+  cd ${BASE_DIR}/samples/resourceops
+  dsl-compile --py volumeop_sequential.py --output volumeop_sequential.tar.gz
+
+  cd "${TEST_DIR}"
+  python3 run_basic_test.py --input ${BASE_DIR}/samples/resourceops/volumeop_sequential.tar.gz --result $SAMPLE_VOLUMEOP_TEST_RESULT --output $SAMPLE_VOLUMEOP_TEST_OUTPUT --testname resource --namespace ${NAMESPACE}
+
+  echo "Copy the test results to GCS ${RESULTS_GCS_DIR}/"
+  gsutil cp ${SAMPLE_VOLUMEOP_TEST_RESULT} ${RESULTS_GCS_DIR}/${SAMPLE_VOLUMEOP_TEST_RESULT}
 elif [ "$TEST_NAME" == "xgboost" ]; then
   SAMPLE_XGBOOST_TEST_RESULT=junit_SampleXGBoostOutput.xml
   SAMPLE_XGBOOST_TEST_OUTPUT=${RESULTS_GCS_DIR}


### PR DESCRIPTION
I think we should start moving to v2.3 already by using the latest pre-release (v2.3.0-rc3). It comes with a lot of features and bug fixes.

This way:
* Users will be able to fully exploit #926 and volume usage in general. See for example the open issue #1303, and how #1327 was fulfilled once the images were updated. People seem to be looking forward to use it. Also,
* we can develop artifacts even further using Alexey's addition (https://github.com/argoproj/argo/pull/1300),
* we can introduce more parameters (e.g. again Alexey's https://github.com/argoproj/argo/pull/1336), which is something you have already expressed you could make use of, as I recall.

I'm sure there are more stuff we can take advantage of. But also, we can start deprecating stuff such as the global `volumes` attribute, to use template-local volumes instead.

I have been using this release extensively and it seems to be working fine.

I'm making this PR to run the E2E tests. I set the deployment scripts accordingly to deploy Argo v2.3.0-rc3.
Then, if all tests are successful, I suggest to update the kubeflow repo's argo deployment, since 0.1.20 release totally covers #1250.

WDYT?

/cc @Ark-kun @vicaire @hongye-sun

If everything works this PR closes #1250.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1342)
<!-- Reviewable:end -->
