### PR TITLE
Add wait_job command

### DIFF
--- a/component_sdk/python/kfp_component/google/ml_engine/__init__.py
+++ b/component_sdk/python/kfp_component/google/ml_engine/__init__.py
@@ -30,3 +30,4 @@ from ._train import train
 from ._batch_predict import batch_predict
 from ._deploy import deploy
 from ._set_default_version import set_default_version
+from ._wait_job import wait_job

--- a/component_sdk/python/kfp_component/google/ml_engine/_wait_job.py
+++ b/component_sdk/python/kfp_component/google/ml_engine/_wait_job.py
@@ -1,0 +1,37 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ._common_ops import wait_for_job_done, cancel_job
+
+from kfp_component.core import KfpExecutionContext
+from ._client import MLEngineClient
+from .. import common as gcp_common
+
+def wait_job(project_id, job_id, wait_interval=30):
+    """Waits a MLEngine job.
+
+    Args:
+        project_id (str): Required. The ID of the parent project of the job.
+        job_id (str): Required. The ID of the job to wait.
+        wait_interval (int): optional wait interval between calls
+            to get job status. Defaults to 30.
+
+    Outputs:
+        /tmp/kfp/output/ml_engine/job.json: The json payload of the waiting job.
+        /tmp/kfp/output/ml_engine/job_id.txt: The ID of the waiting job.
+        /tmp/kfp/output/ml_engine/job_dir.txt: The `jobDir` of the waiting job.
+    """
+    ml_client = MLEngineClient()
+    with KfpExecutionContext(on_cancel=lambda: cancel_job(ml_client, project_id, job_id)):
+        return wait_for_job_done(ml_client, project_id, job_id, wait_interval)

--- a/component_sdk/python/requirements.txt
+++ b/component_sdk/python/requirements.txt
@@ -1,6 +1,0 @@
-kubernetes == 8.0.1
-urllib3>=1.15,<1.25 #Fixing the version conflict with the "requests" package
-fire == 0.1.3
-google-api-python-client == 1.7.8
-google-cloud-storage == 1.14.0
-google-cloud-bigquery == 1.9.0

--- a/component_sdk/python/setup.py
+++ b/component_sdk/python/setup.py
@@ -16,20 +16,20 @@ from setuptools import setup
 
 PACKAGE_NAME = "kfp-component"
 VERSION = '0.1.20'
-REQUIRES = []
-with open('requirements.txt') as f:
-    REQUIRES = f.readlines()
-
-with open('test-requirements.txt') as f:
-    TESTS_REQUIRES = f.readlines()
 
 setup(
     name=PACKAGE_NAME,
     version=VERSION,
     description='KubeFlow Pipelines Component SDK',
     author='google',
-    install_requires=REQUIRES,
-    tests_require=TESTS_REQUIRES,
+    install_requires=[
+      'kubernetes >= 8.0.1',
+      'urllib3>=1.15,<1.25',
+      'fire == 0.1.3',
+      'google-api-python-client == 1.7.8',
+      'google-cloud-storage == 1.14.0',
+      'google-cloud-bigquery == 1.9.0'
+    ],
     packages=[
       'kfp_component',
     ],

--- a/component_sdk/python/test-requirements.txt
+++ b/component_sdk/python/test-requirements.txt
@@ -1,2 +1,3 @@
+.
 pytest
 mock

--- a/component_sdk/python/tests/google/ml_engine/test__create_job.py
+++ b/component_sdk/python/tests/google/ml_engine/test__create_job.py
@@ -18,9 +18,10 @@ from googleapiclient import errors
 from kfp_component.google.ml_engine import create_job
 
 CREATE_JOB_MODULE = 'kfp_component.google.ml_engine._create_job'
+COMMON_OPS_MODEL = 'kfp_component.google.ml_engine._common_ops'
 
-@mock.patch(CREATE_JOB_MODULE + '.display.display')
-@mock.patch(CREATE_JOB_MODULE + '.gcp_common.dump_file')
+@mock.patch(COMMON_OPS_MODEL + '.display.display')
+@mock.patch(COMMON_OPS_MODEL + '.gcp_common.dump_file')
 @mock.patch(CREATE_JOB_MODULE + '.KfpExecutionContext')
 @mock.patch(CREATE_JOB_MODULE + '.MLEngineClient')
 class TestCreateJob(unittest.TestCase):

--- a/component_sdk/python/tests/google/ml_engine/test__wait_job.py
+++ b/component_sdk/python/tests/google/ml_engine/test__wait_job.py
@@ -1,0 +1,70 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mock
+import unittest
+from googleapiclient import errors
+from kfp_component.google.ml_engine import wait_job
+
+CREATE_JOB_MODULE = 'kfp_component.google.ml_engine._wait_job'
+COMMON_OPS_MODEL = 'kfp_component.google.ml_engine._common_ops'
+
+@mock.patch(COMMON_OPS_MODEL + '.display.display')
+@mock.patch(COMMON_OPS_MODEL + '.gcp_common.dump_file')
+@mock.patch(CREATE_JOB_MODULE + '.KfpExecutionContext')
+@mock.patch(CREATE_JOB_MODULE + '.MLEngineClient')
+class TestWaitJob(unittest.TestCase):
+
+    def test_wait_job_succeed(self, mock_mlengine_client,
+        mock_kfp_context, mock_dump_json, mock_display):
+        returned_job = {
+            'jobId': 'mock_job',
+            'state': 'SUCCEEDED'
+        }
+        mock_mlengine_client().get_job.return_value = (
+            returned_job)
+
+        result = wait_job('mock_project', 'mock_job')
+
+        self.assertEqual(returned_job, result)
+
+    def test_wait_job_status_fail(self, mock_mlengine_client,
+        mock_kfp_context, mock_dump_json, mock_display):
+        returned_job = {
+            'jobId': 'mock_job',
+            'trainingInput': {
+                'modelDir': 'test'
+            },
+            'state': 'FAILED'
+        }
+        mock_mlengine_client().get_job.return_value = returned_job
+
+        with self.assertRaises(RuntimeError):
+            wait_job('mock_project', 'mock_job')
+
+    def test_cancel_succeed(self, mock_mlengine_client,
+        mock_kfp_context, mock_dump_json, mock_display):
+        returned_job = {
+            'jobId': 'mock_job',
+            'state': 'SUCCEEDED'
+        }
+        mock_mlengine_client().get_job.return_value = (
+            returned_job)
+        wait_job('mock_project', 'mock_job')
+        cancel_func = mock_kfp_context.call_args[1]['on_cancel']
+        
+        cancel_func()
+
+        mock_mlengine_client().cancel_job.assert_called_with(
+            'mock_project', 'mock_job'
+        )

--- a/component_sdk/python/tox.ini
+++ b/component_sdk/python/tox.ini
@@ -5,7 +5,6 @@ envlist = py27,py36
 usedevelop = True
 install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
-       -r{toxinidir}/requirements.txt
 commands =
    python -V 
-   py.test -vvv -s
+   py.test -vvv -s {posargs}


### PR DESCRIPTION
Extract wait job logic from create_job command and make it as an individual command.
This command can enable scenario when user has an existing component which submits a CMLE job. They can use the wait_job command to wait until the job finishes.

The command supports:
* Cancellation when the pipeline is cancelled.
* Fail if the job is in failed state.
* Output display metadata including job links and tensor-board link.

Some side changes are also included in the PR:
* Remove the need of requirements.txt file.
* Support pass args to pytest via tox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1505)
<!-- Reviewable:end -->
