### PR TITLE
Use sorted(dict.items()) for stable output

### DIFF
--- a/sdk/python/kfp/dsl/_pipeline_volume.py
+++ b/sdk/python/kfp/dsl/_pipeline_volume.py
@@ -70,7 +70,7 @@ class PipelineVolume(V1Volume):
 
         if not name_provided:
             self.name = "pvolume-%s" % hashlib.sha256(
-                bytes(str(self.to_dict()), "utf-8")
+                bytes(str(sorted(self.to_dict().items())), "utf-8")
             ).hexdigest()
         self.dependent_names = []
 

--- a/sdk/python/tests/dsl/pipeline_volume_tests.py
+++ b/sdk/python/tests/dsl/pipeline_volume_tests.py
@@ -65,8 +65,8 @@ class TestPipelineVolume(unittest.TestCase):
         """Test PipelineVolume creation when omitting "name"."""
         vol1 = PipelineVolume(pvc="foo")
         vol2 = PipelineVolume(name="provided", pvc="foo")
-        name1 = ("pvolume-109601a31098e6c92e2ad294fee3fae234e3f52398d3b077b0e0"
-                 "690e4cece686")
+        name1 = ("pvolume-09f01902e87dc9412e06bc23457456afc12ad58115c1e788709e"
+                 "f6a7ab283018")
         name2 = "provided"
 
         self.assertEqual(vol1.name, name1)


### PR DESCRIPTION
**Background**

CI builds are failing [a lot](https://travis-ci.com/kubeflow/pipelines/jobs/210674655#L1459) due to a flaky unit test. 

**Changes**

I used `sorted(dict.items())` to get a stable `str()` output.

**Test Plan**

- [ ] Update the unit tests and make sure it passes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1554)
<!-- Reviewable:end -->
