### PR TITLE
Utils to convert metadata api from callback paradigm to promise paradigm

### DIFF
--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -19,7 +19,7 @@ import { ApiPipeline, PipelineServiceApi } from '../apis/pipeline';
 import { RunServiceApi } from '../apis/run';
 import { ApiVisualization, VisualizationServiceApi } from '../apis/visualization';
 import { PlotType } from '../components/viewers/Viewer';
-import { MetadataStoreServiceClient } from '../generated/src/apis/metadata/metadata_store_service_pb_service';
+import { MetadataStoreServiceClient, ServiceError, UnaryResponse } from '../generated/src/apis/metadata/metadata_store_service_pb_service';
 import * as Utils from './Utils';
 import { StoragePath } from './WorkflowParser';
 
@@ -70,7 +70,30 @@ export interface BuildInfo {
 }
 
 let customVisualizationsAllowed: boolean;
+
+type Callback<R> = (err: ServiceError | null, res: R | null) => void;
+type MetadataApiMethod<T, R> = (request: T, callback: Callback<R>) => UnaryResponse;
+type PromiseBasedMetadataApiMethod<T, R> = (request: T) => Promise<{ response: R | null, error: ServiceError | null }>;
+
+/**
+ * Converts a callback based api method to promise based api method.
+ */
+function makePromiseApi<T, R>(apiMethod: MetadataApiMethod<T, R>): PromiseBasedMetadataApiMethod<T, R> {
+  return (request: T) => new Promise((resolve, reject) => {
+    const handler = (error: ServiceError | null, response: R | null) => {
+      // resolve both response and error to keep type information
+      resolve({ response, error });
+    };
+    apiMethod(request, handler);
+  });
+}
 const metadataServiceClient = new MetadataStoreServiceClient('');
+// TODO: add all other api methods we need here.
+const metadataServicePromiseClient = {
+  getEventsByArtifactIDs: makePromiseApi(metadataServiceClient.getEventsByArtifactIDs.bind(metadataServiceClient)),
+  getEventsByExecutionIDs: makePromiseApi(metadataServiceClient.getEventsByExecutionIDs.bind(metadataServiceClient)),
+  getExecutionsByID: makePromiseApi(metadataServiceClient.getExecutionsByID.bind(metadataServiceClient)),
+};
 
 export class Apis {
 
@@ -231,6 +254,12 @@ export class Apis {
 
   public static getMetadataServiceClient(): MetadataStoreServiceClient {
     return metadataServiceClient;
+  }
+
+  // It will be a lot of boilerplate to type the following method, omit it here.
+  // tslint:disable-next-line:typedef
+  public static getMetadataServicePromiseClient() {
+    return metadataServicePromiseClient;
   }
 
   private static _experimentServiceApi?: ExperimentServiceApi;


### PR DESCRIPTION
Promise based APIs are easier to use, has fewer nestings and integrates better with modern javascript language features like `async function`.

/area front-end
/assign @IronPan

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2153)
<!-- Reviewable:end -->
