### PR TITLE
SDK/DSL: ContainerOp.add_pvolume - Fix volume passed in add_volume

### DIFF
--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -1182,7 +1182,8 @@ class ContainerOp(BaseOp):
                     self.dependent_names.extend(pvolume.dependent_names)
                 else:
                     pvolume = PipelineVolume(volume=pvolume)
-                self.pvolumes[mount_path] = pvolume.after(self)
+                pvolume = pvolume.after(self)
+                self.pvolumes[mount_path] = pvolume
                 self.add_volume(pvolume)
                 self._container.add_volume_mount(V1VolumeMount(
                     name=pvolume.name,

--- a/sdk/python/tests/dsl/container_op_tests.py
+++ b/sdk/python/tests/dsl/container_op_tests.py
@@ -17,7 +17,7 @@ import unittest
 from kubernetes.client.models import V1EnvVar, V1VolumeMount
 
 import kfp
-from kfp.dsl import ContainerOp, UserContainer, Sidecar
+from kfp.dsl import ContainerOp, UserContainer, Sidecar, PipelineVolume
 
 
 class TestContainerOp(unittest.TestCase):
@@ -89,3 +89,12 @@ class TestContainerOp(unittest.TestCase):
       op.add_volume_mount(V1VolumeMount(
         mount_path='/secret/gcp-credentials',
         name='gcp-credentials'))
+
+
+  def test_add_pvolumes(self):
+    pvolume = PipelineVolume(pvc='test')
+    op = ContainerOp(name='op1', image='image', pvolumes={'/mnt': pvolume})
+
+    self.assertEqual(pvolume.dependent_names, [])
+    self.assertEqual(op.pvolume.dependent_names, [op.name])
+    self.assertEqual(op.volumes[0].dependent_names, [op.name])


### PR DESCRIPTION
Dependency information is not passed in `volumes` attribute.
If someone iterates through volumes via `volumes` list, they miss the `dependent_names` update.

This PR fixes the aforementioned behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2306)
<!-- Reviewable:end -->
