### PR TITLE
SDK - Lightweight - Fixed regression for components without outputs

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -287,10 +287,9 @@ def _func_to_component_spec(func, extra_code='', base_image=_default_base_image,
         '_parsed_args = vars(_parser.parse_args())',
     ])
 
-    if component_spec.outputs:
-        arg_parse_code_lines.extend([
-            '_output_files = _parsed_args.pop("_output_paths")',
-        ])
+    arg_parse_code_lines.extend([
+        '_output_files = _parsed_args.pop("_output_paths", [])',
+    ])
 
     full_source = \
 '''\


### PR DESCRIPTION
There was a bug introduced when moving to `argparse`-based command-line argument parsing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1726)
<!-- Reviewable:end -->
