### PR TITLE
SDK - Containers - Made python package installation more robust

### DIFF
--- a/sdk/python/kfp/containers/_component_builder.py
+++ b/sdk/python/kfp/containers/_component_builder.py
@@ -140,9 +140,9 @@ def _generate_dockerfile(filename, base_image, python_version, requirement_filen
     if requirement_filename is not None:
       f.write('ADD ' + requirement_filename + ' /ml/requirements.txt\n')
       if python_version == 'python3':
-        f.write('RUN pip3 install -r /ml/requirements.txt\n')
+        f.write('RUN python3 -m pip install -r /ml/requirements.txt\n')
       else:
-        f.write('RUN pip install -r /ml/requirements.txt\n')
+        f.write('RUN python -m pip install -r /ml/requirements.txt\n')
     
     for src_path, dst_path in (add_files or {}).items():     
       f.write('ADD ' + src_path + ' ' + dst_path + '\n')

--- a/sdk/python/tests/compiler/component_builder_test.py
+++ b/sdk/python/tests/compiler/component_builder_test.py
@@ -122,7 +122,7 @@ ADD main.py /ml/main.py
 FROM gcr.io/ngao-mlpipeline-testing/tensorflow:1.10.0
 RUN apt-get update -y && apt-get install --no-install-recommends -y -q python3 python3-pip python3-setuptools
 ADD requirements.txt /ml/requirements.txt
-RUN pip3 install -r /ml/requirements.txt
+RUN python3 -m pip install -r /ml/requirements.txt
 ADD main.py /ml/main.py
 '''
 
@@ -130,7 +130,7 @@ ADD main.py /ml/main.py
 FROM gcr.io/ngao-mlpipeline-testing/tensorflow:1.10.0
 RUN apt-get update -y && apt-get install --no-install-recommends -y -q python python-pip python-setuptools
 ADD requirements.txt /ml/requirements.txt
-RUN pip install -r /ml/requirements.txt
+RUN python -m pip install -r /ml/requirements.txt
 ADD main.py /ml/main.py
 '''
     # check


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/2252
On some systems (e.g. in DL VM containers) `pip3` does not point to the same environment as `python3`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2316)
<!-- Reviewable:end -->
