### PR TITLE
Fix auto generated resource link for DSL

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -81,7 +81,7 @@ class Client(object):
   def _get_url_prefix(self):
     if self._host:
       # User's own connection.
-      if self._host.startswith('http://'):
+      if self._host.startswith('http://') or self._host.startswith('https://'):
         return self._host
       else:
         return 'http://' + self._host


### PR DESCRIPTION
In case of IAP endpoint, the prefix is https instead of http. without the change the link will be resolved into 
http://https://foo.endpoints.bar.cloud.goog/pipeline
/assign @Ark-kun @hongye-sun

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1400)
<!-- Reviewable:end -->
