### PR TITLE
SDK - Compiler - Fix bugs in the data passing rewriter

### DIFF
--- a/sdk/python/kfp/compiler/_data_passing_rewriter.py
+++ b/sdk/python/kfp/compiler/_data_passing_rewriter.py
@@ -125,6 +125,7 @@ def fix_big_data_passing(workflow: dict) -> dict:
     # Searching for parameter input consumers in DAG templates (.when, .withParam, etc)
     for template in dag_templates:
         template_name = template['name']
+        dag_tasks = template['dag']['tasks']
         task_name_to_template_name = {task['name']: task['template'] for task in dag_tasks}
         for task in template['dag']['tasks']:
             # We do not care about the inputs mentioned in task arguments since we will be free to switch them from parameters to artifacts

--- a/sdk/python/kfp/compiler/_data_passing_rewriter.py
+++ b/sdk/python/kfp/compiler/_data_passing_rewriter.py
@@ -142,10 +142,10 @@ def fix_big_data_passing(workflow: dict) -> dict:
                     else:
                         raise AssertionError
                 elif placeholder_type == 'tasks':
-                    upstream_task_name = argument_placeholder_parts[1]
-                    assert argument_placeholder_parts[2] == 'outputs'
-                    assert argument_placeholder_parts[3] == 'parameters'
-                    upstream_output_name = argument_placeholder_parts[4]
+                    upstream_task_name = parts[1]
+                    assert parts[2] == 'outputs'
+                    assert parts[3] == 'parameters'
+                    upstream_output_name = parts[4]
                     upstream_template_name = task_name_to_template_name[upstream_task_name]
                     outputs_directly_consumed_as_parameters.add((upstream_template_name, upstream_output_name))
                 elif placeholder_type == 'workflow' or placeholder_type == 'pod':


### PR DESCRIPTION
fix for #2295 

`argument_placeholder_parts` seems to have been copied/pasted from the code above. `parts` seems to be the more suitable here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2297)
<!-- Reviewable:end -->
