### PR TITLE
api: fix generate_api.sh script with bash shebang

### DIFF
--- a/backend/api/generate_api.sh
+++ b/backend/api/generate_api.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# !/bin/sh
 
 # This file generates API sources from the protocol buffers defined in this
 # directory using Bazel, then copies them back into the source tree so they can


### PR DESCRIPTION
The `generate_api.sh` script contains [bashims](https://mywiki.wooledge.org/Bashism) which will not work with a general `/bin/sh`.
For example, it uses brace expansion: 
```bash
' ${DIR}/swagger/{run,job,pipeline,experiment,pipeline.upload}.swagger.json > "${DIR}/swagger/kfp_api_single_file.swagger.json"
```

This PR adds a bash shebang to the script, to ensure it runs correctly.

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2017)
<!-- Reviewable:end -->
