### PR TITLE
clusterrole for pipeline-runner with seldondeployments

### DIFF
--- a/manifests/kustomize/base/pipeline/pipeline-runner-role.yaml
+++ b/manifests/kustomize/base/pipeline/pipeline-runner-role.yaml
@@ -72,3 +72,9 @@ rules:
   - jobs
   verbs:
   - '*'
+- apiGroups:
+  - machinelearning.seldon.io
+  resources:
+  - seldondeployments
+  verbs:
+  - '*'


### PR DESCRIPTION
Considering the with [issue 2455](https://github.com/kubeflow/pipelines/issues/2455)

Since now Seldon is a default component in the kubeflow toolkits, it would be nice if we add seldondeployment clusterrole for pipeline-runner when initializing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2456)
<!-- Reviewable:end -->
