### PR TITLE
use cluster role for viewer crd for now since viewer crd doesn't support namespaced deployemnt

### DIFF
--- a/manifests/base/pipeline/ml-pipeline-viewer-crd-role.yaml
+++ b/manifests/base/pipeline/ml-pipeline-viewer-crd-role.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: Role
+kind: ClusterRole
 metadata:
   name: ml-pipeline-viewer-controller-role
 rules:

--- a/manifests/base/pipeline/ml-pipeline-viewer-crd-rolebinding.yaml
+++ b/manifests/base/pipeline/ml-pipeline-viewer-crd-rolebinding.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: ml-pipeline-viewer-crd-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: ml-pipeline-viewer-controller-role
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
/assign @jingzhang36

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1499)
<!-- Reviewable:end -->
