### PR TITLE
Improve sql efficiency for getting the run

### DIFF
--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -169,9 +169,11 @@ func (s *RunStore) buildSelectRunsQuery(selectCount bool, opts *list.Options,
 
 // GetRun Get the run manifest from Workflow CRD
 func (s *RunStore) GetRun(runId string) (*model.RunDetail, error) {
-	sql, args, err := s.addMetricsAndResourceReferences(sq.Select(runColumns...).From("run_details")).
-		Where(sq.Eq{"UUID": runId}).
-		Limit(1).
+	sql, args, err := s.addMetricsAndResourceReferences(
+		sq.Select(runColumns...).
+			From("run_details").
+			Where(sq.Eq{"UUID": runId}).
+			Limit(1)).
 		ToSql()
 
 	if err != nil {


### PR DESCRIPTION
Original query 
```
SELECT
   subq.*,
   CONCAT("[", GROUP_CONCAT(r.Payload SEPARATOR ", "), "]") AS refs 
FROM
   (
      SELECT
         rd.*,
         CONCAT("[", GROUP_CONCAT(m.Payload SEPARATOR ", "), "]") AS metrics 
      FROM
         (
            SELECT
               UUID,
               DisplayName,
               Name,
               StorageState,
               Namespace,
               Description,
               CreatedAtInSec,
               ScheduledAtInSec,
               FinishedAtInSec,
               Conditions,
               PipelineId,
               PipelineSpecManifest,
               WorkflowSpecManifest,
               Parameters,
               pipelineRuntimeManifest,
               WorkflowRuntimeManifest 
            FROM
               run_details
         )
         AS rd 
         LEFT JOIN
            run_metrics AS m 
            ON rd.UUID = m.RunUUID 
      GROUP BY
         rd.UUID
   )
   AS subq 
   LEFT JOIN
      (
         select
            * 
         from
            resource_references 
         where
            ResourceType = 'Run'
      )
      AS r 
      ON subq.UUID = r.ResourceUUID 
WHERE
   UUID = 'a0af02a9-bacb-11e9-a841-42010ad4009a' 
GROUP BY
   subq.UUID LIMIT 1;
```

This can be improved by moving the where clause to the first select statement. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1835)
<!-- Reviewable:end -->
