### PR TITLE
Change the type of resource reference payload column

### DIFF
--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -220,6 +220,12 @@ func initDBClient(initConnectionTimeout time.Duration) *storage.DB {
 	if response.Error != nil {
 		glog.Fatalf("Failed to initialize the databases.")
 	}
+
+	response = db.Model(&model.ResourceReference{}).ModifyColumn("Payload", "longtext")
+	if response.Error != nil {
+		glog.Fatalf("Failed to update the resource reference payload type. Error: %s", response.Error)
+	}
+
 	response = db.Model(&model.RunMetric{}).
 		AddForeignKey("RunUUID", "run_details(UUID)", "CASCADE" /* onDelete */, "CASCADE" /* update */)
 	if response.Error != nil {


### PR DESCRIPTION
Gorm doesn't automatically change the type of a column. Following changes introduced a column type change which might not be effective for an existing cluster doing upgrade. 
https://github.com/kubeflow/pipelines/commit/4e43750c9dcebe37b75aedadd7b1c829b409caaa#diff-c4afa92d7e54eecff0a482cf57490aa8R40

/assign @hongye-sun

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1905)
<!-- Reviewable:end -->
