### PR TITLE
gcp-marketplace: Updating metadata deployment to use gRPC server

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/metadata.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/metadata.yaml
@@ -34,19 +34,27 @@ spec:
         app.kubernetes.io/name: {{ .Release.Name }}
     spec:
       containers:
-        - command:
-            - ./server/server
-            - --http_port=8080
-            - --mysql_service_host=mysql
-            - --mysql_service_port=3306
-            {{ if .Values.managedstorage.databaseNamePrefix }}
-            - --mlmd_db_name={{ .Values.managedstorage.databaseNamePrefix }}_metadata
-            {{ else }}
-            - --mlmd_db_name={{ .Release.Name | replace "-" "_" | replace "." "_" | trunc 50 }}_metadata
-            {{ end }}
-
-          image: {{ .Values.images.metadataserver }}
-          name: container
-          ports:
-            - containerPort: 8080
-              name: md-backendapi
+      - name: container
+        image: {{ .Values.images.metadataserver }}
+        env:
+        - name: DBCONFIG_USER
+            valueFrom:
+              secretKeyRef:
+                name: mysql-credential
+                key: username
+        - name: DBCONFIG_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: mysql-credential
+                key: password
+        command: ["/bin/metadata_store_server"]
+        args: ["--grpc_port=8080",
+                 "--mysql_config_host=mysql",
+                 "--mysql_config_database=metadb",
+                 "--mysql_config_port=3306",
+                 "--mysql_config_user=$(DBCONFIG_USER)",
+                 "--mysql_config_password=$(DBCONFIG_PASSWORD)"
+                ]
+        ports:
+        - containerPort: 8080
+          name: md-backendapi

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/values.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/values.yaml
@@ -4,7 +4,7 @@ images:
   argoworkflowcontroller: gcr.io/ml-pipeline/workflow-controller:v2.3.0
   cloudsqlproxy: gcr.io/cloudsql-docker/gce-proxy:1.14
   frontend: gcr.io/ml-pipeline/frontend:0.1.27
-  metadataserver: gcr.io/kubeflow-images-public/metadata:v0.1.8
+  metadataserver: gcr.io/tfx-oss-public/ml_metadata_store_server:0.14.0
   minio: gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z
   mysql: gcr.io/ml-pipeline/mysql:5.6
   persistenceagent: gcr.io/ml-pipeline/persistenceagent:0.1.27


### PR DESCRIPTION
Change to update gcp marketplace helm charts to use gRPC MLMD metadata server.