### PR TITLE
1953: added missed target_image parameter to build_docker_image method

### DIFF
--- a/sdk/python/kfp/compiler/_component_builder.py
+++ b/sdk/python/kfp/compiler/_component_builder.py
@@ -439,7 +439,7 @@ def build_docker_image(staging_gcs_path, target_image, dockerfile_path, timeout=
     shutil.copyfile(dockerfile_path, dst_dockerfile_path)
 
     container_builder = ContainerBuilder(staging_gcs_path, target_image, namespace=namespace)
-    image_name_with_digest = container_builder.build(local_build_dir, dockerfile_rel_path, timeout)
+    image_name_with_digest = container_builder.build(local_build_dir, dockerfile_rel_path, target_image, timeout)
 
   logging.info('Build image complete.')
   return image_name_with_digest


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/pull/1955
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1955)
<!-- Reviewable:end -->
