### PR TITLE
Refactor resource op sample for sample test coverage

### DIFF
--- a/samples/core/resource_ops/resource_ops.py
+++ b/samples/core/resource_ops/resource_ops.py
@@ -38,7 +38,7 @@ _CONTAINER_MANIFEST = """
                 "containers": [{
                     "name": "sample-container",
                     "image": "k8s.gcr.io/busybox",
-                    "command": ["/bin/sh", "-c", "env"]
+                    "command": ["/usr/bin/env"]
                 }],
                 "restartPolicy": "Never"
             }

--- a/samples/core/resource_ops/resource_ops.py
+++ b/samples/core/resource_ops/resource_ops.py
@@ -56,7 +56,7 @@ _CONTAINER_MANIFEST = """
 def resourceop_basic():
 
     # Start a container. Print out env vars.
-    cop = dsl.ResourceOp(
+    op = dsl.ResourceOp(
         name='test-step',
         k8s_resource=json.loads(_CONTAINER_MANIFEST),
         action='create'

--- a/samples/core/resource_ops/resource_ops.py
+++ b/samples/core/resource_ops/resource_ops.py
@@ -22,22 +22,6 @@ import kfp
 import kfp.dsl as dsl
 
 
-_ENV_CONFIG = """
-{
-    "apiVersion": "v1",
-    "kind": "ConfigMap",
-    "metadata": {
-        "name": "sample-env-config",
-        "namespace": "default"
-    },
-    "data": {
-        "SPECIAL_LEVEL": "level",
-        "SPECIAL_TYPE": "type"
-    }
-}    
-"""
-
-
 _CONTAINER_MANIFEST = """
 {
     "apiVersion": "batch/v1",
@@ -54,12 +38,7 @@ _CONTAINER_MANIFEST = """
                 "containers": [{
                     "name": "sample-container",
                     "image": "k8s.gcr.io/busybox",
-                    "command": ["/bin/sh", "-c", "env"],
-                    "envFrom": [{
-                        "configMapRef": {
-                            "name": "sample-env-config"
-                        }
-                    }]
+                    "command": ["/bin/sh", "-c", "env"]
                 }],
                 "restartPolicy": "Never"
             }
@@ -75,19 +54,13 @@ _CONTAINER_MANIFEST = """
     description="A Basic Example on ResourceOp Usage."
 )
 def resourceop_basic():
-    # Create a ConfigMap.
-    env_config_map_op = dsl.ResourceOp(
-        name='environment-config',
-        k8s_resource=json.loads(_ENV_CONFIG),
-        action='create'
-    )
 
-    # Referring the ConfigMap in a Container.
+    # Start a container. Print out env vars.
     cop = dsl.ResourceOp(
         name='test-step',
         k8s_resource=json.loads(_CONTAINER_MANIFEST),
         action='create'
-    ).after(env_config_map_op)
+    )
 
 
 if __name__ == '__main__':

--- a/samples/core/resource_ops/resource_ops.py
+++ b/samples/core/resource_ops/resource_ops.py
@@ -20,8 +20,6 @@ This example demonstrates how to use ResourceOp to specify the value of env var.
 import json
 import kfp
 import kfp.dsl as dsl
-from kubernetes import client as k8s_client
-from string import Template
 
 
 _ENV_CONFIG = """
@@ -29,7 +27,8 @@ _ENV_CONFIG = """
     "apiVersion": "v1",
     "kind": "ConfigMap",
     "metadata": {
-        "name": "sample-env-config"
+        "name": "sample-env-config",
+        "namespace": "default"
     },
     "data": {
         "SPECIAL_LEVEL": "level",
@@ -37,6 +36,7 @@ _ENV_CONFIG = """
     }
 }    
 """
+
 
 _CONTAINER_MANIFEST = """
 {

--- a/test/sample_test.yaml
+++ b/test/sample_test.yaml
@@ -85,6 +85,7 @@ spec:
               - loop_output
               - loop_parameter
               - loop_static
+              - resource_ops
     # Build and push image
     - name: build-image-by-dockerfile
       inputs:


### PR DESCRIPTION
Currently resource op sample illustrates the usage of mounting credential through resource op, which is not a good practice because password might not be masked in the KFP UI.

This PR changes that to an example showing how to run a container by a resource op.

Also sample test coverage is added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2274)
<!-- Reviewable:end -->
