### PR TITLE
fix api doc link URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Kubeflow pipelines service has the following goals:
 
 Get started with your first pipeline and read further information in the [Kubeflow Pipelines documentation](https://www.kubeflow.org/docs/guides/pipelines/pipelines-overview/).
 
-See the Kubeflow [Pipelines API doc](https://www.kubeflow.org/docs/pipelines/reference/api/) for API specification.
+See the Kubeflow [Pipelines API doc](https://www.kubeflow.org/docs/pipelines/reference/api/kubeflow-pipeline-api-spec/) for API specification.
 
 Consult the [Python SDK reference docs](https://kubeflow-pipelines.readthedocs.io/en/latest/) when writing pipelines using the python SDK.
 


### PR DESCRIPTION
Fix the broken Pipelines API doc link URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1495)
<!-- Reviewable:end -->
