### PR TITLE
Fixed broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Kubeflow pipelines service has the following goals:
 
 Get started with your first pipeline and read further information in the [Kubeflow Pipelines documentation](https://www.kubeflow.org/docs/guides/pipelines/pipelines-overview/).
 
-See the Kubeflow [Pipelines API doc](https://www.kubeflow.org/docs/pipelines/reference/api/) for API specification.
+See the Kubeflow [Pipelines API doc](https://www.kubeflow.org/docs/pipelines/reference/api/kubeflow-pipeline-api-spec/) for API specification.
 
 Consult the [Python SDK reference docs](https://kubeflow-pipelines.readthedocs.io/en/latest/) when writing pipelines using the python SDK.
 


### PR DESCRIPTION
This PR addresses and fixes issue #1479. The link to documentation appears to have changed and when clicking the **Pipelines API doc** link within the README file a 404 error is presented. This change fixes the link within the README file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1480)
<!-- Reviewable:end -->
