### PR TITLE
Close the streams after getting gcloud auth token

### DIFF
--- a/sdk/python/kfp/_auth.py
+++ b/sdk/python/kfp/_auth.py
@@ -31,7 +31,8 @@ def get_gcp_access_token():
     Credentials. If not set, returns None. For more information, see
     https://cloud.google.com/sdk/gcloud/reference/auth/application-default/print-access-token
     """
-    return os.popen('gcloud auth print-access-token').read().rstrip()
+    with os.popen('gcloud auth print-access-token') as token:
+        return token.read().rstrip()
 
 def get_auth_token(client_id):
     """Gets auth token from default service account.


### PR DESCRIPTION
Error message saw in some cases
```
/tmpfs/BUILD_ENV/lib/python3.5/site-packages/kfp/_auth.py:34: ResourceWarning: unclosed file <_io.TextIOWrapper name=6 encoding='UTF-8'>
  return os.popen('gcloud auth print-access-token').read().rstrip()

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2084)
<!-- Reviewable:end -->
