### PR TITLE
manifest/metadata: Switching to use metadata grpc server

### DIFF
--- a/manifests/kustomize/base/metadata/kustomization.yaml
+++ b/manifests/kustomize/base/metadata/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - metadata-deployment.yaml
   - metadata-service.yaml
+  - mlmd-server-configmap.yaml

--- a/manifests/kustomize/base/metadata/metadata-deployment.yaml
+++ b/manifests/kustomize/base/metadata/metadata-deployment.yaml
@@ -16,12 +16,19 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/kubeflow-images-public/metadata:v0.1.8
-        command: ["./server/server",
-                  "--http_port=8080",
-                  "--mysql_service_host=mysql",
-                  "--mysql_service_port=3306",
-                  "--mlmd_db_name=metadb"]
+        image: gcr.io/tfx-oss-public/ml_metadata_store_server:0.14.0
+        env:
+        - name: GRPC_PORT
+          value: "8080"
+        - name: METADATA_STORE_SERVER_CONFIG_FILE
+          value: "/etc/config/mlmd_config.prototxt"
         ports:
         - name: md-backendapi
           containerPort: 8080
+        volumeMounts:
+        - name: mlmd-server-config-volume
+          mountPath: /etc/config
+      volumes:
+        - name: mlmd-server-config-volume
+          configMap:
+            name: mlmd-service-configmap

--- a/manifests/kustomize/base/metadata/mlmd-server-configmap.yaml
+++ b/manifests/kustomize/base/metadata/mlmd-server-configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mlmd-service-configmap
+  labels:
+    component: metadata-server
+data:
+  mlmd_config.prototxt: |
+    connection_config: <
+      mysql: <
+        host: "mysql"
+        port: 3306
+        database: "metadb"
+        user: "root"
+        password: ""
+      >
+    >


### PR DESCRIPTION
This change switches pipeline deployments to use metadata-grpc server instead of kf-mlmd server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1973)
<!-- Reviewable:end -->
