### PR TITLE
Remove outdated argo install instruction

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -28,14 +28,10 @@ Here are the one-time steps to prepare for your GKE testing cluster:
 - Follow the [main page](https://github.com/kubeflow/pipelines#setup-gke) to
 create a GKE cluster.
 - Install [Argo](https://github.com/argoproj/argo/blob/master/demo.md#argo-v20-getting-started)
-in the cluster. If you have Argo CLI installed locally, just run
-  ```
-  argo install
-  ```
+in the cluster.
 - Create cluster role binding.
   ```
-  kubectl create clusterrolebinding default-as-admin
-  --clusterrole=cluster-admin --serviceaccount default:default
+  kubectl create clusterrolebinding default-as-admin --clusterrole=cluster-admin --serviceaccount=default:default
   ```
 - Follow the
 [guideline](https://developer.github.com/v3/guides/managing-deploy-keys/) to


### PR DESCRIPTION
argo cli no longer has argo install sub command. ref: https://github.com/argoproj/argo/blob/dc5491930e09eebe700952e28359deeb8e0d2314/CHANGELOG.md#220-2018-08-30

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1719)
<!-- Reviewable:end -->
