### PR TITLE
[pipeline-ui] Retrieve pod logs from argo archive

### DIFF
--- a/frontend/server/aws-helper.ts
+++ b/frontend/server/aws-helper.ts
@@ -71,7 +71,7 @@ class AWSInstanceProfileCredentials {
     /**
      * Get the AWS metadata store session credentials.
      */
-    async get_credentials(): Promise<IAWSMetadataCredentials> {
+    async getCredentials(): Promise<IAWSMetadataCredentials> {
         // query for credentials if going to expire or no credentials yet
         if (Date.now() + 10 >= this._expiration || !this._credentials) {
             this._credentials = await this._fetchCredentials();

--- a/frontend/server/aws-helper.ts
+++ b/frontend/server/aws-helper.ts
@@ -73,12 +73,12 @@ class AWSInstanceProfileCredentials {
      */
     async getCredentials(): Promise<IAWSMetadataCredentials> {
         // query for credentials if going to expire or no credentials yet
-        if (Date.now() + 10 >= this._expiration || !this._credentials) {
+        if ((Date.now() + 10 >= this._expiration) || !this._credentials) {
             this._credentials = await this._fetchCredentials();
             if (this._credentials.Expiration)
                 this._expiration = new Date(this._credentials.Expiration).getTime();
             else 
-                this._expiration = -1;  // never expires
+                this._expiration = -1;  // always expire
         }
         return this._credentials
     }

--- a/frontend/server/aws-helper.ts
+++ b/frontend/server/aws-helper.ts
@@ -1,0 +1,88 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import fetch from 'node-fetch';
+
+/** IAWSMetadataCredentials describes the credentials provided by aws metadata store. */
+export interface IAWSMetadataCredentials {
+    Code: string;
+    LastUpdated: string;
+    Type: string;
+    AccessKeyId: string;
+    SecretAccessKey: string;
+    Token: string;
+    Expiration: string;
+}
+
+/** url for aws metadata store. */
+const metadataUrl = "http://169.254.169.254/latest/meta-data/";
+
+
+/**
+ * Get the AWS IAM instance profile.
+ */
+async function getIAMInstanceProfile() : Promise<string|undefined> {
+    try {
+        const resp = await fetch(`${metadataUrl}/iam/security-credentials/`);
+        const profiles = (await resp.text()).split('\n');
+        if (profiles.length > 0) {
+            return profiles[0].trim();  // return first profile
+        }
+        return;
+    } catch (error) {
+        console.error(`Unable to fetch credentials from AWS metadata store: ${error}`)
+        return;
+    }
+}
+
+/**
+ * Class to handle the session credentials for AWS ec2 instance profile.
+ */
+class AWSInstanceProfileCredentials {
+    _iamProfilePromise = getIAMInstanceProfile();
+    _credentials?: IAWSMetadataCredentials;
+    _expiration: number = 0;
+
+    async ok() {
+        return !!(await this._iamProfilePromise);
+    }
+
+    async _fetchCredentials(): Promise<IAWSMetadataCredentials|undefined> {
+        try {
+            const profile = await this._iamProfilePromise;
+            const resp = await fetch(`${metadataUrl}/iam/security-credentials/${profile}`)
+            return resp.json();
+        } catch (error) {
+            console.error(`Unable to fetch credentials from AWS metadata store:${error}`)
+            return;
+        }
+    }
+
+    /**
+     * Get the AWS metadata store session credentials.
+     */
+    async get_credentials(): Promise<IAWSMetadataCredentials> {
+        // query for credentials if going to expire or no credentials yet
+        if (Date.now() + 10 >= this._expiration || !this._credentials) {
+            this._credentials = await this._fetchCredentials();
+            if (this._credentials.Expiration)
+                this._expiration = new Date(this._credentials.Expiration).getTime();
+            else 
+                this._expiration = -1;  // never expires
+        }
+        return this._credentials
+    }
+
+}
+
+export const awsInstanceProfileCredentials = new AWSInstanceProfileCredentials();

--- a/frontend/server/k8s-helper.ts
+++ b/frontend/server/k8s-helper.ts
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 // @ts-ignore
-import {Client as MinioClient} from 'minio';
-import {Core_v1Api, Custom_objectsApi, KubeConfig} from '@kubernetes/client-node';
+import {Core_v1Api, Custom_objectsApi, KubeConfig, V1ConfigMapKeySelector} from '@kubernetes/client-node';
 import * as crypto from 'crypto-js';
 import * as fs from 'fs';
 import * as Utils from './utils';
+import {IPartialArgoWorkflow} from './workflow-helper';
 
 // If this is running inside a k8s Pod, its namespace should be written at this
 // path, this is also how we can tell whether we're running in the cluster.
@@ -31,6 +31,12 @@ const viewerGroup = 'kubeflow.org';
 const viewerVersion = 'v1beta1';
 const viewerPlural = 'viewers';
 
+// Constants for argo workflow
+const workflowGroup = 'argoproj.io'
+const workflowVersion = 'v1alpha1'
+const workflowPlural = 'workflows'
+
+/** Default pod template spec used to create tensorboard viewer. */
 export const defaultPodTemplateSpec = {
   spec: {
     containers: [{
@@ -158,17 +164,36 @@ export function getPodLogs(podName: string): Promise<string> {
     );
 }
 
-/** Returns a function to retrieve pod logs archived by argo. */
-export function getPodLogsFromArtifactoryHelper(client: MinioClient, bucketName: string, prefix: string) {
-  return function(podName: string) {
-    let workflowName = workflowNameFromPodName(podName);
-    return client.getObject(bucketName, `${prefix}/${workflowName}/${podName}/main.log`)
+/**
+ * Retrieves the argo workflow CRD.
+ * @param workflowName name of the argo workflow
+ */
+export async function getArgoWorkflow(workflowName: string): Promise<IPartialArgoWorkflow> {
+  if (!k8sV1CustomObjectClient) {
+    throw new Error('Cannot access kubernetes Custom Object API');
   }
-}
 
-/** Infers workflow name from pod name. */
-function workflowNameFromPodName(podName: string) {
-  let chunks = podName.split("-");
-  chunks.pop();
-  return chunks.join("-");
+  const res = await k8sV1CustomObjectClient.getNamespacedCustomObject(
+    workflowGroup, workflowVersion, namespace, workflowPlural, workflowName)
+  
+  if (res.response.statusCode >= 400) {
+    throw new Error(`Unable to query workflow:${workflowName}: Access denied.`);
+  }
+  return res.body;
+}
+  
+/**
+ * Retrieves k8s secret by key and decode from base64.
+ * @param name name of the secret 
+ * @param key key in the secret
+ */
+export async function getK8sSecret(name: string, key: string) {
+  if (!k8sV1Client) {
+    throw new Error('Cannot access kubernetes API');
+  }
+
+  const k8sSecret = await k8sV1Client.readNamespacedSecret(name, namespace);
+  const secretb64 = k8sSecret.body.data[key];
+  const buff = new Buffer(secretb64, 'base64');
+  return buff.toString('ascii');  
 }

--- a/frontend/server/minio-helper.ts
+++ b/frontend/server/minio-helper.ts
@@ -1,0 +1,66 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import {Stream} from 'stream';
+import * as tar from 'tar';
+import {Client as MinioClient, ClientOptions as MinioClientOptions} from 'minio';
+import {awsInstanceProfileCredentials} from './aws-helper';
+
+
+/** IMinioRequestConfig describes the info required to retrieve an artifact. */
+export interface IMinioRequestConfig {
+    bucket: string;
+    key: string;
+    client: MinioClient;
+}
+
+/**
+ * Create minio client with aws instance profile credentials if needed.
+ * @param config minio client options where `accessKey` and `secretKey` are optional.
+ */
+export async function createMinioClient(config: Partial<MinioClientOptions>) {
+
+    if (!config.accessKey || !config.secretKey) {
+        if (await awsInstanceProfileCredentials.ok()) {
+            const credentials = await awsInstanceProfileCredentials.get_credentials();
+            if (credentials) {
+              const {AccessKeyId: accessKey, SecretAccessKey: secretKey, Token: sessionToken} = credentials;
+              return new MinioClient({...config, accessKey, secretKey, sessionToken} as MinioClientOptions);
+            }
+            console.error('unable to get credentials from AWS metadata store.')
+        }
+    }
+    
+    return new MinioClient(config as MinioClientOptions);
+}
+
+export function getTarObjectAsString({bucket, key, client}: IMinioRequestConfig) {
+    return new Promise<string>(async (resolve, reject) => {
+      try {
+        const stream = await getObjectStream({bucket, key, client});
+        let contents = '';
+        stream.pipe(new tar.Parse()).on('entry', (entry: Stream) => {
+          entry.on('data', (buffer) => contents += buffer.toString());
+        });
+        stream.on('end', () => {
+          resolve(contents);
+        });
+      } catch (err) {
+        reject(err);
+      }
+    });
+}
+
+export function getObjectStream({bucket, key, client}: IMinioRequestConfig) {
+  return client.getObject(bucket, key);
+}

--- a/frontend/server/minio-helper.ts
+++ b/frontend/server/minio-helper.ts
@@ -24,15 +24,20 @@ export interface IMinioRequestConfig {
     client: MinioClient;
 }
 
+/** IMinioClientOptionsWithOptionalSecrets wraps around MinioClientOptions where only endPoint is required (accesskey and secretkey are optional). */
+export interface IMinioClientOptionsWithOptionalSecrets extends Partial<MinioClientOptions> {
+  endPoint: string;
+}
+
 /**
  * Create minio client with aws instance profile credentials if needed.
  * @param config minio client options where `accessKey` and `secretKey` are optional.
  */
-export async function createMinioClient(config: Partial<MinioClientOptions>) {
+export async function createMinioClient(config: IMinioClientOptionsWithOptionalSecrets) {
 
     if (!config.accessKey || !config.secretKey) {
         if (await awsInstanceProfileCredentials.ok()) {
-            const credentials = await awsInstanceProfileCredentials.get_credentials();
+            const credentials = await awsInstanceProfileCredentials.getCredentials();
             if (credentials) {
               const {AccessKeyId: accessKey, SecretAccessKey: secretKey, Token: sessionToken} = credentials;
               return new MinioClient({...config, accessKey, secretKey, sessionToken} as MinioClientOptions);

--- a/frontend/server/minio-helper.ts
+++ b/frontend/server/minio-helper.ts
@@ -40,7 +40,7 @@ export async function createMinioClient(config: IMinioClientOptionsWithOptionalS
             const credentials = await awsInstanceProfileCredentials.getCredentials();
             if (credentials) {
               const {AccessKeyId: accessKey, SecretAccessKey: secretKey, Token: sessionToken} = credentials;
-              return new MinioClient({...config, accessKey, secretKey, sessionToken} as MinioClientOptions);
+              return new MinioClient({...config, accessKey, secretKey, sessionToken});
             }
             console.error('unable to get credentials from AWS metadata store.')
         }

--- a/frontend/server/package-lock.json
+++ b/frontend/server/package-lock.json
@@ -171,9 +171,9 @@
       "dev": true
     },
     "@types/minio": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/minio/-/minio-6.0.2.tgz",
-      "integrity": "sha512-Zn5W6/NxQJI6Z3OvkLfYkJ0/V+hYLxwIKSQTvohWt5z0PUGvez2M0A6S/E3BHrTRkQ+n0TS8Z5A7itYMwrSQag==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minio/-/minio-7.0.3.tgz",
+      "integrity": "sha512-UBDtfaN2fsl86JFewFSZKPxxruAN7n9+VdBxw6nRblzdf+4DFpQUcry4vERjMuVRuyKoOFqaDUlRY0AmSd6utw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1720,11 +1720,11 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-minipass": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
-      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "^2.6.0"
       }
     },
     "fs-mkdirp-stream": {
@@ -3226,18 +3226,18 @@
       }
     },
     "minipass": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.6.5.tgz",
+      "integrity": "sha512-ewSKOPFH9blOLXx0YSE+mbrNMBFPS+11a2b03QZ+P4LVrUHW/GAlqeYC7DBknDyMWkHzrzTpDhUvy7MUxqyrPA==",
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
       }
     },
     "minizlib": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.2.tgz",
+      "integrity": "sha512-hR3At21uSrsjjDTWrbu0IMLTpnkpv8IIMFDFaoz43Tmu4LkmAXfH44vNNzpTnf+OAQQCHrb91y/wc2J4x5XgSQ==",
       "requires": {
         "minipass": "^2.2.1"
       }
@@ -4389,13 +4389,13 @@
       }
     },
     "tar": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
-      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.11.tgz",
+      "integrity": "sha512-iI4zh3ktLJKaDNZKZc+fUONiQrSn9HkCFzamtb7k8FFmVilHVob7QsLX/VySAW8lAviMzMbFw4QtFb4errwgYA==",
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.5",
+        "minipass": "^2.6.4",
         "minizlib": "^1.2.1",
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",

--- a/frontend/server/package.json
+++ b/frontend/server/package.json
@@ -11,11 +11,11 @@
     "lodash": ">=4.17.13",
     "minio": "^7.0.0",
     "node-fetch": "^2.1.2",
-    "tar": "^4.4.6"
+    "tar": "^4.4.11"
   },
   "devDependencies": {
     "@types/express": "^4.11.1",
-    "@types/minio": "^6.0.2",
+    "@types/minio": "^7.0.3",
     "@types/node-fetch": "^2.1.2",
     "typescript": "3.3.1"
   },

--- a/frontend/server/server.ts
+++ b/frontend/server/server.ts
@@ -95,7 +95,7 @@ const s3Options: MinioClientOptions = {
   secretKey: AWS_SECRET_ACCESS_KEY,
 };
 /** minio client to s3 with AWS instance profile IAM if access keys are not provided. */
-const s3ClientPromise = createMinioClient(s3Options);
+const s3ClientPromise = () => createMinioClient(s3Options);
 
 /** pod template spec to use for viewer crd */
 const podTemplateSpec = loadJSON(VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH, k8sHelper.defaultPodTemplateSpec)
@@ -232,7 +232,7 @@ const artifactsHandler = async (req, res) => {
 
     case 's3':
       try {
-        const stream = await getObjectStream({bucket, key, client: await s3ClientPromise});
+        const stream = await getObjectStream({bucket, key, client: await s3ClientPromise()});
         stream.on('end', () => res.end());
         stream.on('error', err => res.status(500).send(`Failed to get object in bucket ${bucket} at path ${key}: ${err}`))
         stream.pipe(res);

--- a/frontend/server/server.ts
+++ b/frontend/server/server.ts
@@ -16,15 +16,16 @@ import * as express from 'express';
 import {Application, static as StaticHandler} from 'express';
 import * as fs from 'fs';
 import * as proxy from 'http-proxy-middleware';
-import {Client as MinioClient} from 'minio';
+import {Client as MinioClient, ClientOptions as MinioClienOptions} from 'minio';
 import fetch from 'node-fetch';
 import * as path from 'path';
 import * as process from 'process';
 // @ts-ignore
-import * as tar from 'tar';
 import * as k8sHelper from './k8s-helper';
+import podLogsHandler from './workflow-helper';
 import proxyMiddleware from './proxy-middleware';
-import { Storage } from '@google-cloud/storage';
+import {getTarObjectAsString, getObjectStream, createMinioClient} from './minio-helper';
+import {Storage} from '@google-cloud/storage';
 import {Stream} from 'stream';
 
 import {loadJSON} from './utils';
@@ -78,30 +79,36 @@ const MINIO_ENDPOINT = MINIO_NAMESPACE && MINIO_NAMESPACE.length > 0 ? `${MINIO_
 const _as_bool = (value: string) => ['true', '1'].indexOf(value.toLowerCase()) >= 0
 
 /** minio client for minio storage */
-const minioClient = new MinioClient({
+const minioOptions: MinioClienOptions = {
   accessKey: MINIO_ACCESS_KEY,
   endPoint: MINIO_ENDPOINT,
   port: parseInt(MINIO_PORT, 10),
   secretKey: MINIO_SECRET_KEY,
   useSSL: _as_bool(MINIO_SSL),
-} as any);
+};
+const minioClient = new MinioClient(minioOptions);
 
 /** minio client for s3 objects */
-const s3Client = new MinioClient({
+const s3Options: MinioClienOptions = {
   endPoint: 's3.amazonaws.com',
   accessKey: AWS_ACCESS_KEY_ID,
   secretKey: AWS_SECRET_ACCESS_KEY,
-} as any);
+};
+/** minio client to s3 with AWS instance profile IAM if access keys are not provided. */
+const s3ClientPromise = createMinioClient(s3Options);
 
 /** pod template spec to use for viewer crd */
 const podTemplateSpec = loadJSON(VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH, k8sHelper.defaultPodTemplateSpec)
 
-/** helper function to retrieve pod logs from argo artifactory. */
-const getPodLogsFromArtifactory = _as_bool(ARGO_ARCHIVE_LOGS) ? k8sHelper.getPodLogsFromArtifactoryHelper(
-  ARGO_ARCHIVE_ARTIFACTORY==='minio' ? minioClient : s3Client,
-  ARGO_ARCHIVE_BUCKETNAME,
-  ARGO_ARCHIVE_PREFIX
-) : undefined;
+/** set a fallback query to a s3 or minio endpoint for the pod logs. */
+if (_as_bool(ARGO_ARCHIVE_LOGS)) {
+  podLogsHandler.setFallbackHandler(
+    ARGO_ARCHIVE_ARTIFACTORY==='minio' ? minioOptions : s3Options,
+    ARGO_ARCHIVE_BUCKETNAME,
+    ARGO_ARCHIVE_PREFIX,
+  )
+}
+
 
 const app = express() as Application;
 
@@ -214,48 +221,26 @@ const artifactsHandler = async (req, res) => {
         res.status(500).send('Failed to download GCS file(s). Error: ' + err);
       }
       break;
+
     case 'minio':
-      minioClient.getObject(bucket, key, (err, stream) => {
-        if (err) {
-          res.status(500).send(`Failed to get object in bucket ${bucket} at path ${key}: ${err}`);
-          return;
-        }
-
-        try {
-          let contents = '';
-          stream.pipe(new tar.Parse()).on('entry', (entry: Stream) => {
-            entry.on('data', (buffer) => contents += buffer.toString());
-          });
-
-          stream.on('end', () => {
-            res.send(contents);
-          });
-        } catch (err) {
-          res.status(500).send(`Failed to get object in bucket ${bucket} at path ${key}: ${err}`);
-        }
-      });
+      try {
+        res.send(await getTarObjectAsString({bucket, key, client: minioClient}));
+      } catch (err) {
+        res.status(500).send(`Failed to get object in bucket ${bucket} at path ${key}: ${err}`);
+      }
       break;
+
     case 's3':
-      s3Client.getObject(bucket, key, (err, stream) => {
-        if (err) {
-          res.status(500).send(`Failed to get object in bucket ${bucket} at path ${key}: ${err}`);
-          return;
-        }
-
-        try {
-          let contents = '';
-          stream.on('data', (chunk) => {
-            contents = chunk.toString();
-          });
-
-          stream.on('end', () => {
-            res.send(contents);
-          });
-        } catch (err) {
-          res.status(500).send(`Failed to get object in bucket ${bucket} at path ${key}: ${err}`);
-        }
-      });
+      try {
+        const stream = await getObjectStream({bucket, key, client: await s3ClientPromise});
+        stream.on('end', () => res.end());
+        stream.on('error', err => res.status(500).send(`Failed to get object in bucket ${bucket} at path ${key}: ${err}`))
+        stream.pipe(res);
+      } catch (err) {
+        res.send(`Failed to get object in bucket ${bucket} at path ${key}: ${err}`);
+      }
       break;
+
     case 'http':
     case 'https':
       // trim `/` from both ends of the base URL, then append with a single `/` to the end (empty string remains empty)
@@ -329,20 +314,11 @@ const logsHandler = async (req, res) => {
   }
 
   try {
-    res.send(await k8sHelper.getPodLogs(podName));
+    const stream = await podLogsHandler.getPodLogs(podName);
+    stream.on('error', (err) => res.status(500).send('Could not get main container logs: ' + err))
+    stream.on('end', () => res.end());
+    stream.pipe(res);
   } catch (err) {
-    // try argo archive if cannot retrieve from k8s pod
-    if (!!getPodLogsFromArtifactory) {
-      try {
-        let stream = await getPodLogsFromArtifactory(podName);
-        stream.pipe(res);
-        return;
-      } catch (archiveErr) {
-        res.status(500).send(
-          `Could not get main container logs: ${err}\nCould not get main container logs from archive: ${archiveErr}`);
-        return;
-      }
-    }
     res.status(500).send('Could not get main container logs: ' + err);
   }
 };

--- a/frontend/server/server.ts
+++ b/frontend/server/server.ts
@@ -16,7 +16,7 @@ import * as express from 'express';
 import {Application, static as StaticHandler} from 'express';
 import * as fs from 'fs';
 import * as proxy from 'http-proxy-middleware';
-import {Client as MinioClient, ClientOptions as MinioClienOptions} from 'minio';
+import {Client as MinioClient, ClientOptions as MinioClientOptions} from 'minio';
 import fetch from 'node-fetch';
 import * as path from 'path';
 import * as process from 'process';
@@ -79,7 +79,7 @@ const MINIO_ENDPOINT = MINIO_NAMESPACE && MINIO_NAMESPACE.length > 0 ? `${MINIO_
 const _as_bool = (value: string) => ['true', '1'].indexOf(value.toLowerCase()) >= 0
 
 /** minio client for minio storage */
-const minioOptions: MinioClienOptions = {
+const minioOptions: MinioClientOptions = {
   accessKey: MINIO_ACCESS_KEY,
   endPoint: MINIO_ENDPOINT,
   port: parseInt(MINIO_PORT, 10),
@@ -89,7 +89,7 @@ const minioOptions: MinioClienOptions = {
 const minioClient = new MinioClient(minioOptions);
 
 /** minio client for s3 objects */
-const s3Options: MinioClienOptions = {
+const s3Options: MinioClientOptions = {
   endPoint: 's3.amazonaws.com',
   accessKey: AWS_ACCESS_KEY_ID,
   secretKey: AWS_SECRET_ACCESS_KEY,

--- a/frontend/server/workflow-helper.ts
+++ b/frontend/server/workflow-helper.ts
@@ -1,0 +1,184 @@
+
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import {PassThrough} from 'stream';
+import {ClientOptions as MinioClientOptions} from 'minio';
+import {getK8sSecret, getArgoWorkflow, getPodLogs} from './k8s-helper';
+import {createMinioClient, IMinioRequestConfig, getObjectStream} from './minio-helper';
+
+
+export interface IPartialArgoWorkflow {
+    status: {
+        nodes?: IArgoWorkflowStatusNode
+    }
+}
+
+export interface IArgoWorkflowStatusNode {
+    [key: string]: IArgoWorkflowStatusNodeInfo;
+}
+
+export interface IArgoWorkflowStatusNodeInfo {
+    outputs?: {
+        artifacts?: IArtifactRecord[]
+    }
+}
+
+export interface IArtifactRecord {
+    archiveLogs?: boolean;
+    name: string;
+    s3?: IS3Artifact;
+}
+  
+export interface IS3Artifact {
+    accessKeySecret?: ISecretSelector;
+    bucket: string;
+    endpoint: string;
+    insecure: boolean;
+    key: string;
+    secretKeySecret?: ISecretSelector;
+}
+
+export interface ISecretSelector {
+    key: string;
+    name: string;
+}
+
+/**
+ * Returns the k8s access key and secret used to connect to the s3 artifactory.
+ * @param s3artifact s3artifact object describing the s3 artifactory config for argo workflow. 
+ */
+async function getMinioClientSecrets({accessKeySecret, secretKeySecret}: IS3Artifact) {
+    if (!accessKeySecret || !secretKeySecret) {
+        return {}
+    }
+    const accessKey = await getK8sSecret(accessKeySecret.name, accessKeySecret.key);
+    const secretKey = await getK8sSecret(secretKeySecret.name, secretKeySecret.key);
+    return {accessKey, secretKey};
+}
+
+/**
+ * Split an uri into host and port.
+ * @param uri uri to split
+ * @param insecure if port is not provided in uri, return port depending on whether ssl is enabled.
+ */  
+function urlSplit(uri: string, insecure: boolean) {
+    let chunks = uri.split(":");
+    if (chunks.length==1) 
+        return {host: chunks[0], port: !!insecure ? 80 : 443};
+    return {host: chunks[0], port: parseInt(chunks[1], 10)};
+}
+
+/**
+ * Infers workflow name from pod name.
+ * @param podName name of the pod.
+ */
+function workflowNameFromPodName(podName: string) {
+    let chunks = podName.split("-");
+    chunks.pop();
+    return chunks.join("-");
+}
+
+export class PodLogsHandler {
+    fromConfig?: (podName: string) => Promise<IMinioRequestConfig>;
+
+    async getPodLogs(podName: string) {
+        try {
+            // retrieve from k8s
+            const stream = new PassThrough();
+            stream.end(await getPodLogs(podName));
+            console.log(`Getting logs for pod:${podName}.`)
+            return stream;
+        } catch (k8sError) {
+            console.error(`Unable to get logs for pod:${podName}: ${k8sError}`);
+            return this.getPodLogsFromArchive(podName);
+        }
+    }
+
+    async getPodLogsFromArchive(podName: string) {
+        try {
+            // try argo workflow crd status
+            const request = await this.fromWorkflow(podName);
+            const stream = await getObjectStream(request);
+            console.log(`Getting logs for pod:${podName} from ${request.bucket}/${request.key}.`)
+            return stream;
+        } catch (workflowError) {
+            if (!!this.fromConfig) {
+                try {
+                    const request = await this.fromConfig(podName);
+                    const stream = await getObjectStream(request);
+                    console.log(`Getting logs for pod:${podName} from ${request.bucket}/${request.key}.`)
+                    return stream;
+                } catch (configError) {
+                    console.error(`Unable to get logs for pod:${podName}: ${configError}`);
+                    throw new Error(`Unable to retrieve logs from ${podName}: ${workflowError}, ${configError}`)
+                }
+            }
+            console.error(`Unable to get logs for pod:${podName}: ${workflowError}`);
+            console.error(workflowError);
+            throw new Error(`Unable to retrieve logs from ${podName}: ${workflowError}`)
+        }        
+    }
+
+    setFallbackHandler(minioOptions: MinioClientOptions, bucket: string, prefix: string) {
+        const client = createMinioClient(minioOptions);
+        this.fromConfig = async function(podName: string): Promise<IMinioRequestConfig> {
+            const workflowName = workflowNameFromPodName(podName);
+            return {
+                bucket,
+                key: `${prefix}/${workflowName}/${podName}/main.log`,
+                client: await client
+            };
+        }
+        return this;
+    }
+
+    async fromWorkflow(podName: string): Promise<IMinioRequestConfig> {
+        const workflow = await getArgoWorkflow(workflowNameFromPodName(podName));
+    
+        // check if required fields are available
+        if (!workflow.status || !workflow.status.nodes || 
+            !workflow.status.nodes[podName] || 
+            !workflow.status.nodes[podName].outputs ||
+            !workflow.status.nodes[podName].outputs.artifacts)
+          throw new Error('Unable to find pod info in workflow status to retrieve logs.')
+      
+        const artifacts: IArtifactRecord[] = workflow.status.nodes[podName].outputs.artifacts;
+        const archiveLogs: IArtifactRecord[] = artifacts.filter((artifact: any) => artifact.archiveLogs)
+      
+        if (archiveLogs.length === 0) 
+          throw new Error('Unable to find pod log archive information from workflow status.')
+        
+        const s3Artifact = archiveLogs[0].s3;
+        if (!s3Artifact) 
+            throw new Error('Unable to find s3 artifact info from workflow status.')
+       
+        const {host, port} = urlSplit(s3Artifact.endpoint, s3Artifact.insecure);
+        const {accessKey, secretKey} = await getMinioClientSecrets(s3Artifact);
+        const client = await createMinioClient({
+            endPoint: host,
+            port,
+            accessKey,
+            secretKey,
+            useSSL: !s3Artifact.insecure,
+        });
+        return {
+            bucket: s3Artifact.bucket,
+            key: s3Artifact.key,
+            client,
+        };
+    }
+}
+
+const podLogsHandler = new PodLogsHandler();
+export default podLogsHandler;

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
@@ -157,6 +157,13 @@ rules:
       - get
       - list
   - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - get
+    - list
+  - apiGroups:
       - kubeflow.org
     resources:
       - viewers
@@ -166,6 +173,13 @@ rules:
       - list
       - watch
       - delete
+  - apiGroups:
+    - "argoproj.io"
+    resources:
+    - workflows
+    verbs:
+    - get
+    - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/manifests/kustomize/base/pipeline/ml-pipeline-ui-role.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-ui-role.yaml
@@ -15,6 +15,13 @@ rules:
   - get
   - list
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
   - "kubeflow.org"
   resources:
   - viewers
@@ -24,3 +31,10 @@ rules:
   - list
   - watch
   - delete
+- apiGroups:
+  - "argoproj.io"
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list


### PR DESCRIPTION
A possible workaround for #1803 

Currently, I persist pod logs with argo's archiveLogs config to s3 bucket. 

This PR allow the UI to fallback to retrieving GCed pods logs from the argo archive artifactory - this can be either minio store or a s3 bucket.

This feature can be enabled by setting the following env variables:
```js
  /** Is Argo log archive enabled? */
  ARGO_ARCHIVE_LOGS = "true",
  /** Use minio or s3 client to retrieve archives. */
  ARGO_ARCHIVE_ARTIFACTORY = 'minio',
  /** Bucket to retrive logs from */
  ARGO_ARCHIVE_BUCKETNAME = 'mlpipeline',
  /** Prefix to logs. */
  ARGO_ARCHIVE_PREFIX = 'logs',
```

### Updates 20 sep 2019:
Investigate the feasibility of getting pod logs archive location from argo workflow status:
- conclusion is yes, but if the pipeline did not complete successfully, the status will not be updated with the output information (even if the logs are actually archived)

##### Changes
- Updated @types/minio  to match the minio package (`useSSL` instead of `insecure` <- old)
- Created a few additional helpers modules:
  - `aws-helper` provides utils to query and handles AWS instance profile session credentials (aka `kube2iam`  or ec2 profiles can be used instead of providing access key and secret to minio client)
  - `workflow-helper` provides utils to retrieve pod logs archive info from argo workflow status
  - `minio-helper` provides utils to retrieve objects from minio or s3 backends, includes capability to use AWS ec2 credentials to access s3
- Replace existing handlers for `s3` and `minio` objects with utils from `minio-helper`
- Update get pod logs handler to try getting the pod logs in the following orders:
  - get logs from pod with k8s api
  - get archive location from workflow status, and retrieve from archive
  - if workflow status does not have required info, fallback to the values provided in the environment variables (by user) and try to retrieve the logs.

- I have build the image and test on my own cluster in AWS. However, i only tested on the pod logs, have not really test on the ui-metadata yet.

### TODO
- probably shld use the schema from third-party/argo
- some unit tests?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2081)
<!-- Reviewable:end -->
