### PR TITLE
Fix the test name of image pull secrets sample test.

### DIFF
--- a/test/sample-test/configs/imagepullsecrets.config.yaml
+++ b/test/sample-test/configs/imagepullsecrets.config.yaml
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-test_name: xgboost_training_cm
+test_name: imagepullsecrets
 arguments:
   message: 'This is a long long message.'


### PR DESCRIPTION
Fix of #2113

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2132)
<!-- Reviewable:end -->
