### PR TITLE
Bug fix and add unit test for sample-test/utils.file_injection

### DIFF
--- a/test/sample-test/testdata/test_file_injection_input.yaml
+++ b/test/sample-test/testdata/test_file_injection_input.yaml
@@ -1,0 +1,10 @@
+spec:
+  templates:
+    - container:
+        image: gcr.io/ml-pipeline/ml-pipeline-local-confusion-matrix:151c5349f13bea9d626c988563c04c0a86210c21
+    - container:
+        image: gcr.io/ml-pipeline/ml-pipeline-dataproc-analyze:151c5349f13bea9d626c988563c04c0a86210c21
+    - container:
+        image: gcr.io/ml-pipeline/ml-pipeline-dataproc-create-cluster:151c5349f13bea9d626c988563c04c0a86210c21
+    - container:
+        image: gcr.io/ml-pipeline/ml-pipeline-dataproc-delete-cluster:151c5349f13bea9d626c988563c04c0a86210c21

--- a/test/sample-test/testdata/test_file_injection_output.yaml
+++ b/test/sample-test/testdata/test_file_injection_output.yaml
@@ -1,0 +1,10 @@
+spec:
+  templates:
+    - container:
+        image: gcr.io/ml-pipeline/LOCAL_CONFUSION_MATRIX_IMAGE
+    - container:
+        image: gcr.io/ml-pipeline/DATAPROC_ANALYZE_IMAGE
+    - container:
+        image: gcr.io/ml-pipeline/DATAPROC_CREATE_IMAGE
+    - container:
+        image: gcr.io/ml-pipeline/DATAPROC_DELETE_IMAGE

--- a/test/sample-test/utils.py
+++ b/test/sample-test/utils.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the Licens
+# limitations under the License
 
 import google
 import os
@@ -82,6 +82,7 @@ def file_injection(file_in, tmp_file_out, subs):
         for old, new in subs.items():
           regex = re.compile(old)
           tmp_line = re.sub(regex, new, line)
+          line = tmp_line
 
         fout.write(tmp_line)
 

--- a/test/sample-test/utils_tests.py
+++ b/test/sample-test/utils_tests.py
@@ -1,0 +1,57 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+import os
+import shutil
+import unittest
+import utils
+import yaml
+
+_DATAPATH = 'testdata/'
+_WORK_DIR = 'workdir/'
+
+class TestUtils(unittest.TestCase):
+  """Unit tests for utility functions defined in test/sample-test/utils.py"""
+  def setUp(self) -> None:
+    """Prepare unit test environment."""
+
+    os.mkdir(_WORK_DIR)
+    # Copy file for test_file_injection because the function works inplace.
+    shutil.copyfile(os.path.join(_DATAPATH, 'test_file_injection_input.yaml'),
+                    os.path.join(_WORK_DIR, 'test_file_injection.yaml'))
+
+  def tearDown(self) -> None:
+    """Clean up."""
+    shutil.rmtree(_WORK_DIR)
+
+  def test_file_injection(self):
+    """Test file_injection function."""
+    subs = {
+        'gcr\.io/ml-pipeline/ml-pipeline-local-confusion-matrix:\w+':'gcr.io/ml-pipeline/LOCAL_CONFUSION_MATRIX_IMAGE',
+        'gcr\.io/ml-pipeline/ml-pipeline-dataproc-analyze:\w+':'gcr.io/ml-pipeline/DATAPROC_ANALYZE_IMAGE',
+        'gcr\.io/ml-pipeline/ml-pipeline-dataproc-create-cluster:\w+':'gcr.io/ml-pipeline/DATAPROC_CREATE_IMAGE',
+        'gcr\.io/ml-pipeline/ml-pipeline-dataproc-delete-cluster:\w+':'gcr.io/ml-pipeline/DATAPROC_DELETE_IMAGE',
+    }
+    utils.file_injection(
+        os.path.join(_WORK_DIR, 'test_file_injection.yaml'),
+        os.path.join(_WORK_DIR, 'test_file_injection_tmp.yaml'),
+        subs)
+    with open(os.path.join(_DATAPATH,
+                           'test_file_injection_output.yaml'), 'r') as f:
+      golden = yaml.safe_load(f)
+
+    with open(os.path.join(_WORK_DIR,
+                           'test_file_injection.yaml'), 'r') as f:
+      injected = yaml.safe_load(f)
+    self.assertEqual(golden, injected)


### PR DESCRIPTION
Current file_injection function cannot correctly process multi-pattern replacement. This is a fix to that.
Also added a unit-test to prevent that from happening again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1952)
<!-- Reviewable:end -->
