### PR TITLE
Extend KFServing component with autoscaling and server mode

### DIFF
--- a/components/kubeflow/kfserving/Dockerfile
+++ b/components/kubeflow/kfserving/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-slim
 
-RUN pip install kubernetes==9.0.0 kfserving==0.1.1 requests==2.22.0 Flask==1.1.1 flask-cors==3.0.8
+RUN pip3 install kubernetes==9.0.0 kfserving==0.1.1 requests==2.22.0 Flask==1.1.1 flask-cors==3.0.8
 
 ENV APP_HOME /app
 COPY src $APP_HOME

--- a/components/kubeflow/kfserving/Dockerfile
+++ b/components/kubeflow/kfserving/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-slim
 
-RUN pip install kubernetes==9.0.0 kfserving==0.1.1 requests==2.22.0
+RUN pip install kubernetes==9.0.0 kfserving==0.1.1 requests==2.22.0 Flask==1.1.1 flask-cors==3.0.8
 
 ENV APP_HOME /app
 COPY src $APP_HOME

--- a/components/kubeflow/kfserving/component.yaml
+++ b/components/kubeflow/kfserving/component.yaml
@@ -8,10 +8,10 @@ inputs:
   - {name: Canary Model Traffic Percentage, type: String, default: '0',        description: 'Optional Traffic to be sent to default model'}
   - {name: Namespace,                       type: String, default: 'kubeflow', description: 'Kubernetes namespace where the KFServing service is deployed.'}
   - {name: Framework,                       type: String, default: 'tensorflow', description: 'Machine Learning Framework for Model Serving.'}
-  - {name: default_custom_model_spec,       type: String, default: '{}', description: 'Custom runtime default custom model container spec.'}
-  - {name: canary_custom_model_spec,        type: String, default: '{}', description: 'Custom runtime canary custom model container spec.'}
+  - {name: Default Custom Model Spec,       type: String, default: '{}', description: 'Custom runtime default custom model container spec.'}
+  - {name: Canary Custom Model Spec,        type: String, default: '{}', description: 'Custom runtime canary custom model container spec.'}
   - {name: Autoscaling Target,              type: String, default: '0',        description: 'Autoscaling Target Number'}
-  - {name: KFServing Deployer API,          type: String, default: '', description: 'Custom runtime canary custom model container spec.'}
+  - {name: KFServing Endpoint,              type: String, default: '', description: 'KFServing remote deployer API endpoint'}
 outputs:
   - {name: Endpoint URI, type: String,                      description: 'URI of the deployed prediction service..'}
 implementation:
@@ -27,9 +27,9 @@ implementation:
       --canary-model-traffic,     {inputValue: Canary Model Traffic Percentage},
       --namespace,                {inputValue: Namespace},
       --framework,                {inputValue: Framework},
-      --default-custom-model-spec,{inputValue: default_custom_model_spec},
-      --canary-custom-model-spec, {inputValue: canary_custom_model_spec},
-      --kfserving-deployer-api,   {inputValue: KFServing Deployer API},
+      --default-custom-model-spec,{inputValue: Default Custom Model Spec},
+      --canary-custom-model-spec, {inputValue: Canary Custom Model Spec},
+      --kfserving-deployer-api,   {inputValue: KFServing Endpoint},
       --autoscaling-target,       {inputValue: Autoscaling Target},
       --output_path,              {outputPath: Endpoint URI}
     ]

--- a/components/kubeflow/kfserving/component.yaml
+++ b/components/kubeflow/kfserving/component.yaml
@@ -10,11 +10,13 @@ inputs:
   - {name: Framework,                       type: String, default: 'tensorflow', description: 'Machine Learning Framework for Model Serving.'}
   - {name: default_custom_model_spec,       type: String, default: '{}', description: 'Custom runtime default custom model container spec.'}
   - {name: canary_custom_model_spec,        type: String, default: '{}', description: 'Custom runtime canary custom model container spec.'}
+  - {name: Autoscaling Target,              type: String, default: '0',        description: 'Autoscaling Target Number'}
+  - {name: KFServing Deployer API,          type: String, default: '', description: 'Custom runtime canary custom model container spec.'}
 outputs:
   - {name: Endpoint URI, type: String,                      description: 'URI of the deployed prediction service..'}
 implementation:
   container:
-    image: animeshsingh/kfserving-component
+    image: aipipeline/kfserving-component:v0.1.0
     command: ['python']
     args: [
       -u, kfservingdeployer.py,
@@ -27,5 +29,7 @@ implementation:
       --framework,                {inputValue: Framework},
       --default-custom-model-spec,{inputValue: default_custom_model_spec},
       --canary-custom-model-spec, {inputValue: canary_custom_model_spec},
+      --kfserving-deployer-api,   {inputValue: KFServing Deployer API},
+      --autoscaling-target,       {inputValue: Autoscaling Target},
       --output_path,              {outputPath: Endpoint URI}
     ]

--- a/components/kubeflow/kfserving/sample-pipeline.py
+++ b/components/kubeflow/kfserving/sample-pipeline.py
@@ -25,14 +25,14 @@ def kfservingPipeline(
     action = 'create',
     model_name='tensorflow-sample',
     default_model_uri='gs://kfserving-samples/models/tensorflow/flowers',
-    canary_model_uri='gs://kfserving-samples/models/tensorflow/flowers',
+    canary_model_uri='gs://kfserving-samples/models/tensorflow/flowers-2',
     canary_model_traffic_percentage='10',
     namespace='kubeflow',
     framework='tensorflow',
     default_custom_model_spec='{}',
     canary_custom_model_spec='{}',
     autoscaling_target=0,
-    kfserving_deployer_api=''
+    kfserving_endpoint=''
 ):
 
     # define workflow
@@ -46,7 +46,7 @@ def kfservingPipeline(
                              default_custom_model_spec=default_custom_model_spec,
                              canary_custom_model_spec=canary_custom_model_spec,
                              autoscaling_target=autoscaling_target,
-                             kfserving_deployer_api=kfserving_deployer_api)
+                             kfserving_endpoint=kfserving_endpoint)
 
 if __name__ == '__main__':
     import kfp.compiler as compiler

--- a/components/kubeflow/kfserving/sample-pipeline.py
+++ b/components/kubeflow/kfserving/sample-pipeline.py
@@ -28,7 +28,11 @@ def kfservingPipeline(
     canary_model_uri='gs://kfserving-samples/models/tensorflow/flowers',
     canary_model_traffic_percentage='10',
     namespace='kubeflow',
-    framework='tensorflow'
+    framework='tensorflow',
+    default_custom_model_spec='{}',
+    canary_custom_model_spec='{}',
+    autoscaling_target=0,
+    kfserving_deployer_api=''
 ):
 
     # define workflow
@@ -38,7 +42,11 @@ def kfservingPipeline(
                              canary_model_uri=canary_model_uri,
                              canary_model_traffic_percentage=canary_model_traffic_percentage,
                              namespace=namespace,
-                             framework=framework)
+                             framework=framework,
+                             default_custom_model_spec=default_custom_model_spec,
+                             canary_custom_model_spec=canary_custom_model_spec,
+                             autoscaling_target=autoscaling_target,
+                             kfserving_deployer_api=kfserving_deployer_api)
 
 if __name__ == '__main__':
     import kfp.compiler as compiler

--- a/components/kubeflow/kfserving/src/app.py
+++ b/components/kubeflow/kfserving/src/app.py
@@ -22,7 +22,8 @@ def deploy_model_post():
                 namespace=request.json['namespace'],
                 framework=request.json['framework'],
                 default_custom_model_spec=request.json['default_custom_model_spec'],
-                canary_custom_model_spec=request.json['canary_custom_model_spec']
+                canary_custom_model_spec=request.json['canary_custom_model_spec'],
+                autoscaling_target=request.json['autoscaling_target']
                 ))
 
 

--- a/components/kubeflow/kfserving/src/app.py
+++ b/components/kubeflow/kfserving/src/app.py
@@ -1,0 +1,40 @@
+from flask import Flask, request, abort
+from flask_cors import CORS
+import json
+import os
+
+from kfservingdeployer import deploy_model
+
+app = Flask(__name__)
+CORS(app)
+
+
+@app.route('/deploy-model', methods=['POST'])
+def deploy_model_post():
+    if not request.json:
+        abort(400)
+    return json.dumps(deploy_model(
+                action=request.json['action'],
+                model_name=request.json['model_name'],
+                default_model_uri=request.json['default_model_uri'],
+                canary_model_uri=request.json['canary_model_uri'],
+                canary_model_traffic=request.json['canary_model_traffic'],
+                namespace=request.json['namespace'],
+                framework=request.json['framework'],
+                default_custom_model_spec=request.json['default_custom_model_spec'],
+                canary_custom_model_spec=request.json['canary_custom_model_spec']
+                ))
+
+
+@app.route('/', methods=['GET'])
+def root_get():
+    return 200
+
+
+@app.route('/', methods=['OPTIONS'])
+def root_options():
+    return "200"
+
+
+if __name__ == "__main__":
+    app.run(debug=True, host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))

--- a/components/kubeflow/kfserving/src/kfservingdeployer.py
+++ b/components/kubeflow/kfserving/src/kfservingdeployer.py
@@ -167,11 +167,13 @@ if __name__ == "__main__":
         )
     print(model_status)
     try:
-        print(model_status['status']['url'] + ' is the knative domain header. $CLUSTER_IP:31380 is the endpoint to post predictions to the model.')
-        print('Sample test curl below: ')
-        print('curl -X GET -H "Host: ' + url.sub('', model_status['status']['url']) + '" $CLUSTER_IP:31380')
+        print(model_status['status']['url'] + ' is the knative domain header. $ISTIO_INGRESS_ENDPOINT are defined in the below commands')
+        print('Sample test commands: ')
+        print('# Note: If Istio Ingress gateway is not served with LoadBalancer, use $CLUSTER_NODE_IP:31380 as the ISTIO_INGRESS_ENDPOINT')
+        print('ISTIO_INGRESS_ENDPOINT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath=\'{.status.loadBalancer.ingress[0].ip}\')')
+        print('curl -X GET -H "Host: ' + url.sub('', model_status['status']['url']) + '" $ISTIO_INGRESS_ENDPOINT')
     except:
-        print('Model is not ready, check the logs for more status on the Knative URL.')
+        print('Model is not ready, check the logs for the Knative URL status.')
     if not os.path.exists(os.path.dirname(output_path)):
         os.makedirs(os.path.dirname(output_path))
     with open(output_path, "w") as report:

--- a/components/kubeflow/kfserving/src/kfservingdeployer.py
+++ b/components/kubeflow/kfserving/src/kfservingdeployer.py
@@ -14,6 +14,8 @@
 import json
 import argparse
 import os
+import requests
+import re
 
 from kubernetes import client
 
@@ -70,32 +72,12 @@ def kfserving_deployment(metadata, default_model_spec, canary_model_spec=None, c
                                                         canary_traffic_percent=canary_model_traffic))
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--action', type=str, help='Action to execute on KFServing', default='create')
-    parser.add_argument('--model-name', type=str, help='Name to give to the deployed model', default="")
-    parser.add_argument('--default-model-uri', type=str, help='Path of the S3, GCS or PVC directory containing default model.')
-    parser.add_argument('--canary-model-uri', type=str, help='Optional path of the S3, GCS or PVC directory containing canary model.', default="")
-    parser.add_argument('--canary-model-traffic', type=str, help='Optional Traffic to be sent to the default model', default='0')
-    parser.add_argument('--namespace', type=str, help='Kubernetes namespace where the KFServing service is deployed.', default='kubeflow')
-    parser.add_argument('--framework', type=str, help='Model Serving Framework', default='tensorflow')
-    parser.add_argument('--default-custom-model-spec', type=json.loads, help='Custom runtime default custom model container spec', default={})
-    parser.add_argument('--canary-custom-model-spec', type=json.loads, help='Custom runtime canary custom model container spec', default={})
-    parser.add_argument('--output_path', type=str, help='Path to store URI output')
-    args = parser.parse_args()
-
-    action = args.action.lower()
-    model_name = args.model_name
-    default_model_uri = args.default_model_uri
-    canary_model_uri = args.canary_model_uri
-    canary_model_traffic = int(args.canary_model_traffic)
-    namespace = args.namespace
-    framework = args.framework.lower()
-    output_path = args.output_path
-    default_custom_model_spec = args.default_custom_model_spec
-    canary_custom_model_spec = args.canary_custom_model_spec
-
-    metadata = client.V1ObjectMeta(name=model_name, namespace=namespace)
+def deploy_model(action, model_name, default_model_uri, canary_model_uri, canary_model_traffic, namespace, framework, default_custom_model_spec, canary_custom_model_spec, autoscaling_target=0):
+    if int(autoscaling_target) != 0:
+        annotations = {"autoscaling.knative.dev/target": str(autoscaling_target)}
+    else:
+        annotations = None
+    metadata = client.V1ObjectMeta(name=model_name, namespace=namespace, annotations=annotations)
     if framework != 'custom':
         default_model_spec = ModelSpec(framework, default_model_uri)
     else:
@@ -122,8 +104,74 @@ if __name__ == "__main__":
         raise("Error: No matching action: " + action)
 
     model_status = KFServing.get(model_name, namespace=namespace)
-    print(model_status)
+    return model_status
 
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--action', type=str, help='Action to execute on KFServing', default='create')
+    parser.add_argument('--model-name', type=str, help='Name to give to the deployed model', default="")
+    parser.add_argument('--default-model-uri', type=str, help='Path of the S3, GCS or PVC directory containing default model.')
+    parser.add_argument('--canary-model-uri', type=str, help='Optional path of the S3, GCS or PVC directory containing canary model.', default="")
+    parser.add_argument('--canary-model-traffic', type=str, help='Optional Traffic to be sent to the default model', default='0')
+    parser.add_argument('--namespace', type=str, help='Kubernetes namespace where the KFServing service is deployed.', default='kubeflow')
+    parser.add_argument('--framework', type=str, help='Model Serving Framework', default='tensorflow')
+    parser.add_argument('--default-custom-model-spec', type=json.loads, help='Custom runtime default custom model container spec', default={})
+    parser.add_argument('--canary-custom-model-spec', type=json.loads, help='Custom runtime canary custom model container spec', default={})
+    parser.add_argument('--kfserving-deployer-api', type=str, help='kfserving remote deployer api endpoint', default='')
+    parser.add_argument('--autoscaling-target', type=str, help='Autoscaling target number', default='0')
+    parser.add_argument('--output_path', type=str, help='Path to store URI output')
+    args = parser.parse_args()
+
+    url = re.compile(r"https?://")
+
+    action = args.action.lower()
+    model_name = args.model_name
+    default_model_uri = args.default_model_uri
+    canary_model_uri = args.canary_model_uri
+    canary_model_traffic = int(args.canary_model_traffic)
+    namespace = args.namespace
+    framework = args.framework.lower()
+    output_path = args.output_path
+    default_custom_model_spec = args.default_custom_model_spec
+    canary_custom_model_spec = args.canary_custom_model_spec
+    kfserving_deployer_api = url.sub('', args.kfserving_deployer_api)
+    autoscaling_target = int(args.autoscaling_target)
+
+    if kfserving_deployer_api:
+        formData = {
+            "action": action,
+            "model_name": model_name,
+            "default_model_uri": default_model_uri,
+            "canary_model_uri": canary_model_uri,
+            "canary_model_traffic": canary_model_traffic,
+            "namespace": namespace,
+            "framework": framework,
+            "default_custom_model_spec": default_custom_model_spec,
+            "canary_custom_model_spec": canary_custom_model_spec,
+            "autoscaling_target": autoscaling_target
+            }
+        response = requests.post("http://" + kfserving_deployer_api + "/deploy-model", json=formData)
+        model_status = response.json()
+    else:
+        model_status = deploy_model(
+            action=action,
+            model_name=model_name,
+            default_model_uri=default_model_uri,
+            canary_model_uri=canary_model_uri,
+            canary_model_traffic=canary_model_traffic,
+            namespace=namespace,
+            framework=framework,
+            default_custom_model_spec=default_custom_model_spec,
+            canary_custom_model_spec=canary_custom_model_spec,
+            autoscaling_target=autoscaling_target
+        )
+    print(model_status)
+    try:
+        print(model_status['status']['url'] + ' is the knative domain header. $CLUSTER_IP:31380 is the endpoint to post predictions to the model.')
+        print('Sample test curl below: ')
+        print('curl -X GET -H "Host: ' + url.sub('', model_status['status']['url']) + '" $CLUSTER_IP:31380')
+    except:
+        print('Model is not ready, check the logs for more status on the Knative URL.')
     if not os.path.exists(os.path.dirname(output_path)):
         os.makedirs(os.path.dirname(output_path))
     with open(output_path, "w") as report:


### PR DESCRIPTION
Extend KFServing component with the following features:
- Add autoscaling annotations
- Add server mode to accept external requests for model serving.
- minor code refactor

/assign @animeshsingh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2315)
<!-- Reviewable:end -->
