### PR TITLE
Fix Katib-launcher component with python file open issue

### DIFF
--- a/components/kubeflow/katib-launcher/src/launch_study_job.py
+++ b/components/kubeflow/katib-launcher/src/launch_study_job.py
@@ -153,6 +153,8 @@ def main(argv=None):
   if wait_response.get("status", {}).get("condition") == "Completed":
     succ = True
     trial = get_best_trial(wait_response["status"]["bestTrialId"])
+    if not os.path.exists(os.path.dirname(args.outputfile)):
+      os.makedirs(os.path.dirname(args.outputfile))
     with open(args.outputfile, 'w') as f:
       ps_dict = {}
       for ps in trial.parameter_set:


### PR DESCRIPTION
The current Katib-launcher component will break using the component.yaml since the `outputfile`'s parent directory does not exist. Therefore, we need to create parent directory if it doesn't exist.

Note: This image is using python 2.7, so the `exist_ok ` parameter is not yet available for ` os.makedirs`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1441)
<!-- Reviewable:end -->
