### PR TITLE
Fix naming from sagamaker to sagemaker

### DIFF
--- a/components/aws/sagemaker/deploy/component.yaml
+++ b/components/aws/sagemaker/deploy/component.yaml
@@ -1,4 +1,4 @@
-name: 'Sagamaker - Deploy Model'
+name: 'Sagemaker - Deploy Model'
 description: |
   Deploy Machine Learning Model Endpoint in SageMaker
 inputs:

--- a/components/aws/sagemaker/model/component.yaml
+++ b/components/aws/sagemaker/model/component.yaml
@@ -1,4 +1,4 @@
-name: 'Sagamaker - Create Model'
+name: 'Sagemaker - Create Model'
 description: |
   Create Models in SageMaker
 inputs:

--- a/components/aws/sagemaker/train/component.yaml
+++ b/components/aws/sagemaker/train/component.yaml
@@ -1,4 +1,4 @@
-name: 'Sagamaker - Training Job'
+name: 'Sagemaker - Training Job'
 description: |
   Train Machine Learning and Deep Learning Models using SageMaker
 inputs:


### PR DESCRIPTION
Sagemaker is misspelled a few times as sagamaker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1386)
<!-- Reviewable:end -->
