### PR TITLE
KFServing move to v1alpha2

### DIFF
--- a/components/kubeflow/kfserving/Dockerfile
+++ b/components/kubeflow/kfserving/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-slim
 
-RUN pip3 install kubernetes==9.0.0 kfserving==0.1.1 requests==2.22.0 Flask==1.1.1 flask-cors==3.0.8
+RUN pip3 install kubernetes==9.0.0 kfserving requests==2.22.0 Flask==1.1.1 flask-cors==3.0.8
 
 ENV APP_HOME /app
 COPY src $APP_HOME

--- a/components/kubeflow/kfserving/Dockerfile
+++ b/components/kubeflow/kfserving/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-slim
 
-RUN pip3 install kubernetes==9.0.0 kfserving==0.2.0 requests==2.22.0 Flask==1.1.1 flask-cors==3.0.8
+RUN pip3 install kubernetes==10.0.1 kfserving==0.2.1 requests==2.22.0 Flask==1.1.1 flask-cors==3.0.8
 
 ENV APP_HOME /app
 COPY src $APP_HOME

--- a/components/kubeflow/kfserving/Dockerfile
+++ b/components/kubeflow/kfserving/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-slim
 
-RUN pip3 install kubernetes==9.0.0 kfserving requests==2.22.0 Flask==1.1.1 flask-cors==3.0.8
+RUN pip3 install kubernetes==9.0.0 kfserving==0.2.0 requests==2.22.0 Flask==1.1.1 flask-cors==3.0.8
 
 ENV APP_HOME /app
 COPY src $APP_HOME

--- a/components/kubeflow/kfserving/component.yaml
+++ b/components/kubeflow/kfserving/component.yaml
@@ -16,7 +16,7 @@ outputs:
   - {name: Service Endpoint URI, type: String,                      description: 'URI of the deployed prediction service..'}
 implementation:
   container:
-    image: aipipeline/kfserving-component:v0.1.0
+    image: aipipeline/kfserving-component:v0.2.1
     command: ['python']
     args: [
       -u, kfservingdeployer.py,

--- a/components/kubeflow/kfserving/component.yaml
+++ b/components/kubeflow/kfserving/component.yaml
@@ -13,7 +13,7 @@ inputs:
   - {name: Autoscaling Target,              type: String, default: '0',        description: 'Autoscaling Target Number'}
   - {name: KFServing Endpoint,              type: String, default: '', description: 'KFServing remote deployer API endpoint'}
 outputs:
-  - {name: Endpoint URI, type: String,                      description: 'URI of the deployed prediction service..'}
+  - {name: Service Endpoint URI, type: String,                      description: 'URI of the deployed prediction service..'}
 implementation:
   container:
     image: aipipeline/kfserving-component:v0.1.0
@@ -29,7 +29,7 @@ implementation:
       --framework,                {inputValue: Framework},
       --default-custom-model-spec,{inputValue: Default Custom Model Spec},
       --canary-custom-model-spec, {inputValue: Canary Custom Model Spec},
-      --kfserving-deployer-api,   {inputValue: KFServing Endpoint},
+      --kfserving-endpoint,       {inputValue: KFServing Endpoint},
       --autoscaling-target,       {inputValue: Autoscaling Target},
-      --output_path,              {outputPath: Endpoint URI}
+      --output_path,              {outputPath: Service Endpoint URI}
     ]

--- a/components/kubeflow/kfserving/sample-pipeline.py
+++ b/components/kubeflow/kfserving/sample-pipeline.py
@@ -1,16 +1,17 @@
-# Copyright 2019 IBM Corporation
+# Copyright 2019 kubeflow.org.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import kfp.dsl as dsl
 from kfp import components
 import json

--- a/components/kubeflow/kfserving/src/app.py
+++ b/components/kubeflow/kfserving/src/app.py
@@ -1,3 +1,17 @@
+# Copyright 2019 kubeflow.org.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from flask import Flask, request, abort
 from flask_cors import CORS
 import json

--- a/components/kubeflow/kfserving/src/kfservingdeployer.py
+++ b/components/kubeflow/kfserving/src/kfservingdeployer.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import json
 import argparse
 import os
@@ -21,33 +22,36 @@ from kubernetes import client
 
 from kfserving import KFServingClient
 from kfserving import constants
-from kfserving import V1alpha1ModelSpec
-from kfserving import V1alpha1TensorflowSpec
-from kfserving import V1alpha1PyTorchSpec
-from kfserving import V1alpha1SKLearnSpec
-from kfserving import V1alpha1XGBoostSpec
-from kfserving import V1alpha1TensorRTSpec
-from kfserving import V1alpha1CustomSpec
-from kfserving import V1alpha1KFServiceSpec
-from kfserving import V1alpha1KFService
+from kfserving import V1alpha2EndpointSpec
+from kfserving import V1alpha2PredictorSpec
+from kfserving import V1alpha2TensorflowSpec
+from kfserving import V1alpha2PyTorchSpec
+from kfserving import V1alpha2SKLearnSpec
+from kfserving import V1alpha2XGBoostSpec
+from kfserving import V1alpha2ONNXSpec
+from kfserving import V1alpha2TensorRTSpec
+from kfserving import V1alpha2CustomSpec
+from kfserving import V1alpha2InferenceServiceSpec
+from kfserving import V1alpha2InferenceService
 
-
-def ModelSpec(framework, model_uri):
+def EndpointSpec(framework, model_uri):
     if framework == 'tensorflow':
-        return V1alpha1ModelSpec(tensorflow=V1alpha1TensorflowSpec(model_uri=model_uri))
+        return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(tensorflow=V1alpha2TensorflowSpec(model_uri=model_uri)))
     elif framework == 'pytorch':
-        return V1alpha1ModelSpec(pytorch=V1alpha1PyTorchSpec(model_uri=model_uri))
+        return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(pytorch=V1alpha2PyTorchSpec(model_uri=model_uri)))
     elif framework == 'sklearn':
-        return V1alpha1ModelSpec(sklearn=V1alpha1SKLearnSpec(model_uri=model_uri))
+        return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(sklearn=V1alpha2SKLearnSpec(model_uri=model_uri)))
     elif framework == 'xgboost':
-        return V1alpha1ModelSpec(xgboost=V1alpha1XGBoostSpec(model_uri=model_uri))
+        return VV1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(xgboost=V1alpha2XGBoostSpec(model_uri=model_uri)))
+    elif framework == 'onnx':
+        return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(onnx=V1alpha2ONNXSpec(model_uri=model_uri)))
     elif framework == 'tensorrt':
-        return V1alpha1ModelSpec(tensorrt=V1alpha1TensorRTSpec(model_uri=model_uri))
+        return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(tensorrt=V1alpha2TensorRTSpec(model_uri=model_uri)))
     else:
         raise("Error: No matching framework: " + framework)
 
 
-def customModelSpec(custom_model_spec):
+def customEndpointSpec(custom_model_spec):
     env = [client.V1EnvVar(name=i['name'], value=i['value']) for i in custom_model_spec['env']] if custom_model_spec.get('env', '') else None
     ports = [client.V1ContainerPort(container_port=int(custom_model_spec.get('port', '')))] if custom_model_spec.get('port', '') else None
     containerSpec = client.V1Container(
@@ -60,14 +64,14 @@ def customModelSpec(custom_model_spec):
         image_pull_policy=custom_model_spec.get('image_pull_policy', None),
         working_dir=custom_model_spec.get('working_dir', None)
     )
-    return V1alpha1ModelSpec(custom=V1alpha1CustomSpec(container=containerSpec))
+    return V1alpha2EndpointSpec(custom=V1alpha2CustomSpec(container=containerSpec))
 
 
-def kfserving_deployment(metadata, default_model_spec, canary_model_spec=None, canary_model_traffic=None):
-    return V1alpha1KFService(api_version=constants.KFSERVING_GROUP + '/' + constants.KFSERVING_VERSION,
+def InferenceService(metadata, default_model_spec, canary_model_spec=None, canary_model_traffic=None):
+    return V1alpha2InferenceService(api_version=constants.KFSERVING_GROUP + '/' + constants.KFSERVING_VERSION,
                              kind=constants.KFSERVING_KIND,
                              metadata=metadata,
-                             spec=V1alpha1KFServiceSpec(default=default_model_spec,
+                             spec=V1alpha2InferenceServiceSpec(default=default_model_spec,
                                                         canary=canary_model_spec,
                                                         canary_traffic_percent=canary_model_traffic))
 
@@ -78,26 +82,33 @@ def deploy_model(action, model_name, default_model_uri, canary_model_uri, canary
     else:
         annotations = None
     metadata = client.V1ObjectMeta(name=model_name, namespace=namespace, annotations=annotations)
-    if framework != 'custom':
-        default_model_spec = ModelSpec(framework, default_model_uri)
-    else:
-        default_model_spec = customModelSpec(default_custom_model_spec)
+    
+    # Create Default deployment if default model uri is provided.
+    if framework != 'custom' and default_model_uri::
+        default_model_spec = EndpointSpec(framework, default_model_uri)
+    elif framework == 'custom' and default_custom_model_spec:
+        default_model_spec = customEndpointSpec(default_custom_model_spec)
+    
     # Create Canary deployment if canary model uri is provided.
     if framework != 'custom' and canary_model_uri:
-        canary_model_spec = ModelSpec(framework, canary_model_uri)
-        kfsvc = kfserving_deployment(metadata, default_model_spec, canary_model_spec, canary_model_traffic)
+        canary_model_spec = EndpointSpec(framework, canary_model_uri)
+        kfsvc = InferenceService(metadata, default_model_spec, canary_model_spec, canary_model_traffic)
     elif framework == 'custom' and canary_custom_model_spec:
-        canary_model_spec = customModelSpec(canary_custom_model_spec)
-        kfsvc = kfserving_deployment(metadata, default_model_spec, canary_model_spec, canary_model_traffic)
+        canary_model_spec = customEndpointSpec(canary_custom_model_spec)
+        kfsvc = InferenceService(metadata, default_model_spec, canary_model_spec, canary_model_traffic)
     else:
-        kfsvc = kfserving_deployment(metadata, default_model_spec)
+        kfsvc = InferenceService(metadata, default_model_spec)
 
     KFServing = KFServingClient()
 
     if action == 'create':
-        KFServing.create(kfsvc)
+        KFServing.create(kfsvc, watch=True, timeout_seconds=120)
     elif action == 'update':
         KFServing.patch(model_name, kfsvc)
+    elif action == 'rollout':
+        KFServing.rollout_canary(model_name, canary=canary_model_spec, percent=canary_model_traffic, namespace=namespace, watch=True, timeout_seconds=120)
+    elif action == 'promote':
+        KFServing.promote(model_name, namespace=namespace, watch=True, timeout_seconds=120)
     elif action == 'delete':
         KFServing.delete(model_name, namespace=namespace)
     else:
@@ -117,7 +128,7 @@ if __name__ == "__main__":
     parser.add_argument('--framework', type=str, help='Model Serving Framework', default='tensorflow')
     parser.add_argument('--default-custom-model-spec', type=json.loads, help='Custom runtime default custom model container spec', default={})
     parser.add_argument('--canary-custom-model-spec', type=json.loads, help='Custom runtime canary custom model container spec', default={})
-    parser.add_argument('--kfserving-deployer-api', type=str, help='kfserving remote deployer api endpoint', default='')
+    parser.add_argument('--kfserving-endpoint', type=str, help='kfserving remote deployer api endpoint', default='')
     parser.add_argument('--autoscaling-target', type=str, help='Autoscaling target number', default='0')
     parser.add_argument('--output_path', type=str, help='Path to store URI output')
     args = parser.parse_args()
@@ -134,10 +145,10 @@ if __name__ == "__main__":
     output_path = args.output_path
     default_custom_model_spec = args.default_custom_model_spec
     canary_custom_model_spec = args.canary_custom_model_spec
-    kfserving_deployer_api = url.sub('', args.kfserving_deployer_api)
+    kfserving-endpoint = url.sub('', args.kfserving-endpoint)
     autoscaling_target = int(args.autoscaling_target)
 
-    if kfserving_deployer_api:
+    if kfserving-endpoint:
         formData = {
             "action": action,
             "model_name": model_name,
@@ -150,7 +161,7 @@ if __name__ == "__main__":
             "canary_custom_model_spec": canary_custom_model_spec,
             "autoscaling_target": autoscaling_target
             }
-        response = requests.post("http://" + kfserving_deployer_api + "/deploy-model", json=formData)
+        response = requests.post("http://" + kfserving-endpoint + "/deploy-model", json=formData)
         model_status = response.json()
     else:
         model_status = deploy_model(

--- a/components/kubeflow/kfserving/src/kfservingdeployer.py
+++ b/components/kubeflow/kfserving/src/kfservingdeployer.py
@@ -42,7 +42,7 @@ def EndpointSpec(framework, storage_uri):
     elif framework == 'sklearn':
         return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(sklearn=V1alpha2SKLearnSpec(storage_uri=storage_uri)))
     elif framework == 'xgboost':
-        return VV1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(xgboost=V1alpha2XGBoostSpec(storage_uri=storage_uri)))
+        return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(xgboost=V1alpha2XGBoostSpec(storage_uri=storage_uri)))
     elif framework == 'onnx':
         return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(onnx=V1alpha2ONNXSpec(storage_uri=storage_uri)))
     elif framework == 'tensorrt':

--- a/components/kubeflow/kfserving/src/kfservingdeployer.py
+++ b/components/kubeflow/kfserving/src/kfservingdeployer.py
@@ -1,10 +1,10 @@
-# Copyright 2019 IBM Corporation
+# Copyright 2019 kubeflow.org.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/components/kubeflow/kfserving/src/kfservingdeployer.py
+++ b/components/kubeflow/kfserving/src/kfservingdeployer.py
@@ -34,7 +34,7 @@ from kfserving import V1alpha2CustomSpec
 from kfserving import V1alpha2InferenceServiceSpec
 from kfserving import V1alpha2InferenceService
 
-def EndpointSpec(framework, model_uri):
+def EndpointSpec(framework, storage_uri):
     if framework == 'tensorflow':
         return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(tensorflow=V1alpha2TensorflowSpec(storage_uri=storage_uri)))
     elif framework == 'pytorch':

--- a/components/kubeflow/kfserving/src/kfservingdeployer.py
+++ b/components/kubeflow/kfserving/src/kfservingdeployer.py
@@ -28,7 +28,7 @@ from kfserving import V1alpha2TensorflowSpec
 from kfserving import V1alpha2PyTorchSpec
 from kfserving import V1alpha2SKLearnSpec
 from kfserving import V1alpha2XGBoostSpec
-from kfserving import V1alpha2ONNXSpec
+from kfserving.models.v1alpha2_onnx_spec import V1alpha2ONNXSpec
 from kfserving import V1alpha2TensorRTSpec
 from kfserving import V1alpha2CustomSpec
 from kfserving import V1alpha2InferenceServiceSpec
@@ -36,17 +36,17 @@ from kfserving import V1alpha2InferenceService
 
 def EndpointSpec(framework, model_uri):
     if framework == 'tensorflow':
-        return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(tensorflow=V1alpha2TensorflowSpec(model_uri=model_uri)))
+        return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(tensorflow=V1alpha2TensorflowSpec(storage_uri=storage_uri)))
     elif framework == 'pytorch':
-        return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(pytorch=V1alpha2PyTorchSpec(model_uri=model_uri)))
+        return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(pytorch=V1alpha2PyTorchSpec(storage_uri=storage_uri)))
     elif framework == 'sklearn':
-        return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(sklearn=V1alpha2SKLearnSpec(model_uri=model_uri)))
+        return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(sklearn=V1alpha2SKLearnSpec(storage_uri=storage_uri)))
     elif framework == 'xgboost':
-        return VV1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(xgboost=V1alpha2XGBoostSpec(model_uri=model_uri)))
+        return VV1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(xgboost=V1alpha2XGBoostSpec(storage_uri=storage_uri)))
     elif framework == 'onnx':
-        return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(onnx=V1alpha2ONNXSpec(model_uri=model_uri)))
+        return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(onnx=V1alpha2ONNXSpec(storage_uri=storage_uri)))
     elif framework == 'tensorrt':
-        return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(tensorrt=V1alpha2TensorRTSpec(model_uri=model_uri)))
+        return V1alpha2EndpointSpec(predictor=V1alpha2PredictorSpec(tensorrt=V1alpha2TensorRTSpec(storage_uri=storage_uri)))
     else:
         raise("Error: No matching framework: " + framework)
 
@@ -72,8 +72,8 @@ def InferenceService(metadata, default_model_spec, canary_model_spec=None, canar
                              kind=constants.KFSERVING_KIND,
                              metadata=metadata,
                              spec=V1alpha2InferenceServiceSpec(default=default_model_spec,
-                                                        canary=canary_model_spec,
-                                                        canary_traffic_percent=canary_model_traffic))
+                                                               canary=canary_model_spec,
+                                                               canary_traffic_percent=canary_model_traffic))
 
 
 def deploy_model(action, model_name, default_model_uri, canary_model_uri, canary_model_traffic, namespace, framework, default_custom_model_spec, canary_custom_model_spec, autoscaling_target=0):
@@ -84,7 +84,7 @@ def deploy_model(action, model_name, default_model_uri, canary_model_uri, canary
     metadata = client.V1ObjectMeta(name=model_name, namespace=namespace, annotations=annotations)
     
     # Create Default deployment if default model uri is provided.
-    if framework != 'custom' and default_model_uri::
+    if framework != 'custom' and default_model_uri:
         default_model_spec = EndpointSpec(framework, default_model_uri)
     elif framework == 'custom' and default_custom_model_spec:
         default_model_spec = customEndpointSpec(default_custom_model_spec)
@@ -145,10 +145,10 @@ if __name__ == "__main__":
     output_path = args.output_path
     default_custom_model_spec = args.default_custom_model_spec
     canary_custom_model_spec = args.canary_custom_model_spec
-    kfserving-endpoint = url.sub('', args.kfserving-endpoint)
+    kfserving_endpoint = url.sub('', args.kfserving_endpoint)
     autoscaling_target = int(args.autoscaling_target)
 
-    if kfserving-endpoint:
+    if kfserving_endpoint:
         formData = {
             "action": action,
             "model_name": model_name,
@@ -161,7 +161,7 @@ if __name__ == "__main__":
             "canary_custom_model_spec": canary_custom_model_spec,
             "autoscaling_target": autoscaling_target
             }
-        response = requests.post("http://" + kfserving-endpoint + "/deploy-model", json=formData)
+        response = requests.post("http://" + kfserving_endpoint + "/deploy-model", json=formData)
         model_status = response.json()
     else:
         model_status = deploy_model(


### PR DESCRIPTION
Moving KFServing Pipeline to v1alpha2 and handling rename from kfservice to inference service

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2369)
<!-- Reviewable:end -->
