### PR TITLE
Update npm test to not use coverall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - cd $TRAVIS_BUILD_DIR/frontend
         - node -v
         - npm i
-        - npm run test:coveralls
+        - npm run test -- --coverage
     - language: generic
       env:
         - BAZEL_URL="https://github.com/bazelbuild/bazel/releases/download/0.23.0/bazel-0.23.0-installer-linux-x86_64.sh"


### PR DESCRIPTION
Consistently getting the following error
```
/home/travis/build/kubeflow/pipelines/frontend/node_modules/coveralls/bin/coveralls.js:18
        throw err;
        ^
Bad response: 405 <html>
<head><title>405 Not Allowed</title></head>
<body bgcolor="white">
<center><h1>405 Not Allowed</h1></center>
<hr><center>nginx</center>
</body>
</html>
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! pipelines-frontend@0.1.0 test:coveralls: `npm run test:coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the pipelines-frontend@0.1.0 test:coveralls script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/travis/.npm/_logs/2019-08-13T06_28_02_279Z-debug.log
The command "npm run test:coveralls" exited with 1.
```
https://travis-ci.com/kubeflow/pipelines/jobs/224697449

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1819)
<!-- Reviewable:end -->
