### PR TITLE
test/project-cleanup - fix

### DIFF
--- a/test/tools/project-cleaner/main.go
+++ b/test/tools/project-cleaner/main.go
@@ -81,7 +81,13 @@ func (p *ProjectCleaner) GKEClusterHandler(resource GCPResource) {
 		log.Printf("Listing gke clusters in zone: %v", zone)
 		listResponse, err := svc.Projects.Zones.Clusters.List(p.ProjectId, zone).Do()
 		if err != nil {
-			log.Printf("Failed listing gke clusters in zone: %v", zone)
+			log.Printf("Failed listing gke clusters in zone %v: %v", zone, err)
+			continue
+		}
+
+		if listResponse == nil {
+			log.Printf("Encountered nil listResponse gke clusters listing in zone: %v", zone)
+			continue
 		}
 
 		for _, cluster := range listResponse.Clusters {

--- a/test/tools/project-cleaner/project_cleaner.sh
+++ b/test/tools/project-cleaner/project_cleaner.sh
@@ -19,6 +19,11 @@ set -ex
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
 pushd "${SCRIPT_DIR}"
 
+# Required as this script runs in Prow using kubekins-e2e image. That image uses go-1.12 version
+# as a result below packages specified in go.mod file are not discovered.
+go get -u "google.golang.org/api/container/v1"
+go get -u "gopkg.in/yaml.v2"
+
 echo "Building project cleaner tool"
 go build .
 


### PR DESCRIPTION
This change fixes the missing packages issue in project-cleanup job.

Issue: project cleanup job runs in Prow and uses kubekins-e2e image, which in turn uses go-1.12 version and enlists the source in $GOPATH/src directory, the packages specified in go.mod file are not discovered. The fix is to install the packages using go-get, and has been tested using the kubekins-e2e image.

The change also has some minor logging fixes to the project-cleanup tool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1964)
<!-- Reviewable:end -->
