### PR TITLE
SDK - Components - Creating graph components from python pipeline function 

### DIFF
--- a/sdk/python/kfp/components/__init__.py
+++ b/sdk/python/kfp/components/__init__.py
@@ -15,4 +15,5 @@
 from ._airflow_op import *
 from ._components import *
 from ._python_op import *
+from ._python_to_graph_component import *
 from ._component_store import *

--- a/sdk/python/kfp/components/_python_to_graph_component.py
+++ b/sdk/python/kfp/components/_python_to_graph_component.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sdk/python/kfp/components/_python_to_graph_component.py
+++ b/sdk/python/kfp/components/_python_to_graph_component.py
@@ -1,0 +1,108 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    'create_graph_component_from_pipeline_func',
+]
+
+
+import inspect
+from collections import OrderedDict
+
+import kfp.components as comp
+from kfp.components._structures import TaskSpec, ComponentSpec, TaskOutputReference, InputSpec, OutputSpec, GraphInputArgument, TaskOutputArgument, GraphImplementation, GraphSpec
+from kfp.components._naming import _make_name_unique_by_adding_index, generate_unique_name_conversion_table, _sanitize_python_function_name, _convert_to_human_name
+
+
+def create_graph_component_from_pipeline_func(pipeline_func) -> ComponentSpec:
+    '''Converts python pipeline function to a graph component object that can be saved, shared, composed or submitted for execution.
+
+    Example:
+
+        producer_op = load_component(component_with_0_inputs_and_2_outputs)
+        processor_op = load_component(component_with_2_inputs_and_2_outputs)
+
+        def pipeline1(pipeline_param_1: int):
+            producer_task = producer_op()
+            processor_task = processor_op(pipeline_param_1, producer_task.outputs['Output 2'])
+
+            return OrderedDict([
+                ('Pipeline output 1', producer_task.outputs['Output 1']),
+                ('Pipeline output 2', processor_task.outputs['Output 2']),
+            ])
+        
+        graph_component = create_graph_component_from_pipeline_func(pipeline1)
+    '''
+
+    task_map = OrderedDict() #Preserving task order
+
+    def task_construction_handler(task: TaskSpec):
+        #Rewriting task ids so that they're same every time
+        task_id = task.component_ref.spec.name or "Task"
+        task_id = _make_name_unique_by_adding_index(task_id, task_map.keys(), ' ')
+        for output_ref in task.outputs.values():
+            output_ref.task_output.task_id = task_id
+        task_map[task_id] = task
+
+        return task #The handler is a transformation function, so it must pass the task through.
+
+    pipeline_signature = inspect.signature(pipeline_func)
+    parameters = list(pipeline_signature.parameters.values())
+    parameter_names = [param.name for param in parameters]
+    human_parameter_names_map = generate_unique_name_conversion_table(parameter_names, _convert_to_human_name)
+
+    #Preparing the pipeline_func arguments 
+    pipeline_func_args = {param.name: GraphInputArgument(input_name=human_parameter_names_map[param.name]) for param in parameters}
+
+    try:
+        #Setting the contextmanager to fix and catch the tasks.
+        comp._components._created_task_transformation_handler.append(task_construction_handler)
+        
+        #Calling the pipeline_func with GraphInputArgument instances as arguments 
+        pipeline_func_result = pipeline_func(**pipeline_func_args)
+    finally:
+        comp._components._created_task_transformation_handler.pop()
+
+    graph_output_value_map = OrderedDict()
+    if pipeline_func_result is None:
+        pass
+    elif isinstance(pipeline_func_result, dict):
+        graph_output_value_map = pipeline_func_result
+    else:
+        raise TypeError('Pipeline must return outputs as OrderedDict.')
+    
+    #Checking the pipeline_func output object types
+    for output_name, output_value in graph_output_value_map.items():
+        if not isinstance(output_value, TaskOutputArgument):
+            raise TypeError('Only TaskOutputArgument instances should be returned from graph component, but got "{output_name}" = "{}".'.format(output_name, str(output_value)))
+
+    graph_output_specs = [OutputSpec(name=output_name, type=output_value.task_output.type) for output_name, output_value in graph_output_value_map.items()]
+    
+    def convert_inspect_empty_to_none(value):
+        return value if value is not inspect.Parameter.empty else None
+    graph_input_specs = [InputSpec(name=human_parameter_names_map[param.name], default=convert_inspect_empty_to_none(param.default)) for param in parameters] #TODO: Convert type annotations to component artifact types
+
+    component_name = _convert_to_human_name(pipeline_func.__name__)
+    component = ComponentSpec(
+        name=component_name,
+        inputs=graph_input_specs,
+        outputs=graph_output_specs,
+        implementation=GraphImplementation(
+            graph=GraphSpec(
+                tasks=task_map,
+                output_values=graph_output_value_map,
+            )
+        )
+    )
+    return component

--- a/sdk/python/kfp/components/_python_to_graph_component.py
+++ b/sdk/python/kfp/components/_python_to_graph_component.py
@@ -21,10 +21,10 @@ import inspect
 from collections import OrderedDict
 from typing import Callable
 
-import kfp.components as comp
-from kfp.components._structures import TaskSpec, ComponentSpec, TaskOutputReference, InputSpec, OutputSpec, GraphInputArgument, TaskOutputArgument, GraphImplementation, GraphSpec
-from kfp.components._naming import _make_name_unique_by_adding_index, generate_unique_name_conversion_table, _sanitize_python_function_name, _convert_to_human_name
-from kfp.components._python_op import _extract_component_interface
+from . import _components
+from ._structures import TaskSpec, ComponentSpec, OutputSpec, GraphInputArgument, TaskOutputArgument, GraphImplementation, GraphSpec
+from ._naming import _make_name_unique_by_adding_index
+from ._python_op import _extract_component_interface
 
 
 def create_graph_component_from_pipeline_func(pipeline_func: Callable, output_component_file: str, embed_component_specs: bool = False) -> None:
@@ -94,12 +94,12 @@ def create_graph_component_spec_from_pipeline_func(pipeline_func: Callable, embe
 
     try:
         #Setting the handler to fix and catch the tasks.
-        comp._components._created_task_transformation_handler.append(task_construction_handler)
+        _components._created_task_transformation_handler.append(task_construction_handler)
         
         #Calling the pipeline_func with GraphInputArgument instances as arguments 
         pipeline_func_result = pipeline_func(**pipeline_func_args)
     finally:
-        comp._components._created_task_transformation_handler.pop()
+        _components._created_task_transformation_handler.pop()
 
 
     # Getting graph outputs

--- a/sdk/python/kfp/components/_python_to_graph_component.py
+++ b/sdk/python/kfp/components/_python_to_graph_component.py
@@ -79,6 +79,7 @@ def create_graph_component_spec_from_pipeline_func(pipeline_func: Callable) -> C
         task_id = _make_name_unique_by_adding_index(task_id, task_map.keys(), ' ')
         for output_ref in task.outputs.values():
             output_ref.task_output.task_id = task_id
+            output_ref.task_output.task = None
         task_map[task_id] = task
 
         return task #The handler is a transformation function, so it must pass the task through.

--- a/sdk/python/tests/components/test_data/component_with_0_inputs_and_2_outputs.component.yaml
+++ b/sdk/python/tests/components/test_data/component_with_0_inputs_and_2_outputs.component.yaml
@@ -1,0 +1,15 @@
+name: Component with 0 inputs and 2 outputs
+outputs:
+- {name: Output 1}
+- {name: Output 2}
+implementation:
+  container:
+    image: busybox
+    command: [sh, -c, '
+        echo "Data 1" > $0
+        echo "Data 2" > $1
+        '
+    ]
+    args:
+    - {outputPath: Output 1}
+    - {outputPath: Output 2}

--- a/sdk/python/tests/components/test_data/component_with_2_inputs_and_0_outputs.component.yaml
+++ b/sdk/python/tests/components/test_data/component_with_2_inputs_and_0_outputs.component.yaml
@@ -1,0 +1,15 @@
+name: Component with 2 inputs and 0 outputs
+inputs:
+- {name: Input parameter}
+- {name: Input artifact}
+implementation:
+  container:
+    image: busybox
+    command: [sh, -c, '
+        echo "Input parameter = $0"
+        echo "Input artifact = $(< $1)"
+        '
+    ]
+    args: 
+    - {inputValue: Input parameter}
+    - {inputPath: Input artifact}

--- a/sdk/python/tests/components/test_data/component_with_2_inputs_and_2_outputs.component.yaml
+++ b/sdk/python/tests/components/test_data/component_with_2_inputs_and_2_outputs.component.yaml
@@ -1,0 +1,22 @@
+name: Component with 2 inputs and 2 outputs
+inputs:
+- {name: Input parameter}
+- {name: Input artifact}
+outputs:
+- {name: Output 1}
+- {name: Output 2}
+implementation:
+  container:
+    image: busybox
+    command: [sh, -c, '
+        mkdir -p $(dirname "$2")
+        mkdir -p $(dirname "$3")
+        echo "$0" > "$2"
+        cp "$1" "$3"
+        '
+    ]
+    args: 
+    - {inputValue: Input parameter}
+    - {inputPath: Input artifact}
+    - {outputPath: Output 1}
+    - {outputPath: Output 2}

--- a/sdk/python/tests/components/test_python_pipeline_to_graph_component.py
+++ b/sdk/python/tests/components/test_python_pipeline_to_graph_component.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sdk/python/tests/components/test_python_pipeline_to_graph_component.py
+++ b/sdk/python/tests/components/test_python_pipeline_to_graph_component.py
@@ -18,104 +18,33 @@ import unittest
 from collections import OrderedDict
 from pathlib import Path
 
-sys.path.insert(0, __file__ + '/../../../')
-
 import kfp.components as comp
 from kfp.components._python_to_graph_component import create_graph_component_spec_from_pipeline_func
 
 
-component_with_2_inputs_and_0_outputs = '''\
-name: Component with 2 inputs and 0 outputs
-inputs:
-- {name: Input parameter}
-- {name: Input artifact}
-implementation:
-  container:
-    image: busybox
-    command: [sh, -c, '
-        echo "Input parameter = $0"
-        echo "Input artifact = $(< $1)"
-        '
-    ]
-    args: 
-    - {inputValue: Input parameter}
-    - {inputPath: Input artifact}
-'''
-
-
-component_with_0_inputs_and_2_outputs = '''\
-name: Component with 0 inputs and 2 outputs
-outputs:
-- {name: Output 1}
-- {name: Output 2}
-implementation:
-  container:
-    image: busybox
-    command: [sh, -c, '
-        echo "Data 1" > $0
-        echo "Data 2" > $1
-        '
-    ]
-    args:
-    - {outputPath: Output 1}
-    - {outputPath: Output 2}
-'''
-
-
-component_with_2_inputs_and_2_outputs = '''\
-name: Component with 2 inputs and 2 outputs
-inputs:
-- {name: Input parameter}
-- {name: Input artifact}
-outputs:
-- {name: Output 1}
-- {name: Output 2}
-implementation:
-  container:
-    image: busybox
-    command: [sh, -c, '
-        mkdir -p $(dirname "$2")
-        mkdir -p $(dirname "$3")
-        echo "$0" > "$2"
-        cp "$1" "$3"
-        '
-    ]
-    args: 
-    - {inputValue: Input parameter}
-    - {inputPath: Input artifact}
-    - {outputPath: Output 1}
-    - {outputPath: Output 2}
-'''
-
-
 class PythonPipelineToGraphComponentTestCase(unittest.TestCase):
     def test_handle_creating_graph_component_from_pipeline_that_uses_container_components(self):
-        producer_op = comp.load_component_from_text(component_with_0_inputs_and_2_outputs)
-        processor_op = comp.load_component_from_text(component_with_2_inputs_and_2_outputs)
-        #consumer_op = comp.load_component_from_text(component_with_2_inputs_and_0_outputs)
+        test_data_dir = Path(__file__).parent / 'test_data'
+        producer_op = comp.load_component_from_file(str(test_data_dir / 'component_with_0_inputs_and_2_outputs.component.yaml'))
+        processor_op = comp.load_component_from_file(str(test_data_dir / 'component_with_2_inputs_and_2_outputs.component.yaml'))
+        consumer_op = comp.load_component_from_file(str(test_data_dir / 'component_with_2_inputs_and_0_outputs.component.yaml'))
 
-        #def pipeline(pipeline_param_1: int):
         def pipeline1(pipeline_param_1: int):
             producer_task = producer_op()
             processor_task = processor_op(pipeline_param_1, producer_task.outputs['Output 2'])
-            #processor_task = processor_op(pipeline_param_1, producer_task.outputs.output_2)
-            #consumer_task = consumer_op(processor_task.outputs['Output 1'], processor_task.outputs['Output 2'])
+            consumer_task = consumer_op(processor_task.outputs['Output 1'], processor_task.outputs['Output 2'])
 
-            #return (producer_task.outputs['Output 1'], processor_task.outputs['Output 2'])
-            #return [producer_task.outputs['Output 1'], processor_task.outputs['Output 2']]
-            #return {'Pipeline output 1': producer_task.outputs['Output 1'], 'Pipeline output 2': processor_task.outputs['Output 2']}
-            return OrderedDict([
+            return OrderedDict([ # You can safely return normal dict in python 3.6+
                 ('Pipeline output 1', producer_task.outputs['Output 1']),
                 ('Pipeline output 2', processor_task.outputs['Output 2']),
             ])
-            #return namedtuple('Pipeline1Outputs', ['Pipeline output 1', 'Pipeline output 2'])(producer_task.outputs['Output 1'], processor_task.outputs['Output 2'])
 
-        
         graph_component = create_graph_component_spec_from_pipeline_func(pipeline1)
+
         self.assertEqual(len(graph_component.inputs), 1)
         self.assertListEqual([input.name for input in graph_component.inputs], ['pipeline_param_1']) #Relies on human name conversion function stability
         self.assertListEqual([output.name for output in graph_component.outputs], ['Pipeline output 1', 'Pipeline output 2'])
-        self.assertEqual(len(graph_component.implementation.graph.tasks), 2)
+        self.assertEqual(len(graph_component.implementation.graph.tasks), 3)
 
 
 if __name__ == '__main__':

--- a/sdk/python/tests/components/test_python_pipeline_to_graph_component.py
+++ b/sdk/python/tests/components/test_python_pipeline_to_graph_component.py
@@ -21,7 +21,7 @@ from pathlib import Path
 sys.path.insert(0, __file__ + '/../../../')
 
 import kfp.components as comp
-from kfp.components._python_to_graph_component import create_graph_component_from_pipeline_func
+from kfp.components._python_to_graph_component import create_graph_component_spec_from_pipeline_func
 
 
 component_with_2_inputs_and_0_outputs = '''\
@@ -111,7 +111,7 @@ class PythonPipelineToGraphComponentTestCase(unittest.TestCase):
             #return namedtuple('Pipeline1Outputs', ['Pipeline output 1', 'Pipeline output 2'])(producer_task.outputs['Output 1'], processor_task.outputs['Output 2'])
 
         
-        graph_component = create_graph_component_from_pipeline_func(pipeline1)
+        graph_component = create_graph_component_spec_from_pipeline_func(pipeline1)
         self.assertEqual(len(graph_component.inputs), 1)
         self.assertListEqual([input.name for input in graph_component.inputs], ['Pipeline param 1']) #Relies on human name conversion function stability
         self.assertListEqual([output.name for output in graph_component.outputs], ['Pipeline output 1', 'Pipeline output 2'])

--- a/sdk/python/tests/components/test_python_pipeline_to_graph_component.py
+++ b/sdk/python/tests/components/test_python_pipeline_to_graph_component.py
@@ -1,0 +1,122 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+from collections import OrderedDict
+from pathlib import Path
+
+sys.path.insert(0, __file__ + '/../../../')
+
+import kfp.components as comp
+from kfp.components._python_to_graph_component import create_graph_component_from_pipeline_func
+
+
+component_with_2_inputs_and_0_outputs = '''\
+name: Component with 2 inputs and 0 outputs
+inputs:
+- {name: Input parameter}
+- {name: Input artifact}
+implementation:
+  container:
+    image: busybox
+    command: [sh, -c, '
+        echo "Input parameter = $0"
+        echo "Input artifact = $(< $1)"
+        '
+    ]
+    args: 
+    - {inputValue: Input parameter}
+    - {inputPath: Input artifact}
+'''
+
+
+component_with_0_inputs_and_2_outputs = '''\
+name: Component with 0 inputs and 2 outputs
+outputs:
+- {name: Output 1}
+- {name: Output 2}
+implementation:
+  container:
+    image: busybox
+    command: [sh, -c, '
+        echo "Data 1" > $0
+        echo "Data 2" > $1
+        '
+    ]
+    args:
+    - {outputPath: Output 1}
+    - {outputPath: Output 2}
+'''
+
+
+component_with_2_inputs_and_2_outputs = '''\
+name: Component with 2 inputs and 2 outputs
+inputs:
+- {name: Input parameter}
+- {name: Input artifact}
+outputs:
+- {name: Output 1}
+- {name: Output 2}
+implementation:
+  container:
+    image: busybox
+    command: [sh, -c, '
+        mkdir -p $(dirname "$2")
+        mkdir -p $(dirname "$3")
+        echo "$0" > "$2"
+        cp "$1" "$3"
+        '
+    ]
+    args: 
+    - {inputValue: Input parameter}
+    - {inputPath: Input artifact}
+    - {outputPath: Output 1}
+    - {outputPath: Output 2}
+'''
+
+
+class PythonPipelineToGraphComponentTestCase(unittest.TestCase):
+    def test_handle_creating_graph_component_from_pipeline_that_uses_container_components(self):
+        producer_op = comp.load_component_from_text(component_with_0_inputs_and_2_outputs)
+        processor_op = comp.load_component_from_text(component_with_2_inputs_and_2_outputs)
+        #consumer_op = comp.load_component_from_text(component_with_2_inputs_and_0_outputs)
+
+        #def pipeline(pipeline_param_1: int):
+        def pipeline1(pipeline_param_1: int):
+            producer_task = producer_op()
+            processor_task = processor_op(pipeline_param_1, producer_task.outputs['Output 2'])
+            #processor_task = processor_op(pipeline_param_1, producer_task.outputs.output_2)
+            #consumer_task = consumer_op(processor_task.outputs['Output 1'], processor_task.outputs['Output 2'])
+
+            #return (producer_task.outputs['Output 1'], processor_task.outputs['Output 2'])
+            #return [producer_task.outputs['Output 1'], processor_task.outputs['Output 2']]
+            #return {'Pipeline output 1': producer_task.outputs['Output 1'], 'Pipeline output 2': processor_task.outputs['Output 2']}
+            return OrderedDict([
+                ('Pipeline output 1', producer_task.outputs['Output 1']),
+                ('Pipeline output 2', processor_task.outputs['Output 2']),
+            ])
+            #return namedtuple('Pipeline1Outputs', ['Pipeline output 1', 'Pipeline output 2'])(producer_task.outputs['Output 1'], processor_task.outputs['Output 2'])
+
+        
+        graph_component = create_graph_component_from_pipeline_func(pipeline1)
+        self.assertEqual(len(graph_component.inputs), 1)
+        self.assertListEqual([input.name for input in graph_component.inputs], ['Pipeline param 1']) #Relies on human name conversion function stability
+        self.assertListEqual([output.name for output in graph_component.outputs], ['Pipeline output 1', 'Pipeline output 2'])
+        self.assertEqual(len(graph_component.implementation.graph.tasks), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/python/tests/components/test_python_pipeline_to_graph_component.py
+++ b/sdk/python/tests/components/test_python_pipeline_to_graph_component.py
@@ -113,7 +113,7 @@ class PythonPipelineToGraphComponentTestCase(unittest.TestCase):
         
         graph_component = create_graph_component_spec_from_pipeline_func(pipeline1)
         self.assertEqual(len(graph_component.inputs), 1)
-        self.assertListEqual([input.name for input in graph_component.inputs], ['Pipeline param 1']) #Relies on human name conversion function stability
+        self.assertListEqual([input.name for input in graph_component.inputs], ['pipeline_param_1']) #Relies on human name conversion function stability
         self.assertListEqual([output.name for output in graph_component.outputs], ['Pipeline output 1', 'Pipeline output 2'])
         self.assertEqual(len(graph_component.implementation.graph.tasks), 2)
 


### PR DESCRIPTION
The experimental `create_graph_component_from_pipeline_func` creates graph component definition from a python pipeline function. The component file can be published for sharing.
Pipeline function is a function that only calls component functions and passes outputs to inputs.
This feature is experimental and lacks support for some of the DSL features like conditions and loops.
Only pipelines consisting of loaded components or python components are supported at this moment(no manually created ContainerOps or ResourceOps).

Example:

```python
producer_op = load_component_from_file('producer/component.yaml')
processor_op = load_component_from_file('processor/component.yaml')

def pipeline1(pipeline_param_1: int):
    producer_task = producer_op()
    processor_task = processor_op(pipeline_param_1, producer_task.outputs['Output 2'])

    return OrderedDict([ # You can safely return normal dict in python 3.6+
        ('Pipeline output 1', producer_task.outputs['Output 1']),
        ('Pipeline output 2', processor_task.outputs['Output 2']),
    ])

create_graph_component_from_pipeline_func(pipeline1, output_component_file='pipeline1.component.yaml')
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2273)
<!-- Reviewable:end -->
