### PR TITLE
SDK - Components - Add support for the List, Dict and Json types

### DIFF
--- a/sdk/python/kfp/components/_data_passing.py
+++ b/sdk/python/kfp/components/_data_passing.py
@@ -44,11 +44,19 @@ _bool_deserializer_definitions = inspect.getsource(_deserialize_bool)
 _bool_deserializer_code = _deserialize_bool.__name__
 
 
+def _serialize_json(obj) -> str:
+    import json
+    return json.dumps(obj)
+
+
 _converters = [
     Converter([str], ['String', 'str'], str, 'str', None),
     Converter([int], ['Integer', 'int'], str, 'int', None),
     Converter([float], ['Float', 'float'], str, 'float', None),
     Converter([bool], ['Boolean', 'bool'], str, _bool_deserializer_code, _bool_deserializer_definitions),
+    Converter([list], ['JsonArray', 'List', 'list'], _serialize_json, 'json.loads', 'import json'), # ! JSON map keys are always strings. Python converts all keys to strings without warnings
+    Converter([dict], ['JsonObject', 'Dictionary', 'Dict', 'dict'], _serialize_json, 'json.loads', 'import json'), # ! JSON map keys are always strings. Python converts all keys to strings without warnings
+    Converter([], ['Json'], _serialize_json, 'json.loads', 'import json'),
 ]
 
 

--- a/sdk/python/tests/components/test_python_op.py
+++ b/sdk/python/tests/components/test_python_op.py
@@ -386,6 +386,25 @@ class PythonOpTestCase(unittest.TestCase):
         self.helper_test_2_in_1_out_component_using_local_call(func, op, arguments=[True, False])
 
 
+    def test_handling_list_dict_arguments(self):
+        def assert_values_are_same(
+            list_param: list,
+            dict_param: dict,
+        ) -> int:
+            import unittest
+            unittest.TestCase().assertEqual(list_param, ["string", 1, 2.2, True, False, None, [3, 4], {'s': 5}])
+            unittest.TestCase().assertEqual(dict_param, {'str': "string", 'int': 1, 'float':  2.2, 'false': False, 'true': True, 'none': None, 'list': [3, 4], 'dict': {'s': 4}})
+            return 1
+        
+        # ! JSON map keys are always strings. Python converts all keys to strings without warnings
+        func = assert_values_are_same
+        op = comp.func_to_container_op(func)
+        self.helper_test_2_in_1_out_component_using_local_call(func, op, arguments=[
+            ["string", 1, 2.2, True, False, None, [3, 4], {'s': 5}],
+            {'str': "string", 'int': 1, 'float':  2.2, 'false': False, 'true': True, 'none': None, 'list': [3, 4], 'dict': {'s': 4}},
+        ])
+
+
     def test_end_to_end_python_component_pipeline_compilation(self):
         import kfp.components as comp
 


### PR DESCRIPTION
I've considered several serialization formats for pass `dict`s and `list`s:
* JSON
* YAML
* Pickle

I chose JSON based on it's portability and popularity.
Fixes https://github.com/kubeflow/pipelines/issues/1901

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1945)
<!-- Reviewable:end -->
