### PR TITLE
[WIP] Move image specifications into config.yaml

### DIFF
--- a/test/sample-test/configs/schema.config.yaml
+++ b/test/sample-test/configs/schema.config.yaml
@@ -16,3 +16,4 @@
 test_name: str()
 arguments: map(required=False)
 test_timeout: int(min=0, required=False)
+images: map(str(), required=False)

--- a/test/sample-test/configs/tfx_cab_classification.config.yaml
+++ b/test/sample-test/configs/tfx_cab_classification.config.yaml
@@ -21,3 +21,12 @@ arguments:
   train: gs://ml-pipeline-dataset/sample-test/taxi-cab-classification/train20.csv
   hidden-layer-size: 5
   steps: 5
+images:
+  local_confusionmatrix_image: gcr\.io/ml-pipeline/ml-pipeline/ml-pipeline-local-confusion-matrix:\w+
+  local_roc_image: gcr\.io/ml-pipeline/ml-pipeline/ml-pipeline-local-roc:\w+
+  dataflow_tft_image: gcr\.io/ml-pipeline/ml-pipeline-dataflow-tft:\w+
+  dataflow_predict_image: gcr\.io/ml-pipeline/ml-pipeline-dataflow-tf-predict:\w+
+  dataflow_tfdv_image: gcr\.io/ml-pipeline/ml-pipeline/ml-pipeline-dataflow-tfdv:\w+
+  dataflow_tfma_image: gcr\.io/ml-pipeline/ml-pipeline/ml-pipeline-dataflow-tfma:\w+
+  kubeflow_dnntrainer_image: gcr\.io/ml-pipeline/ml-pipeline/ml-pipeline-kubeflow-tf-trainer:\w+
+  kubeflow_deployer_image: gcr\.io/ml-pipeline/ml-pipeline/ml-pipeline-kubeflow-deployer:\w+

--- a/test/sample-test/configs/xgboost_training_cm.config.yaml
+++ b/test/sample-test/configs/xgboost_training_cm.config.yaml
@@ -22,3 +22,12 @@ arguments:
   rounds: 5
   workers: 2
 test_timeout: 1800 # xgboost needs extra time.
+images:
+  dataproc_create_cluster_image: gcr\.io/ml-pipeline/ml-pipeline-dataproc-create-cluster:\w+
+  dataproc_delete_cluster_image: gcr\.io/ml-pipeline/ml-pipeline-dataproc-delete-cluster:\w+
+  dataproc_analyze_image: gcr\.io/ml-pipeline/ml-pipeline-dataproc-analyze:\w+
+  dataproc_transform_image: gcr\.io/ml-pipeline/ml-pipeline-dataproc-transform:\w+
+  dataproc_train_image: gcr\.io/ml-pipeline/ml-pipeline-dataproc-train
+  dataproc_predict_image: gcr\.io/ml-pipeline/ml-pipeline-dataproc-predict:\w+
+  local_confusionmatrix_image: gcr\.io/ml-pipeline/ml-pipeline/ml-pipeline-local-confusion-matrix:\w+
+  local_roc_image: gcr\.io/ml-pipeline/ml-pipeline/ml-pipeline-local-roc:\w+


### PR DESCRIPTION
Currently image injection specification is specified in sample_test_launcher.py file. It will be a better practice to separate this from the actual sample test infra logic. 

This PR moves the image injection specifications into config.yaml associated with each sample test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2011)
<!-- Reviewable:end -->
