### PR TITLE
SDK - Added kfp.run_pipeline_func_on_cluster function (alias)

### DIFF
--- a/sdk/python/kfp/__init__.py
+++ b/sdk/python/kfp/__init__.py
@@ -15,3 +15,4 @@
 
 from ._client import Client
 from ._config import *
+from ._runners import *

--- a/sdk/python/kfp/_runners.py
+++ b/sdk/python/kfp/_runners.py
@@ -1,0 +1,37 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    'run_pipeline_func_on_cluster',
+]
+
+
+from typing import Mapping, Callable
+
+from . import Client
+
+
+def run_pipeline_func_on_cluster(pipeline_func: Callable, arguments: Mapping[str, str], run_name : str = None, experiment_name : str = None, kfp_client : Client = None):
+    '''Runs pipeline on KFP-enabled Kubernetes cluster.
+    This command compiles the pipeline function, creates or gets an experiment and submits the pipeline for execution.
+
+    Args:
+      pipeline_func: A function that describes a pipeline by calling components and composing them into execution graph.
+      arguments: Arguments to the pipeline function provided as a dict.
+      run_name: Optional. Name of the run to be shown in the UI.
+      experiment_name: Optional. Name of the experiment to add the run to.
+      kfp_client: Optional. An instance of kfp.Client configured for the desired KFP cluster.
+    '''
+    kfp_client = kfp_client or Client()
+    return kfp_client.create_run_from_pipeline_func(pipeline_func, arguments, run_name, experiment_name)


### PR DESCRIPTION
This commit adds alias to the `kfp.Client.create_run_from_pipeline_func` method as the root `kfp.run_pipeline_func_on_cluster` function.
In future more runners can be added (local, etc).

Currently the running the pipeline operation is performed using the API server client concept. I want to add a way to run a pipeline without thinking of server API clients. This way all runners can be grouped in the same place. Also, this way, the compilation options do not creep into the `kfp.Client` class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1521)
<!-- Reviewable:end -->
