### PR TITLE
Load auth from kube config.

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -70,11 +70,11 @@ class Client(object):
     if token:
       config.api_key['authorization'] = token
       config.api_key_prefix['authorization'] = 'Bearer'
-      return
+      return config
 
     if host:
       # if host is explicitly set with auth token, it's probably a port forward address.
-      return
+      return config
 
     import kubernetes as k8s
     in_cluster = True
@@ -86,9 +86,14 @@ class Client(object):
 
     if in_cluster:
       config.host = Client.IN_CLUSTER_DNS_NAME.format(namespace)
-      return
+      return config
 
-    k8s.config.load_kube_config(client_configuration=config)
+    try:
+      k8s.config.load_kube_config(client_configuration=config)
+    except:
+      print('Failed to load kube config.')
+      return config
+
     if config.host:
       config.host = os.path.join(config.host, Client.KUBE_PROXY_PATH.format(namespace))
     return config

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -34,9 +34,10 @@ class Client(object):
   """
 
   # in-cluster DNS name of the pipeline service
-  IN_CLUSTER_DNS_NAME = 'ml-pipeline.kubeflow.svc.cluster.local:8888'
+  IN_CLUSTER_DNS_NAME = 'ml-pipeline.{}.svc.cluster.local:8888'
+  KUBE_PROXY_PATH = 'api/v1/namespaces/{}/services/ml-pipeline:http/proxy/'
 
-  def __init__(self, host=None, client_id=None):
+  def __init__(self, host=None, client_id=None, namespace='kubeflow'):
     """Create a new instance of kfp client.
 
     Args:
@@ -51,22 +52,46 @@ class Client(object):
     """
 
     self._host = host
-
-    token = None
-    if host and client_id:
-      token = get_auth_token(client_id)
-  
-    config = kfp_server_api.configuration.Configuration()
-    config.host = host if host else Client.IN_CLUSTER_DNS_NAME
-    self._configure_auth(config, token)
+    config = self._load_config(host, client_id, namespace)
     api_client = kfp_server_api.api_client.ApiClient(config)
     self._run_api = kfp_server_api.api.run_service_api.RunServiceApi(api_client)
     self._experiment_api = kfp_server_api.api.experiment_service_api.ExperimentServiceApi(api_client)
 
-  def _configure_auth(self, config, token):
+  def _load_config(self, host, client_id, namespace):
+    config = kfp_server_api.configuration.Configuration()
+    if host:
+      config.host = host
+
+    token = None
+    if host and client_id:
+      # fetch IAP auth token
+      token = get_auth_token(client_id)
+    
     if token:
       config.api_key['authorization'] = token
       config.api_key_prefix['authorization'] = 'Bearer'
+      return
+
+    if host:
+      # if host is explicitly set with auth token, it's probably a port forward address.
+      return
+
+    import kubernetes as k8s
+    in_cluster = True
+    try:
+      k8s.config.load_incluster_config()
+    except:
+      in_cluster = False
+      pass
+
+    if in_cluster:
+      config.host = Client.IN_CLUSTER_DNS_NAME.format(namespace)
+      return
+
+    k8s.config.load_kube_config(client_configuration=config)
+    if config.host:
+      config.host = os.path.join(config.host, Client.KUBE_PROXY_PATH.format(namespace))
+    return config
 
   def _is_ipython(self):
     """Returns whether we are running in notebook."""


### PR DESCRIPTION
This PR supports:
1. Optionally load auth config from kube config.
2. Make namespace to be configurable.


Fix https://github.com/kubeflow/pipelines/issues/1318
This PR can kind of fix https://github.com/kubeflow/pipelines/issues/1104 as well, except that it doesn't go through IAP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1443)
<!-- Reviewable:end -->
