### PR TITLE
SDK - Airflow - Fixed bug in AirFlow op creation

### DIFF
--- a/sdk/python/kfp/components/_airflow_op.py
+++ b/sdk/python/kfp/components/_airflow_op.py
@@ -70,6 +70,7 @@ def _create_component_spec_from_airflow_op(
     variables_output_names = variables_to_output or []
     xcoms_output_names = xcoms_to_output or []
     modules_to_capture = modules_to_capture or [op_class.__module__]
+    modules_to_capture.append(_run_airflow_op.__module__)
 
     output_names = []
     if result_output_name is not None:


### PR DESCRIPTION
This PR fixes a bug in AirFlow op creation.
The `_run_airflow_op` helper function was not captured along with the `_run_airflow_op_closure` function, because they belong to different modules (`_run_airflow_op_closure` was module-less).
This was not discovered during the notebook testing of the code since in that environment the `_run_airflow_op` was also module-less as it was defined in a notebook (not in .py file).

TODO: Add sample tests for Airflow operators.
TODO: Think of how to unit-test the feature (it's non-trivial since it runs the airflow server and DB).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1911)
<!-- Reviewable:end -->
