### PR TITLE
GUI: should pop-up a correct info when delete more than one pipeline

### DIFF
--- a/frontend/src/lib/Buttons.ts
+++ b/frontend/src/lib/Buttons.ts
@@ -353,7 +353,7 @@ export default class Buttons {
     callback: (selectedIds: string[], success: boolean) => void): void {
     this._dialogActionHandler(
       selectedIds,
-      'Do you want to delete this Pipeline? This action cannot be undone.',
+      `Do you want to delete ${selectedIds.length === 1 ? 'this Pipeline' : 'these Pipelines'}? This action cannot be undone.`,
       useCurrentResource,
       id => Apis.pipelineServiceApi.deletePipeline(id),
       callback,


### PR DESCRIPTION
When user select and delete more than one pipeline,  the confirmation info should be changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2156)
<!-- Reviewable:end -->
