### PR TITLE
SDK - Components - Restored attribute order when generating component.yaml files

### DIFF
--- a/components/gcp/automl/create_dataset_for_tables/component.yaml
+++ b/components/gcp/automl/create_dataset_for_tables/component.yaml
@@ -1,48 +1,38 @@
+name: Automl create dataset for tables
 description: |
   automl_create_dataset_for_tables creates an empty Dataset for AutoML tables
+inputs:
+- name: gcp_project_id
+  type: String
+- name: gcp_region
+  type: String
+- name: display_name
+  type: String
+- name: description
+  type: String
+  optional: true
+- name: tables_dataset_metadata
+  type: JsonObject
+  default: '{}'
+  optional: true
+- name: retry
+  optional: true
+- name: timeout
+  type: Float
+  optional: true
+- name: metadata
+  type: JsonObject
+  optional: true
+outputs:
+- name: dataset_path
+  type: String
+- name: create_time
+  type: String
+- name: dataset_id
+  type: String
 implementation:
   container:
-    args:
-    - --gcp-project-id
-    - inputValue: gcp_project_id
-    - --gcp-region
-    - inputValue: gcp_region
-    - --display-name
-    - inputValue: display_name
-    - if:
-        cond:
-          isPresent: description
-        then:
-        - --description
-        - inputValue: description
-    - if:
-        cond:
-          isPresent: tables_dataset_metadata
-        then:
-        - --tables-dataset-metadata
-        - inputValue: tables_dataset_metadata
-    - if:
-        cond:
-          isPresent: retry
-        then:
-        - --retry
-        - inputValue: retry
-    - if:
-        cond:
-          isPresent: timeout
-        then:
-        - --timeout
-        - inputValue: timeout
-    - if:
-        cond:
-          isPresent: metadata
-        then:
-        - --metadata
-        - inputValue: metadata
-    - '----output-paths'
-    - outputPath: dataset_path
-    - outputPath: create_time
-    - outputPath: dataset_id
+    image: python:3.7
     command:
     - python3
     - -u
@@ -116,34 +106,44 @@ implementation:
               pass
           with open(output_file, 'w') as f:
               f.write(str(_outputs[idx]))
-    image: python:3.7
-inputs:
-- name: gcp_project_id
-  type: String
-- name: gcp_region
-  type: String
-- name: display_name
-  type: String
-- name: description
-  optional: true
-  type: String
-- default: '{}'
-  name: tables_dataset_metadata
-  optional: true
-  type: JsonObject
-- name: retry
-  optional: true
-- name: timeout
-  optional: true
-  type: Float
-- name: metadata
-  optional: true
-  type: JsonObject
-name: Automl create dataset for tables
-outputs:
-- name: dataset_path
-  type: String
-- name: create_time
-  type: String
-- name: dataset_id
-  type: String
+    args:
+    - --gcp-project-id
+    - inputValue: gcp_project_id
+    - --gcp-region
+    - inputValue: gcp_region
+    - --display-name
+    - inputValue: display_name
+    - if:
+        cond:
+          isPresent: description
+        then:
+        - --description
+        - inputValue: description
+    - if:
+        cond:
+          isPresent: tables_dataset_metadata
+        then:
+        - --tables-dataset-metadata
+        - inputValue: tables_dataset_metadata
+    - if:
+        cond:
+          isPresent: retry
+        then:
+        - --retry
+        - inputValue: retry
+    - if:
+        cond:
+          isPresent: timeout
+        then:
+        - --timeout
+        - inputValue: timeout
+    - if:
+        cond:
+          isPresent: metadata
+        then:
+        - --metadata
+        - inputValue: metadata
+    - '----output-paths'
+    - outputPath: dataset_path
+    - outputPath: create_time
+    - outputPath: dataset_id

--- a/components/gcp/automl/create_model_for_tables/component.yaml
+++ b/components/gcp/automl/create_model_for_tables/component.yaml
@@ -1,41 +1,35 @@
+name: Automl create model for tables
+inputs:
+- name: gcp_project_id
+  type: String
+- name: gcp_region
+  type: String
+- name: display_name
+  type: String
+- name: dataset_id
+  type: String
+- name: target_column_path
+  type: String
+  optional: true
+- name: input_feature_column_paths
+  type: JsonArray
+  optional: true
+- name: optimization_objective
+  type: String
+  default: MAXIMIZE_AU_PRC
+  optional: true
+- name: train_budget_milli_node_hours
+  type: Integer
+  default: '1000'
+  optional: true
+outputs:
+- name: model_path
+  type: String
+- name: model_id
+  type: String
 implementation:
   container:
-    args:
-    - --gcp-project-id
-    - inputValue: gcp_project_id
-    - --gcp-region
-    - inputValue: gcp_region
-    - --display-name
-    - inputValue: display_name
-    - --dataset-id
-    - inputValue: dataset_id
-    - if:
-        cond:
-          isPresent: target_column_path
-        then:
-        - --target-column-path
-        - inputValue: target_column_path
-    - if:
-        cond:
-          isPresent: input_feature_column_paths
-        then:
-        - --input-feature-column-paths
-        - inputValue: input_feature_column_paths
-    - if:
-        cond:
-          isPresent: optimization_objective
-        then:
-        - --optimization-objective
-        - inputValue: optimization_objective
-    - if:
-        cond:
-          isPresent: train_budget_milli_node_hours
-        then:
-        - --train-budget-milli-node-hours
-        - inputValue: train_budget_milli_node_hours
-    - '----output-paths'
-    - outputPath: model_path
-    - outputPath: model_id
+    image: python:3.7
     command:
     - python3
     - -u
@@ -109,33 +103,39 @@ implementation:
               pass
           with open(output_file, 'w') as f:
               f.write(str(_outputs[idx]))
-    image: python:3.7
-inputs:
-- name: gcp_project_id
-  type: String
-- name: gcp_region
-  type: String
-- name: display_name
-  type: String
-- name: dataset_id
-  type: String
-- name: target_column_path
-  optional: true
-  type: String
-- name: input_feature_column_paths
-  optional: true
-  type: JsonArray
-- default: MAXIMIZE_AU_PRC
-  name: optimization_objective
-  optional: true
-  type: String
-- default: '1000'
-  name: train_budget_milli_node_hours
-  optional: true
-  type: Integer
-name: Automl create model for tables
-outputs:
-- name: model_path
-  type: String
-- name: model_id
-  type: String
+    args:
+    - --gcp-project-id
+    - inputValue: gcp_project_id
+    - --gcp-region
+    - inputValue: gcp_region
+    - --display-name
+    - inputValue: display_name
+    - --dataset-id
+    - inputValue: dataset_id
+    - if:
+        cond:
+          isPresent: target_column_path
+        then:
+        - --target-column-path
+        - inputValue: target_column_path
+    - if:
+        cond:
+          isPresent: input_feature_column_paths
+        then:
+        - --input-feature-column-paths
+        - inputValue: input_feature_column_paths
+    - if:
+        cond:
+          isPresent: optimization_objective
+        then:
+        - --optimization-objective
+        - inputValue: optimization_objective
+    - if:
+        cond:
+          isPresent: train_budget_milli_node_hours
+        then:
+        - --train-budget-milli-node-hours
+        - inputValue: train_budget_milli_node_hours
+    - '----output-paths'
+    - outputPath: model_path
+    - outputPath: model_id

--- a/components/gcp/automl/import_data_from_bigquery/component.yaml
+++ b/components/gcp/automl/import_data_from_bigquery/component.yaml
@@ -1,30 +1,21 @@
+name: Automl import data from bigquery
+inputs:
+- name: dataset_path
+- name: input_uri
+  type: String
+- name: retry
+  optional: true
+- name: timeout
+  optional: true
+- name: metadata
+  type: JsonObject
+  optional: true
+outputs:
+- name: dataset_path
+  type: String
 implementation:
   container:
-    args:
-    - --dataset-path
-    - inputValue: dataset_path
-    - --input-uri
-    - inputValue: input_uri
-    - if:
-        cond:
-          isPresent: retry
-        then:
-        - --retry
-        - inputValue: retry
-    - if:
-        cond:
-          isPresent: timeout
-        then:
-        - --timeout
-        - inputValue: timeout
-    - if:
-        cond:
-          isPresent: metadata
-        then:
-        - --metadata
-        - inputValue: metadata
-    - '----output-paths'
-    - outputPath: dataset_path
+    image: python:3.7
     command:
     - python3
     - -u
@@ -90,19 +81,28 @@ implementation:
               pass
           with open(output_file, 'w') as f:
               f.write(str(_outputs[idx]))
-    image: python:3.7
-inputs:
-- name: dataset_path
-- name: input_uri
-  type: String
-- name: retry
-  optional: true
-- name: timeout
-  optional: true
-- name: metadata
-  optional: true
-  type: JsonObject
-name: Automl import data from bigquery
-outputs:
-- name: dataset_path
-  type: String
+    args:
+    - --dataset-path
+    - inputValue: dataset_path
+    - --input-uri
+    - inputValue: input_uri
+    - if:
+        cond:
+          isPresent: retry
+        then:
+        - --retry
+        - inputValue: retry
+    - if:
+        cond:
+          isPresent: timeout
+        then:
+        - --timeout
+        - inputValue: timeout
+    - if:
+        cond:
+          isPresent: metadata
+        then:
+        - --metadata
+        - inputValue: metadata
+    - '----output-paths'
+    - outputPath: dataset_path

--- a/components/gcp/automl/import_data_from_gcs/component.yaml
+++ b/components/gcp/automl/import_data_from_gcs/component.yaml
@@ -1,30 +1,22 @@
+name: Automl import data from gcs
+inputs:
+- name: dataset_path
+  type: String
+- name: input_uris
+  type: JsonArray
+- name: retry
+  optional: true
+- name: timeout
+  optional: true
+- name: metadata
+  type: JsonObject
+  optional: true
+outputs:
+- name: dataset_path
+  type: String
 implementation:
   container:
-    args:
-    - --dataset-path
-    - inputValue: dataset_path
-    - --input-uris
-    - inputValue: input_uris
-    - if:
-        cond:
-          isPresent: retry
-        then:
-        - --retry
-        - inputValue: retry
-    - if:
-        cond:
-          isPresent: timeout
-        then:
-        - --timeout
-        - inputValue: timeout
-    - if:
-        cond:
-          isPresent: metadata
-        then:
-        - --metadata
-        - inputValue: metadata
-    - '----output-paths'
-    - outputPath: dataset_path
+    image: python:3.7
     command:
     - python3
     - -u
@@ -90,20 +82,28 @@ implementation:
               pass
           with open(output_file, 'w') as f:
               f.write(str(_outputs[idx]))
-    image: python:3.7
-inputs:
-- name: dataset_path
-  type: String
-- name: input_uris
-  type: JsonArray
-- name: retry
-  optional: true
-- name: timeout
-  optional: true
-- name: metadata
-  optional: true
-  type: JsonObject
-name: Automl import data from gcs
-outputs:
-- name: dataset_path
-  type: String
+    args:
+    - --dataset-path
+    - inputValue: dataset_path
+    - --input-uris
+    - inputValue: input_uris
+    - if:
+        cond:
+          isPresent: retry
+        then:
+        - --retry
+        - inputValue: retry
+    - if:
+        cond:
+          isPresent: timeout
+        then:
+        - --timeout
+        - inputValue: timeout
+    - if:
+        cond:
+          isPresent: metadata
+        then:
+        - --metadata
+        - inputValue: metadata
+    - '----output-paths'
+    - outputPath: dataset_path

--- a/components/gcp/automl/prediction_service_batch_predict/component.yaml
+++ b/components/gcp/automl/prediction_service_batch_predict/component.yaml
@@ -1,59 +1,35 @@
+name: Automl prediction service batch predict
+inputs:
+- name: model_path
+- name: gcs_input_uris
+  type: String
+  optional: true
+- name: gcs_output_uri_prefix
+  type: String
+  optional: true
+- name: bq_input_uri
+  type: String
+  optional: true
+- name: bq_output_uri
+  type: String
+  optional: true
+- name: params
+  optional: true
+- name: retry
+  optional: true
+- name: timeout
+  optional: true
+- name: metadata
+  type: JsonObject
+  optional: true
+outputs:
+- name: gcs_output_directory
+  type: String
+- name: bigquery_output_dataset
+  type: String
 implementation:
   container:
-    args:
-    - --model-path
-    - inputValue: model_path
-    - if:
-        cond:
-          isPresent: gcs_input_uris
-        then:
-        - --gcs-input-uris
-        - inputValue: gcs_input_uris
-    - if:
-        cond:
-          isPresent: gcs_output_uri_prefix
-        then:
-        - --gcs-output-uri-prefix
-        - inputValue: gcs_output_uri_prefix
-    - if:
-        cond:
-          isPresent: bq_input_uri
-        then:
-        - --bq-input-uri
-        - inputValue: bq_input_uri
-    - if:
-        cond:
-          isPresent: bq_output_uri
-        then:
-        - --bq-output-uri
-        - inputValue: bq_output_uri
-    - if:
-        cond:
-          isPresent: params
-        then:
-        - --params
-        - inputValue: params
-    - if:
-        cond:
-          isPresent: retry
-        then:
-        - --retry
-        - inputValue: retry
-    - if:
-        cond:
-          isPresent: timeout
-        then:
-        - --timeout
-        - inputValue: timeout
-    - if:
-        cond:
-          isPresent: metadata
-        then:
-        - --metadata
-        - inputValue: metadata
-    - '----output-paths'
-    - outputPath: gcs_output_directory
-    - outputPath: bigquery_output_dataset
+    image: python:3.7
     command:
     - python3
     - -u
@@ -139,33 +115,57 @@ implementation:
               pass
           with open(output_file, 'w') as f:
               f.write(str(_outputs[idx]))
-    image: python:3.7
-inputs:
-- name: model_path
-- name: gcs_input_uris
-  optional: true
-  type: String
-- name: gcs_output_uri_prefix
-  optional: true
-  type: String
-- name: bq_input_uri
-  optional: true
-  type: String
-- name: bq_output_uri
-  optional: true
-  type: String
-- name: params
-  optional: true
-- name: retry
-  optional: true
-- name: timeout
-  optional: true
-- name: metadata
-  optional: true
-  type: JsonObject
-name: Automl prediction service batch predict
-outputs:
-- name: gcs_output_directory
-  type: String
-- name: bigquery_output_dataset
-  type: String
+    args:
+    - --model-path
+    - inputValue: model_path
+    - if:
+        cond:
+          isPresent: gcs_input_uris
+        then:
+        - --gcs-input-uris
+        - inputValue: gcs_input_uris
+    - if:
+        cond:
+          isPresent: gcs_output_uri_prefix
+        then:
+        - --gcs-output-uri-prefix
+        - inputValue: gcs_output_uri_prefix
+    - if:
+        cond:
+          isPresent: bq_input_uri
+        then:
+        - --bq-input-uri
+        - inputValue: bq_input_uri
+    - if:
+        cond:
+          isPresent: bq_output_uri
+        then:
+        - --bq-output-uri
+        - inputValue: bq_output_uri
+    - if:
+        cond:
+          isPresent: params
+        then:
+        - --params
+        - inputValue: params
+    - if:
+        cond:
+          isPresent: retry
+        then:
+        - --retry
+        - inputValue: retry
+    - if:
+        cond:
+          isPresent: timeout
+        then:
+        - --timeout
+        - inputValue: timeout
+    - if:
+        cond:
+          isPresent: metadata
+        then:
+        - --metadata
+        - inputValue: metadata
+    - '----output-paths'
+    - outputPath: gcs_output_directory
+    - outputPath: bigquery_output_dataset

--- a/components/gcp/automl/split_dataset_table_column_names/component.yaml
+++ b/components/gcp/automl/split_dataset_table_column_names/component.yaml
@@ -1,19 +1,21 @@
+name: Automl split dataset table column names
+inputs:
+- name: dataset_path
+  type: String
+- name: target_column_name
+  type: String
+- name: table_index
+  type: Integer
+  default: '0'
+  optional: true
+outputs:
+- name: target_column_path
+  type: String
+- name: feature_column_paths
+  type: JsonArray
 implementation:
   container:
-    args:
-    - --dataset-path
-    - inputValue: dataset_path
-    - --target-column-name
-    - inputValue: target_column_name
-    - if:
-        cond:
-          isPresent: table_index
-        then:
-        - --table-index
-        - inputValue: table_index
-    - '----output-paths'
-    - outputPath: target_column_path
-    - outputPath: feature_column_paths
+    image: python:3.7
     command:
     - python3
     - -u
@@ -73,19 +75,17 @@ implementation:
               pass
           with open(output_file, 'w') as f:
               f.write(str(_outputs[idx]))
-    image: python:3.7
-inputs:
-- name: dataset_path
-  type: String
-- name: target_column_name
-  type: String
-- default: '0'
-  name: table_index
-  optional: true
-  type: Integer
-name: Automl split dataset table column names
-outputs:
-- name: target_column_path
-  type: String
-- name: feature_column_paths
-  type: JsonArray
+    args:
+    - --dataset-path
+    - inputValue: dataset_path
+    - --target-column-name
+    - inputValue: target_column_name
+    - if:
+        cond:
+          isPresent: table_index
+        then:
+        - --table-index
+        - inputValue: table_index
+    - '----output-paths'
+    - outputPath: target_column_path
+    - outputPath: feature_column_paths

--- a/sdk/python/kfp/components/_yaml_utils.py
+++ b/sdk/python/kfp/components/_yaml_utils.py
@@ -41,6 +41,7 @@ def dump_yaml(data):
                 yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
                 data.items())
         OrderedDumper.add_representer(OrderedDict, _dict_representer)
+        OrderedDumper.add_representer(dict, _dict_representer)
 
         #Hack to force the code (multi-line string) to be output using the '|' style.
         def represent_str_or_text(self, data):


### PR DESCRIPTION

This makes the generated files more readable.
The attributes were properly ordered before, but the ordering broke when the `.to_dict` methods started outputting `dict` instead of `OrderedDict`.
Also fixed the existing generated `component.yaml` files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2262)
<!-- Reviewable:end -->
