### PR TITLE
Add SageMaker HPO component and sample usage in a pipeline

### DIFF
--- a/components/aws/sagemaker/Dockerfile
+++ b/components/aws/sagemaker/Dockerfile
@@ -17,8 +17,9 @@ RUN apt-get update -y && apt-get install --no-install-recommends -y -q ca-certif
 
 RUN easy_install pip
 
-RUN pip install boto3==1.9.130 sagemaker pathlib2
+RUN pip install boto3==1.9.169 sagemaker pathlib2 pyyaml==3.12
 
+COPY hyperparameter_tuning/src/hyperparameter_tuning.py .
 COPY train/src/train.py .
 COPY deploy/src/deploy.py .
 COPY model/src/create_model.py .

--- a/components/aws/sagemaker/common/_utils.py
+++ b/components/aws/sagemaker/common/_utils.py
@@ -274,7 +274,7 @@ def create_hyperparameter_tuning_job_request(args):
         logging.error('Please specify training image or algorithm name.')
         raise Exception('Could not create job request')
     if args['image'] and args['algorithm_name']:
-        logging.error('Both image and algorithm name inputted, only one allowed. Proceeding with image.')
+        logging.error('Both image and algorithm name inputted, only one should be specified. Proceeding with image.')
 
     if args['image']:
         request['TrainingJobDefinition']['AlgorithmSpecification']['TrainingImage'] = args['image']
@@ -300,7 +300,6 @@ def create_hyperparameter_tuning_job_request(args):
     else:
         request['TrainingJobDefinition']['AlgorithmSpecification'].pop('MetricDefinitions')
 
-    # TODO: clarify if both security group ids and subnets are required for vpc config
     ### Update or pop VPC configs
     if args['vpc_security_group_ids'] and args['vpc_subnets']:
         request['TrainingJobDefinition']['VpcConfig']['SecurityGroupIds'] = [args['vpc_security_group_ids']]
@@ -345,9 +344,7 @@ def create_hyperparameter_tuning_job_request(args):
                 logging.error('Must specify warm start type as either "IdenticalDataAndAlgorithm" or "TransferLearning".')
             if not args['parent_hpo_jobs']:
                 logging.error("Must specify at least one parent hyperparameter tuning job")
-            # TODO: determine what should actually happen here
-            # raise Exception('Could not create job request')
-            logging.info("Proceeding without warm start")
+            raise Exception('Could not make job request')
         request.pop('WarmStartConfig')
 
     ### Update tags

--- a/components/aws/sagemaker/common/_utils.py
+++ b/components/aws/sagemaker/common/_utils.py
@@ -19,11 +19,16 @@ import time
 import string
 import random
 import json
+import yaml
 from urlparse import urlparse
 
 import boto3
 from botocore.exceptions import ClientError
 from sagemaker import get_execution_role
+from sagemaker.amazon.amazon_estimator import get_image_uri
+
+import logging
+logging.getLogger().setLevel(logging.INFO)
 
 def get_client(region=None):
     """Builds a client to the AWS SageMaker API."""
@@ -53,10 +58,10 @@ def create_training_job(client, image, instance_type, instance_count, volume_siz
           "VolumeSizeInGB": volume_size
       },
       "TrainingJobName": job_name,
-      "HyperParameters": {	
-          "k": "10",	
-          "feature_dim": "784",	
-          "mini_batch_size": "500"	
+      "HyperParameters": {
+          "k": "10",
+          "feature_dim": "784",
+          "mini_batch_size": "500"
       },
       "StoppingCondition": {
           "MaxRuntimeInSeconds": 60 * 60
@@ -220,6 +225,175 @@ def print_tranformation_job_result(output_location):
   with open('valid-result') as f:
     results = f.readlines()
   print("Sample transform result: {}".format(results[0]))
+
+
+def create_hyperparameter_tuning_job_request(args):
+    with open('/app/common/hpo.template.yaml', 'r') as f:
+        request = yaml.safe_load(f)
+
+    built_in_algos = {
+        'blazingtext': 'blazingtext',
+        'deepar forecasting': 'forecasting-deepar',
+        'factorization machines': 'factorization-machines',
+        'image classification': 'image-classification',
+        'ip insights': 'ipinsights',
+        'k-means': 'kmeans',
+        'k-nearest neighbors': 'knn',
+        'k-nn': 'knn',
+        'lda': 'lda',
+        'linear learner': 'linear-learner',
+        'neural topic model': 'ntm',
+        'object2vec': 'object2vec',
+        'object detection': 'object-detection',
+        'pca': 'pca',
+        'random cut forest': 'randomcutforest',
+        'semantic segmentation': 'semantic-segmentation',
+        'sequence to sequence': 'seq2seq',
+        'seq2seq modeling': 'seq2seq',
+        'xgboost': 'xgboost'
+    }
+
+    ### Create a hyperparameter tuning job
+    if args['job_name']:
+        hpo_job_name = args['job_name']
+    else:
+        hpo_job_name = "HPOJob-" + strftime("%Y%m%d%H%M%S", gmtime()) + '-' + id_generator()
+
+    request['HyperParameterTuningJobName'] = hpo_job_name
+
+    request['HyperParameterTuningJobConfig']['Strategy'] = args['strategy']
+    request['HyperParameterTuningJobConfig']['HyperParameterTuningJobObjective']['Type'] = args['metric_type']
+    request['HyperParameterTuningJobConfig']['HyperParameterTuningJobObjective']['MetricName'] = args['metric_name']
+    request['HyperParameterTuningJobConfig']['ResourceLimits']['MaxNumberOfTrainingJobs'] = args['max_num_jobs']
+    request['HyperParameterTuningJobConfig']['ResourceLimits']['MaxParallelTrainingJobs'] = args['max_parallel_jobs']
+    request['HyperParameterTuningJobConfig']['ParameterRanges']['IntegerParameterRanges'] = args['integer_parameters']
+    request['HyperParameterTuningJobConfig']['ParameterRanges']['ContinuousParameterRanges'] = args['continuous_parameters']
+    request['HyperParameterTuningJobConfig']['ParameterRanges']['CategoricalParameterRanges'] = args['categorical_parameters']
+    request['HyperParameterTuningJobConfig']['TrainingJobEarlyStoppingType'] = args['early_stopping_type']
+
+    request['TrainingJobDefinition']['StaticHyperParameters'] = args['static_parameters']
+    request['TrainingJobDefinition']['AlgorithmSpecification']['TrainingInputMode'] = args['training_input_mode']
+
+    # TODO: determine if algorithm name or training image is used for algorithms from AWS marketplace
+    ### Update training image (for BYOC) or algorithm resource name
+    if not args['image'] and not args['algorithm_name']:
+        logging.error('Please specify training image or algorithm name.')
+        raise Exception('Could not create job request')
+    if args['image'] and args['algorithm_name']:
+        logging.error('Both image and algorithm name inputted, only one allowed. Proceeding with image.')
+
+    if args['image']:
+        request['TrainingJobDefinition']['AlgorithmSpecification']['TrainingImage'] = args['image']
+        request['TrainingJobDefinition']['AlgorithmSpecification'].pop('AlgorithmName')
+    else:
+        # TODO: determine if users can make custom algorithm resources that have the same name as built-in algorithm names
+        algo_name = args['algorithm_name'].lower().strip()
+        if algo_name in built_in_algos.keys():
+            request['TrainingJobDefinition']['AlgorithmSpecification']['TrainingImage'] = get_image_uri(args['region'], built_in_algos[algo_name])
+            request['TrainingJobDefinition']['AlgorithmSpecification'].pop('AlgorithmName')
+        # Just to give the user more leeway for built-in algorithm name inputs
+        elif algo_name in built_in_algos.values():
+            request['TrainingJobDefinition']['AlgorithmSpecification']['TrainingImage'] = get_image_uri(args['region'], algo_name)
+            request['TrainingJobDefinition']['AlgorithmSpecification'].pop('AlgorithmName')
+        else:
+            request['TrainingJobDefinition']['AlgorithmSpecification']['AlgorithmName'] = args['algorithm_name']
+            request['TrainingJobDefinition']['AlgorithmSpecification'].pop('TrainingImage')
+
+    ### Update metric definitions
+    if args['metric_definitions']:
+        for key, val in args['metric_definitions'].items():
+            request['TrainingJobDefinition']['AlgorithmSpecification']['MetricDefinitions'].append({'Name': key, 'Regex': val})
+    else:
+        request['TrainingJobDefinition']['AlgorithmSpecification'].pop('MetricDefinitions')
+
+    # TODO: clarify if both security group ids and subnets are required for vpc config
+    ### Update or pop VPC configs
+    if args['vpc_security_group_ids'] and args['vpc_subnets']:
+        request['TrainingJobDefinition']['VpcConfig']['SecurityGroupIds'] = [args['vpc_security_group_ids']]
+        request['TrainingJobDefinition']['VpcConfig']['Subnets'] = [args['vpc_subnets']]
+    else:
+        request['TrainingJobDefinition'].pop('VpcConfig')
+
+    ### Update input channels, must have at least one specified
+    if len(args['channels']) > 0:
+        request['TrainingJobDefinition']['InputDataConfig'] = args['channels']
+    else:
+        logging.error("Must specify at least one input channel.")
+        raise Exception('Could not make job request')
+
+    request['TrainingJobDefinition']['OutputDataConfig']['S3OutputPath'] = args['output_location']
+    request['TrainingJobDefinition']['OutputDataConfig']['KmsKeyId'] = args['output_encryption_key']
+    request['TrainingJobDefinition']['ResourceConfig']['InstanceType'] = args['instance_type']
+    request['TrainingJobDefinition']['ResourceConfig']['InstanceCount'] = args['instance_count']
+    request['TrainingJobDefinition']['ResourceConfig']['VolumeSizeInGB'] = args['volume_size']
+    request['TrainingJobDefinition']['ResourceConfig']['VolumeKmsKeyId'] = args['resource_encryption_key']
+    request['TrainingJobDefinition']['StoppingCondition']['MaxRuntimeInSeconds'] = args['max_run_time']
+    request['TrainingJobDefinition']['EnableNetworkIsolation'] = args['network_isolation']
+    request['TrainingJobDefinition']['EnableInterContainerTrafficEncryption'] = args['traffic_encryption']
+    request['TrainingJobDefinition']['RoleArn'] = args['role']
+
+    ### Update or pop warm start configs
+    if args['warm_start_type'] and args['parent_hpo_jobs']:
+        request['WarmStartConfig']['WarmStartType'] = args['warm_start_type']
+        parent_jobs = [n.strip() for n in args['parent_hpo_jobs'].split(',')]
+        for i in range(len(parent_jobs)):
+            request['WarmStartConfig']['ParentHyperParameterTuningJobs'].append({'HyperParameterTuningJobName': parent_jobs[i]})
+    else:
+        if args['warm_start_type'] or args['parent_hpo_jobs']:
+            if not args['warm_start_type']:
+                logging.error('Must specify warm start type as either "IdenticalDataAndAlgorithm" or "TransferLearning".')
+            if not args['parent_hpo_jobs']:
+                logging.error("Must specify at least one parent hyperparameter tuning job")
+            # TODO: determine what should actually happen here
+            # raise Exception('Could not create job request')
+            logging.info("Proceeding without warm start")
+        request.pop('WarmStartConfig')
+
+    ### Update tags
+    for key, val in args['tags'].items():
+        request['Tags'].append({'Key': key, 'Value': val})
+
+    return request
+
+
+def create_hyperparameter_tuning_job(client, args):
+    """Create a Sagemaker HPO job"""
+    request = create_hyperparameter_tuning_job_request(args)
+    try:
+        job_arn = client.create_hyper_parameter_tuning_job(**request)
+        hpo_job_name = request['HyperParameterTuningJobName']
+        logging.info("Created Hyperparameter Training Job with name: " + hpo_job_name)
+        logging.info("URL: https://{}.console.aws.amazon.com/sagemaker/home?region={}#/hyper-tuning-jobs/{}".format(args['region'], args['region'], hpo_job_name))
+        return hpo_job_name
+    except ClientError as e:
+        raise Exception(e.response['Error']['Message'])
+
+
+def wait_for_hyperparameter_training_job(client, hpo_job_name):
+    ### Wait until the job finishes
+    while(True):
+        response = client.describe_hyper_parameter_tuning_job(HyperParameterTuningJobName=hpo_job_name)
+        status = response['HyperParameterTuningJobStatus']
+        if status == 'Completed':
+            logging.info("Hyperparameter tuning job ended with status: " + status)
+            break
+        if status == 'Failed':
+            message = response['FailureReason']
+            logging.error('Hyperparameter tuning failed with the following error: {}'.format(message))
+            raise Exception('Hyperparameter tuning job failed')
+        logging.info("Hyperparameter tuning job is still in status: " + status)
+        time.sleep(30)
+
+
+def get_best_training_job_and_hyperparameters(client, hpo_job_name):
+    ### Get and return best training job and its hyperparameters, without the objective metric
+    info = client.describe_hyper_parameter_tuning_job(HyperParameterTuningJobName=hpo_job_name)
+    best_job = info['BestTrainingJob']['TrainingJobName']
+    training_info = client.describe_training_job(TrainingJobName=best_job)
+    train_hyperparameters = training_info['HyperParameters']
+    train_hyperparameters.pop('_tuning_objective_metric')
+    return best_job, train_hyperparameters
+
 
 def id_generator(size=4, chars=string.ascii_uppercase + string.digits):
   return ''.join(random.choice(chars) for _ in range(size))

--- a/components/aws/sagemaker/common/hpo.template.yaml
+++ b/components/aws/sagemaker/common/hpo.template.yaml
@@ -1,0 +1,42 @@
+HyperParameterTuningJobName: ''
+HyperParameterTuningJobConfig:
+  Strategy: ''
+  HyperParameterTuningJobObjective:
+    Type: ''
+    MetricName: ''
+  ResourceLimits:
+    MaxNumberOfTrainingJobs: 0
+    MaxParallelTrainingJobs: 0
+  ParameterRanges:
+    IntegerParameterRanges: []
+    ContinuousParameterRanges: []
+    CategoricalParameterRanges: []
+  TrainingJobEarlyStoppingType: ''
+TrainingJobDefinition:
+  StaticHyperParameters: {}
+  AlgorithmSpecification:
+    TrainingImage: ''
+    TrainingInputMode: ''
+    AlgorithmName: ''
+    MetricDefinitions: []
+  RoleArn: ''
+  InputDataConfig: []
+  VpcConfig:
+    SecurityGroupIds: []
+    Subnets: []
+  OutputDataConfig:
+    KmsKeyId: ''
+    S3OutputPath: ''
+  ResourceConfig:
+    InstanceType: ''
+    InstanceCount: 0
+    VolumeSizeInGB: 0
+    VolumeKmsKeyId: ''
+  StoppingCondition:
+    MaxRuntimeInSeconds: 0
+  EnableNetworkIsolation: True
+  EnableInterContainerTrafficEncryption: False
+WarmStartConfig:
+  ParentHyperParameterTuningJobs: []
+  WarmStartType: ''
+Tags: []

--- a/components/aws/sagemaker/common/hpo.template.yaml
+++ b/components/aws/sagemaker/common/hpo.template.yaml
@@ -29,11 +29,11 @@ TrainingJobDefinition:
     S3OutputPath: ''
   ResourceConfig:
     InstanceType: ''
-    InstanceCount: 0
-    VolumeSizeInGB: 0
+    InstanceCount: 1
+    VolumeSizeInGB: 1
     VolumeKmsKeyId: ''
   StoppingCondition:
-    MaxRuntimeInSeconds: 0
+    MaxRuntimeInSeconds: 86400
   EnableNetworkIsolation: True
   EnableInterContainerTrafficEncryption: False
 WarmStartConfig:

--- a/components/aws/sagemaker/hyperparameter_tuning/Dockerfile
+++ b/components/aws/sagemaker/hyperparameter_tuning/Dockerfile
@@ -1,0 +1,28 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+FROM ubuntu:16.04
+
+RUN apt-get update -y && apt-get install --no-install-recommends -y -q ca-certificates python-dev python-setuptools wget unzip
+
+RUN easy_install pip
+
+RUN pip install boto3==1.9.169 sagemaker pathlib2 pyyaml==3.12
+
+COPY hyperparameter_tuning/src/hyperparameter_tuning.py .
+
+COPY common /app/common/
+
+ENV PYTHONPATH /app
+
+ENTRYPOINT [ "bash" ]

--- a/components/aws/sagemaker/hyperparameter_tuning/README.md
+++ b/components/aws/sagemaker/hyperparameter_tuning/README.md
@@ -51,14 +51,14 @@ best_job_name | Best hyperparameter tuning training job name
 best_hyperparameters | Tuned hyperparameters
 
 # Requirements
-* Kubeflow pipelines SDK: https://www.kubeflow.org/docs/pipelines/sdk/install-sdk/
-* Kubeflow set-up
+* [Kubeflow pipelines SDK](https://www.kubeflow.org/docs/pipelines/sdk/install-sdk/)
+* [Kubeflow set-up](https://www.kubeflow.org/docs/aws/deploy/install-kubeflow/)
 
 # Samples
 ## On its own
 K-Means algorithm tuning on MNIST dataset: /kubeflow/pipelines/samples/aws-samples/mnist-kmeans-sagemaker/kmeans-hpo-pipeline.py
 
-Follow the same steps as in the README for the MNIST classification pipeline:
+Follow the same steps as in the [README](https://github.com/kubeflow/pipelines/blob/master/samples/aws-samples/mnist-kmeans-sagemaker/README.md) for the [MNIST classification pipeline](https://github.com/kubeflow/pipelines/blob/master/samples/aws-samples/mnist-kmeans-sagemaker/mnist-classification-pipeline.py):
 1. Get and store data in S3 buckets
 2. Prepare an IAM roles with permissions to run SageMaker jobs
 3. Add 'aws-secret' to your kubeflow namespace
@@ -73,4 +73,5 @@ dsl-compile --py kmeans-hpo-pipeline.py --output kmeans-hpo-pipeline.tar.gz
 MNIST Classification using K-Means pipeline: [Coming Soon]
 
 # Resources
-* Using Amazon built-in algorithms https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
+* [Using Amazon built-in algorithms](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html)
+* [More information on request parameters](https://github.com/awsdocs/amazon-sagemaker-developer-guide/blob/master/doc_source/API_CreateHyperParameterTuningJob.md#request-parameters)

--- a/components/aws/sagemaker/hyperparameter_tuning/README.md
+++ b/components/aws/sagemaker/hyperparameter_tuning/README.md
@@ -1,0 +1,76 @@
+# SageMaker hyperparameter optimization Kubeflow Pipeline component
+## Summary
+Component to submit hyperparameter tuning jobs to SageMaker directly from a Kubeflow Pipelines workflow.
+
+# Details
+
+## Intended Use
+For hyperparameter tuning jobs using AWS SageMaker.
+
+## Runtime Arguments
+Argument        | Description                 | Optional   | Data type  | Accepted values | Default    |
+:---            | :----------                 | :----------| :----------| :----------     | :----------|
+region | The region where the cluster launches | No | String | | |
+job_name | The name of the tuning job. Must be unique within the same AWS account and AWS region | Yes | String | | |
+image | The registry path of the Docker image that contains the training algorithm | No | String | | |
+role | The Amazon Resource Name (ARN) that Amazon SageMaker assumes to perform tasks on your behalf | No | String | | |
+algorithm_name | The name of the algorithm resource to use for the hyperparameter tuning job; only specify this parameter if training image is not specified | Yes | String | | |
+training_input_mode | The input mode that the algorithm supports | No | String | File, Pipe | File |
+metric_definitions | The dictionary of name-regex pairs specify the metrics that the algorithm emits | Yes | Dict | | {} |
+strategy | How hyperparameter tuning chooses the combinations of hyperparameter values to use for the training job it launches | No | String | Bayesian, Random | Bayesian |
+metric_name | The name of the metric to use for the objective metric | No | String | | |
+metric_type | Whether to minimize or maximize the objective metric | No | String | Maximize, Minimize | |
+early_stopping_type | Whether to minimize or maximize the objective metric | No | String | Off, Auto | Off |
+static_parameters | The values of hyperparameters that do not change for the tuning job | Yes | Dict | | {} |
+integer_parameters | The array of IntegerParameterRange objects that specify ranges of integer hyperparameters that you want to search | Yes | List of Dicts | | [] |
+continuous_parameters | The array of ContinuousParameterRange objects that specify ranges of continuous hyperparameters that you want to search | Yes | List of Dicts | | [] |
+categorical_parameters | The array of CategoricalParameterRange objects that specify ranges of categorical hyperparameters that you want to search | Yes | List of Dicts | | [] |
+channels | A list of dicts specifying the input channels (at least one); refer to documentation for parameters | No | List of Dicts | | [{}] |
+output_location | The Amazon S3 path where you want Amazon SageMaker to store the results of the transform job | No | String | | |
+output_encryption_key | The AWS KMS key that Amazon SageMaker uses to encrypt the model artifacts | Yes | String | | |
+instance_type | The ML compute instance type | No | String | ml.m4.xlarge, ml.m4.2xlarge, ml.m4.4xlarge, ml.m4.10xlarge, ml.m4.16xlarge, ml.m5.large, ml.m5.xlarge, ml.m5.2xlarge, ml.m5.4xlarge, ml.m5.12xlarge, ml.m5.24xlarge, ml.c4.xlarge, ml.c4.2xlarge, ml.c4.4xlarge, ml.c4.8xlarge, ml.p2.xlarge, ml.p2.8xlarge, ml.p2.16xlarge, ml.p3.2xlarge, ml.p3.8xlarge, ml.p3.16xlarge, ml.c5.xlarge, ml.c5.2xlarge, ml.c5.4xlarge, ml.c5.9xlarge, ml.c5.18xlarge | ml.m4.xlarge |
+instance_count | The number of ML compute instances to use in each training job | No | Int | ≥ 1 | 1 |
+volume_size | The size of the ML storage volume that you want to provision in GB | No | Int | ≥ 1 | 1 |
+max_num_jobs | The maximum number of training jobs that a hyperparameter tuning job can launch | No | Int | [1, 500] | |
+max_parallel_jobs | The maximum number of concurrent training jobs that a hyperparameter tuning job can launch | No | Int | [1, 10] | |
+max_run_time | The maximum run time in seconds per training job | No | Int | ≤ 432000 (5 days) | 86400 (1 day) |
+resource_encryption_key | The AWS KMS key that Amazon SageMaker uses to encrypt data on the storage volume attached to the ML compute instance(s) | Yes | String | | |
+vpc_security_group_ids | The VPC security group IDs, in the form sg-xxxxxxxx | Yes | String | | |
+vpc_subnets | The ID of the subnets in the VPC to which you want to connect your hpo job | Yes | String | | |
+network_isolation | Isolates the training container if true | Yes | Boolean | False, True | True |
+traffic_encryption | Encrypts all communications between ML compute instances in distributed training if true | Yes | Boolean | False, True | False |
+warm_start_type | Specifies the type of warm start used | Yes | String | IdenticalDataAndAlgorithm, TransferLearning | |
+parent_hpo_jobs | List of previously completed or stopped hyperparameter tuning jobs to be used as a starting point | Yes | String | Yes | | |
+tags | Key-value pairs to categorize AWS resources | Yes | Dict | | {} |
+
+## Outputs
+Name | Description
+:--- | :----------
+model_artifact_url | URL where model artifacts were stored
+best_job_name | Best hyperparameter tuning training job name
+best_hyperparameters | Tuned hyperparameters
+
+# Requirements
+* Kubeflow pipelines SDK: https://www.kubeflow.org/docs/pipelines/sdk/install-sdk/
+* Kubeflow set-up
+
+# Samples
+## On its own
+K-Means algorithm tuning on MNIST dataset: /kubeflow/pipelines/samples/aws-samples/mnist-kmeans-sagemaker/kmeans-hpo-pipeline.py
+
+Follow the same steps as in the README for the MNIST classification pipeline:
+1. Get and store data in S3 buckets
+2. Prepare an IAM roles with permissions to run SageMaker jobs
+3. Add 'aws-secret' to your kubeflow namespace
+4. Compile the pipeline:
+```bash
+dsl-compile --py kmeans-hpo-pipeline.py --output kmeans-hpo-pipeline.tar.gz
+```
+5. In the Kubeflow UI, upload the compiled pipeline specification (the .tar.gz file) and create a new run. Update the role_arn and the data paths, and optionally any other run parameters.
+6. Once the pipeline completes, you can see the outputs under 'Output parameters' in the HPO component's Input/Output section.
+
+## Integrated into a pipeline
+MNIST Classification using K-Means pipeline: [Coming Soon]
+
+# Resources
+* Using Amazon built-in algorithms https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html

--- a/components/aws/sagemaker/hyperparameter_tuning/component.yaml
+++ b/components/aws/sagemaker/hyperparameter_tuning/component.yaml
@@ -102,7 +102,7 @@ outputs:
     description: 'Tuned hyperparameters'
 implementation:
   container:
-    image: carowang/kfp-aws-sm-hpo:190716-01
+    image: carowang/kfp-aws-sm-hpo:20190719-01
     command: ['python']
     args: [
       hyperparameter_tuning.py,

--- a/components/aws/sagemaker/hyperparameter_tuning/component.yaml
+++ b/components/aws/sagemaker/hyperparameter_tuning/component.yaml
@@ -1,0 +1,146 @@
+name: 'SageMaker - Hyperparameter Tuning'
+description: |
+  Hyperparameter Tuning Jobs in SageMaker
+inputs:
+  - name: region
+    description: 'The region where the cluster launches.'
+  - name: job_name
+    description: 'The name of the tuning job. Must be unique within the same AWS account and AWS region.'
+    default: ''
+  - name: role
+    description: 'The Amazon Resource Name (ARN) that Amazon SageMaker assumes to perform tasks on your behalf.'
+  - name: image
+    description: 'The registry path of the Docker image that contains the training algorithm.'
+    default: ''
+  - name: algorithm_name
+    description: 'The name of the algorithm resource to use for the hyperparameter tuning job. Do not specify a value for this if using training image.'
+    default: ''
+  - name: training_input_mode
+    description: 'The input mode that the algorithm supports. File or Pipe.'
+    default: 'File'
+  - name: metric_definitions
+    description: 'The dictionary of name-regex pairs specify the metrics that the algorithm emits.'
+    default: '{}'
+  - name: strategy
+    description: 'How hyperparameter tuning chooses the combinations of hyperparameter values to use for the training job it launches.'
+    default: 'Bayesian'
+  - name: metric_name
+    description: 'The name of the metric to use for the objective metric.'
+  - name: metric_type
+    description: 'Whether to minimize or maximize the objective metric.'
+  - name: early_stopping_type
+    description: 'Whether to use early stopping for training jobs launched by the tuning job.'
+    default: 'Off'
+  - name: static_parameters
+    description: 'The values of hyperparameters that do not change for the tuning job.'
+    default: '{}'
+  - name: integer_parameters
+    description: 'The array of IntegerParameterRange objects that specify ranges of integer hyperparameters that you want to search.'
+    default: '[]'
+  - name: continuous_parameters
+    description: 'The array of ContinuousParameterRange objects that specify ranges of continuous hyperparameters that you want to search.'
+    default: '[]'
+  - name: categorical_parameters
+    description: 'The array of CategoricalParameterRange objects that specify ranges of categorical hyperparameters that you want to search.'
+    default: '[]'
+  - name: channels
+    description: 'A list of dicts specifying the input channels. Must have at least one.'
+    default: '[{}]'
+  - name: shuffle_config_seed_8
+    description: 'Determines the shuffling order.'
+    default: '0'
+  - name: output_location
+    description: 'The Amazon S3 path where you want Amazon SageMaker to store the model artifacts is from the best training job.'
+  - name: output_encryption_key
+    description: 'The AWS KMS key that Amazon SageMaker uses to encrypt the model artifacts.'
+    default: ''
+  - name: instance_type
+    description: 'The ML compute instance type.'
+    default: 'ml.m4.xlarge'
+  - name: instance_count
+    description: 'The number of ML compute instances to use in each training job.'
+    default: '1'
+  - name: volume_size
+    description: 'The size of the ML storage volume that you want to provision.'
+    default: '1'
+  - name: max_num_jobs
+    description: 'The maximum number of training jobs that a hyperparameter tuning job can launch.'
+  - name: max_parallel_jobs
+    description: 'The maximum number of concurrent training jobs that a hyperparameter tuning job can launch.'
+  - name: max_run_time
+    description: 'The maximum run time in seconds per training job.'
+    default: '86400'
+  - name: resource_encryption_key
+    description: 'The AWS KMS key that Amazon SageMaker uses to encrypt data on the storage volume attached to the ML compute instance(s).'
+    default: ''
+  - name: vpc_security_group_ids
+    description: 'The VPC security group IDs, in the form sg-xxxxxxxx.'
+    default: ''
+  - name: vpc_subnets
+    description: 'The ID of the subnets in the VPC to which you want to connect your hpo job.'
+    default: ''
+  - name: network_isolation
+    description: 'Isolates the training container.'
+    default: 'True'
+  - name: traffic_encryption
+    description: 'Encrypts all communications between ML compute instances in distributed training.'
+    default: 'False'
+  - name: warm_start_type
+    description: 'Specifies either "IdenticalDataAndAlgorithm" or "TransferLearning"'
+    default: ''
+  - name: parent_hpo_jobs
+    description: 'List of previously completed or stopped hyperparameter tuning jobs to be used as a starting point.'
+    default: ''
+  - name: tags
+    description: 'Key-value pairs, to categorize AWS resources.'
+    default: '{}'
+outputs:
+  - name: model_artifact_url
+    description: 'Model artifacts url'
+  - name: best_job_name
+    description: 'Best training job in the hyperparameter tuning job'
+  - name: best_hyperparameters
+    description: 'Tuned hyperparameters'
+implementation:
+  container:
+    image: carowang/kubeflow-pipeline-aws-sm:20190715-03
+    command: ['python']
+    args: [
+      hyperparameter_tuning.py,
+      --region, {inputValue: region},
+      --job_name, {inputValue: job_name},
+      --role, {inputValue: role},
+      --image, {inputValue: image},
+      --algorithm_name, {inputValue: algorithm_name},
+      --training_input_mode, {inputValue: training_input_mode},
+      --metric_definitions, {inputValue: metric_definitions},
+      --strategy, {inputValue: strategy},
+      --metric_name, {inputValue: metric_name},
+      --metric_type, {inputValue: metric_type},
+      --early_stopping_type, {inputValue: early_stopping_type},
+      --static_parameters, {inputValue: static_parameters},
+      --integer_parameters, {inputValue: integer_parameters},
+      --continuous_parameters, {inputValue: continuous_parameters},
+      --categorical_parameters, {inputValue: categorical_parameters},
+      --channels, {inputValue: channels},
+      --output_location, {inputValue: output_location},
+      --output_encryption_key, {inputValue: output_encryption_key},
+      --instance_type, {inputValue: instance_type},
+      --instance_count, {inputValue: instance_count},
+      --volume_size, {inputValue: volume_size},
+      --max_num_jobs, {inputValue: max_num_jobs},
+      --max_parallel_jobs, {inputValue: max_parallel_jobs},
+      --resource_encryption_key, {inputValue: resource_encryption_key},
+      --max_run_time, {inputValue: max_run_time},
+      --vpc_security_group_ids, {inputValue: vpc_security_group_ids},
+      --vpc_subnets, {inputValue: vpc_subnets},
+      --network_isolation, {inputValue: network_isolation},
+      --traffic_encryption, {inputValue: traffic_encryption},
+      --warm_start_type, {inputValue: warm_start_type},
+      --parent_hpo_jobs, {inputValue: parent_hpo_jobs},
+      --tags, {inputValue: tags}
+    ]
+    fileOutputs:
+      model_artifact_url: /tmp/model_artifact_url.txt
+      best_job_name: /tmp/best_job_name.txt
+      best_hyperparameters: /tmp/best_hyperparameters.txt

--- a/components/aws/sagemaker/hyperparameter_tuning/component.yaml
+++ b/components/aws/sagemaker/hyperparameter_tuning/component.yaml
@@ -103,7 +103,7 @@ outputs:
     description: 'Tuned hyperparameters'
 implementation:
   container:
-    image: carowang/kubeflow-pipeline-aws-sm:20190715-03
+    image: carowang/kfp-aws-sm-hpo:190716-01
     command: ['python']
     args: [
       hyperparameter_tuning.py,

--- a/components/aws/sagemaker/hyperparameter_tuning/component.yaml
+++ b/components/aws/sagemaker/hyperparameter_tuning/component.yaml
@@ -6,7 +6,6 @@ inputs:
     description: 'The region where the cluster launches.'
   - name: job_name
     description: 'The name of the tuning job. Must be unique within the same AWS account and AWS region.'
-    default: ''
   - name: role
     description: 'The Amazon Resource Name (ARN) that Amazon SageMaker assumes to perform tasks on your behalf.'
   - name: image

--- a/components/aws/sagemaker/hyperparameter_tuning/src/hyperparameter_tuning.py
+++ b/components/aws/sagemaker/hyperparameter_tuning/src/hyperparameter_tuning.py
@@ -27,11 +27,17 @@ def str_to_bool(s):
   else:
     raise argparse.ArgumentTypeError('"True" or "False" expected.')
 
+def str_to_int(s):
+  if s:
+    return int(s)
+  else:
+    return 0
+
 def main(argv=None):
   parser = argparse.ArgumentParser(description='SageMaker Hyperparameter Tuning Job')
   # Set required=True only if parameter is required in the request and there is no default value for it, where default values are based on default values in SageMaker UI
   parser.add_argument('--region', type=str, required=True, help='The region where the cluster launches.')
-  parser.add_argument('--job_name', type=str, required=False, help='The name of the tuning job. Must be unique within the same AWS account and AWS region.', default='')
+  parser.add_argument('--job_name', type=str, required=True, help='The name of the tuning job. Must be unique within the same AWS account and AWS region.')
   parser.add_argument('--role', type=str, required=True, help='The Amazon Resource Name (ARN) that Amazon SageMaker assumes to perform tasks on your behalf.')
   parser.add_argument('--image', type=str, required=False, help='The registry path of the Docker image that contains the training algorithm.')
   parser.add_argument('--algorithm_name', type=str, required=False, help='The name of the resource algorithm to use for the hyperparameter tuning job.')
@@ -51,11 +57,11 @@ def main(argv=None):
   parser.add_argument('--instance_type', choices=['ml.m4.xlarge', 'ml.m4.2xlarge', 'ml.m4.4xlarge', 'ml.m4.10xlarge', 'ml.m4.16xlarge', 'ml.m5.large', 'ml.m5.xlarge', 'ml.m5.2xlarge', 'ml.m5.4xlarge',
     'ml.m5.12xlarge', 'ml.m5.24xlarge', 'ml.c4.xlarge', 'ml.c4.2xlarge', 'ml.c4.4xlarge', 'ml.c4.8xlarge', 'ml.p2.xlarge', 'ml.p2.8xlarge', 'ml.p2.16xlarge', 'ml.p3.2xlarge', 'ml.p3.8xlarge', 'ml.p3.16xlarge',
     'ml.c5.xlarge', 'ml.c5.2xlarge', 'ml.c5.4xlarge', 'ml.c5.9xlarge', 'ml.c5.18xlarge'], required=False, help='The ML compute instance type.', default='ml.m4.xlarge')
-  parser.add_argument('--instance_count', type=int, required=False, help='The number of ML compute instances to use in each training job.', default=1)
-  parser.add_argument('--volume_size', type=int, required=False, help='The size of the ML storage volume that you want to provision.', default=1)
-  parser.add_argument('--max_num_jobs', type=int, required=True, help='The maximum number of training jobs that a hyperparameter tuning job can launch.')
-  parser.add_argument('--max_parallel_jobs', type=int, required=True, help='The maximum number of concurrent training jobs that a hyperparameter tuning job can launch.')
-  parser.add_argument('--max_run_time', type=int, required=False, help='The maximum run time in seconds per training job.', default=86400)
+  parser.add_argument('--instance_count', type=str_to_int, required=False, help='The number of ML compute instances to use in each training job.', default=1)
+  parser.add_argument('--volume_size', type=str_to_int, required=False, help='The size of the ML storage volume that you want to provision.', default=1)
+  parser.add_argument('--max_num_jobs', type=str_to_int, required=True, help='The maximum number of training jobs that a hyperparameter tuning job can launch.')
+  parser.add_argument('--max_parallel_jobs', type=str_to_int, required=True, help='The maximum number of concurrent training jobs that a hyperparameter tuning job can launch.')
+  parser.add_argument('--max_run_time', type=str_to_int, required=False, help='The maximum run time in seconds per training job.', default=86400)
   parser.add_argument('--resource_encryption_key', type=str, required=False, help='The AWS KMS key that Amazon SageMaker uses to encrypt data on the storage volume attached to the ML compute instance(s).', default='')
   parser.add_argument('--vpc_security_group_ids', type=str, required=False, help='The VPC security group IDs, in the form sg-xxxxxxxx.')
   parser.add_argument('--vpc_subnets', type=str, required=False, help='The ID of the subnets in the VPC to which you want to connect your hpo job.')

--- a/components/aws/sagemaker/hyperparameter_tuning/src/hyperparameter_tuning.py
+++ b/components/aws/sagemaker/hyperparameter_tuning/src/hyperparameter_tuning.py
@@ -1,0 +1,90 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+import random
+import json
+from datetime import datetime
+from pathlib2 import Path
+
+from common import _utils
+
+def str_to_bool(s):
+  if s.lower() == 'true':
+    return True
+  elif s.lower() == 'false':
+    return False
+  else:
+    raise argparse.ArgumentTypeError('"True" or "False" expected.')
+
+def main(argv=None):
+  parser = argparse.ArgumentParser(description='SageMaker Hyperparameter Tuning Job')
+  # Set required=True only if parameter is required in the request and there is no default value for it, where default values are based on default values in SageMaker UI
+  parser.add_argument('--region', type=str, required=True, help='The region where the cluster launches.')
+  parser.add_argument('--job_name', type=str, required=False, help='The name of the tuning job. Must be unique within the same AWS account and AWS region.', default='')
+  parser.add_argument('--role', type=str, required=True, help='The Amazon Resource Name (ARN) that Amazon SageMaker assumes to perform tasks on your behalf.')
+  parser.add_argument('--image', type=str, required=False, help='The registry path of the Docker image that contains the training algorithm.')
+  parser.add_argument('--algorithm_name', type=str, required=False, help='The name of the resource algorithm to use for the hyperparameter tuning job.')
+  parser.add_argument('--training_input_mode', choices=['File', 'Pipe'], required=True, help='The input mode that the algorithm supports. File or Pipe.', default='File')
+  parser.add_argument('--metric_definitions', type=json.loads, required=False, help='The dictionary of name-regex pairs specify the metrics that the algorithm emits.', default='{}')
+  parser.add_argument('--strategy', choices=['Bayesian', 'Random'], required=False, help='How hyperparameter tuning chooses the combinations of hyperparameter values to use for the training job it launches.', default='Bayesian')
+  parser.add_argument('--metric_name', type=str, required=True, help='The name of the metric to use for the objective metric.')
+  parser.add_argument('--metric_type', choices=['Maximize', 'Minimize'], required=True, help='Whether to minimize or maximize the objective metric.')
+  parser.add_argument('--early_stopping_type', choices=['Off', 'Auto'], required=False, help='Whether to minimize or maximize the objective metric.', default='Off')
+  parser.add_argument('--static_parameters', type=json.loads, required=False, help='The values of hyperparameters that do not change for the tuning job.', default='{}')
+  parser.add_argument('--integer_parameters', type=json.loads, required=False, help='The array of IntegerParameterRange objects that specify ranges of integer hyperparameters that you want to search.', default='[]')
+  parser.add_argument('--continuous_parameters', type=json.loads, required=False, help='The array of ContinuousParameterRange objects that specify ranges of continuous hyperparameters that you want to search.', default='[]')
+  parser.add_argument('--categorical_parameters', type=json.loads, required=False, help='The array of CategoricalParameterRange objects that specify ranges of categorical hyperparameters that you want to search.', default='[]')
+  parser.add_argument('--channels', type=json.loads, required=True, help='A list of dicts specifying the input channels. Must have at least one.', default='[{}]')
+  parser.add_argument('--output_location', type=str, required=True, help='The Amazon S3 path where you want Amazon SageMaker to store the results of the transform job.')
+  parser.add_argument('--output_encryption_key', type=str, required=False, help='The AWS KMS key that Amazon SageMaker uses to encrypt the model artifacts.', default='')
+  parser.add_argument('--instance_type', choices=['ml.m4.xlarge', 'ml.m4.2xlarge', 'ml.m4.4xlarge', 'ml.m4.10xlarge', 'ml.m4.16xlarge', 'ml.m5.large', 'ml.m5.xlarge', 'ml.m5.2xlarge', 'ml.m5.4xlarge',
+    'ml.m5.12xlarge', 'ml.m5.24xlarge', 'ml.c4.xlarge', 'ml.c4.2xlarge', 'ml.c4.4xlarge', 'ml.c4.8xlarge', 'ml.p2.xlarge', 'ml.p2.8xlarge', 'ml.p2.16xlarge', 'ml.p3.2xlarge', 'ml.p3.8xlarge', 'ml.p3.16xlarge',
+    'ml.c5.xlarge', 'ml.c5.2xlarge', 'ml.c5.4xlarge', 'ml.c5.9xlarge', 'ml.c5.18xlarge'], required=False, help='The ML compute instance type.', default='ml.m4.xlarge')
+  parser.add_argument('--instance_count', type=int, required=False, help='The number of ML compute instances to use in each training job.', default=1)
+  parser.add_argument('--volume_size', type=int, required=False, help='The size of the ML storage volume that you want to provision.', default=1)
+  parser.add_argument('--max_num_jobs', type=int, required=True, help='The maximum number of training jobs that a hyperparameter tuning job can launch.')
+  parser.add_argument('--max_parallel_jobs', type=int, required=True, help='The maximum number of concurrent training jobs that a hyperparameter tuning job can launch.')
+  parser.add_argument('--max_run_time', type=int, required=False, help='The maximum run time in seconds per training job.', default=86400)
+  parser.add_argument('--resource_encryption_key', type=str, required=False, help='The AWS KMS key that Amazon SageMaker uses to encrypt data on the storage volume attached to the ML compute instance(s).', default='')
+  parser.add_argument('--vpc_security_group_ids', type=str, required=False, help='The VPC security group IDs, in the form sg-xxxxxxxx.')
+  parser.add_argument('--vpc_subnets', type=str, required=False, help='The ID of the subnets in the VPC to which you want to connect your hpo job.')
+  parser.add_argument('--network_isolation', type=str_to_bool, required=False, help='Isolates the training container.', default=True)
+  parser.add_argument('--traffic_encryption', type=str_to_bool, required=False, help='Encrypts all communications between ML compute instances in distributed training.', default=False)
+  parser.add_argument('--warm_start_type', choices=['IdenticalDataAndAlgorithm', 'TransferLearning', ''], required=False, help='Specifies either "IdenticalDataAndAlgorithm" or "TransferLearning"')
+  parser.add_argument('--parent_hpo_jobs', type=str, required=False, help='List of previously completed or stopped hyperparameter tuning jobs to be used as a starting point.', default='')
+  parser.add_argument('--tags', type=json.loads, required=False, help='An array of key-value pairs, to categorize AWS resources.', default='{}')
+
+  args = parser.parse_args()
+
+  logging.getLogger().setLevel(logging.INFO)
+  client = _utils.get_client(args.region)
+  logging.info('Submitting HyperParameter Tuning Job request to SageMaker...')
+  hpo_job_name = _utils.create_hyperparameter_tuning_job(client, vars(args))
+  logging.info('HyperParameter Tuning Job request submitted. Waiting for completion...')
+  _utils.wait_for_hyperparameter_training_job(client, hpo_job_name)
+  best_job, best_hyperparameters = _utils.get_best_training_job_and_hyperparameters(client, hpo_job_name)
+  model_artifact_url = _utils.get_model_artifacts_from_job(client, best_job)
+
+  logging.info('HyperParameter Tuning Job completed.')
+
+  with open('/tmp/best_job_name.txt', 'w') as f:
+    f.write(best_job)
+  with open('/tmp/best_hyperparameters.txt', 'w') as f:
+    f.write(json.dumps(best_hyperparameters))
+  with open('/tmp/model_artifact_url.txt', 'w') as f:
+    f.write(model_artifact_url)
+
+
+if __name__== "__main__":
+  main()

--- a/samples/aws-samples/mnist-kmeans-sagemaker/kmeans-hpo-pipeline.py
+++ b/samples/aws-samples/mnist-kmeans-sagemaker/kmeans-hpo-pipeline.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+import kfp
+from kfp import components
+from kfp import dsl
+from kfp.aws import use_aws_secret
+
+sagemaker_hpo_op = components.load_component_from_file('../../../components/aws/sagemaker/hyperparameter_tuning/component.yaml')
+
+@dsl.pipeline(
+    name='MNIST HPO test pipeline',
+    description='SageMaker hyperparameter tuning job test'
+)
+def hpo_test(region='us-west-2',
+    hpo_job_name='HPO-kmeans-sample',
+    image='',
+    algorithm_name='K-Means',
+    training_input_mode='File',
+    metric_definitions='{}',
+    strategy='Bayesian',
+    metric_name='test:msd',
+    metric_type='Minimize',
+    early_stopping_type='Off',
+    static_parameters='{"k": "10", "feature_dim": "784"}',
+    integer_parameters='[{"Name": "mini_batch_size", "MinValue": "450", "MaxValue": "550"}, \
+                         {"Name": "extra_center_factor", "MinValue": "10", "MaxValue": "20"}]',
+    continuous_parameters='[]',
+    categorical_parameters='[{"Name": "init_method", "Values": ["random", "kmeans++"]}]',
+    channels='[{"ChannelName": "train", \
+                "DataSource": { \
+                    "S3DataSource": { \
+                        "S3Uri": "s3://kubeflow-pipeline-data/mnist_kmeans_example/data",  \
+                        "S3DataType": "S3Prefix", \
+                        "S3DataDistributionType": "FullyReplicated" \
+                        } \
+                    }, \
+                "ContentType": "", \
+                "CompressionType": "None", \
+                "RecordWrapperType": "None", \
+                "InputMode": "File"}, \
+               {"ChannelName": "test", \
+                "DataSource": { \
+                    "S3DataSource": { \
+                        "S3Uri": "s3://kubeflow-pipeline-data/mnist_kmeans_example/data", \
+                        "S3DataType": "S3Prefix", \
+                        "S3DataDistributionType": "FullyReplicated" \
+                        } \
+                    }, \
+                "ContentType": "", \
+                "CompressionType": "None", \
+                "RecordWrapperType": "None", \
+                "InputMode": "File"}]',
+    output_location='s3://kubeflow-pipeline-data/mnist_kmeans_example/output',
+    output_encryption_key='',
+    instance_type='ml.p2.16xlarge',
+    instance_count='1',
+    volume_size='50',
+    max_num_jobs='1',
+    max_parallel_jobs='1',
+    resource_encryption_key='',
+    max_run_time='3600',
+    vpc_security_group_ids='',
+    vpc_subnets='',
+    network_isolation='True',
+    traffic_encryption='False',
+    warm_start_type='',
+    parent_hpo_jobs='',
+    tags='{}',
+    role_arn='',
+    ):
+
+    training = sagemaker_hpo_op(
+        region=region,
+        job_name=hpo_job_name,
+        image=image,
+        training_input_mode=training_input_mode,
+        algorithm_name=algorithm_name,
+        metric_definitions=metric_definitions,
+        strategy=strategy,
+        metric_name=metric_name,
+        metric_type=metric_type,
+        early_stopping_type=early_stopping_type,
+        static_parameters=static_parameters,
+        integer_parameters=integer_parameters,
+        continuous_parameters=continuous_parameters,
+        categorical_parameters=categorical_parameters,
+        channels=channels,
+        output_location=output_location,
+        output_encryption_key=output_encryption_key,
+        instance_type=instance_type,
+        instance_count=instance_count,
+        volume_size=volume_size,
+        max_num_jobs=max_num_jobs,
+        max_parallel_jobs=max_parallel_jobs,
+        resource_encryption_key=resource_encryption_key,
+        max_run_time=max_run_time,
+        vpc_security_group_ids=vpc_security_group_ids,
+        vpc_subnets=vpc_subnets,
+        network_isolation=network_isolation,
+        traffic_encryption=traffic_encryption,
+        warm_start_type=warm_start_type,
+        parent_hpo_jobs=parent_hpo_jobs,
+        tags=tags,
+        role=role_arn,
+    ).apply(use_aws_secret('aws-secret', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'))
+
+if __name__ == '__main__':
+    kfp.compiler.Compiler().compile(hpo_test, __file__ + '.zip')


### PR DESCRIPTION
### **Summary**
@Jeffwan @mbaijal @gautamkmr @kalyc

**Updated Dockerfile**
- Copies hyperparameter_tuning.py into the container 
- Updated install for boto3 and installs pyyaml

**Added Dockerfile for just HPO**
- Same as original but only copies the script for HPO in

**Added hyperparameter tuning component**
- hpo.template.yaml: template for API call request generation
- _utils.py: additional functions for hyperparameter tuning
- hyperparameter_tuning.py
- README: details inputs/outputs for the HPO component and how to run the sample
- component.yaml: the docker image used in this built from the HPO-only Dockerfile

**Sample pipeline (of just the HPO component)**
- Show sample usage for the HPO component for the K-Means algorithm using the MNIST dataset
- Uses all possible parameters, though some parameters have default values
- Note: the default inputs used in the parameters is not actually practical and is just being used to demonstrate that the component works

### **Testing**
**HPO component functionality**
- kmeans-hpo-pipeline.py compiles and runs without errors using the default values set in the pipeline parameters
- Note: has not been tested with SageMaker custom algorithm resources, AWS marketplace algorithm resources, BYOC, or any other built-in algorithms aside from K-Means.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1628)
<!-- Reviewable:end -->
