### PR TITLE
Components - Removed trailing whitespace from AutoML components code

### DIFF
--- a/components/gcp/automl/create_model_for_tables/component.py
+++ b/components/gcp/automl/create_model_for_tables/component.py
@@ -35,13 +35,13 @@ def automl_create_model_for_tables(
     location_path = client.location_path(gcp_project_id, gcp_region)
     model_dict = {
         'display_name': display_name,
-        'dataset_id': dataset_id, 
+        'dataset_id': dataset_id,
         'tables_model_metadata': {
             'target_column_spec': automl.types.ColumnSpec(name=target_column_path),
             'input_feature_column_specs': [automl.types.ColumnSpec(name=path) for path in input_feature_column_paths] if input_feature_column_paths else None,
             'optimization_objective': optimization_objective,
             'train_budget_milli_node_hours': train_budget_milli_node_hours,
-        },  
+        },
     }
 
     create_model_response = client.create_model(location_path, model_dict)

--- a/components/gcp/automl/split_dataset_table_column_names/component.py
+++ b/components/gcp/automl/split_dataset_table_column_names/component.py
@@ -40,7 +40,7 @@ def automl_split_dataset_table_column_names(
     target_column_spec = [s for s in column_specs if s.display_name == target_column_name][0]
     feature_column_specs = [s for s in column_specs if s.display_name != target_column_name]
     feature_column_names = [s.name for s in feature_column_specs]
-    
+
     import json
     return (target_column_spec.name, json.dumps(feature_column_names))
 


### PR DESCRIPTION

Trailing whitespace causes PyYaml-serialized strings to become hard to read.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2263)
<!-- Reviewable:end -->
