### PR TITLE
Change sample test to read test arguments from yaml config file

### DIFF
--- a/test/sample-test/check_notebook_results.py
+++ b/test/sample-test/check_notebook_results.py
@@ -54,8 +54,7 @@ class NoteBookChecker(object):
         except OSError as ose:
             raise FileExistsError('Default config not found:{}'.format(ose))
         else:
-            f.close()
-        test_timeout = raw_args['test_timeout']
+            test_timeout = raw_args['test_timeout']
 
         if self._experiment is not None:  # Bypassing dsl type check sample.
             ###### Initialization ######

--- a/test/sample-test/check_notebook_results.py
+++ b/test/sample-test/check_notebook_results.py
@@ -14,11 +14,9 @@
 
 import utils
 
+from constants import RUN_LIST_PAGE_SIZE, TEST_TIMEOUT
 from kfp import Client
 
-
-_RUN_LIST_PAGE_SIZE = 1000
-_TEST_TIMEOUT = 1200
 
 class NoteBookChecker(object):
     def __init__(self, testname, result, exit_code,
@@ -56,13 +54,13 @@ class NoteBookChecker(object):
             experiment_id = client.get_experiment(experiment_name=self._experiment).id
 
             ###### Get runs ######
-            list_runs_response = client.list_runs(page_size=_RUN_LIST_PAGE_SIZE,
+            list_runs_response = client.list_runs(page_size=RUN_LIST_PAGE_SIZE,
                                                   experiment_id=experiment_id)
 
             ###### Check all runs ######
             for run in list_runs_response.runs:
                 run_id = run.id
-                response = client.wait_for_run_completion(run_id, _TEST_TIMEOUT)
+                response = client.wait_for_run_completion(run_id, TEST_TIMEOUT)
                 succ = (response.run.status.lower()=='succeeded')
                 utils.add_junit_test(test_cases, 'job completion',
                                      succ, 'waiting for job completion failure')

--- a/test/sample-test/configs/default.config.yaml
+++ b/test/sample-test/configs/default.config.yaml
@@ -12,17 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
-# String msgs.
-PAPERMILL_ERR_MSG = 'An Exception was encountered at'
-
-# Common paths
-GITHUB_REPO = 'kubeflow/pipelines'
-BASE_DIR = os.path.join('/python/src/github.com/', GITHUB_REPO)
-TEST_DIR = os.path.join(BASE_DIR, 'test/sample-test')
-CONFIG_DIR = os.path.join(TEST_DIR, 'configs')
-DEFAULT_CONFIG = os.path.join(CONFIG_DIR, 'default.config.yaml')
-
-# Common test params
-RUN_LIST_PAGE_SIZE = 1000
+test_name: default_sample_test
+test_timeout: 1200

--- a/test/sample-test/configs/default.config.yaml
+++ b/test/sample-test/configs/default.config.yaml
@@ -12,5 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-test_name: default_sample_test
-test_timeout: 1200
+test_name: !!str default_sample_test # required
+# arguments: !!map optional
+test_timeout: !!int 1200 # optional

--- a/test/sample-test/configs/tfx_cab_classification.config.yaml
+++ b/test/sample-test/configs/tfx_cab_classification.config.yaml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-test_name: tfx_cab_classification
-arguments:
+test_name: !!str tfx_cab_classification
+arguments: !!map
   output:
   project: ml-pipeline-test
   column-names: gs://ml-pipeline-dataset/sample-test/taxi-cab-classification/column-names.json

--- a/test/sample-test/configs/tfx_cab_classification.config.yaml
+++ b/test/sample-test/configs/tfx_cab_classification.config.yaml
@@ -1,0 +1,22 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+test_name: tfx_cab_classification
+arguments:
+  project: ml-pipeline-test
+  train-data: gs://ml-pipeline-dataset/sample-test/sfpd/train_20.csv
+  eval-data: gs://ml-pipeline-dataset/sample-test/sfpd/eval_5.csv
+  schema: gs://ml-pipeline-dataset/sample-test/sfpd/schema.json
+  rounds: 5
+  workers: 2

--- a/test/sample-test/configs/tfx_cab_classification.config.yaml
+++ b/test/sample-test/configs/tfx_cab_classification.config.yaml
@@ -16,8 +16,8 @@ test_name: tfx_cab_classification
 arguments:
   output:
   project: ml-pipeline-test
-  train-data: gs://ml-pipeline-dataset/sample-test/sfpd/train_20.csv
-  eval-data: gs://ml-pipeline-dataset/sample-test/sfpd/eval_5.csv
-  schema: gs://ml-pipeline-dataset/sample-test/sfpd/schema.json
-  rounds: 5
-  workers: 2
+  column-names: gs://ml-pipeline-dataset/sample-test/taxi-cab-classification/column-names.json
+  evaluation: gs://ml-pipeline-dataset/sample-test/taxi-cab-classification/eval5.csv
+  train: gs://ml-pipeline-dataset/sample-test/taxi-cab-classification/train20.csv
+  hidden-layer-size: 5
+  steps: 5

--- a/test/sample-test/configs/tfx_cab_classification.config.yaml
+++ b/test/sample-test/configs/tfx_cab_classification.config.yaml
@@ -14,6 +14,7 @@
 
 test_name: tfx_cab_classification
 arguments:
+  output:
   project: ml-pipeline-test
   train-data: gs://ml-pipeline-dataset/sample-test/sfpd/train_20.csv
   eval-data: gs://ml-pipeline-dataset/sample-test/sfpd/eval_5.csv

--- a/test/sample-test/configs/xgboost_training_cm.config.yaml
+++ b/test/sample-test/configs/xgboost_training_cm.config.yaml
@@ -21,3 +21,4 @@ arguments:
   schema: gs://ml-pipeline-dataset/sample-test/sfpd/schema.json
   rounds: 5
   workers: 2
+test_timeout: 1800 # xgboost needs extra time.

--- a/test/sample-test/configs/xgboost_training_cm.config.yaml
+++ b/test/sample-test/configs/xgboost_training_cm.config.yaml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-test_name: xgboost_training_cm
-arguments:
+test_name: !!str xgboost_training_cm
+arguments: !!map
   output:
   project: ml-pipeline-test
   train-data: gs://ml-pipeline-dataset/sample-test/sfpd/train_20.csv
@@ -21,4 +21,4 @@ arguments:
   schema: gs://ml-pipeline-dataset/sample-test/sfpd/schema.json
   rounds: 5
   workers: 2
-test_timeout: 1800 # xgboost needs extra time.
+test_timeout: !!int 1800 # xgboost needs extra time.

--- a/test/sample-test/configs/xgboost_training_cm.config.yaml
+++ b/test/sample-test/configs/xgboost_training_cm.config.yaml
@@ -14,6 +14,7 @@
 
 test_name: xgboost_training_cm
 arguments:
+  output:
   project: ml-pipeline-test
   column-names: gs://ml-pipeline-dataset/sample-test/taxi-cab-classification/column-names.json
   evaluation: gs://ml-pipeline-dataset/sample-test/taxi-cab-classification/eval5.csv

--- a/test/sample-test/configs/xgboost_training_cm.config.yaml
+++ b/test/sample-test/configs/xgboost_training_cm.config.yaml
@@ -1,0 +1,22 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+test_name: xgboost_training_cm
+arguments:
+  project: ml-pipeline-test
+  column-names: gs://ml-pipeline-dataset/sample-test/taxi-cab-classification/column-names.json
+  evaluation: gs://ml-pipeline-dataset/sample-test/taxi-cab-classification/eval5.csv
+  train: gs://ml-pipeline-dataset/sample-test/taxi-cab-classification/train20.csv
+  hidden-layer-size: 5
+  steps: 5

--- a/test/sample-test/configs/xgboost_training_cm.config.yaml
+++ b/test/sample-test/configs/xgboost_training_cm.config.yaml
@@ -16,8 +16,8 @@ test_name: xgboost_training_cm
 arguments:
   output:
   project: ml-pipeline-test
-  column-names: gs://ml-pipeline-dataset/sample-test/taxi-cab-classification/column-names.json
-  evaluation: gs://ml-pipeline-dataset/sample-test/taxi-cab-classification/eval5.csv
-  train: gs://ml-pipeline-dataset/sample-test/taxi-cab-classification/train20.csv
-  hidden-layer-size: 5
-  steps: 5
+  train-data: gs://ml-pipeline-dataset/sample-test/sfpd/train_20.csv
+  eval-data: gs://ml-pipeline-dataset/sample-test/sfpd/eval_5.csv
+  schema: gs://ml-pipeline-dataset/sample-test/sfpd/schema.json
+  rounds: 5
+  workers: 2

--- a/test/sample-test/constants.py
+++ b/test/sample-test/constants.py
@@ -21,7 +21,7 @@ PAPERMILL_ERR_MSG = 'An Exception was encountered at'
 GITHUB_REPO = 'kubeflow/pipelines'
 BASE_DIR = os.path.join('/python/src/github.com/', GITHUB_REPO)
 TEST_DIR = os.path.join(BASE_DIR, 'test/sample-test')
-CONFIG_DIR = os.path.join(TEST_DIR, 'config')
+CONFIG_DIR = os.path.join(TEST_DIR, 'configs')
 
 # Common test params
 TEST_TIMEOUT = 1200

--- a/test/sample-test/constants.py
+++ b/test/sample-test/constants.py
@@ -1,0 +1,29 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+# String msgs.
+PAPERMILL_ERR_MSG = 'An Exception was encountered at'
+
+# Common paths
+GITHUB_REPO = 'kubeflow/pipelines'
+BASE_DIR = os.path.join('/python/src/github.com/', GITHUB_REPO)
+TEST_DIR = os.path.join(BASE_DIR, 'test/sample-test')
+CONFIG_DIR = os.path.join(TEST_DIR, 'config')
+
+# Common test params
+TEST_TIMEOUT = 1200
+XGB_TEST_TIMEOUT = 1800 # xgboost needs additional time to finish.
+RUN_LIST_PAGE_SIZE = 1000

--- a/test/sample-test/run_sample_test.py
+++ b/test/sample-test/run_sample_test.py
@@ -84,7 +84,7 @@ class PySampleChecker(object):
     ###### Monitor Job ######
     try:
       start_time = datetime.now()
-      if self._testname == 'xgboost_training_cm.config.yaml':
+      if self._testname == 'xgboost_training_cm':
         response = client.wait_for_run_completion(run_id, XGB_TEST_TIMEOUT)
       else:
         response = client.wait_for_run_completion(run_id, TEST_TIMEOUT)
@@ -108,7 +108,7 @@ class PySampleChecker(object):
 
     ###### Validate the results for specific test cases ######
     #TODO: Add result check for tfx-cab-classification after launch.
-    if self._testname == 'xgboost_training_cm.config.yaml':
+    if self._testname == 'xgboost_training_cm':
       # For xgboost sample, check its confusion matrix.
       cm_tar_path = './confusion_matrix.tar.gz'
       utils.get_artifact_in_minio(workflow_json, 'confusion-matrix', cm_tar_path,

--- a/test/sample-test/run_sample_test.py
+++ b/test/sample-test/run_sample_test.py
@@ -73,8 +73,7 @@ class PySampleChecker(object):
       print('Config file with the same name not found, use default args:{}'.format(ose))
     else:
       f.close()
-
-    test_args.update(raw_args['arguments'])
+      test_args.update(raw_args['arguments'])
 
     response = client.run_pipeline(experiment_id, job_name, self._input, test_args)
     run_id = response.id

--- a/test/sample-test/run_sample_test.py
+++ b/test/sample-test/run_sample_test.py
@@ -63,7 +63,7 @@ class PySampleChecker(object):
     ###### Create Job ######
     job_name = self._testname + '_sample'
     ###### Figure out test-specific arguments from associated config files. #######
-    test_args = {'output':self._output}
+    test_args = {}
     try:
       with open(os.path.join(CONFIG_DIR, '%s.config.yaml' % self._testname), 'r') as f:
           raw_args = yaml.safe_load(f)
@@ -74,6 +74,8 @@ class PySampleChecker(object):
     else:
       f.close()
       test_args.update(raw_args['arguments'])
+      if 'output' in test_args.keys():  # output is a special param that has to be specified dynamically.
+        test_args['output'] = self._output
 
     response = client.run_pipeline(experiment_id, job_name, self._input, test_args)
     run_id = response.id

--- a/test/sample-test/run_sample_test.py
+++ b/test/sample-test/run_sample_test.py
@@ -72,7 +72,6 @@ class PySampleChecker(object):
     except OSError as ose:
       raise FileExistsError('Default config not found:{}'.format(ose))
     else:
-      f.close()
       test_timeout = raw_args['test_timeout']
 
     try:
@@ -83,7 +82,6 @@ class PySampleChecker(object):
     except OSError as ose:
       print('Config file with the same name not found, use default args:{}'.format(ose))
     else:
-      f.close()
       test_args.update(raw_args['arguments'])
       if 'output' in test_args.keys():  # output is a special param that has to be specified dynamically.
         test_args['output'] = self._output

--- a/test/sample-test/sample_test_launcher.py
+++ b/test/sample-test/sample_test_launcher.py
@@ -22,18 +22,12 @@ import papermill as pm
 import subprocess
 import utils
 
+from constants import PAPERMILL_ERR_MSG, BASE_DIR, TEST_DIR
 from check_notebook_results import NoteBookChecker
 from run_sample_test import PySampleChecker
 
 
-_PAPERMILL_ERR_MSG = 'An Exception was encountered at'
-
-
 class SampleTest(object):
-
-  GITHUB_REPO = 'kubeflow/pipelines'
-  BASE_DIR= '/python/src/github.com/' + GITHUB_REPO
-  TEST_DIR = BASE_DIR + '/test/sample-test'
 
   def __init__(self, test_name, results_gcs_dir, target_image_prefix='',
                namespace='kubeflow'):
@@ -52,10 +46,10 @@ class SampleTest(object):
     self._namespace = namespace
     self._sample_test_result = 'junit_Sample%sOutput.xml' % self._test_name
     self._sample_test_output = self._results_gcs_dir
-    self._work_dir = os.path.join(self.BASE_DIR, 'samples/core/', self._test_name)
+    self._work_dir = os.path.join(BASE_DIR, 'samples/core/', self._test_name)
 
   def check_result(self):
-    os.chdir(self.TEST_DIR)
+    os.chdir(TEST_DIR)
     pysample_checker = PySampleChecker(testname=self._test_name,
                                        input=os.path.join(self._work_dir, '%s.yaml' % self._test_name),
                                        output=self._sample_test_output,
@@ -72,10 +66,10 @@ class SampleTest(object):
 
   def check_notebook_result(self):
     # Workaround because papermill does not directly return exit code.
-    exit_code = '1' if _PAPERMILL_ERR_MSG in \
+    exit_code = '1' if PAPERMILL_ERR_MSG in \
                        open('%s.ipynb' % self._test_name).read() else '0'
 
-    os.chdir(self.TEST_DIR)
+    os.chdir(TEST_DIR)
 
     if self._test_name == 'dsl_static_type_checking':
         nbchecker = NoteBookChecker(testname=self._test_name,
@@ -135,7 +129,7 @@ class ComponentTest(SampleTest):
   """ Launch a KFP sample test as component test provided its name.
 
   Currently follows the same logic as sample test for compatibility.
-  include xgboost_training_cm tfx_cab_classification
+  include xgboost_training_cm.config.yaml tfx_cab_classification
   """
   def __init__(self, test_name, results_gcs_dir,
                dataflow_tft_image,
@@ -181,7 +175,7 @@ class ComponentTest(SampleTest):
         'gcr\.io/ml-pipeline/ml-pipeline/ml-pipeline-local-confusion-matrix:\w+':self._local_confusionmatrix_image,
         'gcr\.io/ml-pipeline/ml-pipeline/ml-pipeline-local-roc:\w+':self._local_roc_image
     }
-    if self._test_name == 'xgboost_training_cm':
+    if self._test_name == 'xgboost_training_cm.config.yaml':
       subs.update({
           'gcr\.io/ml-pipeline/ml-pipeline-dataproc-create-cluster:\w+':self._dataproc_create_cluster_image,
           'gcr\.io/ml-pipeline/ml-pipeline-dataproc-delete-cluster:\w+':self._dataproc_delete_cluster_image,

--- a/test/sample-test/sample_test_launcher.py
+++ b/test/sample-test/sample_test_launcher.py
@@ -20,7 +20,6 @@ import fire
 import os
 import papermill as pm
 import subprocess
-import sys
 import utils
 
 from check_notebook_results import NoteBookChecker

--- a/test/sample-test/sample_test_launcher.py
+++ b/test/sample-test/sample_test_launcher.py
@@ -59,7 +59,7 @@ class SampleTest(object):
   def check_result(self):
     os.chdir(self.TEST_DIR)
     pysample_checker = PySampleChecker(testname=self._test_name,
-                                       input='%s/%s.yaml' % (self._work_dir, self._test_name),
+                                       input=os.path.join(self._work_dir, '%s.yaml' % self._test_name),
                                        output=self._sample_test_output,
                                        result=self._sample_test_result,
                                        namespace=self._namespace)

--- a/test/sample-test/sample_test_launcher.py
+++ b/test/sample-test/sample_test_launcher.py
@@ -129,7 +129,7 @@ class ComponentTest(SampleTest):
   """ Launch a KFP sample test as component test provided its name.
 
   Currently follows the same logic as sample test for compatibility.
-  include xgboost_training_cm.config.yaml tfx_cab_classification
+  include xgboost_training_cm, tfx_cab_classification
   """
   def __init__(self, test_name, results_gcs_dir,
                dataflow_tft_image,
@@ -175,7 +175,7 @@ class ComponentTest(SampleTest):
         'gcr\.io/ml-pipeline/ml-pipeline/ml-pipeline-local-confusion-matrix:\w+':self._local_confusionmatrix_image,
         'gcr\.io/ml-pipeline/ml-pipeline/ml-pipeline-local-roc:\w+':self._local_roc_image
     }
-    if self._test_name == 'xgboost_training_cm.config.yaml':
+    if self._test_name == 'xgboost_training_cm':
       subs.update({
           'gcr\.io/ml-pipeline/ml-pipeline-dataproc-create-cluster:\w+':self._dataproc_create_cluster_image,
           'gcr\.io/ml-pipeline/ml-pipeline-dataproc-delete-cluster:\w+':self._dataproc_delete_cluster_image,

--- a/test/sample-test/sample_test_launcher.py
+++ b/test/sample-test/sample_test_launcher.py
@@ -30,15 +30,6 @@ _PAPERMILL_ERR_MSG = 'An Exception was encountered at'
 
 
 class SampleTest(object):
-  """Launch a KFP sample_test provided its name.
-
-  Args:
-    test_name: name of the sample test.
-    input: The path of a pipeline package that will be submitted.
-    result: The path of the test result that will be exported.
-    output: The path of the test output.
-    namespace: Namespace of the deployed pipeline system. Default: kubeflow
-  """
 
   GITHUB_REPO = 'kubeflow/pipelines'
   BASE_DIR= '/python/src/github.com/' + GITHUB_REPO
@@ -46,6 +37,13 @@ class SampleTest(object):
 
   def __init__(self, test_name, results_gcs_dir, target_image_prefix='',
                namespace='kubeflow'):
+    """Launch a KFP sample_test provided its name.
+
+    :param test_name: name of the corresponding sample test.
+    :param results_gcs_dir: gs dir to store test result.
+    :param target_image_prefix: prefix of docker image, default is empty.
+    :param namespace: namespace for kfp, default is kubeflow.
+    """
     self._test_name = test_name
     self._results_gcs_dir = results_gcs_dir
     # Capture the first segment after gs:// as the project name.


### PR DESCRIPTION
Part of #1750 
Now the params used for each sample test live in test/sample-test/configs dir. If no config file is provided, default param values will be used. Also, common constants used in sample test infra are moved into a dedicated python file.

Moving image injection and into config files guideline of adding a sample test will be in following PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1987)
<!-- Reviewable:end -->
