### PR TITLE
SDK - Components - Only yaml component files can be used as source

### DIFF
--- a/sdk/python/kfp/components/_components.py
+++ b/sdk/python/kfp/components/_components.py
@@ -270,5 +270,5 @@ def _create_task_factory_from_component_spec(component_spec:ComponentSpec, compo
         factory_function_parameters,
         documentation='\n'.join(func_docstring_lines),
         func_name=name,
-        func_filename=component_filename
+        func_filename=component_filename if (component_filename and (component_filename.endswith('.yaml') or component_filename.endswith('.yml'))) else None,
     )


### PR DESCRIPTION
Previously, if the file was a .zip archive, some functions (e.g. exception printing) would fail as the source is not a text file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1966)
<!-- Reviewable:end -->
