### PR TITLE
SDK - Compiler - Failing when PipelineParam is unresolved

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -800,5 +800,7 @@ class Compiler(object):
         raise ValueError('The output path '+ package_path + ' should ends with one of the following formats: [.tar.gz, .tgz, .zip, .yaml, .yml]')
     finally:
       kfp.TYPE_CHECK = type_check_old_value
+    if '{{pipelineparam' in yaml_text:
+      raise RuntimeError('Internal compiler error: Found unresolved PipelineParam. Please create a new issue at https://github.com/kubeflow/pipelines/issues attaching the pipeline code and the pipeline package.' )
 
 


### PR DESCRIPTION
Instead of silently producing a broken pipeline package, the compiler now raises error and instructs the user to submit a bug report.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2055)
<!-- Reviewable:end -->
