### PR TITLE
SDK: fix label check for ContainerOP entities

### DIFF
--- a/sdk/python/kfp/compiler/_default_transformers.py
+++ b/sdk/python/kfp/compiler/_default_transformers.py
@@ -17,7 +17,7 @@ from ..dsl._container_op import BaseOp, ContainerOp
 def add_pod_env(op: BaseOp) -> BaseOp:
     """Adds pod environment info to ContainerOp.
     """
-    if isinstance(op, ContainerOp) and op.pod_labels and op.pod_labels['add-pod-env'] == 'true':
+    if isinstance(op, ContainerOp) and op.pod_labels and 'add-pod-env' in op.pod_labels and op.pod_labels['add-pod-env'] == 'true':
         from kubernetes import client as k8s_client
         op.container.add_env_variable(
             k8s_client.V1EnvVar(


### PR DESCRIPTION
Fix ContainerOp label check during compilation step. Previously it was failing with `KeyError: 'add-pod-env'` if you added custom labels to ContainerOp object with `ContainerOp.add_pod_label()` function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2243)
<!-- Reviewable:end -->
