### PR TITLE
Artifact list column creation time

### DIFF
--- a/frontend/src/lib/MetadataUtils.ts
+++ b/frontend/src/lib/MetadataUtils.ts
@@ -1,0 +1,35 @@
+import { Event } from '../generated/src/apis/metadata/metadata_store_pb';
+import { GetEventsByArtifactIDsRequest, GetEventsByArtifactIDsResponse } from '../generated/src/apis/metadata/metadata_store_service_pb';
+import { Apis } from '../lib/Apis';
+import { formatDateString, serviceErrorToString } from './Utils';
+
+export const getArtifactCreationTime = (artifactId: number): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const eventsRequest = new GetEventsByArtifactIDsRequest();
+    if (!artifactId) {
+      return reject(new Error('artifactId is empty'));
+    }
+
+    eventsRequest.setArtifactIdsList([artifactId]);
+    Apis.getMetadataServiceClient().getEventsByArtifactIDs(eventsRequest, (err, res) => {
+      if (err) {
+        return reject(new Error(serviceErrorToString(err)));
+      } else {
+        const data = (res as GetEventsByArtifactIDsResponse).getEventsList().map(event => ({
+          time: event.getMillisecondsSinceEpoch(),
+          type: event.getType() || Event.Type.UNKNOWN,
+        }));
+        // The last output event is the event that produced current artifact.
+        const lastOutputEvent = data.reverse().find(event =>
+          event.type === Event.Type.DECLARED_OUTPUT || event.type === Event.Type.OUTPUT
+        );
+        if (lastOutputEvent && lastOutputEvent.time) {
+          resolve(formatDateString(new Date(lastOutputEvent.time)));
+        } else {
+          // No valid time found, just return empty
+          resolve('');
+        }
+      }
+    });
+  });
+};

--- a/frontend/src/pages/ArtifactList.tsx
+++ b/frontend/src/pages/ArtifactList.tsx
@@ -26,6 +26,7 @@ import { Link } from 'react-router-dom';
 import { Artifact, ArtifactType } from '../generated/src/apis/metadata/metadata_store_pb';
 import { ArtifactProperties, ArtifactCustomProperties, ListRequest, Apis } from '../lib/Apis';
 import { GetArtifactTypesRequest, GetArtifactsRequest } from '../generated/src/apis/metadata/metadata_store_service_pb';
+import { getArtifactCreationTime } from '../lib/MetadataUtils';
 
 interface ArtifactListState {
   artifacts: Artifact[];
@@ -57,8 +58,7 @@ class ArtifactList extends Page<{}, ArtifactListState> {
         { label: 'ID', flex: 1, sortKey: 'id' },
         { label: 'Type', flex: 2, sortKey: 'type' },
         { label: 'URI', flex: 2, sortKey: 'uri', },
-        // TODO: Get timestamp from the event that created this artifact.
-        // {label: 'Created at', flex: 1, sortKey: 'created_at'},
+        { label: 'Created at', flex: 1, sortKey: 'created_at' },
       ],
       expandedRows: new Map(),
       rows: [],
@@ -129,7 +129,7 @@ class ArtifactList extends Page<{}, ArtifactListState> {
           {props.value}
         </Link>
       );
-  }
+    }
 
   /**
    * Temporary solution to apply sorting, filtering, and pagination to the
@@ -150,9 +150,24 @@ class ArtifactList extends Page<{}, ArtifactListState> {
         artifactTypesMap.set(artifactType.getId()!, artifactType);
       });
 
-      const collapsedAndExpandedRows =
-        groupRows(artifacts
-          .map((artifact) => { // Flattens
+      const artifactsWithCreationTimePromise = Promise.all(artifacts.map(async (artifact) => {
+        const artifactId = artifact.getId();
+        if (!artifactId) {
+          return {
+            artifact,
+          };
+        }
+
+        const time = await getArtifactCreationTime(artifactId);
+        return ({
+          artifact,
+          creationTime: time,
+        });
+      }));
+
+      artifactsWithCreationTimePromise.then(artifactsWithCreationTime => {
+        const collapsedAndExpandedRows = groupRows(
+          artifactsWithCreationTime.map(({ artifact, creationTime }) => {
             const typeId = artifact.getTypeId();
             const type = (typeId && artifactTypesMap && artifactTypesMap.get(typeId))
               ? artifactTypesMap.get(typeId)!.getName()
@@ -166,20 +181,19 @@ class ArtifactList extends Page<{}, ArtifactListState> {
                 artifact.getId(),
                 type,
                 artifact.getUri(),
-                // TODO: Get timestamp from the event that created this artifact.
-                // formatDateString(
-                //   getArtifactProperty(a, ArtifactProperties.CREATE_TIME) || ''),
+                creationTime || '',
               ],
             } as Row;
           })
-          .filter(rowFilterFn(request))
-          .sort(rowCompareFn(request, this.state.columns))
+            .filter(rowFilterFn(request))
+            .sort(rowCompareFn(request, this.state.columns))
         );
 
-      this.setState({
-        artifacts,
-        expandedRows: collapsedAndExpandedRows.expandedRows,
-        rows: collapsedAndExpandedRows.collapsedRows,
+        this.setState({
+          artifacts,
+          expandedRows: collapsedAndExpandedRows.expandedRows,
+          rows: collapsedAndExpandedRows.collapsedRows,
+        });
       });
     });
   }


### PR DESCRIPTION
Implements feature mentioned in https://github.com/kubeflow/pipelines/issues/2086#issue-492003078

> We should add a column showing the creation time of each artifact. In order to get this, we'll need to query the metadata API server for events, and find the associated event that produced any given artifact. The event will have a timestamp.

Implementation video: https://drive.google.com/file/d/1tk6rFIuFn2H3yt9rwA7RYOPj0Loxhq_P/view

Current trade off, we need to send an extra request for each artifact to get its creation time. Therefore
* this is not scalable when artifact count is large.
* this shows data very slowly only until all the data is ready.

Thoughts?
Ideal fix is letting backend provide an api that lists artifacts with their creation time.
Before that, I can probably first show other fields, and then show creation time when data is ready.

/area front-end

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2105)
<!-- Reviewable:end -->
