### PR TITLE
SDK/DSL: Make 'name' argument of a PipelineVolume omittable

### DIFF
--- a/sdk/python/kfp/dsl/_pipeline_volume.py
+++ b/sdk/python/kfp/dsl/_pipeline_volume.py
@@ -14,13 +14,10 @@
 
 
 from kubernetes.client.models import (
-    V1Volume, V1PersistentVolumeClaimVolumeSource,
-    V1ObjectMeta, V1TypedLocalObjectReference
+    V1Volume, V1PersistentVolumeClaimVolumeSource
 )
 
 from . import _pipeline
-from ._pipeline_param import sanitize_k8s_name, match_serialized_pipelineparam
-from ._volume_snapshot_op import VolumeSnapshotOp
 
 
 class PipelineVolume(V1Volume):
@@ -42,13 +39,10 @@ class PipelineVolume(V1Volume):
             volume: Create a deep copy out of a V1Volume or PipelineVolume
                 with no deps
         Raises:
-            ValueError: if pvc is not None and name is None
-                        if volume is not None and kwargs is not None
+            ValueError: if volume is not None and kwargs is not None
                         if pvc is not None and kwargs.pop("name") is not None
         """
-        if pvc and "name" not in kwargs:
-            raise ValueError("Please provide name.")
-        elif volume and kwargs:
+        if volume and kwargs:
             raise ValueError("You can't pass a volume along with other "
                              "kwargs.")
 
@@ -57,8 +51,8 @@ class PipelineVolume(V1Volume):
             init_volume = {attr: getattr(volume, attr)
                            for attr in self.attribute_map.keys()}
         else:
-            init_volume = {"name": kwargs.pop("name")
-                           if "name" in kwargs else None}
+            init_volume = {"name": kwargs.pop("name") if "name" in kwargs
+                           else "pvolume-%s" % id(self)}
             if pvc and kwargs:
                 raise ValueError("You can only pass 'name' along with 'pvc'.")
             elif pvc and not kwargs:

--- a/sdk/python/tests/dsl/pipeline_volume_tests.py
+++ b/sdk/python/tests/dsl/pipeline_volume_tests.py
@@ -63,8 +63,11 @@ class TestPipelineVolume(unittest.TestCase):
 
     def test_omitting_name(self):
         """Test PipelineVolume creation when omitting "name"."""
-        vol = PipelineVolume(pvc="foo")
+        vol1 = PipelineVolume(pvc="foo")
+        vol2 = PipelineVolume(name="provided", pvc="foo")
+        name1 = ("pvolume-109601a31098e6c92e2ad294fee3fae234e3f52398d3b077b0e0"
+                 "690e4cece686")
+        name2 = "provided"
 
-        name = ("pvolume-109601a31098e6c92e2ad294fee3fae234e3f52398d3b077b0e0"
-                "690e4cece686")
-        self.assertEqual(vol.name, name)
+        self.assertEqual(vol1.name, name1)
+        self.assertEqual(vol2.name, name2)

--- a/sdk/python/tests/dsl/pipeline_volume_tests.py
+++ b/sdk/python/tests/dsl/pipeline_volume_tests.py
@@ -58,4 +58,11 @@ class TestPipelineVolume(unittest.TestCase):
         self.assertEqual(vol2.dependent_names, [op1.name])
         self.assertEqual(vol3.dependent_names, [op2.name])
         self.assertEqual(sorted(vol4.dependent_names), [op1.name, op2.name])
-        self.assertEqual(sorted(vol5.dependent_names), [op1.name, op2.name, op3.name])
+        self.assertEqual(sorted(vol5.dependent_names),
+                         [op1.name, op2.name, op3.name])
+
+    def test_omitting_name(self):
+        """Test PipelineVolume creation when omitting "name"."""
+        vol = PipelineVolume(pvc="foo")
+
+        self.assertEqual(vol.name, "pvolume-%s" % id(vol))

--- a/sdk/python/tests/dsl/pipeline_volume_tests.py
+++ b/sdk/python/tests/dsl/pipeline_volume_tests.py
@@ -65,4 +65,6 @@ class TestPipelineVolume(unittest.TestCase):
         """Test PipelineVolume creation when omitting "name"."""
         vol = PipelineVolume(pvc="foo")
 
-        self.assertEqual(vol.name, "pvolume-%s" % id(vol))
+        name = ("pvolume-109601a31098e6c92e2ad294fee3fae234e3f52398d3b077b0e0"
+                "690e4cece686")
+        self.assertEqual(vol.name, name)


### PR DESCRIPTION
This PR makes the creation of a `PipelineVolume` without specifying a `name` possible.
The `name` of the `volume` is an orchestration detail [1] that the user should be able to be agnostic about.

I also removed any unused imports from the `_pipeline_volume` module.

[1]: It is only needed for the matching of `volumeMount`s with the `volume` entries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1402)
<!-- Reviewable:end -->
