### PR TITLE
 SDK - Cleanup - Serialized PipelineParamTuple does not need value or type

### DIFF
--- a/sdk/python/kfp/dsl/_pipeline_param.py
+++ b/sdk/python/kfp/dsl/_pipeline_param.py
@@ -22,7 +22,7 @@ from ._metadata import TypeMeta
 # TODO: Move this to a separate class
 # For now, this identifies a condition with only "==" operator supported.
 ConditionOperator = namedtuple('ConditionOperator', 'operator operand1 operand2')
-PipelineParamTuple = namedtuple('PipelineParamTuple', 'name op value pattern')
+PipelineParamTuple = namedtuple('PipelineParamTuple', 'name op pattern')
 
 
 def sanitize_k8s_name(name):
@@ -40,14 +40,13 @@ def match_serialized_pipelineparam(payload: str):
   Returns:
     PipelineParamTuple
   """
-  matches = re.findall(r'{{pipelineparam:op=([\w\s_-]*);name=([\w\s_-]+);value=(.*?)}}', payload)
+  matches = re.findall(r'{{pipelineparam:op=([\w\s_-]*);name=([\w\s_-]+)}}', payload)
   param_tuples = []
   for match in matches:
-      pattern = '{{pipelineparam:op=%s;name=%s;value=%s}}' % (match[0], match[1], match[2])
+      pattern = '{{pipelineparam:op=%s;name=%s}}' % (match[0], match[1])
       param_tuples.append(PipelineParamTuple(
                             name=sanitize_k8s_name(match[1]), 
                             op=sanitize_k8s_name(match[0]), 
-                            value=match[2],
                             pattern=pattern))
   return param_tuples
 
@@ -69,7 +68,6 @@ def _extract_pipelineparams(payloads: str or List[str]):
   for param_tuple in list(set(param_tuples)):
     pipeline_params.append(PipelineParam(param_tuple.name, 
                                          param_tuple.op, 
-                                         param_tuple.value, 
                                          pattern=param_tuple.pattern))
   return pipeline_params
 
@@ -192,8 +190,7 @@ class PipelineParam(object):
     #  return str(self.value)
 
     op_name = self.op_name if self.op_name else ''
-    value = self.value if self.value else ''
-    return '{{pipelineparam:op=%s;name=%s;value=%s}}' % (op_name, self.name, value)
+    return '{{pipelineparam:op=%s;name=%s}}' % (op_name, self.name)
   
   def __repr__(self):
       return str({self.__class__.__name__: self.__dict__})

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -85,7 +85,7 @@ class TestCompiler(unittest.TestCase):
       'inputs': {'parameters':
         [
           {'name': 'msg1'},
-          {'name': 'msg2', 'value': 'value2'},
+          {'name': 'msg2'},
         ]},
       'name': 'echo',
       'outputs': {

--- a/sdk/python/tests/dsl/pipeline_param_tests.py
+++ b/sdk/python/tests/dsl/pipeline_param_tests.py
@@ -30,13 +30,13 @@ class TestPipelineParam(unittest.TestCase):
     """Test string representation."""
 
     p = PipelineParam(name='param1', op_name='op1')
-    self.assertEqual('{{pipelineparam:op=op1;name=param1;value=;type=;}}', str(p))
+    self.assertEqual('{{pipelineparam:op=op1;name=param1;value=}}', str(p))
 
     p = PipelineParam(name='param2')
-    self.assertEqual('{{pipelineparam:op=;name=param2;value=;type=;}}', str(p))
+    self.assertEqual('{{pipelineparam:op=;name=param2;value=}}', str(p))
 
     p = PipelineParam(name='param3', value='value3')
-    self.assertEqual('{{pipelineparam:op=;name=param3;value=value3;type=;}}', str(p))
+    self.assertEqual('{{pipelineparam:op=;name=param3;value=value3}}', str(p))
 
   def test_extract_pipelineparams(self):
     """Test _extract_pipeleineparams."""

--- a/sdk/python/tests/dsl/pipeline_param_tests.py
+++ b/sdk/python/tests/dsl/pipeline_param_tests.py
@@ -30,13 +30,13 @@ class TestPipelineParam(unittest.TestCase):
     """Test string representation."""
 
     p = PipelineParam(name='param1', op_name='op1')
-    self.assertEqual('{{pipelineparam:op=op1;name=param1;value=}}', str(p))
+    self.assertEqual('{{pipelineparam:op=op1;name=param1}}', str(p))
 
     p = PipelineParam(name='param2')
-    self.assertEqual('{{pipelineparam:op=;name=param2;value=}}', str(p))
+    self.assertEqual('{{pipelineparam:op=;name=param2}}', str(p))
 
     p = PipelineParam(name='param3', value='value3')
-    self.assertEqual('{{pipelineparam:op=;name=param3;value=value3}}', str(p))
+    self.assertEqual('{{pipelineparam:op=;name=param3}}', str(p))
 
   def test_extract_pipelineparams(self):
     """Test _extract_pipeleineparams."""


### PR DESCRIPTION
Default values are only relevant when PipelineParam is used in the pipeline function signature and even in this case compiler captures them explicitly from the PipelineParam objects in the signature.
There seem to be no other uses for them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1469)
<!-- Reviewable:end -->
