### PR TITLE
Allow visualization kernel timeout to be specifiable via environment variables

### DIFF
--- a/backend/src/apiserver/visualization/server.py
+++ b/backend/src/apiserver/visualization/server.py
@@ -16,6 +16,7 @@ import argparse
 from argparse import Namespace
 import importlib
 import json
+import os
 from pathlib import Path
 from typing import Text
 import shlex
@@ -31,7 +32,7 @@ parser = argparse.ArgumentParser(description="Server Arguments")
 parser.add_argument(
     "--timeout",
     type=int,
-    default=100,
+    default=os.getenv('KERNEL_TIMEOUT', 100),
     help="Amount of time in seconds that a visualization can run for before " +
          "being stopped."
 )


### PR DESCRIPTION
Adds support for visualization kernel timeout to be specified via environment variables. This removes the previous necessity of having to build a new image to change the kernel timeout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1920)
<!-- Reviewable:end -->
