### PR TITLE
Make wget quieter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
       before_install:
         # Install Bazel
         - |
-          wget -O install.sh "${BAZEL_URL}"
+          wget --no-verbose -O install.sh "${BAZEL_URL}"
           chmod +x install.sh
           ./install.sh --user
           rm -f install.sh

--- a/backend/api/build_kfp_server_api_python_package.sh
+++ b/backend/api/build_kfp_server_api_python_package.sh
@@ -37,7 +37,7 @@ fi
 codegen_file=/tmp/swagger-codegen-cli.jar
 codegen_uri=http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.7/swagger-codegen-cli-2.4.7.jar
 if ! [ -f "$codegen_file" ]; then
-    wget "$codegen_uri" -O "$codegen_file"
+    wget --no-verbose "$codegen_uri" -O "$codegen_file"
 fi
 
 pushd "$(dirname "$0")"

--- a/components/arena/docker/Dockerfile
+++ b/components/arena/docker/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /go/src/github.com/kubeflow/arena
 
 RUN cd /go/src/github.com/kubeflow/arena && make
 
-RUN wget https://storage.googleapis.com/kubernetes-helm/helm-v2.9.1-linux-amd64.tar.gz && \
-    tar -xvf helm-v2.9.1-linux-amd64.tar.gz && \
+RUN wget --no-verbose https://storage.googleapis.com/kubernetes-helm/helm-v2.9.1-linux-amd64.tar.gz && \
+    tar -xf helm-v2.9.1-linux-amd64.tar.gz && \
     mv linux-amd64/helm /usr/local/bin/helm && \
     chmod u+x /usr/local/bin/helm
 

--- a/components/deprecated/dataproc/train/src/xgb4j_build.sh
+++ b/components/deprecated/dataproc/train/src/xgb4j_build.sh
@@ -29,7 +29,7 @@ sudo apt-get update
 sudo apt install -t jessie-backports build-essential git maven openjdk-8-jre-headless \
                     openjdk-8-jre openjdk-8-jdk-headless openjdk-8-jdk ca-certificates-java -y
 
-wget http://www.cmake.org/files/v3.5/cmake-3.5.2.tar.gz
+wget --no-verbose http://www.cmake.org/files/v3.5/cmake-3.5.2.tar.gz
 tar xf cmake-3.5.2.tar.gz
 cd cmake-3.5.2
 ./configure

--- a/components/kubeflow/deployer/Dockerfile
+++ b/components/kubeflow/deployer/Dockerfile
@@ -23,20 +23,20 @@ RUN apt-get update -q && apt-get upgrade -y && \
       lsb-release \
       unzip \
       wget && \
-    wget -O /opt/ks_0.13.1_linux_amd64.tar.gz \
+    wget --no-verbose -O /opt/ks_0.13.1_linux_amd64.tar.gz \
       https://github.com/ksonnet/ksonnet/releases/download/v0.13.1/ks_0.13.1_linux_amd64.tar.gz && \
     tar -C /opt -xzf /opt/ks_0.13.1_linux_amd64.tar.gz && \
     cp /opt/ks_0.13.1_linux_amd64/ks /bin/. && \
     rm -f /opt/ks_0.13.1_linux_amd64.tar.gz && \
-    wget -O /bin/kubectl \
+    wget --no-verbose -O /bin/kubectl \
       https://storage.googleapis.com/kubernetes-release/release/v1.11.2/bin/linux/amd64/kubectl && \
     chmod u+x /bin/kubectl && \
-    wget -O /opt/kubernetes_v1.11.2 \
+    wget --no-verbose -O /opt/kubernetes_v1.11.2 \
       https://github.com/kubernetes/kubernetes/archive/v1.11.2.tar.gz && \
     mkdir -p /src && \
     tar -C /src -xzf /opt/kubernetes_v1.11.2 && \
     rm -rf /opt/kubernetes_v1.11.2 && \
-    wget -O /opt/google-apt-key.gpg \
+    wget --no-verbose -O /opt/google-apt-key.gpg \
       https://packages.cloud.google.com/apt/doc/apt-key.gpg && \
     apt-key add /opt/google-apt-key.gpg && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \

--- a/contrib/components/openvino/ovms-deployer/containers/Dockerfile
+++ b/contrib/components/openvino/ovms-deployer/containers/Dockerfile
@@ -9,20 +9,20 @@ RUN apt-get update -q && apt-get upgrade -y && \
       lsb-release \
       unzip \
       wget && \
-    wget -O /opt/ks_0.12.0_linux_amd64.tar.gz \
+    wget --no-verbose -O /opt/ks_0.12.0_linux_amd64.tar.gz \
       https://github.com/ksonnet/ksonnet/releases/download/v0.12.0/ks_0.12.0_linux_amd64.tar.gz && \
     tar -C /opt -xzf /opt/ks_0.12.0_linux_amd64.tar.gz && \
     cp /opt/ks_0.12.0_linux_amd64/ks /bin/. && \
     rm -f /opt/ks_0.12.0_linux_amd64.tar.gz && \
-    wget -O /bin/kubectl \
+    wget --no-verbose -O /bin/kubectl \
       https://storage.googleapis.com/kubernetes-release/release/v1.11.2/bin/linux/amd64/kubectl && \
     chmod u+x /bin/kubectl && \
-    wget -O /opt/kubernetes_v1.11.2 \
+    wget --no-verbose -O /opt/kubernetes_v1.11.2 \
       https://github.com/kubernetes/kubernetes/archive/v1.11.2.tar.gz && \
     mkdir -p /src && \
     tar -C /src -xzf /opt/kubernetes_v1.11.2 && \
     rm -rf /opt/kubernetes_v1.11.2 && \
-    wget -O /opt/google-apt-key.gpg \
+    wget --no-verbose -O /opt/google-apt-key.gpg \
       https://packages.cloud.google.com/apt/doc/apt-key.gpg && \
     apt-key add /opt/google-apt-key.gpg && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR ./frontend
 
 # Workaround for ppc64le since phantomjs does not support ppc64le
 RUN if [ "$(uname -m)" = "ppc64le" ]; then \
-        wget -O /tmp/phantomjs-2.1.1-linux-ppc64.tar.bz2 https://github.com/ibmsoe/phantomjs/releases/download/2.1.1/phantomjs-2.1.1-linux-ppc64.tar.bz2 \
+        wget --no-verbose -O /tmp/phantomjs-2.1.1-linux-ppc64.tar.bz2 https://github.com/ibmsoe/phantomjs/releases/download/2.1.1/phantomjs-2.1.1-linux-ppc64.tar.bz2 \
         && tar xf /tmp/phantomjs-2.1.1-linux-ppc64.tar.bz2 -C /usr/local/ \
         && ln -s /usr/local/phantomjs-2.1.1-linux-ppc64/bin/phantomjs /usr/bin/phantomjs; \
     fi

--- a/samples/contrib/aws-samples/ground_truth_pipeline_demo/README.md
+++ b/samples/contrib/aws-samples/ground_truth_pipeline_demo/README.md
@@ -11,7 +11,7 @@ For this demo, you will be using a very small subset of the [Google Open Images 
 
 Run the following to download `openimgs-annotations.csv`:
 ```bash
-wget https://storage.googleapis.com/openimages/2018_04/test/test-annotations-human-imagelabels-boxable.csv -O openimgs-annotations.csv
+wget --no-verbose https://storage.googleapis.com/openimages/2018_04/test/test-annotations-human-imagelabels-boxable.csv -O openimgs-annotations.csv
 ```
 Create a s3 bucket and run [this python script](https://github.com/kubeflow/pipelines/tree/master/samples/contrib/aws-samples/ground_truth_pipeline_demo/prep_inputs.py) to get the images and generate `train.manifest`, `validation.manifest`, `class_labels.json`, and `instuctions.template`.
 

--- a/samples/contrib/nvidia-resnet/install_kubeflow_and_dependencies.sh
+++ b/samples/contrib/nvidia-resnet/install_kubeflow_and_dependencies.sh
@@ -42,9 +42,9 @@ sudo apt-get install -y kubectl
 
 # Install ksonnet
 export KS_VER=0.13.1
-wget https://github.com/ksonnet/ksonnet/releases/download/v${KS_VER}/ks_${KS_VER}_linux_amd64.tar.gz -O ksonnet.tar.gz
+wget --no-verbose https://github.com/ksonnet/ksonnet/releases/download/v${KS_VER}/ks_${KS_VER}_linux_amd64.tar.gz -O ksonnet.tar.gz
 mkdir -p ksonnet
-tar -xvf ksonnet.tar.gz -C ksonnet --strip-components=1
+tar -xf ksonnet.tar.gz -C ksonnet --strip-components=1
 sudo cp ksonnet/ks /usr/local/bin
 rm -fr ksonnet
 rm ksonnet.tar.gz

--- a/samples/contrib/nvidia-resnet/prepare_test_inference_data.sh
+++ b/samples/contrib/nvidia-resnet/prepare_test_inference_data.sh
@@ -15,6 +15,6 @@
 
 IMAGES_URL=https://storage.googleapis.com/nvidia-kubeflow-demo/test_images.tar.gz
 
-wget -O images.tar.gz $IMAGES_URL
+wget --no-verbose -O images.tar.gz $IMAGES_URL
 tar -zxvf images.tar.gz -C components/webapp/src/static
 rm images.tar.gz

--- a/test/deploy-pipeline-lite.sh
+++ b/test/deploy-pipeline-lite.sh
@@ -25,7 +25,7 @@ if ! which kustomize; then
   # Download kustomize cli tool
   TOOL_DIR=${DIR}/bin
   mkdir -p ${TOOL_DIR}
-  wget https://github.com/kubernetes-sigs/kustomize/releases/download/v3.1.0/kustomize_3.1.0_linux_amd64 \
+  wget --no-verbose https://github.com/kubernetes-sigs/kustomize/releases/download/v3.1.0/kustomize_3.1.0_linux_amd64 \
     -O ${TOOL_DIR}/kustomize --no-verbose
   chmod +x ${TOOL_DIR}/kustomize
   PATH=${PATH}:${TOOL_DIR}


### PR DESCRIPTION
Some of our logs are so big that services line CloudBuilder truncate them.
This PR makes wget and tar less noisy.

> Log size limit of 1MiB exceeded, download the logs to see the full content


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2069)
<!-- Reviewable:end -->
