### PR TITLE
Typo in Data passing in python components.ipynb

### DIFF
--- a/samples/tutorials/Data passing in python components.ipynb
+++ b/samples/tutorials/Data passing in python components.ipynb
@@ -48,7 +48,7 @@
    "source": [
     "## Small data\n",
     "\n",
-    "Small data is the data that you'll be comfortable passing as program's command-line argument. Smal data size should not exceed few kilobytes.\n",
+    "Small data is the data that you'll be comfortable passing as program's command-line argument. Small data size should not exceed few kilobytes.\n",
     "\n",
     "Some examples of typical types of small data are: number, URL, small string (e.g. column name).\n",
     "\n",


### PR DESCRIPTION
smal should be small

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2347)
<!-- Reviewable:end -->
