### PR TITLE
SDK - Started to explicitly import submodules into kfp namespace

### DIFF
--- a/sdk/python/kfp/__init__.py
+++ b/sdk/python/kfp/__init__.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from . import components
+from . import containers
+from . import dsl
 from ._client import Client
 from ._config import *
 from ._runners import *


### PR DESCRIPTION
Previously, some submodules like `containers` were not getting imported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2117)
<!-- Reviewable:end -->
