### PR TITLE
SDK/Compiler - Fix s3 artifact key names

### DIFF
--- a/sdk/python/kfp/dsl/_artifact_location.py
+++ b/sdk/python/kfp/dsl/_artifact_location.py
@@ -29,9 +29,9 @@ def _dict_to_secret(
 class ArtifactLocation:
     """
     ArtifactLocation describes a location for a single or multiple artifacts.
-    It is used as single artifact in the context of inputs/outputs 
-    (e.g. outputs.artifacts.artname). It is also used to describe the location 
-    of multiple artifacts such as the archive location of a single workflow 
+    It is used as single artifact in the context of inputs/outputs
+    (e.g. outputs.artifacts.artname). It is also used to describe the location
+    of multiple artifacts such as the archive location of a single workflow
     step, which the executor will use as a default location to store its files.
     """
 
@@ -49,7 +49,7 @@ class ArtifactLocation:
         backend.
 
         Example::
-  
+
           from kubernetes.client.models import V1SecretKeySelector
           from kfp.dsl import ArtifactLocation
 
@@ -69,10 +69,10 @@ class ArtifactLocation:
           insecure (bool): use TLS if set to True.
           region (str): bucket region (for s3 buckets).
           access_key_secret (Union[V1SecretKeySelector, Dict[str, Any]]): k8s secret selector to access key.
-          secret_key_secret (Union[V1SecretKeySelector, Dict[str, Any]]): k8s secret selector to secret key. 
+          secret_key_secret (Union[V1SecretKeySelector, Dict[str, Any]]): k8s secret selector to secret key.
 
         Returns:
-          V1alpha1ArtifactLocation: a new instance of V1alpha1ArtifactLocation.       
+          V1alpha1ArtifactLocation: a new instance of V1alpha1ArtifactLocation.
         """
         return V1alpha1ArtifactLocation(
             s3=V1alpha1S3Artifact(
@@ -128,8 +128,8 @@ class ArtifactLocation:
               endpoint=s3_artifact.get("endpoint"),
               insecure=s3_artifact.get("insecure"),
               region=s3_artifact.get("region"),
-              access_key_secret=_dict_to_secret(s3_artifact.get("access_key_secret")),
-              secret_key_secret=_dict_to_secret(s3_artifact.get("secret_key_secret")),
+              access_key_secret=_dict_to_secret(s3_artifact.get("accessKeySecret")),
+              secret_key_secret=_dict_to_secret(s3_artifact.get("secretKeySecret")),
               key=key
             )
           )

--- a/sdk/python/tests/compiler/testdata/artifact_location.py
+++ b/sdk/python/tests/compiler/testdata/artifact_location.py
@@ -18,13 +18,13 @@ from kubernetes.client.models import V1SecretKeySelector
 
 @dsl.pipeline(name='foo', description='hello world')
 def foo_pipeline(tag: str, namespace: str = "kubeflow", bucket: str = "foobar"):
-    
+
     # configures artifact location
     pipeline_artifact_location = dsl.ArtifactLocation.s3(
                             bucket=bucket,
                             endpoint="minio-service.%s:9000" % namespace,
                             insecure=True,
-                            access_key_secret=V1SecretKeySelector(name="minio", key="accesskey"),
+                            access_key_secret={"name": "minio", "key": "accesskey"},
                             secret_key_secret=V1SecretKeySelector(name="minio", key="secretkey"))
 
     # configures artifact location using AWS IAM role (no access key provided)
@@ -41,7 +41,7 @@ def foo_pipeline(tag: str, namespace: str = "kubeflow", bucket: str = "foobar"):
     op1 = dsl.ContainerOp(name='foo', image='busybox:%s' % tag)
 
     # op level artifact location (to s3 bucket)
-    op2 = dsl.ContainerOp(name='foo', 
+    op2 = dsl.ContainerOp(name='foo',
                           image='busybox:%s' % tag,
                           # configures artifact location
                           artifact_location=artifact_location)

--- a/sdk/python/tests/compiler/testdata/artifact_location.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_location.yaml
@@ -67,29 +67,29 @@ spec:
         path: /mlpipeline-ui-metadata.json
         s3:
           accessKeySecret:
-            key: ''
-            optional: true
+            key: 'accesskey'
+            name: 'minio'
           bucket: '{{inputs.parameters.bucket}}'
           endpoint: minio-service.{{inputs.parameters.namespace}}:9000
           insecure: true
           key: runs/{{workflow.uid}}/{{pod.name}}/mlpipeline-ui-metadata.tgz
           secretKeySecret:
-            key: ''
-            optional: true
+            key: 'secretkey'
+            name: 'minio'
       - name: mlpipeline-metrics
         optional: true
         path: /mlpipeline-metrics.json
         s3:
           accessKeySecret:
-            key: ''
-            optional: true
+            key: 'accesskey'
+            name: 'minio'
           bucket: '{{inputs.parameters.bucket}}'
           endpoint: minio-service.{{inputs.parameters.namespace}}:9000
           insecure: true
           key: runs/{{workflow.uid}}/{{pod.name}}/mlpipeline-metrics.tgz
           secretKeySecret:
-            key: ''
-            optional: true
+            key: 'secretkey'
+            name: 'minio'
   - container:
       image: busybox:{{inputs.parameters.tag}}
     inputs:

--- a/sdk/python/tests/dsl/artifact_location_tests.py
+++ b/sdk/python/tests/dsl/artifact_location_tests.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from kfp.compiler._k8s_helper import K8sHelper
 from kfp.dsl import ArtifactLocation
 from kubernetes.client.models import V1SecretKeySelector
 
@@ -35,7 +36,7 @@ class TestArtifactLocation(unittest.TestCase):
         "endpoint": "s3.amazonaws.com",
         "insecure": False,
         "region": "ap-southeast-1",
-        "access_key_secret": {"name": "s3-secret", "key": "accesskey"}, 
+        "access_key_secret": {"name": "s3-secret", "key": "accesskey"},
         "secret_key_secret": {"name": "s3-secret", "key": "secretkey"}
     }
 
@@ -52,7 +53,7 @@ class TestArtifactLocation(unittest.TestCase):
     # should trigger pending deprecation warning about not having a default
     # artifact_location if artifact_location is not provided.
     artifact = ArtifactLocation.create_artifact_for_s3(
-        None, 
+        None,
         name="foo",
         path="path/to",
         key="key")
@@ -70,7 +71,7 @@ class TestArtifactLocation(unittest.TestCase):
         secret_key_secret=V1SecretKeySelector(name="s3-secret", key="secretkey")
     )
     artifact = ArtifactLocation.create_artifact_for_s3(
-        artifact_location, 
+        artifact_location,
         name="foo",
         path="path/to",
         key="key")
@@ -86,16 +87,17 @@ class TestArtifactLocation(unittest.TestCase):
     self.assertEqual(artifact.s3.secret_key_secret.key, "secretkey")
 
   def test_create_artifact_for_s3_with_dict(self):
-    artifact_location_dict = ArtifactLocation.s3(
+    # use the K8sHelper to mimick the compiler
+    artifact_location_dict = K8sHelper.convert_k8s_obj_to_json(ArtifactLocation.s3(
         bucket="foo",
         endpoint="s3.amazonaws.com",
         insecure=False,
         region="ap-southeast-1",
         access_key_secret={"name": "s3-secret", "key": "accesskey"},
         secret_key_secret=V1SecretKeySelector(name="s3-secret", key="secretkey")
-    ).to_dict()
+    ))
     artifact = ArtifactLocation.create_artifact_for_s3(
-        artifact_location_dict, 
+        artifact_location_dict,
         name="foo",
         path="path/to",
         key="key")


### PR DESCRIPTION
The current implementation generates an incorrect s3 output artifact snippet:

```
        s3:
          accessKeySecret:
            key: ''
            optional: true
          bucket: mlpipeline
          endpoint: minio-service.kubeflow:9000
          insecure: true
          key: runs/{{workflow.uid}}/{{pod.name}}/mlpipeline-metrics.tgz
          secretKeySecret:
            key: ''
            optional: true
```

Instead it should be:
```
        s3:
          accessKeySecret:
            key: accesskey
            name: mlpipeline-minio-artifact
          bucket: mlpipeline
          endpoint: minio-service.kubeflow:9000
          insecure: true
          key: runs/{{workflow.uid}}/{{pod.name}}/mlpipeline-metrics.tgz
          secretKeySecret:
            key: secretkey
            name: mlpipeline-minio-artifact
```

Related PR: https://github.com/kubeflow/pipelines/pull/1064

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1451)
<!-- Reviewable:end -->
