### PR TITLE
SDK/DSL: Fix bug when using PipelineParam in `pvc` of PipelineVolume

### DIFF
--- a/sdk/python/kfp/dsl/_pipeline_volume.py
+++ b/sdk/python/kfp/dsl/_pipeline_volume.py
@@ -64,7 +64,7 @@ class PipelineVolume(V1Volume):
                 raise ValueError("You can only pass 'name' along with 'pvc'.")
             elif pvc and not kwargs:
                 pvc_volume_source = V1PersistentVolumeClaimVolumeSource(
-                    claim_name=pvc
+                    claim_name=str(pvc)
                 )
                 init_volume["persistent_volume_claim"] = pvc_volume_source
         super().__init__(**init_volume, **kwargs)

--- a/sdk/python/tests/dsl/pipeline_volume_tests.py
+++ b/sdk/python/tests/dsl/pipeline_volume_tests.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 
-from kfp.dsl import Pipeline, VolumeOp, ContainerOp, PipelineVolume
+from kfp.dsl import (Pipeline, VolumeOp, ContainerOp, PipelineVolume,
+                     PipelineParam)
 import unittest
 
 
@@ -70,3 +71,8 @@ class TestPipelineVolume(unittest.TestCase):
         name2 = "provided"
         self.assertEqual(vol1.name, name1)
         self.assertEqual(vol2.name, name2)
+
+        # Testing json.dumps() when pvc is a PipelineParam to avoid
+        # `TypeError: Object of type PipelineParam is not JSON serializable`
+        param = PipelineParam(name="foo")
+        vol3 = PipelineVolume(pvc=param)


### PR DESCRIPTION
#1402 introduced the following bug:

If no `name` is provided to `PipelineVolume` constructor, a custom name is generated. It relies on `json.dumps()` of the struct after getting converted to dict.
When `pvc` is provided and `name` is not, the following error is raised:
 ```
TypeError: Object of type PipelineParam is not JSON serializable
```

This PR fixes it and extends tests to catch it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2018)
<!-- Reviewable:end -->
