### PR TITLE
Not throw exception if no row change for update run call

### DIFF
--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -400,9 +400,6 @@ func (s *RunStore) UpdateRun(runID string, condition string, finishedAtInSec int
 	if r > 1 {
 		tx.Rollback()
 		return util.NewInternalServerError(errors.New("Failed to update run"), "Failed to update run %s. More than 1 rows affected", runID)
-	} else if r == 0 {
-		tx.Rollback()
-		return util.NewInternalServerError(errors.New("Failed to update run"), "Failed to update run %s. Row not found", runID)
 	}
 
 	if err := tx.Commit(); err != nil {


### PR DESCRIPTION
There are cases that the persistence agent still call runs when there is no status change. In such as we shouldn't have to throw exception. 
/assign @dushyanthsc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2085)
<!-- Reviewable:end -->
