### PR TITLE
SDK - Containers - Getting namespace lazily

### DIFF
--- a/sdk/python/kfp/containers/_container_builder.py
+++ b/sdk/python/kfp/containers/_container_builder.py
@@ -64,15 +64,17 @@ class ContainerBuilder(object):
     self._gcs_staging = gcs_staging
     self._gcs_staging_checked = False
     self._default_image_name = gcr_image_tag
-
-    # Configure the namespace
     self._namespace = namespace
-    if namespace is None:
+
+  def _get_namespace(self):
+    if self._namespace is None:
+      # Configure the namespace
       if os.path.exists(SERVICEACCOUNT_NAMESPACE):
         with open(SERVICEACCOUNT_NAMESPACE, 'r') as f:
           self._namespace = f.read()
       else:
         self._namespace = 'kubeflow'
+    return self._namespace
 
   def _get_staging_location(self):
     if self._gcs_staging_checked:
@@ -114,7 +116,7 @@ class ContainerBuilder(object):
         'apiVersion': 'v1',
         'metadata': {
             'generateName': 'kaniko-',
-            'namespace': self._namespace,
+            'namespace': self._get_namespace(),
             'annotations': {
                 'sidecar.istio.io/inject': 'false'
             },


### PR DESCRIPTION
Class constructors should ideally do as little work as possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2256)
<!-- Reviewable:end -->
