### PR TITLE
[Frontend] Fix log viewer double scrollbar bug + not scrolling to bottom bug

### DIFF
--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -48,17 +48,26 @@ const css = stylesheet({
     userSelect: 'none',
   },
   root: {
+    // We cannot easily add padding here without breaking react-virtualized size calculation, for
+    // details: https://github.com/bvaughn/react-virtualized/issues/992
+    // Specifically, a complex solution was proposed in https://github.com/bvaughn/react-virtualized/issues/992#issuecomment-371145943.
+    // We may consider that later.
     backgroundColor: '#222',
     color: '#fff',
     fontFamily: fonts.code,
     fontSize: fontsize.small,
-    padding: '10px 0',
+    // This override and listContainerStyleOverride workarounds to allow horizontal scroll.
+    // Reference: https://github.com/bvaughn/react-virtualized/issues/1248
+    overflow: 'auto !important',
     whiteSpace: 'pre',
   },
 });
 
+const listContainerStyleOverride = {
+  overflow: 'visible',
+};
+
 interface LogViewerProps {
-  classes?: string;
   logLines: string[];
 }
 
@@ -117,6 +126,7 @@ class LogViewer extends React.Component<LogViewerProps, LogViewerState> {
         {({ height, width }) => (
           <List
             id='logViewer'
+            containerStyle={listContainerStyleOverride}
             width={width}
             height={height}
             rowCount={this.props.logLines.length}

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -367,12 +367,15 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
                                     )}
                                     {!this.state.logsBannerMessage &&
                                       this.state.selectedNodeDetails && (
-                                        <LogViewer
-                                          logLines={(
-                                            this.state.selectedNodeDetails.logs || ''
-                                          ).split('\n')}
-                                          classes={commonCss.page}
-                                        />
+                                        // Overflow hidden here, because scroll is handled inside
+                                        // LogViewer.
+                                        <div className={commonCss.pageOverflowHidden}>
+                                          <LogViewer
+                                            logLines={(
+                                              this.state.selectedNodeDetails.logs || ''
+                                            ).split('\n')}
+                                          />
+                                        </div>
                                       )}
                                   </div>
                                 )}

--- a/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
@@ -577,14 +577,17 @@ exports[`RunDetails logs tab does not load logs if clicked node status is skippe
                 <div
                   className="page"
                 >
-                  <LogViewer
-                    classes="page"
-                    logLines={
-                      Array [
-                        "",
-                      ]
-                    }
-                  />
+                  <div
+                    className="pageOverflowHidden"
+                  >
+                    <LogViewer
+                      logLines={
+                        Array [
+                          "",
+                        ]
+                      }
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -688,14 +691,17 @@ exports[`RunDetails logs tab keeps side pane open and on same tab when logs chan
                 <div
                   className="page"
                 >
-                  <LogViewer
-                    classes="page"
-                    logLines={
-                      Array [
-                        "new test logs",
-                      ]
-                    }
-                  />
+                  <div
+                    className="pageOverflowHidden"
+                  >
+                    <LogViewer
+                      logLines={
+                        Array [
+                          "new test logs",
+                        ]
+                      }
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -799,14 +805,17 @@ exports[`RunDetails logs tab loads and shows logs in side pane 1`] = `
                 <div
                   className="page"
                 >
-                  <LogViewer
-                    classes="page"
-                    logLines={
-                      Array [
-                        "test logs",
-                      ]
-                    }
-                  />
+                  <div
+                    className="pageOverflowHidden"
+                  >
+                    <LogViewer
+                      logLines={
+                        Array [
+                          "test logs",
+                        ]
+                      }
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -1260,14 +1269,17 @@ exports[`RunDetails logs tab switches to logs tab in side pane 1`] = `
                 <div
                   className="page"
                 >
-                  <LogViewer
-                    classes="page"
-                    logLines={
-                      Array [
-                        "",
-                      ]
-                    }
-                  />
+                  <div
+                    className="pageOverflowHidden"
+                  >
+                    <LogViewer
+                      logLines={
+                        Array [
+                          "",
+                        ]
+                      }
+                    />
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Bug double scrollbar:
![download (18)](https://user-images.githubusercontent.com/4957653/67468493-28f4fd80-f67d-11e9-8332-75f01f6b2352.png)

Bug cannot scroll horizontally (introduced by me in an earlier PR), notice in the screenshot, log lines are long, but there is no horizontal scrollbar:
![download (19)](https://user-images.githubusercontent.com/4957653/67468848-d2d48a00-f67d-11e9-92dc-def0e168d346.png)

Bug "not scrolling to bottom", when user goes to log viewer tab, it should go to the bottom line of logs. However, it goes to a few pixels above that.

This fixes three of them.
Demo: https://drive.google.com/file/d/1xpZYI5QYlbzBquGxxKGfF4ukL91WA1MM/view

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2480)
<!-- Reviewable:end -->
