### PR TITLE
Add --bind_all option for tensorboard

### DIFF
--- a/backend/src/crd/controller/viewer/reconciler/reconciler.go
+++ b/backend/src/crd/controller/viewer/reconciler/reconciler.go
@@ -170,6 +170,7 @@ func setPodSpecForTensorboard(view *viewerV1beta1.Viewer, s *corev1.PodSpec) {
 		"tensorboard",
 		fmt.Sprintf("--logdir=%s", view.Spec.TensorboardSpec.LogDir),
 		fmt.Sprintf("--path_prefix=/tensorboard/%s/", view.Name),
+		"--bind_all",
 	}
 	c.Ports = []corev1.ContainerPort{
 		corev1.ContainerPort{ContainerPort: viewerTargetPort},

--- a/backend/src/crd/controller/viewer/reconciler/reconciler_test.go
+++ b/backend/src/crd/controller/viewer/reconciler/reconciler_test.go
@@ -178,7 +178,8 @@ func TestReconcile_EachViewerCreatesADeployment(t *testing.T) {
 						Args: []string{
 							"tensorboard",
 							"--logdir=gs://tensorboard/logdir",
-							"--path_prefix=/tensorboard/viewer-123/"},
+							"--path_prefix=/tensorboard/viewer-123/",
+							"--bind_all"},
 						Ports: []corev1.ContainerPort{{ContainerPort: 6006}},
 					}}}}}}}
 
@@ -275,7 +276,8 @@ func TestReconcile_ViewerUsesSpecifiedVolumeMountsForDeployment(t *testing.T) {
 						Args: []string{
 							"tensorboard",
 							"--logdir=gs://tensorboard/logdir",
-							"--path_prefix=/tensorboard/viewer-123/"},
+							"--path_prefix=/tensorboard/viewer-123/",
+							"--bind_all"},
 						Ports: []corev1.ContainerPort{{ContainerPort: 6006}},
 						VolumeMounts: []v1.VolumeMount{
 							{Name: "/volume-mount-name", MountPath: "/mount/path"},


### PR DESCRIPTION
This PR fixes https://github.com/kubeflow/pipelines/issues/2440. Adding `--bind_all` option allows  tensorboard to serve on all public interfaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2441)
<!-- Reviewable:end -->
