### PR TITLE
SDK - Components - component_ref.name should only be set when component was loaded by name

### DIFF
--- a/sdk/python/kfp/components/_components.py
+++ b/sdk/python/kfp/components/_components.py
@@ -205,8 +205,9 @@ def _create_task_factory_from_component_spec(component_spec:ComponentSpec, compo
     pythonic_name_to_input_name = {v: k for k, v in input_name_to_pythonic.items()}
 
     if component_ref is None:
-        component_ref = ComponentReference(name=component_spec.name or component_filename or _default_component_name)
-    component_ref.spec = component_spec
+        component_ref = ComponentReference(spec=component_spec, url=component_filename)
+    else:
+        component_ref.spec = component_spec
 
     def create_task_from_component_and_arguments(pythonic_arguments):
         arguments = {}


### PR DESCRIPTION

Problem: It's hard to distinguish components loaded by name (e.g. using `ComponentStore`) from components that were never loaded (e.g. just created from python function).
`component_ref.name` was previously being set, since it was a required parameter.
`component_ref.name` should only be set if component was loaded by name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2265)
<!-- Reviewable:end -->
