### PR TITLE
Release - Creating the release branch from the specified commit

### DIFF
--- a/components/release.sh
+++ b/components/release.sh
@@ -58,8 +58,8 @@ clone_dir=$(mktemp -d)
 git clone "git@github.com:${REPO}.git" "$clone_dir"
 cd "$clone_dir"
 branch="release-$COMMIT_SHA"
-# Currently the release is based on master
-release_head=master
+# Creating the release branch from the specified commit
+release_head=$COMMIT_SHA
 git checkout "$release_head" -b "$branch"
 
 # Releasing the container images to public. Updating components and samples.


### PR DESCRIPTION
Enable specifying release branch from a specified commit instead of HEAD.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2062)
<!-- Reviewable:end -->
