### PR TITLE
SDK - DSL - Make is_exit_handler unnecessary in ContainerOp

### DIFF
--- a/samples/core/exit_handler/exit_handler.py
+++ b/samples/core/exit_handler/exit_handler.py
@@ -36,7 +36,6 @@ def echo_op(text, is_exit_handler=False):
         image='library/bash:4.4.23',
         command=['sh', '-c'],
         arguments=['echo "$0"', text],
-        is_exit_handler=is_exit_handler
     )
 
 
@@ -47,7 +46,7 @@ def echo_op(text, is_exit_handler=False):
 def download_and_print(url='gs://ml-pipeline-playground/shakespeare1.txt'):
     """A sample pipeline showing exit handler."""
 
-    exit_task = echo_op('exit!', is_exit_handler=True)
+    exit_task = echo_op('exit!')
 
     with dsl.ExitHandler(exit_task):
         download_task = gcs_download_op(url)

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -697,7 +697,7 @@ class BaseOp(object):
                     to deploy before the `main` container.
           sidecars: the list of `Sidecar` objects describing the sidecar containers to deploy
                     together with the `main` container.
-          is_exit_handler: Whether it is used as an exit handler.
+          is_exit_handler: Deprecated.
         """
 
         valid_name_regex = r'^[A-Za-z][A-Za-z0-9\s_-]*$'
@@ -705,6 +705,9 @@ class BaseOp(object):
             raise ValueError(
                 'Only letters, numbers, spaces, "_", and "-"  are allowed in name. Must begin with letter: %s'
                 % (name))
+
+        if is_exit_handler:
+            warnings.warn('is_exit_handler=True is no longer needed.', DeprecationWarning)
 
         self.is_exit_handler = is_exit_handler
 
@@ -1006,7 +1009,7 @@ class ContainerOp(BaseOp):
           artifact_location: configures the default artifact location for artifacts
                in the argo workflow template. Must be a `V1alpha1ArtifactLocation`
                object.
-          is_exit_handler: Whether it is used as an exit handler.
+          is_exit_handler: Deprecated. This is no longer needed.
           pvolumes: Dictionary for the user to match a path on the op's fs with a
               V1Volume or it inherited type.
               E.g {"/my/path": vol, "/mnt": other_op.pvolumes["/output"]}.

--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -232,6 +232,10 @@ class Pipeline():
     """Remove the current OpsGroup from the stack."""
     del self.groups[-1]
 
+  def remove_op_from_groups(self, op):
+    for group in self.groups:
+      group.remove_op_recursive(op)
+
   def get_next_group_id(self):
     """Get next id for a new group. """
 

--- a/sdk/python/kfp/dsl/_resource_op.py
+++ b/sdk/python/kfp/dsl/_resource_op.py
@@ -86,7 +86,7 @@ class ResourceOp(BaseOp):
                 https://github.com/argoproj/argo/blob/master/examples/k8s-jobs.yaml
             attribute_outputs: Maps output labels to resource's json paths,
                 similarly to file_outputs of ContainerOp
-            kwargs: name, sidecars & is_exit_handler. See BaseOp definition
+            kwargs: name, sidecars. See BaseOp definition
         Raises:
         ValueError: if not inside a pipeline
                     if the name is an invalid string

--- a/sdk/python/tests/compiler/testdata/basic.yaml
+++ b/sdk/python/tests/compiler/testdata/basic.yaml
@@ -113,8 +113,6 @@ spec:
             value: '{{inputs.parameters.outputpath}}'
         name: exit-handler-1
         template: exit-handler-1
-      - name: exiting
-        template: exiting
     inputs:
       parameters:
       - name: message

--- a/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
+++ b/sdk/python/tests/compiler/testdata/basic_no_decorator.yaml
@@ -114,8 +114,6 @@ spec:
                   value: '{{inputs.parameters.outputpath}}'
             name: exit-handler-1
             template: exit-handler-1
-          - name: exiting
-            template: exiting
       inputs:
         parameters:
           - name: message


### PR DESCRIPTION
Make `is_exit_handler` unnecessary in ContainerOp.

Also fixed two broken tests. The tests did not have `is_exit_handler=True` which was required before this commit.
Fixes https://github.com/kubeflow/pipelines/issues/2405

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2411)
<!-- Reviewable:end -->
