### PR TITLE
Manifests: Update pipeline-runner permissions

### DIFF
--- a/manifests/base/pipeline/pipeline-runner-role.yaml
+++ b/manifests/base/pipeline/pipeline-runner-role.yaml
@@ -25,6 +25,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
   - argoproj.io
   resources:
   - workflows


### PR DESCRIPTION
Supplement pipeline-runner permissions according to kubeflow/kubeflow#2556

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1570)
<!-- Reviewable:end -->
