### PR TITLE
Remove jingzhang36 and rmgogogo from frontend reviewer list

### DIFF
--- a/frontend/OWNERS
+++ b/frontend/OWNERS
@@ -1,10 +1,6 @@
 approvers:
-  - rileyjbauer
   - bobgy
   - jingzhang36
   - rmgogogo
 reviewers:
-  - rileyjbauer
   - bobgy
-  - jingzhang36
-  - rmgogogo


### PR DESCRIPTION
I will take care of frontend reviews for now. Consider adding people back when they want to review.

/cc @jingzhang36 
/cc @rmgogogo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2388)
<!-- Reviewable:end -->
