### PR TITLE
SDK - Components - Improved serialization and deserialization of arguments and defaults

### DIFF
--- a/sdk/python/kfp/components/_data_passing.py
+++ b/sdk/python/kfp/components/_data_passing.py
@@ -1,0 +1,79 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    'type_to_type_name',
+    'type_name_to_type',
+    'type_to_deserializer',
+    'type_name_to_deserializer',
+    'type_name_to_serializer',
+]
+
+
+import inspect
+from typing import Any, Callable, NamedTuple, Sequence
+import warnings
+
+
+Converter = NamedTuple('Converter', [
+    ('types', Sequence[str]),
+    ('type_names', Sequence[str]),
+    ('serializer', Callable[[Any], str]),
+    ('deserializer_code', str),
+    ('definitions', str),
+])
+
+
+_converters = [
+    Converter([str], ['String', 'str'], str, 'str', None),
+    Converter([int], ['Integer', 'int'], str, 'int', None),
+    Converter([float], ['Float', 'float'], str, 'float', None),
+]
+
+
+type_to_type_name = {typ: converter.type_names[0] for converter in _converters for typ in converter.types}
+type_name_to_type = {type_name: converter.types[0] for converter in _converters for type_name in converter.type_names if converter.types}
+type_to_deserializer = {typ: (converter.deserializer_code, converter.definitions) for converter in _converters for typ in converter.types}
+type_name_to_deserializer = {type_name: (converter.deserializer_code, converter.definitions) for converter in _converters for type_name in converter.type_names}
+type_name_to_serializer = {type_name: converter.serializer for converter in _converters for type_name in converter.type_names}
+
+
+def serialize_value(value, type_name: str) -> str:
+    '''serialize_value converts the passed value to string based on the serializer associated with the passed type_name'''
+    if isinstance(value, str):
+        return value # The value is supposedly already serialized
+
+    if type_name is None:
+        type_name = type_to_type_name.get(type(value), type(value).__name__)
+        warnings.warn('Missing type name was inferred as "{}" based on the value "{}".'.format(type_name, str(value)))
+
+    serializer = type_name_to_serializer.get(type_name, None)
+    if serializer:
+        try:
+            return serializer(value)
+        except Exception as e:
+            raise ValueError('Failed to serialize the value "{}" of type "{}" to type "{}". Exception: {}'.format(
+                str(value),
+                str(type(value).__name__),
+                str(type_name),
+                str(e),
+            ))
+
+    serialized_value = str(value)
+    warnings.warn('There are no registered serializers from type "{}" to type "{}", so the value will be serializers as string "{}".'.format(
+        str(type(value).__name__),
+        str(type_name),
+        serialized_value),
+    )
+    return serialized_value

--- a/sdk/python/kfp/dsl/types.py
+++ b/sdk/python/kfp/dsl/types.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+import warnings
+
+
 class BaseType:
 	'''MetaType is a base type for all scalar and artifact types.
 	'''
@@ -93,6 +97,35 @@ class LocalPath(BaseType):
 class InconsistentTypeException(Exception):
 	'''InconsistencyTypeException is raised when two types are not consistent'''
 	pass
+
+
+class InconsistentTypeWarning(Warning):
+	'''InconsistentTypeWarning is issued when two types are not consistent'''
+	pass
+
+
+def verify_type_compatibility(given_type, expected_type, error_message_prefix : str = ''):
+	'''verify_type_compatibility verifies that the given argument type is compatible with the expected input type.
+	Args:
+		given_type (str/dict): The type of the argument passed to the input
+		expected_type (str/dict): The declared type of the input
+	'''
+	if given_type is None:
+		return
+	if expected_type is None:
+		return
+
+	types_are_compatible = check_types(given_type, expected_type)
+
+	if not types_are_compatible:
+		error_text = error_message_prefix + 'Argument type "{}" is incompatible with the input type "{}"'.format(str(given_type), str(expected_type))
+		import kfp
+		if kfp.TYPE_CHECK:
+			raise InconsistentTypeException(error_text)
+		else:
+			warnings.warn(InconsistentTypeWarning(error_text))
+	return types_are_compatible
+
 
 def check_types(checked_type, expected_type):
 	'''check_types checks the type consistency.

--- a/sdk/python/kfp/dsl/types.py
+++ b/sdk/python/kfp/dsl/types.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+from typing import Dict, Union
 import warnings
 
 
@@ -104,16 +104,17 @@ class InconsistentTypeWarning(Warning):
 	pass
 
 
-def verify_type_compatibility(given_type, expected_type, error_message_prefix : str = ''):
+TypeSpecType = Union[str, Dict]
+
+
+def verify_type_compatibility(given_type: TypeSpecType, expected_type: TypeSpecType, error_message_prefix : str = ''):
 	'''verify_type_compatibility verifies that the given argument type is compatible with the expected input type.
 	Args:
 		given_type (str/dict): The type of the argument passed to the input
 		expected_type (str/dict): The declared type of the input
 	'''
-	if given_type is None:
-		return
-	if expected_type is None:
-		return
+	if given_type is None or expected_type is None:
+		return True # Missing types are treated as being compatible with any types
 
 	types_are_compatible = check_types(given_type, expected_type)
 

--- a/sdk/python/tests/components/test_python_op.py
+++ b/sdk/python/tests/components/test_python_op.py
@@ -214,9 +214,9 @@ class PythonOpTestCase(unittest.TestCase):
             component_spec.inputs,
             [
                 InputSpec(name='required_param'),
-                InputSpec(name='int_param', type='int', default='42', optional=True),
-                InputSpec(name='float_param', type='float', default='3.14', optional=True),
-                InputSpec(name='str_param', type='str', default='string', optional=True),
+                InputSpec(name='int_param', type='Integer', default='42', optional=True),
+                InputSpec(name='float_param', type='Float', default='3.14', optional=True),
+                InputSpec(name='str_param', type='String', default='string', optional=True),
                 InputSpec(name='bool_param', type='bool', default='True', optional=True),
                 InputSpec(name='none_param', optional=True), # No default='None'
                 InputSpec(name='custom_type_param', type='Custom type', optional=True),
@@ -225,9 +225,9 @@ class PythonOpTestCase(unittest.TestCase):
         self.assertEqual(
             component_spec.outputs,
             [
-                OutputSpec(name='int_param', type='int'),
-                OutputSpec(name='float_param', type='float'),
-                OutputSpec(name='str_param', type='str'),
+                OutputSpec(name='int_param', type='Integer'),
+                OutputSpec(name='float_param', type='Float'),
+                OutputSpec(name='str_param', type='String'),
                 OutputSpec(name='bool_param', type='bool'),
                 #OutputSpec(name='custom_type_param', type='Custom type', default='None'),
                 OutputSpec(name='custom_type_param', type='CustomType'),
@@ -242,17 +242,17 @@ class PythonOpTestCase(unittest.TestCase):
                 'description': 'Function docstring\n',
                 'inputs': [
                     {'name': 'required_param'},
-                    {'name': 'int_param', 'type': 'int', 'default': '42', 'optional': True},
-                    {'name': 'float_param', 'type': 'float', 'default': '3.14', 'optional': True},
-                    {'name': 'str_param', 'type': 'str', 'default': 'string', 'optional': True},
+                    {'name': 'int_param', 'type': 'Integer', 'default': '42', 'optional': True},
+                    {'name': 'float_param', 'type': 'Float', 'default': '3.14', 'optional': True},
+                    {'name': 'str_param', 'type': 'String', 'default': 'string', 'optional': True},
                     {'name': 'bool_param', 'type': 'bool', 'default': 'True', 'optional': True},
                     {'name': 'none_param', 'optional': True}, # No default='None'
                     {'name': 'custom_type_param', 'type': 'Custom type', 'optional': True},
                 ],
                 'outputs': [
-                    {'name': 'int_param', 'type': 'int'},
-                    {'name': 'float_param', 'type': 'float'},
-                    {'name': 'str_param', 'type': 'str'},
+                    {'name': 'int_param', 'type': 'Integer'},
+                    {'name': 'float_param', 'type': 'Float'},
+                    {'name': 'str_param', 'type': 'String'},
                     {'name': 'bool_param', 'type': 'bool'},
                     {'name': 'custom_type_param', 'type': 'CustomType'},
                 ]


### PR DESCRIPTION
This PR improves serialization and deserialization of arguments and defaults

The PR is mostly a refactoring.

It's prerequisite for fixing https://github.com/kubeflow/pipelines/issues/1488 and https://github.com/kubeflow/pipelines/issues/1901

Properly serialize default values and passed arguments using the same code.
Check the types of passed argument values and issue warnings.
Improved argument reference type compatibility checking. When types do not match there is always either error or warning.
When creating component from python function, the input types are now canonicalized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1934)
<!-- Reviewable:end -->
