### PR TITLE
SDK+Frontend - Fixed the task display name annotation key

### DIFF
--- a/frontend/src/lib/WorkflowParser.test.ts
+++ b/frontend/src/lib/WorkflowParser.test.ts
@@ -312,7 +312,7 @@ describe('WorkflowParser', () => {
             {
               metadata: {
                 annotations: {
-                  'kubeflow.org/pipelines/task_display_name': 'Customized name',
+                  'pipelines.kubeflow.org/task_display_name': 'Customized name',
                 }
               },
               name: 'some-template',

--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -83,7 +83,7 @@ export default class WorkflowParser {
         if (workflow.spec && workflow.spec.templates) {
           const tmpl = workflow.spec.templates.find(t => !!t && !!t.name && t.name === node.templateName);
           if (tmpl && tmpl.metadata && tmpl.metadata.annotations) {
-            const displayName = tmpl.metadata.annotations['kubeflow.org/pipelines/task_display_name'];
+            const displayName = tmpl.metadata.annotations['pipelines.kubeflow.org/task_display_name'];
             if (displayName) {
               nodeLabel = displayName;
             }

--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -255,6 +255,6 @@ def _op_to_template(op: BaseOp):
 
     # Display name
     if processed_op.display_name:
-        template.setdefault('metadata', {}).setdefault('annotations', {})['kubeflow.org/pipelines/task_display_name'] = processed_op.display_name
+        template.setdefault('metadata', {}).setdefault('annotations', {})['pipelines.kubeflow.org/task_display_name'] = processed_op.display_name
 
     return template

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -525,7 +525,7 @@ implementation:
 
     workflow_dict = kfp.compiler.Compiler()._compile(some_pipeline)
     template = workflow_dict['spec']['templates'][0]
-    self.assertEqual(template['metadata']['annotations']['kubeflow.org/pipelines/task_display_name'], 'Custom name')
+    self.assertEqual(template['metadata']['annotations']['pipelines.kubeflow.org/task_display_name'], 'Custom name')
 
   def test_op_transformers(self):
     def some_op():


### PR DESCRIPTION
Turns out, Kubernetes only allows a single slash character in annotation key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1526)
<!-- Reviewable:end -->
