### PR TITLE
viewer controller is now namespaced so no need for cluster role

### DIFF
--- a/backend/src/crd/controller/viewer/reconciler/reconciler.go
+++ b/backend/src/crd/controller/viewer/reconciler/reconciler.go
@@ -91,7 +91,7 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 	}
 
 	// Check and maybe delete the oldest viewer before creating the next one.
-	if err := r.maybeDeleteOldestViewer(view.Spec.Type); err != nil {
+	if err := r.maybeDeleteOldestViewer(view.Spec.Type, view.Namespace); err != nil {
 		// Couldn't delete. Requeue.
 		return reconcile.Result{Requeue: true}, err
 	}
@@ -254,10 +254,10 @@ func serviceFrom(v *viewerV1beta1.Viewer, deploymentName string) *corev1.Service
 	}
 }
 
-func (r *Reconciler) maybeDeleteOldestViewer(t viewerV1beta1.ViewerType) error {
+func (r *Reconciler) maybeDeleteOldestViewer(t viewerV1beta1.ViewerType, namespace string) error {
 	list := &viewerV1beta1.ViewerList{}
 
-	if err := r.Client.List(context.Background(), &client.ListOptions{}, list); err != nil {
+	if err := r.Client.List(context.Background(), &client.ListOptions{Namespace: namespace}, list); err != nil {
 		return fmt.Errorf("failed to list viewers: %v", err)
 	}
 

--- a/manifests/base/pipeline/ml-pipeline-viewer-crd-role.yaml
+++ b/manifests/base/pipeline/ml-pipeline-viewer-crd-role.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
+kind: Role
 metadata:
   name: ml-pipeline-viewer-controller-role
 rules:

--- a/manifests/base/pipeline/ml-pipeline-viewer-crd-rolebinding.yaml
+++ b/manifests/base/pipeline/ml-pipeline-viewer-crd-rolebinding.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: ml-pipeline-viewer-crd-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: ml-pipeline-viewer-controller-role
 subjects:
 - kind: ServiceAccount

--- a/manifests/namespaced-install.yaml
+++ b/manifests/namespaced-install.yaml
@@ -360,9 +360,10 @@ rules:
   - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
+kind: Role
 metadata:
   name: ml-pipeline-viewer-controller-role
+  namespace: kubeflow
 rules:
 - apiGroups:
   - '*'
@@ -495,12 +496,13 @@ subjects:
   namespace: kubeflow
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: ml-pipeline-viewer-crd-binding
+  namespace: kubeflow
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: ml-pipeline-viewer-controller-role
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
Two changes: (1) in reconciler.go, the original r.Client.List without specifying namespace requires cluster scope role, and thus change it to use an explicit namespace (2) remove cluster role and cluster role binding from two places: namespaced_install.yaml and base/pipeline/ml-pipeline-viewer-crd-*.yaml

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1623)
<!-- Reviewable:end -->
