### PR TITLE
User string literals in api resource type and api resource relationship

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -306,8 +306,8 @@ class Client(object):
     api_params = [kfp_server_api.ApiParameter(name=_k8s_helper.K8sHelper.sanitize_k8s_name(k), value=str(v))
                   for k,v in params.items()]
     key = kfp_server_api.models.ApiResourceKey(id=experiment_id,
-                                        type=kfp_server_api.models.ApiResourceType.EXPERIMENT)
-    reference = kfp_server_api.models.ApiResourceReference(key, kfp_server_api.models.ApiRelationship.OWNER)
+                                        type='EXPERIMENT')
+    reference = kfp_server_api.models.ApiResourceReference(key, 'OWNER')
     spec = kfp_server_api.models.ApiPipelineSpec(
         pipeline_id=pipeline_id,
         workflow_manifest=pipeline_json_string,
@@ -392,7 +392,7 @@ class Client(object):
       A response object including a list of experiments and next page token.
     """
     if experiment_id is not None:
-      response = self._run_api.list_runs(page_token=page_token, page_size=page_size, sort_by=sort_by, resource_reference_key_type=kfp_server_api.models.api_resource_type.ApiResourceType.EXPERIMENT, resource_reference_key_id=experiment_id)
+      response = self._run_api.list_runs(page_token=page_token, page_size=page_size, sort_by=sort_by, resource_reference_key_type='EXPERIMENT', resource_reference_key_id=experiment_id)
     else:
       response = self._run_api.list_runs(page_token=page_token, page_size=page_size, sort_by=sort_by)
     return response


### PR DESCRIPTION
For bug https://github.com/kubeflow/pipelines/issues/2430
Newer swagger-codegen-cli seems to produce a different interface for api methods like list run. So change the way we call those api methods in sdk.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2454)
<!-- Reviewable:end -->
