### PR TITLE
Remove broken environment variables in namespace install

### DIFF
--- a/manifests/kustomize/namespaced-install.yaml
+++ b/manifests/kustomize/namespaced-install.yaml
@@ -699,7 +699,6 @@ spec:
       containers:
       - env:
         - name: NAMESPACE
-          value: kubeflow
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -727,7 +726,6 @@ spec:
       containers:
       - env:
         - name: NAMESPACE
-          value: kubeflow
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -755,7 +753,6 @@ spec:
       containers:
       - env:
         - name: MINIO_NAMESPACE
-          value: kubeflow
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace


### PR DESCRIPTION
Likely introduced by a bad merge 
https://github.com/kubeflow/pipelines/pull/1918/files#diff-4f0f86e24382decf794ec0f3d0c4c54cR672

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2087)
<!-- Reviewable:end -->
