### PR TITLE
update service account for non managed storage case

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
@@ -250,6 +250,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
+              value: "{{ .Values.serviceAccount.pipelineRunner }}"
             # Following environment variables are only needed when using Cloud SQL and GCS.
             {{ if .Values.managedstorage.enabled }}
             - name: OBJECTSTORECONFIG_BUCKETNAME
@@ -258,8 +260,6 @@ spec:
               value: "{{ .Values.managedstorage.databaseNamePrefix }}_pipeline"
             - name: DBCONFIG_PASSWORD
               value: "{{ .Values.managedstorage.dbPassword }}"
-            - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
-              value: "{{ .Values.serviceAccount.pipelineRunner }}"
             {{ end }}
           image: {{ .Values.images.apiServer }}
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
The deployment should use the generated service account for both managed storage and non managed storage case. 

/assign @rmgogogo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2023)
<!-- Reviewable:end -->
