### PR TITLE
SDK - Components - Fixed serialization of lists and dicts containing `PipelineParam` items

### DIFF
--- a/sdk/python/kfp/components/_data_passing.py
+++ b/sdk/python/kfp/components/_data_passing.py
@@ -46,7 +46,12 @@ _bool_deserializer_code = _deserialize_bool.__name__
 
 def _serialize_json(obj) -> str:
     import json
-    return json.dumps(obj)
+    def default_serializer(obj):
+        if hasattr(obj, 'to_struct'):
+            return obj.to_struct()
+        else:
+            raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
+    return json.dumps(obj, default=default_serializer)
 
 
 def _serialize_base64_pickle(obj) -> str:

--- a/sdk/python/kfp/dsl/_pipeline_param.py
+++ b/sdk/python/kfp/dsl/_pipeline_param.py
@@ -191,7 +191,13 @@ class PipelineParam(object):
     return '{{pipelineparam:op=%s;name=%s}}' % (op_name, self.name)
   
   def __repr__(self):
-    return str({self.__class__.__name__: self.__dict__})
+    # return str({self.__class__.__name__: self.__dict__})
+    # We make repr return the placeholder string so that if someone uses str()-based serialization of complex objects containing `PipelineParam` it works properly (e.g. str([1, 2, 3, kfp.dsl.PipelineParam("aaa"), 4, 5, 6,]))
+    return str(self)
+
+  def to_struct(self):
+    # Used by the json serializer. Outputs a JSON-serializable representation of the object
+    return str(self)
 
   def __eq__(self, other):
     return ConditionOperator('==', self, other)

--- a/sdk/python/tests/components/test_python_op.py
+++ b/sdk/python/tests/components/test_python_op.py
@@ -460,6 +460,19 @@ class PythonOpTestCase(unittest.TestCase):
         ])
 
 
+    def test_handling_list_arguments_containing_pipelineparam(self):
+        '''Checks that lists containing PipelineParam can be properly serialized'''
+        def consume_list(list_param: list) -> int:
+            pass
+
+        import kfp
+        task_factory = comp.func_to_container_op(consume_list)
+        task = task_factory([1, 2, 3, kfp.dsl.PipelineParam("aaa"), 4, 5, 6])
+        full_command_line = task.command + task.arguments
+        for arg in full_command_line:
+            self.assertNotIn('PipelineParam', arg)
+
+
     def test_handling_base64_pickle_arguments(self):
         def assert_values_are_same(
             obj1: 'Base64Pickle', # noqa: F821


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/2206
The issue is fixed for both `JSON`-based and `str()`-based serialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2212)
<!-- Reviewable:end -->
