### PR TITLE
[xgboost sample] Leave the user specified input empty

### DIFF
--- a/samples/core/xgboost_training_cm/xgboost_training_cm.py
+++ b/samples/core/xgboost_training_cm/xgboost_training_cm.py
@@ -203,8 +203,8 @@ def dataproc_predict_op(
     description='A trainer that does end-to-end distributed training for XGBoost models.'
 )
 def xgb_train_pipeline(
-    output='gs://your-gcs-bucket',
-    project='your-gcp-project',
+    output,
+    project,
     cluster_name='xgb-%s' % dsl.RUN_ID_PLACEHOLDER,
     region='us-central1',
     train_data='gs://ml-pipeline-playground/sfpd/train.csv',


### PR DESCRIPTION
I found it's arguably more clearer to leave these fields empty for user to provide than having a placeholder. 
Ideally we should also support parameter description in UI for more info about the parameter. 
/assign @numerology @Ark-kun

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2470)
<!-- Reviewable:end -->
