### PR TITLE
SDK - Generated paths will be in /tmp by default

### DIFF
--- a/sdk/python/kfp/components/_components.py
+++ b/sdk/python/kfp/components/_components.py
@@ -157,8 +157,8 @@ def _create_task_factory_from_component_dict(component_dict, component_filename=
     return _create_task_factory_from_component_spec(component_spec, component_filename, component_ref)
 
 
-_inputs_dir = '/inputs'
-_outputs_dir = '/outputs'
+_inputs_dir = '/tmp/inputs'
+_outputs_dir = '/tmp/outputs'
 _single_io_file_name = 'data'
 
 


### PR DESCRIPTION
This makes them more compatible with images that have non-root user (e.g. `apache/airflow`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1531)
<!-- Reviewable:end -->
