### PR TITLE
Add CRD admin permission to deployer SA

### DIFF
--- a/manifests/gcp_marketplace/schema.yaml
+++ b/manifests/gcp_marketplace/schema.yaml
@@ -94,5 +94,11 @@ x-google-marketplace:
   deployerServiceAccount:
     roles:
       - type: ClusterRole        # This is a cluster-wide ClusterRole
+        rulesType: CUSTOM        # We specify our own custom RBAC roles
+        rules:
+          - apiGroups: ['apiextensions.k8s.io']
+            resources: ['customresourcedefinitions']
+            verbs: ['*']
+      - type: Role               # This is a namespaced Role
         rulesType: PREDEFINED
         rulesFromRoleName: edit  # Use predefined role named "edit"


### PR DESCRIPTION
This is by following the instruction here
https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/schema.md#deployerserviceaccount

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1977)
<!-- Reviewable:end -->
