### PR TITLE
Delete KFP component before reinstalling again

### DIFF
--- a/test/deploy-kubeflow.sh
+++ b/test/deploy-kubeflow.sh
@@ -45,7 +45,7 @@ function clean_up {
   # delete the storage
   gcloud deployment-manager --project=${PROJECT} deployments delete ${KFAPP}-storage --quiet
 }
-# trap clean_up EXIT SIGINT SIGTERM
+trap clean_up EXIT SIGINT SIGTERM
 
 cd ${DIR}
 ${KUBEFLOW_SRC}/scripts/kfctl.sh init ${KFAPP} --platform ${PLATFORM} --project ${PROJECT} --skipInitProject

--- a/test/deploy-kubeflow.sh
+++ b/test/deploy-kubeflow.sh
@@ -45,7 +45,7 @@ function clean_up {
   # delete the storage
   gcloud deployment-manager --project=${PROJECT} deployments delete ${KFAPP}-storage --quiet
 }
-trap clean_up EXIT SIGINT SIGTERM
+# trap clean_up EXIT SIGINT SIGTERM
 
 cd ${DIR}
 ${KUBEFLOW_SRC}/scripts/kfctl.sh init ${KFAPP} --platform ${PLATFORM} --project ${PROJECT} --skipInitProject

--- a/test/deploy-pipeline.sh
+++ b/test/deploy-pipeline.sh
@@ -53,5 +53,6 @@ ks param set pipeline scheduledWorkflowImage ${GCR_IMAGE_BASE_DIR}/scheduledwork
 ks param set pipeline uiImage ${GCR_IMAGE_BASE_DIR}/frontend:${GCR_IMAGE_TAG}
 # Delete pipeline component first before applying so we guarantee the pipeline component is new.
 ks delete default -c pipeline
+sleep 60s
 ks apply default -c pipeline
 popd

--- a/test/deploy-pipeline.sh
+++ b/test/deploy-pipeline.sh
@@ -51,5 +51,7 @@ ks param set pipeline apiImage ${GCR_IMAGE_BASE_DIR}/api-server:${GCR_IMAGE_TAG}
 ks param set pipeline persistenceAgentImage ${GCR_IMAGE_BASE_DIR}/persistenceagent:${GCR_IMAGE_TAG}
 ks param set pipeline scheduledWorkflowImage ${GCR_IMAGE_BASE_DIR}/scheduledworkflow:${GCR_IMAGE_TAG}
 ks param set pipeline uiImage ${GCR_IMAGE_BASE_DIR}/frontend:${GCR_IMAGE_TAG}
+# Delete pipeline component first before applying so we guarantee the pipeline component is new.
+ks delete default -c pipeline
 ks apply default -c pipeline
 popd


### PR DESCRIPTION
If there is any issue in the code to be tested that causing the KFP components image fail to launch (CrashLoopBackOff for example), Kubernetes will by default keep the old pod running. The test will thus test against an official image instead.
Delete KFP will ensure the KFP to be tested either not start at all, or healthy. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1736)
<!-- Reviewable:end -->
