### PR TITLE
Use GCP external Stackdriver links

### DIFF
--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -311,7 +311,7 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
                     <div>
                       <div className={css.outputTitle}>Metrics</div>
                       <div className={padding(20, 'lt')}>
-                        <CompareTable {...CompareUtils.singleRunToMetricsCompareProps(runMetadata, workflow)}/>
+                        <CompareTable {...CompareUtils.singleRunToMetricsCompareProps(runMetadata, workflow)} />
                       </div>
                     </div>
                   )}
@@ -611,10 +611,10 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
         const projectId = await Apis.getProjectId();
         const clusterName = await Apis.getClusterName();
         this.setStateSafe({
-          legacyStackdriverUrl: `https://pantheon.corp.google.com/logs/viewer?project=${projectId}&interval=NO_LIMIT&advancedFilter=resource.type%3D"container"%0Aresource.labels.cluster_name:"${clusterName}"%0Aresource.labels.pod_id:"${selectedNodeDetails.id}"`,
+          legacyStackdriverUrl: `https://console.cloud.google.com/logs/viewer?project=${projectId}&interval=NO_LIMIT&advancedFilter=resource.type%3D"container"%0Aresource.labels.cluster_name:"${clusterName}"%0Aresource.labels.pod_id:"${selectedNodeDetails.id}"`,
           logsBannerMessage: 'Warning: failed to retrieve pod logs. Possible reasons include cluster autoscaling or pod preemption',
           logsBannerMode: 'warning',
-          stackdriverK8sLogsUrl: `https://pantheon.corp.google.com/logs/viewer?project=${projectId}&interval=NO_LIMIT&advancedFilter=resource.type%3D"k8s_container"%0Aresource.labels.cluster_name:"${clusterName}"%0Aresource.labels.pod_name:"${selectedNodeDetails.id}"`,
+          stackdriverK8sLogsUrl: `https://console.cloud.google.com/logs/viewer?project=${projectId}&interval=NO_LIMIT&advancedFilter=resource.type%3D"k8s_container"%0Aresource.labels.cluster_name:"${clusterName}"%0Aresource.labels.pod_name:"${selectedNodeDetails.id}"`,
         });
       } catch (fetchSystemInfoErr) {
         const errorMessage = await errorToMessage(err);

--- a/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
@@ -1140,7 +1140,7 @@ exports[`RunDetails logs tab shows warning banner and link to Stackdriver in log
                     Logs can still be viewed in either 
                     <a
                       className="link unstyled"
-                      href="https://pantheon.corp.google.com/logs/viewer?project=test-project-id&interval=NO_LIMIT&advancedFilter=resource.type%3D\\"container\\"%0Aresource.labels.cluster_name:\\"test-cluster-name\\"%0Aresource.labels.pod_id:\\"node1\\""
+                      href="https://console.cloud.google.com/logs/viewer?project=test-project-id&interval=NO_LIMIT&advancedFilter=resource.type%3D\\"container\\"%0Aresource.labels.cluster_name:\\"test-cluster-name\\"%0Aresource.labels.pod_id:\\"node1\\""
                       target="_blank"
                     >
                       Legacy Stackdriver
@@ -1148,7 +1148,7 @@ exports[`RunDetails logs tab shows warning banner and link to Stackdriver in log
                      or in 
                     <a
                       className="link unstyled"
-                      href="https://pantheon.corp.google.com/logs/viewer?project=test-project-id&interval=NO_LIMIT&advancedFilter=resource.type%3D\\"k8s_container\\"%0Aresource.labels.cluster_name:\\"test-cluster-name\\"%0Aresource.labels.pod_name:\\"node1\\""
+                      href="https://console.cloud.google.com/logs/viewer?project=test-project-id&interval=NO_LIMIT&advancedFilter=resource.type%3D\\"k8s_container\\"%0Aresource.labels.cluster_name:\\"test-cluster-name\\"%0Aresource.labels.pod_name:\\"node1\\""
                       target="_blank"
                     >
                       Stackdriver Kubernetes Monitoring


### PR DESCRIPTION
**Background**

#1310 added links to show Stackdriver logs. However, the links seem to be some Google-internal links. 

**Changes**

In this PR, I updated the links to using `console.cloud.google.com`.

**Test Plan**

- [x] Verified manually that by changing the prefix from `pantheon.corp.google.com` to `console.cloud.google.com` and keep the rest of the URL the same, we can correctly fetch the logs from Stackdriver k8s logs.

- [ ] I was not able to fetch the logs from Legacy Stackdriver logging though but I don't think that's an issue of this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1552)
<!-- Reviewable:end -->
