### PR TITLE
[Test] Fix XGBoost sample test flakiness

### DIFF
--- a/samples/core/xgboost_training_cm/xgboost_training_cm.py
+++ b/samples/core/xgboost_training_cm/xgboost_training_cm.py
@@ -34,11 +34,13 @@ def dataproc_delete_cluster_op(
 ):
   return dsl.ContainerOp(
       name='Dataproc - Delete cluster',
-      image='gcr.io/ml-pipeline/ml-pipeline-dataproc-delete-cluster:57d9f7f1cfd458e945d297957621716062d89a49',
+      image='gcr.io/ml-pipeline/ml-pipeline-gcp:57d9f7f1cfd458e945d297957621716062d89a49',
       arguments=[
-        '--project', project,
+        'kfp_component.google.dataproc', 'delete_cluster',
+        '--project_id', project,
         '--region', region,
         '--name', cluster_name,
+        '--wait_interval', '30'
       ],
       is_exit_handler=True
   )


### PR DESCRIPTION
Fix #2405 
Temporarily switch back to authoring ContainerOp using existing image. Long term fix requires the ability to set is_exit_handler = True when using component.load_component_from_url/file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2410)
<!-- Reviewable:end -->
