### PR TITLE
Backend - Docker build should fail on sample compilation failures

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,7 +29,7 @@ COPY ./samples .
 #I think it's better to just use a shell loop though.
 #RUN  for pipeline in $(find . -maxdepth 2 -name '*.py' -type f); do dsl-compile --py "$pipeline" --output "$pipeline.tar.gz"; done
 #The "for" loop breaks on all whitespace, so we either need to override IFS or use the "read" command instead.
-RUN  find core -maxdepth 2 -name '*.py' -type f | while read pipeline; do dsl-compile --py "$pipeline" --output "$pipeline.tar.gz"; done
+RUN  set -e; find core -maxdepth 2 -name '*.py' -type f | while read pipeline; do dsl-compile --py "$pipeline" --output "$pipeline.tar.gz"; done
 
 FROM debian:stretch
 


### PR DESCRIPTION
Problem: Docker implicitly prepends "sh -c " to the RUN commands (no "-e"). Without "-e", the exit code of the shell script is the exit code of the last executed command. So the sample compilation script will only fail if the last sample failed the compilation.

Fix: Explicitly adding "set -e" to the command fixes the issue.

Fixes https://github.com/kubeflow/pipelines/issues/1735

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1760)
<!-- Reviewable:end -->
