### PR TITLE
[front-end-server] Allow viewer:tensorboard podTemplateSpec to be customizable

### DIFF
--- a/frontend/server/utils.ts
+++ b/frontend/server/utils.ts
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import {readFileSync} from 'fs';
 
 export function equalArrays(a1: any[], a2: any[]): boolean {
   if (!Array.isArray(a1) || !Array.isArray(a2) || a1.length !== a2.length) {
@@ -31,4 +32,13 @@ export function generateRandomString(length: number): string {
     str += randomChar();
   }
   return str;
+}
+
+export function loadJSON(filepath: string, defaultValue: Object = {}): Object {
+  if (!filepath) return defaultValue;
+  try {
+    return JSON.parse(readFileSync(filepath))
+  } catch (error) {
+    return defaultValue;
+  }
 }

--- a/frontend/server/utils.ts
+++ b/frontend/server/utils.ts
@@ -37,7 +37,7 @@ export function generateRandomString(length: number): string {
 export function loadJSON(filepath: string, defaultValue: Object = {}): Object {
   if (!filepath) return defaultValue;
   try {
-    return JSON.parse(readFileSync(filepath))
+    return JSON.parse(readFileSync(filepath, "utf-8"))
   } catch (error) {
     return defaultValue;
   }


### PR DESCRIPTION
### Background
My kubeflow pipeline is running on AWS infrastructure and we do not allow aws access keys for security reasons. All our infrastructure access are controlled with kube2iam via pod annotations.

The current front-end server creates a hardcoded podTemplateSpec which uses gcp credentials. This result in the tensorboard viewer to be unable to access our logs stored in s3.

### Changes
This PR adds an environment variable: `VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH` which points to a local JSON file with a custom podTemplateSpec (e.g. pod annotation with kube2iam role). 

In kubernetes, custom podTemplateSpec can be achieved by creating a configmap and mounting to the `pipeline-ui` pod.

> I was also thinking of supporting YAML. But that would meant an additional dependency. Cuz it is more inituitive to write the spec in YAML rather in JSON.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1906)
<!-- Reviewable:end -->
