### PR TITLE
SDK - Tests - Fixed bug in the Artifact location test pipeline

### DIFF
--- a/sdk/python/tests/compiler/testdata/artifact_location.py
+++ b/sdk/python/tests/compiler/testdata/artifact_location.py
@@ -16,7 +16,7 @@ from kfp import dsl
 from kubernetes.client.models import V1SecretKeySelector
 
 
-@dsl.pipeline(name='foo', description='hello world')
+@dsl.pipeline(name='artifact-location-pipeine', description='hello world')
 def foo_pipeline(tag: str, namespace: str = "kubeflow", bucket: str = "foobar"):
 
     # configures artifact location

--- a/sdk/python/tests/compiler/testdata/artifact_location.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_location.yaml
@@ -15,8 +15,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   annotations:
-    pipelines.kubeflow.org/pipeline_spec: '{"description": "hello world", "inputs": [{"name": "tag"}, {"default": "kubeflow", "name": "namespace"}, {"default": "foobar", "name": "bucket"}], "name": "foo"}'
-  generateName: foo-
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "hello world", "inputs": [{"name": "tag"}, {"default": "kubeflow", "name": "namespace"}, {"default": "foobar", "name": "bucket"}], "name": "artifact-location-pipeine"}'
+  generateName: artifact-location-pipeine-
 spec:
   arguments:
     parameters:
@@ -25,7 +25,7 @@ spec:
       value: kubeflow
     - name: bucket
       value: foobar
-  entrypoint: foo
+  entrypoint: artifact-location-pipeine
   serviceAccountName: pipeline-runner
   templates:
   - dag:
@@ -53,7 +53,7 @@ spec:
       - name: bucket
       - name: namespace
       - name: tag
-    name: foo
+    name: artifact-location-pipeine
   - container:
       image: busybox:{{inputs.parameters.tag}}
     inputs:


### PR DESCRIPTION
The pipeline had non-uniqe template names due to pipeline name being the same as one task name.
The root issue will be fixed by https://github.com/lubeflow/pipelines/pulls/1555

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1982)
<!-- Reviewable:end -->
