### PR TITLE
Fix presubmit test failure -- build job in QUEUED state

### DIFF
--- a/test/check-build-image-status.sh
+++ b/test/check-build-image-status.sh
@@ -29,7 +29,7 @@ if [ "$IMAGES_BUILDING" == true ]; then
         "SUCCESS")
           echo "Build with id ${id} has succeeded."
         ;;
-        "WORKING")
+        "WORKING" | "QUEUED")
           NEW_PENDING_BUILD_IDS+=( "$id" )
         ;;
         "FETCH_ERROR")


### PR DESCRIPTION
cloud build job can be in 'QUEUED' state too, it's causing some presubmit test failures

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2152)
<!-- Reviewable:end -->
