### PR TITLE
Add op_to_templates_handler to compiler

### DIFF
--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -143,8 +143,8 @@ class TestCompiler(unittest.TestCase):
     }
 
     self.maxDiff = None
-    self.assertEqual(golden_output, compiler.Compiler()._op_to_template(op))
-    self.assertEqual(res_output, compiler.Compiler()._op_to_template(res))
+    self.assertEqual(golden_output, compiler._op_to_template._op_to_template(op))
+    self.assertEqual(res_output, compiler._op_to_template._op_to_template(res))
 
   def _get_yaml_from_zip(self, zip_file):
     with zipfile.ZipFile(zip_file, 'r') as zip:
@@ -475,7 +475,7 @@ class TestCompiler(unittest.TestCase):
     with open(target_yaml, 'r') as f:
       expected = yaml.safe_load(f)['spec']['templates'][0]
 
-    compiled_template = compiler.Compiler()._op_to_template(ops)
+    compiled_template = compiler._op_to_template._op_to_template(ops)
 
     del compiled_template['name'], expected['name']
     del compiled_template['outputs']['parameters'][0]['name'], expected['outputs']['parameters'][0]['name']


### PR DESCRIPTION
The handler is required by injecting metadata tracking steps for ContainerOps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1458)
<!-- Reviewable:end -->
