### PR TITLE
SDK - Components - Fix - Stop serializing string values

### DIFF
--- a/sdk/python/kfp/components/_data_passing.py
+++ b/sdk/python/kfp/components/_data_passing.py
@@ -45,11 +45,15 @@ _bool_deserializer_code = _deserialize_bool.__name__
 
 
 def _serialize_json(obj) -> str:
+    if isinstance(obj, str):
+        return obj
     import json
     return json.dumps(obj)
 
 
 def _serialize_base64_pickle(obj) -> str:
+    if isinstance(obj, str):
+        return obj
     import base64
     import pickle
     return base64.b64encode(pickle.dumps(obj)).decode('ascii')


### PR DESCRIPTION
This can happen with Lightweight component outputs if they've already been serialized manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2227)
<!-- Reviewable:end -->
