### PR TITLE
Add parameter for service account credential

### DIFF
--- a/manifests/gcp_marketplace/README.md
+++ b/manifests/gcp_marketplace/README.md
@@ -37,14 +37,14 @@ cat application_default_credentials.json | base64
 Install Kubeflow Pipelines
 ```
 kubectl create ns test
-mpdev /scripts/install --deployer=gcr.io/ml-pipeline/google/kfp/deployer:0.1.27 --parameters='{"name": "installation-1", "namespace": "test"}'
+mpdev /scripts/install --deployer=gcr.io/ml-pipeline/google/kfp/deployer:0.1.27 --parameters='{"name": "installation-1", "namespace": "test", "serviceAccountCredential": "[your-credential]"}'
 ```
 
 Install with Cloud SQL and GCS
 ```
 mpdev /scripts/install \
-  --deployer=gcr.io/ml-pipeline/google/kfp/deployer:0.1.27 \
-  --parameters='{"name": "installation-1", "namespace": "test" , "managedstorage.enabled": true, "managedstorage.cloudsqlInstanceConnectionName": "your-instance-name", "managedstorage.dbPassword": "your password"}'
+ --deployer=gcr.io/ml-pipeline/google/kfp/deployer:0.1.27 \
+ --parameters='{"name": "installation-1", "namespace": "test", "serviceAccountCredential": "[your-credential]", "managedstorage.enabled": true, "managedstorage.cloudsqlInstanceConnectionName": "[your-name]", "managedstorage.dbPassword": "[your-pwd]"}'
 ```
 
 To uninstall 

--- a/manifests/gcp_marketplace/README.md
+++ b/manifests/gcp_marketplace/README.md
@@ -28,6 +28,12 @@ export MARKETPLACE_TOOLS_TAG=unreleased-pr396
 export MARKETPLACE_TOOLS_IMAGE=gcr.io/cloud-marketplace-staging/marketplace-k8s-app-tools/k8s/dev
 ```
 
+Download token
+```
+gcloud iam service-accounts keys create application_default_credentials.json --iam-account 32498701380-compute@developer.gserviceaccount.com
+cat application_default_credentials.json | base64
+```
+
 Install Kubeflow Pipelines
 ```
 kubectl create ns test

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/gcp_secret.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/gcp_secret.yaml
@@ -7,4 +7,4 @@ metadata:
     app.kubernetes.io/name: {{ .Release.Name }}
 type: Opaque
 data:
-  application_default_credentials.json: {{ .Values.serviceAccountCredential | b64enc | quote }}
+  application_default_credentials.json: {{ .Values.serviceAccountCredential | quote }}

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/gcp_secret.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/gcp_secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.gcpSecretName }}
+  labels:
+    app: gcp-sa
+    app.kubernetes.io/name: {{ .Release.Name }}
+type: Opaque
+data:
+  application_default_credentials.json: {{ .Values.serviceAccountCredential | b64enc | quote }}

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/metadata.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/metadata.yaml
@@ -39,7 +39,12 @@ spec:
             - --http_port=8080
             - --mysql_service_host=mysql
             - --mysql_service_port=3306
+            {{ if .Values.managedstorage.databaseNamePrefix }}
             - --mlmd_db_name={{ .Values.managedstorage.databaseNamePrefix }}_metadata
+            {{ else }}
+            - --mlmd_db_name={{ .Release.Name | replace "-" "_" | replace "." "_" | trunc 50 }}_metadata
+            {{ end }}
+
           image: {{ .Values.images.metadataserver }}
           name: container
           ports:

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/minio.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/minio.yaml
@@ -56,7 +56,7 @@ spec:
       volumes:
         - name: gcp-sa-token
           secret:
-            secretName: {{ .Values.managedstorage.gcpSecretName }}
+            secretName: {{ .Values.gcpSecretName }}
 {{ end }}
 ---
 {{ if not .Values.managedstorage.enabled }}

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
@@ -66,7 +66,7 @@ spec:
           emptyDir:
         - name: gcp-sa-token
           secret:
-            secretName: {{ .Values.managedstorage.gcpSecretName }}
+            secretName: {{ .Values.gcpSecretName }}
 {{ end }}
 ---
 {{ if not .Values.managedstorage.enabled }}

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
@@ -67,9 +67,7 @@ spec:
         - name: gcp-sa-token
           secret:
             secretName: {{ .Values.gcpSecretName }}
-{{ end }}
----
-{{ if not .Values.managedstorage.enabled }}
+{{ else }}
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
@@ -255,7 +255,7 @@ spec:
             # Following environment variables are only needed when using Cloud SQL and GCS.
             {{ if .Values.managedstorage.enabled }}
             - name: OBJECTSTORECONFIG_BUCKETNAME
-              value: "{{ .Values.managedstorage.cloudsqlInstanceConnectionName | replace ':' '-' }}-{{ .Values.managedstorage.databaseNamePrefix }}"
+              value: '{{ .Values.managedstorage.cloudsqlInstanceConnectionName | replace ":" "-" }}-{{ .Values.managedstorage.databaseNamePrefix }}'
             - name: DBCONFIG_DBNAME
               value: "{{ .Values.managedstorage.databaseNamePrefix }}_pipeline"
             - name: DBCONFIG_PASSWORD

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
@@ -255,9 +255,17 @@ spec:
             # Following environment variables are only needed when using Cloud SQL and GCS.
             {{ if .Values.managedstorage.enabled }}
             - name: OBJECTSTORECONFIG_BUCKETNAME
+              {{ if .Values.managedstorage.databaseNamePrefix }}
               value: '{{ .Values.managedstorage.cloudsqlInstanceConnectionName | replace ":" "-" }}-{{ .Values.managedstorage.databaseNamePrefix }}'
+              {{ else }}
+              value: '{{ .Values.managedstorage.cloudsqlInstanceConnectionName | replace ":" "-" }}-{{ .Release.Name | replace "-" "_" | replace "." "_" | trunc 50 }}'
+              {{ end }}
             - name: DBCONFIG_DBNAME
+              {{ if .Values.managedstorage.databaseNamePrefix }}
               value: "{{ .Values.managedstorage.databaseNamePrefix }}_pipeline"
+              {{ else }}
+              value: '{{ .Release.Name | replace "-" "_" | replace "." "_" | trunc 50 }}_pipeline'
+              {{ end }}
             - name: DBCONFIG_PASSWORD
               value: "{{ .Values.managedstorage.dbPassword }}"
             {{ end }}

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/values.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/values.yaml
@@ -13,6 +13,9 @@ images:
   viewercrd: gcr.io/ml-pipeline/viewer-crd-controller:0.1.27
   visualizationserver: gcr.io/ml-pipeline/visualization-server:0.1.27
 
+gcpSecretName: "user-gcp-sa"
+serviceAccountCredential: null
+
 serviceAccount:
   argo: null
   mlPipeline: null
@@ -22,8 +25,6 @@ serviceAccount:
   mlPipelineViewerCrd: null
   pipelineRunner: null
   proxyAgentRunner: null
-
-gcpSecretName: null
 
 managedstorage:
   enabled: false

--- a/manifests/gcp_marketplace/schema.yaml
+++ b/manifests/gcp_marketplace/schema.yaml
@@ -87,26 +87,31 @@ properties:
     type: string
     x-google-marketplace:
       type: NAMESPACE
+  serviceAccountCredential:
+    title: Service Account credentials used to call other GCP services, such as CloudSQL.
+    description: |-
+      To be able to call other GCP services, we need to be
+      authenticated. This field is used to store the content of the service account
+      JSON file. It can be encoded using base64 instead of messing with JSON format.
+    type: string
+    default: ""
+    x-google-marketplace:
+      type: STRING
   managedstorage.enabled:
     type: boolean
     title: Enable managed storage
     description: Use Cloud SQL and GCS for storing the data
     default: false
-  managedstorage.cloudsqlInstanceName:
+  managedstorage.cloudsqlInstanceConnectionName:
     type: string
-    title: CloudSQL instance name
-  managedstorage.cloudsqlZone:
-    type: string
-    title: CloudSQL zone
+    title: CloudSQL instance connection name. Format projectId:zone:instanceName
   managedstorage.dbPassword:
     type: string
     title: database password
-  managedstorage.gcpProject:
-    type: string
-    title: GCP project
   managedstorage.databaseNamePrefix:
     type: string
     title: database name prefix
+
   serviceAccount.proxyAgentRunner:
     type: string
     title: ProxyAgentRunnerServiceAccount
@@ -418,3 +423,5 @@ properties:
 required:
   - name
   - namespace
+  - serviceAccountCredential
+  - managedstorage.enabled

--- a/manifests/gcp_marketplace/schema.yaml
+++ b/manifests/gcp_marketplace/schema.yaml
@@ -424,4 +424,3 @@ required:
   - name
   - namespace
   - serviceAccountCredential
-  - managedstorage.enabled


### PR DESCRIPTION
The helm chart will store the service account credential as K8s secret in the cluster and mount to the  deployments that need it.

/assign @rmgogogo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2039)
<!-- Reviewable:end -->
