### PR TITLE
Refactors toolbar buttons to use a map rather than an array

### DIFF
--- a/frontend/src/TestUtils.tsx
+++ b/frontend/src/TestUtils.tsx
@@ -73,7 +73,7 @@ export default class TestUtils {
       history: { push: historyPushSpy } as any,
       location: location as any,
       match: matchValue,
-      toolbarProps: { actions: [], breadcrumbs: [], pageTitle: '' },
+      toolbarProps: { actions: {}, breadcrumbs: [], pageTitle: '' },
       updateBanner: updateBannerSpy as any,
       updateDialog: updateDialogSpy as any,
       updateSnackbar: updateSnackbarSpy as any,
@@ -88,9 +88,9 @@ export default class TestUtils {
     return pageProps;
   }
 
-  public static getToolbarButton(updateToolbarSpy: jest.SpyInstance, title: string): ToolbarActionConfig {
+  public static getToolbarButton(updateToolbarSpy: jest.SpyInstance, buttonKey: string): ToolbarActionConfig {
     const lastCallIdx = updateToolbarSpy.mock.calls.length - 1;
     const lastCall = updateToolbarSpy.mock.calls[lastCallIdx][0];
-    return lastCall.actions.find((b: any) => b.title === title);
+    return lastCall.actions[buttonKey];
   }
 }

--- a/frontend/src/components/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar.test.tsx
@@ -17,14 +17,14 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { createBrowserHistory, createMemoryHistory } from 'history';
-import Toolbar from './Toolbar';
+import Toolbar, { ToolbarActionMap } from './Toolbar';
 import HelpIcon from '@material-ui/icons/Help';
 import InfoIcon from '@material-ui/icons/Info';
 
 const action1 = jest.fn();
 const action2 = jest.fn();
-const actions = [
-  {
+const actions: ToolbarActionMap = {
+  'action1': {
     action: action1,
     disabledTitle: 'test disabled title',
     icon: HelpIcon,
@@ -32,7 +32,7 @@ const actions = [
     title: 'test title',
     tooltip: 'test tooltip',
   },
-  {
+  'action2': {
     action: action2,
     disabled: true,
     disabledTitle: 'test disabled title2',
@@ -41,7 +41,7 @@ const actions = [
     title: 'test title2',
     tooltip: 'test tooltip2',
   },
-];
+};
 
 const breadcrumbs = [
   {
@@ -62,62 +62,74 @@ describe('Toolbar', () => {
   });
 
   it('renders nothing when there are no breadcrumbs or actions', () => {
-    const tree = shallow(<Toolbar breadcrumbs={[]} actions={[]} history={history} pageTitle='' />);
+    const tree = shallow(<Toolbar breadcrumbs={[]} actions={{}} history={history} pageTitle='' />);
     expect(tree).toMatchSnapshot();
   });
 
   it('renders without breadcrumbs and a string page title', () => {
-    const tree = shallow(<Toolbar breadcrumbs={[]} actions={[actions[0]]} history={history}
+    const tree = shallow(<Toolbar breadcrumbs={[]} actions={actions} history={history}
       pageTitle='test page title' />);
     expect(tree).toMatchSnapshot();
   });
 
   it('renders without breadcrumbs and a component page title', () => {
-    const tree = shallow(<Toolbar breadcrumbs={[]} actions={[actions[0]]} history={history}
+    const tree = shallow(<Toolbar breadcrumbs={[]} actions={actions} history={history}
       pageTitle={<div id='myComponent'>test page title</div>} />);
     expect(tree).toMatchSnapshot();
   });
 
   it('renders without breadcrumbs and one action', () => {
-    const tree = shallow(<Toolbar breadcrumbs={[]} actions={[actions[0]]} history={history}
-      pageTitle='' />);
+    const singleAction = {
+      'action1': {
+        action: action1,
+        disabledTitle: 'test disabled title',
+        icon: HelpIcon,
+        id: 'test id',
+        title: 'test title',
+        tooltip: 'test tooltip',
+      }
+    };
+    const tree = shallow(<Toolbar breadcrumbs={[]} actions={singleAction} history={history}
+      pageTitle='test page title' />);
     expect(tree).toMatchSnapshot();
   });
 
   it('renders without actions and one breadcrumb', () => {
-    const tree = shallow(<Toolbar breadcrumbs={[breadcrumbs[0]]} actions={[]} history={history}
-      pageTitle='' />);
+    const tree = shallow(<Toolbar breadcrumbs={[breadcrumbs[0]]} actions={{}} history={history}
+      pageTitle='test page title' />);
     expect(tree).toMatchSnapshot();
   });
 
   it('renders without actions, one breadcrumb, and a page name', () => {
-    const tree = shallow(<Toolbar breadcrumbs={[breadcrumbs[0]]} actions={[]} history={history}
+    const tree = shallow(<Toolbar breadcrumbs={[breadcrumbs[0]]} actions={{}} history={history}
       pageTitle='test page title' />);
     expect(tree).toMatchSnapshot();
   });
 
   it('renders without breadcrumbs and two actions', () => {
     const tree = shallow(<Toolbar breadcrumbs={[]} actions={actions} history={history}
-      pageTitle='' />);
+      pageTitle='test page title' />);
     expect(tree).toMatchSnapshot();
   });
 
   it('fires the right action function when button is clicked', () => {
     const tree = shallow(<Toolbar breadcrumbs={[]} actions={actions} history={history}
-      pageTitle='' />);
+      pageTitle='test page title' />);
     tree.find('BusyButton').at(0).simulate('click');
     expect(action1).toHaveBeenCalled();
-    action2.mockClear();
+    action1.mockClear();
   });
 
   it('renders outlined action buttons', () => {
-    const outlinedActions = [{
-      action: jest.fn(),
-      id: 'test id',
-      outlined: true,
-      title: 'test title',
-      tooltip: 'test tooltip',
-    }];
+    const outlinedActions = {
+      'action1': {
+        action: jest.fn(),
+        id: 'test outlined id',
+        outlined: true,
+        title: 'test outlined title',
+        tooltip: 'test outlined tooltip',
+      }
+    };
 
     const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={outlinedActions} pageTitle=''
       history={history} />);
@@ -125,30 +137,34 @@ describe('Toolbar', () => {
   });
 
   it('renders primary action buttons', () => {
-    const outlinedActions = [{
-      action: jest.fn(),
-      id: 'test id',
-      primary: true,
-      title: 'test title',
-      tooltip: 'test tooltip',
-    }];
+    const primaryActions = {
+      'action1': {
+        action: jest.fn(),
+        id: 'test primary id',
+        primary: true,
+        title: 'test primary title',
+        tooltip: 'test primary tooltip',
+      }
+    };
 
-    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={outlinedActions} pageTitle=''
+    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={primaryActions} pageTitle=''
       history={history} />);
     expect(tree).toMatchSnapshot();
   });
 
   it('renders primary action buttons without outline, even if outline is true', () => {
-    const outlinedActions = [{
-      action: jest.fn(),
-      id: 'test id',
-      outlined: true,
-      primary: true,
-      title: 'test title',
-      tooltip: 'test tooltip',
-    }];
+    const outlinedPrimaryActions = {
+      'action1': {
+        action: jest.fn(),
+        id: 'test id',
+        outlined: true,
+        primary: true,
+        title: 'test title',
+        tooltip: 'test tooltip',
+      }
+    };
 
-    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={outlinedActions} pageTitle=''
+    const tree = shallow(<Toolbar breadcrumbs={breadcrumbs} actions={outlinedPrimaryActions} pageTitle=''
       history={history} />);
     expect(tree).toMatchSnapshot();
   });

--- a/frontend/src/components/Toolbar.tsx
+++ b/frontend/src/components/Toolbar.tsx
@@ -26,6 +26,8 @@ import { classes, stylesheet } from 'typestyle';
 import { spacing, fonts, fontsize, color, dimension, commonCss } from '../Css';
 import { CSSProperties } from 'react';
 
+export interface ToolbarActionMap { [key: string]: ToolbarActionConfig; }
+
 export interface ToolbarActionConfig {
   action: () => void;
   busy?: boolean;
@@ -106,7 +108,7 @@ const css = stylesheet({
 });
 
 export interface ToolbarProps {
-  actions: ToolbarActionConfig[];
+  actions: ToolbarActionMap;
   breadcrumbs: Breadcrumb[];
   history?: History;
   pageTitle: string | JSX.Element;
@@ -117,9 +119,9 @@ export interface ToolbarProps {
 class Toolbar extends React.Component<ToolbarProps> {
 
   public render(): JSX.Element | null {
-    const { breadcrumbs, pageTitle, pageTitleTooltip } = { ...this.props };
+    const { actions, breadcrumbs, pageTitle, pageTitleTooltip } = { ...this.props };
 
-    if (!this.props.actions.length && !this.props.breadcrumbs.length && !this.props.pageTitle) {
+    if (!actions.length && !breadcrumbs.length && !pageTitle) {
       return null;
     }
 
@@ -160,17 +162,20 @@ class Toolbar extends React.Component<ToolbarProps> {
         </div>
         {/* Actions / Buttons */}
         <div className={css.actions}>
-          {this.props.actions.map((b, i) => (
-            <Tooltip title={(b.disabled && b.disabledTitle) ? b.disabledTitle : b.tooltip}
-              enterDelay={300} key={i}>
-              <div style={b.style}>{/* Extra level needed by tooltip when child is disabled */}
-                <BusyButton id={b.id} color='secondary' onClick={b.action} disabled={b.disabled}
-                  title={b.title} icon={b.icon} busy={b.busy || false}
-                  outlined={(b.outlined && !b.primary) || false}
-                  className={b.primary ? commonCss.buttonAction : ''} />
-              </div>
-            </Tooltip>
-          ))}
+          {Object.keys(actions).map((buttonKey, i) => {
+            const button = actions[buttonKey];
+            return (
+              <Tooltip title={(button.disabled && button.disabledTitle) ? button.disabledTitle : button.tooltip}
+                enterDelay={300} key={i}>
+                <div style={button.style}>{/* Extra level needed by tooltip when child is disabled */}
+                  <BusyButton id={button.id} color='secondary' onClick={button.action} disabled={button.disabled}
+                    title={button.title} icon={button.icon} busy={button.busy || false}
+                    outlined={(button.outlined && !button.primary) || false}
+                    className={button.primary ? commonCss.buttonAction : ''} />
+                </div>
+              </Tooltip>
+            );
+          })}
         </div>
       </div>
     );

--- a/frontend/src/components/__snapshots__/Toolbar.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Toolbar.test.tsx.snap
@@ -84,13 +84,7 @@ exports[`Toolbar disables the back button when there is no browser history 1`] =
           color="secondary"
           icon={[Function]}
           id="test id"
-          onClick={
-            [MockFunction] {
-              "calls": Array [
-                Array [],
-              ],
-            }
-          }
+          onClick={[MockFunction]}
           outlined={false}
           title="test title"
         />
@@ -196,17 +190,17 @@ exports[`Toolbar renders outlined action buttons 1`] = `
     <WithStyles(Tooltip)
       enterDelay={300}
       key="0"
-      title="test tooltip"
+      title="test outlined tooltip"
     >
       <div>
         <BusyButton
           busy={false}
           className=""
           color="secondary"
-          id="test id"
+          id="test outlined id"
           onClick={[MockFunction]}
           outlined={true}
-          title="test title"
+          title="test outlined title"
         />
       </div>
     </WithStyles(Tooltip)>
@@ -289,17 +283,17 @@ exports[`Toolbar renders primary action buttons 1`] = `
     <WithStyles(Tooltip)
       enterDelay={300}
       key="0"
-      title="test tooltip"
+      title="test primary tooltip"
     >
       <div>
         <BusyButton
           busy={false}
           className="buttonAction"
           color="secondary"
-          id="test id"
+          id="test primary id"
           onClick={[MockFunction]}
           outlined={false}
-          title="test title"
+          title="test primary title"
         />
       </div>
     </WithStyles(Tooltip)>
@@ -484,13 +478,7 @@ exports[`Toolbar renders with two breadcrumbs and two actions 1`] = `
           color="secondary"
           icon={[Function]}
           id="test id"
-          onClick={
-            [MockFunction] {
-              "calls": Array [
-                Array [],
-              ],
-            }
-          }
+          onClick={[MockFunction]}
           outlined={false}
           title="test title"
         />
@@ -569,7 +557,9 @@ exports[`Toolbar renders without actions and one breadcrumb 1`] = `
       </WithStyles(Tooltip)>
       <span
         className="pageName ellipsis"
-      />
+      >
+        test page title
+      </span>
     </div>
   </div>
   <div
@@ -688,6 +678,25 @@ exports[`Toolbar renders without breadcrumbs and a component page title 1`] = `
         />
       </div>
     </WithStyles(Tooltip)>
+    <WithStyles(Tooltip)
+      enterDelay={300}
+      key="1"
+      title="test disabled title2"
+    >
+      <div>
+        <BusyButton
+          busy={false}
+          className=""
+          color="secondary"
+          disabled={true}
+          icon={[Function]}
+          id="test id2"
+          onClick={[MockFunction]}
+          outlined={false}
+          title="test title2"
+        />
+      </div>
+    </WithStyles(Tooltip)>
   </div>
 </div>
 `;
@@ -737,6 +746,25 @@ exports[`Toolbar renders without breadcrumbs and a string page title 1`] = `
         />
       </div>
     </WithStyles(Tooltip)>
+    <WithStyles(Tooltip)
+      enterDelay={300}
+      key="1"
+      title="test disabled title2"
+    >
+      <div>
+        <BusyButton
+          busy={false}
+          className=""
+          color="secondary"
+          disabled={true}
+          icon={[Function]}
+          id="test id2"
+          onClick={[MockFunction]}
+          outlined={false}
+          title="test title2"
+        />
+      </div>
+    </WithStyles(Tooltip)>
   </div>
 </div>
 `;
@@ -760,7 +788,9 @@ exports[`Toolbar renders without breadcrumbs and one action 1`] = `
     >
       <span
         className="pageName ellipsis"
-      />
+      >
+        test page title
+      </span>
     </div>
   </div>
   <div
@@ -807,7 +837,9 @@ exports[`Toolbar renders without breadcrumbs and two actions 1`] = `
     >
       <span
         className="pageName ellipsis"
-      />
+      >
+        test page title
+      </span>
     </div>
   </div>
   <div

--- a/frontend/src/lib/Buttons.ts
+++ b/frontend/src/lib/Buttons.ts
@@ -17,27 +17,53 @@
 import AddIcon from '@material-ui/icons/Add';
 import CollapseIcon from '@material-ui/icons/UnfoldLess';
 import ExpandIcon from '@material-ui/icons/UnfoldMore';
-import { ToolbarActionConfig } from '../components/Toolbar';
 import { PageProps } from '../pages/Page';
 import { URLParser } from './URLParser';
 import { RoutePage, QUERY_PARAMS } from '../components/Router';
 import { Apis } from './Apis';
 import { errorToMessage, s } from './Utils';
+import { ToolbarActionMap } from '../components/Toolbar';
+
+export enum ButtonKeys {
+  ARCHIVE = 'archive',
+  CLONE_RUN = 'cloneRun',
+  CLONE_RECURRING_RUN = 'cloneRecurringRun',
+  COLLAPSE = 'collapse',
+  COMPARE = 'compare',
+  DELETE_RUN = 'deleteRun',
+  DISABLE_RECURRING_RUN = 'disableRecurringRun',
+  ENABLE_RECURRING_RUN = 'enableRecurringRun',
+  EXPAND = 'expand',
+  NEW_EXPERIMENT = 'newExperiment',
+  NEW_RUN = 'newRun',
+  NEW_RECURRING_RUN = 'newRecurringRun',
+  NEW_RUN_FROM_PIPELINE = 'newRunFromPipeline',
+  REFRESH = 'refresh',
+  RESTORE = 'restore',
+  TERMINATE_RUN = 'terminateRun',
+  UPLOAD_PIPELINE = 'uploadPipeline',
+}
 
 export default class Buttons {
+  private _map: ToolbarActionMap;
   private _props: PageProps;
   private _refresh: () => void;
   private _urlParser: URLParser;
 
-  constructor(pageProps: PageProps, refresh: () => void) {
+  constructor(pageProps: PageProps, refresh: () => void, map?: ToolbarActionMap) {
     this._props = pageProps;
     this._refresh = refresh;
     this._urlParser = new URLParser(pageProps);
+    this._map = map || {};
+  }
+
+  public getToolbarActionMap(): ToolbarActionMap {
+    return this._map;
   }
 
   public archive(getSelectedIds: () => string[], useCurrentResource: boolean,
-    callback: (selectedIds: string[], success: boolean) => void): ToolbarActionConfig {
-    return {
+    callback: (selectedIds: string[], success: boolean) => void): Buttons {
+    this._map[ButtonKeys.ARCHIVE] = {
       action: () => this._archive(getSelectedIds(), useCurrentResource, callback),
       disabled: !useCurrentResource,
       disabledTitle: useCurrentResource ? undefined : 'Select at least one resource to archive',
@@ -45,10 +71,11 @@ export default class Buttons {
       title: 'Archive',
       tooltip: 'Archive',
     };
+    return this;
   }
 
-  public cloneRun(getSelectedIds: () => string[], useCurrentResource: boolean): ToolbarActionConfig {
-    return {
+  public cloneRun(getSelectedIds: () => string[], useCurrentResource: boolean): Buttons {
+    this._map[ButtonKeys.CLONE_RUN] = {
       action: () => this._cloneRun(getSelectedIds()),
       disabled: !useCurrentResource,
       disabledTitle: useCurrentResource ? undefined : 'Select a run to clone',
@@ -57,10 +84,11 @@ export default class Buttons {
       title: 'Clone run',
       tooltip: 'Create a copy from this run\s initial state',
     };
+    return this;
   }
 
-  public cloneRecurringRun(getSelectedIds: () => string[], useCurrentResource: boolean): ToolbarActionConfig {
-    return {
+  public cloneRecurringRun(getSelectedIds: () => string[], useCurrentResource: boolean): Buttons {
+    this._map[ButtonKeys.CLONE_RECURRING_RUN] = {
       action: () => this._cloneRun(getSelectedIds(), true),
       disabled: !useCurrentResource,
       disabledTitle: useCurrentResource ? undefined : 'Select a recurring run to clone',
@@ -68,20 +96,22 @@ export default class Buttons {
       title: 'Clone recurring run',
       tooltip: 'Create a copy from this run\s initial state',
     };
+    return this;
   }
 
-  public collapseSections(action: () => void): ToolbarActionConfig {
-    return {
+  public collapseSections(action: () => void): Buttons {
+    this._map[ButtonKeys.COLLAPSE] = {
       action,
       icon: CollapseIcon,
       id: 'collapseBtn',
       title: 'Collapse all',
       tooltip: 'Collapse all sections',
     };
+    return this;
   }
 
-  public compareRuns(getSelectedIds: () => string[]): ToolbarActionConfig {
-    return {
+  public compareRuns(getSelectedIds: () => string[]): Buttons {
+    this._map[ButtonKeys.COMPARE] = {
       action: () => this._compareRuns(getSelectedIds()),
       disabled: true,
       disabledTitle: 'Select multiple runs to compare',
@@ -90,11 +120,12 @@ export default class Buttons {
       title: 'Compare runs',
       tooltip: 'Compare up to 10 selected runs',
     };
+    return this;
   }
 
   public delete(getSelectedIds: () => string[], resourceName: 'pipeline' | 'recurring run config',
-    callback: (selectedIds: string[], success: boolean) => void, useCurrentResource: boolean): ToolbarActionConfig {
-    return {
+    callback: (selectedIds: string[], success: boolean) => void, useCurrentResource: boolean): Buttons {
+    this._map[ButtonKeys.DELETE_RUN] = {
       action: () => resourceName === 'pipeline' ?
         this._deletePipeline(getSelectedIds(), useCurrentResource, callback) :
         this._deleteRecurringRun(getSelectedIds()[0], useCurrentResource, callback),
@@ -104,10 +135,11 @@ export default class Buttons {
       title: 'Delete',
       tooltip: 'Delete',
     };
+    return this;
   }
 
-  public disableRecurringRun(getId: () => string): ToolbarActionConfig {
-    return {
+  public disableRecurringRun(getId: () => string): Buttons {
+    this._map[ButtonKeys.DISABLE_RECURRING_RUN] = {
       action: () => this._setRecurringRunEnabledState(getId(), false),
       disabled: true,
       disabledTitle: 'Run schedule already disabled',
@@ -115,10 +147,11 @@ export default class Buttons {
       title: 'Disable',
       tooltip: 'Disable the run\'s trigger',
     };
+    return this;
   }
 
-  public enableRecurringRun(getId: () => string): ToolbarActionConfig {
-    return {
+  public enableRecurringRun(getId: () => string): Buttons {
+    this._map[ButtonKeys.ENABLE_RECURRING_RUN] = {
       action: () => this._setRecurringRunEnabledState(getId(), true),
       disabled: true,
       disabledTitle: 'Run schedule already enabled',
@@ -126,19 +159,21 @@ export default class Buttons {
       title: 'Enable',
       tooltip: 'Enable the run\'s trigger',
     };
+    return this;
   }
-  public expandSections(action: () => void): ToolbarActionConfig {
-    return {
+  public expandSections(action: () => void): Buttons {
+    this._map[ButtonKeys.EXPAND] = {
       action,
       icon: ExpandIcon,
       id: 'expandBtn',
       title: 'Expand all',
       tooltip: 'Expand all sections',
     };
+    return this;
   }
 
-  public newExperiment(getPipelineId?: () => string): ToolbarActionConfig {
-    return {
+  public newExperiment(getPipelineId?: () => string): Buttons {
+    this._map[ButtonKeys.NEW_EXPERIMENT] = {
       action: () => this._createNewExperiment(getPipelineId ? getPipelineId() : ''),
       icon: AddIcon,
       id: 'newExperimentBtn',
@@ -147,10 +182,11 @@ export default class Buttons {
       title: 'Create experiment',
       tooltip: 'Create a new experiment',
     };
+    return this;
   }
 
-  public newRun(getExperimentId?: () => string): ToolbarActionConfig {
-    return {
+  public newRun(getExperimentId?: () => string): Buttons {
+    this._map[ButtonKeys.NEW_RUN] = {
       action: () => this._createNewRun(false, getExperimentId ? getExperimentId() : undefined),
       icon: AddIcon,
       id: 'createNewRunBtn',
@@ -160,10 +196,11 @@ export default class Buttons {
       title: 'Create run',
       tooltip: 'Create a new run',
     };
+    return this;
   }
 
-  public newRunFromPipeline(getPipelineId: () => string): ToolbarActionConfig {
-    return {
+  public newRunFromPipeline(getPipelineId: () => string): Buttons {
+    this._map[ButtonKeys.NEW_RUN_FROM_PIPELINE] = {
       action: () => this._createNewRunFromPipeline(getPipelineId()),
       icon: AddIcon,
       id: 'createNewRunBtn',
@@ -173,10 +210,11 @@ export default class Buttons {
       title: 'Create run',
       tooltip: 'Create a new run',
     };
+    return this;
   }
 
-  public newRecurringRun(experimentId: string): ToolbarActionConfig {
-    return {
+  public newRecurringRun(experimentId: string): Buttons {
+    this._map[ButtonKeys.NEW_RECURRING_RUN] = {
       action: () => this._createNewRun(true, experimentId),
       icon: AddIcon,
       id: 'createNewRecurringRunBtn',
@@ -185,20 +223,22 @@ export default class Buttons {
       title: 'Create recurring run',
       tooltip: 'Create a new recurring run',
     };
+    return this;
   }
 
-  public refresh(action: () => void): ToolbarActionConfig {
-    return {
+  public refresh(action: () => void): Buttons {
+    this._map[ButtonKeys.REFRESH] = {
       action,
       id: 'refreshBtn',
       title: 'Refresh',
       tooltip: 'Refresh the list',
     };
+    return this;
   }
 
   public restore(getSelectedIds: () => string[], useCurrentResource: boolean,
-    callback: (selectedIds: string[], success: boolean) => void): ToolbarActionConfig {
-    return {
+    callback: (selectedIds: string[], success: boolean) => void): Buttons {
+    this._map[ButtonKeys.RESTORE] = {
       action: () => this._restore(getSelectedIds(), useCurrentResource, callback),
       disabled: !useCurrentResource,
       disabledTitle: useCurrentResource ? undefined : 'Select at least one resource to restore',
@@ -206,11 +246,12 @@ export default class Buttons {
       title: 'Restore',
       tooltip: 'Restore',
     };
+    return this;
   }
 
   public terminateRun(getSelectedIds: () => string[], useCurrentResource: boolean,
-      callback: (selectedIds: string[], success: boolean) => void): ToolbarActionConfig {
-    return {
+    callback: (selectedIds: string[], success: boolean) => void): Buttons {
+    this._map[ButtonKeys.TERMINATE_RUN] = {
       action: () => this._terminateRun(getSelectedIds(), useCurrentResource, callback),
       disabled: !useCurrentResource,
       disabledTitle: useCurrentResource ? undefined : 'Select at least one run to terminate',
@@ -218,10 +259,11 @@ export default class Buttons {
       title: 'Terminate',
       tooltip: 'Terminate execution of a run',
     };
+    return this;
   }
 
-  public upload(action: () => void): ToolbarActionConfig {
-    return {
+  public upload(action: () => void): Buttons {
+    this._map[ButtonKeys.UPLOAD_PIPELINE] = {
       action,
       icon: AddIcon,
       id: 'uploadBtn',
@@ -230,6 +272,7 @@ export default class Buttons {
       title: 'Upload pipeline',
       tooltip: 'Upload pipeline',
     };
+    return this;
   }
 
   private _cloneRun(selectedIds: string[], isRecurring?: boolean): void {
@@ -419,11 +462,12 @@ export default class Buttons {
 
   private async _setRecurringRunEnabledState(id: string, enabled: boolean): Promise<void> {
     if (id) {
-      const toolbarActions = [...this._props.toolbarProps.actions];
+      const toolbarActions = this._props.toolbarProps.actions;
 
-      const buttonIndex = enabled ? 1 : 2;
+      // TODO(rileyjbauer): make sure this is working as expected
+      const buttonKey = enabled ? ButtonKeys.ENABLE_RECURRING_RUN : ButtonKeys.DISABLE_RECURRING_RUN;
 
-      toolbarActions[buttonIndex].busy = true;
+      toolbarActions[buttonKey].busy = true;
       this._props.updateToolbar({ actions: toolbarActions });
       try {
         await (enabled ? Apis.jobServiceApi.enableJob(id) : Apis.jobServiceApi.disableJob(id));
@@ -436,7 +480,7 @@ export default class Buttons {
           title: `Failed to ${enabled ? 'enable' : 'disable'} recurring run`,
         });
       } finally {
-        toolbarActions[buttonIndex].busy = false;
+        toolbarActions[buttonKey].busy = false;
         this._props.updateToolbar({ actions: toolbarActions });
       }
     }

--- a/frontend/src/pages/404.tsx
+++ b/frontend/src/pages/404.tsx
@@ -20,7 +20,7 @@ import { ToolbarProps } from '../components/Toolbar';
 
 export default class Page404 extends Page<{}, {}> {
   public getInitialToolbarState(): ToolbarProps {
-    return { actions: [], breadcrumbs: [], pageTitle: '' };
+    return { actions: {}, breadcrumbs: [], pageTitle: '' };
   }
 
   public async refresh(): Promise<void> {

--- a/frontend/src/pages/AllRunsList.test.tsx
+++ b/frontend/src/pages/AllRunsList.test.tsx
@@ -20,6 +20,7 @@ import { PageProps } from './Page';
 import { RoutePage } from '../components/Router';
 import { RunStorageState } from '../apis/run';
 import { shallow, ShallowWrapper } from 'enzyme';
+import { ButtonKeys } from '../lib/Buttons';
 
 describe('AllRunsList', () => {
   const updateBannerSpy = jest.fn();
@@ -67,17 +68,17 @@ describe('AllRunsList', () => {
 
   it('only enables clone button when exactly one run is selected', () => {
     shallowMountComponent();
-    const archiveBtn = _toolbarProps.actions.find((a: any) => a.title === 'Clone run');
-    expect(archiveBtn.disabled).toBeTruthy();
+    const cloneBtn = _toolbarProps.actions[ButtonKeys.CLONE_RUN];
+    expect(cloneBtn.disabled).toBeTruthy();
     tree.find('RunList').simulate('selectionChange', ['run1']);
-    expect(archiveBtn.disabled).toBeFalsy();
+    expect(cloneBtn.disabled).toBeFalsy();
     tree.find('RunList').simulate('selectionChange', ['run1', 'run2']);
-    expect(archiveBtn.disabled).toBeTruthy();
+    expect(cloneBtn.disabled).toBeTruthy();
   });
 
   it('enables archive button when at least one run is selected', () => {
     shallowMountComponent();
-    const archiveBtn = _toolbarProps.actions.find((a: any) => a.title === 'Archive');
+    const archiveBtn = _toolbarProps.actions[ButtonKeys.ARCHIVE];
     expect(archiveBtn.disabled).toBeTruthy();
     tree.find('RunList').simulate('selectionChange', ['run1']);
     expect(archiveBtn.disabled).toBeFalsy();
@@ -89,21 +90,21 @@ describe('AllRunsList', () => {
     shallowMountComponent();
     const spy = jest.fn();
     (tree.instance() as any)._runlistRef = { current: { refresh: spy } };
-    _toolbarProps.actions.find((a: any) => a.title === 'Refresh').action();
+    _toolbarProps.actions[ButtonKeys.REFRESH].action();
     expect(spy).toHaveBeenLastCalledWith();
   });
 
   it('navigates to new run page when clone is clicked', () => {
     shallowMountComponent();
     tree.find('RunList').simulate('selectionChange', ['run1']);
-    _toolbarProps.actions.find((a: any) => a.title === 'Clone run').action();
+    _toolbarProps.actions[ButtonKeys.CLONE_RUN].action();
     expect(historyPushSpy).toHaveBeenLastCalledWith(RoutePage.NEW_RUN + '?cloneFromRun=run1');
   });
 
   it('navigates to compare page when compare button is clicked', () => {
     shallowMountComponent();
     tree.find('RunList').simulate('selectionChange', ['run1', 'run2', 'run3']);
-    _toolbarProps.actions.find((a: any) => a.title === 'Compare runs').action();
+    _toolbarProps.actions[ButtonKeys.COMPARE].action();
     expect(historyPushSpy).toHaveBeenLastCalledWith(RoutePage.COMPARE + '?runlist=run1,run2,run3');
   });
 

--- a/frontend/src/pages/AllRunsList.tsx
+++ b/frontend/src/pages/AllRunsList.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from 'react';
-import Buttons from '../lib/Buttons';
+import Buttons, { ButtonKeys } from '../lib/Buttons';
 import RunList from './RunList';
 import { Page } from './Page';
 import { RunStorageState } from '../apis/run';
@@ -42,18 +42,18 @@ class AllRunsList extends Page<{}, AllRunsListState> {
   public getInitialToolbarState(): ToolbarProps {
     const buttons = new Buttons(this.props, this.refresh.bind(this));
     return {
-      actions: [
-        buttons.newRun(),
-        buttons.newExperiment(),
-        buttons.compareRuns(() => this.state.selectedIds),
-        buttons.cloneRun(() => this.state.selectedIds, false),
-        buttons.archive(
-          () => this.state.selectedIds,
-          false,
-          selectedIds => this._selectionChanged(selectedIds),
-        ),
-        buttons.refresh(this.refresh.bind(this)),
-      ],
+      actions: buttons
+        .newRun()
+        .newExperiment()
+        .compareRuns(() => this.state.selectedIds)
+        .cloneRun(() => this.state.selectedIds, false)
+        .archive(
+            () => this.state.selectedIds,
+            false,
+            selectedIds => this._selectionChanged(selectedIds),
+          )
+        .refresh(this.refresh.bind(this))
+        .getToolbarActionMap(),
       breadcrumbs: [],
       pageTitle: 'Experiments',
     };
@@ -76,15 +76,10 @@ class AllRunsList extends Page<{}, AllRunsListState> {
   }
 
   private _selectionChanged(selectedIds: string[]): void {
-    const toolbarActions = [...this.props.toolbarProps.actions];
-    // TODO: keeping track of indices in the toolbarActions array is not ideal. This should be
-    // refactored so that individual buttons can be referenced with something other than indices.
-    // Compare runs button
-    toolbarActions[2].disabled = selectedIds.length <= 1 || selectedIds.length > 10;
-    // Clone run button
-    toolbarActions[3].disabled = selectedIds.length !== 1;
-    // Archive run button
-    toolbarActions[4].disabled = !selectedIds.length;
+    const toolbarActions = this.props.toolbarProps.actions;
+    toolbarActions[ButtonKeys.COMPARE].disabled = selectedIds.length <= 1 || selectedIds.length > 10;
+    toolbarActions[ButtonKeys.CLONE_RUN].disabled = selectedIds.length !== 1;
+    toolbarActions[ButtonKeys.ARCHIVE].disabled = !selectedIds.length;
     this.props.updateToolbar({ breadcrumbs: this.props.toolbarProps.breadcrumbs, actions: toolbarActions });
     this.setState({ selectedIds });
   }

--- a/frontend/src/pages/Archive.test.tsx
+++ b/frontend/src/pages/Archive.test.tsx
@@ -20,6 +20,7 @@ import TestUtils from '../TestUtils';
 import { PageProps } from './Page';
 import { RunStorageState } from '../apis/run';
 import { ShallowWrapper, shallow } from 'enzyme';
+import { ButtonKeys } from '../lib/Buttons';
 
 describe('Archive', () => {
   const updateBannerSpy = jest.fn();
@@ -55,20 +56,20 @@ describe('Archive', () => {
     tree = shallow(<Archive {...generateProps()} />);
     TestUtils.flushPromises();
     tree.update();
-    expect(TestUtils.getToolbarButton(updateToolbarSpy, 'Restore').disabled).toBeTruthy();
+    expect(TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.RESTORE).disabled).toBeTruthy();
     tree.find('RunList').simulate('selectionChange', ['run1']);
-    expect(TestUtils.getToolbarButton(updateToolbarSpy, 'Restore').disabled).toBeFalsy();
+    expect(TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.RESTORE).disabled).toBeFalsy();
     tree.find('RunList').simulate('selectionChange', ['run1', 'run2']);
-    expect(TestUtils.getToolbarButton(updateToolbarSpy, 'Restore').disabled).toBeFalsy();
+    expect(TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.RESTORE).disabled).toBeFalsy();
     tree.find('RunList').simulate('selectionChange', []);
-    expect(TestUtils.getToolbarButton(updateToolbarSpy, 'Restore').disabled).toBeTruthy();
+    expect(TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.RESTORE).disabled).toBeTruthy();
   });
 
   it('refreshes the run list when refresh button is clicked', async () => {
     tree = shallow(<Archive {...generateProps()} />);
     const spy = jest.fn();
     (tree.instance() as any)._runlistRef = { current: { refresh: spy } };
-    await TestUtils.getToolbarButton(updateToolbarSpy, 'Refresh').action();
+    await TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.REFRESH).action();
     expect(spy).toHaveBeenLastCalledWith();
   });
 

--- a/frontend/src/pages/Archive.tsx
+++ b/frontend/src/pages/Archive.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from 'react';
-import Buttons from '../lib/Buttons';
+import Buttons, { ButtonKeys } from '../lib/Buttons';
 import RunList from './RunList';
 import { Page } from './Page';
 import { RunStorageState } from '../apis/run';
@@ -41,14 +41,14 @@ export default class Archive extends Page<{}, ArchiveState> {
   public getInitialToolbarState(): ToolbarProps {
     const buttons = new Buttons(this.props, this.refresh.bind(this));
     return {
-      actions: [
-        buttons.restore(
+      actions: buttons
+        .restore(
           () => this.state.selectedIds,
           false,
           this._selectionChanged.bind(this),
-        ),
-        buttons.refresh(this.refresh.bind(this)),
-      ],
+        )
+        .refresh(this.refresh.bind(this))
+        .getToolbarActionMap(),
       breadcrumbs: [],
       pageTitle: 'Archive',
     };
@@ -71,9 +71,8 @@ export default class Archive extends Page<{}, ArchiveState> {
   }
 
   private _selectionChanged(selectedIds: string[]): void {
-    const toolbarActions = [...this.props.toolbarProps.actions];
-    // Restore button
-    toolbarActions[0].disabled = !selectedIds.length;
+    const toolbarActions = this.props.toolbarProps.actions;
+    toolbarActions[ButtonKeys.RESTORE].disabled = !selectedIds.length;
     this.props.updateToolbar({ breadcrumbs: this.props.toolbarProps.breadcrumbs, actions: toolbarActions });
     this.setState({ selectedIds });
   }

--- a/frontend/src/pages/Compare.test.tsx
+++ b/frontend/src/pages/Compare.test.tsx
@@ -25,6 +25,7 @@ import { ApiRunDetail } from '../apis/run';
 import { PlotType } from '../components/viewers/Viewer';
 import { OutputArtifactLoader } from '../lib/OutputArtifactLoader';
 import { Workflow } from '../../third_party/argo-ui/argo_template';
+import { ButtonKeys } from '../lib/Buttons';
 
 class TestCompare extends Compare {
   public _selectionChanged(selectedIds: string[]): void {
@@ -396,8 +397,7 @@ describe('Compare', () => {
   it('collapses all sections', async () => {
     await setUpViewersAndShallowMount();
     const instance = tree.instance() as Compare;
-    const collapseBtn =
-      instance.getInitialToolbarState().actions.find(b => b.title === 'Collapse all');
+    const collapseBtn = instance.getInitialToolbarState().actions[ButtonKeys.COLLAPSE];
 
     expect(tree.state('collapseSections')).toEqual({});
 
@@ -417,10 +417,8 @@ describe('Compare', () => {
   it('expands all sections if they were collapsed', async () => {
     await setUpViewersAndShallowMount();
     const instance = tree.instance() as Compare;
-    const collapseBtn =
-      instance.getInitialToolbarState().actions.find(b => b.title === 'Collapse all');
-    const expandBtn =
-      instance.getInitialToolbarState().actions.find(b => b.title === 'Expand all');
+    const collapseBtn = instance.getInitialToolbarState().actions[ButtonKeys.COLLAPSE];
+    const expandBtn = instance.getInitialToolbarState().actions[ButtonKeys.EXPAND];
 
     expect(tree.state('collapseSections')).toEqual({});
 

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -86,11 +86,11 @@ class Compare extends Page<{}, CompareState> {
   public getInitialToolbarState(): ToolbarProps {
     const buttons = new Buttons(this.props, this.refresh.bind(this));
     return {
-      actions: [
-        buttons.expandSections(() => this.setState({ collapseSections: {} })),
-        buttons.collapseSections(this._collapseAllSections.bind(this)),
-        buttons.refresh(this.refresh.bind(this)),
-      ],
+      actions: buttons
+        .expandSections(() => this.setState({ collapseSections: {} }))
+        .collapseSections(this._collapseAllSections.bind(this))
+        .refresh(this.refresh.bind(this))
+        .getToolbarActionMap(),
       breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
       pageTitle: 'Compare runs',
     };

--- a/frontend/src/pages/ExperimentDetails.test.tsx
+++ b/frontend/src/pages/ExperimentDetails.test.tsx
@@ -26,6 +26,7 @@ import { RoutePage, RouteParams, QUERY_PARAMS } from '../components/Router';
 import { RunStorageState } from '../apis/run';
 import { ToolbarProps } from '../components/Toolbar';
 import { range } from 'lodash';
+import { ButtonKeys } from '../lib/Buttons';
 
 describe('ExperimentDetails', () => {
 
@@ -345,8 +346,7 @@ describe('ExperimentDetails', () => {
     tree.find('.tableRow').at(0).simulate('click');
     tree.find('.tableRow').at(1).simulate('click');
 
-    const compareBtn = (tree.state('runListToolbarProps') as ToolbarProps)
-      .actions.find(b => b.title === 'Compare runs');
+    const compareBtn = (tree.state('runListToolbarProps') as ToolbarProps).actions[ButtonKeys.COMPARE];
     await compareBtn!.action();
 
     expect(historyPushSpy).toHaveBeenCalledWith(
@@ -358,8 +358,7 @@ describe('ExperimentDetails', () => {
     await TestUtils.flushPromises();
     tree.update();
 
-    const newRunBtn = (tree.state('runListToolbarProps') as ToolbarProps)
-      .actions.find(b => b.title === 'Create run');
+    const newRunBtn = (tree.state('runListToolbarProps') as ToolbarProps).actions[ButtonKeys.NEW_RUN];
     await newRunBtn!.action();
 
     expect(historyPushSpy).toHaveBeenCalledWith(
@@ -371,8 +370,7 @@ describe('ExperimentDetails', () => {
     await TestUtils.flushPromises();
     tree.update();
 
-    const newRecurringRunBtn = (tree.state('runListToolbarProps') as ToolbarProps)
-      .actions.find(b => b.title === 'Create recurring run');
+    const newRecurringRunBtn = (tree.state('runListToolbarProps') as ToolbarProps).actions[ButtonKeys.NEW_RECURRING_RUN];
     await newRecurringRunBtn!.action();
 
     expect(historyPushSpy).toHaveBeenCalledWith(
@@ -393,8 +391,7 @@ describe('ExperimentDetails', () => {
     // Select the run to clone
     tree.find('.tableRow').simulate('click');
 
-    const cloneBtn = (tree.state('runListToolbarProps') as ToolbarProps)
-      .actions.find(b => b.title === 'Clone run');
+    const cloneBtn = (tree.state('runListToolbarProps') as ToolbarProps).actions[ButtonKeys.CLONE_RUN];
     await cloneBtn!.action();
 
     expect(historyPushSpy).toHaveBeenCalledWith(
@@ -408,8 +405,7 @@ describe('ExperimentDetails', () => {
     await TestUtils.flushPromises();
     tree.update();
 
-    const compareBtn = (tree.state('runListToolbarProps') as ToolbarProps)
-      .actions.find(b => b.title === 'Compare runs');
+    const compareBtn = (tree.state('runListToolbarProps') as ToolbarProps).actions[ButtonKeys.COMPARE];
 
     for (let i = 0; i < 12; i++) {
       if (i < 2 || i > 10) {
@@ -428,8 +424,7 @@ describe('ExperimentDetails', () => {
     await TestUtils.flushPromises();
     tree.update();
 
-    const cloneBtn = (tree.state('runListToolbarProps') as ToolbarProps)
-      .actions.find(b => b.title === 'Clone run');
+    const cloneBtn = (tree.state('runListToolbarProps') as ToolbarProps).actions[ButtonKeys.CLONE_RUN];
 
     for (let i = 0; i < 4; i++) {
       if (i === 1) {

--- a/frontend/src/pages/ExperimentDetails.tsx
+++ b/frontend/src/pages/ExperimentDetails.tsx
@@ -16,7 +16,7 @@
 
 import * as React from 'react';
 import Button from '@material-ui/core/Button';
-import Buttons from '../lib/Buttons';
+import Buttons, { ButtonKeys } from '../lib/Buttons';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
@@ -120,17 +120,17 @@ class ExperimentDetails extends Page<{}, ExperimentDetailsState> {
       experiment: null,
       recurringRunsManagerOpen: false,
       runListToolbarProps: {
-        actions: [
-          buttons.newRun(() => this.props.match.params[RouteParams.experimentId]),
-          buttons.newRecurringRun(this.props.match.params[RouteParams.experimentId]),
-          buttons.compareRuns(() => this.state.selectedIds),
-          buttons.cloneRun(() => this.state.selectedIds, false),
-          buttons.archive(
+        actions: buttons
+          .newRun(() => this.props.match.params[RouteParams.experimentId])
+          .newRecurringRun(this.props.match.params[RouteParams.experimentId])
+          .compareRuns(() => this.state.selectedIds)
+          .cloneRun(() => this.state.selectedIds, false)
+          .archive(
             () => this.state.selectedIds,
             false,
             ids => this._selectionChanged(ids),
-          ),
-        ],
+          )
+          .getToolbarActionMap(),
         breadcrumbs: [],
         pageTitle: 'Runs',
         topLevelToolbar: false,
@@ -144,7 +144,7 @@ class ExperimentDetails extends Page<{}, ExperimentDetailsState> {
   public getInitialToolbarState(): ToolbarProps {
     const buttons = new Buttons(this.props, this.refresh.bind(this));
     return {
-      actions: [buttons.refresh(this.refresh.bind(this))],
+      actions: buttons.refresh(this.refresh.bind(this)).getToolbarActionMap(),
       breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
       // TODO: determine what to show if no props.
       pageTitle: this.props ? this.props.match.params[RouteParams.experimentId] : '',
@@ -279,13 +279,10 @@ class ExperimentDetails extends Page<{}, ExperimentDetailsState> {
   }
 
   private _selectionChanged(selectedIds: string[]): void {
-    const toolbarActions = [...this.state.runListToolbarProps.actions];
-    // Compare runs button
-    toolbarActions[2].disabled = selectedIds.length <= 1 || selectedIds.length > 10;
-    // Clone run button
-    toolbarActions[3].disabled = selectedIds.length !== 1;
-    // Archive run button
-    toolbarActions[4].disabled = !selectedIds.length;
+    const toolbarActions = this.state.runListToolbarProps.actions;
+    toolbarActions[ButtonKeys.COMPARE].disabled = selectedIds.length <= 1 || selectedIds.length > 10;
+    toolbarActions[ButtonKeys.CLONE_RUN].disabled = selectedIds.length !== 1;
+    toolbarActions[ButtonKeys.ARCHIVE].disabled = !selectedIds.length;
     this.setState({
       runListToolbarProps: {
         actions: toolbarActions,

--- a/frontend/src/pages/ExperimentList.test.tsx
+++ b/frontend/src/pages/ExperimentList.test.tsx
@@ -27,6 +27,7 @@ import { PageProps } from './Page';
 import { ReactWrapper, ShallowWrapper, shallow } from 'enzyme';
 import { RoutePage, QUERY_PARAMS } from '../components/Router';
 import { range } from 'lodash';
+import { ButtonKeys } from '../lib/Buttons';
 
 describe('ExperimentList', () => {
   let tree: ShallowWrapper | ReactWrapper;
@@ -145,7 +146,7 @@ describe('ExperimentList', () => {
     await mountWithNExperiments(1, 1);
     const instance = tree.instance() as ExperimentList;
     expect(listExperimentsSpy.mock.calls.length).toBe(1);
-    const refreshBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Refresh');
+    const refreshBtn = instance.getInitialToolbarState().actions[ButtonKeys.REFRESH];
     expect(refreshBtn).toBeDefined();
     await refreshBtn!.action();
     expect(listExperimentsSpy.mock.calls.length).toBe(2);
@@ -184,7 +185,7 @@ describe('ExperimentList', () => {
   it('shows error banner when listing experiments fails after refresh', async () => {
     tree = TestUtils.mountWithRouter(<ExperimentList {...generateProps()} />);
     const instance = tree.instance() as ExperimentList;
-    const refreshBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Refresh');
+    const refreshBtn = instance.getInitialToolbarState().actions[ButtonKeys.REFRESH];
     expect(refreshBtn).toBeDefined();
     TestUtils.makeErrorResponseOnce(listExperimentsSpy, 'bad stuff happened');
     await refreshBtn!.action();
@@ -210,7 +211,7 @@ describe('ExperimentList', () => {
     }));
     updateBannerSpy.mockReset();
 
-    const refreshBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Refresh');
+    const refreshBtn = instance.getInitialToolbarState().actions[ButtonKeys.REFRESH];
     listExperimentsSpy.mockImplementationOnce(() => ({ experiments: [{ name: 'experiment1' }] }));
     listRunsSpy.mockImplementationOnce(() => ({ runs: [{ name: 'run1' }] }));
     await refreshBtn!.action();
@@ -239,7 +240,7 @@ describe('ExperimentList', () => {
   it('navigates to new experiment page when Create experiment button is clicked', async () => {
     tree = TestUtils.mountWithRouter(<ExperimentList {...generateProps()} />);
     const createBtn = (tree.instance() as ExperimentList)
-      .getInitialToolbarState().actions.find(b => b.title === 'Create experiment');
+      .getInitialToolbarState().actions[ButtonKeys.NEW_EXPERIMENT];
     await createBtn!.action();
     expect(historyPushSpy).toHaveBeenLastCalledWith(RoutePage.NEW_EXPERIMENT);
   });
@@ -247,16 +248,16 @@ describe('ExperimentList', () => {
   it('always has new experiment button enabled', async () => {
     await mountWithNExperiments(1, 1);
     const calls = updateToolbarSpy.mock.calls[0];
-    expect(calls[0].actions.find((b: any) => b.title === 'Create experiment')).not.toHaveProperty('disabled');
+    expect(calls[0].actions[ButtonKeys.NEW_EXPERIMENT]).not.toHaveProperty('disabled');
   });
 
   it('enables clone button when one run is selected', async () => {
     await mountWithNExperiments(1, 1);
     (tree.instance() as any)._selectionChanged(['run1']);
     expect(updateToolbarSpy).toHaveBeenCalledTimes(2);
-    expect(updateToolbarSpy.mock.calls[0][0].actions.find((b: any) => b.title === 'Clone run'))
+    expect(updateToolbarSpy.mock.calls[0][0].actions[ButtonKeys.CLONE_RUN])
       .toHaveProperty('disabled', true);
-    expect(updateToolbarSpy.mock.calls[1][0].actions.find((b: any) => b.title === 'Clone run'))
+    expect(updateToolbarSpy.mock.calls[1][0].actions[ButtonKeys.CLONE_RUN])
       .toHaveProperty('disabled', false);
   });
 
@@ -264,9 +265,9 @@ describe('ExperimentList', () => {
     await mountWithNExperiments(1, 1);
     (tree.instance() as any)._selectionChanged(['run1', 'run2']);
     expect(updateToolbarSpy).toHaveBeenCalledTimes(2);
-    expect(updateToolbarSpy.mock.calls[0][0].actions.find((b: any) => b.title === 'Clone run'))
+    expect(updateToolbarSpy.mock.calls[0][0].actions[ButtonKeys.CLONE_RUN])
       .toHaveProperty('disabled', true);
-    expect(updateToolbarSpy.mock.calls[1][0].actions.find((b: any) => b.title === 'Clone run'))
+    expect(updateToolbarSpy.mock.calls[1][0].actions[ButtonKeys.CLONE_RUN])
       .toHaveProperty('disabled', true);
   });
 
@@ -276,13 +277,11 @@ describe('ExperimentList', () => {
     (tree.instance() as any)._selectionChanged(['run1', 'run2']);
     (tree.instance() as any)._selectionChanged(['run1', 'run2', 'run3']);
     expect(updateToolbarSpy).toHaveBeenCalledTimes(4);
-    expect(updateToolbarSpy.mock.calls[0][0].actions.find((b: any) => b.title === 'Compare runs'))
+    expect(updateToolbarSpy.mock.calls[0][0].actions[ButtonKeys.COMPARE])
       .toHaveProperty('disabled', true);
-    expect(updateToolbarSpy.mock.calls[1][0].actions.find((b: any) => b.title === 'Compare runs'))
-      .toHaveProperty('disabled', true);
-    expect(updateToolbarSpy.mock.calls[2][0].actions.find((b: any) => b.title === 'Compare runs'))
+    expect(updateToolbarSpy.mock.calls[1][0].actions[ButtonKeys.COMPARE])
       .toHaveProperty('disabled', false);
-    expect(updateToolbarSpy.mock.calls[3][0].actions.find((b: any) => b.title === 'Compare runs'))
+    expect(updateToolbarSpy.mock.calls[2][0].actions[ButtonKeys.COMPARE])
       .toHaveProperty('disabled', false);
   });
 
@@ -290,7 +289,7 @@ describe('ExperimentList', () => {
     await mountWithNExperiments(1, 1);
     (tree.instance() as any)._selectionChanged(['run1', 'run2', 'run3']);
     const compareBtn = (tree.instance() as ExperimentList)
-      .getInitialToolbarState().actions.find(b => b.title === 'Compare runs');
+      .getInitialToolbarState().actions[ButtonKeys.COMPARE];
     await compareBtn!.action();
     expect(historyPushSpy).toHaveBeenLastCalledWith(
       `${RoutePage.COMPARE}?${QUERY_PARAMS.runlist}=run1,run2,run3`);
@@ -300,7 +299,7 @@ describe('ExperimentList', () => {
     await mountWithNExperiments(1, 1);
     (tree.instance() as any)._selectionChanged(['run1']);
     const cloneBtn = (tree.instance() as ExperimentList)
-      .getInitialToolbarState().actions.find(b => b.title === 'Clone run');
+      .getInitialToolbarState().actions[ButtonKeys.CLONE_RUN];
     await cloneBtn!.action();
     expect(historyPushSpy).toHaveBeenLastCalledWith(
       `${RoutePage.NEW_RUN}?${QUERY_PARAMS.cloneFromRun}=run1`);
@@ -308,13 +307,13 @@ describe('ExperimentList', () => {
 
   it('enables archive button when at least one run is selected', async () => {
     await mountWithNExperiments(1, 1);
-    expect(TestUtils.getToolbarButton(updateToolbarSpy, 'Archive').disabled).toBeTruthy();
+    expect(TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.ARCHIVE).disabled).toBeTruthy();
     (tree.instance() as any)._selectionChanged(['run1']);
-    expect(TestUtils.getToolbarButton(updateToolbarSpy, 'Archive').disabled).toBeFalsy();
+    expect(TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.ARCHIVE).disabled).toBeFalsy();
     (tree.instance() as any)._selectionChanged(['run1', 'run2']);
-    expect(TestUtils.getToolbarButton(updateToolbarSpy, 'Archive').disabled).toBeFalsy();
+    expect(TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.ARCHIVE).disabled).toBeFalsy();
     (tree.instance() as any)._selectionChanged([]);
-    expect(TestUtils.getToolbarButton(updateToolbarSpy, 'Archive').disabled).toBeTruthy();
+    expect(TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.ARCHIVE).disabled).toBeTruthy();
   });
 
   it('renders experiment names as links to their details pages', async () => {

--- a/frontend/src/pages/ExperimentList.tsx
+++ b/frontend/src/pages/ExperimentList.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from 'react';
-import Buttons from '../lib/Buttons';
+import Buttons, { ButtonKeys } from '../lib/Buttons';
 import CustomTable, { Column, Row, ExpandState, CustomRendererProps } from '../components/CustomTable';
 import RunList from './RunList';
 import produce from 'immer';
@@ -61,18 +61,18 @@ class ExperimentList extends Page<{}, ExperimentListState> {
   public getInitialToolbarState(): ToolbarProps {
     const buttons = new Buttons(this.props, this.refresh.bind(this));
     return {
-      actions: [
-        buttons.newRun(),
-        buttons.newExperiment(),
-        buttons.compareRuns(() => this.state.selectedIds),
-        buttons.cloneRun(() => this.state.selectedIds, false),
-        buttons.archive(
+      actions: buttons
+        .newRun()
+        .newExperiment()
+        .compareRuns(() => this.state.selectedIds)
+        .cloneRun(() => this.state.selectedIds, false)
+        .archive(
           () => this.state.selectedIds,
           false,
           ids => this._selectionChanged(ids),
-        ),
-        buttons.refresh(this.refresh.bind(this)),
-      ],
+        )
+        .refresh(this.refresh.bind(this))
+        .getToolbarActionMap(),
       breadcrumbs: [],
       pageTitle: 'Experiments',
     };
@@ -187,14 +187,10 @@ class ExperimentList extends Page<{}, ExperimentListState> {
   }
 
   private _selectionChanged(selectedIds: string[]): void {
-    const actions = produce(this.props.toolbarProps.actions, draft => {
-      // Enable/Disable Run compare button
-      draft[2].disabled = selectedIds.length <= 1 || selectedIds.length > 10;
-      // Enable/Disable Clone button
-      draft[3].disabled = selectedIds.length !== 1;
-      // Archive run button
-      draft[4].disabled = !selectedIds.length;
-    });
+    const actions = this.props.toolbarProps.actions;
+    actions[ButtonKeys.COMPARE].disabled = selectedIds.length <= 1 || selectedIds.length > 10;
+    actions[ButtonKeys.CLONE_RUN].disabled = selectedIds.length !== 1;
+    actions[ButtonKeys.ARCHIVE].disabled = !selectedIds.length;
     this.props.updateToolbar({ actions });
     this.setState({ selectedIds });
   }

--- a/frontend/src/pages/ExperimentsAndRuns.tsx
+++ b/frontend/src/pages/ExperimentsAndRuns.tsx
@@ -40,7 +40,7 @@ interface ExperimentAndRunsState {
 class ExperimentsAndRuns extends Page<ExperimentAndRunsProps, ExperimentAndRunsState> {
 
   public getInitialToolbarState(): ToolbarProps {
-    return { actions: [], breadcrumbs: [], pageTitle: '' };
+    return { actions: {}, breadcrumbs: [], pageTitle: '' };
   }
 
   public render(): JSX.Element {

--- a/frontend/src/pages/NewExperiment.test.tsx
+++ b/frontend/src/pages/NewExperiment.test.tsx
@@ -65,7 +65,7 @@ describe('NewExperiment', () => {
     tree = shallow(<NewExperiment {...generateProps() as any} />);
 
     expect(updateToolbarSpy).toHaveBeenCalledWith({
-      actions: [],
+      actions: {},
       breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
       pageTitle: 'New experiment',
     });

--- a/frontend/src/pages/NewExperiment.tsx
+++ b/frontend/src/pages/NewExperiment.tsx
@@ -64,7 +64,7 @@ class NewExperiment extends Page<{}, NewExperimentState> {
 
   public getInitialToolbarState(): ToolbarProps {
     return {
-      actions: [],
+      actions: {},
       breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
       pageTitle: 'New experiment',
     };

--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -149,7 +149,7 @@ describe('NewRun', () => {
     await TestUtils.flushPromises();
 
     expect(updateToolbarSpy).toHaveBeenLastCalledWith({
-      actions: [],
+      actions: {},
       breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
       pageTitle: 'Start a run',
     });
@@ -256,7 +256,7 @@ describe('NewRun', () => {
     await TestUtils.flushPromises();
 
     expect(updateToolbarSpy).toHaveBeenLastCalledWith({
-      actions: [],
+      actions: {},
       breadcrumbs: [
         { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
         {
@@ -1176,7 +1176,7 @@ describe('NewRun', () => {
       await TestUtils.flushPromises();
 
       expect(updateToolbarSpy).toHaveBeenLastCalledWith({
-        actions: [],
+        actions: {},
         breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
         pageTitle: 'Start a recurring run',
       });

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -120,7 +120,7 @@ class NewRun extends Page<{}, NewRunState> {
 
   public getInitialToolbarState(): ToolbarProps {
     return {
-      actions: [],
+      actions: {},
       breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
       pageTitle: 'Start a new run',
     };

--- a/frontend/src/pages/PipelineDetails.test.tsx
+++ b/frontend/src/pages/PipelineDetails.test.tsx
@@ -26,6 +26,7 @@ import { PageProps } from './Page';
 import { RouteParams, RoutePage, QUERY_PARAMS } from '../components/Router';
 import { graphlib } from 'dagre';
 import { shallow, mount, ShallowWrapper, ReactWrapper } from 'enzyme';
+import { ButtonKeys } from '../lib/Buttons';
 
 describe('PipelineDetails', () => {
   const updateBannerSpy = jest.fn();
@@ -324,8 +325,7 @@ describe('PipelineDetails', () => {
     await getTemplateSpy;
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
-    const newExperimentBtn = instance.getInitialToolbarState().actions.find(
-      b => b.title === 'Create experiment');
+    const newExperimentBtn = instance.getInitialToolbarState().actions[ButtonKeys.NEW_EXPERIMENT];
     expect(newExperimentBtn).toBeDefined();
   });
 
@@ -334,17 +334,16 @@ describe('PipelineDetails', () => {
     await getTemplateSpy;
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
-    expect(instance.getInitialToolbarState().actions).toHaveLength(1);
-    const createRunBtn =
-      instance.getInitialToolbarState().actions.find(b => b.title === 'Create run');
-    expect(createRunBtn).toBeDefined();
+    expect(Object.keys(instance.getInitialToolbarState().actions)).toHaveLength(1);
+    const newRunBtn = instance.getInitialToolbarState().actions[ButtonKeys.NEW_RUN_FROM_PIPELINE];
+    expect(newRunBtn).toBeDefined();
   });
 
   it('clicking new run button when viewing embedded pipeline navigates to the new run page with run ID', async () => {
     tree = shallow(<PipelineDetails {...generateProps(true)} />);
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
-    const newRunBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Create run');
+    const newRunBtn = instance.getInitialToolbarState().actions[ButtonKeys.NEW_RUN_FROM_PIPELINE];
     newRunBtn!.action();
     expect(historyPushSpy).toHaveBeenCalledTimes(1);
     expect(historyPushSpy).toHaveBeenLastCalledWith(
@@ -356,18 +355,18 @@ describe('PipelineDetails', () => {
     await getTemplateSpy;
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
-    expect(instance.getInitialToolbarState().actions).toHaveLength(3);
-    const createRunBtn =
-      instance.getInitialToolbarState().actions.find(b => b.title === 'Create run');
-    expect(createRunBtn).toBeDefined();
+    expect(Object.keys(instance.getInitialToolbarState().actions)).toHaveLength(3);
+    const newRunBtn = instance.getInitialToolbarState().actions[ButtonKeys.NEW_RUN_FROM_PIPELINE];
+    expect(newRunBtn).toBeDefined();
   });
 
   it('clicking new run button navigates to the new run page', async () => {
     tree = shallow(<PipelineDetails {...generateProps(false)} />);
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
-    const newRunBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Create run');
-    newRunBtn!.action();
+    const newRunFromPipelineBtn =
+      instance.getInitialToolbarState().actions[ButtonKeys.NEW_RUN_FROM_PIPELINE];
+    newRunFromPipelineBtn.action();
     expect(historyPushSpy).toHaveBeenCalledTimes(1);
     expect(historyPushSpy).toHaveBeenLastCalledWith(
       RoutePage.NEW_RUN + `?${QUERY_PARAMS.pipelineId}=${testPipeline.id}`);
@@ -378,9 +377,8 @@ describe('PipelineDetails', () => {
     await getTemplateSpy;
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
-    const newExperimentBtn = instance.getInitialToolbarState().actions.find(
-      b => b.title === 'Create experiment');
-    await newExperimentBtn!.action();
+    const newExperimentBtn = instance.getInitialToolbarState().actions[ButtonKeys.NEW_EXPERIMENT];
+    await newExperimentBtn.action();
     expect(historyPushSpy).toHaveBeenCalledTimes(1);
     expect(historyPushSpy).toHaveBeenLastCalledWith(
       RoutePage.NEW_EXPERIMENT + `?${QUERY_PARAMS.pipelineId}=${testPipeline.id}`);
@@ -391,15 +389,14 @@ describe('PipelineDetails', () => {
     await getTemplateSpy;
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
-    const deleteBtn = instance.getInitialToolbarState().actions.find(
-      b => b.title === 'Delete');
+    const deleteBtn = instance.getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     expect(deleteBtn).toBeDefined();
   });
 
   it('shows delete confirmation dialog when delete buttin is clicked', async () => {
     tree = shallow(<PipelineDetails {...generateProps()} />);
     const deleteBtn = (tree.instance() as PipelineDetails)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     expect(updateDialogSpy).toHaveBeenCalledTimes(1);
     expect(updateDialogSpy).toHaveBeenLastCalledWith(expect.objectContaining({
@@ -410,7 +407,7 @@ describe('PipelineDetails', () => {
   it('does not call delete API for selected pipeline when delete dialog is canceled', async () => {
     tree = shallow(<PipelineDetails {...generateProps()} />);
     const deleteBtn = (tree.instance() as PipelineDetails)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const cancelBtn = call.buttons.find((b: any) => b.text === 'Cancel');
@@ -423,7 +420,7 @@ describe('PipelineDetails', () => {
     await getTemplateSpy;
     await TestUtils.flushPromises();
     const deleteBtn = (tree.instance() as PipelineDetails)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const confirmBtn = call.buttons.find((b: any) => b.text === 'Delete');
@@ -438,7 +435,7 @@ describe('PipelineDetails', () => {
     await getTemplateSpy;
     await TestUtils.flushPromises();
     const deleteBtn = (tree.instance() as PipelineDetails)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const confirmBtn = call.buttons.find((b: any) => b.text === 'Delete');
@@ -455,7 +452,7 @@ describe('PipelineDetails', () => {
     await getTemplateSpy;
     await TestUtils.flushPromises();
     const deleteBtn = (tree.instance() as PipelineDetails)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const confirmBtn = call.buttons.find((b: any) => b.text === 'Delete');

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -33,7 +33,7 @@ import { ApiPipeline, ApiGetTemplateResponse } from '../apis/pipeline';
 import { Apis } from '../lib/Apis';
 import { Page } from './Page';
 import { RoutePage, RouteParams, QUERY_PARAMS } from '../components/Router';
-import { ToolbarProps, ToolbarActionConfig } from '../components/Toolbar';
+import { ToolbarProps } from '../components/Toolbar';
 import { URLParser } from '../lib/URLParser';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
 import { Workflow } from '../../third_party/argo-ui/argo_template';
@@ -115,13 +115,11 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
   public getInitialToolbarState(): ToolbarProps {
     const buttons = new Buttons(this.props, this.refresh.bind(this));
     const fromRunId = new URLParser(this.props).get(QUERY_PARAMS.fromRunId);
-    let actions: ToolbarActionConfig[] = [
-      buttons.newRunFromPipeline(() => this.state.pipeline ? this.state.pipeline.id! : ''),
-    ];
+    buttons.newRunFromPipeline(() => this.state.pipeline ? this.state.pipeline.id! : '');
 
     if (fromRunId) {
       return {
-        actions,
+        actions: buttons.getToolbarActionMap(),
         breadcrumbs: [
           { displayName: fromRunId, href: RoutePage.RUN_DETAILS.replace(':' + RouteParams.runId, fromRunId) }
         ],
@@ -129,17 +127,16 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
       };
     } else {
       // Add buttons for creating experiment and deleting pipeline
-      actions = actions.concat([
-        buttons.newExperiment(() => this.state.pipeline ? this.state.pipeline.id! : ''),
-        buttons.delete(
+      buttons
+        .newExperiment(() => this.state.pipeline ? this.state.pipeline.id! : '')
+        .delete(
           () => this.state.pipeline ? [this.state.pipeline.id!] : [],
           'pipeline',
           this._deleteCallback.bind(this),
           true, /* useCurrentResource */
-        ),
-      ]);
+        );
       return {
-        actions,
+        actions: buttons.getToolbarActionMap(),
         breadcrumbs: [{ displayName: 'Pipelines', href: RoutePage.PIPELINES }],
         pageTitle: this.props.match.params[RouteParams.pipelineId],
       };
@@ -251,7 +248,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
     let templateString = '';
     let template: Workflow | undefined;
     let breadcrumbs: Array<{ displayName: string, href: string }> = [];
-    const toolbarActions = [...this.props.toolbarProps.actions];
+    const toolbarActions = this.props.toolbarProps.actions;
     let pageTitle = '';
 
     // If fromRunId is specified, load the run and get the pipeline template from it
@@ -329,7 +326,6 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
       }
 
       breadcrumbs = [{ displayName: 'Pipelines', href: RoutePage.PIPELINES }];
-      toolbarActions[0].disabled = false;
     }
 
     this.props.updateToolbar({ breadcrumbs, actions: toolbarActions, pageTitle });

--- a/frontend/src/pages/PipelineList.test.tsx
+++ b/frontend/src/pages/PipelineList.test.tsx
@@ -24,6 +24,7 @@ import { RoutePage, RouteParams } from '../components/Router';
 import { shallow, ReactWrapper, ShallowWrapper } from 'enzyme';
 import { range } from 'lodash';
 import { ImportMethod } from '../components/UploadPipelineDialog';
+import { ButtonKeys } from '../lib/Buttons';
 
 describe('PipelineList', () => {
 
@@ -123,7 +124,7 @@ describe('PipelineList', () => {
     tree = await mountWithNPipelines(1);
     const instance = tree.instance() as PipelineList;
     expect(listPipelinesSpy.mock.calls.length).toBe(1);
-    const refreshBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Refresh');
+    const refreshBtn = instance.getInitialToolbarState().actions[ButtonKeys.REFRESH];
     expect(refreshBtn).toBeDefined();
     await refreshBtn!.action();
     expect(listPipelinesSpy.mock.calls.length).toBe(2);
@@ -146,7 +147,7 @@ describe('PipelineList', () => {
   it('shows error banner when listing pipelines fails after refresh', async () => {
     tree = TestUtils.mountWithRouter(<PipelineList {...generateProps()} />);
     const instance = tree.instance() as PipelineList;
-    const refreshBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Refresh');
+    const refreshBtn = instance.getInitialToolbarState().actions[ButtonKeys.REFRESH];
     expect(refreshBtn).toBeDefined();
     TestUtils.makeErrorResponseOnce(listPipelinesSpy, 'bad stuff happened');
     await refreshBtn!.action();
@@ -172,7 +173,7 @@ describe('PipelineList', () => {
     }));
     updateBannerSpy.mockReset();
 
-    const refreshBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Refresh');
+    const refreshBtn = instance.getInitialToolbarState().actions[ButtonKeys.REFRESH];
     listPipelinesSpy.mockImplementationOnce(() => ({ pipelines: [{ name: 'pipeline1' }] }));
     await refreshBtn!.action();
     expect(listPipelinesSpy.mock.calls.length).toBe(2);
@@ -191,7 +192,7 @@ describe('PipelineList', () => {
   it('always has upload pipeline button enabled', async () => {
     tree = await mountWithNPipelines(1);
     const calls = updateToolbarSpy.mock.calls[0];
-    expect(calls[0].actions.find((b: any) => b.title === 'Upload pipeline')).not.toHaveProperty('disabled');
+    expect(calls[0].actions[ButtonKeys.UPLOAD_PIPELINE]).not.toHaveProperty('disabled');
   });
 
   it('enables delete button when one pipeline is selected', async () => {
@@ -199,7 +200,7 @@ describe('PipelineList', () => {
     tree.find('.tableRow').simulate('click');
     expect(updateToolbarSpy.mock.calls).toHaveLength(2); // Initial call, then selection update
     const calls = updateToolbarSpy.mock.calls[1];
-    expect(calls[0].actions.find((b: any) => b.title === 'Delete')).toHaveProperty('disabled', false);
+    expect(calls[0].actions[ButtonKeys.DELETE_RUN]).toHaveProperty('disabled', false);
   });
 
   it('enables delete button when two pipelines are selected', async () => {
@@ -208,7 +209,7 @@ describe('PipelineList', () => {
     tree.find('.tableRow').at(1).simulate('click');
     expect(updateToolbarSpy.mock.calls).toHaveLength(3); // Initial call, then selection updates
     const calls = updateToolbarSpy.mock.calls[2];
-    expect(calls[0].actions.find((b: any) => b.title === 'Delete')).toHaveProperty('disabled', false);
+    expect(calls[0].actions[ButtonKeys.DELETE_RUN]).toHaveProperty('disabled', false);
   });
 
   it('re-disables delete button pipelines are unselected', async () => {
@@ -217,14 +218,14 @@ describe('PipelineList', () => {
     tree.find('.tableRow').at(0).simulate('click');
     expect(updateToolbarSpy.mock.calls).toHaveLength(3); // Initial call, then selection updates
     const calls = updateToolbarSpy.mock.calls[2];
-    expect(calls[0].actions.find((b: any) => b.title === 'Delete')).toHaveProperty('disabled', true);
+    expect(calls[0].actions[ButtonKeys.DELETE_RUN]).toHaveProperty('disabled', true);
   });
-
+ 
   it('shows delete dialog when delete button is clicked', async () => {
     tree = await mountWithNPipelines(1);
     tree.find('.tableRow').at(0).simulate('click');
     const deleteBtn = (tree.instance() as PipelineList)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     expect(call).toHaveProperty('title', 'Delete 1 pipeline?');
@@ -236,7 +237,7 @@ describe('PipelineList', () => {
     tree.find('.tableRow').at(2).simulate('click');
     tree.find('.tableRow').at(3).simulate('click');
     const deleteBtn = (tree.instance() as PipelineList)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     expect(call).toHaveProperty('title', 'Delete 3 pipelines?');
@@ -246,7 +247,7 @@ describe('PipelineList', () => {
     tree = await mountWithNPipelines(1);
     tree.find('.tableRow').at(0).simulate('click');
     const deleteBtn = (tree.instance() as PipelineList)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const cancelBtn = call.buttons.find((b: any) => b.text === 'Cancel');
@@ -258,7 +259,7 @@ describe('PipelineList', () => {
     tree = await mountWithNPipelines(1);
     tree.find('.tableRow').at(0).simulate('click');
     const deleteBtn = (tree.instance() as PipelineList)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const confirmBtn = call.buttons.find((b: any) => b.text === 'Delete');
@@ -271,7 +272,7 @@ describe('PipelineList', () => {
     tree.find('.tableRow').at(0).simulate('click');
     expect(tree.state()).toHaveProperty('selectedIds', ['test-pipeline-id0']);
     const deleteBtn = (tree.instance() as PipelineList)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const confirmBtn = call.buttons.find((b: any) => b.text === 'Delete');
@@ -285,7 +286,7 @@ describe('PipelineList', () => {
     tree.find('.tableRow').at(3).simulate('click');
     expect(tree.state()).toHaveProperty('selectedIds', ['test-pipeline-id0', 'test-pipeline-id3']);
     const deleteBtn = (tree.instance() as PipelineList)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const confirmBtn = call.buttons.find((b: any) => b.text === 'Delete');
@@ -299,7 +300,7 @@ describe('PipelineList', () => {
     tree.find('.tableRow').at(1).simulate('click');
     tree.find('.tableRow').at(4).simulate('click');
     const deleteBtn = (tree.instance() as PipelineList)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const confirmBtn = call.buttons.find((b: any) => b.text === 'Delete');
@@ -314,7 +315,7 @@ describe('PipelineList', () => {
     tree = await mountWithNPipelines(1);
     tree.find('.tableRow').at(0).simulate('click');
     const deleteBtn = (tree.instance() as PipelineList)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const confirmBtn = call.buttons.find((b: any) => b.text === 'Delete');
@@ -330,7 +331,7 @@ describe('PipelineList', () => {
     tree.find('.tableRow').at(0).simulate('click');
     TestUtils.makeErrorResponseOnce(deletePipelineSpy, 'woops, failed');
     const deleteBtn = (tree.instance() as PipelineList)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const confirmBtn = call.buttons.find((b: any) => b.text === 'Delete');
@@ -356,7 +357,7 @@ describe('PipelineList', () => {
       }
     });
     const deleteBtn = (tree.instance() as PipelineList)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const confirmBtn = call.buttons.find((b: any) => b.text === 'Delete');
@@ -380,7 +381,7 @@ describe('PipelineList', () => {
   it('shows upload dialog when upload button is clicked', async () => {
     tree = await mountWithNPipelines(0);
     const instance = tree.instance() as PipelineList;
-    const uploadBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Upload pipeline');
+    const uploadBtn = instance.getInitialToolbarState().actions[ButtonKeys.UPLOAD_PIPELINE];
     expect(uploadBtn).toBeDefined();
     await uploadBtn!.action();
     expect(instance.state).toHaveProperty('uploadDialogOpen', true);

--- a/frontend/src/pages/PipelineList.tsx
+++ b/frontend/src/pages/PipelineList.tsx
@@ -15,10 +15,9 @@
  */
 
 import * as React from 'react';
-import Buttons from '../lib/Buttons';
+import Buttons, { ButtonKeys } from '../lib/Buttons';
 import CustomTable, { Column, Row, CustomRendererProps } from '../components/CustomTable';
 import UploadPipelineDialog, { ImportMethod } from '../components/UploadPipelineDialog';
-import produce from 'immer';
 import { ApiPipeline, ApiListPipelinesResponse } from '../apis/pipeline';
 import { Apis, PipelineSortKeys, ListRequest } from '../lib/Apis';
 import { Link } from 'react-router-dom';
@@ -51,16 +50,16 @@ class PipelineList extends Page<{}, PipelineListState> {
   public getInitialToolbarState(): ToolbarProps {
     const buttons = new Buttons(this.props, this.refresh.bind(this));
     return {
-      actions: [
-        buttons.upload(() => this.setStateSafe({ uploadDialogOpen: true })),
-        buttons.refresh(this.refresh.bind(this)),
-        buttons.delete(
+      actions: buttons
+        .upload(() => this.setStateSafe({ uploadDialogOpen: true }))
+        .refresh(this.refresh.bind(this))
+        .delete(
           () => this.state.selectedIds,
           'pipeline',
           ids => this._selectionChanged(ids),
           false, /* useCurrentResource */
-        ),
-      ],
+        )
+        .getToolbarActionMap(),
       breadcrumbs: [],
       pageTitle: 'Pipelines',
     };
@@ -129,11 +128,9 @@ class PipelineList extends Page<{}, PipelineListState> {
   }
 
   private _selectionChanged(selectedIds: string[]): void {
-    const toolbarActions = produce(this.props.toolbarProps.actions, draft => {
-      // Delete pipeline
-      draft[2].disabled = selectedIds.length < 1;
-    });
-    this.props.updateToolbar({ actions: toolbarActions });
+    const actions = this.props.toolbarProps.actions;
+    actions[ButtonKeys.DELETE_RUN].disabled = selectedIds.length < 1;
+    this.props.updateToolbar({ actions });
     this.setStateSafe({ selectedIds });
   }
 

--- a/frontend/src/pages/RecurringRunDetails.test.tsx
+++ b/frontend/src/pages/RecurringRunDetails.test.tsx
@@ -21,8 +21,8 @@ import { ApiJob, ApiResourceType } from '../apis/job';
 import { Apis } from '../lib/Apis';
 import { PageProps } from './Page';
 import { RouteParams, RoutePage, QUERY_PARAMS } from '../components/Router';
-import { ToolbarActionConfig } from '../components/Toolbar';
 import { shallow, ReactWrapper, ShallowWrapper } from 'enzyme';
+import { ButtonKeys } from '../lib/Buttons';
 
 describe('RecurringRunDetails', () => {
   let tree: ReactWrapper<any> | ShallowWrapper<any>;
@@ -178,7 +178,7 @@ describe('RecurringRunDetails', () => {
   it('has a Refresh button, clicking it refreshes the run details', async () => {
     tree = shallow(<RecurringRunDetails {...generateProps()} />);
     const instance = tree.instance() as RecurringRunDetails;
-    const refreshBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Refresh');
+    const refreshBtn = instance.getInitialToolbarState().actions[ButtonKeys.REFRESH];
     expect(refreshBtn).toBeDefined();
     expect(getJobSpy).toHaveBeenCalledTimes(1);
     await refreshBtn!.action();
@@ -190,8 +190,7 @@ describe('RecurringRunDetails', () => {
     tree = shallow(<RecurringRunDetails {...generateProps()} />);
     await TestUtils.flushPromises();
     const instance = tree.instance() as RecurringRunDetails;
-    const cloneBtn = instance.getInitialToolbarState().actions.find(
-      b => b.title === 'Clone recurring run');
+    const cloneBtn = instance.getInitialToolbarState().actions[ButtonKeys.CLONE_RECURRING_RUN];
     expect(cloneBtn).toBeDefined();
     await cloneBtn!.action();
     expect(historyPushSpy).toHaveBeenCalledTimes(1);
@@ -205,11 +204,10 @@ describe('RecurringRunDetails', () => {
     tree = shallow(<RecurringRunDetails {...generateProps()} />);
     await TestUtils.flushPromises();
     expect(updateToolbarSpy).toHaveBeenCalledTimes(2);
-    const lastToolbarButtons = updateToolbarSpy.mock.calls[1][0].actions as ToolbarActionConfig[];
-    const enableBtn = lastToolbarButtons.find(b => b.title === 'Enable');
+    const enableBtn = TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.ENABLE_RECURRING_RUN);
     expect(enableBtn).toBeDefined();
     expect(enableBtn!.disabled).toBe(true);
-    const disableBtn = lastToolbarButtons.find(b => b.title === 'Disable');
+    const disableBtn = TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.DISABLE_RECURRING_RUN);
     expect(disableBtn).toBeDefined();
     expect(disableBtn!.disabled).toBe(false);
   });
@@ -219,11 +217,10 @@ describe('RecurringRunDetails', () => {
     tree = shallow(<RecurringRunDetails {...generateProps()} />);
     await TestUtils.flushPromises();
     expect(updateToolbarSpy).toHaveBeenCalledTimes(2);
-    const lastToolbarButtons = updateToolbarSpy.mock.calls[1][0].actions as ToolbarActionConfig[];
-    const enableBtn = lastToolbarButtons.find(b => b.title === 'Enable');
+    const enableBtn = TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.ENABLE_RECURRING_RUN);
     expect(enableBtn).toBeDefined();
     expect(enableBtn!.disabled).toBe(false);
-    const disableBtn = lastToolbarButtons.find(b => b.title === 'Disable');
+    const disableBtn = TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.DISABLE_RECURRING_RUN);
     expect(disableBtn).toBeDefined();
     expect(disableBtn!.disabled).toBe(true);
   });
@@ -233,11 +230,10 @@ describe('RecurringRunDetails', () => {
     tree = shallow(<RecurringRunDetails {...generateProps()} />);
     await TestUtils.flushPromises();
     expect(updateToolbarSpy).toHaveBeenCalledTimes(2);
-    const lastToolbarButtons = updateToolbarSpy.mock.calls[1][0].actions as ToolbarActionConfig[];
-    const enableBtn = lastToolbarButtons.find(b => b.title === 'Enable');
+    const enableBtn = TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.ENABLE_RECURRING_RUN);
     expect(enableBtn).toBeDefined();
     expect(enableBtn!.disabled).toBe(false);
-    const disableBtn = lastToolbarButtons.find(b => b.title === 'Disable');
+    const disableBtn = TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.DISABLE_RECURRING_RUN);
     expect(disableBtn).toBeDefined();
     expect(disableBtn!.disabled).toBe(true);
   });
@@ -246,7 +242,7 @@ describe('RecurringRunDetails', () => {
     tree = shallow(<RecurringRunDetails {...generateProps()} />);
     await TestUtils.flushPromises();
     const instance = tree.instance() as RecurringRunDetails;
-    const disableBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Disable');
+    const disableBtn = instance.getInitialToolbarState().actions[ButtonKeys.DISABLE_RECURRING_RUN];
     await disableBtn!.action();
     expect(disableJobSpy).toHaveBeenCalledTimes(1);
     expect(disableJobSpy).toHaveBeenLastCalledWith('test-job-id');
@@ -259,7 +255,7 @@ describe('RecurringRunDetails', () => {
     TestUtils.makeErrorResponseOnce(disableJobSpy, 'could not disable');
     await TestUtils.flushPromises();
     const instance = tree.instance() as RecurringRunDetails;
-    const disableBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Disable');
+    const disableBtn = instance.getInitialToolbarState().actions[ButtonKeys.DISABLE_RECURRING_RUN];
     await disableBtn!.action();
     expect(updateDialogSpy).toHaveBeenCalledTimes(1);
     expect(updateDialogSpy).toHaveBeenLastCalledWith(expect.objectContaining({
@@ -274,7 +270,7 @@ describe('RecurringRunDetails', () => {
     TestUtils.makeErrorResponseOnce(enableJobSpy, 'could not enable');
     await TestUtils.flushPromises();
     const instance = tree.instance() as RecurringRunDetails;
-    const enableBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Enable');
+    const enableBtn = instance.getInitialToolbarState().actions[ButtonKeys.ENABLE_RECURRING_RUN];
     await enableBtn!.action();
     expect(updateDialogSpy).toHaveBeenCalledTimes(1);
     expect(updateDialogSpy).toHaveBeenLastCalledWith(expect.objectContaining({
@@ -288,7 +284,7 @@ describe('RecurringRunDetails', () => {
     tree = shallow(<RecurringRunDetails {...generateProps()} />);
     await TestUtils.flushPromises();
     const instance = tree.instance() as RecurringRunDetails;
-    const enableBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Enable');
+    const enableBtn = instance.getInitialToolbarState().actions[ButtonKeys.ENABLE_RECURRING_RUN];
     await enableBtn!.action();
     expect(enableJobSpy).toHaveBeenCalledTimes(1);
     expect(enableJobSpy).toHaveBeenLastCalledWith('test-job-id');
@@ -300,7 +296,7 @@ describe('RecurringRunDetails', () => {
     tree = shallow(<RecurringRunDetails {...generateProps()} />);
     await TestUtils.flushPromises();
     const instance = tree.instance() as RecurringRunDetails;
-    const deleteBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Refresh');
+    const deleteBtn = instance.getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     expect(deleteBtn).toBeDefined();
   });
 
@@ -308,7 +304,7 @@ describe('RecurringRunDetails', () => {
     tree = shallow(<RecurringRunDetails {...generateProps()} />);
     await TestUtils.flushPromises();
     const instance = tree.instance() as RecurringRunDetails;
-    const deleteBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Delete');
+    const deleteBtn = instance.getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     expect(updateDialogSpy).toHaveBeenLastCalledWith(expect.objectContaining({
       title: 'Delete this recurring run config?',
@@ -319,7 +315,7 @@ describe('RecurringRunDetails', () => {
     tree = shallow(<RecurringRunDetails {...generateProps()} />);
     await TestUtils.flushPromises();
     const instance = tree.instance() as RecurringRunDetails;
-    const deleteBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Delete');
+    const deleteBtn = instance.getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const confirmBtn = call.buttons.find((b: any) => b.text === 'Delete');
@@ -332,7 +328,7 @@ describe('RecurringRunDetails', () => {
     tree = shallow(<RecurringRunDetails {...generateProps()} />);
     await TestUtils.flushPromises();
     const instance = tree.instance() as RecurringRunDetails;
-    const deleteBtn = instance.getInitialToolbarState().actions.find(b => b.title === 'Delete');
+    const deleteBtn = instance.getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const confirmBtn = call.buttons.find((b: any) => b.text === 'Cancel');
@@ -349,7 +345,7 @@ describe('RecurringRunDetails', () => {
     tree = shallow(<RecurringRunDetails {...generateProps()} />);
     await TestUtils.flushPromises();
     const deleteBtn = (tree.instance() as RecurringRunDetails)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const confirmBtn = call.buttons.find((b: any) => b.text === 'Delete');
@@ -363,7 +359,7 @@ describe('RecurringRunDetails', () => {
     tree = shallow(<RecurringRunDetails {...generateProps()} />);
     await TestUtils.flushPromises();
     const deleteBtn = (tree.instance() as RecurringRunDetails)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const confirmBtn = call.buttons.find((b: any) => b.text === 'Delete');
@@ -380,7 +376,7 @@ describe('RecurringRunDetails', () => {
     tree = shallow(<RecurringRunDetails {...generateProps()} />);
     await TestUtils.flushPromises();
     const deleteBtn = (tree.instance() as RecurringRunDetails)
-      .getInitialToolbarState().actions.find(b => b.title === 'Delete');
+      .getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     await deleteBtn!.action();
     const call = updateDialogSpy.mock.calls[0][0];
     const confirmBtn = call.buttons.find((b: any) => b.text === 'Delete');

--- a/frontend/src/pages/RecurringRunDetails.tsx
+++ b/frontend/src/pages/RecurringRunDetails.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from 'react';
-import Buttons from '../lib/Buttons';
+import Buttons, { ButtonKeys } from '../lib/Buttons';
 import DetailsTable from '../components/DetailsTable';
 import RunUtils from '../lib/RunUtils';
 import { ApiExperiment } from '../apis/experiment';
@@ -46,18 +46,18 @@ class RecurringRunDetails extends Page<{}, RecurringRunConfigState> {
   public getInitialToolbarState(): ToolbarProps {
     const buttons = new Buttons(this.props, this.refresh.bind(this));
     return {
-      actions: [
-        buttons.cloneRecurringRun(() => this.state.run ? [this.state.run.id!] : [], true),
-        buttons.refresh(this.refresh.bind(this)),
-        buttons.enableRecurringRun(() => this.state.run ? this.state.run.id! : ''),
-        buttons.disableRecurringRun(() => this.state.run ? this.state.run.id! : ''),
-        buttons.delete(
+      actions: buttons
+        .cloneRecurringRun(() => this.state.run ? [this.state.run.id!] : [], true)
+        .refresh(this.refresh.bind(this))
+        .enableRecurringRun(() => this.state.run ? this.state.run.id! : '')
+        .disableRecurringRun(() => this.state.run ? this.state.run.id! : '')
+        .delete(
           () => this.state.run ? [this.state.run!.id!] : [],
           'recurring run config',
           this._deleteCallback.bind(this),
           true, /* useCurrentResource */
-        ),
-      ],
+        )
+        .getToolbarActionMap(),
       breadcrumbs: [],
       pageTitle: '',
     };
@@ -170,9 +170,9 @@ class RecurringRunDetails extends Page<{}, RecurringRunConfigState> {
     }
     const pageTitle = run ? run.name! : runId;
 
-    const toolbarActions = [...this.props.toolbarProps.actions];
-    toolbarActions[2].disabled = !!run.enabled;
-    toolbarActions[3].disabled = !run.enabled;
+    const toolbarActions = this.props.toolbarProps.actions;
+    toolbarActions[ButtonKeys.ENABLE_RECURRING_RUN].disabled = !!run.enabled;
+    toolbarActions[ButtonKeys.DISABLE_RECURRING_RUN].disabled = !run.enabled;
 
     this.props.updateToolbar({ actions: toolbarActions, breadcrumbs, pageTitle });
 

--- a/frontend/src/pages/RecurringRunsManager.tsx
+++ b/frontend/src/pages/RecurringRunsManager.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import BusyButton from '../atoms/BusyButton';
 import CustomTable, { Column, Row, CustomRendererProps } from '../components/CustomTable';
-import Toolbar, { ToolbarActionConfig } from '../components/Toolbar';
+import Toolbar, { ToolbarActionMap } from '../components/Toolbar';
 import { ApiJob, ApiResourceType } from '../apis/job';
 import { Apis, JobSortKeys, ListRequest } from '../lib/Apis';
 import { DialogProps, RoutePage, RouteParams } from '../components/Router';
@@ -37,7 +37,7 @@ interface RecurringRunListState {
   busyIds: Set<string>;
   runs: ApiJob[];
   selectedIds: string[];
-  toolbarActions: ToolbarActionConfig[];
+  toolbarActionMap: ToolbarActionMap;
 }
 
 class RecurringRunsManager extends React.Component<RecurringRunListProps, RecurringRunListState> {
@@ -50,12 +50,12 @@ class RecurringRunsManager extends React.Component<RecurringRunListProps, Recurr
       busyIds: new Set(),
       runs: [],
       selectedIds: [],
-      toolbarActions: [],
+      toolbarActionMap: {},
     };
   }
 
   public render(): JSX.Element {
-    const { runs, selectedIds, toolbarActions } = this.state;
+    const { runs, selectedIds, toolbarActionMap: toolbarActions } = this.state;
 
     const columns: Column[] = [
       {

--- a/frontend/src/pages/ResourceSelector.tsx
+++ b/frontend/src/pages/ResourceSelector.tsx
@@ -16,7 +16,7 @@
 
 import * as React from 'react';
 import CustomTable, { Column, Row } from '../components/CustomTable';
-import Toolbar, { ToolbarActionConfig } from '../components/Toolbar';
+import Toolbar, { ToolbarActionMap } from '../components/Toolbar';
 import { ListRequest } from '../lib/Apis';
 import { RouteComponentProps } from 'react-router-dom';
 import { logger, errorToMessage, formatDateString } from '../lib/Utils';
@@ -50,7 +50,7 @@ interface ResourceSelectorState {
   resources: BaseResource[];
   rows: Row[];
   selectedIds: string[];
-  toolbarActions: ToolbarActionConfig[];
+  toolbarActionMap: ToolbarActionMap;
 }
 
 class ResourceSelector extends React.Component<ResourceSelectorProps, ResourceSelectorState> {
@@ -63,12 +63,12 @@ class ResourceSelector extends React.Component<ResourceSelectorProps, ResourceSe
       resources: [],
       rows: [],
       selectedIds: [],
-      toolbarActions: [],
+      toolbarActionMap: {},
     };
   }
 
   public render(): JSX.Element {
-    const { rows, selectedIds, toolbarActions } = this.state;
+    const { rows, selectedIds, toolbarActionMap: toolbarActions } = this.state;
     const { columns, title, filterLabel, emptyMessage, initialSortColumn } = this.props;
 
     return (

--- a/frontend/src/pages/RunDetails.test.tsx
+++ b/frontend/src/pages/RunDetails.test.tsx
@@ -28,6 +28,7 @@ import { PlotType } from '../components/viewers/Viewer';
 import { RouteParams, RoutePage, QUERY_PARAMS } from '../components/Router';
 import { Workflow } from 'third_party/argo-ui/argo_template';
 import { shallow, ShallowWrapper } from 'enzyme';
+import { ButtonKeys } from '../lib/Buttons';
 
 describe('RunDetails', () => {
   const updateBannerSpy = jest.fn();
@@ -55,7 +56,7 @@ describe('RunDetails', () => {
       history: { push: historyPushSpy } as any,
       location: '' as any,
       match: { params: { [RouteParams.runId]: testRun.run!.id }, isExact: true, path: '', url: '' },
-      toolbarProps: { actions: [], breadcrumbs: [], pageTitle: '' },
+      toolbarProps: { actions: {}, breadcrumbs: [], pageTitle: '' },
       updateBanner: updateBannerSpy,
       updateDialog: updateDialogSpy,
       updateSnackbar: updateSnackbarSpy,
@@ -129,8 +130,7 @@ describe('RunDetails', () => {
     await getRunSpy;
     await TestUtils.flushPromises();
     const instance = tree.instance() as RunDetails;
-    const cloneBtn = instance.getInitialToolbarState().actions.find(
-      b => b.title === 'Clone run');
+    const cloneBtn = instance.getInitialToolbarState().actions[ButtonKeys.CLONE_RUN];
     expect(cloneBtn).toBeDefined();
     await cloneBtn!.action();
     expect(historyPushSpy).toHaveBeenCalledTimes(1);
@@ -142,8 +142,8 @@ describe('RunDetails', () => {
     tree = shallow(<RunDetails {...generateProps()} />);
     await getRunSpy;
     await TestUtils.flushPromises();
-    expect(TestUtils.getToolbarButton(updateToolbarSpy, 'Archive')).toBeDefined();
-    expect(TestUtils.getToolbarButton(updateToolbarSpy, 'Restore')).toBeUndefined();
+    expect(TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.ARCHIVE)).toBeDefined();
+    expect(TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.RESTORE)).toBeUndefined();
   });
 
   it('shows "All runs" in breadcrumbs if the run is not archived', async () => {
@@ -176,8 +176,8 @@ describe('RunDetails', () => {
     tree = shallow(<RunDetails {...generateProps()} />);
     await getRunSpy;
     await TestUtils.flushPromises();
-    expect(TestUtils.getToolbarButton(updateToolbarSpy, 'Restore')).toBeDefined();
-    expect(TestUtils.getToolbarButton(updateToolbarSpy, 'Archive')).toBeUndefined();
+    expect(TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.RESTORE)).toBeDefined();
+    expect(TestUtils.getToolbarButton(updateToolbarSpy, ButtonKeys.ARCHIVE)).toBeUndefined();
   });
 
   it('shows Archive in breadcrumbs if the run is archived', async () => {

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -16,7 +16,7 @@
 
 import * as React from 'react';
 import Banner, { Mode } from '../components/Banner';
-import Buttons from '../lib/Buttons';
+import Buttons, { ButtonKeys } from '../lib/Buttons';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import CompareTable from '../components/CompareTable';
 import CompareUtils from '../lib/CompareUtils';
@@ -151,14 +151,14 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
   public getInitialToolbarState(): ToolbarProps {
     const buttons = new Buttons(this.props, this.refresh.bind(this));
     return {
-      actions: [
-        buttons.cloneRun(() => this.state.runMetadata ? [this.state.runMetadata!.id!] : [], true),
-        buttons.terminateRun(
+      actions: buttons
+        .cloneRun(() => this.state.runMetadata ? [this.state.runMetadata!.id!] : [], true)
+        .terminateRun(
           () => this.state.runMetadata ? [this.state.runMetadata!.id!] : [],
           true,
           () => this.refresh()
-        ),
-      ],
+        )
+        .getToolbarActionMap(),
       breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
       pageTitle: this.props.runId!,
     };
@@ -451,14 +451,14 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
       </div>;
 
       // Update the Archive/Restore button based on the storage state of this run
-      const buttons = new Buttons(this.props, this.refresh.bind(this));
-      const actions = this.getInitialToolbarState().actions;
+      const buttons = new Buttons(this.props, this.refresh.bind(this), this.getInitialToolbarState().actions);
       const idGetter = () => runMetadata ? [runMetadata!.id!] : [];
-      const newButton = runMetadata!.storage_state === RunStorageState.ARCHIVED ?
+      runMetadata!.storage_state === RunStorageState.ARCHIVED ?
         buttons.restore(idGetter, true, () => this.refresh()) :
         buttons.archive(idGetter, true, () => this.refresh());
-      actions.splice(2, 1, newButton);
-      actions[1].disabled = runMetadata.status as NodePhase === NodePhase.TERMINATING || runFinished;
+      const actions = buttons.getToolbarActionMap();
+      actions[ButtonKeys.TERMINATE_RUN].disabled =
+        (runMetadata.status as NodePhase) === NodePhase.TERMINATING || runFinished;
       this.props.updateToolbar({ actions, breadcrumbs, pageTitle, pageTitleTooltip: runMetadata.name });
 
       this.setStateSafe({

--- a/frontend/src/pages/__snapshots__/AllRunsList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/AllRunsList.test.tsx.snap
@@ -18,8 +18,49 @@ exports[`AllRunsList renders all runs 1`] = `
     storageState="STORAGESTATE_AVAILABLE"
     toolbarProps={
       Object {
-        "actions": Array [
-          Object {
+        "actions": Object {
+          "archive": Object {
+            "action": [Function],
+            "disabled": true,
+            "disabledTitle": "Select at least one resource to archive",
+            "id": "archiveBtn",
+            "title": "Archive",
+            "tooltip": "Archive",
+          },
+          "cloneRun": Object {
+            "action": [Function],
+            "disabled": true,
+            "disabledTitle": "Select a run to clone",
+            "id": "cloneBtn",
+            "style": Object {
+              "minWidth": 100,
+            },
+            "title": "Clone run",
+            "tooltip": "Create a copy from this runs initial state",
+          },
+          "compare": Object {
+            "action": [Function],
+            "disabled": true,
+            "disabledTitle": "Select multiple runs to compare",
+            "id": "compareBtn",
+            "style": Object {
+              "minWidth": 125,
+            },
+            "title": "Compare runs",
+            "tooltip": "Compare up to 10 selected runs",
+          },
+          "newExperiment": Object {
+            "action": [Function],
+            "icon": [Function],
+            "id": "newExperimentBtn",
+            "outlined": true,
+            "style": Object {
+              "minWidth": 185,
+            },
+            "title": "Create experiment",
+            "tooltip": "Create a new experiment",
+          },
+          "newRun": Object {
             "action": [Function],
             "icon": [Function],
             "id": "createNewRunBtn",
@@ -31,54 +72,13 @@ exports[`AllRunsList renders all runs 1`] = `
             "title": "Create run",
             "tooltip": "Create a new run",
           },
-          Object {
-            "action": [Function],
-            "icon": [Function],
-            "id": "newExperimentBtn",
-            "outlined": true,
-            "style": Object {
-              "minWidth": 185,
-            },
-            "title": "Create experiment",
-            "tooltip": "Create a new experiment",
-          },
-          Object {
-            "action": [Function],
-            "disabled": true,
-            "disabledTitle": "Select multiple runs to compare",
-            "id": "compareBtn",
-            "style": Object {
-              "minWidth": 125,
-            },
-            "title": "Compare runs",
-            "tooltip": "Compare up to 10 selected runs",
-          },
-          Object {
-            "action": [Function],
-            "disabled": true,
-            "disabledTitle": "Select a run to clone",
-            "id": "cloneBtn",
-            "style": Object {
-              "minWidth": 100,
-            },
-            "title": "Clone run",
-            "tooltip": "Create a copy from this runs initial state",
-          },
-          Object {
-            "action": [Function],
-            "disabled": true,
-            "disabledTitle": "Select at least one resource to archive",
-            "id": "archiveBtn",
-            "title": "Archive",
-            "tooltip": "Archive",
-          },
-          Object {
+          "refresh": Object {
             "action": [Function],
             "id": "refreshBtn",
             "title": "Refresh",
             "tooltip": "Refresh the list",
           },
-        ],
+        },
         "breadcrumbs": Array [],
         "pageTitle": "Experiments",
       }

--- a/frontend/src/pages/__snapshots__/Archive.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/Archive.test.tsx.snap
@@ -18,8 +18,14 @@ exports[`Archive renders archived runs 1`] = `
     storageState="STORAGESTATE_ARCHIVED"
     toolbarProps={
       Object {
-        "actions": Array [
-          Object {
+        "actions": Object {
+          "refresh": Object {
+            "action": [Function],
+            "id": "refreshBtn",
+            "title": "Refresh",
+            "tooltip": "Refresh the list",
+          },
+          "restore": Object {
             "action": [Function],
             "disabled": true,
             "disabledTitle": "Select at least one resource to restore",
@@ -27,13 +33,7 @@ exports[`Archive renders archived runs 1`] = `
             "title": "Restore",
             "tooltip": "Restore",
           },
-          Object {
-            "action": [Function],
-            "id": "refreshBtn",
-            "title": "Refresh",
-            "tooltip": "Refresh the list",
-          },
-        ],
+        },
         "breadcrumbs": Array [],
         "pageTitle": "Archive",
       }
@@ -54,8 +54,14 @@ exports[`Archive renders archived runs 1`] = `
         "calls": Array [
           Array [
             Object {
-              "actions": Array [
-                Object {
+              "actions": Object {
+                "refresh": Object {
+                  "action": [Function],
+                  "id": "refreshBtn",
+                  "title": "Refresh",
+                  "tooltip": "Refresh the list",
+                },
+                "restore": Object {
                   "action": [Function],
                   "disabled": true,
                   "disabledTitle": "Select at least one resource to restore",
@@ -63,13 +69,7 @@ exports[`Archive renders archived runs 1`] = `
                   "title": "Restore",
                   "tooltip": "Restore",
                 },
-                Object {
-                  "action": [Function],
-                  "id": "refreshBtn",
-                  "title": "Refresh",
-                  "tooltip": "Refresh the list",
-                },
-              ],
+              },
               "breadcrumbs": Array [],
               "pageTitle": "Archive",
             },

--- a/frontend/src/pages/__snapshots__/Compare.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/Compare.test.tsx.snap
@@ -132,28 +132,28 @@ exports[`Compare creates a map of viewers 1`] = `
       }
       toolbarProps={
         Object {
-          "actions": Array [
-            Object {
-              "action": [Function],
-              "icon": [Function],
-              "id": "expandBtn",
-              "title": "Expand all",
-              "tooltip": "Expand all sections",
-            },
-            Object {
+          "actions": Object {
+            "collapse": Object {
               "action": [Function],
               "icon": [Function],
               "id": "collapseBtn",
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
-            Object {
+            "expand": Object {
+              "action": [Function],
+              "icon": [Function],
+              "id": "expandBtn",
+              "title": "Expand all",
+              "tooltip": "Expand all sections",
+            },
+            "refresh": Object {
               "action": [Function],
               "id": "refreshBtn",
               "title": "Refresh",
               "tooltip": "Refresh the list",
             },
-          ],
+          },
           "breadcrumbs": Array [
             Object {
               "displayName": "Experiments",
@@ -179,28 +179,28 @@ exports[`Compare creates a map of viewers 1`] = `
           "calls": Array [
             Array [
               Object {
-                "actions": Array [
-                  Object {
-                    "action": [Function],
-                    "icon": [Function],
-                    "id": "expandBtn",
-                    "title": "Expand all",
-                    "tooltip": "Expand all sections",
-                  },
-                  Object {
+                "actions": Object {
+                  "collapse": Object {
                     "action": [Function],
                     "icon": [Function],
                     "id": "collapseBtn",
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
                   },
-                  Object {
+                  "expand": Object {
+                    "action": [Function],
+                    "icon": [Function],
+                    "id": "expandBtn",
+                    "title": "Expand all",
+                    "tooltip": "Expand all sections",
+                  },
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -379,28 +379,28 @@ exports[`Compare creates an extra aggregation plot for compatible viewers 1`] = 
       }
       toolbarProps={
         Object {
-          "actions": Array [
-            Object {
-              "action": [Function],
-              "icon": [Function],
-              "id": "expandBtn",
-              "title": "Expand all",
-              "tooltip": "Expand all sections",
-            },
-            Object {
+          "actions": Object {
+            "collapse": Object {
               "action": [Function],
               "icon": [Function],
               "id": "collapseBtn",
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
-            Object {
+            "expand": Object {
+              "action": [Function],
+              "icon": [Function],
+              "id": "expandBtn",
+              "title": "Expand all",
+              "tooltip": "Expand all sections",
+            },
+            "refresh": Object {
               "action": [Function],
               "id": "refreshBtn",
               "title": "Refresh",
               "tooltip": "Refresh the list",
             },
-          ],
+          },
           "breadcrumbs": Array [
             Object {
               "displayName": "Experiments",
@@ -426,28 +426,28 @@ exports[`Compare creates an extra aggregation plot for compatible viewers 1`] = 
           "calls": Array [
             Array [
               Object {
-                "actions": Array [
-                  Object {
-                    "action": [Function],
-                    "icon": [Function],
-                    "id": "expandBtn",
-                    "title": "Expand all",
-                    "tooltip": "Expand all sections",
-                  },
-                  Object {
+                "actions": Object {
+                  "collapse": Object {
                     "action": [Function],
                     "icon": [Function],
                     "id": "collapseBtn",
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
                   },
-                  Object {
+                  "expand": Object {
+                    "action": [Function],
+                    "icon": [Function],
+                    "id": "expandBtn",
+                    "title": "Expand all",
+                    "tooltip": "Expand all sections",
+                  },
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -677,28 +677,28 @@ exports[`Compare displays a run's metrics if the run has any 1`] = `
       }
       toolbarProps={
         Object {
-          "actions": Array [
-            Object {
-              "action": [Function],
-              "icon": [Function],
-              "id": "expandBtn",
-              "title": "Expand all",
-              "tooltip": "Expand all sections",
-            },
-            Object {
+          "actions": Object {
+            "collapse": Object {
               "action": [Function],
               "icon": [Function],
               "id": "collapseBtn",
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
-            Object {
+            "expand": Object {
+              "action": [Function],
+              "icon": [Function],
+              "id": "expandBtn",
+              "title": "Expand all",
+              "tooltip": "Expand all sections",
+            },
+            "refresh": Object {
               "action": [Function],
               "id": "refreshBtn",
               "title": "Refresh",
               "tooltip": "Refresh the list",
             },
-          ],
+          },
           "breadcrumbs": Array [
             Object {
               "displayName": "Experiments",
@@ -724,28 +724,28 @@ exports[`Compare displays a run's metrics if the run has any 1`] = `
           "calls": Array [
             Array [
               Object {
-                "actions": Array [
-                  Object {
-                    "action": [Function],
-                    "icon": [Function],
-                    "id": "expandBtn",
-                    "title": "Expand all",
-                    "tooltip": "Expand all sections",
-                  },
-                  Object {
+                "actions": Object {
+                  "collapse": Object {
                     "action": [Function],
                     "icon": [Function],
                     "id": "collapseBtn",
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
                   },
-                  Object {
+                  "expand": Object {
+                    "action": [Function],
+                    "icon": [Function],
+                    "id": "expandBtn",
+                    "title": "Expand all",
+                    "tooltip": "Expand all sections",
+                  },
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -869,28 +869,28 @@ exports[`Compare displays metrics from multiple runs 1`] = `
       }
       toolbarProps={
         Object {
-          "actions": Array [
-            Object {
-              "action": [Function],
-              "icon": [Function],
-              "id": "expandBtn",
-              "title": "Expand all",
-              "tooltip": "Expand all sections",
-            },
-            Object {
+          "actions": Object {
+            "collapse": Object {
               "action": [Function],
               "icon": [Function],
               "id": "collapseBtn",
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
-            Object {
+            "expand": Object {
+              "action": [Function],
+              "icon": [Function],
+              "id": "expandBtn",
+              "title": "Expand all",
+              "tooltip": "Expand all sections",
+            },
+            "refresh": Object {
               "action": [Function],
               "id": "refreshBtn",
               "title": "Refresh",
               "tooltip": "Refresh the list",
             },
-          ],
+          },
           "breadcrumbs": Array [
             Object {
               "displayName": "Experiments",
@@ -916,28 +916,28 @@ exports[`Compare displays metrics from multiple runs 1`] = `
           "calls": Array [
             Array [
               Object {
-                "actions": Array [
-                  Object {
-                    "action": [Function],
-                    "icon": [Function],
-                    "id": "expandBtn",
-                    "title": "Expand all",
-                    "tooltip": "Expand all sections",
-                  },
-                  Object {
+                "actions": Object {
+                  "collapse": Object {
                     "action": [Function],
                     "icon": [Function],
                     "id": "collapseBtn",
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
                   },
-                  Object {
+                  "expand": Object {
+                    "action": [Function],
+                    "icon": [Function],
+                    "id": "expandBtn",
+                    "title": "Expand all",
+                    "tooltip": "Expand all sections",
+                  },
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -1065,28 +1065,28 @@ exports[`Compare displays parameters from multiple runs 1`] = `
       }
       toolbarProps={
         Object {
-          "actions": Array [
-            Object {
-              "action": [Function],
-              "icon": [Function],
-              "id": "expandBtn",
-              "title": "Expand all",
-              "tooltip": "Expand all sections",
-            },
-            Object {
+          "actions": Object {
+            "collapse": Object {
               "action": [Function],
               "icon": [Function],
               "id": "collapseBtn",
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
-            Object {
+            "expand": Object {
+              "action": [Function],
+              "icon": [Function],
+              "id": "expandBtn",
+              "title": "Expand all",
+              "tooltip": "Expand all sections",
+            },
+            "refresh": Object {
               "action": [Function],
               "id": "refreshBtn",
               "title": "Refresh",
               "tooltip": "Refresh the list",
             },
-          ],
+          },
           "breadcrumbs": Array [
             Object {
               "displayName": "Experiments",
@@ -1112,28 +1112,28 @@ exports[`Compare displays parameters from multiple runs 1`] = `
           "calls": Array [
             Array [
               Object {
-                "actions": Array [
-                  Object {
-                    "action": [Function],
-                    "icon": [Function],
-                    "id": "expandBtn",
-                    "title": "Expand all",
-                    "tooltip": "Expand all sections",
-                  },
-                  Object {
+                "actions": Object {
+                  "collapse": Object {
                     "action": [Function],
                     "icon": [Function],
                     "id": "collapseBtn",
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
                   },
-                  Object {
+                  "expand": Object {
+                    "action": [Function],
+                    "icon": [Function],
+                    "id": "expandBtn",
+                    "title": "Expand all",
+                    "tooltip": "Expand all sections",
+                  },
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -1264,28 +1264,28 @@ exports[`Compare displays run's parameters if the run has any 1`] = `
       }
       toolbarProps={
         Object {
-          "actions": Array [
-            Object {
-              "action": [Function],
-              "icon": [Function],
-              "id": "expandBtn",
-              "title": "Expand all",
-              "tooltip": "Expand all sections",
-            },
-            Object {
+          "actions": Object {
+            "collapse": Object {
               "action": [Function],
               "icon": [Function],
               "id": "collapseBtn",
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
-            Object {
+            "expand": Object {
+              "action": [Function],
+              "icon": [Function],
+              "id": "expandBtn",
+              "title": "Expand all",
+              "tooltip": "Expand all sections",
+            },
+            "refresh": Object {
               "action": [Function],
               "id": "refreshBtn",
               "title": "Refresh",
               "tooltip": "Refresh the list",
             },
-          ],
+          },
           "breadcrumbs": Array [
             Object {
               "displayName": "Experiments",
@@ -1311,28 +1311,28 @@ exports[`Compare displays run's parameters if the run has any 1`] = `
           "calls": Array [
             Array [
               Object {
-                "actions": Array [
-                  Object {
-                    "action": [Function],
-                    "icon": [Function],
-                    "id": "expandBtn",
-                    "title": "Expand all",
-                    "tooltip": "Expand all sections",
-                  },
-                  Object {
+                "actions": Object {
+                  "collapse": Object {
                     "action": [Function],
                     "icon": [Function],
                     "id": "collapseBtn",
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
                   },
-                  Object {
+                  "expand": Object {
+                    "action": [Function],
+                    "icon": [Function],
+                    "id": "expandBtn",
+                    "title": "Expand all",
+                    "tooltip": "Expand all sections",
+                  },
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -1451,28 +1451,28 @@ exports[`Compare does not show viewers for deselected runs 1`] = `
       selectedIds={Array []}
       toolbarProps={
         Object {
-          "actions": Array [
-            Object {
-              "action": [Function],
-              "icon": [Function],
-              "id": "expandBtn",
-              "title": "Expand all",
-              "tooltip": "Expand all sections",
-            },
-            Object {
+          "actions": Object {
+            "collapse": Object {
               "action": [Function],
               "icon": [Function],
               "id": "collapseBtn",
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
-            Object {
+            "expand": Object {
+              "action": [Function],
+              "icon": [Function],
+              "id": "expandBtn",
+              "title": "Expand all",
+              "tooltip": "Expand all sections",
+            },
+            "refresh": Object {
               "action": [Function],
               "id": "refreshBtn",
               "title": "Refresh",
               "tooltip": "Refresh the list",
             },
-          ],
+          },
           "breadcrumbs": Array [
             Object {
               "displayName": "Experiments",
@@ -1498,28 +1498,28 @@ exports[`Compare does not show viewers for deselected runs 1`] = `
           "calls": Array [
             Array [
               Object {
-                "actions": Array [
-                  Object {
-                    "action": [Function],
-                    "icon": [Function],
-                    "id": "expandBtn",
-                    "title": "Expand all",
-                    "tooltip": "Expand all sections",
-                  },
-                  Object {
+                "actions": Object {
+                  "collapse": Object {
                     "action": [Function],
                     "icon": [Function],
                     "id": "collapseBtn",
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
                   },
-                  Object {
+                  "expand": Object {
+                    "action": [Function],
+                    "icon": [Function],
+                    "id": "expandBtn",
+                    "title": "Expand all",
+                    "tooltip": "Expand all sections",
+                  },
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -1621,28 +1621,28 @@ exports[`Compare expands all sections if they were collapsed 1`] = `
       }
       toolbarProps={
         Object {
-          "actions": Array [
-            Object {
-              "action": [Function],
-              "icon": [Function],
-              "id": "expandBtn",
-              "title": "Expand all",
-              "tooltip": "Expand all sections",
-            },
-            Object {
+          "actions": Object {
+            "collapse": Object {
               "action": [Function],
               "icon": [Function],
               "id": "collapseBtn",
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
-            Object {
+            "expand": Object {
+              "action": [Function],
+              "icon": [Function],
+              "id": "expandBtn",
+              "title": "Expand all",
+              "tooltip": "Expand all sections",
+            },
+            "refresh": Object {
               "action": [Function],
               "id": "refreshBtn",
               "title": "Refresh",
               "tooltip": "Refresh the list",
             },
-          ],
+          },
           "breadcrumbs": Array [
             Object {
               "displayName": "Experiments",
@@ -1668,28 +1668,28 @@ exports[`Compare expands all sections if they were collapsed 1`] = `
           "calls": Array [
             Array [
               Object {
-                "actions": Array [
-                  Object {
-                    "action": [Function],
-                    "icon": [Function],
-                    "id": "expandBtn",
-                    "title": "Expand all",
-                    "tooltip": "Expand all sections",
-                  },
-                  Object {
+                "actions": Object {
+                  "collapse": Object {
                     "action": [Function],
                     "icon": [Function],
                     "id": "collapseBtn",
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
                   },
-                  Object {
+                  "expand": Object {
+                    "action": [Function],
+                    "icon": [Function],
+                    "id": "expandBtn",
+                    "title": "Expand all",
+                    "tooltip": "Expand all sections",
+                  },
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -1917,28 +1917,28 @@ exports[`Compare renders a page with multiple runs 1`] = `
       }
       toolbarProps={
         Object {
-          "actions": Array [
-            Object {
-              "action": [Function],
-              "icon": [Function],
-              "id": "expandBtn",
-              "title": "Expand all",
-              "tooltip": "Expand all sections",
-            },
-            Object {
+          "actions": Object {
+            "collapse": Object {
               "action": [Function],
               "icon": [Function],
               "id": "collapseBtn",
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
-            Object {
+            "expand": Object {
+              "action": [Function],
+              "icon": [Function],
+              "id": "expandBtn",
+              "title": "Expand all",
+              "tooltip": "Expand all sections",
+            },
+            "refresh": Object {
               "action": [Function],
               "id": "refreshBtn",
               "title": "Refresh",
               "tooltip": "Refresh the list",
             },
-          ],
+          },
           "breadcrumbs": Array [
             Object {
               "displayName": "Experiments",
@@ -1964,28 +1964,28 @@ exports[`Compare renders a page with multiple runs 1`] = `
           "calls": Array [
             Array [
               Object {
-                "actions": Array [
-                  Object {
-                    "action": [Function],
-                    "icon": [Function],
-                    "id": "expandBtn",
-                    "title": "Expand all",
-                    "tooltip": "Expand all sections",
-                  },
-                  Object {
+                "actions": Object {
+                  "collapse": Object {
                     "action": [Function],
                     "icon": [Function],
                     "id": "collapseBtn",
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
                   },
-                  Object {
+                  "expand": Object {
+                    "action": [Function],
+                    "icon": [Function],
+                    "id": "expandBtn",
+                    "title": "Expand all",
+                    "tooltip": "Expand all sections",
+                  },
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -2089,28 +2089,28 @@ exports[`Compare renders a page with no runs 1`] = `
       selectedIds={Array []}
       toolbarProps={
         Object {
-          "actions": Array [
-            Object {
-              "action": [Function],
-              "icon": [Function],
-              "id": "expandBtn",
-              "title": "Expand all",
-              "tooltip": "Expand all sections",
-            },
-            Object {
+          "actions": Object {
+            "collapse": Object {
               "action": [Function],
               "icon": [Function],
               "id": "collapseBtn",
               "title": "Collapse all",
               "tooltip": "Collapse all sections",
             },
-            Object {
+            "expand": Object {
+              "action": [Function],
+              "icon": [Function],
+              "id": "expandBtn",
+              "title": "Expand all",
+              "tooltip": "Expand all sections",
+            },
+            "refresh": Object {
               "action": [Function],
               "id": "refreshBtn",
               "title": "Refresh",
               "tooltip": "Refresh the list",
             },
-          ],
+          },
           "breadcrumbs": Array [
             Object {
               "displayName": "Experiments",
@@ -2136,28 +2136,28 @@ exports[`Compare renders a page with no runs 1`] = `
           "calls": Array [
             Array [
               Object {
-                "actions": Array [
-                  Object {
-                    "action": [Function],
-                    "icon": [Function],
-                    "id": "expandBtn",
-                    "title": "Expand all",
-                    "tooltip": "Expand all sections",
-                  },
-                  Object {
+                "actions": Object {
+                  "collapse": Object {
                     "action": [Function],
                     "icon": [Function],
                     "id": "collapseBtn",
                     "title": "Collapse all",
                     "tooltip": "Collapse all sections",
                   },
-                  Object {
+                  "expand": Object {
+                    "action": [Function],
+                    "icon": [Function],
+                    "id": "expandBtn",
+                    "title": "Expand all",
+                    "tooltip": "Expand all sections",
+                  },
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",

--- a/frontend/src/pages/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -81,8 +81,49 @@ exports[`ExperimentDetails fetches this experiment's recurring runs 1`] = `
     </div>
     <Toolbar
       actions={
-        Array [
-          Object {
+        Object {
+          "archive": Object {
+            "action": [Function],
+            "disabled": true,
+            "disabledTitle": "Select at least one resource to archive",
+            "id": "archiveBtn",
+            "title": "Archive",
+            "tooltip": "Archive",
+          },
+          "cloneRun": Object {
+            "action": [Function],
+            "disabled": true,
+            "disabledTitle": "Select a run to clone",
+            "id": "cloneBtn",
+            "style": Object {
+              "minWidth": 100,
+            },
+            "title": "Clone run",
+            "tooltip": "Create a copy from this runs initial state",
+          },
+          "compare": Object {
+            "action": [Function],
+            "disabled": true,
+            "disabledTitle": "Select multiple runs to compare",
+            "id": "compareBtn",
+            "style": Object {
+              "minWidth": 125,
+            },
+            "title": "Compare runs",
+            "tooltip": "Compare up to 10 selected runs",
+          },
+          "newRecurringRun": Object {
+            "action": [Function],
+            "icon": [Function],
+            "id": "createNewRecurringRunBtn",
+            "outlined": true,
+            "style": Object {
+              "minWidth": 195,
+            },
+            "title": "Create recurring run",
+            "tooltip": "Create a new recurring run",
+          },
+          "newRun": Object {
             "action": [Function],
             "icon": [Function],
             "id": "createNewRunBtn",
@@ -94,48 +135,7 @@ exports[`ExperimentDetails fetches this experiment's recurring runs 1`] = `
             "title": "Create run",
             "tooltip": "Create a new run",
           },
-          Object {
-            "action": [Function],
-            "icon": [Function],
-            "id": "createNewRecurringRunBtn",
-            "outlined": true,
-            "style": Object {
-              "minWidth": 195,
-            },
-            "title": "Create recurring run",
-            "tooltip": "Create a new recurring run",
-          },
-          Object {
-            "action": [Function],
-            "disabled": true,
-            "disabledTitle": "Select multiple runs to compare",
-            "id": "compareBtn",
-            "style": Object {
-              "minWidth": 125,
-            },
-            "title": "Compare runs",
-            "tooltip": "Compare up to 10 selected runs",
-          },
-          Object {
-            "action": [Function],
-            "disabled": true,
-            "disabledTitle": "Select a run to clone",
-            "id": "cloneBtn",
-            "style": Object {
-              "minWidth": 100,
-            },
-            "title": "Clone run",
-            "tooltip": "Create a copy from this runs initial state",
-          },
-          Object {
-            "action": [Function],
-            "disabled": true,
-            "disabledTitle": "Select at least one resource to archive",
-            "id": "archiveBtn",
-            "title": "Archive",
-            "tooltip": "Archive",
-          },
-        ]
+        }
       }
       breadcrumbs={Array []}
       pageTitle="Runs"
@@ -163,14 +163,14 @@ exports[`ExperimentDetails fetches this experiment's recurring runs 1`] = `
       storageState="STORAGESTATE_AVAILABLE"
       toolbarProps={
         Object {
-          "actions": Array [
-            Object {
+          "actions": Object {
+            "refresh": Object {
               "action": [Function],
               "id": "refreshBtn",
               "title": "Refresh",
               "tooltip": "Refresh the list",
             },
-          ],
+          },
           "breadcrumbs": Array [
             Object {
               "displayName": "Experiments",
@@ -196,14 +196,14 @@ exports[`ExperimentDetails fetches this experiment's recurring runs 1`] = `
           "calls": Array [
             Array [
               Object {
-                "actions": Array [
-                  Object {
+                "actions": Object {
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -215,14 +215,14 @@ exports[`ExperimentDetails fetches this experiment's recurring runs 1`] = `
             ],
             Array [
               Object {
-                "actions": Array [
-                  Object {
+                "actions": Object {
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -264,14 +264,14 @@ exports[`ExperimentDetails fetches this experiment's recurring runs 1`] = `
           }
           toolbarProps={
             Object {
-              "actions": Array [
-                Object {
+              "actions": Object {
+                "refresh": Object {
                   "action": [Function],
                   "id": "refreshBtn",
                   "title": "Refresh",
                   "tooltip": "Refresh the list",
                 },
-              ],
+              },
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -297,14 +297,14 @@ exports[`ExperimentDetails fetches this experiment's recurring runs 1`] = `
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [
-                      Object {
+                    "actions": Object {
+                      "refresh": Object {
                         "action": [Function],
                         "id": "refreshBtn",
                         "title": "Refresh",
                         "tooltip": "Refresh the list",
                       },
-                    ],
+                    },
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -316,14 +316,14 @@ exports[`ExperimentDetails fetches this experiment's recurring runs 1`] = `
                 ],
                 Array [
                   Object {
-                    "actions": Array [
-                      Object {
+                    "actions": Object {
+                      "refresh": Object {
                         "action": [Function],
                         "id": "refreshBtn",
                         "title": "Refresh",
                         "tooltip": "Refresh the list",
                       },
-                    ],
+                    },
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -447,8 +447,49 @@ exports[`ExperimentDetails removes all description text after second newline and
     </div>
     <Toolbar
       actions={
-        Array [
-          Object {
+        Object {
+          "archive": Object {
+            "action": [Function],
+            "disabled": true,
+            "disabledTitle": "Select at least one resource to archive",
+            "id": "archiveBtn",
+            "title": "Archive",
+            "tooltip": "Archive",
+          },
+          "cloneRun": Object {
+            "action": [Function],
+            "disabled": true,
+            "disabledTitle": "Select a run to clone",
+            "id": "cloneBtn",
+            "style": Object {
+              "minWidth": 100,
+            },
+            "title": "Clone run",
+            "tooltip": "Create a copy from this runs initial state",
+          },
+          "compare": Object {
+            "action": [Function],
+            "disabled": true,
+            "disabledTitle": "Select multiple runs to compare",
+            "id": "compareBtn",
+            "style": Object {
+              "minWidth": 125,
+            },
+            "title": "Compare runs",
+            "tooltip": "Compare up to 10 selected runs",
+          },
+          "newRecurringRun": Object {
+            "action": [Function],
+            "icon": [Function],
+            "id": "createNewRecurringRunBtn",
+            "outlined": true,
+            "style": Object {
+              "minWidth": 195,
+            },
+            "title": "Create recurring run",
+            "tooltip": "Create a new recurring run",
+          },
+          "newRun": Object {
             "action": [Function],
             "icon": [Function],
             "id": "createNewRunBtn",
@@ -460,48 +501,7 @@ exports[`ExperimentDetails removes all description text after second newline and
             "title": "Create run",
             "tooltip": "Create a new run",
           },
-          Object {
-            "action": [Function],
-            "icon": [Function],
-            "id": "createNewRecurringRunBtn",
-            "outlined": true,
-            "style": Object {
-              "minWidth": 195,
-            },
-            "title": "Create recurring run",
-            "tooltip": "Create a new recurring run",
-          },
-          Object {
-            "action": [Function],
-            "disabled": true,
-            "disabledTitle": "Select multiple runs to compare",
-            "id": "compareBtn",
-            "style": Object {
-              "minWidth": 125,
-            },
-            "title": "Compare runs",
-            "tooltip": "Compare up to 10 selected runs",
-          },
-          Object {
-            "action": [Function],
-            "disabled": true,
-            "disabledTitle": "Select a run to clone",
-            "id": "cloneBtn",
-            "style": Object {
-              "minWidth": 100,
-            },
-            "title": "Clone run",
-            "tooltip": "Create a copy from this runs initial state",
-          },
-          Object {
-            "action": [Function],
-            "disabled": true,
-            "disabledTitle": "Select at least one resource to archive",
-            "id": "archiveBtn",
-            "title": "Archive",
-            "tooltip": "Archive",
-          },
-        ]
+        }
       }
       breadcrumbs={Array []}
       pageTitle="Runs"
@@ -529,14 +529,14 @@ exports[`ExperimentDetails removes all description text after second newline and
       storageState="STORAGESTATE_AVAILABLE"
       toolbarProps={
         Object {
-          "actions": Array [
-            Object {
+          "actions": Object {
+            "refresh": Object {
               "action": [Function],
               "id": "refreshBtn",
               "title": "Refresh",
               "tooltip": "Refresh the list",
             },
-          ],
+          },
           "breadcrumbs": Array [
             Object {
               "displayName": "Experiments",
@@ -562,14 +562,14 @@ exports[`ExperimentDetails removes all description text after second newline and
           "calls": Array [
             Array [
               Object {
-                "actions": Array [
-                  Object {
+                "actions": Object {
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -581,14 +581,14 @@ exports[`ExperimentDetails removes all description text after second newline and
             ],
             Array [
               Object {
-                "actions": Array [
-                  Object {
+                "actions": Object {
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -630,14 +630,14 @@ exports[`ExperimentDetails removes all description text after second newline and
           }
           toolbarProps={
             Object {
-              "actions": Array [
-                Object {
+              "actions": Object {
+                "refresh": Object {
                   "action": [Function],
                   "id": "refreshBtn",
                   "title": "Refresh",
                   "tooltip": "Refresh the list",
                 },
-              ],
+              },
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -663,14 +663,14 @@ exports[`ExperimentDetails removes all description text after second newline and
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [
-                      Object {
+                    "actions": Object {
+                      "refresh": Object {
                         "action": [Function],
                         "id": "refreshBtn",
                         "title": "Refresh",
                         "tooltip": "Refresh the list",
                       },
-                    ],
+                    },
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -682,14 +682,14 @@ exports[`ExperimentDetails removes all description text after second newline and
                 ],
                 Array [
                   Object {
-                    "actions": Array [
-                      Object {
+                    "actions": Object {
+                      "refresh": Object {
                         "action": [Function],
                         "id": "refreshBtn",
                         "title": "Refresh",
                         "tooltip": "Refresh the list",
                       },
-                    ],
+                    },
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -800,8 +800,49 @@ exports[`ExperimentDetails renders a page with no runs or recurring runs 1`] = `
     </div>
     <Toolbar
       actions={
-        Array [
-          Object {
+        Object {
+          "archive": Object {
+            "action": [Function],
+            "disabled": true,
+            "disabledTitle": "Select at least one resource to archive",
+            "id": "archiveBtn",
+            "title": "Archive",
+            "tooltip": "Archive",
+          },
+          "cloneRun": Object {
+            "action": [Function],
+            "disabled": true,
+            "disabledTitle": "Select a run to clone",
+            "id": "cloneBtn",
+            "style": Object {
+              "minWidth": 100,
+            },
+            "title": "Clone run",
+            "tooltip": "Create a copy from this runs initial state",
+          },
+          "compare": Object {
+            "action": [Function],
+            "disabled": true,
+            "disabledTitle": "Select multiple runs to compare",
+            "id": "compareBtn",
+            "style": Object {
+              "minWidth": 125,
+            },
+            "title": "Compare runs",
+            "tooltip": "Compare up to 10 selected runs",
+          },
+          "newRecurringRun": Object {
+            "action": [Function],
+            "icon": [Function],
+            "id": "createNewRecurringRunBtn",
+            "outlined": true,
+            "style": Object {
+              "minWidth": 195,
+            },
+            "title": "Create recurring run",
+            "tooltip": "Create a new recurring run",
+          },
+          "newRun": Object {
             "action": [Function],
             "icon": [Function],
             "id": "createNewRunBtn",
@@ -813,48 +854,7 @@ exports[`ExperimentDetails renders a page with no runs or recurring runs 1`] = `
             "title": "Create run",
             "tooltip": "Create a new run",
           },
-          Object {
-            "action": [Function],
-            "icon": [Function],
-            "id": "createNewRecurringRunBtn",
-            "outlined": true,
-            "style": Object {
-              "minWidth": 195,
-            },
-            "title": "Create recurring run",
-            "tooltip": "Create a new recurring run",
-          },
-          Object {
-            "action": [Function],
-            "disabled": true,
-            "disabledTitle": "Select multiple runs to compare",
-            "id": "compareBtn",
-            "style": Object {
-              "minWidth": 125,
-            },
-            "title": "Compare runs",
-            "tooltip": "Compare up to 10 selected runs",
-          },
-          Object {
-            "action": [Function],
-            "disabled": true,
-            "disabledTitle": "Select a run to clone",
-            "id": "cloneBtn",
-            "style": Object {
-              "minWidth": 100,
-            },
-            "title": "Clone run",
-            "tooltip": "Create a copy from this runs initial state",
-          },
-          Object {
-            "action": [Function],
-            "disabled": true,
-            "disabledTitle": "Select at least one resource to archive",
-            "id": "archiveBtn",
-            "title": "Archive",
-            "tooltip": "Archive",
-          },
-        ]
+        }
       }
       breadcrumbs={Array []}
       pageTitle="Runs"
@@ -882,14 +882,14 @@ exports[`ExperimentDetails renders a page with no runs or recurring runs 1`] = `
       storageState="STORAGESTATE_AVAILABLE"
       toolbarProps={
         Object {
-          "actions": Array [
-            Object {
+          "actions": Object {
+            "refresh": Object {
               "action": [Function],
               "id": "refreshBtn",
               "title": "Refresh",
               "tooltip": "Refresh the list",
             },
-          ],
+          },
           "breadcrumbs": Array [
             Object {
               "displayName": "Experiments",
@@ -915,14 +915,14 @@ exports[`ExperimentDetails renders a page with no runs or recurring runs 1`] = `
           "calls": Array [
             Array [
               Object {
-                "actions": Array [
-                  Object {
+                "actions": Object {
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -934,14 +934,14 @@ exports[`ExperimentDetails renders a page with no runs or recurring runs 1`] = `
             ],
             Array [
               Object {
-                "actions": Array [
-                  Object {
+                "actions": Object {
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -983,14 +983,14 @@ exports[`ExperimentDetails renders a page with no runs or recurring runs 1`] = `
           }
           toolbarProps={
             Object {
-              "actions": Array [
-                Object {
+              "actions": Object {
+                "refresh": Object {
                   "action": [Function],
                   "id": "refreshBtn",
                   "title": "Refresh",
                   "tooltip": "Refresh the list",
                 },
-              ],
+              },
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -1016,14 +1016,14 @@ exports[`ExperimentDetails renders a page with no runs or recurring runs 1`] = `
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [
-                      Object {
+                    "actions": Object {
+                      "refresh": Object {
                         "action": [Function],
                         "id": "refreshBtn",
                         "title": "Refresh",
                         "tooltip": "Refresh the list",
                       },
-                    ],
+                    },
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -1035,14 +1035,14 @@ exports[`ExperimentDetails renders a page with no runs or recurring runs 1`] = `
                 ],
                 Array [
                   Object {
-                    "actions": Array [
-                      Object {
+                    "actions": Object {
+                      "refresh": Object {
                         "action": [Function],
                         "id": "refreshBtn",
                         "title": "Refresh",
                         "tooltip": "Refresh the list",
                       },
-                    ],
+                    },
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -1151,8 +1151,49 @@ exports[`ExperimentDetails uses an empty string if the experiment has no descrip
     </div>
     <Toolbar
       actions={
-        Array [
-          Object {
+        Object {
+          "archive": Object {
+            "action": [Function],
+            "disabled": true,
+            "disabledTitle": "Select at least one resource to archive",
+            "id": "archiveBtn",
+            "title": "Archive",
+            "tooltip": "Archive",
+          },
+          "cloneRun": Object {
+            "action": [Function],
+            "disabled": true,
+            "disabledTitle": "Select a run to clone",
+            "id": "cloneBtn",
+            "style": Object {
+              "minWidth": 100,
+            },
+            "title": "Clone run",
+            "tooltip": "Create a copy from this runs initial state",
+          },
+          "compare": Object {
+            "action": [Function],
+            "disabled": true,
+            "disabledTitle": "Select multiple runs to compare",
+            "id": "compareBtn",
+            "style": Object {
+              "minWidth": 125,
+            },
+            "title": "Compare runs",
+            "tooltip": "Compare up to 10 selected runs",
+          },
+          "newRecurringRun": Object {
+            "action": [Function],
+            "icon": [Function],
+            "id": "createNewRecurringRunBtn",
+            "outlined": true,
+            "style": Object {
+              "minWidth": 195,
+            },
+            "title": "Create recurring run",
+            "tooltip": "Create a new recurring run",
+          },
+          "newRun": Object {
             "action": [Function],
             "icon": [Function],
             "id": "createNewRunBtn",
@@ -1164,48 +1205,7 @@ exports[`ExperimentDetails uses an empty string if the experiment has no descrip
             "title": "Create run",
             "tooltip": "Create a new run",
           },
-          Object {
-            "action": [Function],
-            "icon": [Function],
-            "id": "createNewRecurringRunBtn",
-            "outlined": true,
-            "style": Object {
-              "minWidth": 195,
-            },
-            "title": "Create recurring run",
-            "tooltip": "Create a new recurring run",
-          },
-          Object {
-            "action": [Function],
-            "disabled": true,
-            "disabledTitle": "Select multiple runs to compare",
-            "id": "compareBtn",
-            "style": Object {
-              "minWidth": 125,
-            },
-            "title": "Compare runs",
-            "tooltip": "Compare up to 10 selected runs",
-          },
-          Object {
-            "action": [Function],
-            "disabled": true,
-            "disabledTitle": "Select a run to clone",
-            "id": "cloneBtn",
-            "style": Object {
-              "minWidth": 100,
-            },
-            "title": "Clone run",
-            "tooltip": "Create a copy from this runs initial state",
-          },
-          Object {
-            "action": [Function],
-            "disabled": true,
-            "disabledTitle": "Select at least one resource to archive",
-            "id": "archiveBtn",
-            "title": "Archive",
-            "tooltip": "Archive",
-          },
-        ]
+        }
       }
       breadcrumbs={Array []}
       pageTitle="Runs"
@@ -1233,14 +1233,14 @@ exports[`ExperimentDetails uses an empty string if the experiment has no descrip
       storageState="STORAGESTATE_AVAILABLE"
       toolbarProps={
         Object {
-          "actions": Array [
-            Object {
+          "actions": Object {
+            "refresh": Object {
               "action": [Function],
               "id": "refreshBtn",
               "title": "Refresh",
               "tooltip": "Refresh the list",
             },
-          ],
+          },
           "breadcrumbs": Array [
             Object {
               "displayName": "Experiments",
@@ -1266,14 +1266,14 @@ exports[`ExperimentDetails uses an empty string if the experiment has no descrip
           "calls": Array [
             Array [
               Object {
-                "actions": Array [
-                  Object {
+                "actions": Object {
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -1285,14 +1285,14 @@ exports[`ExperimentDetails uses an empty string if the experiment has no descrip
             ],
             Array [
               Object {
-                "actions": Array [
-                  Object {
+                "actions": Object {
+                  "refresh": Object {
                     "action": [Function],
                     "id": "refreshBtn",
                     "title": "Refresh",
                     "tooltip": "Refresh the list",
                   },
-                ],
+                },
                 "breadcrumbs": Array [
                   Object {
                     "displayName": "Experiments",
@@ -1334,14 +1334,14 @@ exports[`ExperimentDetails uses an empty string if the experiment has no descrip
           }
           toolbarProps={
             Object {
-              "actions": Array [
-                Object {
+              "actions": Object {
+                "refresh": Object {
                   "action": [Function],
                   "id": "refreshBtn",
                   "title": "Refresh",
                   "tooltip": "Refresh the list",
                 },
-              ],
+              },
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -1367,14 +1367,14 @@ exports[`ExperimentDetails uses an empty string if the experiment has no descrip
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [
-                      Object {
+                    "actions": Object {
+                      "refresh": Object {
                         "action": [Function],
                         "id": "refreshBtn",
                         "title": "Refresh",
                         "tooltip": "Refresh the list",
                       },
-                    ],
+                    },
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -1386,14 +1386,14 @@ exports[`ExperimentDetails uses an empty string if the experiment has no descrip
                 ],
                 Array [
                   Object {
-                    "actions": Array [
-                      Object {
+                    "actions": Object {
+                      "refresh": Object {
                         "action": [Function],
                         "id": "refreshBtn",
                         "title": "Refresh",
                         "tooltip": "Refresh the list",
                       },
-                    ],
+                    },
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
           title="Choose a pipeline"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -105,7 +105,7 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -117,7 +117,7 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -205,7 +205,7 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
           title="Choose an experiment"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -231,7 +231,7 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -243,7 +243,7 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -488,7 +488,7 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
           title="Choose a pipeline"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -514,7 +514,7 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -526,7 +526,7 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -618,7 +618,7 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
           title="Choose an experiment"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -644,7 +644,7 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -656,7 +656,7 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -905,7 +905,7 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
           title="Choose a pipeline"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -931,7 +931,7 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -943,7 +943,7 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -1040,7 +1040,7 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
           title="Choose an experiment"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -1066,7 +1066,7 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -1078,7 +1078,7 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -1343,7 +1343,7 @@ exports[`NewRun changes title and form to default state if the new run is a one-
           title="Choose a pipeline"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -1369,7 +1369,7 @@ exports[`NewRun changes title and form to default state if the new run is a one-
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -1381,7 +1381,7 @@ exports[`NewRun changes title and form to default state if the new run is a one-
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -1474,7 +1474,7 @@ exports[`NewRun changes title and form to default state if the new run is a one-
           title="Choose an experiment"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -1500,7 +1500,7 @@ exports[`NewRun changes title and form to default state if the new run is a one-
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -1512,7 +1512,7 @@ exports[`NewRun changes title and form to default state if the new run is a one-
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -1762,7 +1762,7 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
           title="Choose a pipeline"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -1788,7 +1788,7 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -1800,7 +1800,7 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -1888,7 +1888,7 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
           title="Choose an experiment"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -1914,7 +1914,7 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -1926,7 +1926,7 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -2171,7 +2171,7 @@ exports[`NewRun renders the new run page 1`] = `
           title="Choose a pipeline"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -2197,7 +2197,7 @@ exports[`NewRun renders the new run page 1`] = `
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -2209,7 +2209,7 @@ exports[`NewRun renders the new run page 1`] = `
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -2301,7 +2301,7 @@ exports[`NewRun renders the new run page 1`] = `
           title="Choose an experiment"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -2327,7 +2327,7 @@ exports[`NewRun renders the new run page 1`] = `
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -2339,7 +2339,7 @@ exports[`NewRun renders the new run page 1`] = `
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -2588,7 +2588,7 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
           title="Choose a pipeline"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -2614,7 +2614,7 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -2626,7 +2626,7 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -2714,7 +2714,7 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
           title="Choose an experiment"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -2740,7 +2740,7 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -2752,7 +2752,7 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -2994,7 +2994,7 @@ exports[`NewRun starting a new run copies pipeline from run in the start API cal
           title="Choose a pipeline"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -3031,7 +3031,7 @@ exports[`NewRun starting a new run copies pipeline from run in the start API cal
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -3043,7 +3043,7 @@ exports[`NewRun starting a new run copies pipeline from run in the start API cal
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -3137,7 +3137,7 @@ exports[`NewRun starting a new run copies pipeline from run in the start API cal
           title="Choose an experiment"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -3174,7 +3174,7 @@ exports[`NewRun starting a new run copies pipeline from run in the start API cal
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -3186,7 +3186,7 @@ exports[`NewRun starting a new run copies pipeline from run in the start API cal
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -3416,7 +3416,7 @@ exports[`NewRun starting a new run updates the parameters in state on handlePara
           title="Choose a pipeline"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -3453,7 +3453,7 @@ exports[`NewRun starting a new run updates the parameters in state on handlePara
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -3465,7 +3465,7 @@ exports[`NewRun starting a new run updates the parameters in state on handlePara
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -3559,7 +3559,7 @@ exports[`NewRun starting a new run updates the parameters in state on handlePara
           title="Choose an experiment"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -3596,7 +3596,7 @@ exports[`NewRun starting a new run updates the parameters in state on handlePara
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -3608,7 +3608,7 @@ exports[`NewRun starting a new run updates the parameters in state on handlePara
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -3862,7 +3862,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
           title="Choose a pipeline"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -3888,7 +3888,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -3900,7 +3900,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -3992,7 +3992,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
           title="Choose an experiment"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -4018,7 +4018,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -4030,7 +4030,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -4279,7 +4279,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
           title="Choose a pipeline"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -4305,7 +4305,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -4317,7 +4317,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -4409,7 +4409,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
           title="Choose an experiment"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -4435,7 +4435,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -4447,7 +4447,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -4707,7 +4707,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
           title="Choose a pipeline"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -4733,7 +4733,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -4745,7 +4745,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -4837,7 +4837,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
           title="Choose an experiment"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -4863,7 +4863,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -4875,7 +4875,7 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -5124,7 +5124,7 @@ exports[`NewRun updates the run's state with the associated experiment if one is
           title="Choose a pipeline"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -5150,7 +5150,7 @@ exports[`NewRun updates the run's state with the associated experiment if one is
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -5162,7 +5162,7 @@ exports[`NewRun updates the run's state with the associated experiment if one is
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -5254,7 +5254,7 @@ exports[`NewRun updates the run's state with the associated experiment if one is
           title="Choose an experiment"
           toolbarProps={
             Object {
-              "actions": Array [],
+              "actions": Object {},
               "breadcrumbs": Array [
                 Object {
                   "displayName": "Experiments",
@@ -5280,7 +5280,7 @@ exports[`NewRun updates the run's state with the associated experiment if one is
               "calls": Array [
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",
@@ -5292,7 +5292,7 @@ exports[`NewRun updates the run's state with the associated experiment if one is
                 ],
                 Array [
                   Object {
-                    "actions": Array [],
+                    "actions": Object {},
                     "breadcrumbs": Array [
                       Object {
                         "displayName": "Experiments",

--- a/frontend/src/pages/__snapshots__/RecurringRunsManager.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RecurringRunsManager.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`RecurringRunsManager calls API to load recurring runs 1`] = `
 <Fragment>
   <Toolbar
-    actions={Array []}
+    actions={Object {}}
     breadcrumbs={Array []}
     pageTitle="Recurring runs"
   />

--- a/frontend/src/pages/__snapshots__/ResourceSelector.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ResourceSelector.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ResourceSelector displays resource selector 1`] = `
 <Fragment>
   <Toolbar
-    actions={Array []}
+    actions={Object {}}
     breadcrumbs={Array []}
     pageTitle="A test selector"
   />


### PR DESCRIPTION
With this change, the toolbar buttons are stored within in a map and can be referenced via the `ButtonKeys` enum within `Buttons.tsx`. This stabilizes the references and prevents needing to keep track of indices and the bugs that accompany that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1812)
<!-- Reviewable:end -->
