### PR TITLE
SDK - Components - Fixed cases where code gets formatted in unreadable way

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -198,6 +198,8 @@ def _capture_function_code_using_source_copy(func) -> str:
     first_line = func_code_lines[0]
     indent = len(first_line) - len(first_line.lstrip())
     func_code_lines = [line[indent:] for line in func_code_lines]
+    # Stripping trailing whitespace from the lines since it triggers unreadable formatting when the text is serialized to YAML
+    func_code_lines = [line.rstrip() + '\n' for line in func_code_lines]
 
     #TODO: Add support for copying the NamedTuple subclass declaration code
     #Adding NamedTuple import if needed


### PR DESCRIPTION
Stripping trailing whitespace from the line which triggers unreadable formatting when the text is serialized to YAML

Readable:
```yaml
    command:
    - python3
    - -c
    - |
      from typing import NamedTuple

      def automl_create_model_for_tables(
          gcp_project_id: str,
          gcp_region: str,
          display_name: str,
          dataset_id: str,
```

Unreadable:
```yaml
    command:
    - python3
    - -c
    - "from typing import NamedTuple\n\ndef automl_create_model_for_tables(\n    gcp_project_id:\
      \ str,\n    gcp_region: str,\n    display_name: str,\n    dataset_id: str,\n\
      \    target_column_path: str = None,\n    input_feature_column_paths: list =\
      \ None,\n    optimization_objective: str = 'MAXIMIZE_AU_PRC',\n    train_budget_milli_node_hours:\
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2290)
<!-- Reviewable:end -->
