### PR TITLE
Undefined name 'e' in openvino

### DIFF
--- a/contrib/components/openvino/ovms-deployer/containers/evaluate.py
+++ b/contrib/components/openvino/ovms-deployer/containers/evaluate.py
@@ -59,7 +59,7 @@ def getJpeg(path, size, path_prefix):
             img = img.astype('float32')
             img = img.transpose(2,0,1).reshape(1,3,size,size)
             print(path, img.shape, "; data range:",np.amin(img),":",np.amax(img))
-        except e:
+        except Exception as e:
             print("Can not read the image file", e)
             img = None
     else:


### PR DESCRIPTION
Discovered in #1721
```
./contrib/components/openvino/ovms-deployer/containers/evaluate.py:62:16: F821 undefined name 'e'
        except e:
               ^
./contrib/components/openvino/ovms-deployer/containers/evaluate.py:63:50: F821 undefined name 'e'
            print("Can not read the image file", e)
                                                 ^
```
Your review please @Ark-kun

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1876)
<!-- Reviewable:end -->
