### PR TITLE
SDK - Compiler - Added the component spec annotations to the compiled workflow

### DIFF
--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -281,4 +281,8 @@ def _op_to_template(op: BaseOp):
     if processed_op.display_name:
         template.setdefault('metadata', {}).setdefault('annotations', {})['pipelines.kubeflow.org/task_display_name'] = processed_op.display_name
 
+    if isinstance(op, dsl.ContainerOp) and op._metadata:
+        import json
+        template.setdefault('metadata', {}).setdefault('annotations', {})['pipelines.kubeflow.org/component_spec'] = json.dumps(op._metadata.to_dict(), sort_keys=True)
+
     return template


### PR DESCRIPTION
Currently most of the component spec information (original input/output names, types, descriptions) is lost during the compilation.
This change adds that data to the workflow as annotation.
This will make it possible for the Frontend (and other services) to get the full component specs information and use it to improve the UX.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2323)
<!-- Reviewable:end -->
