### PR TITLE
Pretty print json value in execution/artifact detail page

### DIFF
--- a/frontend/src/components/ResourceInfo.tsx
+++ b/frontend/src/components/ResourceInfo.tsx
@@ -93,7 +93,6 @@ function prettyPrintJsonValue(value: string | number): JSX.Element | number | st
 
   try {
     const jsonValue = JSON.parse(value);
-    console.log(value);
     return <pre>{JSON.stringify(jsonValue, null, 2)}</pre>;
   } catch {
     // not JSON, return directly

--- a/frontend/src/components/ResourceInfo.tsx
+++ b/frontend/src/components/ResourceInfo.tsx
@@ -65,7 +65,7 @@ export class ResourceInfo extends React.Component<ResourceInfoProps, {}> {
             .map(k =>
               <div className={css.field} key={k[0]}>
                 <dt className={css.term}>{k[0]}</dt>
-                <dd className={css.value}>{propertyMap && getMetadataValue(propertyMap.get(k[0]))}</dd>
+                <dd className={css.value}>{propertyMap && prettyPrintJsonValue(getMetadataValue(propertyMap.get(k[0])))}</dd>
               </div>
             )
           }
@@ -76,12 +76,27 @@ export class ResourceInfo extends React.Component<ResourceInfoProps, {}> {
             <div className={css.field} key={k[0]}>
               <dt className={css.term}>{k[0]}</dt>
               <dd className={css.value}>
-                {customPropertyMap && getMetadataValue(customPropertyMap.get(k[0]))}
+                {customPropertyMap && prettyPrintJsonValue(getMetadataValue(customPropertyMap.get(k[0])))}
               </dd>
             </div>
           )}
         </dl>
       </section>
     );
+  }
+}
+
+function prettyPrintJsonValue(value: string | number): JSX.Element | number | string {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  try {
+    const jsonValue = JSON.parse(value);
+    console.log(value);
+    return <pre>{JSON.stringify(jsonValue, null, 2)}</pre>;
+  } catch {
+    // not JSON, return directly
+    return value;
   }
 }


### PR DESCRIPTION
![before](https://user-images.githubusercontent.com/4957653/65213781-19145780-dada-11e9-846c-0d64587c2e99.png)
![after](https://user-images.githubusercontent.com/4957653/65213777-1580d080-dada-11e9-951a-627ba4cdca95.png)

Part of https://github.com/kubeflow/pipelines/issues/2086#issuecomment-532511139

/area front-end
/kind feature
/cc @neuromage 
/assign @IronPan

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2165)
<!-- Reviewable:end -->
