### PR TITLE
Enable error propagation from nbconvert to frontend

### DIFF
--- a/backend/src/apiserver/visualization/exporter.py
+++ b/backend/src/apiserver/visualization/exporter.py
@@ -85,7 +85,8 @@ class Exporter:
         self.km.start_kernel()
         self.ep = ExecutePreprocessor(
             timeout=self.timeout,
-            kernel_name='python3'
+            kernel_name='python3',
+            allow_errors=True
         )
 
     @staticmethod


### PR DESCRIPTION
Generated visualizations that fail due to an error within Python code now render that error in the returned HTML rather than as a 500 error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1909)
<!-- Reviewable:end -->
