### PR TITLE
Backend - Updated the version of the ml metadata package

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,8 +50,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
 go_repository(
     name = "google_ml_metadata",
-    commit = "0fb82dc56ff7",
     importpath = "github.com/google/ml-metadata",
+    tag = "v0.13.2",
 )
 
 new_git_repository(

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/google/btree v0.0.0-20180124185431-e89373fe6b4a // indirect
 	github.com/google/go-cmp v0.2.0
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
-	github.com/google/ml-metadata v0.0.0-20190214221617-0fb82dc56ff7
+	github.com/google/ml-metadata v0.13.2
 	github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57 // indirect
 	github.com/google/uuid v1.0.0
 	github.com/googleapis/gnostic v0.2.0 // indirect


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/1722

The [v0.13.2](https://github.com/google/ml-metadata/releases/tag/v0.13.2) release points to the [bd91e49a0898](https://github.com/google/ml-metadata/commit/becc26ab61f82bfe7c812894f56f597949ce0fdc) commit. The same one that was used in the `WORKSPACE` initially.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1725)
<!-- Reviewable:end -->
