### PR TITLE
Extend E2E tests: Add VolumeOp test

### DIFF
--- a/samples/core/volume_ops/volume_ops.py
+++ b/samples/core/volume_ops/volume_ops.py
@@ -24,7 +24,7 @@ def volumeop_basic(size):
     vop = dsl.VolumeOp(
         name="create_pvc",
         resource_name="my-pvc",
-        modes=dsl.VOLUME_MODE_RWM,
+        modes=dsl.VOLUME_MODE_RWO,
         size=size
     )
 

--- a/test/e2e_test_gke_v2.yaml
+++ b/test/e2e_test_gke_v2.yaml
@@ -136,6 +136,7 @@ spec:
           - sequential
           - parallel_join
           - recursion
+          - volume_ops
 
   # Build and push image
   - name: build-image

--- a/test/sample-test/configs/volume_ops.config.yaml
+++ b/test/sample-test/configs/volume_ops.config.yaml
@@ -1,0 +1,17 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+test_name: volume_ops
+arguments:
+  size: 1Mi


### PR DESCRIPTION
This PR adds E2E testing of `volume_ops`.

I will be adding tests for `resource_ops` in a following PR, also refactoring the related sample.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2019)
<!-- Reviewable:end -->
