### PR TITLE
Fix pipeline cannot run bug when using marketplace managed storage

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/argo.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/argo.yaml
@@ -93,7 +93,7 @@ data:
     artifactRepository:
     {
         s3: {
-            bucket: mlpipeline,
+            bucket: '{{ if .Values.managedstorage.enabled }}{{ .Values.managedstorage.gcsBucketName }}{{ else }}mlpipeline{{ end }}',
             keyPrefix: artifacts,
             endpoint: minio-service.{{ .Release.Namespace }}:9000,
             insecure: true,

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/argo.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/argo.yaml
@@ -93,7 +93,7 @@ data:
     artifactRepository:
     {
         s3: {
-            bucket: '{{ if .Values.managedstorage.enabled }}{{ .Values.managedstorage.gcsBucketName }}{{ else }}mlpipeline{{ end }}',
+            bucket: '{{ if .Values.managedstorage.enabled }}{{ tpl .Values.managedstorage.gcsBucketName . }}{{ else }}mlpipeline{{ end }}',
             keyPrefix: artifacts,
             endpoint: minio-service.{{ .Release.Namespace }}:9000,
             insecure: true,

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
@@ -624,7 +624,7 @@ spec:
             # Following environment variables are only needed when using Cloud SQL and GCS.
             {{ if .Values.managedstorage.enabled }}
             - name: OBJECTSTORECONFIG_BUCKETNAME
-              value: '{{ .Values.managedstorage.gcsBucketName }}'
+              value: '{{ tpl .Values.managedstorage.gcsBucketName . }}'
             - name: DBCONFIG_DBNAME
               {{ if .Values.managedstorage.databaseNamePrefix }}
               value: '{{ .Values.managedstorage.databaseNamePrefix }}_pipeline'

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
@@ -624,11 +624,7 @@ spec:
             # Following environment variables are only needed when using Cloud SQL and GCS.
             {{ if .Values.managedstorage.enabled }}
             - name: OBJECTSTORECONFIG_BUCKETNAME
-              {{ if .Values.managedstorage.databaseNamePrefix }}
-              value: '{{ printf "%s-%s" .Values.managedstorage.cloudsqlInstanceConnectionName .Values.managedstorage.databaseNamePrefix | replace ":" "-" | trunc 50 }}'
-              {{ else }}
-              value: '{{ printf "%s-%s" .Values.managedstorage.cloudsqlInstanceConnectionName .Release.Name | replace ":" "-" | trunc 50 }}'
-              {{ end }}
+              value: '{{ .Values.managedstorage.gcsBucketName }}'
             - name: DBCONFIG_DBNAME
               {{ if .Values.managedstorage.databaseNamePrefix }}
               value: '{{ .Values.managedstorage.databaseNamePrefix }}_pipeline'

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/values.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/values.yaml
@@ -20,7 +20,12 @@ serviceAccountCredential: null
 managedstorage:
   enabled: false
   cloudsqlInstanceConnectionName: null
-  gcsBucketName: null
+  # gcsBucketName should be determined by cloudsqlInstanceConnectionName to make
+  # sure user is always using a valid pair of connection name + gcs bucket name.
+  #
+  # gcsBucketName is used in two places, so I wrote a template string here that
+  # can be evaluated in each place.
+  gcsBucketName: '{{ if .Values.managedstorage.databaseNamePrefix }}{{ printf "%s-%s" .Values.managedstorage.cloudsqlInstanceConnectionName .Values.managedstorage.databaseNamePrefix | replace ":" "-" | trunc 50 }}{{ else }}{{ printf "%s-%s" .Values.managedstorage.cloudsqlInstanceConnectionName .Release.Name | replace ":" "-" | trunc 50 }}{{ end }}'
   databaseNamePrefix: null
   dbUsername: 'root'
   dbPassword: ''

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/values.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/values.yaml
@@ -20,6 +20,7 @@ serviceAccountCredential: null
 managedstorage:
   enabled: false
   cloudsqlInstanceConnectionName: null
+  gcsBucketName: null
   databaseNamePrefix: null
   dbUsername: 'root'
   dbPassword: ''


### PR DESCRIPTION
Pipeline couldn't run because workflow-controller isn't configured to write output artifacts to the correct gcs bucket. 

I also made gcs bucket a directly configurable parameter for marketplace deployment, because:
* When users need to backup / delete gcp resources, they should be aware which bucket KFP was using.

Pros:
* Clarity on which gcp resources KFP is using

Cons:
* One extra field to configure when using marketplace

I think pros outweigh cons. WDYT?

/assign @numerology 
/cc @jessiezcc 
/cc @rmgogogo 
/kind bug

Reminder note: when we bring back managed storage configs for marketplace, we need to add an extra field for typing gcs bucket name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2341)
<!-- Reviewable:end -->
