### PR TITLE
[Bug Fix] Delete ResourceOp should not have output parameters

### DIFF
--- a/sdk/python/kfp/dsl/_resource_op.py
+++ b/sdk/python/kfp/dsl/_resource_op.py
@@ -105,6 +105,10 @@ class ResourceOp(BaseOp):
 
         if merge_strategy and action != "apply":
             ValueError("You can't set merge_strategy when action != 'apply'")
+        
+        # if action is delete, there should not be any outputs, success_condition, and failure_condition
+        if action == "delete" and (success_condition or failure_condition or attribute_outputs):
+            ValueError("You can't set success_condition, failure_condition, or attribute_outputs when action == 'delete'")
 
         init_resource = {
             "action": action,
@@ -116,6 +120,13 @@ class ResourceOp(BaseOp):
         self._resource = Resource(**init_resource)
 
         self.k8s_resource = k8s_resource
+
+        # if action is delete, there should not be any outputs, success_condition, and failure_condition
+        if action == "delete":
+            self.attribute_outputs = {}
+            self.outputs = {}
+            self.output = None
+            return
 
         # Set attribute_outputs
         extra_attribute_outputs = \
@@ -140,7 +151,7 @@ class ResourceOp(BaseOp):
         self.output = self.outputs["name"]
         if len(extra_attribute_outputs) == 1:
             self.output = self.outputs[list(extra_attribute_outputs)[0]]
-
+        
     @property
     def resource(self):
         """`Resource` object that represents the `resource` property in

--- a/sdk/python/kfp/dsl/_resource_op.py
+++ b/sdk/python/kfp/dsl/_resource_op.py
@@ -151,7 +151,7 @@ class ResourceOp(BaseOp):
         self.output = self.outputs["name"]
         if len(extra_attribute_outputs) == 1:
             self.output = self.outputs[list(extra_attribute_outputs)[0]]
-        
+
     @property
     def resource(self):
         """`Resource` object that represents the `resource` property in

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -641,7 +641,7 @@ implementation:
         )
 
       workflow_dict = kfp.compiler.Compiler()._compile(some_pipeline)
-      delete_op_template = [template for template in workflow_dict['templates'] if template['name'] == 'delete-config-map'][0]
+      delete_op_template = [template for template in workflow_dict['spec']['templates'] if template['name'] == 'delete-config-map'][0]
 
       # delete resource operation should not have success condition, failure condition or output parameters.
       # See https://github.com/argoproj/argo/blob/5331fc02e257266a4a5887dfe6277e5a0b42e7fc/cmd/argoexec/commands/resource.go#L30

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -616,3 +616,35 @@ implementation:
         init_container = init_containers[0]
         self.assertEqual(init_container, {'image':'alpine:latest', 'command': ['echo', 'bye'], 'name': 'echo'})
 
+
+  def test_delete_resource_op(self):
+      """Test a pipeline with a delete resource operation."""
+      from kubernetes import client as k8s
+
+      @dsl.pipeline()
+      def some_pipeline():
+        # create config map object with k6 load test script
+        config_map = k8s.V1ConfigMap(
+          api_version="v1",
+          data={"foo": "bar"},
+          kind="ConfigMap",
+          metadata=k8s.V1ObjectMeta(
+              name="foo-bar-cm",
+              namespace="default"
+          )
+        )        
+        # delete the config map in k8s
+        dsl.ResourceOp(
+          name="delete-config-map", 
+          action="delete", 
+          k8s_resource=config_map
+        )
+
+      workflow_dict = kfp.compiler.Compiler()._compile(some_pipeline)
+      delete_op_template = [template for template in workflow_dict['templates'] if template['name'] == 'delete-config-map'][0]
+
+      # delete resource operation should not have success condition, failure condition or output parameters.
+      # See https://github.com/argoproj/argo/blob/5331fc02e257266a4a5887dfe6277e5a0b42e7fc/cmd/argoexec/commands/resource.go#L30
+      self.assertIsNone(delete_op_template.get("successCondition"))
+      self.assertIsNone(delete_op_template.get("failureCondition"))
+      self.assertDictEqual(delete_op_template.get("outputs"), {})


### PR DESCRIPTION
### Bug

`delete` action for `ResourceOp` should not generate any `output parameters` (See [argo execResource method](https://github.com/argoproj/argo/blob/5331fc02e257266a4a5887dfe6277e5a0b42e7fc/cmd/argoexec/commands/resource.go#L30)).

#### Current state
- no exception are raised when `success_condition`, `failure_condition`, and `attribute_outputs` are provided when `action=="delete"`
- automatically generates `'{.metadata.name}'` and `{}` output parameters even when `attribute_outputs` is `None` and `action=="delete"`

Example of error thrown:
`This step is in Failed state with this message: successCondition, failureCondition and outputs are not supported for delete action`

#### Example
```py
@dsl.pipeline()
def some_pipeline():
  # create config map object with k6 load test script
  config_map = k8s.V1ConfigMap(
    api_version="v1",
    data={"foo": "bar"},
    kind="ConfigMap",
    metadata=k8s.V1ObjectMeta(
        name="foo-bar-cm",
        namespace="default"
    )
  )        
  # delete the config map in k8s
  dsl.ResourceOp(
    name="delete-config-map", 
    action="delete", 
    k8s_resource=config_map
  )      
```
generates
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: some-pipeline-
spec:
  arguments:
    parameters: []
  entrypoint: some-pipeline
  serviceAccountName: pipeline-runner
  templates:
  - name: delete-config-map
    outputs:
      parameters:  # Should not have any parameters
      - name: delete-config-map-manifest . 
        valueFrom:
          jsonPath: '{}'
      - name: delete-config-map-name
        valueFrom:
          jsonPath: '{.metadata.name}'
    resource:
      action: delete
      manifest: "apiVersion: v1\ndata:\n  foo: bar\nkind: ConfigMap\nmetadata:\n \
        \ name: foo-bar-cm\n  namespace: default\n"
  - dag:
      tasks:
      - name: delete-config-map
        template: delete-config-map
    name: some-pipeline

```

The correct output should be:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: some-pipeline-
spec:
  arguments:
    parameters: []
  entrypoint: some-pipeline
  serviceAccountName: pipeline-runner
  templates:
  - name: delete-config-map
    outputs: {}
    resource:
      action: delete
      manifest: "apiVersion: v1\ndata:\n  foo: bar\nkind: ConfigMap\nmetadata:\n \
        \ name: foo-bar-cm\n  namespace: default\n"
  - dag:
      tasks:
      - name: delete-config-map
        template: delete-config-map
    name: some-pipeline
```

#### PR fix
This PR 
- adds a value check when `action=="delete"`
- set output to `{}` (no output parameters) when `action=="delete"`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1822)
<!-- Reviewable:end -->
