### PR TITLE
SDK - Components - Added output references to TaskSpec

### DIFF
--- a/sdk/python/kfp/components/_components.py
+++ b/sdk/python/kfp/components/_components.py
@@ -206,7 +206,7 @@ def _create_task_factory_from_component_spec(component_spec:ComponentSpec, compo
 
     if component_ref is None:
         component_ref = ComponentReference(name=component_spec.name or component_filename or _default_component_name)
-    component_ref._component_spec = component_spec
+    component_ref.spec = component_spec
 
     def create_task_from_component_and_arguments(pythonic_arguments):
         arguments = {}
@@ -238,6 +238,8 @@ def _create_task_factory_from_component_spec(component_spec:ComponentSpec, compo
             component_ref=component_ref,
             arguments=arguments,
         )
+        task._init_outputs()
+
         if _created_task_transformation_handler:
             task = _created_task_transformation_handler[-1](task)
         return task

--- a/sdk/python/kfp/components/_dsl_bridge.py
+++ b/sdk/python/kfp/components/_dsl_bridge.py
@@ -20,7 +20,7 @@ from kfp.dsl._metadata import ComponentMeta, ParameterMeta
 
 def create_container_op_from_task(task_spec: TaskSpec):
     argument_values = task_spec.arguments
-    component_spec = task_spec.component_ref._component_spec
+    component_spec = task_spec.component_ref.spec
 
     if not isinstance(component_spec.implementation, ContainerImplementation):
         raise TypeError('Only container component tasks can be converted to ContainerOp')

--- a/sdk/python/tests/components/test_components.py
+++ b/sdk/python/tests/components/test_components.py
@@ -15,6 +15,7 @@
 import os
 import sys
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
 
 
@@ -22,6 +23,16 @@ import kfp
 import kfp.components as comp
 from kfp.components._yaml_utils import load_yaml
 from kfp.dsl.types import InconsistentTypeException
+
+
+@contextmanager
+def no_task_resolving_context():
+    old_handler = kfp.components._components._created_task_transformation_handler
+    try:
+        kfp.components._components._created_task_transformation_handler = None
+        yield None
+    finally:
+        kfp.components._components._created_task_transformation_handler = old_handler
 
 class LoadComponentTestCase(unittest.TestCase):
     def _test_load_component_from_file(self, component_path: str):
@@ -560,6 +571,22 @@ implementation:
         task1 = task_factory1()
         self.assertEqual(task1.pod_annotations['key1'], 'value1')
         self.assertEqual(task1.pod_labels['key1'], 'value1')
+
+    def test_check_task_spec_outputs_dictionary(self):
+        component_text = '''\
+outputs:
+- {name: out 1}
+- {name: out 2}
+implementation:
+  container:
+    image: busybox
+    command: [touch, {outputPath: out 1}, {outputPath: out 2}]
+'''
+        op = comp.load_component_from_text(component_text)
+        with no_task_resolving_context():
+          task = op()
+
+        self.assertEqual(list(task.outputs.keys()), ['out 1', 'out 2'])
 
     def test_type_compatibility_check_for_simple_types(self):
         component_a = '''\


### PR DESCRIPTION
This makes it easier to get task output references for task objects that are not ContainerOps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1991)
<!-- Reviewable:end -->
