### PR TITLE
fix(sdk/dsl) Made ContainerOp.output_artifact_paths private

### DIFF
--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -172,7 +172,7 @@ def _op_to_template(op: BaseOp):
 
     if isinstance(op, dsl.ContainerOp):
         # default output artifacts
-        output_artifact_paths = OrderedDict(op.output_artifact_paths)
+        output_artifact_paths = OrderedDict(op._output_artifact_paths)
         output_artifact_paths.setdefault('mlpipeline-ui-metadata', '/mlpipeline-ui-metadata.json')
         output_artifact_paths.setdefault('mlpipeline-metrics', '/mlpipeline-metrics.json')
 

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -1023,7 +1023,7 @@ class ContainerOp(BaseOp):
 
         # attributes specific to `ContainerOp`
         self.file_outputs = file_outputs
-        self.output_artifact_paths = output_artifact_paths or {}
+        self._output_artifact_paths = output_artifact_paths or {}
         self.artifact_location = artifact_location
 
         self._metadata = None


### PR DESCRIPTION
It wasn't supposed to be public.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1832)
<!-- Reviewable:end -->
