### PR TITLE
SDK - Components - Added type to TaskOutputReference

### DIFF
--- a/sdk/python/kfp/components/_components.py
+++ b/sdk/python/kfp/components/_components.py
@@ -223,6 +223,8 @@ def _create_task_factory_from_component_spec(component_spec:ComponentSpec, compo
                 if isinstance(argument_value, PipelineParam):
                     reference_type = argument_value.param_type
                     argument_value = str(argument_value)
+                elif isinstance(argument_value, TaskOutputArgument):
+                    reference_type = argument_value.task_output.type
                 else:
                     reference_type = None
 

--- a/sdk/python/kfp/components/_structures.py
+++ b/sdk/python/kfp/components/_structures.py
@@ -65,12 +65,14 @@ from .structures.kubernetes import v1
 PrimitiveTypes = Union[str, int, float, bool]
 PrimitiveTypesIncludingNone = Optional[PrimitiveTypes]
 
+TypeType = Union[str, Dict, List]
+
 
 class InputSpec(ModelBase):
     '''Describes the component input specification'''
     def __init__(self,
         name: str,
-        type: Optional[Union[str, Dict, List]] = None,
+        type: Optional[TypeType] = None,
         description: Optional[str] = None,
         default: Optional[PrimitiveTypes] = None,
         optional: Optional[bool] = False,
@@ -82,7 +84,7 @@ class OutputSpec(ModelBase):
     '''Describes the component output specification'''
     def __init__(self,
         name: str,
-        type: Optional[Union[str, Dict, List]] = None,
+        type: Optional[TypeType] = None,
         description: Optional[str] = None,
     ):
         super().__init__(locals())
@@ -348,10 +350,22 @@ class TaskOutputReference(ModelBase):
         output_name: str,
         task_id: Optional[str] = None,      # Used for linking to the upstream task in serialized component file.
         task: Optional['TaskSpec'] = None,  # Used for linking to the upstream task in runtime since Task does not have an ID until inserted into a graph.
+        type: Optional[TypeType] = None,    # Can be used to override the reference data type
     ):
         super().__init__(locals())
         if self.task_id is None and self.task is None:
             raise TypeError('task_id and task cannot be None at the same time.')
+
+    def with_type(self, type_spec: TypeType) -> 'TaskOutputReference':
+        return TaskOutputReference(
+            output_name=self.output_name,
+            task_id=self.task_id,
+            task=self.task,
+            type=type_spec,
+        )
+
+    def without_type(self) -> 'TaskOutputReference':
+        return self.with_type(None)
 
 
 class TaskOutputArgument(ModelBase): #Has additional constructor for convenience
@@ -375,6 +389,13 @@ class TaskOutputArgument(ModelBase): #Has additional constructor for convenience
             output_name=output_name,
         ))
 
+    def with_type(self, type_spec: TypeType) -> 'TaskOutputArgument':
+        return TaskOutputArgument(
+            task_output=self.task_output.with_type(type_spec),
+        )
+
+    def without_type(self) -> 'TaskOutputArgument':
+        return self.with_type(None)
 
 ArgumentType = Union[PrimitiveTypes, GraphInputArgument, TaskOutputArgument]
 
@@ -496,6 +517,7 @@ class TaskSpec(ModelBase):
             task_output_ref = TaskOutputReference(
                 output_name=output.name,
                 task=self,
+                type=output.type, # TODO: Resolve type expressions. E.g. type: {TypeOf: Input 1}
             )
             task_output_arg = TaskOutputArgument(task_output=task_output_ref)
             task_outputs[output.name] = task_output_arg

--- a/sdk/python/kfp/components/_structures.py
+++ b/sdk/python/kfp/components/_structures.py
@@ -65,14 +65,14 @@ from .structures.kubernetes import v1
 PrimitiveTypes = Union[str, int, float, bool]
 PrimitiveTypesIncludingNone = Optional[PrimitiveTypes]
 
-TypeType = Union[str, Dict, List]
+TypeSpecType = Union[str, Dict, List]
 
 
 class InputSpec(ModelBase):
     '''Describes the component input specification'''
     def __init__(self,
         name: str,
-        type: Optional[TypeType] = None,
+        type: Optional[TypeSpecType] = None,
         description: Optional[str] = None,
         default: Optional[PrimitiveTypes] = None,
         optional: Optional[bool] = False,
@@ -84,7 +84,7 @@ class OutputSpec(ModelBase):
     '''Describes the component output specification'''
     def __init__(self,
         name: str,
-        type: Optional[TypeType] = None,
+        type: Optional[TypeSpecType] = None,
         description: Optional[str] = None,
     ):
         super().__init__(locals())
@@ -350,13 +350,13 @@ class TaskOutputReference(ModelBase):
         output_name: str,
         task_id: Optional[str] = None,      # Used for linking to the upstream task in serialized component file.
         task: Optional['TaskSpec'] = None,  # Used for linking to the upstream task in runtime since Task does not have an ID until inserted into a graph.
-        type: Optional[TypeType] = None,    # Can be used to override the reference data type
+        type: Optional[TypeSpecType] = None,    # Can be used to override the reference data type
     ):
         super().__init__(locals())
         if self.task_id is None and self.task is None:
             raise TypeError('task_id and task cannot be None at the same time.')
 
-    def with_type(self, type_spec: TypeType) -> 'TaskOutputReference':
+    def with_type(self, type_spec: TypeSpecType) -> 'TaskOutputReference':
         return TaskOutputReference(
             output_name=self.output_name,
             task_id=self.task_id,
@@ -389,7 +389,7 @@ class TaskOutputArgument(ModelBase): #Has additional constructor for convenience
             output_name=output_name,
         ))
 
-    def with_type(self, type_spec: TypeType) -> 'TaskOutputArgument':
+    def with_type(self, type_spec: TypeSpecType) -> 'TaskOutputArgument':
         return TaskOutputArgument(
             task_output=self.task_output.with_type(type_spec),
         )

--- a/sdk/python/tests/components/test_components.py
+++ b/sdk/python/tests/components/test_components.py
@@ -605,6 +605,35 @@ implementation:
 
         self.assertEqual(list(task.outputs.keys()), ['out 1', 'out 2'])
 
+    def test_check_type_validation_of_task_spec_outputs(self):
+        producer_component_text = '''\
+outputs:
+- {name: out1, type: Integer}
+- {name: out2, type: String}
+implementation:
+  container:
+    image: busybox
+    command: [touch, {outputPath: out1}, {outputPath: out2}]
+'''
+        consumer_component_text = '''\
+inputs:
+- {name: data, type: Integer}
+implementation:
+  container:
+    image: busybox
+    command: [echo, {inputValue: data}]
+'''
+        producer_op = comp.load_component_from_text(producer_component_text)
+        consumer_op = comp.load_component_from_text(consumer_component_text)
+        with no_task_resolving_context():
+          producer_task = producer_op()
+
+          consumer_op(producer_task.outputs['out1'])
+          consumer_op(producer_task.outputs['out2'].without_type())
+          consumer_op(producer_task.outputs['out2'].with_type('Integer'))
+          with self.assertRaises(InconsistentTypeException):
+            consumer_op(producer_task.outputs['out2'])
+
     def test_type_compatibility_check_for_simple_types(self):
         component_a = '''\
 outputs:
@@ -933,6 +962,7 @@ implementation:
         task_factory_a = comp.load_component_from_text(component_a)
         task_factory_b = comp.load_component_from_text(component_b)
         a_task = task_factory_a()
+
         with self.assertRaises(InconsistentTypeException):
             b_task = task_factory_b(in1=a_task.outputs['out1'])
 


### PR DESCRIPTION
Now the task output references taken from TaskSpec instances can be
type-checked when passed to components.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/1995)
<!-- Reviewable:end -->
