### PR TITLE
Skip storing logs to files

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -51,4 +51,4 @@ RUN apt-get update && apt-get install -y ca-certificates
 EXPOSE 8888
 
 # Start the apiserver
-CMD apiserver --config=/config --sampleconfig=/config/sample_config.json -alsologtostderr=true
+CMD apiserver --config=/config --sampleconfig=/config/sample_config.json -logtostderr=true


### PR DESCRIPTION
Log is not useful and leaks the storage resources. Print to std err instead. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1766)
<!-- Reviewable:end -->
