### PR TITLE
Summaries and links for filter.proto references

### DIFF
--- a/backend/api/swagger/experiment.swagger.json
+++ b/backend/api/swagger/experiment.swagger.json
@@ -55,7 +55,7 @@
           },
           {
             "name": "filter",
-            "description": "A base-64 encoded, JSON-serialized Filter protocol buffer (see\nfilter.proto).",
+            "description": "A base-64 encoded, JSON-serialized Filter protocol buffer (see\n[filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto)).",
             "in": "query",
             "required": false,
             "type": "string"

--- a/backend/api/swagger/job.swagger.json
+++ b/backend/api/swagger/job.swagger.json
@@ -75,7 +75,7 @@
           },
           {
             "name": "filter",
-            "description": "A base-64 encoded, JSON-serialized Filter protocol buffer (see\nfilter.proto).",
+            "description": "A base-64 encoded, JSON-serialized Filter protocol buffer (see\n[filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto)).",
             "in": "query",
             "required": false,
             "type": "string"

--- a/backend/api/swagger/pipeline.swagger.json
+++ b/backend/api/swagger/pipeline.swagger.json
@@ -55,7 +55,7 @@
           },
           {
             "name": "filter",
-            "description": "A base-64 encoded, JSON-serialized Filter protocol buffer (see\nfilter.proto).",
+            "description": "A base-64 encoded, JSON-serialized Filter protocol buffer (see\n[filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto)).",
             "in": "query",
             "required": false,
             "type": "string"

--- a/backend/api/swagger/run.swagger.json
+++ b/backend/api/swagger/run.swagger.json
@@ -17,6 +17,7 @@
   "paths": {
     "/apis/v1beta1/runs": {
       "get": {
+        "summary": "Finds all runs.",
         "operationId": "ListRuns",
         "responses": {
           "200": {
@@ -28,7 +29,7 @@
           "default": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiStatus"
+              "$ref": "#/definitiocns/apiStatus"
             }
           }
         },
@@ -48,14 +49,14 @@
           },
           {
             "name": "sort_by",
-            "description": "Can be format of \"field_name\", \"field_name asc\" or \"field_name des\"\nAscending by default.",
+            "description": "Options include \"field_name\", \"field_name asc\", or \"field_name des\". (Example, \"name asc\" or \"id des\")\nAscending by default.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "resource_reference_key.type",
-            "description": "The type of the resource that referred to.",
+            "name": "resources_reference_key.type",
+            "description": "The type of the resource that is referred to.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -67,15 +68,15 @@
             "default": "UNKNOWN_RESOURCE_TYPE"
           },
           {
-            "name": "resource_reference_key.id",
-            "description": "The ID of the resource that referred to.",
+            "name": "resources_reference_key.id",
+            "description": "The ID of the resource that is referred to.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "filter",
-            "description": "A base-64 encoded, JSON-serialized Filter protocol buffer (see\nfilter.proto).",
+            "description": "A base-64 encoded, JSON-serialized Filter protocol buffer (see\n[filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto)).",
             "in": "query",
             "required": false,
             "type": "string"
@@ -86,6 +87,7 @@
         ]
       },
       "post": {
+        "summary": "Initiate a run.",
         "operationId": "CreateRun",
         "responses": {
           "200": {
@@ -118,6 +120,7 @@
     },
     "/apis/v1beta1/runs/{id}": {
       "delete": {
+        "summary": "Deletes a run.",
         "operationId": "DeleteRun",
         "responses": {
           "200": {
@@ -148,6 +151,7 @@
     },
     "/apis/v1beta1/runs/{id}:archive": {
       "post": {
+        "summary": "Archives a run.",
         "operationId": "ArchiveRun",
         "responses": {
           "200": {
@@ -178,6 +182,7 @@
     },
     "/apis/v1beta1/runs/{id}:unarchive": {
       "post": {
+        "summary": "Restores an archived run.",
         "operationId": "UnarchiveRun",
         "responses": {
           "200": {
@@ -208,6 +213,7 @@
     },
     "/apis/v1beta1/runs/{run_id}": {
       "get": {
+        "summary": "Find a run by ID."
         "operationId": "GetRun",
         "responses": {
           "200": {
@@ -238,6 +244,7 @@
     },
     "/apis/v1beta1/runs/{run_id}/nodes/{node_id}/artifacts/{artifact_name}:read": {
       "get": {
+        "summary": "Finds a run's artifact data."
         "operationId": "ReadArtifact",
         "responses": {
           "200": {
@@ -283,6 +290,7 @@
     },
     "/apis/v1beta1/runs/{run_id}/retry": {
       "post": {
+        "summary": "Re-initiates a failed or terminated run."
         "operationId": "RetryRun",
         "responses": {
           "200": {
@@ -313,6 +321,7 @@
     },
     "/apis/v1beta1/runs/{run_id}/terminate": {
       "post": {
+        "summary": "Terminates an active run."
         "operationId": "TerminateRun",
         "responses": {
           "200": {
@@ -713,7 +722,7 @@
           "description": "Must be a valid serialized protocol buffer of the above specified type."
         }
       },
-      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := ptypes.MarshalAny(foo)\n     ...\n     foo := \u0026pb.Foo{}\n     if err := ptypes.UnmarshalAny(any, foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(&foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := &pb.Foo{...}\n     any, err := ptypes.MarshalAny(foo)\n     ...\n     foo := &pb.Foo{}\n     if err := ptypes.UnmarshalAny(any, foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": <string>,\n      \"lastName\": <string>\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
     }
   },
   "securityDefinitions": {

--- a/backend/api/swagger/run.swagger.json
+++ b/backend/api/swagger/run.swagger.json
@@ -29,7 +29,7 @@
           "default": {
             "description": "",
             "schema": {
-              "$ref": "#/definitiocns/apiStatus"
+              "$ref": "#/definitions/apiStatus"
             }
           }
         },


### PR DESCRIPTION
Making a small PR here to test the water with some quick summaries for the RunService endpoints and some links that were suggested in [issue 1257](https://github.com/kubeflow/website/issues/1257). Line 247 in run.swagger.json may need some additional checking as i'm not sure I understood what that endpoint specifically did.

Also corrected `resource_reference_key` to `resources_reference_key` as the latter is what appears in the JSON response body.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2483)
<!-- Reviewable:end -->
