### PR TITLE
SDK: fix setting pipeline-wide artifact_location for ResourceOp and VolumeOp classes and add description field for create_experiment() function

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -159,10 +159,11 @@ class Client(object):
     # In-cluster pod. We could use relative URL.
     return '/pipeline'
 
-  def create_experiment(self, name):
+  def create_experiment(self, name, description=None):
     """Create a new experiment.
     Args:
       name: the name of the experiment.
+      description: description of the experiment
     Returns:
       An Experiment object. Most important field is id.
     """
@@ -176,7 +177,7 @@ class Client(object):
 
     if not experiment:
       logging.info('Creating experiment {}.'.format(name))
-      experiment = kfp_server_api.models.ApiExperiment(name=name)
+      experiment = kfp_server_api.models.ApiExperiment(name=name, description=description)
       experiment = self._experiment_api.create_experiment(body=experiment)
 
     if self._is_ipython():

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -620,8 +620,9 @@ class Compiler(object):
     for op in p.ops.values():
       # inject pipeline level artifact location into if the op does not have
       # an artifact location config already.
-      if artifact_location and not op.artifact_location:
-        op.artifact_location = artifact_location
+      if hasattr(op, "artifact_location"):
+        if artifact_location and not op.artifact_location:
+          op.artifact_location = artifact_location
 
       sanitized_name = K8sHelper.sanitize_k8s_name(op.name)
       op.name = sanitized_name


### PR DESCRIPTION
Two things to update:
1. Fix setting artifact_location for Pipeline, it crashes due to non-existence of _artifact_location_ field in ResourceOp and VolumeOp classes.
2. Add feature to add description to an experiment with dsl.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2025)
<!-- Reviewable:end -->
