### PR TITLE
Change how Variables are Provided to Visualizations

### DIFF
--- a/backend/src/apiserver/visualization/exporter.py
+++ b/backend/src/apiserver/visualization/exporter.py
@@ -17,10 +17,8 @@ converting those objects to HTML.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import uuid
 from enum import Enum
 import json
-import os
 from pathlib import Path
 from typing import Text
 from jupyter_client import KernelManager
@@ -92,10 +90,7 @@ class Exporter:
 
     @staticmethod
     def create_cell_from_args(variables: dict) -> NotebookNode:
-        """Creates NotebookNode object that loads provided variables from JSON.
-
-        Provided dict is saved to file. It is then loaded by the returned
-        NotebookNode to be used for visualization generation.
+        """Creates NotebookNode object containing dict of provided variables.
 
         Args:
             variables: Arguments that need to be injected into a NotebookNode.
@@ -104,25 +99,7 @@ class Exporter:
             NotebookNode with provided arguments as variables.
 
         """
-        # Generates random file name to ensure variables for visualization are
-        # not overwritten by future visualizations.
-        file_name = "variables-{}.json".format(uuid.uuid4())
-        if os.path.exists(file_name):
-            os.remove(file_name)
-        with open(file_name, "w") as f:
-            json.dump(variables, f)
-
-        return new_code_cell("""
-        import json
-        import os
-        
-        variables = dict()
-        
-        with open("{}", "r") as f:
-            variables = json.load(f)
-        
-        os.remove("{}")
-        """.format(file_name, file_name))
+        return new_code_cell("variables = {}".format(repr(variables)))
 
     @staticmethod
     def create_cell_from_file(filepath: Text) -> NotebookNode:

--- a/backend/src/apiserver/visualization/roc_curve.py
+++ b/backend/src/apiserver/visualization/roc_curve.py
@@ -34,13 +34,13 @@ from tensorflow.python.lib.io import file_io
 # trueclass
 # true_score_column
 
-if variables['is_generated'] is False:
+if "is_generated" is not in variables or variables["is_generated"] is False:
     # Create data from specified csv file(s).
     # The schema file provides column names for the csv file that will be used
     # to generate the roc curve.
-    schema_file = Path(source) / 'schema.json'
+    schema_file = Path(source) / "schema.json"
     schema = json.loads(file_io.read_file_to_string(schema_file))
-    names = [x['name'] for x in schema]
+    names = [x["name"] for x in schema]
 
     dfs = []
     files = file_io.get_matching_files(source)
@@ -48,25 +48,25 @@ if variables['is_generated'] is False:
         dfs.append(pd.read_csv(f, names=names))
 
     df = pd.concat(dfs)
-    if variables['target_lambda']:
-        df['target'] = df.apply(eval(variables['target_lambda']), axis=1)
+    if variables["target_lambda"]:
+        df["target"] = df.apply(eval(variables["target_lambda"]), axis=1)
     else:
-        df['target'] = df['target'].apply(lambda x: 1 if x == variables['trueclass'] else 0)
-    fpr, tpr, thresholds = roc_curve(df['target'], df[variables['true_score_column']])
-    source = pd.DataFrame({'fpr': fpr, 'tpr': tpr, 'thresholds': thresholds})
+        df["target"] = df["target"].apply(lambda x: 1 if x == variables["trueclass"] else 0)
+    fpr, tpr, thresholds = roc_curve(df["target"], df[variables["true_score_column"]])
+    df = pd.DataFrame({"fpr": fpr, "tpr": tpr, "thresholds": thresholds})
 else:
     # Load data from generated csv file.
-    source = pd.read_csv(
+    df = pd.read_csv(
         source,
         header=None,
-        names=['fpr', 'tpr', 'thresholds']
+        names=["fpr", "tpr", "thresholds"]
     )
 
 # Create visualization.
 output_notebook()
 
 p = figure(tools="pan,wheel_zoom,box_zoom,reset,hover,previewsave")
-p.line('fpr', 'tpr', line_width=2, source=source)
+p.line("fpr", "tpr", line_width=2, source=df)
 
 hover = p.select(dict(type=HoverTool))
 hover.tooltips = [("Threshold", "@thresholds")]

--- a/backend/src/apiserver/visualization/roc_curve.py
+++ b/backend/src/apiserver/visualization/roc_curve.py
@@ -34,7 +34,7 @@ from tensorflow.python.lib.io import file_io
 # trueclass
 # true_score_column
 
-if is_generated is False:
+if variables['is_generated'] is False:
     # Create data from specified csv file(s).
     # The schema file provides column names for the csv file that will be used
     # to generate the roc curve.
@@ -48,11 +48,11 @@ if is_generated is False:
         dfs.append(pd.read_csv(f, names=names))
 
     df = pd.concat(dfs)
-    if target_lambda:
-        df['target'] = df.apply(eval(target_lambda), axis=1)
+    if variables['target_lambda']:
+        df['target'] = df.apply(eval(variables['target_lambda']), axis=1)
     else:
-        df['target'] = df['target'].apply(lambda x: 1 if x == trueclass else 0)
-    fpr, tpr, thresholds = roc_curve(df['target'], df[true_score_column])
+        df['target'] = df['target'].apply(lambda x: 1 if x == variables['trueclass'] else 0)
+    fpr, tpr, thresholds = roc_curve(df['target'], df[variables['true_score_column']])
     source = pd.DataFrame({'fpr': fpr, 'tpr': tpr, 'thresholds': thresholds})
 else:
     # Load data from generated csv file.

--- a/backend/src/apiserver/visualization/server.py
+++ b/backend/src/apiserver/visualization/server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+from argparse import Namespace
 import importlib
 import json
 from pathlib import Path
@@ -74,39 +75,33 @@ class VisualizationHandler(tornado.web.RequestHandler):
             help="JSON string of arguments to be provided to visualizations."
         )
 
-    def get_arguments_from_body(self) -> argparse.Namespace:
-        """Converts arguments from post request to argparser.Namespace format.
+    def get_arguments_from_body(self) -> Namespace:
+        """Converts arguments from post request to Namespace format.
 
         This is done because arguments, by default are provided in the
         x-www-form-urlencoded format. This format is difficult to parse compared
-        to argparser.Namespace, which is a dict.
+        to Namespace, which is a dict.
 
         Returns:
-            Arguments provided from post request as arparser.Namespace object.
+            Arguments provided from post request as a Namespace object.
         """
         split_arguments = shlex.split(self.get_body_argument("arguments"))
         return self.requestParser.parse_args(split_arguments)
 
-    def is_valid_request_arguments(self, arguments: argparse.Namespace) -> bool:
-        """Validates arguments from post request and sends error if invalid.
+    def is_valid_request_arguments(self, arguments: Namespace):
+        """Validates arguments from post request and raises error if invalid.
 
         Args:
-            arguments: argparser.Namespace formatted arguments
-
-        Returns:
-            Boolean value representing if provided arguments are valid.
+            arguments: Namespace formatted arguments
         """
         if arguments.type is None:
-            self.send_error(400, reason="No type specified.")
-            return False
+            raise Exception("No type specified.")
         if arguments.source is None:
-            self.send_error(400, reason="No source specified.")
-            return False
+            raise Exception("No source specified.")
         try:
             json.loads(arguments.arguments)
         except json.JSONDecodeError:
-            self.send_error(400, reason="Invalid JSON provided as arguments.")
-            return False
+            raise Exception("Invalid JSON provided as arguments.")
 
         return True
 
@@ -145,16 +140,20 @@ class VisualizationHandler(tornado.web.RequestHandler):
         # Parse arguments from request.
         request_arguments = self.get_arguments_from_body()
         # Validate arguments from request.
-        if self.is_valid_request_arguments(request_arguments):
-            # Create notebook with arguments from request.
-            nb = self.generate_notebook_from_arguments(
-                json.loads(request_arguments.arguments),
-                request_arguments.source,
-                request_arguments.type
-            )
-            # Generate visualization (output for notebook).
-            html = _exporter.generate_html_from_notebook(nb)
-            self.write(html)
+        try:
+            self.is_valid_request_arguments(request_arguments)
+        except Exception as e:
+            return self.send_error(400, reason=str(e))
+
+        # Create notebook with arguments from request.
+        nb = self.generate_notebook_from_arguments(
+            json.loads(request_arguments.arguments),
+            request_arguments.source,
+            request_arguments.type
+        )
+        # Generate visualization (output for notebook).
+        html = _exporter.generate_html_from_notebook(nb)
+        self.write(html)
 
 
 if __name__ == "__main__":

--- a/backend/src/apiserver/visualization/snapshots/snap_test_exporter.py
+++ b/backend/src/apiserver/visualization/snapshots/snap_test_exporter.py
@@ -7,13 +7,73 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['TestExporterMethods::test_create_cell_from_args_with_multiple_args 1'] = '''source = "gs://ml-pipeline/data.csv"
-target_lambda = "lambda x: (x[\'target\'] > x[\'fare\'] * 0.2)"
+snapshots['TestExporterMethods::test_create_cell_from_args_with_multiple_args 1'] = '''
+<div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt"></div>
+
+
+<div class="output_subarea output_stream output_stdout output_text">
+<pre>{&#39;source&#39;: &#39;gs://ml-pipeline/data.csv&#39;, &#39;target_lambda&#39;: &#34;lambda x: (x[&#39;target&#39;] &gt; x[&#39;fare&#39;] * 0.2)&#34;}
+</pre>
+</div>
+</div>
+
+</div>
+</div>
+
+
+
 '''
 
-snapshots['TestExporterMethods::test_create_cell_from_args_with_no_args 1'] = ''
+snapshots['TestExporterMethods::test_create_cell_from_args_with_no_args 1'] = '''
+<div class="output_wrapper">
+<div class="output">
 
-snapshots['TestExporterMethods::test_create_cell_from_args_with_one_arg 1'] = '''source = "gs://ml-pipeline/data.csv"
+
+<div class="output_area">
+
+    <div class="prompt"></div>
+
+
+<div class="output_subarea output_stream output_stdout output_text">
+<pre>{}
+</pre>
+</div>
+</div>
+
+</div>
+</div>
+
+
+
+'''
+
+snapshots['TestExporterMethods::test_create_cell_from_args_with_one_arg 1'] = '''
+<div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt"></div>
+
+
+<div class="output_subarea output_stream output_stdout output_text">
+<pre>{&#39;source&#39;: &#39;gs://ml-pipeline/data.csv&#39;}
+</pre>
+</div>
+</div>
+
+</div>
+</div>
+
+
+
 '''
 
 snapshots['TestExporterMethods::test_create_cell_from_file 1'] = '''# Copyright 2019 Google LLC

--- a/backend/src/apiserver/visualization/snapshots/snap_test_exporter.py
+++ b/backend/src/apiserver/visualization/snapshots/snap_test_exporter.py
@@ -18,7 +18,7 @@ snapshots['TestExporterMethods::test_create_cell_from_args_with_multiple_args 1'
 
 
 <div class="output_subarea output_stream output_stdout output_text">
-<pre>{&#39;source&#39;: &#39;gs://ml-pipeline/data.csv&#39;, &#39;target_lambda&#39;: &#34;lambda x: (x[&#39;target&#39;] &gt; x[&#39;fare&#39;] * 0.2)&#34;}
+<pre>[&#39;gs://ml-pipeline/data.csv&#39;, &#34;lambda x: (x[&#39;target&#39;] &gt; x[&#39;fare&#39;] * 0.2)&#34;]
 </pre>
 </div>
 </div>
@@ -64,7 +64,7 @@ snapshots['TestExporterMethods::test_create_cell_from_args_with_one_arg 1'] = ''
 
 
 <div class="output_subarea output_stream output_stdout output_text">
-<pre>{&#39;source&#39;: &#39;gs://ml-pipeline/data.csv&#39;}
+<pre>[&#39;gs://ml-pipeline/data.csv&#39;]
 </pre>
 </div>
 </div>

--- a/backend/src/apiserver/visualization/test_exporter.py
+++ b/backend/src/apiserver/visualization/test_exporter.py
@@ -58,7 +58,7 @@ class TestExporterMethods(snapshottest.TestCase):
         nb = new_notebook()
         args = {"source": "gs://ml-pipeline/data.csv"}
         nb.cells.append(self.exporter.create_cell_from_args(args))
-        nb.cells.append(new_code_cell("print(variables)"))
+        nb.cells.append(new_code_cell("print([variables[key] for key in sorted(variables.keys())])"))
         html = self.exporter.generate_html_from_notebook(nb)
         self.assertMatchSnapshot(html)
 
@@ -70,7 +70,7 @@ class TestExporterMethods(snapshottest.TestCase):
             "target_lambda": "lambda x: (x['target'] > x['fare'] * 0.2)"
         }
         nb.cells.append(self.exporter.create_cell_from_args(args))
-        nb.cells.append(new_code_cell("print(variables)"))
+        nb.cells.append(new_code_cell("print([variables[key] for key in sorted(variables.keys())])"))
         html = self.exporter.generate_html_from_notebook(nb)
         self.assertMatchSnapshot(html)
 

--- a/backend/src/apiserver/visualization/test_exporter.py
+++ b/backend/src/apiserver/visualization/test_exporter.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import importlib
-import os
 import unittest
 from nbformat.v4 import new_code_cell
 from nbformat.v4 import new_notebook
@@ -26,23 +25,6 @@ class TestExporterMethods(snapshottest.TestCase):
 
     def setUp(self):
         self.exporter = exporter.Exporter(100, exporter.TemplateType.BASIC)
-        # Remove any leftover json files from testing/development. This is done
-        # to ensure that test_create_cell_from_args_deletes_file_on_execution
-        # is tested in a valid environment where no json files are present.
-        files = [x for x in os.listdir("./") if len(x) >= 5 and x[-5:] == ".json"]
-        for f in files:
-            os.remove(f)
-
-    def test_create_cell_from_args_deletes_file_on_execution(self):
-        self.maxDiff = None
-        nb = new_notebook()
-        args = {}
-        nb.cells.append(self.exporter.create_cell_from_args(args))
-        self.exporter.generate_html_from_notebook(nb)
-        self.assertEqual(
-            [x for x in os.listdir("./") if len(x) >= 5 and x[-5:] == ".json"],
-            []
-        )
 
     def test_create_cell_from_args_with_no_args(self):
         self.maxDiff = None

--- a/backend/src/apiserver/visualization/test_server.py
+++ b/backend/src/apiserver/visualization/test_server.py
@@ -70,6 +70,17 @@ class TestServerEndpoints(tornado.testing.AsyncHTTPTestCase):
             response.body
         )
 
+    def test_create_visualization_fails_when_invalid_json_is_provided(self):
+        response = self.fetch(
+            "/",
+            method="POST",
+            body='arguments=--type test --source gs://ml-pipeline/data.csv --arguments "{"')
+        self.assertEqual(400, response.code)
+        self.assertEqual(
+            wrap_error_in_html("400: Invalid JSON provided as arguments."),
+            response.body
+        )
+
     def test_create_visualization(self):
         response = self.fetch(
             "/",


### PR DESCRIPTION
Previously, dependency injection occurred by taking a JSON string and converting it to variables within a NotebookNode.

```python
# This
arguments = '{"key": "value"}'
...
# Will become this
key = "value"
```

This would change this to become the following:
```python
# This
arguments = '{"key": "value"}'
...
# Will become this
variables = json.loads(arguments)
# variables = {
#     "key": "value"
# }
```

This change also addresses typing issues that were present with the previous implementation. The Boolean and None types are [not directly supported by JSON](https://docs.python.org/3/library/json.html#encoders-and-decoders), instead `true`/`false` and `nil` are used in valid JSON while the previous implementation expected `True`/`False` and `None` to be provided as values. This is now fully supported and valid JSON is expected with the new implementation of `json.load`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1754)
<!-- Reviewable:end -->
