### PR TITLE
SDK - Compiler - Fixed deprecation warning when calling compile

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -840,7 +840,7 @@ class Compiler(object):
 
   def _compile(self, pipeline_func, pipeline_conf: dsl.PipelineConf = None):
     """Compile the given pipeline function into workflow."""
-    return self.create_workflow(pipeline_func=pipeline_func, pipeline_conf=pipeline_conf)
+    return self._create_workflow(pipeline_func=pipeline_func, pipeline_conf=pipeline_conf)
 
   def compile(self, pipeline_func, package_path, type_check=True, pipeline_conf: dsl.PipelineConf = None):
     """Compile the given pipeline function into workflow yaml.


### PR DESCRIPTION
Fixes a warning introduced in https://github.com/kubeflow/pipelines/pull/2146

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2303)
<!-- Reviewable:end -->
