### PR TITLE
Removed duplicate CircularProgress within UI

### DIFF
--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -209,9 +209,6 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
                           selectedTab={sidepanelSelectedTab}
                           onSwitch={this._loadSidePaneTab.bind(this)} />
 
-                        {this.state.sidepanelBusy &&
-                          <CircularProgress size={30} className={commonCss.absoluteCenter} />}
-
                         <div className={commonCss.page}>
                           {sidepanelSelectedTab === SidePaneTab.ARTIFACTS && (
                             <div className={commonCss.page}>

--- a/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
@@ -1251,10 +1251,6 @@ exports[`RunDetails logs tab switches to logs tab in side pane 1`] = `
                   ]
                 }
               />
-              <WithStyles(CircularProgress)
-                className="absoluteCenter"
-                size={30}
-              />
               <div
                 className="page"
               >


### PR DESCRIPTION
Previously, there was a CircularProgress to indicate that the UI is busy within the [RunDetails.tsx](https://github.com/kubeflow/pipelines/blob/24aae0d08205d9fc8f06a5bcc41e7d066d623817/frontend/src/pages/RunDetails.tsx#L213) and [SidePanel.tsx](https://github.com/kubeflow/pipelines/blob/a8b910787824d5fe08fc98f9f0dd8be54ac66e8e/frontend/src/components/SidePanel.tsx#L81). This removes the CircularProgress from RunDetails.tsx.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1625)
<!-- Reviewable:end -->
