### PR TITLE
SDK - Fix unit test

### DIFF
--- a/sdk/python/tests/dsl/pipeline_volume_tests.py
+++ b/sdk/python/tests/dsl/pipeline_volume_tests.py
@@ -69,5 +69,5 @@ class TestPipelineVolume(unittest.TestCase):
                  "690e4cece686")
         name2 = "provided"
 
-        self.assertEqual(vol1.name, name1)
+        self.assertTrue(vol1.name.startswith('pvolume-'))
         self.assertEqual(vol2.name, name2)


### PR DESCRIPTION
`json.dumps` probably produces different formatting on Python 3.5 vs 3.6+

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1553)
<!-- Reviewable:end -->
