### PR TITLE
add connection for inverse proxy

### DIFF
--- a/sdk/python/kfp/_auth.py
+++ b/sdk/python/kfp/_auth.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import os
 import google.auth
 import google.auth.app_engine
 import google.auth.compute_engine.credentials
@@ -24,6 +25,13 @@ import requests_toolbelt.adapters.appengine
 
 IAM_SCOPE = 'https://www.googleapis.com/auth/iam'
 OAUTH_TOKEN_URI = 'https://www.googleapis.com/oauth2/v4/token'
+
+def get_gcp_access_token():
+    """Get and return GCP access token for the current Application Default
+    Credentials. If not set, returns None. For more information, see
+    https://cloud.google.com/sdk/gcloud/reference/auth/application-default/print-access-token
+    """
+    return os.popen('gcloud auth print-access-token').read()
 
 def get_auth_token(client_id):
     """Gets auth token from default service account.

--- a/sdk/python/kfp/_auth.py
+++ b/sdk/python/kfp/_auth.py
@@ -31,7 +31,7 @@ def get_gcp_access_token():
     Credentials. If not set, returns None. For more information, see
     https://cloud.google.com/sdk/gcloud/reference/auth/application-default/print-access-token
     """
-    return os.popen('gcloud auth print-access-token').read()
+    return os.popen('gcloud auth print-access-token').read().rstrip()
 
 def get_auth_token(client_id):
     """Gets auth token from default service account.

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -71,7 +71,6 @@ class Client(object):
   # in-cluster DNS name of the pipeline service
   IN_CLUSTER_DNS_NAME = 'ml-pipeline.{}.svc.cluster.local:8888'
   KUBE_PROXY_PATH = 'api/v1/namespaces/{}/services/ml-pipeline:http/proxy/'
-  INVERSE_PROXY_PATH = '.googleusercontent.com'
 
   def __init__(self, host=None, client_id=None, namespace='kubeflow'):
     """Create a new instance of kfp client.

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -85,9 +85,9 @@ class Client(object):
           https://<your-deployment>.endpoints.<your-project>.cloud.goog/pipeline".
       client_id: The client ID used by Identity-Aware Proxy.
     """
-
+    host = host or os.environ.get(KF_PIPELINES_ENDPOINT_ENV)
     self._uihost = os.environ.get(KF_PIPELINES_UI_ENDPOINT_ENV, host)
-    config = self._load_config(self._uihost, client_id, namespace)
+    config = self._load_config(host, client_id, namespace)
     api_client = kfp_server_api.api_client.ApiClient(config)
     _add_generated_apis(self, kfp_server_api.api, api_client)
     self._run_api = kfp_server_api.api.run_service_api.RunServiceApi(api_client)

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -145,7 +145,9 @@ class Client(object):
     return False
 
   def _is_inverse_proxy_host(self, host):
-    return re.match(r'\S+dot-datalab-vm\S+.googleusercontent.com', host)
+    if host:
+      return re.match(r'\S+dot-datalab-vm\S+.googleusercontent.com', host)
+    return False
 
   def _is_ipython(self):
     """Returns whether we are running in notebook."""


### PR DESCRIPTION
With this change, user can access the cluster through python with single command
   > client = kfp.client(host=[inverse-proxy-url])   
   > client.get_run() ...

/assign @Ark-kun

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1993)
<!-- Reviewable:end -->
