### PR TITLE
Fix permission issue running GCP pipelines

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/gcp_secret.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/gcp_secret.yaml
@@ -8,3 +8,4 @@ metadata:
 type: Opaque
 data:
   application_default_credentials.json: {{ .Values.serviceAccountCredential | quote }}
+  user-gcp-sa.json: {{ .Values.serviceAccountCredential | quote }}


### PR DESCRIPTION
The GCP pipelines currently requires user-gcp-sa.json in the user-gcp-sa. 
Add the token will ensure the pipelines calling GCP services continue to work. 
/assign @rmgogogo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2129)
<!-- Reviewable:end -->
