### PR TITLE
[WIP] Allow input and output interceptors

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -421,10 +421,13 @@ def get_deserializer_with_argument_interceptor(deserializer = str):
         param_flag = "--" + input.name.replace("_", "-")
         is_required = isinstance(input, OutputSpec) or not input.optional
         param_type = get_argparse_type_for_input_file(input._passing_style) or get_deserializer_and_register_definitions(input.type)
+        type_func = param_type if not argument_interceptor else 'get_deserializer_with_argument_interceptor({param_type})'.format(
+            param_type=param_type
+        ),
         line = '_parser.add_argument("{param_flag}", dest="{param_var}", type={type_func}, required={is_required}, default=argparse.SUPPRESS)'.format(
             param_flag=param_flag,
             param_var=input.name,
-            type_func=param_type if not argument_interceptor else f'get_deserializer_with_argument_interceptor({param_type})',
+            type_func=type_func,
             is_required=str(is_required),
         )
         arg_parse_code_lines.append(line)

--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -420,10 +420,12 @@ def get_deserializer_with_argument_interceptor(deserializer = str):
     for input in component_spec.inputs + file_outputs_passed_using_func_parameters:
         param_flag = "--" + input.name.replace("_", "-")
         is_required = isinstance(input, OutputSpec) or not input.optional
+
         param_type = get_argparse_type_for_input_file(input._passing_style) or get_deserializer_and_register_definitions(input.type)
         type_func = param_type if not argument_interceptor else 'get_deserializer_with_argument_interceptor({param_type})'.format(
             param_type=param_type
-        ),
+        )
+
         line = '_parser.add_argument("{param_flag}", dest="{param_var}", type={type_func}, required={is_required}, default=argparse.SUPPRESS)'.format(
             param_flag=param_flag,
             param_var=input.name,


### PR DESCRIPTION
### TODO 
- [ ] Discuss the approach 
- [ ] See if it would make more sense to have this feature on the `ContainerOp` itself
- [ ] Implement tests
- [ ] Extend to `func_to_component_file` and `func_to_component_text`

### Background Context
We needed to save into a storage all inputs and outputs of every pipeline step, in order to fully understand what happened during the run and be able to pass huge datasets forward. 

This was being done for every `ContainerOp` (inside the container itself), but we needed to implement it in every step that was created using `python_op`. 

We would modify the data, save in some storage, pass the uri for the next step, load there, modify, save, pass the uri forward and so on.

### What this PR is about
Since the `python_op` already handles serialization and deserialization, would make sense to take advantage of this and implement interceptors that could persist the output data and load it for the next step. As an example, we could have as following:

```python
def load_from_s3(argument):
    ...
    if is_s3_uri(argument):
        ...
        return s3_file.get()['Body'].read().decode('utf-8').strip()
    return argument


def save_to_s3_and_return_uri(output, output_path):
    ...
    prefix = f'kfp/runs/{{workflow.uid}}/{{pod.name}}/{file_name}'
    ...
    return f's3://some-bucket/{prefix}'


op = func_to_container_op(
    sample_fn,
    argument_interceptor=load_from_s3,
    output_interceptor=save_to_s3_and_return_uri)
```

This way the user would not need to worry about it in every new op, and it would be handled internally by the pipeline. Of course, persisting objects is one of the many possible use cases.

We currently have implemented only the concept, in order to be able to discuss what would be the best approach.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2267)
<!-- Reviewable:end -->
