### PR TITLE
Clears the workflow's name in GetWorkflowSpec and uses it for the GenerateName

### DIFF
--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -136,7 +136,7 @@ func (w *Workflow) ScheduledAtInSecOr0() int64 {
 }
 
 func (w *Workflow) FinishedAt() int64 {
-	if w.Status.FinishedAt.IsZero(){
+	if w.Status.FinishedAt.IsZero() {
 		// If workflow is not finished
 		return 0
 	}
@@ -165,7 +165,13 @@ func (w *Workflow) GetWorkflowSpec() *Workflow {
 	workflow := w.DeepCopy()
 	workflow.Status = workflowapi.WorkflowStatus{}
 	workflow.TypeMeta = metav1.TypeMeta{Kind: w.Kind, APIVersion: w.APIVersion}
-	workflow.ObjectMeta = metav1.ObjectMeta{Name: w.Name, GenerateName: w.GenerateName}
+	// To prevent collisions, clear name, set GenerateName to first 200 runes of previous name.
+	nameRunes := []rune(w.Name)
+	length := len(nameRunes)
+	if length > 200 {
+		length = 200
+	}
+	workflow.ObjectMeta = metav1.ObjectMeta{GenerateName: string(nameRunes[:length])}
 	return NewWorkflow(workflow)
 }
 

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -291,7 +291,41 @@ func TestGetWorkflowSpec(t *testing.T) {
 
 	expected := &workflowapi.Workflow{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "WORKFLOW_NAME",
+			GenerateName: "WORKFLOW_NAME",
+		},
+		Spec: workflowapi.WorkflowSpec{
+			Arguments: workflowapi.Arguments{
+				Parameters: []workflowapi.Parameter{
+					{Name: "PARAM", Value: StringPointer("VALUE")},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, workflow.GetWorkflowSpec().Get())
+}
+
+func TestGetWorkflowSpecTruncatesNameIfLongerThan200Runes(t *testing.T) {
+	workflow := NewWorkflow(&workflowapi.Workflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "THIS_NAME_IS_GREATER_THAN_200_CHARACTERS_AND_WILL_BE_TRUNCATED_AFTER_THE_X_OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOXZZZZZZZZ",
+			Labels: map[string]string{"key": "value"},
+		},
+		Spec: workflowapi.WorkflowSpec{
+			Arguments: workflowapi.Arguments{
+				Parameters: []workflowapi.Parameter{
+					{Name: "PARAM", Value: StringPointer("VALUE")},
+				},
+			},
+		},
+		Status: workflowapi.WorkflowStatus{
+			Message: "I AM A MESSAGE",
+		},
+	})
+
+	expected := &workflowapi.Workflow{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "THIS_NAME_IS_GREATER_THAN_200_CHARACTERS_AND_WILL_BE_TRUNCATED_AFTER_THE_X_OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOX",
 		},
 		Spec: workflowapi.WorkflowSpec{
 			Arguments: workflowapi.Arguments{


### PR DESCRIPTION
This will prevent name collisions when cloning runs generated by jobs.
Related to #1266

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1689)
<!-- Reviewable:end -->
