### PR TITLE
SDK - Components - Add support for the Base64Pickle type

### DIFF
--- a/sdk/python/kfp/components/_data_passing.py
+++ b/sdk/python/kfp/components/_data_passing.py
@@ -49,6 +49,22 @@ def _serialize_json(obj) -> str:
     return json.dumps(obj)
 
 
+def _serialize_base64_pickle(obj) -> str:
+    import base64
+    import pickle
+    return base64.b64encode(pickle.dumps(obj)).decode('ascii')
+
+
+def _deserialize_base64_pickle(s):
+    import base64
+    import pickle
+    return pickle.loads(base64.b64decode(s))
+
+
+_deserialize_base64_pickle_definitions = inspect.getsource(_deserialize_base64_pickle)
+_deserialize_base64_pickle_code = _deserialize_base64_pickle.__name__
+
+
 _converters = [
     Converter([str], ['String', 'str'], str, 'str', None),
     Converter([int], ['Integer', 'int'], str, 'int', None),
@@ -57,6 +73,7 @@ _converters = [
     Converter([list], ['JsonArray', 'List', 'list'], _serialize_json, 'json.loads', 'import json'), # ! JSON map keys are always strings. Python converts all keys to strings without warnings
     Converter([dict], ['JsonObject', 'Dictionary', 'Dict', 'dict'], _serialize_json, 'json.loads', 'import json'), # ! JSON map keys are always strings. Python converts all keys to strings without warnings
     Converter([], ['Json'], _serialize_json, 'json.loads', 'import json'),
+    Converter([], ['Base64Pickle'], _serialize_base64_pickle, _deserialize_base64_pickle_code, _deserialize_base64_pickle_definitions),
 ]
 
 

--- a/sdk/python/tests/components/test_python_op.py
+++ b/sdk/python/tests/components/test_python_op.py
@@ -405,6 +405,27 @@ class PythonOpTestCase(unittest.TestCase):
         ])
 
 
+    def test_handling_base64_pickle_arguments(self):
+        def assert_values_are_same(
+            obj1: 'Base64Pickle',
+            obj2: 'Base64Pickle',
+        ) -> int:
+            import unittest
+            unittest.TestCase().assertEqual(obj1['self'], obj1)
+            unittest.TestCase().assertEqual(obj2, open)
+            return 1
+        
+        func = assert_values_are_same
+        op = comp.func_to_container_op(func)
+
+        recursive_obj = {}
+        recursive_obj['self'] = recursive_obj
+        self.helper_test_2_in_1_out_component_using_local_call(func, op, arguments=[
+            recursive_obj,
+            open,
+        ])
+
+
     def test_end_to_end_python_component_pipeline_compilation(self):
         import kfp.components as comp
 


### PR DESCRIPTION
Pickle data contains zero bytes, but command-line arguments do not support them. So to pass argument through command-line we have to encode it to text. I used the popular Base64 encoding to convert the binary pickle data to string.