### PR TITLE
[Test/sample_test] Fix arguments parsing in yaml config.

### DIFF
--- a/test/sample-test/run_sample_test.py
+++ b/test/sample-test/run_sample_test.py
@@ -100,7 +100,8 @@ class PySampleChecker(object):
     except OSError as ose:
       print('Config file with the same name not found, use default args:{}'.format(ose))
     else:
-      self._test_args.update(raw_args['arguments'])
+      if raw_args['arguments']:
+        self._test_args.update(raw_args['arguments'])
       if 'output' in self._test_args.keys():  # output is a special param that has to be specified dynamically.
         self._test_args['output'] = self._output
       if 'test_timeout' in raw_args.keys():


### PR DESCRIPTION
Skip when arguments section is empty.
This problem is blocking #2141

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2150)
<!-- Reviewable:end -->
