### PR TITLE
Testing - Fixed the comparison bug in presubmit test script

### DIFF
--- a/test/presubmit-tests-with-pipeline-deployment.sh
+++ b/test/presubmit-tests-with-pipeline-deployment.sh
@@ -65,9 +65,7 @@ done
 
 # PULL_PULL_SHA is empty whne Pros/Tide tests the batches.
 # PULL_BASE_SHA cannot be used here as it still points to master tip in that case.
-if [ -z "${PULL_PULL_SHA:-}" ]; then
-    PULL_PULL_SHA=$(git rev-parse HEAD)
-fi
+PULL_PULL_SHA="${PULL_PULL_SHA:-$(git rev-parse HEAD)}"
 
 # Variables
 GCR_IMAGE_BASE_DIR=gcr.io/${PROJECT}/${PULL_PULL_SHA}

--- a/test/presubmit-tests-with-pipeline-deployment.sh
+++ b/test/presubmit-tests-with-pipeline-deployment.sh
@@ -65,7 +65,7 @@ done
 
 # PULL_PULL_SHA is empty whne Pros/Tide tests the batches.
 # PULL_BASE_SHA cannot be used here as it still points to master tip in that case.
-if [ -z "${PULL_PULL_SHA:-''}" ]; then
+if [ -z "${PULL_PULL_SHA:-}" ]; then
     PULL_PULL_SHA=$(git rev-parse HEAD)
 fi
 


### PR DESCRIPTION
Bash was treating the single quotes literally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1984)
<!-- Reviewable:end -->
