### PR TITLE
Simplify with dict.get() in roc_curve.py

### DIFF
--- a/backend/src/apiserver/visualization/roc_curve.py
+++ b/backend/src/apiserver/visualization/roc_curve.py
@@ -34,7 +34,7 @@ from tensorflow.python.lib.io import file_io
 # trueclass
 # true_score_column
 
-if variables.get("is_generated", False) is False:
+if not variables.get("is_generated", False):
     # Create data from specified csv file(s).
     # The schema file provides column names for the csv file that will be used
     # to generate the roc curve.

--- a/backend/src/apiserver/visualization/roc_curve.py
+++ b/backend/src/apiserver/visualization/roc_curve.py
@@ -34,7 +34,7 @@ from tensorflow.python.lib.io import file_io
 # trueclass
 # true_score_column
 
-if "is_generated" is not in variables or variables["is_generated"] is False:
+if variables.get("is_generated", False) is False:
     # Create data from specified csv file(s).
     # The schema file provides column names for the csv file that will be used
     # to generate the roc curve.


### PR DESCRIPTION
Discovered in #1721

$ __python2 -c "'a' is not in 'abc'"__  # --> SyntaxError: invalid syntax

```
./backend/src/apiserver/visualization/roc_curve.py:37:27: E999 SyntaxError: invalid syntax
if "is_generated" is not in variables or variables["is_generated"] is False:
                          ^
```

Your reviews please @Ark-kun @ajchili 

/assign @neuromage

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1878)
<!-- Reviewable:end -->
