### PR TITLE
update persistent agence to only store the argo spec

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -443,7 +443,7 @@ func (r *ResourceManager) ReportWorkflowResource(workflow *util.Workflow) error 
 			FinishedAtInSec:  workflow.FinishedAt(),
 			Conditions:       workflow.Condition(),
 			PipelineSpec: model.PipelineSpec{
-				WorkflowSpecManifest: workflow.GetSpec().ToStringForStore(),
+				WorkflowSpecManifest: workflow.GetWorkflowSpec().ToStringForStore(),
 			},
 			ResourceReferences: []*model.ResourceReference{
 				{

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -879,7 +879,7 @@ func TestReportWorkflowResource_ScheduledWorkflowIDNotEmpty_Success(t *testing.T
 			ScheduledAtInSec: 0,
 			FinishedAtInSec:  0,
 			PipelineSpec: model.PipelineSpec{
-				WorkflowSpecManifest: workflow.GetSpec().ToStringForStore(),
+				WorkflowSpecManifest: workflow.GetWorkflowSpec().ToStringForStore(),
 			},
 			ResourceReferences: []*model.ResourceReference{
 				{

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -161,7 +161,7 @@ func (w *Workflow) HasScheduledWorkflowAsParent() bool {
 	return containsScheduledWorkflow(w.Workflow.OwnerReferences)
 }
 
-func (w *Workflow) GetSpec() *Workflow {
+func (w *Workflow) GetWorkflowSpec() *Workflow {
 	workflow := w.DeepCopy()
 	workflow.Status = workflowapi.WorkflowStatus{}
 	workflow.TypeMeta = metav1.TypeMeta{Kind: w.Kind, APIVersion: w.APIVersion}

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -162,9 +162,11 @@ func (w *Workflow) HasScheduledWorkflowAsParent() bool {
 }
 
 func (w *Workflow) GetSpec() *Workflow {
-	spec := w.DeepCopy()
-	spec.Status = workflowapi.WorkflowStatus{}
-	return NewWorkflow(spec)
+	workflow := w.DeepCopy()
+	workflow.Status = workflowapi.WorkflowStatus{}
+	workflow.TypeMeta = metav1.TypeMeta{Kind: w.Kind, APIVersion: w.APIVersion}
+	workflow.ObjectMeta = metav1.ObjectMeta{Name: w.Name, GenerateName: w.GenerateName}
+	return NewWorkflow(workflow)
 }
 
 // OverrideName sets the name of a Workflow.

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -302,7 +302,7 @@ func TestGetWorkflowSpec(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, expected, workflow.GetSpec().Get())
+	assert.Equal(t, expected, workflow.GetWorkflowSpec().Get())
 }
 
 func TestVerifyParameters(t *testing.T) {

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -271,7 +271,7 @@ func TestSetLabels(t *testing.T) {
 	assert.Equal(t, expected, workflow.Get())
 }
 
-func TestGetSpec(t *testing.T) {
+func TestGetWorkflowSpec(t *testing.T) {
 	workflow := NewWorkflow(&workflowapi.Workflow{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "WORKFLOW_NAME",
@@ -292,7 +292,6 @@ func TestGetSpec(t *testing.T) {
 	expected := &workflowapi.Workflow{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "WORKFLOW_NAME",
-			Labels: map[string]string{"key": "value"},
 		},
 		Spec: workflowapi.WorkflowSpec{
 			Arguments: workflowapi.Arguments{


### PR DESCRIPTION
Currently when persisting the runs spawned from a job, PersistentAgent stores more information than needed into the pipeline manifest, and also miss the TypeMetadata. This resulted in storing lots of runtime information that's not needed.

Example WorkflowSpec
```
   "metadata":{
      "name":"fffpw4fh-2-2911767673",
      "namespace":"kubeflow",
      "selfLink":"/apis/argoproj.io/v1alpha1/namespaces/kubeflow/workflows/fffpw4fh-2-2911767673",
      "uid":"de23bd5c-a8c1-11e9-a176-42010a800233",
      "resourceVersion":"3975687",
      "generation":1,
      "creationTimestamp":"2019-07-17T18:37:02Z",
      "labels":{
         "scheduledworkflows.kubeflow.org/isOwnedByScheduledWorkflow":"true",
         "scheduledworkflows.kubeflow.org/scheduledWorkflowName":"fffpw4fh",
         "scheduledworkflows.kubeflow.org/workflowEpoch":"1563388612",
         "scheduledworkflows.kubeflow.org/workflowIndex":"2",
         "workflows.argoproj.io/phase":"Running"
      },
      "ownerReferences":[
         {
            "apiVersion":"kubeflow.org/v1beta1",
            "kind":"ScheduledWorkflow",
            "name":"fffpw4fh",
            "uid":"91039a28-a8c1-11e9-a176-42010a800233",
            "controller":true,
            "blockOwnerDeletion":true
         }
      ]
   },
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1634)
<!-- Reviewable:end -->
