### PR TITLE
Reduce API usage by utilizing reference name in reference resource API

### DIFF
--- a/frontend/src/apis/run/api.ts
+++ b/frontend/src/apis/run/api.ts
@@ -347,7 +347,7 @@ export interface ApiRun {
      */
     scheduled_at?: Date;
     /**
-     * Output. The time this run is finished.
+     * Output. When this run is finished.
      * @type {Date}
      * @memberof ApiRun
      */
@@ -850,42 +850,6 @@ export const RunServiceApiFetchParamCreator = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        retryRun(run_id: string, options: any = {}): FetchArgs {
-            // verify required parameter 'run_id' is not null or undefined
-            if (run_id === null || run_id === undefined) {
-                throw new RequiredError('run_id','Required parameter run_id was null or undefined when calling retryRun.');
-            }
-            const localVarPath = `/apis/v1beta1/runs/{run_id}/retry`
-                .replace(`{${"run_id"}}`, encodeURIComponent(String(run_id)));
-            const localVarUrlObj = url.parse(localVarPath, true);
-            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication Bearer required
-            if (configuration && configuration.apiKey) {
-                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
-					? configuration.apiKey("authorization")
-					: configuration.apiKey;
-                localVarHeaderParameter["authorization"] = localVarApiKeyValue;
-            }
-
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
-
-            return {
-                url: url.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * 
-         * @param {string} run_id 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
         terminateRun(run_id: string, options: any = {}): FetchArgs {
             // verify required parameter 'run_id' is not null or undefined
             if (run_id === null || run_id === undefined) {
@@ -1102,24 +1066,6 @@ export const RunServiceApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        retryRun(run_id: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<any> {
-            const localVarFetchArgs = RunServiceApiFetchParamCreator(configuration).retryRun(run_id, options);
-            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
-                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
-                    if (response.status >= 200 && response.status < 300) {
-                        return response.json();
-                    } else {
-                        throw response;
-                    }
-                });
-            };
-        },
-        /**
-         * 
-         * @param {string} run_id 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
         terminateRun(run_id: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<any> {
             const localVarFetchArgs = RunServiceApiFetchParamCreator(configuration).terminateRun(run_id, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
@@ -1237,15 +1183,6 @@ export const RunServiceApiFactory = function (configuration?: Configuration, fet
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        retryRun(run_id: string, options?: any) {
-            return RunServiceApiFp(configuration).retryRun(run_id, options)(fetch, basePath);
-        },
-        /**
-         * 
-         * @param {string} run_id 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
         terminateRun(run_id: string, options?: any) {
             return RunServiceApiFp(configuration).terminateRun(run_id, options)(fetch, basePath);
         },
@@ -1352,17 +1289,6 @@ export class RunServiceApi extends BaseAPI {
      */
     public reportRunMetrics(run_id: string, body: ApiReportRunMetricsRequest, options?: any) {
         return RunServiceApiFp(this.configuration).reportRunMetrics(run_id, body, options)(this.fetch, this.basePath);
-    }
-
-    /**
-     * 
-     * @param {} run_id 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof RunServiceApi
-     */
-    public retryRun(run_id: string, options?: any) {
-        return RunServiceApiFp(this.configuration).retryRun(run_id, options)(this.fetch, this.basePath);
     }
 
     /**

--- a/frontend/src/apis/run/api.ts
+++ b/frontend/src/apis/run/api.ts
@@ -268,6 +268,12 @@ export interface ApiResourceReference {
      */
     key?: ApiResourceKey;
     /**
+     * The name of the resource that referred to.
+     * @type {string}
+     * @memberof ApiResourceReference
+     */
+    name?: string;
+    /**
      * Required field. The relationship from referred resource to the object.
      * @type {ApiRelationship}
      * @memberof ApiResourceReference
@@ -341,7 +347,7 @@ export interface ApiRun {
      */
     scheduled_at?: Date;
     /**
-     * Output. When this run is finished.
+     * Output. The time this run is finished.
      * @type {Date}
      * @memberof ApiRun
      */
@@ -844,6 +850,42 @@ export const RunServiceApiFetchParamCreator = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
+        retryRun(run_id: string, options: any = {}): FetchArgs {
+            // verify required parameter 'run_id' is not null or undefined
+            if (run_id === null || run_id === undefined) {
+                throw new RequiredError('run_id','Required parameter run_id was null or undefined when calling retryRun.');
+            }
+            const localVarPath = `/apis/v1beta1/runs/{run_id}/retry`
+                .replace(`{${"run_id"}}`, encodeURIComponent(String(run_id)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Bearer required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+					? configuration.apiKey("authorization")
+					: configuration.apiKey;
+                localVarHeaderParameter["authorization"] = localVarApiKeyValue;
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @param {string} run_id 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
         terminateRun(run_id: string, options: any = {}): FetchArgs {
             // verify required parameter 'run_id' is not null or undefined
             if (run_id === null || run_id === undefined) {
@@ -1060,6 +1102,24 @@ export const RunServiceApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
+        retryRun(run_id: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<any> {
+            const localVarFetchArgs = RunServiceApiFetchParamCreator(configuration).retryRun(run_id, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         * 
+         * @param {string} run_id 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
         terminateRun(run_id: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<any> {
             const localVarFetchArgs = RunServiceApiFetchParamCreator(configuration).terminateRun(run_id, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
@@ -1177,6 +1237,15 @@ export const RunServiceApiFactory = function (configuration?: Configuration, fet
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
+        retryRun(run_id: string, options?: any) {
+            return RunServiceApiFp(configuration).retryRun(run_id, options)(fetch, basePath);
+        },
+        /**
+         * 
+         * @param {string} run_id 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
         terminateRun(run_id: string, options?: any) {
             return RunServiceApiFp(configuration).terminateRun(run_id, options)(fetch, basePath);
         },
@@ -1283,6 +1352,17 @@ export class RunServiceApi extends BaseAPI {
      */
     public reportRunMetrics(run_id: string, body: ApiReportRunMetricsRequest, options?: any) {
         return RunServiceApiFp(this.configuration).reportRunMetrics(run_id, body, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * 
+     * @param {} run_id 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof RunServiceApi
+     */
+    public retryRun(run_id: string, options?: any) {
+        return RunServiceApiFp(this.configuration).retryRun(run_id, options)(this.fetch, this.basePath);
     }
 
     /**

--- a/frontend/src/lib/RunUtils.ts
+++ b/frontend/src/lib/RunUtils.ts
@@ -60,28 +60,18 @@ function getPipelineSpec(run?: ApiRun | ApiJob): string | null {
   return (run && run.pipeline_spec && run.pipeline_spec.workflow_manifest) || null;
 }
 
-function getFirstExperimentReferenceId(run?: ApiRun | ApiJob): string | null {
-  if (run) {
-    const reference = getAllExperimentReferences(run)[0];
-    return reference && reference.key && reference.key.id || null;
-  }
-  return null;
-}
-
 function getFirstExperimentReference(run?: ApiRun | ApiJob): ApiResourceReference | null {
-  return run && getAllExperimentReferences(run)[0] || null;
+  return getAllExperimentReferences(run)[0] || null;
 }
 
-function getFirstExperimentReferenceWithName(run?: ApiRun | ApiJob): ExperimentInfo | null {
-  const reference = (run && getAllExperimentReferences(run) || [])
-    .find((ref) => !!ref.key && !!ref.key.id && !!ref.name);
-  if (reference) {
-    return {
-      displayName: reference.name,
-      id: reference.key!.id!,
-    };
-  }
-  return null;
+function getFirstExperimentReferenceId(run?: ApiRun | ApiJob): string | null {
+  const reference = getFirstExperimentReference(run);
+  return reference && reference.key && reference.key.id || null;
+}
+
+function getFirstExperimentReferenceName(run?: ApiRun | ApiJob): string | null {
+  const reference = getFirstExperimentReference(run);
+  return reference && reference.name || null;
 }
 
 function getAllExperimentReferences(run?: ApiRun | ApiJob): ApiResourceReference[] {
@@ -145,7 +135,7 @@ export default {
   getAllExperimentReferences,
   getFirstExperimentReference,
   getFirstExperimentReferenceId,
-  getFirstExperimentReferenceWithName,
+  getFirstExperimentReferenceName,
   getParametersFromRun,
   getParametersFromRuntime,
   getPipelineId,

--- a/frontend/src/lib/RunUtils.ts
+++ b/frontend/src/lib/RunUtils.ts
@@ -67,6 +67,11 @@ function getFirstExperimentReference(run?: ApiRun | ApiJob): ApiResourceReferenc
   return run && getAllExperimentReferences(run)[0] || null;
 }
 
+function getFirstExperimentReferenceWithName(run?: ApiRun | ApiJob): ApiResourceReference | null {
+  return (run && getAllExperimentReferences(run) || [])
+    .find((ref) => !!ref.key && !!ref.key.id && !!ref.name) || null;
+}
+
 function getAllExperimentReferences(run?: ApiRun | ApiJob): ApiResourceReference[] {
   return (run && run.resource_references || [])
     .filter((ref) => ref.key && ref.key.type && ref.key.type === ApiResourceType.EXPERIMENT || false);
@@ -128,6 +133,7 @@ export default {
   getAllExperimentReferences,
   getFirstExperimentReference,
   getFirstExperimentReferenceId,
+  getFirstExperimentReferenceWithName,
   getParametersFromRun,
   getParametersFromRuntime,
   getPipelineId,

--- a/frontend/src/lib/RunUtils.ts
+++ b/frontend/src/lib/RunUtils.ts
@@ -29,6 +29,11 @@ export interface MetricMetadata {
   name: string;
 }
 
+export interface ExperimentInfo {
+  displayName?: string;
+  id: string;
+}
+
 function getParametersFromRun(run: ApiRunDetail): ApiParameter[] {
   return getParametersFromRuntime(run.pipeline_runtime);
 }
@@ -67,9 +72,16 @@ function getFirstExperimentReference(run?: ApiRun | ApiJob): ApiResourceReferenc
   return run && getAllExperimentReferences(run)[0] || null;
 }
 
-function getFirstExperimentReferenceWithName(run?: ApiRun | ApiJob): ApiResourceReference | null {
-  return (run && getAllExperimentReferences(run) || [])
-    .find((ref) => !!ref.key && !!ref.key.id && !!ref.name) || null;
+function getFirstExperimentReferenceWithName(run?: ApiRun | ApiJob): ExperimentInfo | null {
+  const reference = (run && getAllExperimentReferences(run) || [])
+    .find((ref) => !!ref.key && !!ref.key.id && !!ref.name);
+  if (reference) {
+    return {
+      displayName: reference.name,
+      id: reference.key!.id!,
+    };
+  }
+  return null;
 }
 
 function getAllExperimentReferences(run?: ApiRun | ApiJob): ApiResourceReference[] {

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -400,18 +400,16 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
    * ApiResourceReference is returned as an ExperimentInfo object, otherwise,
    * undefined is returned if no valid data is found. 
    */
-  private _getFirstExperimentInfoInReferences(resourceReferences: ApiResourceReference[] | undefined): ExperimentInfo | undefined {
-    if (resourceReferences) {
-      for (const resourceReference of resourceReferences) {
-        if (resourceReference.key
-          && resourceReference.key.id
-          && resourceReference.key.type === ApiResourceType.EXPERIMENT
-          && resourceReference.name) {
-          return {
-            displayName: resourceReference.name,
-            id: resourceReference.key.id
-          } as ExperimentInfo;
-        }
+  private _getFirstExperimentInfoInReferences(resourceReferences: ApiResourceReference[] = []): ExperimentInfo | undefined {
+    for (const resourceReference of resourceReferences) {
+      if (resourceReference.key
+        && resourceReference.key.id
+        && resourceReference.key.type === ApiResourceType.EXPERIMENT
+        && resourceReference.name) {
+        return {
+          displayName: resourceReference.name,
+          id: resourceReference.key.id
+        } as ExperimentInfo;
       }
     }
     return undefined;

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -386,7 +386,6 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
           const experiment = await Apis.experimentServiceApi.getExperiment(experimentId);
           displayRun.experiment = { displayName: experiment.name || '', id: experimentId };
         } catch (err) {
-          // This could be an API exception, or a JSON parse exception.
           displayRun.error = 'Failed to get associated experiment: ' + await errorToMessage(err);
         }
       }

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -316,7 +316,22 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
         await this._getAndSetPipelineNames(displayRun);
 
         if (!this.props.hideExperimentColumn) {
-          await this._getAndSetExperimentNames(displayRun);
+          // Check to see if run has a provided resource reference that is an
+          // experiment that includes its name. If any condition fails, fetch
+          // the experiment manually.
+          if (displayRun.run.resource_references != null
+            && !!displayRun.run.resource_references.length
+            && displayRun.run.resource_references[0].key != null
+            && displayRun.run.resource_references[0].key.id != null
+            && displayRun.run.resource_references[0].key.type === ApiResourceType.EXPERIMENT
+            && displayRun.run.resource_references[0].name != null) {
+              displayRun.experiment = {
+                displayName: displayRun.run.resource_references[0].name,
+                id: displayRun.run.resource_references[0].key.id
+              };
+          } else {
+            await this._getAndSetExperimentNames(displayRun);
+          }
         }
         return displayRun;
       })

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -371,19 +371,22 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
    * DisplayRun will show '-'.
    */
   private async _getAndSetExperimentNames(displayRun: DisplayRun): Promise<void> {
-    const experimentReference = RunUtils.getFirstExperimentReferenceWithName(displayRun.run);
-    if (experimentReference) {
-      displayRun.experiment = experimentReference;
-    } else {
-      const experimentId = RunUtils.getFirstExperimentReferenceId(displayRun.run);
-      if (experimentId) {
+    const experimentId = RunUtils.getFirstExperimentReferenceId(displayRun.run);
+    if (experimentId) {
+      let experimentName = RunUtils.getFirstExperimentReferenceName(displayRun.run);
+      if (!experimentName) {
         try {
           const experiment = await Apis.experimentServiceApi.getExperiment(experimentId);
-          displayRun.experiment = { displayName: experiment.name || '', id: experimentId };
+          experimentName = experiment.name || '';
         } catch (err) {
           displayRun.error = 'Failed to get associated experiment: ' + await errorToMessage(err);
+          return;
         }
       }
+      displayRun.experiment = {
+        displayName: experimentName,
+        id: experimentId
+      };
     }
   }
 }

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import CustomTable, { Column, Row, CustomRendererProps } from '../components/CustomTable';
 import Metric from '../components/Metric';
-import RunUtils, { MetricMetadata } from '../../src/lib/RunUtils';
+import RunUtils, { MetricMetadata, ExperimentInfo } from '../../src/lib/RunUtils';
 import { ApiRun, ApiResourceType, ApiRunMetric, RunStorageState, ApiRunDetail } from '../../src/apis/run';
 import { Apis, RunSortKeys, ListRequest } from '../lib/Apis';
 import { Link, RouteComponentProps } from 'react-router-dom';
@@ -28,11 +28,6 @@ import { URLParser } from '../lib/URLParser';
 import { commonCss, color } from '../Css';
 import { formatDateString, logger, errorToMessage, getRunDuration } from '../lib/Utils';
 import { statusToIcon } from './Status';
-
-interface ExperimentInfo {
-  displayName?: string;
-  id: string;
-}
 
 interface PipelineInfo {
   displayName?: string;
@@ -378,13 +373,7 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
   private async _getAndSetExperimentNames(displayRun: DisplayRun): Promise<void> {
     const experimentReference = RunUtils.getFirstExperimentReferenceWithName(displayRun.run);
     if (experimentReference) {
-      displayRun.experiment = {
-        displayName: experimentReference.name,
-        // experimentReference.key.id is know to exist because
-        // RunUtils.getFirstExperimentReferenceWithName checks for its
-        // existence.
-        id: experimentReference.key!.id!,
-      };
+      displayRun.experiment = experimentReference;
     } else {
       const experimentId = RunUtils.getFirstExperimentReferenceId(displayRun.run);
       if (experimentId) {


### PR DESCRIPTION
Frontend now checks if a name is provided with a `resource_reference`. If a name is provided and it is a valid object within the resource reference (see if statement in PR), it will now be used to display the experiment name rather than making an additional API call to retrieve the experiment name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1824)
<!-- Reviewable:end -->
