### PR TITLE
IBM Watson samples: from six.moves import xrange

### DIFF
--- a/samples/contrib/ibm-samples/watson/source/model-source-code/tf-model/input_data.py
+++ b/samples/contrib/ibm-samples/watson/source/model-source-code/tf-model/input_data.py
@@ -4,6 +4,7 @@
 """Functions for downloading and reading MNIST data."""
 import gzip
 import os
+from six.moves import xrange
 from six.moves.urllib.request import urlretrieve
 import numpy
 


### PR DESCRIPTION
Discovered in #1721

__xrange()__ was removed in Python 3 in favor of an improved version of __range()__.  This PR ensures equivalent functionality in both Python 2 and Python 3.

```
./samples/contrib/ibm-samples/watson/source/model-source-code/tf-model/input_data.py:100:40: F821 undefined name 'xrange'
            fake_image = [1.0 for _ in xrange(784)]
                                       ^
./samples/contrib/ibm-samples/watson/source/model-source-code/tf-model/input_data.py:102:41: F821 undefined name 'xrange'
            return [fake_image for _ in xrange(batch_size)], [
                                        ^
./samples/contrib/ibm-samples/watson/source/model-source-code/tf-model/input_data.py:103:37: F821 undefined name 'xrange'
                fake_label for _ in xrange(batch_size)]
                                    ^
```

@gaoning777 @Ark-kun Your reviews please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1877)
<!-- Reviewable:end -->
