### PR TITLE
SDK - Cleanup - Serialized PipelineParam does not need type

### DIFF
--- a/sdk/python/tests/dsl/pipeline_param_tests.py
+++ b/sdk/python/tests/dsl/pipeline_param_tests.py
@@ -30,13 +30,13 @@ class TestPipelineParam(unittest.TestCase):
     """Test string representation."""
 
     p = PipelineParam(name='param1', op_name='op1')
-    self.assertEqual('{{pipelineparam:op=op1;name=param1;value=;type=;}}', str(p))
+    self.assertEqual('{{pipelineparam:op=op1;name=param1;value=}}', str(p))
 
     p = PipelineParam(name='param2')
-    self.assertEqual('{{pipelineparam:op=;name=param2;value=;type=;}}', str(p))
+    self.assertEqual('{{pipelineparam:op=;name=param2;value=}}', str(p))
 
     p = PipelineParam(name='param3', value='value3')
-    self.assertEqual('{{pipelineparam:op=;name=param3;value=value3;type=;}}', str(p))
+    self.assertEqual('{{pipelineparam:op=;name=param3;value=value3}}', str(p))
 
   def test_extract_pipelineparams(self):
     """Test _extract_pipeleineparams."""


### PR DESCRIPTION
Only the types in non-serialized PipelineParams are ever used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1468)
<!-- Reviewable:end -->
