### PR TITLE
SDK - Only install cloudpickle if it's not available

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -58,9 +58,12 @@ def _capture_function_code_using_cloudpickle(func) -> str:
     func_code = '{func_name} = pickle.loads({func_pickle})'.format(func_name=func.__name__, func_pickle=repr(func_pickle))
 
     code_lines = [
-        'import subprocess',
-        'import sys',
-        'subprocess.call([sys.executable, "-m", "pip", "install", "cloudpickle"])'
+        'try:',
+        '    import cloudpickle as _cloudpickle',
+        'except ImportError:',
+        '    import subprocess',
+        '    import sys',
+        '    subprocess.call([sys.executable, "-m", "pip", "install", "cloudpickle==1.1.1", "--quiet"])'
         '',
         'import pickle',
         '',


### PR DESCRIPTION
This makes unit tests much faster.
Also:
Pined the version to 1.1.1.
Made the installation quiet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1434)
<!-- Reviewable:end -->
