### PR TITLE
SDK - ContainerOp.set_display_name should return self

### DIFF
--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -877,6 +877,7 @@ class BaseOp(object):
 
     def set_display_name(self, name: str):
         self.display_name = name
+        return self
 
     def __repr__(self):
         return str({self.__class__.__name__: self.__dict__})


### PR DESCRIPTION
This is needed so that it can be chained:
```
task = op(...).set_display_name('Bla')
```

/assign @gaoning777

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1718)
<!-- Reviewable:end -->
