### PR TITLE
[MKP] Remove service account credential from deployment page.

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/values.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/values.yaml
@@ -15,7 +15,7 @@ images:
   metadataenvoy: gcr.io/ml-pipeline/google/pipelines/metadataenvoy:0.1.31
 
 gcpSecretName: "user-gcp-sa"
-serviceAccountCredential: null
+serviceAccountCredential: ""
 
 managedstorage:
   enabled: false

--- a/manifests/gcp_marketplace/schema.yaml
+++ b/manifests/gcp_marketplace/schema.yaml
@@ -100,23 +100,8 @@ properties:
     type: string
     x-google-marketplace:
       type: NAMESPACE
-# TODO: temporarily remove sa credential from deploy page in MKP. SA will be added by user manually
-# after deployment.
-#
-#  serviceAccountCredential:
-#    title: |-
-#     GCP Service Account credentials used to call other GCP services.
-#    description: |-
-#      This deployment requires a service account to use for authentication when calling other GCP services.
-#      Specify the base64-encoded credentials for the service account you want to use.
-#      You can get these credentials by running the following command in a terminal window.
-#      \"$ gcloud iam service-accounts keys create application_default_credentials.json --iam-account [your-service-account] && cat application_default_credentials.json | base64\"
-#      If you are using Linux, please use \"base64 -w 0\" to disable line wrapping.
-#    type: string
-#    default: ""
-#    x-google-marketplace:
-#      type: STRING
+
 required:
   - name
   - namespace
-#  - serviceAccountCredential
+

--- a/manifests/gcp_marketplace/schema.yaml
+++ b/manifests/gcp_marketplace/schema.yaml
@@ -100,20 +100,23 @@ properties:
     type: string
     x-google-marketplace:
       type: NAMESPACE
-  serviceAccountCredential:
-    title: |-
-     GCP Service Account credentials used to call other GCP services.
-    description: |-
-      This deployment requires a service account to use for authentication when calling other GCP services. 
-      Specify the base64-encoded credentials for the service account you want to use. 
-      You can get these credentials by running the following command in a terminal window. 
-      \"$ gcloud iam service-accounts keys create application_default_credentials.json --iam-account [your-service-account] && cat application_default_credentials.json | base64\"
-      If you are using Linux, please use \"base64 -w 0\" to disable line wrapping.
-    type: string
-    default: ""
-    x-google-marketplace:
-      type: STRING
+# TODO: temporarily remove sa credential from deploy page in MKP. SA will be added by user manually
+# after deployment.
+#
+#  serviceAccountCredential:
+#    title: |-
+#     GCP Service Account credentials used to call other GCP services.
+#    description: |-
+#      This deployment requires a service account to use for authentication when calling other GCP services.
+#      Specify the base64-encoded credentials for the service account you want to use.
+#      You can get these credentials by running the following command in a terminal window.
+#      \"$ gcloud iam service-accounts keys create application_default_credentials.json --iam-account [your-service-account] && cat application_default_credentials.json | base64\"
+#      If you are using Linux, please use \"base64 -w 0\" to disable line wrapping.
+#    type: string
+#    default: ""
+#    x-google-marketplace:
+#      type: STRING
 required:
   - name
   - namespace
-  - serviceAccountCredential
+#  - serviceAccountCredential


### PR DESCRIPTION
Per offline discussion. The current way of generating and specifying SA credential brings additional security risk. We temporarily remove it from our MKP deploy page and users can inject their credential after deployment.

Will update the guidance and doc in another PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2308)
<!-- Reviewable:end -->
