### PR TITLE
Fix missing execution name in execution list/detail page.

### DIFF
--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as Utils from './Utils';
+import { HTMLViewerConfig } from 'src/components/viewers/HTMLViewer';
 import { ExperimentServiceApi } from '../apis/experiment';
 import { JobServiceApi } from '../apis/job';
+import { ApiPipeline, PipelineServiceApi } from '../apis/pipeline';
 import { RunServiceApi } from '../apis/run';
-import { PipelineServiceApi, ApiPipeline } from '../apis/pipeline';
-import { StoragePath } from './WorkflowParser';
-import { VisualizationServiceApi, ApiVisualization } from '../apis/visualization';
-import { HTMLViewerConfig } from 'src/components/viewers/HTMLViewer';
+import { ApiVisualization, VisualizationServiceApi } from '../apis/visualization';
 import { PlotType } from '../components/viewers/Viewer';
 import { MetadataStoreServiceClient } from '../generated/src/apis/metadata/metadata_store_service_pb_service';
+import * as Utils from './Utils';
+import { StoragePath } from './WorkflowParser';
 
 const v1beta1Prefix = 'apis/v1beta1';
 
@@ -43,7 +43,8 @@ export enum ArtifactCustomProperties {
 
 /** Known Execution properties */
 export enum ExecutionProperties {
-  NAME = 'name',
+  NAME = 'name', // currently not available in api, use component_id instead
+  COMPONENT_ID = 'component_id',
   PIPELINE_NAME = 'pipeline_name',
   STATE = 'state',
 }

--- a/frontend/src/pages/ExecutionDetails.tsx
+++ b/frontend/src/pages/ExecutionDetails.tsx
@@ -113,7 +113,7 @@ export default class ExecutionDetails extends Page<{}, ExecutionDetailsState> {
 
       const execution = res.getExecutionsList()[0];
 
-      const executionName = getResourceProperty(execution, ExecutionProperties.NAME);
+      const executionName = getResourceProperty(execution, ExecutionProperties.COMPONENT_ID);
       this.props.updateToolbar({
         pageTitle: executionName ? executionName.toString() : ''
       });

--- a/frontend/src/pages/ExecutionList.tsx
+++ b/frontend/src/pages/ExecutionList.tsx
@@ -161,7 +161,7 @@ class ExecutionList extends Page<{}, ExecutionListState> {
               otherFields: [
                 getResourceProperty(execution, ExecutionProperties.PIPELINE_NAME)
                 || getResourceProperty(execution, ExecutionCustomProperties.WORKSPACE, true),
-                getResourceProperty(execution, ExecutionProperties.NAME),
+                getResourceProperty(execution, ExecutionProperties.COMPONENT_ID),
                 getResourceProperty(execution, ExecutionProperties.STATE),
                 execution.getId(),
                 type,


### PR DESCRIPTION
Bug: execution names are missing in execution list page.
After the fix: https://drive.google.com/file/d/1NJRFc8T5rWkSLJy_RbzT1yEJb4VyIgjz/view

Part of https://github.com/kubeflow/pipelines/issues/2086

/assign @IronPan 
/cc @neuromage 
/kind bug
/area front-end

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2135)
<!-- Reviewable:end -->
