### PR TITLE
SDK - Capturing function dependencies when creating lightweight components

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -69,15 +69,15 @@ def _capture_function_code_using_source_copy(func) -> str:
 
 
 def _capture_function_code_using_cloudpickle(func) -> str:
+    import sys
     import cloudpickle
     import pickle
     # Hack to force cloudpickle to capture the whole function instead of just referencing the code file. See https://github.com/cloudpipe/cloudpickle/blob/74d69d759185edaeeac7bdcb7015cfc0c652f204/cloudpickle/cloudpickle.py#L490
     try: # Try is needed to restore the state if something goes wrong
-        old_module = func.__module__
-        func.__module__ = '__main__'
+        old_module = sys.modules.pop(func.__module__)
         func_pickle = cloudpickle.dumps(func, pickle.DEFAULT_PROTOCOL)
     finally:
-        func.__module__ = old_module
+        sys.modules[func.__module__] = old_module
     func_code = '{func_name} = pickle.loads({func_pickle})'.format(func_name=func.__name__, func_pickle=repr(func_pickle))
     return 'import pickle' + '\n\n' + func_code
 

--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -127,14 +127,7 @@ def _func_to_component_spec(func, extra_code='', base_image=_default_base_image)
 
     func_name=func.__name__
 
-    #TODO: Add support for copying the NamedTuple subclass declaration code
-    #Adding NamedTuple import if needed
-    func_type_declarations_code = ""
-
     if False:
-        if hasattr(return_ann, '_fields'): #NamedTuple
-            func_type_declarations_code = func_type_declarations_code + '\n' + 'from typing import NamedTuple'
-
         #Source code can include decorators line @python_op. Remove them
         (func_code_lines, _) = inspect.getsourcelines(func) 
         while func_code_lines[0].lstrip().startswith('@'): #decorator
@@ -145,6 +138,12 @@ def _func_to_component_spec(func, extra_code='', base_image=_default_base_image)
         first_line = func_code_lines[0]
         indent = len(first_line) - len(first_line.lstrip())
         func_code_lines = [line[indent:] for line in func_code_lines]
+
+        #TODO: Add support for copying the NamedTuple subclass declaration code
+        #Adding NamedTuple import if needed
+        if hasattr(return_ann, '_fields'): #NamedTuple
+            func_code_lines.insert(0, '')
+            func_code_lines.insert(0, 'from typing import NamedTuple')
 
         func_code = ''.join(func_code_lines) #Lines retain their \n endings
 
@@ -159,7 +158,7 @@ def _func_to_component_spec(func, extra_code='', base_image=_default_base_image)
         finally:
             func.__module__ = old_module
         func_code = '{func_name} = pickle.loads({func_pickle})'.format(func_name=func_name, func_pickle=repr(func_pickle))
-        func_type_declarations_code = 'import pickle'
+        func_code = 'import pickle' + '\n\n' + func_code
 
     extra_output_external_names = [name + '_file' for name in extra_output_names]
 
@@ -180,8 +179,6 @@ def _func_to_component_spec(func, extra_code='', base_image=_default_base_image)
     full_source = \
 '''\
 {extra_code}
-
-{func_type_declarations_code}
 
 {func_code}
 
@@ -206,7 +203,6 @@ for idx, filename in enumerate(_output_files):
 '''.format(
         func_name=func_name,
         func_code=func_code,
-        func_type_declarations_code=func_type_declarations_code,
         extra_code=extra_code,
         input_args_parsing_code='\n'.join(input_args_parsing_code_lines),
         output_files_parsing_code='\n'.join(output_files_parsing_code_lines),

--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -45,29 +45,6 @@ def _python_function_name_to_component_name(name):
     return re.sub(' +', ' ', name.replace('_', ' ')).strip(' ').capitalize()
 
 
-def _capture_function_code_using_source_copy(func) -> str:
-    import inspect
-
-    #Source code can include decorators line @python_op. Remove them
-    (func_code_lines, _) = inspect.getsourcelines(func) 
-    while func_code_lines[0].lstrip().startswith('@'): #decorator
-        del func_code_lines[0]
-
-    #Function might be defined in some indented scope (e.g. in another function).
-    #We need to handle this and properly dedent the function source code
-    first_line = func_code_lines[0]
-    indent = len(first_line) - len(first_line.lstrip())
-    func_code_lines = [line[indent:] for line in func_code_lines]
-
-    #TODO: Add support for copying the NamedTuple subclass declaration code
-    #Adding NamedTuple import if needed
-    if hasattr(inspect.signature(func).return_annotation, '_fields'): #NamedTuple
-        func_code_lines.insert(0, '\n')
-        func_code_lines.insert(0, 'from typing import NamedTuple\n')
-
-    return ''.join(func_code_lines) #Lines retain their \n endings
-
-
 def _capture_function_code_using_cloudpickle(func) -> str:
     import sys
     import cloudpickle
@@ -80,10 +57,6 @@ def _capture_function_code_using_cloudpickle(func) -> str:
         sys.modules[func.__module__] = old_module
     func_code = '{func_name} = pickle.loads({func_pickle})'.format(func_name=func.__name__, func_pickle=repr(func_pickle))
     return 'import pickle' + '\n\n' + func_code
-
-
-#_extract_function_code = _capture_function_code_using_source_copy
-_extract_function_code = _capture_function_code_using_cloudpickle
 
 
 def _func_to_component_spec(func, extra_code='', base_image=_default_base_image) -> ComponentSpec:
@@ -168,7 +141,7 @@ def _func_to_component_spec(func, extra_code='', base_image=_default_base_image)
 
     func_name=func.__name__
 
-    func_code = _extract_function_code(func)
+    func_code = _capture_function_code_using_cloudpickle(func)
 
     extra_output_external_names = [name + '_file' for name in extra_output_names]
 

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -29,6 +29,7 @@ REQUIRES = [
     'cryptography>=2.4.2',
     'google-auth>=1.6.1',
     'requests_toolbelt>=0.8.0',
+    'cloudpickle',
     'kfp-server-api >= 0.1.18, < 0.1.19', #Update the upper version whenever a new version of the kfp-server-api package is released. Update the lower version when there is a breaking change in kfp-server-api.
 ]
 

--- a/sdk/python/tests/components/test_python_op.py
+++ b/sdk/python/tests/components/test_python_op.py
@@ -34,6 +34,23 @@ def components_local_output_dir_context(output_dir: str):
     finally:
         comp._components._outputs_dir = old_dir
 
+
+module_level_variable = 10
+
+
+class ModuleLevelClass:
+    def class_method(self, x):
+        return x * module_level_variable
+
+
+def module_func(a: float) -> float:
+    return a * 5
+
+
+def module_func_with_deps(a: float, b: float) -> float:
+    return ModuleLevelClass().class_method(a) + module_func(b)
+
+
 class PythonOpTestCase(unittest.TestCase):
     def helper_test_2_in_1_out_component_using_local_call(self, func, op):
         arg1 = float(3)
@@ -109,6 +126,12 @@ class PythonOpTestCase(unittest.TestCase):
             return ExtraClass().class_method(a) + extra_func(b)
 
         func = main_func
+        op = comp.func_to_container_op(func, output_component_file='comp.yaml')
+
+        self.helper_test_2_in_1_out_component_using_local_call(func, op)
+
+    def test_func_to_container_op_call_other_func_global(self):
+        func = module_func_with_deps
         op = comp.func_to_container_op(func, output_component_file='comp.yaml')
 
         self.helper_test_2_in_1_out_component_using_local_call(func, op)

--- a/sdk/python/tests/components/test_python_op.py
+++ b/sdk/python/tests/components/test_python_op.py
@@ -95,6 +95,24 @@ class PythonOpTestCase(unittest.TestCase):
 
         self.helper_test_2_in_1_out_component_using_local_call(func, op)
 
+    def test_func_to_container_op_call_other_func(self):
+        extra_variable = 10
+
+        class ExtraClass:
+            def class_method(self, x):
+                return x * extra_variable
+
+        def extra_func(a: float) -> float:
+            return a * 5
+
+        def main_func(a: float, b: float) -> float:
+            return ExtraClass().class_method(a) + extra_func(b)
+
+        func = main_func
+        op = comp.func_to_container_op(func, output_component_file='comp.yaml')
+
+        self.helper_test_2_in_1_out_component_using_local_call(func, op)
+
     def test_func_to_container_op_multiple_named_typed_outputs(self):
         from typing import NamedTuple
         def add_multiply_two_numbers(a: float, b: float) -> NamedTuple('DummyName', [('sum', float), ('product', float)]):


### PR DESCRIPTION
Lightweight components convert a python function into a component usable as a pipeline step.

Previously, not every function could be converted - the function must be self-contained (not use imports, variables, functions and classes defined outside of the function).

This change removes those limitations.

Which dependencies are now captured alongside the function? All objects that are in the same python *module* as the function being converted to pipeline op.
* If the function is defined in a notebook, then all required functions and classes declared in that notebook can be captured.
* If the function is defined in a python file, then all required functions and classes declared in that file can be captured.
* If the function is defined in a python module, then all required functions and classes declared in that python module can be captured.

Everything outside of the function's module will be referenced and must exist in the base image or be installed dynamically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1372)
<!-- Reviewable:end -->
