### PR TITLE
SDK - Lightweight - Added support for "None" default values

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -156,8 +156,12 @@ def _extract_component_interface(func) -> ComponentSpec:
         input_spec = InputSpec(
             name=parameter.name,
             type=type_struct,
-            default=str(parameter.default) if parameter.default is not inspect.Parameter.empty else None,
         )
+        if parameter.default is not inspect.Parameter.empty:
+            if parameter.default is None:
+                input_spec.optional = True
+            else:
+                input_spec.default = str(parameter.default)
         inputs.append(input_spec)
 
     #Analyzing the return type annotations.
@@ -245,16 +249,27 @@ def _func_to_component_spec(func, extra_code='', base_image=_default_base_image,
     arguments = []
     for input in component_spec.inputs:
         param_flag = "--" + input.name.replace("_", "-")
+        is_required = not input.optional and input.default is None
         line = '_parser.add_argument("{param_flag}", dest="{param_var}", type={param_type}, required={is_required}, default={default_repr})'.format(
             param_flag=param_flag,
             param_var=input.name,
             param_type=(input.type if input.type in ['int', 'float', 'bool'] else 'str'),
-            is_required=str(input.default is None), # TODO: Handle actual 'None' defaults!
+            is_required=str(is_required),
             default_repr=repr(str(input.default)) if input.default is not None else None,
         )
         arg_parse_code_lines.append(line)
-        arguments.append(param_flag)
-        arguments.append(InputValuePlaceholder(input.name))
+        if is_required:
+            arguments.append(param_flag)
+            arguments.append(InputValuePlaceholder(input.name))
+        else:
+            arguments.append(
+                IfPlaceholder(
+                    IfPlaceholderStructure(
+                        condition=IsPresentPlaceholder(input.name),
+                        then_value=[param_flag, InputValuePlaceholder(input.name)],
+                    )
+                )
+            )
 
     if component_spec.outputs:
         param_flag="----output-paths"

--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -249,7 +249,7 @@ def _func_to_component_spec(func, extra_code='', base_image=_default_base_image,
     arguments = []
     for input in component_spec.inputs:
         param_flag = "--" + input.name.replace("_", "-")
-        is_required = not input.optional and input.default is None
+        is_required = not input.optional #TODO: Make all parameters with default values optional in argparse so that the complex defaults can be preserved.
         line = '_parser.add_argument("{param_flag}", dest="{param_var}", type={param_type}, required={is_required}, default={default_repr})'.format(
             param_flag=param_flag,
             param_var=input.name,

--- a/sdk/python/kfp/components/_structures.py
+++ b/sdk/python/kfp/components/_structures.py
@@ -21,6 +21,7 @@ __all__ = [
     'OutputPathPlaceholder',
     'ConcatPlaceholder',
     'IsPresentPlaceholder',
+    'IfPlaceholderStructure',
     'IfPlaceholder',
 
     'ContainerSpec',

--- a/sdk/python/tests/components/test_python_op.py
+++ b/sdk/python/tests/components/test_python_op.py
@@ -270,6 +270,15 @@ class PythonOpTestCase(unittest.TestCase):
         self.assertEqual(component_spec.inputs[0].default, '3')
         self.assertEqual(component_spec.inputs[1].default, '5')
 
+    def test_handling_default_value_of_none(self):
+        def assert_is_none(a, b, arg=None) -> int:
+            assert arg is None
+            return 1
+
+        func = assert_is_none
+        op = comp.func_to_container_op(func, output_component_file='comp.yaml')
+        self.helper_test_2_in_1_out_component_using_local_call(func, op)
+
     def test_end_to_end_python_component_pipeline_compilation(self):
         import kfp.components as comp
 


### PR DESCRIPTION
Previously it was impossible to pass None to components since it was being converted to the string "None".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1626)
<!-- Reviewable:end -->
