### PR TITLE
Add pipeline id to pipeline summary card

### DIFF
--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -179,6 +179,8 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
                         Hide
                         </Button>
                     </div>
+                    <div className={css.summaryKey}>ID</div>
+                    <div>{pipeline.id || 'Unable to obtain Pipeline ID'}</div>
                     <div className={css.summaryKey}>Uploaded on</div>
                     <div>{formatDateString(pipeline.created_at)}</div>
                     <div className={css.summaryKey}>Description</div>

--- a/frontend/src/pages/__snapshots__/PipelineDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/PipelineDetails.test.tsx.snap
@@ -59,6 +59,14 @@ exports[`PipelineDetails closes side panel when close button is clicked 1`] = `
             <div
               className="summaryKey"
             >
+              ID
+            </div>
+            <div>
+              test-pipeline-id
+            </div>
+            <div
+              className="summaryKey"
+            >
               Uploaded on
             </div>
             <div>
@@ -288,6 +296,14 @@ exports[`PipelineDetails opens side panel on clicked node, shows message when no
             <div
               className="summaryKey"
             >
+              ID
+            </div>
+            <div>
+              test-pipeline-id
+            </div>
+            <div
+              className="summaryKey"
+            >
               Uploaded on
             </div>
             <div>
@@ -416,6 +432,14 @@ exports[`PipelineDetails shows clicked node info in the side panel if it is in t
               >
                 Hide
               </WithStyles(Button)>
+            </div>
+            <div
+              className="summaryKey"
+            >
+              ID
+            </div>
+            <div>
+              test-pipeline-id
             </div>
             <div
               className="summaryKey"
@@ -642,6 +666,14 @@ exports[`PipelineDetails shows empty pipeline details with empty graph 1`] = `
               >
                 Hide
               </WithStyles(Button)>
+            </div>
+            <div
+              className="summaryKey"
+            >
+              ID
+            </div>
+            <div>
+              test-pipeline-id
             </div>
             <div
               className="summaryKey"


### PR DESCRIPTION
Implement suggestion in #1919 to add pipeline id to pipeline summary card.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1927)
<!-- Reviewable:end -->
