### PR TITLE
Add run with json data as input within fixed-data.ts for UI testing and development

### DIFF
--- a/frontend/mock-backend/fixed-data.ts
+++ b/frontend/mock-backend/fixed-data.ts
@@ -17,6 +17,7 @@ import helloWorldWithStepsRun from './hello-world-with-steps-runtime';
 import coinflipRun from './mock-coinflip-runtime';
 import errorRun from './mock-error-runtime';
 import xgboostRun from './mock-xgboost-runtime';
+import jsonRun from './json-runtime';
 import { ApiExperiment } from '../src/apis/experiment';
 import { ApiJob } from '../src/apis/job';
 import { ApiPipeline } from '../src/apis/pipeline';
@@ -346,6 +347,40 @@ const runs: ApiRunDetail[] = [
       scheduled_at: new Date('2018-04-17T21:00:00.000Z'),
       status: 'Error',
     },
+  },
+  {
+    pipeline_runtime: {
+      workflow_manifest: JSON.stringify(jsonRun),
+    },
+    run: {
+      created_at: new Date('2018-05-17T21:58:23.000Z'),
+      description: 'A simple run with json input',
+      id: 'fa5d897e-88d3-4dfc-b189-9dea6947c9bc',
+      metrics: [{
+        format: RunMetricFormat.PERCENTAGE,
+        name: 'accuracy',
+        node_id: 'json-12abc',
+        number_value: 0.5423,
+      }],
+      name: 'json-12abc',
+      pipeline_spec: {
+        parameters: [
+          { name: 'paramName1', value: 'paramVal1' },
+          { name: 'paramName2', value: 'paramVal2' },
+        ],
+        pipeline_id: pipelines[2].id,
+        pipeline_name: pipelines[2].name,
+      },
+      resource_references: [{
+        key: {
+          id: 'a4d4f8c6-ce9c-4200-a92e-c48ec759b733',
+          type: ApiResourceType.EXPERIMENT,
+        },
+        relationship: ApiRelationship.OWNER,
+      }],
+      scheduled_at: new Date('2018-05-17T21:58:23.000Z'),
+      status: 'Running',
+    }
   },
   {
     pipeline_runtime: {

--- a/frontend/mock-backend/fixed-data.ts
+++ b/frontend/mock-backend/fixed-data.ts
@@ -355,7 +355,7 @@ const runs: ApiRunDetail[] = [
     run: {
       created_at: new Date('2018-05-17T21:58:23.000Z'),
       description: 'A simple run with json input',
-      id: 'fa5d897e-88d3-4dfc-b189-9dea6947c9bc',
+      id: '183ac01f-dc26-4ebf-b817-7b3f96fdc3ac',
       metrics: [{
         format: RunMetricFormat.PERCENTAGE,
         name: 'accuracy',

--- a/frontend/mock-backend/json-runtime.ts
+++ b/frontend/mock-backend/json-runtime.ts
@@ -1,0 +1,99 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// tslint:disable:object-literal-sort-keys
+export default {
+  metadata: {
+    name: 'json-12abc',
+    generateName: 'json-',
+    namespace: 'default',
+    selfLink: '/apis/argoproj.io/v1alpha1/namespaces/default/workflows/json-7sm94',
+    uid: '3ac97065-691d-11e8-802f-42010af0033a',
+    resourceVersion: '1322',
+    creationTimestamp: '2018-06-06T00:04:49Z',
+    labels: {
+      'workflows.argoproj.io/completed': 'true',
+      'workflows.argoproj.io/phase': 'Succeeded'
+    }
+  },
+  spec: {
+    templates: [
+      {
+        name: 'whalesay1',
+        inputs: {},
+        outputs: {},
+        metadata: {},
+        container: {
+          name: '',
+          image: 'docker/whalesay:latest',
+          command: [
+            'cowsay'
+          ],
+          args: [
+            '{{workflow.parameters.message}}'
+          ],
+          resources: {}
+        }
+      }
+    ],
+    entrypoint: 'whalesay1',
+    arguments: {
+      parameters: [
+        {
+          name: 'message',
+          value: 'hello world'
+        }
+      ]
+    }
+  },
+  status: {
+    phase: 'Succeeded',
+    startedAt: '2018-06-06T00:04:49Z',
+    finishedAt: '2018-06-06T00:05:23Z',
+    nodes: {
+      'json-12abc': {
+        id: 'json-12abc',
+        name: 'json-12abc',
+        displayName: 'json-12abc',
+        type: 'Pod',
+        templateName: 'whalesay1',
+        phase: 'Succeeded',
+        startedAt: '2018-06-06T00:04:49Z',
+        finishedAt: '2018-06-06T00:05:23Z',
+        inputs: {
+          parameters: [
+            {
+              name: 'JSON Data',
+              value: JSON.stringify({
+                'string1': 'a',
+                'string2': 'b',
+                'number1': 1,
+                'number2': 2.2,
+                'object': {
+                  'string': 'a',
+                  'number': 2
+                },
+                'array': [
+                  'a',
+                  'b',
+                  'c'
+                ]
+              })
+            }
+          ]
+        }
+      }
+    }
+  }
+};

--- a/frontend/mock-backend/json-runtime.ts
+++ b/frontend/mock-backend/json-runtime.ts
@@ -19,7 +19,7 @@ export default {
     generateName: 'json-',
     namespace: 'default',
     selfLink: '/apis/argoproj.io/v1alpha1/namespaces/default/workflows/json-7sm94',
-    uid: '3ac97065-691d-11e8-802f-42010af0033a',
+    uid: 'dfc82af5-c5cb-43b1-822b-52487cb872d2',
     resourceVersion: '1322',
     creationTimestamp: '2018-06-06T00:04:49Z',
     labels: {


### PR DESCRIPTION
This PR allows developers to test UI changes that revolve around JSON data as an input/output for a component without having to write the input/output manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1895)
<!-- Reviewable:end -->
