### PR TITLE
SDK - Refactoring - Replaced the TypeMeta class

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -25,7 +25,7 @@ from ._k8s_helper import K8sHelper
 from ._op_to_template import _op_to_template
 from ._default_transformers import add_pod_env
 
-from ..dsl._metadata import TypeMeta, _extract_pipeline_metadata
+from ..dsl._metadata import _extract_pipeline_metadata
 from ..dsl._ops_group import OpsGroup
 
 class Compiler(object):
@@ -596,7 +596,7 @@ class Compiler(object):
 
     args_list = []
     for arg_name in argspec.args:
-      arg_type = TypeMeta()
+      arg_type = None
       for input in pipeline_meta.inputs:
         if arg_name == input.name:
           arg_type = input.param_type

--- a/sdk/python/kfp/components/_components.py
+++ b/sdk/python/kfp/components/_components.py
@@ -235,8 +235,8 @@ def _create_task_factory_from_component_spec(component_spec:ComponentSpec, compo
                 if kfp.TYPE_CHECK:
                     for input_spec in component_spec.inputs:
                         if input_spec.name == key:
-                            if arguments[key].param_type is not None and not check_types(arguments[key].param_type.to_dict_or_str(), '' if input_spec.type is None else input_spec.type):
-                                raise InconsistentTypeException('Component "' + name + '" is expecting ' + key + ' to be type(' + str(input_spec.type) + '), but the passed argument is type(' + arguments[key].param_type.serialize() + ')')
+                            if arguments[key].param_type is not None and not check_types(arguments[key].param_type, '' if input_spec.type is None else input_spec.type):
+                                raise InconsistentTypeException('Component "' + name + '" is expecting ' + key + ' to be type(' + str(input_spec.type) + '), but the passed argument is type(' + str(arguments[key].param_type) + ')')
                 arguments[key] = str(arguments[key])
 
         task = TaskSpec(

--- a/sdk/python/kfp/components/_dsl_bridge.py
+++ b/sdk/python/kfp/components/_dsl_bridge.py
@@ -16,7 +16,7 @@ from collections import OrderedDict
 from typing import Mapping
 from ._structures import ContainerImplementation, ConcatPlaceholder, IfPlaceholder, InputValuePlaceholder, InputPathPlaceholder, IsPresentPlaceholder, OutputPathPlaceholder, TaskSpec
 from ._components import _generate_output_file_name, _default_component_name
-from kfp.dsl._metadata import ComponentMeta, ParameterMeta, TypeMeta, _annotation_to_typemeta
+from kfp.dsl._metadata import ComponentMeta, ParameterMeta
 
 def create_container_op_from_task(task_spec: TaskSpec):
     argument_values = task_spec.arguments
@@ -143,10 +143,10 @@ def _create_container_op_from_resolved_task(name:str, container_image:str, comma
     # Inputs
     if component_spec.inputs is not None:
         for input in component_spec.inputs:
-            component_meta.inputs.append(ParameterMeta(name=input.name, description=input.description, param_type=_annotation_to_typemeta(input.type), default=input.default))
+            component_meta.inputs.append(ParameterMeta(name=input.name, description=input.description, param_type=input.type, default=input.default))
     if component_spec.outputs is not None:
         for output in component_spec.outputs:
-            component_meta.outputs.append(ParameterMeta(name=output.name, description=output.description, param_type=_annotation_to_typemeta(output.type)))
+            component_meta.outputs.append(ParameterMeta(name=output.name, description=output.description, param_type=output.type))
 
     task = dsl.ContainerOp(
         name=name,

--- a/sdk/python/kfp/dsl/_component.py
+++ b/sdk/python/kfp/dsl/_component.py
@@ -71,19 +71,19 @@ def component(func):
     if kfp.TYPE_CHECK:
       arg_index = 0
       for arg in args:
-        if isinstance(arg, PipelineParam) and not check_types(arg.param_type.to_dict_or_str(), component_meta.inputs[arg_index].param_type.to_dict_or_str()):
+        if isinstance(arg, PipelineParam) and not check_types(arg.param_type, component_meta.inputs[arg_index].param_type):
           raise InconsistentTypeException('Component "' + component_meta.name + '" is expecting ' + component_meta.inputs[arg_index].name +
-                                          ' to be type(' + component_meta.inputs[arg_index].param_type.serialize() +
-                                          '), but the passed argument is type(' + arg.param_type.serialize() + ')')
+                                          ' to be type(' + str(component_meta.inputs[arg_index].param_type) +
+                                          '), but the passed argument is type(' + str(arg.param_type) + ')')
         arg_index += 1
       if kargs is not None:
         for key in kargs:
           if isinstance(kargs[key], PipelineParam):
             for input_spec in component_meta.inputs:
-              if input_spec.name == key and not check_types(kargs[key].param_type.to_dict_or_str(), input_spec.param_type.to_dict_or_str()):
+              if input_spec.name == key and not check_types(kargs[key].param_type, input_spec.param_type):
                 raise InconsistentTypeException('Component "' + component_meta.name + '" is expecting ' + input_spec.name +
-                                                ' to be type(' + input_spec.param_type.serialize() +
-                                                '), but the passed argument is type(' + kargs[key].param_type.serialize() + ')')
+                                                ' to be type(' + str(input_spec.param_type) +
+                                                '), but the passed argument is type(' + str(kargs[key].param_type) + ')')
 
     container_op = func(*args, **kargs)
     container_op._set_metadata(component_meta)

--- a/sdk/python/kfp/dsl/_pipeline_param.py
+++ b/sdk/python/kfp/dsl/_pipeline_param.py
@@ -15,7 +15,7 @@
 
 import re
 from collections import namedtuple
-from typing import List
+from typing import Dict, List, Union
 
 
 # TODO: Move this to a separate class
@@ -135,7 +135,7 @@ class PipelineParam(object):
   value passed between components.
   """
   
-  def __init__(self, name: str, op_name: str=None, value: str=None, param_type = None, pattern: str=None):
+  def __init__(self, name: str, op_name: str=None, value: str=None, param_type : Union[str, Dict] = None, pattern: str=None):
     """Create a new instance of PipelineParam.
     Args:
       name: name of the pipeline parameter.

--- a/sdk/python/kfp/dsl/_pipeline_param.py
+++ b/sdk/python/kfp/dsl/_pipeline_param.py
@@ -16,7 +16,6 @@
 import re
 from collections import namedtuple
 from typing import List
-from ._metadata import TypeMeta
 
 
 # TODO: Move this to a separate class
@@ -136,7 +135,7 @@ class PipelineParam(object):
   value passed between components.
   """
   
-  def __init__(self, name: str, op_name: str=None, value: str=None, param_type: TypeMeta=TypeMeta(), pattern: str=None):
+  def __init__(self, name: str, op_name: str=None, value: str=None, param_type = None, pattern: str=None):
     """Create a new instance of PipelineParam.
     Args:
       name: name of the pipeline parameter.
@@ -218,6 +217,6 @@ class PipelineParam(object):
 
   def ignore_type(self):
     """ignore_type ignores the type information such that type checking would also pass"""
-    self.param_type = TypeMeta()
+    self.param_type = None
     return self
 

--- a/sdk/python/kfp/dsl/types.py
+++ b/sdk/python/kfp/dsl/types.py
@@ -145,6 +145,9 @@ def _check_dict_types(checked_type, expected_type):
   	checked_type (dict): A dict that describes a type from the upstream component output
   	expected_type (dict): A dict that describes a type from the downstream component input
 	'''
+	if not checked_type or not expected_type:
+		# If the type is empty, it matches any types
+		return True
 	checked_type_name,_ = list(checked_type.items())[0]
 	expected_type_name,_ = list(expected_type.items())[0]
 	if checked_type_name == '' or expected_type_name == '':

--- a/sdk/python/tests/dsl/component_tests.py
+++ b/sdk/python/tests/dsl/component_tests.py
@@ -15,7 +15,7 @@
 import kfp
 import kfp.dsl as dsl
 from kfp.dsl import component, graph_component
-from kfp.dsl._metadata import ComponentMeta, ParameterMeta, TypeMeta
+from kfp.dsl._metadata import ComponentMeta, ParameterMeta
 from kfp.dsl.types import Integer, GCSPath, InconsistentTypeException
 from kfp.dsl import ContainerOp, Pipeline, PipelineParam
 import unittest
@@ -36,10 +36,10 @@ class TestPythonComponent(unittest.TestCase):
     containerOp = componentA(1,2,c=3)
 
     golden_meta = ComponentMeta(name='componentA', description='')
-    golden_meta.inputs.append(ParameterMeta(name='a', description='', param_type=TypeMeta(name='ArtifactA', properties={'file_type': 'csv'})))
-    golden_meta.inputs.append(ParameterMeta(name='b', description='', param_type=TypeMeta(name='Integer', properties={'openapi_schema_validator': {"type": "integer"}}), default=12))
-    golden_meta.inputs.append(ParameterMeta(name='c', description='', param_type=TypeMeta(name='ArtifactB', properties={'path_type':'file', 'file_type': 'tsv'}), default='gs://hello/world'))
-    golden_meta.outputs.append(ParameterMeta(name='model', description='', param_type=TypeMeta(name='Integer', properties={'openapi_schema_validator': {"type": "integer"}})))
+    golden_meta.inputs.append(ParameterMeta(name='a', description='', param_type={'ArtifactA': {'file_type': 'csv'}}))
+    golden_meta.inputs.append(ParameterMeta(name='b', description='', param_type={'Integer': {'openapi_schema_validator': {"type": "integer"}}}, default=12))
+    golden_meta.inputs.append(ParameterMeta(name='c', description='', param_type={'ArtifactB': {'path_type':'file', 'file_type': 'tsv'}}, default='gs://hello/world'))
+    golden_meta.outputs.append(ParameterMeta(name='model', description='', param_type={'Integer': {'openapi_schema_validator': {"type": "integer"}}}))
 
     self.assertEqual(containerOp._metadata, golden_meta)
 

--- a/sdk/python/tests/dsl/metadata_tests.py
+++ b/sdk/python/tests/dsl/metadata_tests.py
@@ -12,38 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kfp.dsl._metadata import ComponentMeta, ParameterMeta, TypeMeta
+from kfp.dsl._metadata import ComponentMeta, ParameterMeta
 import unittest
-
-class TestTypeMeta(unittest.TestCase):
-  def test_deserialize(self):
-    component_dict = {
-        'GCSPath': {
-            'bucket_type': 'directory',
-            'file_type': 'csv'
-        }
-    }
-    golden_type_meta = TypeMeta(name='GCSPath', properties={'bucket_type': 'directory',
-                                                          'file_type': 'csv'})
-    self.assertEqual(TypeMeta.deserialize(component_dict), golden_type_meta)
-
-    component_str = 'GCSPath'
-    golden_type_meta = TypeMeta(name='GCSPath')
-    self.assertEqual(TypeMeta.deserialize(component_str), golden_type_meta)
-
-
-  def test_eq(self):
-    type_a = TypeMeta(name='GCSPath', properties={'bucket_type': 'directory',
-                                                  'file_type': 'csv'})
-    type_b = TypeMeta(name='GCSPath', properties={'bucket_type': 'directory',
-                                                  'file_type': 'tsv'})
-    type_c = TypeMeta(name='GCSPatha', properties={'bucket_type': 'directory',
-                                                  'file_type': 'csv'})
-    type_d = TypeMeta(name='GCSPath', properties={'bucket_type': 'directory',
-                                                  'file_type': 'csv'})
-    self.assertNotEqual(type_a, type_b)
-    self.assertNotEqual(type_a, type_c)
-    self.assertEqual(type_a, type_d)
 
 
 class TestComponentMeta(unittest.TestCase):
@@ -53,34 +23,31 @@ class TestComponentMeta(unittest.TestCase):
                                    description='foobar example',
                                    inputs=[ParameterMeta(name='input1',
                                                          description='input1 desc',
-                                                         param_type=TypeMeta(name='GCSPath',
-                                                                             properties={'bucket_type': 'directory',
-                                                                                         'file_type': 'csv'
-                                                                                         }
-                                                                             ),
+                                                         param_type={'GCSPath': {
+                                                             'bucket_type': 'directory',
+                                                             'file_type': 'csv'
+                                                         }},
                                                          default='default1'
                                                          ),
                                            ParameterMeta(name='input2',
                                                          description='input2 desc',
-                                                         param_type=TypeMeta(name='TFModel',
-                                                                             properties={'input_data': 'tensor',
-                                                                                         'version': '1.8.0'
-                                                                                         }
-                                                                             ),
+                                                         param_type={'TFModel': {
+                                                            'input_data': 'tensor',
+                                                            'version': '1.8.0'
+                                                         }},
                                                          default='default2'
                                                          ),
                                            ParameterMeta(name='input3',
                                                          description='input3 desc',
-                                                         param_type=TypeMeta(name='Integer'),
+                                                         param_type='Integer',
                                                          default='default3'
                                                          ),
                                            ],
                                    outputs=[ParameterMeta(name='output1',
                                                           description='output1 desc',
-                                                          param_type=TypeMeta(name='Schema',
-                                                                              properties={'file_type': 'tsv'
-                                                                                          }
-                                                                              ),
+                                                          param_type={'Schema': {
+                                                              'file_type': 'tsv'
+                                                          }},
                                                           default='default_output1'
                                                           )
                                             ]

--- a/sdk/python/tests/dsl/pipeline_param_tests.py
+++ b/sdk/python/tests/dsl/pipeline_param_tests.py
@@ -15,7 +15,6 @@
 from kubernetes.client.models import V1Container, V1EnvVar
 from kfp.dsl import PipelineParam
 from kfp.dsl._pipeline_param import _extract_pipelineparams, extract_pipelineparams_from_any
-from kfp.dsl._metadata import TypeMeta
 import unittest
 
 
@@ -69,9 +68,9 @@ class TestPipelineParam(unittest.TestCase):
     
   def test_extract_pipelineparam_with_types(self):
     """Test _extract_pipelineparams. """
-    p1 = PipelineParam(name='param1', op_name='op1', param_type=TypeMeta(name='customized_type_a', properties={'property_a': 'value_a'}))
-    p2 = PipelineParam(name='param2', param_type=TypeMeta(name='customized_type_b'))
-    p3 = PipelineParam(name='param3', value='value3', param_type=TypeMeta(name='customized_type_c', properties={'property_c': 'value_c'}))
+    p1 = PipelineParam(name='param1', op_name='op1', param_type={'customized_type_a': {'property_a': 'value_a'}})
+    p2 = PipelineParam(name='param2', param_type='customized_type_b')
+    p3 = PipelineParam(name='param3', value='value3', param_type={'customized_type_c': {'property_c': 'value_c'}})
     stuff_chars = ' between '
     payload = str(p1) + stuff_chars + str(p2) + stuff_chars + str(p3)
     params = _extract_pipelineparams(payload)

--- a/sdk/python/tests/dsl/pipeline_tests.py
+++ b/sdk/python/tests/dsl/pipeline_tests.py
@@ -14,7 +14,7 @@
 
 import kfp
 from kfp.dsl import Pipeline, PipelineParam, ContainerOp, pipeline
-from kfp.dsl._metadata import PipelineMeta, ParameterMeta, TypeMeta, _extract_pipeline_metadata
+from kfp.dsl._metadata import PipelineMeta, ParameterMeta, _extract_pipeline_metadata
 from kfp.dsl.types import GCSPath, Integer
 import unittest
 
@@ -70,8 +70,8 @@ class TestPipeline(unittest.TestCase):
       pass
 
     golden_meta = PipelineMeta(name='p1', description='description1')
-    golden_meta.inputs.append(ParameterMeta(name='a', description='', param_type=TypeMeta(name='Schema', properties={'file_type': 'csv'}), default='good'))
-    golden_meta.inputs.append(ParameterMeta(name='b', description='', param_type=TypeMeta(name='Integer', properties={'openapi_schema_validator': {"type": "integer"}}), default=12))
+    golden_meta.inputs.append(ParameterMeta(name='a', description='', param_type={'Schema': {'file_type': 'csv'}}, default='good'))
+    golden_meta.inputs.append(ParameterMeta(name='b', description='', param_type={'Integer': {'openapi_schema_validator': {"type": "integer"}}}, default=12))
 
     pipeline_meta = _extract_pipeline_metadata(my_pipeline1)
     self.assertEqual(pipeline_meta, golden_meta)


### PR DESCRIPTION
The PipelineParam no longer exposes the private TypeMeta class
Fixes https://github.com/kubeflow/pipelines/issues/1420

The refactoring PR is part of a series of PR which unifies the metadata and specification types.

All the tests continue to pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1930)
<!-- Reviewable:end -->
