### PR TITLE
Revert "Backend - Starting the api-server container build from scratch"

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 FROM l.gcr.io/google/bazel:0.24.0 as builder
 
 RUN apt-get update && \
-  apt-get install -y cmake clang musl-dev openssl ca-certificates
+  apt-get install -y cmake clang musl-dev openssl
 WORKDIR /go/src/github.com/kubeflow/pipelines
 
 COPY WORKSPACE WORKSPACE
@@ -31,7 +31,7 @@ COPY ./samples .
 #The "for" loop breaks on all whitespace, so we either need to override IFS or use the "read" command instead.
 RUN  find core -maxdepth 2 -name '*.py' -type f | while read pipeline; do dsl-compile --py "$pipeline" --output "$pipeline.tar.gz"; done
 
-FROM scratch
+FROM debian:stretch
 
 ARG COMMIT_SHA=unknown
 ENV COMMIT_SHA=${COMMIT_SHA}
@@ -45,7 +45,7 @@ COPY backend/src/apiserver/config/ /config
 COPY --from=compiler /samples/ /samples/
 
 # Adding CA certificate so API server can download pipeline through URL
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+RUN apt-get update && apt-get install -y ca-certificates
 
 # Expose apiserver port
 EXPOSE 8888

--- a/backend/Dockerfile.persistenceagent
+++ b/backend/Dockerfile.persistenceagent
@@ -9,7 +9,7 @@ RUN apk update && apk upgrade && \
 
 RUN GO111MODULE=on go build -o /bin/persistence_agent backend/src/agent/persistence/*.go
 
-FROM scratch
+FROM alpine:3.8
 WORKDIR /bin
 
 COPY --from=builder /bin/persistence_agent /bin/persistence_agent

--- a/backend/Dockerfile.scheduledworkflow
+++ b/backend/Dockerfile.scheduledworkflow
@@ -9,11 +9,12 @@ RUN apk update && apk upgrade && \
 
 RUN GO111MODULE=on go build -o /bin/controller backend/src/crd/controller/scheduledworkflow/*.go
 
-FROM scratch
+FROM alpine:3.8
 WORKDIR /bin
 
 COPY --from=builder /bin/controller /bin/controller
 COPY --from=builder /go/src/github.com/kubeflow/pipelines/third_party/license.txt /bin/license.txt
+RUN chmod +x /bin/controller
 
 ENV NAMESPACE ""
 

--- a/backend/Dockerfile.viewercontroller
+++ b/backend/Dockerfile.viewercontroller
@@ -9,7 +9,7 @@ COPY . .
 RUN go mod vendor
 RUN go build -o /bin/controller backend/src/crd/controller/viewer/*.go
 
-FROM scratch
+FROM alpine
 WORKDIR /src
 COPY --from=builder /src/github.com/kubeflow/pipelines/vendor vendor
 
@@ -17,6 +17,7 @@ WORKDIR /bin
 
 COPY --from=builder /bin/controller /bin/controller
 COPY --from=builder /src/github.com/kubeflow/pipelines/third_party/license.txt /bin/license.txt
+RUN chmod +x /bin/controller
 
 ENV MAX_NUM_VIEWERS "50"
 ENV NAMESPACE "kubeflow"


### PR DESCRIPTION
Reverts kubeflow/pipelines#1699

There are some unusual failures in https://github.com/kubeflow/pipelines/pull/1739, so let's rollback the CL for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1742)
<!-- Reviewable:end -->
