### PR TITLE
Expose an API for appending params/names/descriptions in a programmable way.

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -718,7 +718,7 @@ class Compiler(object):
       pipeline_func: Callable,
       pipeline_name: Text,
       pipeline_description: Text=None,
-      params_list: List[dsl.PipelineParam]=None) -> Dict[Text, Any]:
+      params_list: List[dsl.PipelineParam]=[]) -> Dict[Text, Any]:
     """ Create workflow spec from pipeline function and specified pipeline
     params/metadata. Currently, the pipeline params are either specified in
     the signature of the pipeline function or by passing a list of

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -719,7 +719,7 @@ class Compiler(object):
       pipeline_name: Text,
       pipeline_description: Text=None,
       params_list: List[dsl.PipelineParam]=None) -> Dict[Text, Any]:
-    """ Create workflow dict from pipeline function and specified pipeline
+    """ Create workflow spec from pipeline function and specified pipeline
     params/metadata. Currently, the pipeline params are either specified in
     the signature of the pipeline function or by passing a list of
     dsl.PipelineParam. Conflict will cause ValueError.

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -718,7 +718,7 @@ class Compiler(object):
       pipeline_func: Callable,
       pipeline_name: Text,
       pipeline_description: Text=None,
-      params_list: List[dsl.PipelineParam]=[]) -> Dict[Text, Any]:
+      params_list: List[dsl.PipelineParam]=()) -> Dict[Text, Any]:
     """ Create workflow spec from pipeline function and specified pipeline
     params/metadata. Currently, the pipeline params are either specified in
     the signature of the pipeline function or by passing a list of

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -714,9 +714,9 @@ class Compiler(object):
       sanitized_ops[sanitized_name] = op
     pipeline.ops = sanitized_ops
 
-  def create_workflow_from_func(self,
+  def create_workflow(self,
       pipeline_func: Callable,
-      pipeline_name: Text,
+      pipeline_name: Text=None,
       pipeline_description: Text=None,
       params_list: List[dsl.PipelineParam]=()) -> Dict[Text, Any]:
     """ Create workflow spec from pipeline function and specified pipeline
@@ -741,7 +741,7 @@ class Compiler(object):
 
     # Currently only allow specifying pipeline params at one place.
     if params_list and pipeline_meta.inputs:
-      raise ValueError('Only support specifying params by pipeline function signature, or params_list')
+      raise ValueError('Either specify pipeline params in the pipeline function, or in "params_list", but not both.')
 
     args_list = []
     if pipeline_meta.inputs:
@@ -793,7 +793,7 @@ class Compiler(object):
 
   def _compile(self, pipeline_func):
     """Compile the given pipeline function into workflow."""
-    return self.create_workflow_from_func(pipeline_func, [])
+    return self.create_workflow(pipeline_func, [])
 
   def compile(self, pipeline_func, package_path, type_check=True):
     """Compile the given pipeline function into workflow yaml.

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -179,6 +179,28 @@ class TestCompiler(unittest.TestCase):
       shutil.rmtree(tmpdir)
       # print(tmpdir)
 
+  def test_basic_workflow_without_decorator(self):
+    """Test compiling a workflow and appending pipeline params."""
+    test_data_dir = os.path.join(os.path.dirname(__file__), 'testdata')
+    sys.path.append(test_data_dir)
+    import basic_no_decorator
+    tmpdir = tempfile.mkdtemp()
+    try:
+      compiled_workflow = compiler.Compiler().create_workflow_from_func(
+          basic_no_decorator.save_most_frequent_word,
+          'Save Most Frequent',
+          'Get Most Frequent Word and Save to GCS',
+          [
+            basic_no_decorator.message_param,
+            basic_no_decorator.output_path_param
+          ])
+      with open(os.path.join(test_data_dir, 'basic_no_decorator.yaml'), 'r') as f:
+        golden = yaml.safe_load(f)
+
+      self.assertEqual(golden, compiled_workflow)
+    finally:
+      shutil.rmtree(tmpdir)
+
   def test_composing_workflow(self):
     """Test compiling a simple workflow, and a bigger one composed from the simple one."""
 

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -186,7 +186,7 @@ class TestCompiler(unittest.TestCase):
     import basic_no_decorator
     tmpdir = tempfile.mkdtemp()
     try:
-      compiled_workflow = compiler.Compiler().create_workflow_from_func(
+      compiled_workflow = compiler.Compiler().create_workflow(
           basic_no_decorator.save_most_frequent_word,
           'Save Most Frequent',
           'Get Most Frequent Word and Save to GCS',

--- a/sdk/python/tests/compiler/testdata/basic_no_decorator.py
+++ b/sdk/python/tests/compiler/testdata/basic_no_decorator.py
@@ -1,0 +1,91 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import kfp.dsl as dsl
+import kfp.gcp as gcp
+
+
+message_param = dsl.PipelineParam(name='message')
+output_path_param = dsl.PipelineParam(name='outputpath')
+
+class GetFrequentWordOp(dsl.ContainerOp):
+  """A get frequent word class representing a component in ML Pipelines.
+
+  The class provides a nice interface to users by hiding details such as container,
+  command, arguments.
+  """
+  def __init__(self, name, message):
+    """Args:
+         name: An identifier of the step which needs to be unique within a pipeline.
+         message: a dsl.PipelineParam object representing an input message.
+    """
+    super(GetFrequentWordOp, self).__init__(
+        name=name,
+        image='python:3.5-jessie',
+        command=['sh', '-c'],
+        arguments=['python -c "from collections import Counter; '
+                   'words = Counter(\'%s\'.split()); print(max(words, key=words.get))" '
+                   '| tee /tmp/message.txt' % message],
+        file_outputs={'word': '/tmp/message.txt'})
+
+
+class SaveMessageOp(dsl.ContainerOp):
+  """A class representing a component in ML Pipelines.
+
+  It saves a message to a given output_path.
+  """
+  def __init__(self, name, message, output_path):
+    """Args:
+         name: An identifier of the step which needs to be unique within a pipeline.
+         message: a dsl.PipelineParam object representing the message to be saved.
+         output_path: a dsl.PipelineParam object representing the GCS path for output file.
+    """
+    super(SaveMessageOp, self).__init__(
+        name=name,
+        image='google/cloud-sdk',
+        command=['sh', '-c'],
+        arguments=['echo %s | tee /tmp/results.txt | gsutil cp /tmp/results.txt %s'
+                   % (message, output_path)])
+
+
+class ExitHandlerOp(dsl.ContainerOp):
+  """A class representing a component in ML Pipelines.
+  """
+  def __init__(self, name):
+    super(ExitHandlerOp, self).__init__(
+        name=name,
+        image='python:3.5-jessie',
+        command=['sh', '-c'],
+        arguments=['echo exit!'])
+
+def save_most_frequent_word():
+  exit_op = ExitHandlerOp('exiting')
+  with dsl.ExitHandler(exit_op):
+    counter = GetFrequentWordOp(
+        name='get-Frequent',
+        message=message_param)
+    counter.set_memory_request('200M')
+
+    saver = SaveMessageOp(
+        name='save',
+        message=counter.output,
+        output_path=output_path_param)
+    saver.set_cpu_limit('0.5')
+    saver.set_gpu_limit('2')
+    saver.add_node_selector_constraint(
+        'cloud.google.com/gke-accelerator',
+        'nvidia-tesla-k80')
+    saver.apply(
+        gcp.use_tpu(tpu_cores = 8, tpu_resource = 'v2', tf_version = '1.12'))

--- a/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
+++ b/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
@@ -1,0 +1,119 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "Get Most Frequent Word and Save to GCS", "inputs": [{"name": "message"}, {"name": "outputpath"}], "name": "Save Most Frequent"}'
+  generateName: save-most-frequent-
+spec:
+  arguments:
+    parameters:
+      - name: message
+      - name: outputpath
+  entrypoint: save-most-frequent
+  serviceAccountName: pipeline-runner
+  onExit: exiting
+  templates:
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: message
+                  value: '{{inputs.parameters.message}}'
+            name: get-frequent
+            template: get-frequent
+          - arguments:
+              parameters:
+                - name: get-frequent-word
+                  value: '{{tasks.get-frequent.outputs.parameters.get-frequent-word}}'
+                - name: outputpath
+                  value: '{{inputs.parameters.outputpath}}'
+            dependencies:
+              - get-frequent
+            name: save
+            template: save
+      inputs:
+        parameters:
+          - name: message
+          - name: outputpath
+      name: exit-handler-1
+    - container:
+        args:
+          - echo exit!
+        command:
+          - sh
+          - -c
+        image: python:3.5-jessie
+      name: exiting
+    - container:
+        args:
+          - python -c "from collections import Counter; words = Counter('{{inputs.parameters.message}}'.split());
+            print(max(words, key=words.get))" | tee /tmp/message.txt
+        command:
+          - sh
+          - -c
+        image: python:3.5-jessie
+        resources:
+          requests:
+            memory: 200M
+      inputs:
+        parameters:
+          - name: message
+      name: get-frequent
+      outputs:
+        parameters:
+          - name: get-frequent-word
+            valueFrom:
+              path: /tmp/message.txt
+    - container:
+        args:
+          - echo {{inputs.parameters.get-frequent-word}} | tee /tmp/results.txt | gsutil
+            cp /tmp/results.txt {{inputs.parameters.outputpath}}
+        command:
+          - sh
+          - -c
+        image: google/cloud-sdk
+        resources:
+          limits:
+            cloud-tpus.google.com/v2: "8"
+            cpu: "0.5"
+            nvidia.com/gpu: "2"
+      inputs:
+        parameters:
+          - name: get-frequent-word
+          - name: outputpath
+      metadata:
+        annotations:
+          tf-version.cloud-tpus.google.com: "1.12"
+      name: save
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-tesla-k80
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: message
+                  value: '{{inputs.parameters.message}}'
+                - name: outputpath
+                  value: '{{inputs.parameters.outputpath}}'
+            name: exit-handler-1
+            template: exit-handler-1
+          - name: exiting
+            template: exiting
+      inputs:
+        parameters:
+          - name: message
+          - name: outputpath
+      name: save-most-frequent


### PR DESCRIPTION
An effort towards #1942

Add an API ``kfp.compiler.Compiler.create_workflow_from_func(func, name, description, params_list)``
Usage:
  Create workflow spec from pipeline function and specified pipeline params/metadata. 

Now we can do something like the following:
```python
ppl_param = dsl.PipelineParam(name='arg_specified_at_runtime')

def some_op():
  '''Example containerOp'''
  return dsl.ContainerOp(
      name='some op',
      image='busybox',
      command=['sleep 1'],
      arguments=[ppl_param]
  )

def pipeline_func():
  task = some_op()

compiler.Compiler().create_workflow_from_func(
    func=pipeline_func,
    name='Example Pipeline',
    description='Example description',
    params_list=[ppl_param])
```
It returns the workflow spec of the pipeline, then it can be dumped to yaml spec.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2082)
<!-- Reviewable:end -->
