### PR TITLE
[Test/sample] Fix the model version in kubeflow_tf_serving sample to avoid potential conflict.

### DIFF
--- a/samples/core/kubeflow_tf_serving/kubeflow_tf_serving.ipynb
+++ b/samples/core/kubeflow_tf_serving/kubeflow_tf_serving.ipynb
@@ -174,7 +174,7 @@
     "model_name = 'model-name'                                      # Model name matching TF_serve naming requirements       \n",
     "experiment_name = 'serving_component'\n",
     "import time\n",
-    "ts = int(time.time())\n"
+    "ts = int(time.time())\n",
     "model_version = str(ts)                                            # Here we use timestamp as version to avoid conflict \n",
     "output = 'Your-Gcs-Path'     # A GCS bucket for asset outputs\n",
     "KUBEFLOW_DEPLOYER_IMAGE = 'gcr.io/ml-pipeline/ml-pipeline-kubeflow-deployer:1449d08aeeeb47731d019ea046d90904d9c77953'"

--- a/samples/core/kubeflow_tf_serving/kubeflow_tf_serving.ipynb
+++ b/samples/core/kubeflow_tf_serving/kubeflow_tf_serving.ipynb
@@ -173,7 +173,9 @@
     "project =  'Your-Gcp-Project-ID'                          #'Your-GCP-Project-ID'\n",
     "model_name = 'model-name'                                      # Model name matching TF_serve naming requirements       \n",
     "experiment_name = 'serving_component'\n",
-    "model_version = '1'                                            # A number representing the version model \n",
+    "import time\n",
+    "ts = int(time.time())\n"
+    "model_version = str(ts)                                            # Here we use timestamp as version to avoid conflict \n",
     "output = 'Your-Gcs-Path'     # A GCS bucket for asset outputs\n",
     "KUBEFLOW_DEPLOYER_IMAGE = 'gcr.io/ml-pipeline/ml-pipeline-kubeflow-deployer:1449d08aeeeb47731d019ea046d90904d9c77953'"
    ]


### PR DESCRIPTION
When there is no new commit detected in a PR, PULL_PULL_SHA will be reused, causing conflict in the export model path.

This can be fixed by using timestamp as the version number. See #2047 for context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2170)
<!-- Reviewable:end -->
