### PR TITLE
Sort keys in nested dictionaries for fixing unit tests

### DIFF
--- a/sdk/python/kfp/dsl/_pipeline_volume.py
+++ b/sdk/python/kfp/dsl/_pipeline_volume.py
@@ -14,6 +14,7 @@
 
 
 import hashlib
+import json
 
 from kubernetes.client.models import (
     V1Volume, V1PersistentVolumeClaimVolumeSource
@@ -70,7 +71,7 @@ class PipelineVolume(V1Volume):
 
         if not name_provided:
             self.name = "pvolume-%s" % hashlib.sha256(
-                bytes(str(sorted(self.to_dict().items())), "utf-8")
+                bytes(json.dumps(self.to_dict(), sort_keys=True), "utf-8")
             ).hexdigest()
         self.dependent_names = []
 

--- a/sdk/python/tests/dsl/pipeline_volume_tests.py
+++ b/sdk/python/tests/dsl/pipeline_volume_tests.py
@@ -65,8 +65,8 @@ class TestPipelineVolume(unittest.TestCase):
         """Test PipelineVolume creation when omitting "name"."""
         vol1 = PipelineVolume(pvc="foo")
         vol2 = PipelineVolume(name="provided", pvc="foo")
-        name1 = ("pvolume-09f01902e87dc9412e06bc23457456afc12ad58115c1e788709e"
-                 "f6a7ab283018")
+        name1 = ("pvolume-127ac63cf2013e9b95c192eb6a2c7d5a023ebeb51f6a114486e31"
+                 "216e083a563")
         name2 = "provided"
 
         self.assertEqual(vol1.name, name1)

--- a/sdk/python/tests/dsl/pipeline_volume_tests.py
+++ b/sdk/python/tests/dsl/pipeline_volume_tests.py
@@ -65,8 +65,8 @@ class TestPipelineVolume(unittest.TestCase):
         """Test PipelineVolume creation when omitting "name"."""
         vol1 = PipelineVolume(pvc="foo")
         vol2 = PipelineVolume(name="provided", pvc="foo")
-        name1 = ("pvolume-127ac63cf2013e9b95c192eb6a2c7d5a023ebeb51f6a114486e31"
-                 "216e083a563")
+        name1 = ("pvolume-127ac63cf2013e9b95c192eb6a2c7d5a023ebeb51f6a114486e3"
+                 "1216e083a563")
         name2 = "provided"
 
         self.assertEqual(vol1.name, name1)


### PR DESCRIPTION
**Background**

#1554 actually still doesn't work since the `self.to_dict()` output contains nested dictionaries so just `sort(dict.items())` won't work.

**Changes**

Used `json.dumps(dict, sort_keys=True)` instead.

**Test Plan**

- [x] Verified the output locally and it seems OK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1558)
<!-- Reviewable:end -->
