### PR TITLE
Fix inverse proxy matching regex

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -152,7 +152,7 @@ class Client(object):
 
   def _is_inverse_proxy_host(self, host):
     if host:
-      return re.match(r'\S+dot-datalab-vm\S+.googleusercontent.com/{0,1}$', host)
+      return re.match(r'\S+.googleusercontent.com/{0,1}$', host)
     return False
 
   def _is_ipython(self):


### PR DESCRIPTION
The new format is now 
36a59b5371d6ab2-dot-us-west1.notebooks.googleusercontent.com
Remove the part that break the SDL to use a more generic matching string 
/assign @numerology @hongye-sun

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2486)
<!-- Reviewable:end -->
