### PR TITLE
  SDK - Python components - Properly serializing outputs

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -21,7 +21,7 @@ __all__ = [
 
 from ._yaml_utils import dump_yaml
 from ._components import _create_task_factory_from_component_spec
-from ._data_passing import serialize_value, type_name_to_deserializer, type_to_type_name
+from ._data_passing import serialize_value, type_name_to_deserializer, type_name_to_serializer, type_to_type_name
 from ._structures import *
 
 import inspect
@@ -281,6 +281,17 @@ def _func_to_component_spec(func, extra_code='', base_image : str = None, module
             return deserializer_code_str
         return 'str'
 
+    def get_serializer_and_register_definitions(type_name) -> str:
+        if type_name in type_name_to_serializer:
+            serializer_func = type_name_to_serializer[type_name]
+            # If serializer is not part of the standard python library, then include its code in the generated program
+            if hasattr(serializer_func, '__module__') and not _module_is_builtin_or_standard(serializer_func.__module__):
+                import inspect
+                serializer_code_str = inspect.getsource(serializer_func)
+                definitions.add(serializer_code_str)
+            return serializer_func.__name__
+        return 'str'
+
     arg_parse_code_lines = [
         'import argparse',
         '_missing_arg = object()',
@@ -325,6 +336,13 @@ def _func_to_component_spec(func, extra_code='', base_image : str = None, module
         arguments.append(param_flag)
         arguments.extend(OutputPathPlaceholder(output.name) for output in component_spec.outputs)
 
+    output_serialization_expression_strings = []
+    if component_spec.outputs:
+        outputs_produced_by_func_return_value = component_spec.outputs
+        for output in outputs_produced_by_func_return_value:
+            serializer_call_str = get_serializer_and_register_definitions(output.type)
+            output_serialization_expression_strings.append(serializer_call_str)
+
     arg_parse_code_lines = list(definitions) + arg_parse_code_lines
 
     arg_parse_code_lines.extend([
@@ -348,6 +366,10 @@ _outputs = {func_name}(**_parsed_args)
 if not hasattr(_outputs, '__getitem__') or isinstance(_outputs, str):
     _outputs = [_outputs]
 
+_output_serializers = [
+    {output_serialization_code}
+]
+
 import os
 for idx, output_file in enumerate(_output_files):
     try:
@@ -355,12 +377,13 @@ for idx, output_file in enumerate(_output_files):
     except OSError:
         pass
     with open(output_file, 'w') as f:
-        f.write(str(_outputs[idx]))
+        f.write(_output_serializers[idx](_outputs[idx]))
 '''.format(
         func_name=func.__name__,
         func_code=func_code,
         extra_code=extra_code,
         arg_parse_code='\n'.join(arg_parse_code_lines),
+        output_serialization_code=',\n    '.join(output_serialization_expression_strings),
     )
 
     #Removing consecutive blank lines
@@ -472,3 +495,15 @@ def func_to_container_op(func, output_component_file=None, base_image: str = Non
         #TODO: assert ComponentSpec.from_dict(load_yaml(output_component_file)) == component_spec
 
     return _create_task_factory_from_component_spec(component_spec)
+
+
+def _module_is_builtin_or_standard(module_name: str) -> bool:
+    import sys
+    if module_name in sys.builtin_module_names:
+        return True
+    import distutils.sysconfig as sysconfig
+    import os
+    std_lib_dir = sysconfig.get_python_lib(standard_lib=True)
+    module_name_parts = module_name.split('.')
+    expected_module_path = os.path.join(std_lib_dir, *module_name_parts)
+    return os.path.exists(expected_module_path) or os.path.exists(expected_module_path + '.py')

--- a/sdk/python/tests/components/test_python_op.py
+++ b/sdk/python/tests/components/test_python_op.py
@@ -481,6 +481,19 @@ class PythonOpTestCase(unittest.TestCase):
         ])
 
 
+    def test_handling_list_dict_output_values(self):
+        def produce_list() -> list:
+            return (["string", 1, 2.2, True, False, None, [3, 4], {'s': 5}], )
+        
+        # ! JSON map keys are always strings. Python converts all keys to strings without warnings
+        task_factory = comp.func_to_container_op(produce_list)
+
+        import json
+        expected_output = json.dumps(["string", 1, 2.2, True, False, None, [3, 4], {'s': 5}])
+
+        self.helper_test_component_using_local_call(task_factory, arguments={}, expected_output_values={'output': expected_output})
+
+
     def test_end_to_end_python_component_pipeline_compilation(self):
         import kfp.components as comp
 

--- a/sdk/python/tests/components/test_python_op.py
+++ b/sdk/python/tests/components/test_python_op.py
@@ -17,6 +17,7 @@ import tempfile
 import unittest
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Callable
 
 import kfp.components as comp
 
@@ -92,6 +93,42 @@ class PythonOpTestCase(unittest.TestCase):
 
         self.assertEqual(float(actual1_str), float(expected1_str))
         self.assertEqual(float(actual2_str), float(expected2_str))
+
+    def helper_test_component_created_from_func_using_local_call(self, func: Callable, arguments: dict):
+        task_factory = comp.func_to_container_op(func)
+        self.helper_test_component_against_func_using_local_call(func, task_factory, arguments)
+
+    def helper_test_component_against_func_using_local_call(self, func: Callable, op: Callable, arguments: dict):
+        # ! This function cannot be used when component has output types that use custom serialization since it will compare non-serialized function outputs with serialized component outputs.
+        # Evaluating the function to get the expected output values
+        expected_output_values_list = func(**arguments)
+        expected_output_values_list = [str(value) for value in expected_output_values_list]
+
+        output_names = [output.name for output in op.outputs]
+        from kfp.components._naming import generate_unique_name_conversion_table, _sanitize_python_function_name
+        output_name_to_pythonic = generate_unique_name_conversion_table(output_names, _sanitize_python_function_name)
+        pythonic_output_names = [output_name_to_pythonic[name] for name in output_names]
+        from collections import OrderedDict
+        expected_output_values_dict = OrderedDict(zip(pythonic_output_names, expected_output_values_list))
+
+        self.helper_test_component_using_local_call(op, arguments, expected_output_values_dict)
+
+    def helper_test_component_using_local_call(self, component_task_factory: Callable, arguments: dict, expected_output_values: dict):
+        with tempfile.TemporaryDirectory() as temp_dir_name:
+            # Creating task from the component.
+            # We do it in a special context that allows us to control the output file locations.
+            with components_local_output_dir_context(temp_dir_name):
+                task = component_task_factory(**arguments)
+
+            # Constructing the full command-line from resolved command+args
+            full_command = task.command + task.arguments
+
+            # Executing the command-line locally
+            subprocess.run(full_command, check=True)
+
+            actual_output_values_dict = {output_name: Path(output_path).read_text() for output_name, output_path in task.file_outputs.items()}
+
+        self.assertEqual(actual_output_values_dict, expected_output_values)
 
     def test_func_to_container_op_local_call(self):
         func = add_two_numbers


### PR DESCRIPTION
To be merged after https://github.com/kubeflow/pipelines/pull/2195

Background:
Component arguments are already properly serialized when calling the component program and then deserialized before the execution of the component function.
But the component outputs were only serialized using `str()` which is inadequate for data types like lists or dictionaries.

This commit fixes the mismatch - the outputs are now serialized the same ways as arguments and default values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2198)
<!-- Reviewable:end -->
