### PR TITLE
Docs - Added the direct kfp module members to documentation

### DIFF
--- a/docs/source/kfp.rst
+++ b/docs/source/kfp.rst
@@ -13,3 +13,10 @@ kfp package
     kfp.client
     kfp.notebook
     kfp.extensions
+
+.. automodule:: kfp
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :imported-members:
+    :exclude-members: Client


### PR DESCRIPTION
Problem: We've added some members to the root of kfp module (not some sub-module). E.g. `kfp.run_pipeline_function_on_kfp_cluster`.
These members are not shown in the Python SDK reference docs.
The change auto-adds those members to the docs.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2183)
<!-- Reviewable:end -->
