### PR TITLE
Update Watson Machine Learning auth with IAM

### DIFF
--- a/components/ibm-components/spark/store_spark_model/src/store_spark_model.py
+++ b/components/ibm-components/spark/store_spark_model/src/store_spark_model.py
@@ -40,6 +40,7 @@ if __name__ == "__main__":
     wml_username = get_secret_creds("/app/secrets/wml_username")
     wml_password = get_secret_creds("/app/secrets/wml_password")
     wml_instance_id = get_secret_creds("/app/secrets/wml_instance_id")
+    wml_apikey = get_secret_creds("/app/secrets/wml_apikey")
     cos_endpoint = get_secret_creds("/app/secrets/cos_endpoint")
     cos_access_key = get_secret_creds("/app/secrets/cos_access_key")
     cos_secret_key = get_secret_creds("/app/secrets/cos_secret_key")
@@ -52,7 +53,8 @@ if __name__ == "__main__":
                        "url": wml_url,
                        "username": wml_username,
                        "password": wml_password,
-                       "instance_id": wml_instance_id
+                       "instance_id": wml_instance_id,
+                       "apikey": wml_apikey
                       }
     ''' Load Spark model '''
     cos = Minio(cos_endpoint,

--- a/components/ibm-components/spark/store_spark_model/src/store_spark_model.py
+++ b/components/ibm-components/spark/store_spark_model/src/store_spark_model.py
@@ -37,8 +37,6 @@ if __name__ == "__main__":
     DEPLOYMENT_NAME = args.deployment_name
 
     wml_url = get_secret_creds("/app/secrets/wml_url")
-    wml_username = get_secret_creds("/app/secrets/wml_username")
-    wml_password = get_secret_creds("/app/secrets/wml_password")
     wml_instance_id = get_secret_creds("/app/secrets/wml_instance_id")
     wml_apikey = get_secret_creds("/app/secrets/wml_apikey")
     cos_endpoint = get_secret_creds("/app/secrets/cos_endpoint")
@@ -51,8 +49,6 @@ if __name__ == "__main__":
 
     WML_CREDENTIALS = {
                        "url": wml_url,
-                       "username": wml_username,
-                       "password": wml_password,
                        "instance_id": wml_instance_id,
                        "apikey": wml_apikey
                       }

--- a/components/ibm-components/watson/deploy/src/wml-deploy.py
+++ b/components/ibm-components/watson/deploy/src/wml-deploy.py
@@ -34,13 +34,15 @@ def deploy(args):
     wml_username = getSecret("/app/secrets/wml_username")
     wml_password = getSecret("/app/secrets/wml_password")
     wml_instance_id = getSecret("/app/secrets/wml_instance_id")
+    wml_apikey = getSecret("/app/secrets/wml_apikey")
 
     # set up the WML client
     wml_credentials = {
                        "url": wml_url,
                        "username": wml_username,
                        "password": wml_password,
-                       "instance_id": wml_instance_id
+                       "instance_id": wml_instance_id,
+                       "apikey": wml_apikey
                       }
     client = WatsonMachineLearningAPIClient(wml_credentials)
 

--- a/components/ibm-components/watson/deploy/src/wml-deploy.py
+++ b/components/ibm-components/watson/deploy/src/wml-deploy.py
@@ -31,16 +31,12 @@ def deploy(args):
 
     # retrieve credentials
     wml_url = getSecret("/app/secrets/wml_url")
-    wml_username = getSecret("/app/secrets/wml_username")
-    wml_password = getSecret("/app/secrets/wml_password")
     wml_instance_id = getSecret("/app/secrets/wml_instance_id")
     wml_apikey = getSecret("/app/secrets/wml_apikey")
 
     # set up the WML client
     wml_credentials = {
                        "url": wml_url,
-                       "username": wml_username,
-                       "password": wml_password,
                        "instance_id": wml_instance_id,
                        "apikey": wml_apikey
                       }

--- a/components/ibm-components/watson/manage/subscribe/src/subscribe.py
+++ b/components/ibm-components/watson/manage/subscribe/src/subscribe.py
@@ -35,8 +35,6 @@ if __name__ == "__main__":
     problem_type = args.problem_type
 
     wml_url = get_secret_creds("/app/secrets/wml_url")
-    wml_username = get_secret_creds("/app/secrets/wml_username")
-    wml_password = get_secret_creds("/app/secrets/wml_password")
     wml_instance_id = get_secret_creds("/app/secrets/wml_instance_id")
     wml_apikey = get_secret_creds("/app/secrets/wml_apikey")
     aios_guid = get_secret_creds("/app/secrets/aios_guid")
@@ -52,8 +50,6 @@ if __name__ == "__main__":
 
     WML_CREDENTIALS = {
                        "url": wml_url,
-                       "username": wml_username,
-                       "password": wml_password,
                        "instance_id": wml_instance_id,
                        "apikey": wml_apikey
                       }

--- a/components/ibm-components/watson/store/src/wml-store.py
+++ b/components/ibm-components/watson/store/src/wml-store.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 # define the function to store the model
 
 def getSecret(secret):
@@ -26,16 +26,18 @@ def store(wml_model_name, run_uid):
     wml_username = getSecret("/app/secrets/wml_username")
     wml_password = getSecret("/app/secrets/wml_password")
     wml_instance_id = getSecret("/app/secrets/wml_instance_id")
-    
+    wml_apikey = getSecret("/app/secrets/wml_apikey")
+
     # set up the WML client
     wml_credentials = {
                        "url": wml_url,
                        "username": wml_username,
                        "password": wml_password,
-                       "instance_id": wml_instance_id
+                       "instance_id": wml_instance_id,
+                       "apikey": wml_apikey
                       }
     client = WatsonMachineLearningAPIClient( wml_credentials )
-        
+
     # store the model
     stored_model_name    = wml_model_name
     stored_model_details = client.repository.store_model( run_uid, stored_model_name )

--- a/components/ibm-components/watson/store/src/wml-store.py
+++ b/components/ibm-components/watson/store/src/wml-store.py
@@ -23,16 +23,12 @@ def store(wml_model_name, run_uid):
 
     # retrieve credentials
     wml_url = getSecret("/app/secrets/wml_url")
-    wml_username = getSecret("/app/secrets/wml_username")
-    wml_password = getSecret("/app/secrets/wml_password")
     wml_instance_id = getSecret("/app/secrets/wml_instance_id")
     wml_apikey = getSecret("/app/secrets/wml_apikey")
 
     # set up the WML client
     wml_credentials = {
                        "url": wml_url,
-                       "username": wml_username,
-                       "password": wml_password,
                        "instance_id": wml_instance_id,
                        "apikey": wml_apikey
                       }

--- a/components/ibm-components/watson/train/src/wml-train.py
+++ b/components/ibm-components/watson/train/src/wml-train.py
@@ -36,8 +36,6 @@ def train(args):
 
     # retrieve credentials
     wml_url = getSecret("/app/secrets/wml_url")
-    wml_username = getSecret("/app/secrets/wml_username")
-    wml_password = getSecret("/app/secrets/wml_password")
     wml_apikey = getSecret("/app/secrets/wml_apikey")
     wml_instance_id = getSecret("/app/secrets/wml_instance_id")
 
@@ -67,8 +65,6 @@ def train(args):
     # set up the WML client
     wml_credentials = {
                        "url": wml_url,
-                       "username": wml_username,
-                       "password": wml_password,
                        "instance_id": wml_instance_id,
                        "apikey": wml_apikey
                       }

--- a/components/ibm-components/watson/train/src/wml-train.py
+++ b/components/ibm-components/watson/train/src/wml-train.py
@@ -38,6 +38,7 @@ def train(args):
     wml_url = getSecret("/app/secrets/wml_url")
     wml_username = getSecret("/app/secrets/wml_username")
     wml_password = getSecret("/app/secrets/wml_password")
+    wml_apikey = getSecret("/app/secrets/wml_apikey")
     wml_instance_id = getSecret("/app/secrets/wml_instance_id")
 
     wml_data_source_type = getSecret("/app/secrets/wml_data_source_type")
@@ -68,7 +69,8 @@ def train(args):
                        "url": wml_url,
                        "username": wml_username,
                        "password": wml_password,
-                       "instance_id": wml_instance_id
+                       "instance_id": wml_instance_id,
+                       "apikey": wml_apikey
                       }
     client = WatsonMachineLearningAPIClient( wml_credentials )
 

--- a/samples/contrib/ibm-samples/openscale/README.md
+++ b/samples/contrib/ibm-samples/openscale/README.md
@@ -11,7 +11,7 @@ To provision your own OpenScale, Spark, Watson Machine Learning services and clo
 
 To create a Watson Machine Learning service, go to [IBM Cloud](https://cloud.ibm.com/), login with IBM account id first. From the `Catalog` page, click on `AI` tab on the left side to go to this [page](https://cloud.ibm.com/catalog?category=ai). Then click on the [`Machine Learning`](https://cloud.ibm.com/catalog/services/machine-learning) link and follow the instructions to create the service.
 
-Once the service is created, from the service's `Dashboard`, follow the instructions to generate `service credentials`. Refer to IBM Cloud [documents](https://cloud.ibm.com/docs) for help if needed. Collect the `url`, `username`, `password`, `apikey`, and `instance_id` info from the service credentials as these will be required to access the service.
+Once the service is created, from the service's `Dashboard`, follow the instructions to generate `service credentials`. Refer to IBM Cloud [documents](https://cloud.ibm.com/docs) for help if needed. Collect the `url`, `apikey`, and `instance_id` info from the service credentials as these will be required to access the service.
 
 2. IBM Watson OpenScale service instance
 

--- a/samples/contrib/ibm-samples/openscale/credentials/creds.ini
+++ b/samples/contrib/ibm-samples/openscale/credentials/creds.ini
@@ -13,7 +13,5 @@ cos_access_key = ObjectStoreAccessKeyID
 cos_secret_key = ObjectStoreSecretAccessKey
 
 wml_url = https://us-south.ml.cloud.ibm.com
-wml_username = WMLUserName
-wml_password = WMLPassword
 wml_instance_id = WMLInstanceId
 wml_apikey = WMLAPIKey

--- a/samples/contrib/ibm-samples/watson/README.md
+++ b/samples/contrib/ibm-samples/watson/README.md
@@ -10,7 +10,7 @@ To provision your own Watson Machine Learning services and cloud object store, f
 
 To create a machine learning service, go to [IBM Cloud](https://console.bluemix.net), login with IBM account id first. From the `Catalog` page, click on `AI` tab on the left side to go to this [page](https://console.bluemix.net/catalog/?category=ai). Then click on the [`Machine Learning`](https://console.bluemix.net/catalog/services/machine-learning) link and follow the instructions to create the service.
 
-Once the service is created, from service's `Dashboard`, follow the instruction to generate `service credentials`. Refer to IBM Cloud [documents](https://console.bluemix.net/docs/) for help if needed. Collect the `url`, `username`, `password` and `instance_id` info from the service credentials as these will be required to access the service.
+Once the service is created, from service's `Dashboard`, follow the instruction to generate `service credentials`. Refer to IBM Cloud [documents](https://console.bluemix.net/docs/) for help if needed. Collect the `url`, `username`, `password`, `apikey`, and `instance_id` info from the service credentials as these will be required to access the service.
 
 * A cloud object store
 

--- a/samples/contrib/ibm-samples/watson/README.md
+++ b/samples/contrib/ibm-samples/watson/README.md
@@ -10,7 +10,7 @@ To provision your own Watson Machine Learning services and cloud object store, f
 
 To create a machine learning service, go to [IBM Cloud](https://console.bluemix.net), login with IBM account id first. From the `Catalog` page, click on `AI` tab on the left side to go to this [page](https://console.bluemix.net/catalog/?category=ai). Then click on the [`Machine Learning`](https://console.bluemix.net/catalog/services/machine-learning) link and follow the instructions to create the service.
 
-Once the service is created, from service's `Dashboard`, follow the instruction to generate `service credentials`. Refer to IBM Cloud [documents](https://console.bluemix.net/docs/) for help if needed. Collect the `url`, `username`, `password`, `apikey`, and `instance_id` info from the service credentials as these will be required to access the service.
+Once the service is created, from service's `Dashboard`, follow the instruction to generate `service credentials`. Refer to IBM Cloud [documents](https://console.bluemix.net/docs/) for help if needed. Collect the `url`, `apikey`, and `instance_id` info from the service credentials as these will be required to access the service.
 
 * A cloud object store
 

--- a/samples/contrib/ibm-samples/watson/credentials/creds.ini
+++ b/samples/contrib/ibm-samples/watson/credentials/creds.ini
@@ -1,7 +1,5 @@
 [CREDENTIALS]
 wml_url=https://us-south.ml.cloud.ibm.com
-wml_username=WMLUserName
-wml_password=WMLPassword
 wml_instance_id=WMLInstanceId
 wml_apikey=WMLAPIKey
 

--- a/samples/contrib/ibm-samples/watson/credentials/creds.ini
+++ b/samples/contrib/ibm-samples/watson/credentials/creds.ini
@@ -3,6 +3,7 @@ wml_url=https://us-south.ml.cloud.ibm.com
 wml_username=WMLUserName
 wml_password=WMLPassword
 wml_instance_id=WMLInstanceId
+wml_apikey=WMLAPIKey
 
 wml_data_source_type=s3
 


### PR DESCRIPTION
Starting from Aug 1st, Watson ML requires IAM auth using the `apikey` for authentication. Thus, we need to update our client code and creds.ini to include `apikey` from now on. 

/assign @animeshsingh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1737)
<!-- Reviewable:end -->
