### PR TITLE
Frontend uses experiment name directly from ApiResourceReference

### DIFF
--- a/frontend/src/apis/run/api.ts
+++ b/frontend/src/apis/run/api.ts
@@ -268,6 +268,12 @@ export interface ApiResourceReference {
      */
     key?: ApiResourceKey;
     /**
+     * The name of the resource that referred to.
+     * @type {string}
+     * @memberof ApiResourceReference
+     */
+    name?: string;
+    /**
      * Required field. The relationship from referred resource to the object.
      * @type {ApiRelationship}
      * @memberof ApiResourceReference

--- a/frontend/src/lib/RunUtils.ts
+++ b/frontend/src/lib/RunUtils.ts
@@ -63,6 +63,25 @@ function getFirstExperimentReferenceId(run?: ApiRun | ApiJob): string | null {
   return null;
 }
 
+export interface ExperimentReferenceInfo {
+  name: string;
+  id: string;
+}
+
+function getFirstExperimentReferenceInfo(run?: ApiRun | ApiJob): ExperimentReferenceInfo | null {
+  if (run) {
+    const reference = getAllExperimentReferences(run)[0];
+    if (reference && reference.name && reference.key && reference.key.id) {
+      return {
+        id: reference.key.id,
+        name: reference.name,
+      };
+    }
+  }
+
+  return null;
+}
+
 function getFirstExperimentReference(run?: ApiRun | ApiJob): ApiResourceReference | null {
   return run && getAllExperimentReferences(run)[0] || null;
 }
@@ -128,6 +147,7 @@ export default {
   getAllExperimentReferences,
   getFirstExperimentReference,
   getFirstExperimentReferenceId,
+  getFirstExperimentReferenceInfo,
   getParametersFromRun,
   getParametersFromRuntime,
   getPipelineId,

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -28,7 +28,6 @@ import Paper from '@material-ui/core/Paper';
 import RunUtils from '../lib/RunUtils';
 import SidePanel from '../components/SidePanel';
 import StaticNodeDetails from '../components/StaticNodeDetails';
-import { ApiExperiment } from '../apis/experiment';
 import { ApiPipeline, ApiGetTemplateResponse } from '../apis/pipeline';
 import { Apis } from '../lib/Apis';
 import { Page } from './Page';
@@ -274,19 +273,14 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
             `Failed to parse pipeline spec JSON from run with ID: ${runDetails.run!.id}.`, err);
         }
 
-        const relatedExperimentId = RunUtils.getFirstExperimentReferenceId(runDetails.run);
-        let experiment: ApiExperiment | undefined;
-        if (relatedExperimentId) {
-          experiment = await Apis.experimentServiceApi.getExperiment(relatedExperimentId);
-        }
-
+        const experiment = RunUtils.getFirstExperimentReferenceInfo(runDetails.run);
         // Build the breadcrumbs, by adding experiment and run names
         if (experiment) {
           breadcrumbs.push(
             { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
             {
-              displayName: experiment.name!,
-              href: RoutePage.EXPERIMENT_DETAILS.replace(':' + RouteParams.experimentId, experiment.id!)
+              displayName: experiment.name,
+              href: RoutePage.EXPERIMENT_DETAILS.replace(':' + RouteParams.experimentId, experiment.id)
             });
         } else {
           breadcrumbs.push(

--- a/frontend/src/pages/RecurringRunDetails.tsx
+++ b/frontend/src/pages/RecurringRunDetails.tsx
@@ -18,7 +18,6 @@ import * as React from 'react';
 import Buttons, { ButtonKeys } from '../lib/Buttons';
 import DetailsTable from '../components/DetailsTable';
 import RunUtils from '../lib/RunUtils';
-import { ApiExperiment } from '../apis/experiment';
 import { ApiJob } from '../apis/job';
 import { Apis } from '../lib/Apis';
 import { Page } from './Page';
@@ -141,27 +140,14 @@ class RecurringRunDetails extends Page<{}, RecurringRunConfigState> {
       return;
     }
 
-    const relatedExperimentId = RunUtils.getFirstExperimentReferenceId(run);
-    let experiment: ApiExperiment | undefined;
-    if (relatedExperimentId) {
-      try {
-        experiment = await Apis.experimentServiceApi.getExperiment(relatedExperimentId);
-      } catch (err) {
-        const errorMessage = await errorToMessage(err);
-        await this.showPageError(
-          `Error: failed to retrieve this recurring run\'s experiment.`,
-          new Error(errorMessage),
-          'warning'
-        );
-      }
-    }
+    const experiment = RunUtils.getFirstExperimentReferenceInfo(run);
     const breadcrumbs: Breadcrumb[] = [];
     if (experiment) {
       breadcrumbs.push(
         { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
         {
-          displayName: experiment.name!,
-          href: RoutePage.EXPERIMENT_DETAILS.replace(':' + RouteParams.experimentId, experiment.id!)
+          displayName: experiment.name,
+          href: RoutePage.EXPERIMENT_DETAILS.replace(':' + RouteParams.experimentId, experiment.id)
         });
     } else {
       breadcrumbs.push(

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -31,7 +31,6 @@ import RunUtils from '../lib/RunUtils';
 import Separator from '../atoms/Separator';
 import SidePanel from '../components/SidePanel';
 import WorkflowParser from '../lib/WorkflowParser';
-import { ApiExperiment } from '../apis/experiment';
 import { ApiRun, RunStorageState } from '../apis/run';
 import { Apis } from '../lib/Apis';
 import { NodePhase, hasFinished } from '../lib/StatusUtils';
@@ -74,7 +73,6 @@ interface AnnotatedConfig {
 
 interface RunDetailsState {
   allArtifactConfigs: AnnotatedConfig[];
-  experiment?: ApiExperiment;
   legacyStackdriverUrl: string;
   logsBannerAdditionalInfo: string;
   logsBannerMessage: string;
@@ -385,13 +383,7 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
 
     try {
       const runDetail = await Apis.runServiceApi.getRun(runId);
-
-      const relatedExperimentId = RunUtils.getFirstExperimentReferenceId(runDetail.run);
-      let experiment: ApiExperiment | undefined;
-      if (relatedExperimentId) {
-        experiment = await Apis.experimentServiceApi.getExperiment(relatedExperimentId);
-      }
-
+      const experiment = RunUtils.getFirstExperimentReferenceInfo(runDetail.run);
       const runMetadata = runDetail.run!;
 
       let runFinished = this.state.runFinished;
@@ -436,8 +428,8 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
           breadcrumbs.push(
             { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
             {
-              displayName: experiment.name!,
-              href: RoutePage.EXPERIMENT_DETAILS.replace(':' + RouteParams.experimentId, experiment.id!)
+              displayName: experiment.name,
+              href: RoutePage.EXPERIMENT_DETAILS.replace(':' + RouteParams.experimentId, experiment.id)
             });
         } else {
           breadcrumbs.push(
@@ -462,7 +454,6 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
       this.props.updateToolbar({ actions, breadcrumbs, pageTitle, pageTitleTooltip: runMetadata.name });
 
       this.setStateSafe({
-        experiment,
         graph,
         legacyStackdriverUrl: '', // Reset legacy Stackdriver logs URL
         runFinished,

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -378,12 +378,7 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
   private async _getAndSetExperimentNames(displayRun: DisplayRun): Promise<void> {
     const experiment = RunUtils.getFirstExperimentReferenceInfo(displayRun.run);
     if (experiment) {
-      try {
-        displayRun.experiment = { displayName: experiment.name, id: experiment.id };
-      } catch (err) {
-        // This could be an API exception, or a JSON parse exception.
-        displayRun.error = 'Failed to get associated experiment: ' + await errorToMessage(err);
-      }
+      displayRun.experiment = { displayName: experiment.name, id: experiment.id };
     }
   }
 }

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -376,11 +376,10 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
    * DisplayRun will show '-'.
    */
   private async _getAndSetExperimentNames(displayRun: DisplayRun): Promise<void> {
-    const experimentId = RunUtils.getFirstExperimentReferenceId(displayRun.run);
-    if (experimentId) {
+    const experiment = RunUtils.getFirstExperimentReferenceInfo(displayRun.run);
+    if (experiment) {
       try {
-        const experiment = await Apis.experimentServiceApi.getExperiment(experimentId);
-        displayRun.experiment = { displayName: experiment.name || '', id: experimentId };
+        displayRun.experiment = { displayName: experiment.name, id: experiment.id };
       } catch (err) {
         // This could be an API exception, or a JSON parse exception.
         displayRun.error = 'Failed to get associated experiment: ' + await errorToMessage(err);


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/1773

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1837)
<!-- Reviewable:end -->
