### PR TITLE
SDK/Compiler: Fix Ops after() method to handle multiple arguments

### DIFF
--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -733,9 +733,10 @@ class BaseOp(object):
         """
         return mod_func(self)
 
-    def after(self, op):
-        """Specify explicit dependency on another op."""
-        self.dependent_names.append(op.name)
+    def after(self, *ops):
+        """Specify explicit dependency on other ops."""
+        for op in ops:
+            self.dependent_names.append(op.name)
         return self
 
     def add_volume(self, volume):


### PR DESCRIPTION
Instead of doing
```
op = dsl.ContainerOp(...).after(step1).after(step2)....
```
make the following possible
```
op = dsl.ContainerOp(...).after(step1, step2, ...)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1346)
<!-- Reviewable:end -->
