### PR TITLE
SDK - Setup - Added cloudpickle to requirements

### DIFF
--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -9,6 +9,7 @@ PyJWT>=1.6.4
 cryptography>=2.4.2
 google-auth>=1.6.1
 requests_toolbelt>=0.8.0
+cloudpickle
 kfp-server-api >= 0.1.18, < 0.1.19
 argo-models == 2.2.1a
 jsonschema >= 3.0.1

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -9,7 +9,7 @@ PyJWT>=1.6.4
 cryptography>=2.4.2
 google-auth>=1.6.1
 requests_toolbelt>=0.8.0
-cloudpickle
+cloudpickle==1.1.1
 kfp-server-api >= 0.1.18, < 0.1.19
 argo-models == 2.2.1a
 jsonschema >= 3.0.1

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -29,7 +29,7 @@ REQUIRES = [
     'cryptography>=2.4.2',
     'google-auth>=1.6.1',
     'requests_toolbelt>=0.8.0',
-    'cloudpickle',
+    'cloudpickle==1.1.1',
     'kfp-server-api >= 0.1.18, <= 0.1.25',  #Update the upper version whenever a new version of the kfp-server-api package is released. Update the lower version when there is a breaking change in kfp-server-api.
     'argo-models == 2.2.1a',  #2.2.1a is equivalent to argo 2.2.1
     'jsonschema >= 3.0.1',


### PR DESCRIPTION
Cloudpickle is used by the `func_to_container_op(..., use_code_pickling=True)` and `create_component_from_airflow_operator`.
`setup.py` installs it, but requirements.txt did not have it.

Long-term fix: We need to make `setup.py` use `requirements.txt`. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2437)
<!-- Reviewable:end -->
