### PR TITLE
Apiserver s3 and MySQL env vars

### DIFF
--- a/backend/src/apiserver/client/sql.go
+++ b/backend/src/apiserver/client/sql.go
@@ -20,7 +20,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 )
 
-func CreateMySQLConfig(user string, mysqlServiceHost string,
+func CreateMySQLConfig(user, password string, mysqlServiceHost string,
 	mysqlServicePort string, dbName string) *mysql.Config {
 	return &mysql.Config{
 		User:                 user,

--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -17,6 +17,7 @@ package main
 import (
 	"database/sql"
 	"fmt"
+	"os"
 	"strconv"
 	"time"
 
@@ -263,8 +264,10 @@ func initMysql(driverName string, initConnectionTimeout time.Duration) string {
 
 func initMinioClient(initConnectionTimeout time.Duration) storage.ObjectStoreInterface {
 	// Create minio client.
-	minioServiceHost := getStringConfig(minioServiceHost)
-	minioServicePort := getStringConfig(minioServicePort)
+	minioServiceHost := getStringConfigWithDefault(
+		"ObjectStoreConfig.Host", os.Getenv(minioServiceHost))
+	minioServicePort := getStringConfigWithDefault(
+		"ObjectStoreConfig.Port", os.Getenv(minioServicePort))
 	accessKey := getStringConfig("ObjectStoreConfig.AccessKey")
 	secretKey := getStringConfig("ObjectStoreConfig.SecretAccessKey")
 	bucketName := getStringConfig("ObjectStoreConfig.BucketName")

--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -42,7 +42,10 @@ const (
 	minioServiceHost      = "MINIO_SERVICE_SERVICE_HOST"
 	minioServicePort      = "MINIO_SERVICE_SERVICE_PORT"
 	mysqlServiceHost      = "MYSQL_SERVICE_HOST"
+	mysqlUser             = "DBConfig.User"
+	mysqlPassword         = "DBConfig.Password"
 	mysqlServicePort      = "MYSQL_SERVICE_PORT"
+
 	podNamespace          = "POD_NAMESPACE"
 	dbName                = "mlpipeline"
 	initConnectionTimeout = "InitConnectionTimeout"
@@ -164,7 +167,8 @@ func initMetadataStore() *metadata.Store {
 				Host:     proto.String(getStringConfig(mysqlServiceHost)),
 				Port:     proto.Uint32(uint32(port)),
 				Database: proto.String("mlmetadata"),
-				User:     proto.String("root"),
+				User:     proto.String(getStringConfigWithDefault(mysqlUser, "root")),
+				Password: proto.String(getStringConfigWithDefault(mysqlPassword, "")),
 			},
 		},
 	}
@@ -218,7 +222,8 @@ func initDBClient(initConnectionTimeout time.Duration) *storage.DB {
 // Format would be something like root@tcp(ip:port)/dbname?charset=utf8&loc=Local&parseTime=True
 func initMysql(driverName string, initConnectionTimeout time.Duration) string {
 	mysqlConfig := client.CreateMySQLConfig(
-		"root",
+		getStringConfigWithDefault(mysqlUser, "root"),
+		getStringConfigWithDefault(mysqlPassword, ""),
 		getStringConfig(mysqlServiceHost),
 		getStringConfig(mysqlServicePort),
 		"")

--- a/backend/src/apiserver/config.go
+++ b/backend/src/apiserver/config.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"strings"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -23,7 +24,9 @@ import (
 )
 
 func initConfig() {
-	// Import environment variable
+	// Import environment variable, support nested vars e.g. OBJECTSTORECONFIG_ACCESSKEY
+	replacer := strings.NewReplacer(".", "_")
+	viper.SetEnvKeyReplacer(replacer)
 	viper.AutomaticEnv()
 
 	// Set configuration file name. The format is auto detected in this case.
@@ -45,6 +48,13 @@ func initConfig() {
 func getStringConfig(configName string) string {
 	if !viper.IsSet(configName) {
 		glog.Fatalf("Please specify flag %s", configName)
+	}
+	return viper.GetString(configName)
+}
+
+func getStringConfigWithDefault(configName, value string) string {
+	if !viper.IsSet(configName) {
+		return value
 	}
 	return viper.GetString(configName)
 }


### PR DESCRIPTION
add support to specify S3 and MySQL credentials and endpoints through environment variables (and secrets)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1455)
<!-- Reviewable:end -->
