### PR TITLE
[Auto lint] Refactor sdk.python.kfp.dsl by yapf and docformatter

### DIFF
--- a/sdk/python/kfp/dsl/__init__.py
+++ b/sdk/python/kfp/dsl/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from ._pipeline_param import PipelineParam, match_serialized_pipelineparam
 from ._pipeline import Pipeline, pipeline, get_pipeline_conf, PipelineConf
 from ._container_op import ContainerOp, InputArgumentPath, UserContainer, Sidecar

--- a/sdk/python/kfp/dsl/_artifact_location.py
+++ b/sdk/python/kfp/dsl/_artifact_location.py
@@ -20,133 +20,131 @@ from kubernetes.client.models import V1SecretKeySelector
 def _dict_to_secret(
     value: Union[V1SecretKeySelector, Dict[str, Any]]
 ) -> V1SecretKeySelector:
-    """Converts a dict to a kubernetes V1SecretKeySelector."""
-    if isinstance(value, dict) and value.get("name") and value.get("key"):
-        return V1SecretKeySelector(**value)
-    return value or V1SecretKeySelector(key="", optional=True)
+  """Converts a dict to a kubernetes V1SecretKeySelector."""
+  if isinstance(value, dict) and value.get("name") and value.get("key"):
+    return V1SecretKeySelector(**value)
+  return value or V1SecretKeySelector(key="", optional=True)
 
 
 class ArtifactLocation:
+  """ArtifactLocation describes a location for a single or multiple artifacts.
+
+  It is used as single artifact in the context of inputs/outputs (e.g.
+  outputs.artifacts.artname). It is also used to describe the location of
+  multiple artifacts such as the archive location of a single workflow step,
+  which the executor will use as a default location to store its files.
+
+  """
+
+  @staticmethod
+  def s3(
+      bucket: str = None,
+      endpoint: str = None,
+      insecure: bool = None,
+      region: str = None,
+      access_key_secret: Union[V1SecretKeySelector, Dict[str, Any]] = None,
+      secret_key_secret: Union[V1SecretKeySelector, Dict[str, Any]] = None,
+  ) -> V1alpha1ArtifactLocation:
+    """Creates a new instance of V1alpha1ArtifactLocation with a s3 artifact
+    backend.
+
+    Example::
+
+      from kubernetes.client.models import V1SecretKeySelector
+      from kfp.dsl import ArtifactLocation
+
+
+      artifact_location = ArtifactLocation(
+        bucket="foo",
+        endpoint="s3.amazonaws.com",
+        insecure=False,
+        region="ap-southeast-1",
+        access_key_secret={"name": "s3-secret", "key": "accesskey"},
+        secret_key_secret=V1SecretKeySelector(name="s3-secret", key="secretkey")
+      )
+
+    Args:
+      bucket (str): name of the bucket.
+      endpoint (str): hostname to the bucket endpoint.
+      insecure (bool): use TLS if set to True.
+      region (str): bucket region (for s3 buckets).
+      access_key_secret (Union[V1SecretKeySelector, Dict[str, Any]]): k8s secret selector to access key.
+      secret_key_secret (Union[V1SecretKeySelector, Dict[str, Any]]): k8s secret selector to secret key.
+
+    Returns:
+      V1alpha1ArtifactLocation: a new instance of V1alpha1ArtifactLocation.
+
     """
-    ArtifactLocation describes a location for a single or multiple artifacts.
-    It is used as single artifact in the context of inputs/outputs
-    (e.g. outputs.artifacts.artname). It is also used to describe the location
-    of multiple artifacts such as the archive location of a single workflow
-    step, which the executor will use as a default location to store its files.
-    """
-
-    @staticmethod
-    def s3(
-        bucket: str = None,
-        endpoint: str = None,
-        insecure: bool = None,
-        region: str = None,
-        access_key_secret: Union[V1SecretKeySelector, Dict[str, Any]] = None,
-        secret_key_secret: Union[V1SecretKeySelector, Dict[str, Any]] = None,
-    ) -> V1alpha1ArtifactLocation:
-        """
-        Creates a new instance of V1alpha1ArtifactLocation with a s3 artifact
-        backend.
-
-        Example::
-
-          from kubernetes.client.models import V1SecretKeySelector
-          from kfp.dsl import ArtifactLocation
-
-
-          artifact_location = ArtifactLocation(
-            bucket="foo",
-            endpoint="s3.amazonaws.com",
-            insecure=False,
-            region="ap-southeast-1",
-            access_key_secret={"name": "s3-secret", "key": "accesskey"},
-            secret_key_secret=V1SecretKeySelector(name="s3-secret", key="secretkey")
-          )
-
-        Args:
-          bucket (str): name of the bucket.
-          endpoint (str): hostname to the bucket endpoint.
-          insecure (bool): use TLS if set to True.
-          region (str): bucket region (for s3 buckets).
-          access_key_secret (Union[V1SecretKeySelector, Dict[str, Any]]): k8s secret selector to access key.
-          secret_key_secret (Union[V1SecretKeySelector, Dict[str, Any]]): k8s secret selector to secret key.
-
-        Returns:
-          V1alpha1ArtifactLocation: a new instance of V1alpha1ArtifactLocation.
-        """
-        return V1alpha1ArtifactLocation(
-            s3=V1alpha1S3Artifact(
-                bucket=bucket,
-                endpoint=endpoint,
-                insecure=insecure,
-                region=region,
-                access_key_secret=_dict_to_secret(access_key_secret),
-                secret_key_secret=_dict_to_secret(secret_key_secret),
-                key="",  # key is a required value for V1alpha1S3Artifact
-            )
+    return V1alpha1ArtifactLocation(
+        s3=V1alpha1S3Artifact(
+            bucket=bucket,
+            endpoint=endpoint,
+            insecure=insecure,
+            region=region,
+            access_key_secret=_dict_to_secret(access_key_secret),
+            secret_key_secret=_dict_to_secret(secret_key_secret),
+            key="",  # key is a required value for V1alpha1S3Artifact
         )
+    )
 
-    @staticmethod
-    def create_artifact_for_s3(
-        artifact_location: Union[V1alpha1ArtifactLocation, Dict[str, Any]],
-        name: str,
-        path: str,
-        key: str,
-        **kwargs
-    ) -> V1alpha1Artifact:
-        """
-        Creates a s3-backed `V1alpha1Artifact` object using a
-        `V1alpha1ArtifactLocation` object.
+  @staticmethod
+  def create_artifact_for_s3(
+      artifact_location: Union[V1alpha1ArtifactLocation, Dict[str, Any]],
+      name: str, path: str, key: str, **kwargs
+  ) -> V1alpha1Artifact:
+    """Creates a s3-backed `V1alpha1Artifact` object using a
+    `V1alpha1ArtifactLocation` object.
 
-        Args:
-          artifact_location (Union[V1alpha1ArtifactLocation, Dict[str, Any]]): `V1alpha1ArtifactLocation`
-            object or a dict representing it.
-          name (str): name of the artifact. must be unique within a template's
-            inputs/outputs.
-          path (str): container path to the artifact.
-          key (str): key in bucket to store artifact.
-          **kwargs: any other keyword arguments accepted by `V1alpha1Artifact`.
+    Args:
+      artifact_location (Union[V1alpha1ArtifactLocation, Dict[str, Any]]): `V1alpha1ArtifactLocation`
+        object or a dict representing it.
+      name (str): name of the artifact. must be unique within a template's
+        inputs/outputs.
+      path (str): container path to the artifact.
+      key (str): key in bucket to store artifact.
+      **kwargs: any other keyword arguments accepted by `V1alpha1Artifact`.
 
-        Returns:
-          V1alpha1Artifact: V1alpha1Artifact object.
-        """
-        if not artifact_location:
-            return V1alpha1Artifact(
-                name=name,
-                path=path,
-                **kwargs
-            )
+    Returns:
+      V1alpha1Artifact: V1alpha1Artifact object.
 
-        # dict representation of artifact location
-        if isinstance(artifact_location, dict) and artifact_location.get("s3"):
-          s3_artifact = artifact_location.get("s3")
-          return V1alpha1Artifact(
-            name=name,
-            path=path,
-            s3=V1alpha1S3Artifact(
+    """
+    if not artifact_location:
+      return V1alpha1Artifact(name=name, path=path, **kwargs)
+
+    # dict representation of artifact location
+    if isinstance(artifact_location, dict) and artifact_location.get("s3"):
+      s3_artifact = artifact_location.get("s3")
+      return V1alpha1Artifact(
+          name=name,
+          path=path,
+          s3=V1alpha1S3Artifact(
               bucket=s3_artifact.get("bucket"),
               endpoint=s3_artifact.get("endpoint"),
               insecure=s3_artifact.get("insecure"),
               region=s3_artifact.get("region"),
-              access_key_secret=_dict_to_secret(s3_artifact.get("accessKeySecret")),
-              secret_key_secret=_dict_to_secret(s3_artifact.get("secretKeySecret")),
+              access_key_secret=_dict_to_secret(
+                  s3_artifact.get("accessKeySecret")
+              ),
+              secret_key_secret=_dict_to_secret(
+                  s3_artifact.get("secretKeySecret")
+              ),
               key=key
-            )
           )
+      )
 
-        if artifact_location.s3:
-            return V1alpha1Artifact(
-                name=name,
-                path=path,
-                s3=V1alpha1S3Artifact(
-                    bucket=artifact_location.s3.bucket,
-                    endpoint=artifact_location.s3.endpoint,
-                    insecure=artifact_location.s3.insecure,
-                    region=artifact_location.s3.region,
-                    access_key_secret=artifact_location.s3.access_key_secret,
-                    secret_key_secret=artifact_location.s3.secret_key_secret,
-                    key=key,
-                ),
-                **kwargs
-            )
-        raise ValueError("artifact_location does not have s3 configuration.")
+    if artifact_location.s3:
+      return V1alpha1Artifact(
+          name=name,
+          path=path,
+          s3=V1alpha1S3Artifact(
+              bucket=artifact_location.s3.bucket,
+              endpoint=artifact_location.s3.endpoint,
+              insecure=artifact_location.s3.insecure,
+              region=artifact_location.s3.region,
+              access_key_secret=artifact_location.s3.access_key_secret,
+              secret_key_secret=artifact_location.s3.secret_key_secret,
+              key=key,
+          ),
+          **kwargs
+      )
+    raise ValueError("artifact_location does not have s3 configuration.")

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -34,638 +34,662 @@ StringOrStringList = Union[str, List[str]]
 
 
 # util functions
-def deprecation_warning(func: Callable, op_name: str,
-                        container_name: str) -> Callable:
-    """Decorator function to give a pending deprecation warning"""
+def deprecation_warning(
+    func: Callable, op_name: str, container_name: str
+) -> Callable:
+  """Decorator function to give a pending deprecation warning."""
 
-    def _wrapped(*args, **kwargs):
-        warnings.warn(
-            '`dsl.ContainerOp.%s` will be removed in future releases. '
-            'Use `dsl.ContainerOp.container.%s` instead.' %
-            (op_name, container_name), PendingDeprecationWarning)
-        return func(*args, **kwargs)
+  def _wrapped(*args, **kwargs):
+    warnings.warn(
+        '`dsl.ContainerOp.%s` will be removed in future releases. '
+        'Use `dsl.ContainerOp.container.%s` instead.' %
+        (op_name, container_name), PendingDeprecationWarning
+    )
+    return func(*args, **kwargs)
 
-    return _wrapped
+  return _wrapped
 
 
 def _create_getter_setter(prop):
-    """Create a tuple of getter and setter methods for a property in `Container`."""
-    def _getter(self):
-        return getattr(self._container, prop)   
-    def _setter(self, value):
-        return setattr(self._container, prop, value)
-    return _getter, _setter
+  """Create a tuple of getter and setter methods for a property in
+  `Container`."""
+
+  def _getter(self):
+    return getattr(self._container, prop)
+
+  def _setter(self, value):
+    return setattr(self._container, prop, value)
+
+  return _getter, _setter
 
 
 def _proxy_container_op_props(cls: "ContainerOp"):
-    """Takes the `ContainerOp` class and proxy the PendingDeprecation properties
-    in `ContainerOp` to the `Container` instance.
-    """
-    # properties mapping to proxy: ContainerOps.<prop> => Container.<prop>
-    prop_map = dict(image='image', env_variables='env')
-    # itera and create class props
-    for op_prop, container_prop in prop_map.items():
-        # create getter and setter
-        _getter, _setter = _create_getter_setter(container_prop)
-        # decorate with deprecation warning
-        getter = deprecation_warning(_getter, op_prop, container_prop)
-        setter = deprecation_warning(_setter, op_prop, container_prop)
-        # update attribites with properties
-        setattr(cls, op_prop, property(getter, setter))
-    return cls
+  """Takes the `ContainerOp` class and proxy the PendingDeprecation properties
+  in `ContainerOp` to the `Container` instance."""
+  # properties mapping to proxy: ContainerOps.<prop> => Container.<prop>
+  prop_map = dict(image='image', env_variables='env')
+  # itera and create class props
+  for op_prop, container_prop in prop_map.items():
+    # create getter and setter
+    _getter, _setter = _create_getter_setter(container_prop)
+    # decorate with deprecation warning
+    getter = deprecation_warning(_getter, op_prop, container_prop)
+    setter = deprecation_warning(_setter, op_prop, container_prop)
+    # update attribites with properties
+    setattr(cls, op_prop, property(getter, setter))
+  return cls
 
 
-def as_string_list(list_or_str: Optional[Union[Any, Sequence[Any]]]) -> List[str]:
-    """Convert any value except None to a list if not already a list."""
-    if list_or_str is None:
-        return None
-    if isinstance(list_or_str, Sequence) and not isinstance(list_or_str, str):
-        list_value = list_or_str
-    else:
-        list_value = [list_or_str]
-    return [str(item) for item in list_value]
+def as_string_list(list_or_str: Optional[Union[Any, Sequence[Any]]]
+                  ) -> List[str]:
+  """Convert any value except None to a list if not already a list."""
+  if list_or_str is None:
+    return None
+  if isinstance(list_or_str, Sequence) and not isinstance(list_or_str, str):
+    list_value = list_or_str
+  else:
+    list_value = [list_or_str]
+  return [str(item) for item in list_value]
 
 
 def create_and_append(current_list: Union[List[T], None], item: T) -> List[T]:
-    """Create a list (if needed) and appends an item to it."""
-    current_list = current_list or []
-    current_list.append(item)
-    return current_list
+  """Create a list (if needed) and appends an item to it."""
+  current_list = current_list or []
+  current_list.append(item)
+  return current_list
 
 
 class Container(V1Container):
-    """
-    A wrapper over k8s container definition object (io.k8s.api.core.v1.Container),
-    which is used to represent the `container` property in argo's workflow 
-    template (io.argoproj.workflow.v1alpha1.Template).
-    
-    `Container` class also comes with utility functions to set and update the 
-    the various properties for a k8s container definition.
+  """A wrapper over k8s container definition object
+  (io.k8s.api.core.v1.Container), which is used to represent the `container`
+  property in argo's workflow template (io.argoproj.workflow.v1alpha1.Template).
 
-    NOTE: A notable difference is that `name` is not required and will not be 
-    processed for `Container` (in contrast to `V1Container` where `name` is a
-    required property). 
+  `Container` class also comes with utility functions to set and update the
+  the various properties for a k8s container definition.
 
-    See: 
-    - https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_container.py
-    - https://github.com/argoproj/argo/blob/master/api/openapi-spec/swagger.json
+  NOTE: A notable difference is that `name` is not required and will not be
+  processed for `Container` (in contrast to `V1Container` where `name` is a
+  required property).
 
-    
-    Example:
+  See:
+  - https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_container.py
+  - https://github.com/argoproj/argo/blob/master/api/openapi-spec/swagger.json
 
-      from kfp.dsl import ContainerOp
-      from kubernetes.client.models import V1EnvVar
-      
 
-      # creates a operation
-      op = ContainerOp(name='bash-ops', 
-                       image='busybox:latest', 
-                       command=['echo'], 
-                       arguments=['$MSG'])
+  Example:
 
-      # returns a `Container` object from `ContainerOp`
-      # and add an environment variable to `Container`
-      op.container.add_env_variable(V1EnvVar(name='MSG', value='hello world'))
+    from kfp.dsl import ContainerOp
+    from kubernetes.client.models import V1EnvVar
 
-    """
-    """
+
+    # creates a operation
+    op = ContainerOp(name='bash-ops',
+                     image='busybox:latest',
+                     command=['echo'],
+                     arguments=['$MSG'])
+
+    # returns a `Container` object from `ContainerOp`
+    # and add an environment variable to `Container`
+    op.container.add_env_variable(V1EnvVar(name='MSG', value='hello world'))
+
+  """
+  """
     Attributes:
       swagger_types (dict): The key is attribute name
                             and the value is attribute type.
       attribute_map (dict): The key is attribute name
                             and the value is json key in definition.
     """
-    # remove `name` from swagger_types so `name` is not generated in the JSON
-    swagger_types = {
-        key: value
-        for key, value in V1Container.swagger_types.items() if key != 'name'
-    }
-    attribute_map = {
-        key: value
-        for key, value in V1Container.attribute_map.items() if key != 'name'
-    }
-
-    def __init__(self, image: str, command: List[str], args: List[str],
-                 **kwargs):
-        """Creates a new instance of `Container`.
-        
-        Args:
-            image {str}: image to use, e.g. busybox:latest
-            command {List[str]}: entrypoint array.  Not executed within a shell.
-            args {List[str]}: arguments to entrypoint.
-            **kwargs: keyword arguments for `V1Container`
-        """
-        # set name to '' if name is not provided
-        # k8s container MUST have a name
-        # argo workflow template does not need a name for container def
-        if not kwargs.get('name'):
-            kwargs['name'] = ''
-
-        super(Container, self).__init__(
-            image=image, command=command, args=args, **kwargs)
-
-    def _validate_memory_string(self, memory_string):
-        """Validate a given string is valid for memory request or limit."""
-
-        if isinstance(memory_string, _pipeline_param.PipelineParam):
-            if memory_string.value:
-                memory_string = memory_string.value
-            else:
-                return
-
-        if re.match(r'^[0-9]+(E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki){0,1}$',
-                    memory_string) is None:
-            raise ValueError(
-                'Invalid memory string. Should be an integer, or integer followed '
-                'by one of "E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki"')
-
-    def _validate_cpu_string(self, cpu_string):
-        "Validate a given string is valid for cpu request or limit."
-
-        if isinstance(cpu_string, _pipeline_param.PipelineParam):
-            if cpu_string.value:
-                cpu_string = cpu_string.value
-            else:
-                return
-
-        if re.match(r'^[0-9]+m$', cpu_string) is not None:
-            return
-
-        try:
-            float(cpu_string)
-        except ValueError:
-            raise ValueError(
-                'Invalid cpu string. Should be float or integer, or integer followed '
-                'by "m".')
-
-    def _validate_positive_number(self, str_value, param_name):
-        "Validate a given string is in positive integer format."
-
-        if isinstance(str_value, _pipeline_param.PipelineParam):
-            if str_value.value:
-                str_value = str_value.value
-            else:
-                return
-
-        try:
-            int_value = int(str_value)
-        except ValueError:
-            raise ValueError(
-                'Invalid {}. Should be integer.'.format(param_name))
-
-        if int_value <= 0:
-            raise ValueError('{} must be positive integer.'.format(param_name))
-
-    def add_resource_limit(self, resource_name, value):
-        """Add the resource limit of the container.
-
-        Args:
-          resource_name: The name of the resource. It can be cpu, memory, etc.
-          value: The string value of the limit.
-        """
-
-        self.resources = self.resources or V1ResourceRequirements()
-        self.resources.limits = self.resources.limits or {}
-        self.resources.limits.update({resource_name: value})
-        return self
-
-    def add_resource_request(self, resource_name, value):
-        """Add the resource request of the container.
-
-        Args:
-          resource_name: The name of the resource. It can be cpu, memory, etc.
-          value: The string value of the request.
-        """
-
-        self.resources = self.resources or V1ResourceRequirements()
-        self.resources.requests = self.resources.requests or {}
-        self.resources.requests.update({resource_name: value})
-        return self
-
-    def set_memory_request(self, memory):
-        """Set memory request (minimum) for this operator.
-
-        Args:
-          memory: a string which can be a number or a number followed by one of
-                  "E", "P", "T", "G", "M", "K".
-        """
-
-        self._validate_memory_string(memory)
-        return self.add_resource_request("memory", memory)
-
-    def set_memory_limit(self, memory):
-        """Set memory limit (maximum) for this operator.
+  # remove `name` from swagger_types so `name` is not generated in the JSON
+  swagger_types = {
+      key: value
+      for key, value in V1Container.swagger_types.items()
+      if key != 'name'
+  }
+  attribute_map = {
+      key: value
+      for key, value in V1Container.attribute_map.items()
+      if key != 'name'
+  }
+
+  def __init__(self, image: str, command: List[str], args: List[str], **kwargs):
+    """Creates a new instance of `Container`.
+
+    Args:
+        image {str}: image to use, e.g. busybox:latest
+        command {List[str]}: entrypoint array.  Not executed within a shell.
+        args {List[str]}: arguments to entrypoint.
+        **kwargs: keyword arguments for `V1Container`
+
+    """
+    # set name to '' if name is not provided
+    # k8s container MUST have a name
+    # argo workflow template does not need a name for container def
+    if not kwargs.get('name'):
+      kwargs['name'] = ''
+
+    super(Container, self).__init__(
+        image=image, command=command, args=args, **kwargs
+    )
+
+  def _validate_memory_string(self, memory_string):
+    """Validate a given string is valid for memory request or limit."""
+
+    if isinstance(memory_string, _pipeline_param.PipelineParam):
+      if memory_string.value:
+        memory_string = memory_string.value
+      else:
+        return
+
+    if re.match(r'^[0-9]+(E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki){0,1}$',
+                memory_string) is None:
+      raise ValueError(
+          'Invalid memory string. Should be an integer, or integer followed '
+          'by one of "E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki"'
+      )
+
+  def _validate_cpu_string(self, cpu_string):
+    """Validate a given string is valid for cpu request or limit."""
+
+    if isinstance(cpu_string, _pipeline_param.PipelineParam):
+      if cpu_string.value:
+        cpu_string = cpu_string.value
+      else:
+        return
+
+    if re.match(r'^[0-9]+m$', cpu_string) is not None:
+      return
+
+    try:
+      float(cpu_string)
+    except ValueError:
+      raise ValueError(
+          'Invalid cpu string. Should be float or integer, or integer followed '
+          'by "m".'
+      )
+
+  def _validate_positive_number(self, str_value, param_name):
+    """Validate a given string is in positive integer format."""
+
+    if isinstance(str_value, _pipeline_param.PipelineParam):
+      if str_value.value:
+        str_value = str_value.value
+      else:
+        return
+
+    try:
+      int_value = int(str_value)
+    except ValueError:
+      raise ValueError('Invalid {}. Should be integer.'.format(param_name))
+
+    if int_value <= 0:
+      raise ValueError('{} must be positive integer.'.format(param_name))
+
+  def add_resource_limit(self, resource_name, value):
+    """Add the resource limit of the container.
 
-        Args:
-          memory: a string which can be a number or a number followed by one of
-                  "E", "P", "T", "G", "M", "K".
-        """
-        self._validate_memory_string(memory)
-        return self.add_resource_limit("memory", memory)
-
-    def set_cpu_request(self, cpu):
-        """Set cpu request (minimum) for this operator.
-
-        Args:
-          cpu: A string which can be a number or a number followed by "m", which means 1/1000.
-        """
-
-        self._validate_cpu_string(cpu)
-        return self.add_resource_request("cpu", cpu)
-
-    def set_cpu_limit(self, cpu):
-        """Set cpu limit (maximum) for this operator.
-
-        Args:
-          cpu: A string which can be a number or a number followed by "m", which means 1/1000.
-        """
-
-        self._validate_cpu_string(cpu)
-        return self.add_resource_limit("cpu", cpu)
-
-    def set_gpu_limit(self, gpu, vendor="nvidia"):
-        """Set gpu limit for the operator. This function add '<vendor>.com/gpu' into resource limit. 
-        Note that there is no need to add GPU request. GPUs are only supposed to be specified in 
-        the limits section. See https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/.
-
-        Args:
-          gpu: A string which must be a positive number.
-          vendor: Optional. A string which is the vendor of the requested gpu. The supported values 
-            are: 'nvidia' (default), and 'amd'. 
-        """
-
-        self._validate_positive_number(gpu, 'gpu')
-        if vendor != 'nvidia' and vendor != 'amd':
-            raise ValueError('vendor can only be nvidia or amd.')
-
-        return self.add_resource_limit("%s.com/gpu" % vendor, gpu)
-
-    def add_volume_mount(self, volume_mount):
-        """Add volume to the container
-
-        Args:
-          volume_mount: Kubernetes volume mount
-          For detailed spec, check volume mount definition
-          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_volume_mount.py
-        """
-
-        if not isinstance(volume_mount, V1VolumeMount):
-            raise ValueError(
-                'invalid argument. Must be of instance `V1VolumeMount`.')
-
-        self.volume_mounts = create_and_append(self.volume_mounts,
-                                               volume_mount)
-        return self
-
-    def add_volume_devices(self, volume_device):
-        """
-        Add a block device to be used by the container.
-
-        Args:
-          volume_device: Kubernetes volume device
-          For detailed spec, volume device definition
-          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_volume_device.py
-        """
-
-        if not isinstance(volume_device, V1VolumeDevice):
-            raise ValueError(
-                'invalid argument. Must be of instance `V1VolumeDevice`.')
-
-        self.volume_devices = create_and_append(self.volume_devices,
-                                                volume_device)
-        return self
-
-    def add_env_variable(self, env_variable):
-        """Add environment variable to the container.
-
-        Args:
-          env_variable: Kubernetes environment variable
-          For detailed spec, check environment variable definition
-          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_env_var.py
-        """
-
-        if not isinstance(env_variable, V1EnvVar):
-            raise ValueError(
-                'invalid argument. Must be of instance `V1EnvVar`.')
-
-        self.env = create_and_append(self.env, env_variable)
-        return self
-
-    def add_env_from(self, env_from):
-        """Add a source to populate environment variables int the container.
-
-        Args:
-          env_from: Kubernetes environment from source
-          For detailed spec, check environment from source definition
-          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_env_var_source.py
-        """
-
-        if not isinstance(env_from, V1EnvFromSource):
-            raise ValueError(
-                'invalid argument. Must be of instance `V1EnvFromSource`.')
-
-        self.env_from = create_and_append(self.env_from, env_from)
-        return self
-
-    def set_image_pull_policy(self, image_pull_policy):
-        """Set image pull policy for the container.
-
-        Args:
-          image_pull_policy: One of `Always`, `Never`, `IfNotPresent`. 
-        """
-        if image_pull_policy not in ['Always', 'Never', 'IfNotPresent']:
-            raise ValueError(
-                'Invalid imagePullPolicy. Must be one of `Always`, `Never`, `IfNotPresent`.'
-            )
-
-        self.image_pull_policy = image_pull_policy
-        return self
-
-    def add_port(self, container_port):
-        """Add a container port to the container.
-
-        Args:
-          container_port: Kubernetes container port
-          For detailed spec, check container port definition
-          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_container_port.py
-        """
-
-        if not isinstance(container_port, V1ContainerPort):
-            raise ValueError(
-                'invalid argument. Must be of instance `V1ContainerPort`.')
-
-        self.ports = create_and_append(self.ports, container_port)
-        return self
-
-    def set_security_context(self, security_context):
-        """Set security configuration to be applied on the container.  
-
-        Args:
-          security_context: Kubernetes security context
-          For detailed spec, check security context definition
-          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_security_context.py
-        """
-
-        if not isinstance(security_context, V1SecurityContext):
-            raise ValueError(
-                'invalid argument. Must be of instance `V1SecurityContext`.')
-
-        self.security_context = security_context
-        return self
-
-    def set_stdin(self, stdin=True):
-        """
-        Whether this container should allocate a buffer for stdin in the container 
-        runtime. If this is not set, reads from stdin in the container will always 
-        result in EOF.
-
-        Args:
-          stdin: boolean flag
-        """
-
-        self.stdin = stdin
-        return self
-
-    def set_stdin_once(self, stdin_once=True):
-        """
-        Whether the container runtime should close the stdin channel after it has 
-        been opened by a single attach. When stdin is true the stdin stream will 
-        remain open across multiple attach sessions. If stdinOnce is set to true, 
-        stdin is opened on container start, is empty until the first client attaches 
-        to stdin, and then remains open and accepts data until the client 
-        disconnects, at which time stdin is closed and remains closed until the 
-        container is restarted. If this flag is false, a container processes that 
-        reads from stdin will never receive an EOF. 
-
-        Args:
-          stdin_once: boolean flag
-        """
-
-        self.stdin_once = stdin_once
-        return self
-
-    def set_termination_message_path(self, termination_message_path):
-        """
-        Path at which the file to which the container's termination message will be 
-        written is mounted into the container's filesystem. Message written is 
-        intended to be brief final status, such as an assertion failure message. 
-        Will be truncated by the node if greater than 4096 bytes. The total message 
-        length across all containers will be limited to 12kb. 
-
-        Args:
-          termination_message_path: path for the termination message
-        """
-        self.termination_message_path = termination_message_path
-        return self
-
-    def set_termination_message_policy(self, termination_message_policy):
-        """
-        Indicate how the termination message should be populated. File will use the 
-        contents of terminationMessagePath to populate the container status message 
-        on both success and failure. FallbackToLogsOnError will use the last chunk 
-        of container log output if the termination message file is empty and the 
-        container exited with an error. The log output is limited to 2048 bytes or 
-        80 lines, whichever is smaller.
-
-        Args:
-          termination_message_policy: `File` or `FallbackToLogsOnError`
-        """
-        if termination_message_policy not in ['File', 'FallbackToLogsOnError']:
-            raise ValueError(
-                'terminationMessagePolicy must be `File` or `FallbackToLogsOnError`'
-            )
-        self.termination_message_policy = termination_message_policy
-        return self
-
-    def set_tty(self, tty=True):
-        """
-        Whether this container should allocate a TTY for itself, also requires 
-        'stdin' to be true.
-
-        Args:
-          tty: boolean flag
-        """
-
-        self.tty = tty
-        return self
-
-    def set_readiness_probe(self, readiness_probe):
-        """
-        Set a readiness probe for the container.
-
-        Args:
-          readiness_probe: Kubernetes readiness probe
-          For detailed spec, check probe definition
-          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_probe.py
-        """
-
-        if not isinstance(readiness_probe, V1Probe):
-            raise ValueError(
-                'invalid argument. Must be of instance `V1Probe`.')
-
-        self.readiness_probe = readiness_probe
-        return self
-
-    def set_liveness_probe(self, liveness_probe):
-        """
-        Set a liveness probe for the container.
-
-        Args:
-          liveness_probe: Kubernetes liveness probe
-          For detailed spec, check probe definition
-          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_probe.py
-        """
-
-        if not isinstance(liveness_probe, V1Probe):
-            raise ValueError(
-                'invalid argument. Must be of instance `V1Probe`.')
-
-        self.liveness_probe = liveness_probe
-        return self
-
-    def set_lifecycle(self, lifecycle):
-        """
-        Setup a lifecycle config for the container.
-
-        Args:
-          lifecycle: Kubernetes lifecycle
-          For detailed spec, lifecycle definition
-          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_lifecycle.py
-        """
-
-        if not isinstance(lifecycle, V1Lifecycle):
-            raise ValueError(
-                'invalid argument. Must be of instance `V1Lifecycle`.')
-
-        self.lifecycle = lifecycle
-        return self
+    Args:
+      resource_name: The name of the resource. It can be cpu, memory, etc.
+      value: The string value of the limit.
+
+    """
+
+    self.resources = self.resources or V1ResourceRequirements()
+    self.resources.limits = self.resources.limits or {}
+    self.resources.limits.update({resource_name: value})
+    return self
+
+  def add_resource_request(self, resource_name, value):
+    """Add the resource request of the container.
+
+    Args:
+      resource_name: The name of the resource. It can be cpu, memory, etc.
+      value: The string value of the request.
+
+    """
+
+    self.resources = self.resources or V1ResourceRequirements()
+    self.resources.requests = self.resources.requests or {}
+    self.resources.requests.update({resource_name: value})
+    return self
+
+  def set_memory_request(self, memory):
+    """Set memory request (minimum) for this operator.
+
+    Args:
+      memory: a string which can be a number or a number followed by one of
+              "E", "P", "T", "G", "M", "K".
+
+    """
+
+    self._validate_memory_string(memory)
+    return self.add_resource_request("memory", memory)
+
+  def set_memory_limit(self, memory):
+    """Set memory limit (maximum) for this operator.
+
+    Args:
+      memory: a string which can be a number or a number followed by one of
+              "E", "P", "T", "G", "M", "K".
+
+    """
+    self._validate_memory_string(memory)
+    return self.add_resource_limit("memory", memory)
+
+  def set_cpu_request(self, cpu):
+    """Set cpu request (minimum) for this operator.
+
+    Args:
+      cpu: A string which can be a number or a number followed by "m", which means 1/1000.
+
+    """
+
+    self._validate_cpu_string(cpu)
+    return self.add_resource_request("cpu", cpu)
+
+  def set_cpu_limit(self, cpu):
+    """Set cpu limit (maximum) for this operator.
+
+    Args:
+      cpu: A string which can be a number or a number followed by "m", which means 1/1000.
+
+    """
+
+    self._validate_cpu_string(cpu)
+    return self.add_resource_limit("cpu", cpu)
+
+  def set_gpu_limit(self, gpu, vendor="nvidia"):
+    """Set gpu limit for the operator. This function add '<vendor>.com/gpu' into
+    resource limit. Note that there is no need to add GPU request. GPUs are only
+    supposed to be specified in the limits section. See
+    https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/.
+
+    Args:
+      gpu: A string which must be a positive number.
+      vendor: Optional. A string which is the vendor of the requested gpu. The supported values
+        are: 'nvidia' (default), and 'amd'.
+
+    """
+
+    self._validate_positive_number(gpu, 'gpu')
+    if vendor != 'nvidia' and vendor != 'amd':
+      raise ValueError('vendor can only be nvidia or amd.')
+
+    return self.add_resource_limit("%s.com/gpu" % vendor, gpu)
+
+  def add_volume_mount(self, volume_mount):
+    """Add volume to the container.
+
+    Args:
+      volume_mount: Kubernetes volume mount
+      For detailed spec, check volume mount definition
+      https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_volume_mount.py
+
+    """
+
+    if not isinstance(volume_mount, V1VolumeMount):
+      raise ValueError('invalid argument. Must be of instance `V1VolumeMount`.')
+
+    self.volume_mounts = create_and_append(self.volume_mounts, volume_mount)
+    return self
+
+  def add_volume_devices(self, volume_device):
+    """Add a block device to be used by the container.
+
+    Args:
+      volume_device: Kubernetes volume device
+      For detailed spec, volume device definition
+      https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_volume_device.py
+
+    """
+
+    if not isinstance(volume_device, V1VolumeDevice):
+      raise ValueError(
+          'invalid argument. Must be of instance `V1VolumeDevice`.'
+      )
+
+    self.volume_devices = create_and_append(self.volume_devices, volume_device)
+    return self
+
+  def add_env_variable(self, env_variable):
+    """Add environment variable to the container.
+
+    Args:
+      env_variable: Kubernetes environment variable
+      For detailed spec, check environment variable definition
+      https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_env_var.py
+
+    """
+
+    if not isinstance(env_variable, V1EnvVar):
+      raise ValueError('invalid argument. Must be of instance `V1EnvVar`.')
+
+    self.env = create_and_append(self.env, env_variable)
+    return self
+
+  def add_env_from(self, env_from):
+    """Add a source to populate environment variables int the container.
+
+    Args:
+      env_from: Kubernetes environment from source
+      For detailed spec, check environment from source definition
+      https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_env_var_source.py
+
+    """
+
+    if not isinstance(env_from, V1EnvFromSource):
+      raise ValueError(
+          'invalid argument. Must be of instance `V1EnvFromSource`.'
+      )
+
+    self.env_from = create_and_append(self.env_from, env_from)
+    return self
+
+  def set_image_pull_policy(self, image_pull_policy):
+    """Set image pull policy for the container.
+
+    Args:
+      image_pull_policy: One of `Always`, `Never`, `IfNotPresent`.
+
+    """
+    if image_pull_policy not in ['Always', 'Never', 'IfNotPresent']:
+      raise ValueError(
+          'Invalid imagePullPolicy. Must be one of `Always`, `Never`, `IfNotPresent`.'
+      )
+
+    self.image_pull_policy = image_pull_policy
+    return self
+
+  def add_port(self, container_port):
+    """Add a container port to the container.
+
+    Args:
+      container_port: Kubernetes container port
+      For detailed spec, check container port definition
+      https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_container_port.py
+
+    """
+
+    if not isinstance(container_port, V1ContainerPort):
+      raise ValueError(
+          'invalid argument. Must be of instance `V1ContainerPort`.'
+      )
+
+    self.ports = create_and_append(self.ports, container_port)
+    return self
+
+  def set_security_context(self, security_context):
+    """Set security configuration to be applied on the container.
+
+    Args:
+      security_context: Kubernetes security context
+      For detailed spec, check security context definition
+      https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_security_context.py
+
+    """
+
+    if not isinstance(security_context, V1SecurityContext):
+      raise ValueError(
+          'invalid argument. Must be of instance `V1SecurityContext`.'
+      )
+
+    self.security_context = security_context
+    return self
+
+  def set_stdin(self, stdin=True):
+    """Whether this container should allocate a buffer for stdin in the
+    container runtime. If this is not set, reads from stdin in the container
+    will always result in EOF.
+
+    Args:
+      stdin: boolean flag
+
+    """
+
+    self.stdin = stdin
+    return self
+
+  def set_stdin_once(self, stdin_once=True):
+    """Whether the container runtime should close the stdin channel after it has
+    been opened by a single attach. When stdin is true the stdin stream will
+    remain open across multiple attach sessions. If stdinOnce is set to true,
+    stdin is opened on container start, is empty until the first client attaches
+    to stdin, and then remains open and accepts data until the client
+    disconnects, at which time stdin is closed and remains closed until the
+    container is restarted. If this flag is false, a container processes that
+    reads from stdin will never receive an EOF.
+
+    Args:
+      stdin_once: boolean flag
+
+    """
+
+    self.stdin_once = stdin_once
+    return self
+
+  def set_termination_message_path(self, termination_message_path):
+    """Path at which the file to which the container's termination message will
+    be written is mounted into the container's filesystem. Message written is
+    intended to be brief final status, such as an assertion failure message.
+    Will be truncated by the node if greater than 4096 bytes. The total message
+    length across all containers will be limited to 12kb.
+
+    Args:
+      termination_message_path: path for the termination message
+
+    """
+    self.termination_message_path = termination_message_path
+    return self
+
+  def set_termination_message_policy(self, termination_message_policy):
+    """Indicate how the termination message should be populated. File will use
+    the contents of terminationMessagePath to populate the container status
+    message on both success and failure. FallbackToLogsOnError will use the last
+    chunk of container log output if the termination message file is empty and
+    the container exited with an error. The log output is limited to 2048 bytes
+    or 80 lines, whichever is smaller.
+
+    Args:
+      termination_message_policy: `File` or `FallbackToLogsOnError`
+
+    """
+    if termination_message_policy not in ['File', 'FallbackToLogsOnError']:
+      raise ValueError(
+          'terminationMessagePolicy must be `File` or `FallbackToLogsOnError`'
+      )
+    self.termination_message_policy = termination_message_policy
+    return self
+
+  def set_tty(self, tty=True):
+    """Whether this container should allocate a TTY for itself, also requires
+    'stdin' to be true.
+
+    Args:
+      tty: boolean flag
+
+    """
+
+    self.tty = tty
+    return self
+
+  def set_readiness_probe(self, readiness_probe):
+    """Set a readiness probe for the container.
+
+    Args:
+      readiness_probe: Kubernetes readiness probe
+      For detailed spec, check probe definition
+      https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_probe.py
+
+    """
+
+    if not isinstance(readiness_probe, V1Probe):
+      raise ValueError('invalid argument. Must be of instance `V1Probe`.')
+
+    self.readiness_probe = readiness_probe
+    return self
+
+  def set_liveness_probe(self, liveness_probe):
+    """Set a liveness probe for the container.
+
+    Args:
+      liveness_probe: Kubernetes liveness probe
+      For detailed spec, check probe definition
+      https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_probe.py
+
+    """
+
+    if not isinstance(liveness_probe, V1Probe):
+      raise ValueError('invalid argument. Must be of instance `V1Probe`.')
+
+    self.liveness_probe = liveness_probe
+    return self
+
+  def set_lifecycle(self, lifecycle):
+    """Setup a lifecycle config for the container.
+
+    Args:
+      lifecycle: Kubernetes lifecycle
+      For detailed spec, lifecycle definition
+      https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_lifecycle.py
+
+    """
+
+    if not isinstance(lifecycle, V1Lifecycle):
+      raise ValueError('invalid argument. Must be of instance `V1Lifecycle`.')
+
+    self.lifecycle = lifecycle
+    return self
 
 
 class UserContainer(Container):
-    """
-    Represents an argo workflow UserContainer (io.argoproj.workflow.v1alpha1.UserContainer)
-    to be used in `UserContainer` property in argo's workflow template
-    (io.argoproj.workflow.v1alpha1.Template).
+  """Represents an argo workflow UserContainer
+  (io.argoproj.workflow.v1alpha1.UserContainer) to be used in `UserContainer`
+  property in argo's workflow template (io.argoproj.workflow.v1alpha1.Template).
 
-    `UserContainer` inherits from `Container` class with an addition of `mirror_volume_mounts`
-    attribute (`mirrorVolumeMounts` property).
+  `UserContainer` inherits from `Container` class with an addition of `mirror_volume_mounts`
+  attribute (`mirrorVolumeMounts` property).
 
-    See https://github.com/argoproj/argo/blob/master/api/openapi-spec/swagger.json
+  See https://github.com/argoproj/argo/blob/master/api/openapi-spec/swagger.json
 
-    Example
+  Example
 
-        from kfp.dsl import ContainerOp, UserContainer
+      from kfp.dsl import ContainerOp, UserContainer
 
-        # creates a `ContainerOp` and adds a redis init container
-        op = (ContainerOp(name='foo-op', image='busybox:latest')
-                .add_initContainer(
-                    UserContainer(name='redis', image='redis:alpine')))
+      # creates a `ContainerOp` and adds a redis init container
+      op = (ContainerOp(name='foo-op', image='busybox:latest')
+              .add_initContainer(
+                  UserContainer(name='redis', image='redis:alpine')))
 
-    """
-    """
+  """
+  """
     Attributes:
       swagger_types (dict): The key is attribute name
                             and the value is attribute type.
       attribute_map (dict): The key is attribute name
                             and the value is json key in definition.
     """
-    # adds `mirror_volume_mounts` to `UserContainer` swagger definition
-    # NOTE inherits definition from `V1Container` rather than `Container`
-    #      because `Container` has no `name` property.
-    swagger_types = dict(
-        **V1Container.swagger_types, mirror_volume_mounts='bool')
+  # adds `mirror_volume_mounts` to `UserContainer` swagger definition
+  # NOTE inherits definition from `V1Container` rather than `Container`
+  #      because `Container` has no `name` property.
+  swagger_types = dict(**V1Container.swagger_types, mirror_volume_mounts='bool')
 
-    attribute_map = dict(
-        **V1Container.attribute_map, mirror_volume_mounts='mirrorVolumeMounts')
+  attribute_map = dict(
+      **V1Container.attribute_map, mirror_volume_mounts='mirrorVolumeMounts'
+  )
 
-    def __init__(self,
-        name: str,
-        image: str,
-        command: StringOrStringList = None,
-        args: StringOrStringList = None,
-        mirror_volume_mounts: bool = None,
-        **kwargs):
-        """Creates a new instance of `UserContainer`.
+  def __init__(
+      self,
+      name: str,
+      image: str,
+      command: StringOrStringList = None,
+      args: StringOrStringList = None,
+      mirror_volume_mounts: bool = None,
+      **kwargs
+  ):
+    """Creates a new instance of `UserContainer`.
 
-        Args:
-            name {str}: unique name for the user container
-            image {str}: image to use for the user container, e.g. redis:alpine
-            command {StringOrStringList}: entrypoint array.  Not executed within a shell.
-            args {StringOrStringList}: arguments to the entrypoint.
-            mirror_volume_mounts {bool}: MirrorVolumeMounts will mount the same
-                volumes specified in the main container to the container (including artifacts),
-                at the same mountPaths. This enables dind daemon to partially see the same
-                filesystem as the main container in order to use features such as docker
-                volume binding
-            **kwargs: keyword arguments available for `Container`
+    Args:
+        name {str}: unique name for the user container
+        image {str}: image to use for the user container, e.g. redis:alpine
+        command {StringOrStringList}: entrypoint array.  Not executed within a shell.
+        args {StringOrStringList}: arguments to the entrypoint.
+        mirror_volume_mounts {bool}: MirrorVolumeMounts will mount the same
+            volumes specified in the main container to the container (including artifacts),
+            at the same mountPaths. This enables dind daemon to partially see the same
+            filesystem as the main container in order to use features such as docker
+            volume binding
+        **kwargs: keyword arguments available for `Container`
 
-        """
-        super().__init__(
-            name=name,
-            image=image,
-            command=as_string_list(command),
-            args=as_string_list(args),
-            **kwargs)
+    """
+    super().__init__(
+        name=name,
+        image=image,
+        command=as_string_list(command),
+        args=as_string_list(args),
+        **kwargs
+    )
 
-        self.mirror_volume_mounts = mirror_volume_mounts
+    self.mirror_volume_mounts = mirror_volume_mounts
 
-    def set_mirror_volume_mounts(self, mirror_volume_mounts=True):
-        """
-        Setting mirrorVolumeMounts to true will mount the same volumes specified
-        in the main container to the container (including artifacts), at the same
-        mountPaths. This enables dind daemon to partially see the same filesystem
-        as the main container in order to use features such as docker volume
-        binding.
+  def set_mirror_volume_mounts(self, mirror_volume_mounts=True):
+    """Setting mirrorVolumeMounts to true will mount the same volumes specified
+    in the main container to the container (including artifacts), at the same
+    mountPaths. This enables dind daemon to partially see the same filesystem as
+    the main container in order to use features such as docker volume binding.
 
-        Args:
-            mirror_volume_mounts: boolean flag
-        """
+    Args:
+        mirror_volume_mounts: boolean flag
 
-        self.mirror_volume_mounts = mirror_volume_mounts
-        return self
+    """
 
-    @property
-    def inputs(self):
-        """A list of PipelineParam found in the UserContainer object."""
-        return _pipeline_param.extract_pipelineparams_from_any(self)
+    self.mirror_volume_mounts = mirror_volume_mounts
+    return self
+
+  @property
+  def inputs(self):
+    """A list of PipelineParam found in the UserContainer object."""
+    return _pipeline_param.extract_pipelineparams_from_any(self)
 
 
 class Sidecar(UserContainer):
 
-    def __init__(self,
-        name: str,
-        image: str,
-        command: StringOrStringList = None,
-        args: StringOrStringList = None,
-        mirror_volume_mounts: bool = None,
-        **kwargs):
-        """Creates a new instance of `Sidecar`.
+  def __init__(
+      self,
+      name: str,
+      image: str,
+      command: StringOrStringList = None,
+      args: StringOrStringList = None,
+      mirror_volume_mounts: bool = None,
+      **kwargs
+  ):
+    """Creates a new instance of `Sidecar`.
 
-        Args:
-            name {str}: unique name for the sidecar container
-            image {str}: image to use for the sidecar container, e.g. redis:alpine
-            command {StringOrStringList}: entrypoint array.  Not executed within a shell.
-            args {StringOrStringList}: arguments to the entrypoint.
-            mirror_volume_mounts {bool}: MirrorVolumeMounts will mount the same
-                volumes specified in the main container to the sidecar (including artifacts),
-                at the same mountPaths. This enables dind daemon to partially see the same
-                filesystem as the main container in order to use features such as docker
-                volume binding
-            **kwargs: keyword arguments available for `Container`
+    Args:
+        name {str}: unique name for the sidecar container
+        image {str}: image to use for the sidecar container, e.g. redis:alpine
+        command {StringOrStringList}: entrypoint array.  Not executed within a shell.
+        args {StringOrStringList}: arguments to the entrypoint.
+        mirror_volume_mounts {bool}: MirrorVolumeMounts will mount the same
+            volumes specified in the main container to the sidecar (including artifacts),
+            at the same mountPaths. This enables dind daemon to partially see the same
+            filesystem as the main container in order to use features such as docker
+            volume binding
+        **kwargs: keyword arguments available for `Container`
 
-        """
-        super().__init__(
-            name=name,
-            image=image,
-            command=command,
-            args=args,
-            mirror_volume_mounts=mirror_volume_mounts,
-            **kwargs)
+    """
+    super().__init__(
+        name=name,
+        image=image,
+        command=command,
+        args=args,
+        mirror_volume_mounts=mirror_volume_mounts,
+        **kwargs
+    )
 
 
 def _make_hash_based_id_for_op(op):
-    # Generating a unique ID for Op. For class instances, the hash is the object's memory address which is unique.
-    return op.human_name + ' ' + hex(2**63 + hash(op))[2:]
+  # Generating a unique ID for Op. For class instances, the hash is the object's memory address which is unique.
+  return op.human_name + ' ' + hex(2**63 + hash(op))[2:]
 
 
 # Pointer to a function that generates a unique ID for the Op instance (Possibly by registering the Op instance in some system).
@@ -674,138 +698,148 @@ _register_op_handler = _make_hash_based_id_for_op
 
 class BaseOp(object):
 
-    # list of attributes that might have pipeline params - used to generate
-    # the input parameters during compilation.
-    # Excludes `file_outputs` and `outputs` as they are handled separately
-    # in the compilation process to generate the DAGs and task io parameters.
-    attrs_with_pipelineparams = [
-        'node_selector', 'volumes', 'pod_annotations', 'pod_labels',
-        'num_retries', 'init_containers', 'sidecars', 'tolerations'
-    ]
+  # list of attributes that might have pipeline params - used to generate
+  # the input parameters during compilation.
+  # Excludes `file_outputs` and `outputs` as they are handled separately
+  # in the compilation process to generate the DAGs and task io parameters.
+  attrs_with_pipelineparams = [
+      'node_selector', 'volumes', 'pod_annotations', 'pod_labels',
+      'num_retries', 'init_containers', 'sidecars', 'tolerations'
+  ]
 
-    def __init__(self,
-                 name: str,
-                 init_containers: List[UserContainer] = None,
-                 sidecars: List[Sidecar] = None,
-                 is_exit_handler: bool = False):
-        """Create a new instance of BaseOp
+  def __init__(
+      self,
+      name: str,
+      init_containers: List[UserContainer] = None,
+      sidecars: List[Sidecar] = None,
+      is_exit_handler: bool = False
+  ):
+    """Create a new instance of BaseOp.
 
-        Args:
-          name: the name of the op. It does not have to be unique within a pipeline
-              because the pipeline will generates a unique new name in case of conflicts.
-          init_containers: the list of `InitContainer` objects describing the InitContainer
-                    to deploy before the `main` container.
-          sidecars: the list of `Sidecar` objects describing the sidecar containers to deploy
-                    together with the `main` container.
-          is_exit_handler: Deprecated.
-        """
+    Args:
+      name: the name of the op. It does not have to be unique within a pipeline
+          because the pipeline will generates a unique new name in case of conflicts.
+      init_containers: the list of `InitContainer` objects describing the InitContainer
+                to deploy before the `main` container.
+      sidecars: the list of `Sidecar` objects describing the sidecar containers to deploy
+                together with the `main` container.
+      is_exit_handler: Deprecated.
 
-        valid_name_regex = r'^[A-Za-z][A-Za-z0-9\s_-]*$'
-        if not re.match(valid_name_regex, name):
-            raise ValueError(
-                'Only letters, numbers, spaces, "_", and "-"  are allowed in name. Must begin with letter: %s'
-                % (name))
+    """
 
-        if is_exit_handler:
-            warnings.warn('is_exit_handler=True is no longer needed.', DeprecationWarning)
+    valid_name_regex = r'^[A-Za-z][A-Za-z0-9\s_-]*$'
+    if not re.match(valid_name_regex, name):
+      raise ValueError(
+          'Only letters, numbers, spaces, "_", and "-"  are allowed in name. Must begin with letter: %s'
+          % (name)
+      )
 
-        self.is_exit_handler = is_exit_handler
+    if is_exit_handler:
+      warnings.warn(
+          'is_exit_handler=True is no longer needed.', DeprecationWarning
+      )
 
-        # human_name must exist to construct operator's name
-        self.human_name = name
-        self.display_name = None #TODO Set display_name to human_name
-        # ID of the current Op. Ideally, it should be generated by the compiler that sees the bigger context.
-        # However, the ID is used in the task output references (PipelineParams) which can be serialized to strings.
-        # Because of this we must obtain a unique ID right now.
-        self.name = _register_op_handler(self)
+    self.is_exit_handler = is_exit_handler
 
-        # TODO: proper k8s definitions so that `convert_k8s_obj_to_json` can be used?
-        # `io.argoproj.workflow.v1alpha1.Template` properties
-        self.node_selector = {}
-        self.volumes = []
-        self.tolerations = []
-        self.affinity = {}
-        self.pod_annotations = {}
-        self.pod_labels = {}
-        self.num_retries = 0
-        self.timeout = 0
-        self.init_containers = init_containers or []
-        self.sidecars = sidecars or []
+    # human_name must exist to construct operator's name
+    self.human_name = name
+    self.display_name = None  #TODO Set display_name to human_name
+    # ID of the current Op. Ideally, it should be generated by the compiler that sees the bigger context.
+    # However, the ID is used in the task output references (PipelineParams) which can be serialized to strings.
+    # Because of this we must obtain a unique ID right now.
+    self.name = _register_op_handler(self)
 
-        # used to mark this op with loop arguments
-        self.loop_args = None
+    # TODO: proper k8s definitions so that `convert_k8s_obj_to_json` can be used?
+    # `io.argoproj.workflow.v1alpha1.Template` properties
+    self.node_selector = {}
+    self.volumes = []
+    self.tolerations = []
+    self.affinity = {}
+    self.pod_annotations = {}
+    self.pod_labels = {}
+    self.num_retries = 0
+    self.timeout = 0
+    self.init_containers = init_containers or []
+    self.sidecars = sidecars or []
 
-        # attributes specific to `BaseOp`
-        self._inputs = []
-        self.dependent_names = []
+    # used to mark this op with loop arguments
+    self.loop_args = None
 
-    @property
-    def inputs(self):
-        """List of PipelineParams that will be converted into input parameters
-        (io.argoproj.workflow.v1alpha1.Inputs) for the argo workflow.
-        """
-        # Iterate through and extract all the `PipelineParam` in Op when
-        # called the 1st time (because there are in-place updates to `PipelineParam`
-        # during compilation - remove in-place updates for easier debugging?)
-        if not self._inputs:
-            self._inputs = []
-            # TODO replace with proper k8s obj?
-            for key in self.attrs_with_pipelineparams:
-                self._inputs += _pipeline_param.extract_pipelineparams_from_any(getattr(self, key))
-            # keep only unique
-            self._inputs = list(set(self._inputs))
-        return self._inputs
+    # attributes specific to `BaseOp`
+    self._inputs = []
+    self.dependent_names = []
 
-    @inputs.setter
-    def inputs(self, value):
-        # to support in-place updates
-        self._inputs = value
+  @property
+  def inputs(self):
+    """List of PipelineParams that will be converted into input parameters
+    (io.argoproj.workflow.v1alpha1.Inputs) for the argo workflow."""
+    # Iterate through and extract all the `PipelineParam` in Op when
+    # called the 1st time (because there are in-place updates to `PipelineParam`
+    # during compilation - remove in-place updates for easier debugging?)
+    if not self._inputs:
+      self._inputs = []
+      # TODO replace with proper k8s obj?
+      for key in self.attrs_with_pipelineparams:
+        self._inputs += _pipeline_param.extract_pipelineparams_from_any(
+            getattr(self, key)
+        )
+      # keep only unique
+      self._inputs = list(set(self._inputs))
+    return self._inputs
 
-    def apply(self, mod_func):
-        """Applies a modifier function to self. The function should return the passed object.
-        This is needed to chain "extention methods" to this class.
+  @inputs.setter
+  def inputs(self, value):
+    # to support in-place updates
+    self._inputs = value
 
-        Example:
-          from kfp.gcp import use_gcp_secret
-          task = (
-            train_op(...)
-              .set_memory_request('1GB')
-              .apply(use_gcp_secret('user-gcp-sa'))
-              .set_memory_limit('2GB')
-          )
-        """
-        return mod_func(self) or self
+  def apply(self, mod_func):
+    """Applies a modifier function to self. The function should return the
+    passed object. This is needed to chain "extention methods" to this class.
 
-    def after(self, *ops):
-        """Specify explicit dependency on other ops."""
-        for op in ops:
-            self.dependent_names.append(op.name)
-        return self
+    Example:
+      from kfp.gcp import use_gcp_secret
+      task = (
+        train_op(...)
+          .set_memory_request('1GB')
+          .apply(use_gcp_secret('user-gcp-sa'))
+          .set_memory_limit('2GB')
+      )
 
-    def add_volume(self, volume):
-        """Add K8s volume to the container
+    """
+    return mod_func(self) or self
 
-        Args:
-          volume: Kubernetes volumes
-          For detailed spec, check volume definition
-          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_volume.py
-        """
-        self.volumes.append(volume)
-        return self
+  def after(self, *ops):
+    """Specify explicit dependency on other ops."""
+    for op in ops:
+      self.dependent_names.append(op.name)
+    return self
 
-    def add_toleration(self, tolerations: V1Toleration):
-        """Add K8s tolerations
+  def add_volume(self, volume):
+    """Add K8s volume to the container.
 
-        Args:
-          tolerations: Kubernetes toleration
-          For detailed spec, check toleration definition
-          https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_toleration.py
-        """
-        self.tolerations.append(tolerations)
-        return self
+    Args:
+      volume: Kubernetes volumes
+      For detailed spec, check volume definition
+      https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_volume.py
 
-    def add_affinity(self, affinity: V1Affinity):
-        """Add K8s Affinity
+    """
+    self.volumes.append(volume)
+    return self
+
+  def add_toleration(self, tolerations: V1Toleration):
+    """Add K8s tolerations.
+
+    Args:
+      tolerations: Kubernetes toleration
+      For detailed spec, check toleration definition
+      https://github.com/kubernetes-client/python/blob/master/kubernetes/client/models/v1_toleration.py
+
+    """
+    self.tolerations.append(tolerations)
+    return self
+
+  def add_affinity(self, affinity: V1Affinity):
+    """Add K8s Affinity
         Args:
           affinity: Kubernetes affinity
           For detailed spec, check affinity definition
@@ -817,152 +851,159 @@ class BaseOp(object):
                                 match_expressions=[V1NodeSelectorRequirement(
                                     key='beta.kubernetes.io/instance-type', operator='In', values=['p2.xlarge'])])])))
         """
-        self.affinity = affinity
-        return self
+    self.affinity = affinity
+    return self
 
-    def add_node_selector_constraint(self, label_name, value):
-        """Add a constraint for nodeSelector. Each constraint is a key-value pair label. For the 
-        container to be eligible to run on a node, the node must have each of the constraints appeared
-        as labels.
+  def add_node_selector_constraint(self, label_name, value):
+    """Add a constraint for nodeSelector. Each constraint is a key-value pair
+    label. For the container to be eligible to run on a node, the node must have
+    each of the constraints appeared as labels.
 
-        Args:
-          label_name: The name of the constraint label.
-          value: The value of the constraint label.
-        """
+    Args:
+      label_name: The name of the constraint label.
+      value: The value of the constraint label.
 
-        self.node_selector[label_name] = value
-        return self
+    """
 
-    def add_pod_annotation(self, name: str, value: str):
-        """Adds a pod's metadata annotation.
+    self.node_selector[label_name] = value
+    return self
 
-        Args:
-          name: The name of the annotation.
-          value: The value of the annotation.
-        """
+  def add_pod_annotation(self, name: str, value: str):
+    """Adds a pod's metadata annotation.
 
-        self.pod_annotations[name] = value
-        return self
+    Args:
+      name: The name of the annotation.
+      value: The value of the annotation.
 
-    def add_pod_label(self, name: str, value: str):
-        """Adds a pod's metadata label.
+    """
 
-        Args:
-          name: The name of the label.
-          value: The value of the label.
-        """
+    self.pod_annotations[name] = value
+    return self
 
-        self.pod_labels[name] = value
-        return self
+  def add_pod_label(self, name: str, value: str):
+    """Adds a pod's metadata label.
 
-    def set_retry(self, num_retries: int):
-        """Sets the number of times the task is retried until it's declared failed.
+    Args:
+      name: The name of the label.
+      value: The value of the label.
 
-        Args:
-          num_retries: Number of times to retry on failures.
-        """
+    """
 
-        self.num_retries = num_retries
-        return self
+    self.pod_labels[name] = value
+    return self
 
-    def set_timeout(self, seconds: int):
-        """Sets the timeout for the task in seconds.
+  def set_retry(self, num_retries: int):
+    """Sets the number of times the task is retried until it's declared failed.
 
-        Args:
-          seconds: Number of seconds.
-        """
+    Args:
+      num_retries: Number of times to retry on failures.
 
-        self.timeout = seconds
-        return self
+    """
 
-    def add_init_container(self, init_container: UserContainer):
-        """Add a init container to the Op.
+    self.num_retries = num_retries
+    return self
 
-        Args:
-          init_container: InitContainer object.
-        """
+  def set_timeout(self, seconds: int):
+    """Sets the timeout for the task in seconds.
 
-        self.init_containers.append(init_container)
-        return self
+    Args:
+      seconds: Number of seconds.
 
-    def add_sidecar(self, sidecar: Sidecar):
-        """Add a sidecar to the Op.
+    """
 
-        Args:
-          sidecar: SideCar object.
-        """
+    self.timeout = seconds
+    return self
 
-        self.sidecars.append(sidecar)
-        return self
+  def add_init_container(self, init_container: UserContainer):
+    """Add a init container to the Op.
 
-    def set_display_name(self, name: str):
-        self.display_name = name
-        return self
+    Args:
+      init_container: InitContainer object.
 
-    def __repr__(self):
-        return str({self.__class__.__name__: self.__dict__})
+    """
+
+    self.init_containers.append(init_container)
+    return self
+
+  def add_sidecar(self, sidecar: Sidecar):
+    """Add a sidecar to the Op.
+
+    Args:
+      sidecar: SideCar object.
+
+    """
+
+    self.sidecars.append(sidecar)
+    return self
+
+  def set_display_name(self, name: str):
+    self.display_name = name
+    return self
+
+  def __repr__(self):
+    return str({self.__class__.__name__: self.__dict__})
 
 
 from ._pipeline_volume import PipelineVolume  # The import is here to prevent circular reference problems.
 
 
 class InputArgumentPath:
-    def __init__(self, argument, input=None, path=None):
-        self.argument = argument
-        self.input = input
-        self.path = path
+
+  def __init__(self, argument, input=None, path=None):
+    self.argument = argument
+    self.input = input
+    self.path = path
 
 
 class ContainerOp(BaseOp):
-    """
-    Represents an op implemented by a container image.
-    
-    Example::
+  """Represents an op implemented by a container image.
 
-        from kfp import dsl
-        from kubernetes.client.models import V1EnvVar, V1SecretKeySelector
+  Example::
+
+      from kfp import dsl
+      from kubernetes.client.models import V1EnvVar, V1SecretKeySelector
 
 
-        @dsl.pipeline(
-            name='foo',
-            description='hello world')
-        def foo_pipeline(tag: str, pull_image_policy: str):
+      @dsl.pipeline(
+          name='foo',
+          description='hello world')
+      def foo_pipeline(tag: str, pull_image_policy: str):
 
-            # configures artifact location
-            artifact_location = dsl.ArtifactLocation.s3(
-                                    bucket="foobar",
-                                    endpoint="minio-service:9000",
-                                    insecure=True,
-                                    access_key_secret=V1SecretKeySelector(name="minio", key="accesskey"),
-                                    secret_key_secret=V1SecretKeySelector(name="minio", key="secretkey"))
+          # configures artifact location
+          artifact_location = dsl.ArtifactLocation.s3(
+                                  bucket="foobar",
+                                  endpoint="minio-service:9000",
+                                  insecure=True,
+                                  access_key_secret=V1SecretKeySelector(name="minio", key="accesskey"),
+                                  secret_key_secret=V1SecretKeySelector(name="minio", key="secretkey"))
 
-            # any attributes can be parameterized (both serialized string or actual PipelineParam)
-            op = dsl.ContainerOp(name='foo', 
-                                image='busybox:%s' % tag,
-                                # pass in init_container list
-                                init_containers=[dsl.InitContainer('print', 'busybox:latest', command='echo "hello"')],
-                                # pass in sidecars list
-                                sidecars=[dsl.Sidecar('print', 'busybox:latest', command='echo "hello"')],
-                                # pass in k8s container kwargs
-                                container_kwargs={'env': [V1EnvVar('foo', 'bar')]},
-                                # configures artifact location
-                                artifact_location=artifact_location)
+          # any attributes can be parameterized (both serialized string or actual PipelineParam)
+          op = dsl.ContainerOp(name='foo',
+                              image='busybox:%s' % tag,
+                              # pass in init_container list
+                              init_containers=[dsl.InitContainer('print', 'busybox:latest', command='echo "hello"')],
+                              # pass in sidecars list
+                              sidecars=[dsl.Sidecar('print', 'busybox:latest', command='echo "hello"')],
+                              # pass in k8s container kwargs
+                              container_kwargs={'env': [V1EnvVar('foo', 'bar')]},
+                              # configures artifact location
+                              artifact_location=artifact_location)
 
-            # set `imagePullPolicy` property for `container` with `PipelineParam` 
-            op.container.set_pull_image_policy(pull_image_policy)
+          # set `imagePullPolicy` property for `container` with `PipelineParam`
+          op.container.set_pull_image_policy(pull_image_policy)
 
-            # add sidecar with parameterized image tag
-            # sidecar follows the argo sidecar swagger spec
-            op.add_sidecar(dsl.Sidecar('redis', 'redis:%s' % tag).set_image_pull_policy('Always'))
-    
-    """
+          # add sidecar with parameterized image tag
+          # sidecar follows the argo sidecar swagger spec
+          op.add_sidecar(dsl.Sidecar('redis', 'redis:%s' % tag).set_image_pull_policy('Always'))
 
-    # list of attributes that might have pipeline params - used to generate
-    # the input parameters during compilation.
-    # Excludes `file_outputs` and `outputs` as they are handled separately
-    # in the compilation process to generate the DAGs and task io parameters.
+  """
 
-    def __init__(
+  # list of attributes that might have pipeline params - used to generate
+  # the input parameters during compilation.
+  # Excludes `file_outputs` and `outputs` as they are handled separately
+  # in the compilation process to generate the DAGs and task io parameters.
+
+  def __init__(
       self,
       name: str,
       image: str,
@@ -973,230 +1014,240 @@ class ContainerOp(BaseOp):
       container_kwargs: Dict = None,
       artifact_argument_paths: List[InputArgumentPath] = None,
       file_outputs: Dict[str, str] = None,
-      output_artifact_paths: Dict[str, str]=None,
-      artifact_location: V1alpha1ArtifactLocation=None,
+      output_artifact_paths: Dict[str, str] = None,
+      artifact_location: V1alpha1ArtifactLocation = None,
       is_exit_handler=False,
       pvolumes: Dict[str, V1Volume] = None,
-    ):
-        """Create a new instance of ContainerOp.
+  ):
+    """Create a new instance of ContainerOp.
 
-        Args:
-          name: the name of the op. It does not have to be unique within a pipeline
-              because the pipeline will generates a unique new name in case of conflicts.
-          image: the container image name, such as 'python:3.5-jessie'
-          command: the command to run in the container.
-              If None, uses default CMD in defined in container.
-          arguments: the arguments of the command. The command can include "%s" and supply
-              a PipelineParam as the string replacement. For example, ('echo %s' % input_param).
-              At container run time the argument will be 'echo param_value'.
-          init_containers: the list of `InitContainer` objects describing the InitContainer
-                    to deploy before the `main` container.
-          sidecars: the list of `Sidecar` objects describing the sidecar containers to deploy
-                    together with the `main` container.
-          container_kwargs: the dict of additional keyword arguments to pass to the
-                            op's `Container` definition.
-          artifact_argument_paths: Optional. Maps input artifact arguments (values or references) to the local file paths where they'll be placed.
-              At pipeline run time, the value of the artifact argument is saved to a local file with specified path.
-              This parameter is only needed when the input file paths are hard-coded in the program.
-              Otherwise it's better to pass input artifact placement paths by including artifact arguments in the command-line using the InputArgumentPath class instances.
-          file_outputs: Maps output labels to local file paths. At pipeline run time,
-              the value of a PipelineParam is saved to its corresponding local file. It's
-              one way for outside world to receive outputs of the container.
-          output_artifact_paths: Maps output artifact labels to local artifact file paths.
-              It has the following default artifact paths during compile time.
-              {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json',
-               'mlpipeline-metrics': '/mlpipeline-metrics.json'}
-          artifact_location: configures the default artifact location for artifacts
-               in the argo workflow template. Must be a `V1alpha1ArtifactLocation`
-               object.
-          is_exit_handler: Deprecated. This is no longer needed.
-          pvolumes: Dictionary for the user to match a path on the op's fs with a
-              V1Volume or it inherited type.
-              E.g {"/my/path": vol, "/mnt": other_op.pvolumes["/output"]}.
-        """
+    Args:
+      name: the name of the op. It does not have to be unique within a pipeline
+          because the pipeline will generates a unique new name in case of conflicts.
+      image: the container image name, such as 'python:3.5-jessie'
+      command: the command to run in the container.
+          If None, uses default CMD in defined in container.
+      arguments: the arguments of the command. The command can include "%s" and supply
+          a PipelineParam as the string replacement. For example, ('echo %s' % input_param).
+          At container run time the argument will be 'echo param_value'.
+      init_containers: the list of `InitContainer` objects describing the InitContainer
+                to deploy before the `main` container.
+      sidecars: the list of `Sidecar` objects describing the sidecar containers to deploy
+                together with the `main` container.
+      container_kwargs: the dict of additional keyword arguments to pass to the
+                        op's `Container` definition.
+      artifact_argument_paths: Optional. Maps input artifact arguments (values or references) to the local file paths where they'll be placed.
+          At pipeline run time, the value of the artifact argument is saved to a local file with specified path.
+          This parameter is only needed when the input file paths are hard-coded in the program.
+          Otherwise it's better to pass input artifact placement paths by including artifact arguments in the command-line using the InputArgumentPath class instances.
+      file_outputs: Maps output labels to local file paths. At pipeline run time,
+          the value of a PipelineParam is saved to its corresponding local file. It's
+          one way for outside world to receive outputs of the container.
+      output_artifact_paths: Maps output artifact labels to local artifact file paths.
+          It has the following default artifact paths during compile time.
+          {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json',
+           'mlpipeline-metrics': '/mlpipeline-metrics.json'}
+      artifact_location: configures the default artifact location for artifacts
+           in the argo workflow template. Must be a `V1alpha1ArtifactLocation`
+           object.
+      is_exit_handler: Deprecated. This is no longer needed.
+      pvolumes: Dictionary for the user to match a path on the op's fs with a
+          V1Volume or it inherited type.
+          E.g {"/my/path": vol, "/mnt": other_op.pvolumes["/output"]}.
 
-        super().__init__(name=name, init_containers=init_containers, sidecars=sidecars, is_exit_handler=is_exit_handler)
-        self.attrs_with_pipelineparams = BaseOp.attrs_with_pipelineparams + ['_container', 'artifact_location', 'artifact_arguments'] #Copying the BaseOp class variable!
+    """
 
-        input_artifact_paths = {}
-        artifact_arguments = {}
-        file_outputs = dict(file_outputs or {}) # Making a copy
-        output_artifact_paths = dict(output_artifact_paths or {}) # Making a copy
+    super().__init__(
+        name=name,
+        init_containers=init_containers,
+        sidecars=sidecars,
+        is_exit_handler=is_exit_handler
+    )
+    self.attrs_with_pipelineparams = BaseOp.attrs_with_pipelineparams + [
+        '_container', 'artifact_location', 'artifact_arguments'
+    ]  #Copying the BaseOp class variable!
 
-        def resolve_artifact_argument(artarg):
-            from ..components._components import _generate_input_file_name
-            if not isinstance(artarg, InputArgumentPath):
-                return artarg
-            input_name = getattr(artarg.input, 'name', artarg.input) or ('input-' + str(len(artifact_arguments)))
-            input_path = artarg.path or _generate_input_file_name(input_name)
-            input_artifact_paths[input_name] = input_path
-            artifact_arguments[input_name] = str(artarg.argument)
-            return input_path
+    input_artifact_paths = {}
+    artifact_arguments = {}
+    file_outputs = dict(file_outputs or {})  # Making a copy
+    output_artifact_paths = dict(output_artifact_paths or {})  # Making a copy
 
-        for artarg in artifact_argument_paths or []:
-            resolve_artifact_argument(artarg)
+    def resolve_artifact_argument(artarg):
+      from ..components._components import _generate_input_file_name
+      if not isinstance(artarg, InputArgumentPath):
+        return artarg
+      input_name = getattr(artarg.input, 'name', artarg.input
+                          ) or ('input-' + str(len(artifact_arguments)))
+      input_path = artarg.path or _generate_input_file_name(input_name)
+      input_artifact_paths[input_name] = input_path
+      artifact_arguments[input_name] = str(artarg.argument)
+      return input_path
 
-        if isinstance(command, Sequence) and not isinstance(command, str):
-            command = list(map(resolve_artifact_argument, command))
-        if isinstance(arguments, Sequence) and not isinstance(arguments, str):
-            arguments = list(map(resolve_artifact_argument, arguments))
+    for artarg in artifact_argument_paths or []:
+      resolve_artifact_argument(artarg)
 
-        # convert to list if not a list
-        command = as_string_list(command)
-        arguments = as_string_list(arguments)
+    if isinstance(command, Sequence) and not isinstance(command, str):
+      command = list(map(resolve_artifact_argument, command))
+    if isinstance(arguments, Sequence) and not isinstance(arguments, str):
+      arguments = list(map(resolve_artifact_argument, arguments))
 
-        # `container` prop in `io.argoproj.workflow.v1alpha1.Template`
-        container_kwargs = container_kwargs or {}
-        self._container = Container(
-            image=image, args=arguments, command=command, **container_kwargs)
+    # convert to list if not a list
+    command = as_string_list(command)
+    arguments = as_string_list(arguments)
 
-        # NOTE for backward compatibility (remove in future?)
-        # proxy old ContainerOp callables to Container
+    # `container` prop in `io.argoproj.workflow.v1alpha1.Template`
+    container_kwargs = container_kwargs or {}
+    self._container = Container(
+        image=image, args=arguments, command=command, **container_kwargs
+    )
 
-        # attributes to NOT proxy
-        ignore_set = frozenset(['to_dict', 'to_str'])
+    # NOTE for backward compatibility (remove in future?)
+    # proxy old ContainerOp callables to Container
 
-        # decorator func to proxy a method in `Container` into `ContainerOp`
-        def _proxy(proxy_attr):
-            """Decorator func to proxy to ContainerOp.container"""
+    # attributes to NOT proxy
+    ignore_set = frozenset(['to_dict', 'to_str'])
 
-            def _decorated(*args, **kwargs):
-                # execute method
-                ret = getattr(self._container, proxy_attr)(*args, **kwargs)
-                if ret == self._container:
-                    return self
-                return ret
+    # decorator func to proxy a method in `Container` into `ContainerOp`
+    def _proxy(proxy_attr):
+      """Decorator func to proxy to ContainerOp.container."""
 
-            return deprecation_warning(_decorated, proxy_attr, proxy_attr)
+      def _decorated(*args, **kwargs):
+        # execute method
+        ret = getattr(self._container, proxy_attr)(*args, **kwargs)
+        if ret == self._container:
+          return self
+        return ret
 
-        # iter thru container and attach a proxy func to the container method
-        for attr_to_proxy in dir(self._container):
-            func = getattr(self._container, attr_to_proxy)
-            # ignore private methods
-            if hasattr(func, '__call__') and (attr_to_proxy[0] != '_') and (
-                    attr_to_proxy not in ignore_set):
-                # only proxy public callables
-                setattr(self, attr_to_proxy, _proxy(attr_to_proxy))
+      return deprecation_warning(_decorated, proxy_attr, proxy_attr)
 
-        # Special handling for the mlpipeline-ui-metadata and mlpipeline-metrics outputs that should always be saved as artifacts
-        # TODO: Remove when outputs are always saved as artifacts
-        for output_name, path in dict(file_outputs).items():
-            normalized_output_name = re.sub('[^a-zA-Z0-9]', '-', output_name.lower())
-            if normalized_output_name in ['mlpipeline-ui-metadata', 'mlpipeline-metrics']:
-                output_artifact_paths[normalized_output_name] = path
-                del file_outputs[output_name]
+    # iter thru container and attach a proxy func to the container method
+    for attr_to_proxy in dir(self._container):
+      func = getattr(self._container, attr_to_proxy)
+      # ignore private methods
+      if hasattr(func, '__call__') and (attr_to_proxy[0] != '_') and (
+          attr_to_proxy not in ignore_set):
+        # only proxy public callables
+        setattr(self, attr_to_proxy, _proxy(attr_to_proxy))
 
-        # attributes specific to `ContainerOp`
-        self.input_artifact_paths = input_artifact_paths
-        self.artifact_arguments = artifact_arguments
-        self.file_outputs = file_outputs
-        self.output_artifact_paths = output_artifact_paths or {}
-        self.artifact_location = artifact_location
+    # Special handling for the mlpipeline-ui-metadata and mlpipeline-metrics outputs that should always be saved as artifacts
+    # TODO: Remove when outputs are always saved as artifacts
+    for output_name, path in dict(file_outputs).items():
+      normalized_output_name = re.sub('[^a-zA-Z0-9]', '-', output_name.lower())
+      if normalized_output_name in ['mlpipeline-ui-metadata',
+                                    'mlpipeline-metrics']:
+        output_artifact_paths[normalized_output_name] = path
+        del file_outputs[output_name]
 
-        self._metadata = None
+    # attributes specific to `ContainerOp`
+    self.input_artifact_paths = input_artifact_paths
+    self.artifact_arguments = artifact_arguments
+    self.file_outputs = file_outputs
+    self.output_artifact_paths = output_artifact_paths or {}
+    self.artifact_location = artifact_location
 
-        self.outputs = {}
-        if file_outputs:
-            self.outputs = {
-                name: _pipeline_param.PipelineParam(name, op_name=self.name)
-                for name in file_outputs.keys()
-            }
+    self._metadata = None
 
-        if len(self.outputs) == 1:
-            self.output = list(self.outputs.values())[0]
-        else:
-            self.output = _MultipleOutputsError()
+    self.outputs = {}
+    if file_outputs:
+      self.outputs = {
+          name: _pipeline_param.PipelineParam(name, op_name=self.name)
+          for name in file_outputs.keys()
+      }
 
-        self.pvolumes = {}
-        self.add_pvolumes(pvolumes)
+    if len(self.outputs) == 1:
+      self.output = list(self.outputs.values())[0]
+    else:
+      self.output = _MultipleOutputsError()
 
+    self.pvolumes = {}
+    self.add_pvolumes(pvolumes)
 
-    @property
-    def command(self):
-        return self._container.command
+  @property
+  def command(self):
+    return self._container.command
 
-    @command.setter
-    def command(self, value):
-        self._container.command = as_string_list(value)
+  @command.setter
+  def command(self, value):
+    self._container.command = as_string_list(value)
 
-    @property
-    def arguments(self):
-        return self._container.args
+  @property
+  def arguments(self):
+    return self._container.args
 
-    @arguments.setter
-    def arguments(self, value):
-        self._container.args = as_string_list(value)
+  @arguments.setter
+  def arguments(self, value):
+    self._container.args = as_string_list(value)
 
-    @property
-    def container(self):
-        """`Container` object that represents the `container` property in 
-        `io.argoproj.workflow.v1alpha1.Template`. Can be used to update the
-        container configurations. 
-        
-        Example:
-            import kfp.dsl as dsl
-            from kubernetes.client.models import V1EnvVar
-    
-            @dsl.pipeline(name='example_pipeline')
-            def immediate_value_pipeline():
-                op1 = (dsl.ContainerOp(name='example', image='nginx:alpine')
-                          .container
-                            .add_env_variable(V1EnvVar(name='HOST', value='foo.bar'))
-                            .add_env_variable(V1EnvVar(name='PORT', value='80'))
-                            .parent # return the parent `ContainerOp`
-                        )
-        """
-        return self._container
+  @property
+  def container(self):
+    """`Container` object that represents the `container` property in
+    `io.argoproj.workflow.v1alpha1.Template`. Can be used to update the
+    container configurations.
 
-    def _set_metadata(self, metadata):
-        '''_set_metadata passes the containerop the metadata information
+    Example:
+        import kfp.dsl as dsl
+        from kubernetes.client.models import V1EnvVar
+
+        @dsl.pipeline(name='example_pipeline')
+        def immediate_value_pipeline():
+            op1 = (dsl.ContainerOp(name='example', image='nginx:alpine')
+                      .container
+                        .add_env_variable(V1EnvVar(name='HOST', value='foo.bar'))
+                        .add_env_variable(V1EnvVar(name='PORT', value='80'))
+                        .parent # return the parent `ContainerOp`
+                    )
+
+    """
+    return self._container
+
+  def _set_metadata(self, metadata):
+    '''_set_metadata passes the containerop the metadata information
         and configures the right output
         Args:
           metadata (ComponentSpec): component metadata
         '''
-        if not isinstance(metadata, ComponentSpec):
-            raise ValueError('_set_metadata is expecting ComponentSpec.')
+    if not isinstance(metadata, ComponentSpec):
+      raise ValueError('_set_metadata is expecting ComponentSpec.')
 
-        self._metadata = metadata
+    self._metadata = metadata
 
-        if self.file_outputs:
-            for output in self.file_outputs.keys():
-                output_type = self.outputs[output].param_type
-                for output_meta in self._metadata.outputs:
-                    if output_meta.name == output:
-                        output_type = output_meta.type
-                self.outputs[output].param_type = output_type
+    if self.file_outputs:
+      for output in self.file_outputs.keys():
+        output_type = self.outputs[output].param_type
+        for output_meta in self._metadata.outputs:
+          if output_meta.name == output:
+            output_type = output_meta.type
+        self.outputs[output].param_type = output_type
 
-            if len(self.outputs) == 1:
-                self.output = list(self.outputs.values())[0]
+      if len(self.outputs) == 1:
+        self.output = list(self.outputs.values())[0]
 
-    def add_pvolumes(self,
-                     pvolumes: Dict[str, V1Volume] = None):
-        """Updates the existing pvolumes dict, extends volumes and volume_mounts
-        and redefines the pvolume attribute.
+  def add_pvolumes(self, pvolumes: Dict[str, V1Volume] = None):
+    """Updates the existing pvolumes dict, extends volumes and volume_mounts and
+    redefines the pvolume attribute.
 
-        Args:
-            pvolumes: Dictionary. Keys are mount paths, values are Kubernetes
-                      volumes or inherited types (e.g. PipelineVolumes).
-        """
-        if pvolumes:
-            for mount_path, pvolume in pvolumes.items():
-                if hasattr(pvolume, "dependent_names"):
-                    self.dependent_names.extend(pvolume.dependent_names)
-                else:
-                    pvolume = PipelineVolume(volume=pvolume)
-                pvolume = pvolume.after(self)
-                self.pvolumes[mount_path] = pvolume
-                self.add_volume(pvolume)
-                self._container.add_volume_mount(V1VolumeMount(
-                    name=pvolume.name,
-                    mount_path=mount_path
-                ))
+    Args:
+        pvolumes: Dictionary. Keys are mount paths, values are Kubernetes
+                  volumes or inherited types (e.g. PipelineVolumes).
 
-        self.pvolume = None
-        if len(self.pvolumes) == 1:
-            self.pvolume = list(self.pvolumes.values())[0]
-        return self
+    """
+    if pvolumes:
+      for mount_path, pvolume in pvolumes.items():
+        if hasattr(pvolume, "dependent_names"):
+          self.dependent_names.extend(pvolume.dependent_names)
+        else:
+          pvolume = PipelineVolume(volume=pvolume)
+        pvolume = pvolume.after(self)
+        self.pvolumes[mount_path] = pvolume
+        self.add_volume(pvolume)
+        self._container.add_volume_mount(
+            V1VolumeMount(name=pvolume.name, mount_path=mount_path)
+        )
+
+    self.pvolume = None
+    if len(self.pvolumes) == 1:
+      self.pvolume = list(self.pvolumes.values())[0]
+    return self
 
 
 # proxy old ContainerOp properties to ContainerOp.container
@@ -1205,12 +1256,15 @@ ContainerOp = _proxy_container_op_props(ContainerOp)
 
 
 class _MultipleOutputsError:
-    @staticmethod
-    def raise_error():
-        raise RuntimeError('This task has multiple outputs. Use `task.outputs[<output name>]` dictionary to refer to the one you need.')
 
-    def __getattribute__(self, name):
-        _MultipleOutputsError.raise_error()
+  @staticmethod
+  def raise_error():
+    raise RuntimeError(
+        'This task has multiple outputs. Use `task.outputs[<output name>]` dictionary to refer to the one you need.'
+    )
 
-    def __str__(self):
-        _MultipleOutputsError.raise_error()
+  def __getattribute__(self, name):
+    _MultipleOutputsError.raise_error()
+
+  def __str__(self):
+    _MultipleOutputsError.raise_error()

--- a/sdk/python/kfp/dsl/_for_loop.py
+++ b/sdk/python/kfp/dsl/_for_loop.py
@@ -7,100 +7,133 @@ ItemList = List[Union[int, float, str, Dict[Text, Any]]]
 
 
 class LoopArguments(dsl.PipelineParam):
-    """Class representing the arguments that are looped over in a ParallelFor loop in the KFP DSL.
-    This doesn't need to be instantiated by the end user, rather it will be automatically created by a
-    ParallelFor ops group."""
-    LOOP_ITEM_PARAM_NAME_BASE = 'loop-item-param'
-    # number of characters in the code which is passed to the constructor
-    NUM_CODE_CHARS = 8
-    LEGAL_SUBVAR_NAME_REGEX = re.compile(r'[a-zA-Z_][0-9a-zA-Z_]*')
+  """Class representing the arguments that are looped over in a ParallelFor loop
+  in the KFP DSL.
 
-    @classmethod
-    def _subvar_name_is_legal(cls, proposed_variable_name: Text):
-        return re.match(cls.LEGAL_SUBVAR_NAME_REGEX, proposed_variable_name) is not None
+  This doesn't need to be instantiated by the end user, rather it will be
+  automatically created by a ParallelFor ops group.
 
-    def __init__(self, items: Union[ItemList, dsl.PipelineParam], code: Text, name_override: Optional[Text]=None, op_name: Optional[Text]=None, *args, **kwargs):
-        """_LoopArguments represent the set of items to loop over in a ParallelFor loop.  This class shoudn't be
-        instantiated by the user but rather is created by _ops_group.ParallelFor.
+  """
+  LOOP_ITEM_PARAM_NAME_BASE = 'loop-item-param'
+  # number of characters in the code which is passed to the constructor
+  NUM_CODE_CHARS = 8
+  LEGAL_SUBVAR_NAME_REGEX = re.compile(r'[a-zA-Z_][0-9a-zA-Z_]*')
 
-        Args:
-            items: List of items to loop over.  If a list of dicts then, all dicts must have the same keys and every
-                key must be a legal Python variable name.
-            code: A unique code used to identify these loop arguments.  Should match the code for the ParallelFor
-                ops_group which created these _LoopArguments.  This prevents parameter name collissions.
-        """
-        if name_override is None:
-            super().__init__(name=self._make_name(code), *args, **kwargs)
-        else:
-            super().__init__(name=name_override, op_name=op_name, *args, **kwargs)
+  @classmethod
+  def _subvar_name_is_legal(cls, proposed_variable_name: Text):
+    return re.match(
+        cls.LEGAL_SUBVAR_NAME_REGEX, proposed_variable_name
+    ) is not None
 
-        if not isinstance(items, (list, tuple, dsl.PipelineParam)):
-            raise TypeError("Expected list, tuple, or PipelineParam, got {}.".format(type(items)))
+  def __init__(
+      self,
+      items: Union[ItemList, dsl.PipelineParam],
+      code: Text,
+      name_override: Optional[Text] = None,
+      op_name: Optional[Text] = None,
+      *args,
+      **kwargs
+  ):
+    """_LoopArguments represent the set of items to loop over in a ParallelFor
+    loop.  This class shoudn't be instantiated by the user but rather is created
+    by _ops_group.ParallelFor.
 
-        if isinstance(items, tuple):
-            items = list(items)
+    Args:
+        items: List of items to loop over.  If a list of dicts then, all dicts must have the same keys and every
+            key must be a legal Python variable name.
+        code: A unique code used to identify these loop arguments.  Should match the code for the ParallelFor
+            ops_group which created these _LoopArguments.  This prevents parameter name collissions.
 
-        if isinstance(items, list) and isinstance(items[0], dict):
-            subvar_names = set(items[0].keys())
-            for item in items:
-                if not set(item.keys()) == subvar_names:
-                    raise ValueError("If you input a list of dicts then all dicts should have the same keys. "
-                                     "Got: {}.".format(items))
+    """
+    if name_override is None:
+      super().__init__(name=self._make_name(code), *args, **kwargs)
+    else:
+      super().__init__(name=name_override, op_name=op_name, *args, **kwargs)
 
-            # then this block creates loop_args.variable_a and loop_args.variable_b
-            for subvar_name in subvar_names:
-                if not self._subvar_name_is_legal(subvar_name):
-                    raise ValueError("Tried to create subvariable named {} but that's not a legal Python variable "
-                                     "name.".format(subvar_name))
-                setattr(self, subvar_name, LoopArgumentVariable(self.name, subvar_name))
+    if not isinstance(items, (list, tuple, dsl.PipelineParam)):
+      raise TypeError(
+          "Expected list, tuple, or PipelineParam, got {}.".format(type(items))
+      )
 
-        self.items_or_pipeline_param = items
-        self.referenced_subvar_names = []
+    if isinstance(items, tuple):
+      items = list(items)
 
-    @classmethod
-    def from_pipeline_param(cls, param: dsl.PipelineParam) -> 'LoopArguments':
-        return LoopArguments(
-            items=param,
-            code=None,
-            name_override=param.name,
-            op_name=param.op_name,
-            value=param.value,
-        )
+    if isinstance(items, list) and isinstance(items[0], dict):
+      subvar_names = set(items[0].keys())
+      for item in items:
+        if not set(item.keys()) == subvar_names:
+          raise ValueError(
+              "If you input a list of dicts then all dicts should have the same keys. "
+              "Got: {}.".format(items)
+          )
 
-    def __getattr__(self, item):
-        # this is being overridden so that we can access subvariables of the LoopArguments (i.e.: item.a) without
-        # knowing the subvariable names ahead of time
-        self.referenced_subvar_names.append(item)
-        return LoopArgumentVariable(self.name, item)
+      # then this block creates loop_args.variable_a and loop_args.variable_b
+      for subvar_name in subvar_names:
+        if not self._subvar_name_is_legal(subvar_name):
+          raise ValueError(
+              "Tried to create subvariable named {} but that's not a legal Python variable "
+              "name.".format(subvar_name)
+          )
+        setattr(self, subvar_name, LoopArgumentVariable(self.name, subvar_name))
 
-    def to_list_for_task_yaml(self):
-        if isinstance(self.items_or_pipeline_param, (list, tuple)):
-            return self.items_or_pipeline_param
-        else:
-            raise ValueError("You should only call this method on loop args which have list items, "
-                             "not pipeline param items.")
+    self.items_or_pipeline_param = items
+    self.referenced_subvar_names = []
 
-    @classmethod
-    def _make_name(cls, code: Text):
-        """Make a name for this parameter.  Code is a """
-        return '{}-{}'.format(cls.LOOP_ITEM_PARAM_NAME_BASE, code)
+  @classmethod
+  def from_pipeline_param(cls, param: dsl.PipelineParam) -> 'LoopArguments':
+    return LoopArguments(
+        items=param,
+        code=None,
+        name_override=param.name,
+        op_name=param.op_name,
+        value=param.value,
+    )
 
-    @classmethod
-    def name_is_loop_arguments(cls, param_name: Text) -> bool:
-        """Return True if the given parameter name looks like it came from a loop arguments parameter."""
-        return re.match(
-            '%s-[0-9a-f]{%s}' % (cls.LOOP_ITEM_PARAM_NAME_BASE, cls.NUM_CODE_CHARS),
-            param_name,
-        ) is not None
+  def __getattr__(self, item):
+    # this is being overridden so that we can access subvariables of the LoopArguments (i.e.: item.a) without
+    # knowing the subvariable names ahead of time
+    self.referenced_subvar_names.append(item)
+    return LoopArgumentVariable(self.name, item)
+
+  def to_list_for_task_yaml(self):
+    if isinstance(self.items_or_pipeline_param, (list, tuple)):
+      return self.items_or_pipeline_param
+    else:
+      raise ValueError(
+          "You should only call this method on loop args which have list items, "
+          "not pipeline param items."
+      )
+
+  @classmethod
+  def _make_name(cls, code: Text):
+    """Make a name for this parameter.
+
+    Code is a
+
+    """
+    return '{}-{}'.format(cls.LOOP_ITEM_PARAM_NAME_BASE, code)
+
+  @classmethod
+  def name_is_loop_arguments(cls, param_name: Text) -> bool:
+    """Return True if the given parameter name looks like it came from a loop
+    arguments parameter."""
+    return re.match(
+        '%s-[0-9a-f]{%s}' % (cls.LOOP_ITEM_PARAM_NAME_BASE, cls.NUM_CODE_CHARS),
+        param_name,
+    ) is not None
 
 
 class LoopArgumentVariable(dsl.PipelineParam):
-    """Represents a subvariable for loop arguments.  This is used for cases where we're looping over maps,
-    each of which contains several variables."""
-    SUBVAR_NAME_DELIMITER = '-subvar-'
+  """Represents a subvariable for loop arguments.
 
-    def __init__(self, loop_args_name: Text, this_variable_name: Text):
-        """
+  This is used for cases where we're looping over maps, each of which contains
+  several variables.
+
+  """
+  SUBVAR_NAME_DELIMITER = '-subvar-'
+
+  def __init__(self, loop_args_name: Text, this_variable_name: Text):
+    """
         If the user ran:
             with dsl.ParallelFor([{'a': 1, 'b': 2}, {'a': 3, 'b': 4}]) as item:
                 ...
@@ -111,41 +144,55 @@ class LoopArgumentVariable(dsl.PipelineParam):
             this_variable_name: the name of this subvariable, which is the name of the dict key that spawned
                 this subvariable.
         """
-        super().__init__(name=self.get_name(loop_args_name=loop_args_name, this_variable_name=this_variable_name))
+    super().__init__(
+        name=self.get_name(
+            loop_args_name=loop_args_name,
+            this_variable_name=this_variable_name
+        )
+    )
 
-    @classmethod
-    def get_name(cls, loop_args_name: Text, this_variable_name: Text) -> Text:
-        """Get the name
+  @classmethod
+  def get_name(cls, loop_args_name: Text, this_variable_name: Text) -> Text:
+    """Get the name.
 
-        Args:
-            loop_args_name: the name of the loop args parameter that this LoopArgsVariable is attached to.
-            this_variable_name: the name of this LoopArgumentsVariable subvar.
+    Args:
+        loop_args_name: the name of the loop args parameter that this LoopArgsVariable is attached to.
+        this_variable_name: the name of this LoopArgumentsVariable subvar.
 
-        Returns: The name of this loop args variable.
-        """
-        return '{}{}{}'.format(loop_args_name, cls.SUBVAR_NAME_DELIMITER, this_variable_name)
+    Returns: The name of this loop args variable.
 
-    @classmethod
-    def name_is_loop_arguments_variable(cls, param_name: Text) -> bool:
-        """Return True if the given parameter name looks like it came from a LoopArgumentsVariable."""
-        return re.match(
-            '.+%s.+' % cls.SUBVAR_NAME_DELIMITER,
-            param_name
-        ) is not None
+    """
+    return '{}{}{}'.format(
+        loop_args_name, cls.SUBVAR_NAME_DELIMITER, this_variable_name
+    )
 
-    @classmethod
-    def parse_loop_args_name_and_this_var_name(cls, t: Text) -> Tuple[Text, Text]:
-        """Get the loop arguments param name and this subvariable name from the given parameter name."""
-        m = re.match('(?P<loop_args_name>.*){}(?P<this_var_name>.*)'.format(cls.SUBVAR_NAME_DELIMITER), t)
-        if m is None:
-            return None
-        else:
-            return m.groupdict()['loop_args_name'], m.groupdict()['this_var_name']
+  @classmethod
+  def name_is_loop_arguments_variable(cls, param_name: Text) -> bool:
+    """Return True if the given parameter name looks like it came from a
+    LoopArgumentsVariable."""
+    return re.match(
+        '.+%s.+' % cls.SUBVAR_NAME_DELIMITER, param_name
+    ) is not None
 
-    @classmethod
-    def get_subvar_name(cls, t: Text) -> Text:
-        """Get the subvariable name from a given LoopArgumentsVariable parameter name."""
-        out = cls.parse_loop_args_name_and_this_var_name(t)
-        if out is None:
-            raise ValueError("Couldn't parse variable name: {}".format(t))
-        return out[1]
+  @classmethod
+  def parse_loop_args_name_and_this_var_name(cls, t: Text) -> Tuple[Text, Text]:
+    """Get the loop arguments param name and this subvariable name from the
+    given parameter name."""
+    m = re.match(
+        '(?P<loop_args_name>.*){}(?P<this_var_name>.*)'.format(
+            cls.SUBVAR_NAME_DELIMITER
+        ), t
+    )
+    if m is None:
+      return None
+    else:
+      return m.groupdict()['loop_args_name'], m.groupdict()['this_var_name']
+
+  @classmethod
+  def get_subvar_name(cls, t: Text) -> Text:
+    """Get the subvariable name from a given LoopArgumentsVariable parameter
+    name."""
+    out = cls.parse_loop_args_name_and_this_var_name(t)
+    if out is None:
+      raise ValueError("Couldn't parse variable name: {}".format(t))
+    return out[1]

--- a/sdk/python/kfp/dsl/_metadata.py
+++ b/sdk/python/kfp/dsl/_metadata.py
@@ -34,7 +34,9 @@ def _annotation_to_typemeta(annotation):
     arg_type = annotation
   elif isinstance(annotation, dict):
     if not _check_valid_type_dict(annotation):
-      raise ValueError('Annotation ' + str(annotation) + ' is not a valid type dictionary.')
+      raise ValueError(
+          'Annotation ' + str(annotation) + ' is not a valid type dictionary.'
+      )
     arg_type = annotation
   else:
     return None
@@ -42,7 +44,8 @@ def _annotation_to_typemeta(annotation):
 
 
 def _extract_component_metadata(func):
-  '''Creates component metadata structure instance based on the function signature.'''
+  """Creates component metadata structure instance based on the function
+  signature."""
 
   # Importing here to prevent circular import failures
   #TODO: Change _pipeline_param to stop importing _metadata
@@ -55,7 +58,8 @@ def _extract_component_metadata(func):
   # defaults
   arg_defaults = {}
   if fullargspec.defaults:
-    for arg, default in zip(reversed(fullargspec.args), reversed(fullargspec.defaults)):
+    for arg, default in zip(reversed(fullargspec.args),
+                            reversed(fullargspec.defaults)):
       arg_defaults[arg] = default
 
   # Inputs
@@ -64,12 +68,16 @@ def _extract_component_metadata(func):
     arg_type = None
     arg_default = arg_defaults[arg] if arg in arg_defaults else None
     if isinstance(arg_default, PipelineParam):
-      warnings.warn('Explicit creation of `kfp.dsl.PipelineParam`s by the users is deprecated. The users should define the parameter type and default values using standard pythonic constructs: def my_func(a: int = 1, b: str = "default"):')
+      warnings.warn(
+          'Explicit creation of `kfp.dsl.PipelineParam`s by the users is deprecated. The users should define the parameter type and default values using standard pythonic constructs: def my_func(a: int = 1, b: str = "default"):'
+      )
       arg_default = arg_default.value
     if arg in annotations:
       arg_type = _annotation_to_typemeta(annotations[arg])
     if arg_default is not None:
-      arg_default = serialize_value(arg_default, type_name=str(arg_type) if arg_type else None) # TODO: Improve _annotation_to_typemeta or just replace the whole function with kfp.component._python_op._extract_component_interface
+      arg_default = serialize_value(
+          arg_default, type_name=str(arg_type) if arg_type else None
+      )  # TODO: Improve _annotation_to_typemeta or just replace the whole function with kfp.component._python_op._extract_component_interface
     inputs.append(InputSpec(name=arg, type=arg_type, default=arg_default))
   # Outputs
   outputs = []
@@ -85,14 +93,15 @@ def _extract_component_metadata(func):
 
   # Construct the ComponentSpec
   return ComponentSpec(
-    name=func.__name__,
-    inputs=inputs if inputs else None,
-    outputs=outputs if outputs else None,
+      name=func.__name__,
+      inputs=inputs if inputs else None,
+      outputs=outputs if outputs else None,
   )
 
 
 def _extract_pipeline_metadata(func):
-  '''Creates pipeline metadata structure instance based on the function signature.'''
+  """Creates pipeline metadata structure instance based on the function
+  signature."""
 
   # Importing here to prevent circular import failures
   #TODO: Change _pipeline_param to stop importing _metadata
@@ -106,7 +115,8 @@ def _extract_pipeline_metadata(func):
   # defaults
   arg_defaults = {}
   if fullargspec.defaults:
-    for arg, default in zip(reversed(fullargspec.args), reversed(fullargspec.defaults)):
+    for arg, default in zip(reversed(fullargspec.args),
+                            reversed(fullargspec.defaults)):
       arg_defaults[arg] = default
 
   # Inputs
@@ -115,11 +125,14 @@ def _extract_pipeline_metadata(func):
     arg_type = None
     arg_default = arg_defaults[arg] if arg in arg_defaults else None
     if isinstance(arg_default, PipelineParam):
-      warnings.warn('Explicit creation of `kfp.dsl.PipelineParam`s by the users is deprecated. The users should define the parameter type and default values using standard pythonic constructs: def my_func(a: int = 1, b: str = "default"):')
+      warnings.warn(
+          'Explicit creation of `kfp.dsl.PipelineParam`s by the users is deprecated. The users should define the parameter type and default values using standard pythonic constructs: def my_func(a: int = 1, b: str = "default"):'
+      )
       arg_default = arg_default.value
     if arg in annotations:
       arg_type = _annotation_to_typemeta(annotations[arg])
-    arg_type_properties = list(arg_type.values())[0] if isinstance(arg_type, dict) else {}
+    arg_type_properties = list(arg_type.values()
+                              )[0] if isinstance(arg_type, dict) else {}
     if 'openapi_schema_validator' in arg_type_properties and arg_default is not None:
       from jsonschema import validate
       import json
@@ -130,7 +143,9 @@ def _extract_pipeline_metadata(func):
       # Only validating non-serialized values
       validate(instance=arg_default, schema=schema_object)
     if arg_default is not None:
-      arg_default = serialize_value(arg_default, type_name=str(arg_type) if arg_type else None) # TODO: Improve _annotation_to_typemeta or just replace the whole function with kfp.component._python_op._extract_component_interface
+      arg_default = serialize_value(
+          arg_default, type_name=str(arg_type) if arg_type else None
+      )  # TODO: Improve _annotation_to_typemeta or just replace the whole function with kfp.component._python_op._extract_component_interface
     inputs.append(InputSpec(name=arg, type=arg_type, default=arg_default))
 
   #TODO: add descriptions to the metadata
@@ -140,8 +155,8 @@ def _extract_pipeline_metadata(func):
 
   # Construct the ComponentSpec
   pipeline_meta = ComponentSpec(
-    name=getattr(func, '_pipeline_name', func.__name__),
-    description=getattr(func, '_pipeline_description', func.__doc__),
-    inputs=inputs if inputs else None,
+      name=getattr(func, '_pipeline_name', func.__name__),
+      description=getattr(func, '_pipeline_description', func.__doc__),
+      inputs=inputs if inputs else None,
   )
   return pipeline_meta

--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -12,20 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from . import _container_op
 from . import _resource_op
 from . import _ops_group
 from ..components._naming import _make_name_unique_by_adding_index
 import sys
 
-
 # This handler is called whenever the @pipeline decorator is applied.
 # It can be used by command-line DSL compiler to inject code that runs for every pipeline definition.
 _pipeline_decorator_handler = None
 
 
-def pipeline(name : str = None, description : str = None):
+def pipeline(name: str = None, description: str = None):
   """Decorator of pipeline functions.
 
   Usage:
@@ -37,7 +35,9 @@ def pipeline(name : str = None, description : str = None):
   def my_pipeline(a: PipelineParam, b: PipelineParam):
     ...
   ```
+
   """
+
   def _pipeline(func):
     if name:
       func._pipeline_name = name
@@ -51,9 +51,10 @@ def pipeline(name : str = None, description : str = None):
 
   return _pipeline
 
+
 class PipelineConf():
-  """PipelineConf contains pipeline level settings
-  """
+  """PipelineConf contains pipeline level settings."""
+
   def __init__(self):
     self.image_pull_secrets = []
     self.timeout = 0
@@ -62,21 +63,23 @@ class PipelineConf():
     self.op_transformers = []
 
   def set_image_pull_secrets(self, image_pull_secrets):
-    """Configures the pipeline level imagepullsecret
+    """Configures the pipeline level imagepullsecret.
 
     Args:
       image_pull_secrets: a list of Kubernetes V1LocalObjectReference
       For detailed description, check Kubernetes V1LocalObjectReference definition
       https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1LocalObjectReference.md
+
     """
     self.image_pull_secrets = image_pull_secrets
     return self
 
   def set_timeout(self, seconds: int):
-    """Configures the pipeline level timeout
+    """Configures the pipeline level timeout.
 
     Args:
       seconds: number of seconds for timeout
+
     """
     self.timeout = seconds
     return self
@@ -86,6 +89,7 @@ class PipelineConf():
 
     Args:
       seconds: number of seconds for the workflow to be garbage collected after it is finished.
+
     """
     self.ttl_seconds_after_finished = seconds
     return self
@@ -120,15 +124,18 @@ class PipelineConf():
       For detailed description, check Argo V1alpha1ArtifactLocation definition
       https://github.com/e2fyi/argo-models/blob/release-2.2/argo/models/v1alpha1_artifact_location.py
       https://github.com/argoproj/argo/blob/release-2.2/api/openapi-spec/swagger.json
+
     """
     self.artifact_location = artifact_location
     return self
 
   def add_op_transformer(self, transformer):
-    """Configures the op_transformers which will be applied to all ops in the pipeline.
+    """Configures the op_transformers which will be applied to all ops in the
+    pipeline.
 
     Args:
       transformer: a function that takes a ContainOp as input and returns a ContainerOp
+
     """
     self.op_transformers.append(transformer)
 
@@ -138,6 +145,7 @@ def get_pipeline_conf():
     Note: call the function inside the user defined pipeline function.
   """
   return Pipeline.get_default_pipeline().conf
+
 
 #TODO: Pipeline is in fact an opsgroup, refactor the code.
 class Pipeline():
@@ -154,6 +162,7 @@ class Pipeline():
 
   traverse(p.ops)
   ```
+
   """
 
   # _default_pipeline is set when it (usually a compiler) runs "with Pipeline()"
@@ -161,7 +170,7 @@ class Pipeline():
 
   @staticmethod
   def get_default_pipeline():
-    """Get default pipeline. """
+    """Get default pipeline."""
     return Pipeline._default_pipeline
 
   @staticmethod
@@ -175,6 +184,7 @@ class Pipeline():
 
     Args:
       name: the name of the pipeline. Once deployed, the name will show up in Pipeline System UI.
+
     """
     self.name = name
     self.ops = {}
@@ -209,9 +219,12 @@ class Pipeline():
 
     Returns
       op_name: a unique op name.
+
     """
     #If there is an existing op with this name then generate a new name.
-    op_name = _make_name_unique_by_adding_index(op.human_name, list(self.ops.keys()), ' ')
+    op_name = _make_name_unique_by_adding_index(
+        op.human_name, list(self.ops.keys()), ' '
+    )
 
     self.ops[op_name] = op
     if not define_only:
@@ -224,6 +237,7 @@ class Pipeline():
 
     Args:
       group: An OpsGroup. Typically it is one of ExitHandler, Branch, and Loop.
+
     """
     self.groups[-1].groups.append(group)
     self.groups.append(group)
@@ -237,7 +251,7 @@ class Pipeline():
       group.remove_op_recursive(op)
 
   def get_next_group_id(self):
-    """Get next id for a new group. """
+    """Get next id for a new group."""
 
     self.group_id += 1
     return self.group_id
@@ -248,5 +262,3 @@ class Pipeline():
       metadata (ComponentMeta): component metadata
     '''
     self._metadata = metadata
-
-

--- a/sdk/python/kfp/dsl/_pipeline_volume.py
+++ b/sdk/python/kfp/dsl/_pipeline_volume.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import hashlib
 import json
 
@@ -24,86 +23,86 @@ from . import _pipeline
 
 
 class PipelineVolume(V1Volume):
-    """Representing a volume that is passed between pipeline operators and is
-    to be mounted by a ContainerOp or its inherited type.
+  """Representing a volume that is passed between pipeline operators and is to
+  be mounted by a ContainerOp or its inherited type.
 
-    A PipelineVolume object can be used as an extention of the pipeline
-    function's filesystem. It may then be passed between ContainerOps,
-    exposing dependencies.
+  A PipelineVolume object can be used as an extention of the pipeline function's
+  filesystem. It may then be passed between ContainerOps, exposing dependencies.
+
+  """
+
+  def __init__(self, pvc: str = None, volume: V1Volume = None, **kwargs):
+    """Create a new instance of PipelineVolume.
+
+    Args:
+        pvc: The name of an existing PVC
+        volume: Create a deep copy out of a V1Volume or PipelineVolume
+            with no deps
+    Raises:
+        ValueError: if volume is not None and kwargs is not None
+                    if pvc is not None and kwargs.pop("name") is not None
+
     """
-    def __init__(self,
-                 pvc: str = None,
-                 volume: V1Volume = None,
-                 **kwargs):
-        """Create a new instance of PipelineVolume.
+    if volume and kwargs:
+      raise ValueError("You can't pass a volume along with other " "kwargs.")
 
-        Args:
-            pvc: The name of an existing PVC
-            volume: Create a deep copy out of a V1Volume or PipelineVolume
-                with no deps
-        Raises:
-            ValueError: if volume is not None and kwargs is not None
-                        if pvc is not None and kwargs.pop("name") is not None
-        """
-        if volume and kwargs:
-            raise ValueError("You can't pass a volume along with other "
-                             "kwargs.")
+    name_provided = True
+    init_volume = {}
+    if volume:
+      init_volume = {
+          attr: getattr(volume, attr) for attr in self.attribute_map.keys()
+      }
+    else:
+      if "name" in kwargs:
+        init_volume = {"name": kwargs.pop("name")}
+      else:
+        name_provided = False
+        init_volume = {"name": "pvolume-placeholder"}
+      if pvc and kwargs:
+        raise ValueError("You can only pass 'name' along with 'pvc'.")
+      elif pvc and not kwargs:
+        pvc_volume_source = V1PersistentVolumeClaimVolumeSource(
+            claim_name=str(pvc)
+        )
+        init_volume["persistent_volume_claim"] = pvc_volume_source
+    super().__init__(**init_volume, **kwargs)
+    if not name_provided:
+      self.name = "pvolume-%s" % hashlib.sha256(
+          bytes(json.dumps(self.to_dict(), sort_keys=True), "utf-8")
+      ).hexdigest()
+    self.dependent_names = []
 
-        name_provided = True
-        init_volume = {}
-        if volume:
-            init_volume = {attr: getattr(volume, attr)
-                           for attr in self.attribute_map.keys()}
-        else:
-            if "name" in kwargs:
-                init_volume = {"name": kwargs.pop("name")}
-            else:
-                name_provided = False
-                init_volume = {"name": "pvolume-placeholder"}
-            if pvc and kwargs:
-                raise ValueError("You can only pass 'name' along with 'pvc'.")
-            elif pvc and not kwargs:
-                pvc_volume_source = V1PersistentVolumeClaimVolumeSource(
-                    claim_name=str(pvc)
-                )
-                init_volume["persistent_volume_claim"] = pvc_volume_source
-        super().__init__(**init_volume, **kwargs)
-        if not name_provided:
-            self.name = "pvolume-%s" % hashlib.sha256(
-                bytes(json.dumps(self.to_dict(), sort_keys=True), "utf-8")
-            ).hexdigest()
-        self.dependent_names = []
-
-    def after(self, *ops):
-        """Creates a duplicate of self with the required dependecies excluding
+  def after(self, *ops):
+    """Creates a duplicate of self with the required dependecies excluding
         the redundant dependenices.
         Args:
             *ops: Pipeline operators to add as dependencies
         """
-        def implies(newdep, olddep):
-            if newdep.name == olddep:
-                return True
-            for parentdep_name in newdep.dependent_names:
-                if parentdep_name == olddep:
-                    return True
-                else:
-                    parentdep = _pipeline.Pipeline.get_default_pipeline(
-                    ).ops[parentdep_name]
-                    if parentdep:
-                        if implies(parentdep, olddep):
-                            return True
-            return False
 
-        ret = self.__class__(volume=self)
-        ret.dependent_names = [op.name for op in ops]
+    def implies(newdep, olddep):
+      if newdep.name == olddep:
+        return True
+      for parentdep_name in newdep.dependent_names:
+        if parentdep_name == olddep:
+          return True
+        else:
+          parentdep = _pipeline.Pipeline.get_default_pipeline(
+          ).ops[parentdep_name]
+          if parentdep:
+            if implies(parentdep, olddep):
+              return True
+      return False
 
-        for olddep in self.dependent_names:
-            implied = False
-            for newdep in ops:
-                implied = implies(newdep, olddep)
-                if implied:
-                    break
-            if not implied:
-                ret.dependent_names.append(olddep)
+    ret = self.__class__(volume=self)
+    ret.dependent_names = [op.name for op in ops]
 
-        return ret
+    for olddep in self.dependent_names:
+      implied = False
+      for newdep in ops:
+        implied = implies(newdep, olddep)
+        if implied:
+          break
+      if not implied:
+        ret.dependent_names.append(olddep)
+
+    return ret

--- a/sdk/python/kfp/dsl/_resource_op.py
+++ b/sdk/python/kfp/dsl/_resource_op.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from typing import Dict
 
 from ._container_op import BaseOp
@@ -20,141 +19,146 @@ from . import _pipeline_param
 
 
 class Resource(object):
-    """
-    A wrapper over Argo ResourceTemplate definition object
-    (io.argoproj.workflow.v1alpha1.ResourceTemplate)
-    which is used to represent the `resource` property in argo's workflow
-    template (io.argoproj.workflow.v1alpha1.Template).
-    """
-    """
+  """A wrapper over Argo ResourceTemplate definition object
+  (io.argoproj.workflow.v1alpha1.ResourceTemplate) which is used to represent
+  the `resource` property in argo's workflow template
+  (io.argoproj.workflow.v1alpha1.Template)."""
+  """
     Attributes:
       swagger_types (dict): The key is attribute name
                             and the value is attribute type.
       attribute_map (dict): The key is attribute name
                             and the value is json key in definition.
     """
-    swagger_types = {
-        "action": "str",
-        "merge_strategy": "str",
-        "success_condition": "str",
-        "failure_condition": "str",
-        "manifest": "str"
-    }
-    attribute_map = {
-        "action": "action",
-        "merge_strategy": "mergeStrategy",
-        "success_condition": "successCondition",
-        "failure_condition": "failureCondition",
-        "manifest": "manifest"
-    }
+  swagger_types = {
+      "action": "str",
+      "merge_strategy": "str",
+      "success_condition": "str",
+      "failure_condition": "str",
+      "manifest": "str"
+  }
+  attribute_map = {
+      "action": "action",
+      "merge_strategy": "mergeStrategy",
+      "success_condition": "successCondition",
+      "failure_condition": "failureCondition",
+      "manifest": "manifest"
+  }
 
-    def __init__(self,
-                 action: str = None,
-                 merge_strategy: str = None,
-                 success_condition: str = None,
-                 failure_condition: str = None,
-                 manifest: str = None):
-        """Create a new instance of Resource"""
-        self.action = action
-        self.merge_strategy = merge_strategy
-        self.success_condition = success_condition
-        self.failure_condition = failure_condition
-        self.manifest = manifest
+  def __init__(
+      self,
+      action: str = None,
+      merge_strategy: str = None,
+      success_condition: str = None,
+      failure_condition: str = None,
+      manifest: str = None
+  ):
+    """Create a new instance of Resource."""
+    self.action = action
+    self.merge_strategy = merge_strategy
+    self.success_condition = success_condition
+    self.failure_condition = failure_condition
+    self.manifest = manifest
 
 
 class ResourceOp(BaseOp):
-    """Represents an op which will be translated into a resource template"""
+  """Represents an op which will be translated into a resource template."""
 
-    def __init__(self,
-                 k8s_resource=None,
-                 action: str = "create",
-                 merge_strategy: str = None,
-                 success_condition: str = None,
-                 failure_condition: str = None,
-                 attribute_outputs: Dict[str, str] = None,
-                 **kwargs):
-        """Create a new instance of ResourceOp.
+  def __init__(
+      self,
+      k8s_resource=None,
+      action: str = "create",
+      merge_strategy: str = None,
+      success_condition: str = None,
+      failure_condition: str = None,
+      attribute_outputs: Dict[str, str] = None,
+      **kwargs
+  ):
+    """Create a new instance of ResourceOp.
 
-        Args:
-            k8s_resource: A k8s resource which will be submitted to the cluster
-            action: One of "create"/"delete"/"apply"/"patch"
-                (default is "create")
-            merge_strategy: The merge strategy for the "apply" action
-            success_condition: The successCondition of the template
-            failure_condition: The failureCondition of the template
-                For more info see:
-                https://github.com/argoproj/argo/blob/master/examples/k8s-jobs.yaml
-            attribute_outputs: Maps output labels to resource's json paths,
-                similarly to file_outputs of ContainerOp
-            kwargs: name, sidecars. See BaseOp definition
-        Raises:
-        ValueError: if not inside a pipeline
-                    if the name is an invalid string
-                    if no k8s_resource is provided
-                    if merge_strategy is set without "apply" action
-        """
+    Args:
+        k8s_resource: A k8s resource which will be submitted to the cluster
+        action: One of "create"/"delete"/"apply"/"patch"
+            (default is "create")
+        merge_strategy: The merge strategy for the "apply" action
+        success_condition: The successCondition of the template
+        failure_condition: The failureCondition of the template
+            For more info see:
+            https://github.com/argoproj/argo/blob/master/examples/k8s-jobs.yaml
+        attribute_outputs: Maps output labels to resource's json paths,
+            similarly to file_outputs of ContainerOp
+        kwargs: name, sidecars. See BaseOp definition
+    Raises:
+    ValueError: if not inside a pipeline
+                if the name is an invalid string
+                if no k8s_resource is provided
+                if merge_strategy is set without "apply" action
 
-        super().__init__(**kwargs)
-        self.attrs_with_pipelineparams = list(self.attrs_with_pipelineparams)
-        self.attrs_with_pipelineparams.extend([
-            "_resource", "k8s_resource", "attribute_outputs"
-        ])
+    """
 
-        if k8s_resource is None:
-            ValueError("You need to provide a k8s_resource.")
+    super().__init__(**kwargs)
+    self.attrs_with_pipelineparams = list(self.attrs_with_pipelineparams)
+    self.attrs_with_pipelineparams.extend([
+        "_resource", "k8s_resource", "attribute_outputs"
+    ])
 
-        if merge_strategy and action != "apply":
-            ValueError("You can't set merge_strategy when action != 'apply'")
-        
-        # if action is delete, there should not be any outputs, success_condition, and failure_condition
-        if action == "delete" and (success_condition or failure_condition or attribute_outputs):
-            ValueError("You can't set success_condition, failure_condition, or attribute_outputs when action == 'delete'")
+    if k8s_resource is None:
+      ValueError("You need to provide a k8s_resource.")
 
-        init_resource = {
-            "action": action,
-            "merge_strategy": merge_strategy,
-            "success_condition": success_condition,
-            "failure_condition": failure_condition
-        }
-        # `resource` prop in `io.argoproj.workflow.v1alpha1.Template`
-        self._resource = Resource(**init_resource)
+    if merge_strategy and action != "apply":
+      ValueError("You can't set merge_strategy when action != 'apply'")
 
-        self.k8s_resource = k8s_resource
+    # if action is delete, there should not be any outputs, success_condition, and failure_condition
+    if action == "delete" and (success_condition or failure_condition or
+                               attribute_outputs):
+      ValueError(
+          "You can't set success_condition, failure_condition, or attribute_outputs when action == 'delete'"
+      )
 
-        # if action is delete, there should not be any outputs, success_condition, and failure_condition
-        if action == "delete":
-            self.attribute_outputs = {}
-            self.outputs = {}
-            self.output = None
-            return
+    init_resource = {
+        "action": action,
+        "merge_strategy": merge_strategy,
+        "success_condition": success_condition,
+        "failure_condition": failure_condition
+    }
+    # `resource` prop in `io.argoproj.workflow.v1alpha1.Template`
+    self._resource = Resource(**init_resource)
 
-        # Set attribute_outputs
-        extra_attribute_outputs = \
-            attribute_outputs if attribute_outputs else {}
-        self.attribute_outputs = \
-            self.attribute_outputs if hasattr(self, "attribute_outputs") \
-            else {}
-        self.attribute_outputs.update(extra_attribute_outputs)
-        # Add name and manifest if not specified by the user
-        if "name" not in self.attribute_outputs:
-            self.attribute_outputs["name"] = "{.metadata.name}"
-        if "manifest" not in self.attribute_outputs:
-            self.attribute_outputs["manifest"] = "{}"
+    self.k8s_resource = k8s_resource
 
-        # Set outputs
-        self.outputs = {
-            name: _pipeline_param.PipelineParam(name, op_name=self.name)
-            for name in self.attribute_outputs.keys()
-        }
-        # If user set a single attribute_output, set self.output as that
-        # parameter, else set it as the resource name
-        self.output = self.outputs["name"]
-        if len(extra_attribute_outputs) == 1:
-            self.output = self.outputs[list(extra_attribute_outputs)[0]]
+    # if action is delete, there should not be any outputs, success_condition, and failure_condition
+    if action == "delete":
+      self.attribute_outputs = {}
+      self.outputs = {}
+      self.output = None
+      return
 
-    @property
-    def resource(self):
-        """`Resource` object that represents the `resource` property in
-        `io.argoproj.workflow.v1alpha1.Template`.
-        """
-        return self._resource
+    # Set attribute_outputs
+    extra_attribute_outputs = \
+        attribute_outputs if attribute_outputs else {}
+    self.attribute_outputs = \
+        self.attribute_outputs if hasattr(self, "attribute_outputs") \
+        else {}
+    self.attribute_outputs.update(extra_attribute_outputs)
+    # Add name and manifest if not specified by the user
+    if "name" not in self.attribute_outputs:
+      self.attribute_outputs["name"] = "{.metadata.name}"
+    if "manifest" not in self.attribute_outputs:
+      self.attribute_outputs["manifest"] = "{}"
+
+    # Set outputs
+    self.outputs = {
+        name: _pipeline_param.PipelineParam(name, op_name=self.name)
+        for name in self.attribute_outputs.keys()
+    }
+    # If user set a single attribute_output, set self.output as that
+    # parameter, else set it as the resource name
+    self.output = self.outputs["name"]
+    if len(extra_attribute_outputs) == 1:
+      self.output = self.outputs[list(extra_attribute_outputs)[0]]
+
+  @property
+  def resource(self):
+    """`Resource` object that represents the `resource` property in
+    `io.argoproj.workflow.v1alpha1.Template`."""
+    return self._resource

--- a/sdk/python/kfp/dsl/_volume_op.py
+++ b/sdk/python/kfp/dsl/_volume_op.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import re
 from typing import List, Dict
 from kubernetes.client.models import (
@@ -26,117 +25,120 @@ from ._pipeline_param import (
 )
 from ._pipeline_volume import PipelineVolume
 
-
 VOLUME_MODE_RWO = ["ReadWriteOnce"]
 VOLUME_MODE_RWM = ["ReadWriteMany"]
 VOLUME_MODE_ROM = ["ReadOnlyMany"]
 
 
 class VolumeOp(ResourceOp):
-    """Represents an op which will be translated into a resource template
-    which will be creating a PVC.
+  """Represents an op which will be translated into a resource template which
+  will be creating a PVC."""
+
+  def __init__(
+      self,
+      resource_name: str = None,
+      size: str = None,
+      storage_class: str = None,
+      modes: List[str] = None,
+      annotations: Dict[str, str] = None,
+      data_source=None,
+      **kwargs
+  ):
+    """Create a new instance of VolumeOp.
+
+    Args:
+        resource_name: A desired name for the PVC which will be created
+        size: The size of the PVC which will be created
+        storage_class: The storage class to use for the dynamically created
+            PVC
+        modes: The access modes for the PVC
+        annotations: Annotations to be patched in the PVC
+        data_source: May be a V1TypedLocalObjectReference, and then it is
+            used in the data_source field of the PVC as is. Can also be a
+            string/PipelineParam, and in that case it will be used as a
+            VolumeSnapshot name (Alpha feature)
+        kwargs: See ResourceOp definition
+    Raises:
+        ValueError: if k8s_resource is provided along with other arguments
+                    if k8s_resource is not a V1PersistentVolumeClaim
+                    if size is None
+                    if size is an invalid memory string (when not a
+                        PipelineParam)
+                    if data_source is not one of (str, PipelineParam,
+                        V1TypedLocalObjectReference)
+
     """
+    # Add size to attribute outputs
+    self.attribute_outputs = {"size": "{.status.capacity.storage}"}
 
-    def __init__(self,
-                 resource_name: str = None,
-                 size: str = None,
-                 storage_class: str = None,
-                 modes: List[str] = None,
-                 annotations: Dict[str, str] = None,
-                 data_source=None,
-                 **kwargs):
-        """Create a new instance of VolumeOp.
-
-        Args:
-            resource_name: A desired name for the PVC which will be created
-            size: The size of the PVC which will be created
-            storage_class: The storage class to use for the dynamically created
-                PVC
-            modes: The access modes for the PVC
-            annotations: Annotations to be patched in the PVC
-            data_source: May be a V1TypedLocalObjectReference, and then it is
-                used in the data_source field of the PVC as is. Can also be a
-                string/PipelineParam, and in that case it will be used as a
-                VolumeSnapshot name (Alpha feature)
-            kwargs: See ResourceOp definition
-        Raises:
-            ValueError: if k8s_resource is provided along with other arguments
-                        if k8s_resource is not a V1PersistentVolumeClaim
-                        if size is None
-                        if size is an invalid memory string (when not a
-                            PipelineParam)
-                        if data_source is not one of (str, PipelineParam,
-                            V1TypedLocalObjectReference)
-        """
-        # Add size to attribute outputs
-        self.attribute_outputs = {"size": "{.status.capacity.storage}"}
-
-        if "k8s_resource" in kwargs:
-            if resource_name or size or storage_class or modes or annotations:
-                raise ValueError("You cannot provide k8s_resource along with "
-                                 "other arguments.")
-            if not isinstance(kwargs["k8s_resource"], V1PersistentVolumeClaim):
-                raise ValueError("k8s_resource in VolumeOp must be an instance"
-                                 " of V1PersistentVolumeClaim")
-            super().__init__(**kwargs)
-            self.volume = PipelineVolume(
-                name=sanitize_k8s_name(self.name),
-                pvc=self.outputs["name"]
-            )
-            return
-
-        if not size:
-            raise ValueError("Please provide size")
-        elif not match_serialized_pipelineparam(str(size)):
-            self._validate_memory_string(size)
-
-        if data_source and not isinstance(
-           data_source, (str, PipelineParam, V1TypedLocalObjectReference)):
-            raise ValueError("data_source can be one of (str, PipelineParam, "
-                             "V1TypedLocalObjectReference).")
-        if data_source and isinstance(data_source, (str, PipelineParam)):
-            data_source = V1TypedLocalObjectReference(
-                api_group="snapshot.storage.k8s.io",
-                kind="VolumeSnapshot",
-                name=data_source
-            )
-
-        # Set the k8s_resource
-        if not match_serialized_pipelineparam(str(resource_name)):
-            resource_name = sanitize_k8s_name(resource_name)
-        pvc_metadata = V1ObjectMeta(
-            name="{{workflow.name}}-%s" % resource_name,
-            annotations=annotations
+    if "k8s_resource" in kwargs:
+      if resource_name or size or storage_class or modes or annotations:
+        raise ValueError(
+            "You cannot provide k8s_resource along with "
+            "other arguments."
         )
-        requested_resources = V1ResourceRequirements(
-            requests={"storage": size}
+      if not isinstance(kwargs["k8s_resource"], V1PersistentVolumeClaim):
+        raise ValueError(
+            "k8s_resource in VolumeOp must be an instance"
+            " of V1PersistentVolumeClaim"
         )
-        pvc_spec = V1PersistentVolumeClaimSpec(
-            access_modes=modes or VOLUME_MODE_RWM,
-            resources=requested_resources,
-            storage_class_name=storage_class,
-            data_source=data_source
-        )
-        k8s_resource = V1PersistentVolumeClaim(
-            api_version="v1",
-            kind="PersistentVolumeClaim",
-            metadata=pvc_metadata,
-            spec=pvc_spec
-        )
+      super().__init__(**kwargs)
+      self.volume = PipelineVolume(
+          name=sanitize_k8s_name(self.name), pvc=self.outputs["name"]
+      )
+      return
 
-        super().__init__(
-            k8s_resource=k8s_resource,
-            **kwargs,
-        )
-        self.volume = PipelineVolume(
-            name=sanitize_k8s_name(self.name),
-            pvc=self.outputs["name"]
-        )
+    if not size:
+      raise ValueError("Please provide size")
+    elif not match_serialized_pipelineparam(str(size)):
+      self._validate_memory_string(size)
 
-    def _validate_memory_string(self, memory_string):
-        """Validate a given string is valid for memory request or limit."""
-        if re.match(r'^[0-9]+(E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki){0,1}$',
-                    memory_string) is None:
-            raise ValueError('Invalid memory string. Should be an integer, ' +
-                             'or integer followed by one of ' +
-                             '"E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki"')
+    if data_source and not isinstance(
+        data_source, (str, PipelineParam, V1TypedLocalObjectReference)):
+      raise ValueError(
+          "data_source can be one of (str, PipelineParam, "
+          "V1TypedLocalObjectReference)."
+      )
+    if data_source and isinstance(data_source, (str, PipelineParam)):
+      data_source = V1TypedLocalObjectReference(
+          api_group="snapshot.storage.k8s.io",
+          kind="VolumeSnapshot",
+          name=data_source
+      )
+
+    # Set the k8s_resource
+    if not match_serialized_pipelineparam(str(resource_name)):
+      resource_name = sanitize_k8s_name(resource_name)
+    pvc_metadata = V1ObjectMeta(
+        name="{{workflow.name}}-%s" % resource_name, annotations=annotations
+    )
+    requested_resources = V1ResourceRequirements(requests={"storage": size})
+    pvc_spec = V1PersistentVolumeClaimSpec(
+        access_modes=modes or VOLUME_MODE_RWM,
+        resources=requested_resources,
+        storage_class_name=storage_class,
+        data_source=data_source
+    )
+    k8s_resource = V1PersistentVolumeClaim(
+        api_version="v1",
+        kind="PersistentVolumeClaim",
+        metadata=pvc_metadata,
+        spec=pvc_spec
+    )
+
+    super().__init__(
+        k8s_resource=k8s_resource,
+        **kwargs,
+    )
+    self.volume = PipelineVolume(
+        name=sanitize_k8s_name(self.name), pvc=self.outputs["name"]
+    )
+
+  def _validate_memory_string(self, memory_string):
+    """Validate a given string is valid for memory request or limit."""
+    if re.match(r'^[0-9]+(E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki){0,1}$',
+                memory_string) is None:
+      raise ValueError(
+          'Invalid memory string. Should be an integer, ' +
+          'or integer followed by one of ' + '"E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki"'
+      )

--- a/sdk/python/kfp/dsl/_volume_snapshot_op.py
+++ b/sdk/python/kfp/dsl/_volume_snapshot_op.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from typing import Dict
 from kubernetes.client.models import (
     V1Volume, V1TypedLocalObjectReference, V1ObjectMeta
@@ -23,104 +22,107 @@ from ._pipeline_param import match_serialized_pipelineparam, sanitize_k8s_name
 
 
 class VolumeSnapshotOp(ResourceOp):
-    """Represents an op which will be translated into a resource template
-    which will be creating a VolumeSnapshot.
+  """Represents an op which will be translated into a resource template which
+  will be creating a VolumeSnapshot.
 
-    At the time that this feature is written, VolumeSnapshots are an Alpha
-    feature in Kubernetes. You should check with your Kubernetes Cluster admin
-    if they have it enabled.
+  At the time that this feature is written, VolumeSnapshots are an Alpha feature
+  in Kubernetes. You should check with your Kubernetes Cluster admin if they
+  have it enabled.
+
+  """
+
+  def __init__(
+      self,
+      resource_name: str = None,
+      pvc: str = None,
+      snapshot_class: str = None,
+      annotations: Dict[str, str] = None,
+      volume: V1Volume = None,
+      **kwargs
+  ):
+    """Create a new instance of VolumeSnapshotOp.
+
+    Args:
+        resource_name: A desired name for the VolumeSnapshot which will be
+            created
+        pvc: The name of the PVC which will be snapshotted
+        snapshot_class: The snapshot class to use for the dynamically
+            created VolumeSnapshot
+        annotations: Annotations to be patched in the VolumeSnapshot
+        volume: An instance of V1Volume
+        kwargs: See ResourceOp definition
+    Raises:
+        ValueError: if k8s_resource is provided along with other arguments
+                    if k8s_resource is not a VolumeSnapshot
+                    if pvc and volume are None
+                    if pvc and volume are not None
+                    if volume does not reference a PVC
+
     """
+    # Add size to output params
+    self.attribute_outputs = {"size": "{.status.restoreSize}"}
+    # Add default success_condition if None provided
+    if "success_condition" not in kwargs:
+      kwargs["success_condition"] = "status.readyToUse == true"
 
-    def __init__(self,
-                 resource_name: str = None,
-                 pvc: str = None,
-                 snapshot_class: str = None,
-                 annotations: Dict[str, str] = None,
-                 volume: V1Volume = None,
-                 **kwargs):
-        """Create a new instance of VolumeSnapshotOp.
-
-        Args:
-            resource_name: A desired name for the VolumeSnapshot which will be
-                created
-            pvc: The name of the PVC which will be snapshotted
-            snapshot_class: The snapshot class to use for the dynamically
-                created VolumeSnapshot
-            annotations: Annotations to be patched in the VolumeSnapshot
-            volume: An instance of V1Volume
-            kwargs: See ResourceOp definition
-        Raises:
-            ValueError: if k8s_resource is provided along with other arguments
-                        if k8s_resource is not a VolumeSnapshot
-                        if pvc and volume are None
-                        if pvc and volume are not None
-                        if volume does not reference a PVC
-        """
-        # Add size to output params
-        self.attribute_outputs = {"size": "{.status.restoreSize}"}
-        # Add default success_condition if None provided
-        if "success_condition" not in kwargs:
-            kwargs["success_condition"] = "status.readyToUse == true"
-
-        if "k8s_resource" in kwargs:
-            if resource_name or pvc or snapshot_class or annotations or volume:
-                raise ValueError("You cannot provide k8s_resource along with "
-                                 "other arguments.")
-            # TODO: Check if is VolumeSnapshot
-            super().__init__(**kwargs)
-            self.snapshot = V1TypedLocalObjectReference(
-                api_group="snapshot.storage.k8s.io",
-                kind="VolumeSnapshot",
-                name=self.outputs["name"]
-            )
-            return
-
-        if not (pvc or volume):
-            raise ValueError("You must provide a pvc or a volume.")
-        elif pvc and volume:
-            raise ValueError("You can't provide both pvc and volume.")
-
-        source = None
-        deps = []
-        if pvc:
-            source = V1TypedLocalObjectReference(
-                kind="PersistentVolumeClaim",
-                name=pvc
-            )
-        else:
-            if not hasattr(volume, "persistent_volume_claim"):
-                raise ValueError("The volume must be referencing a PVC.")
-            if hasattr(volume, "dependent_names"): #TODO: Replace with type check
-                deps = list(volume.dependent_names)
-            source = V1TypedLocalObjectReference(
-                kind="PersistentVolumeClaim",
-                name=volume.persistent_volume_claim.claim_name
-            )
-
-        # Set the k8s_resource
-        # TODO: Use VolumeSnapshot
-        if not match_serialized_pipelineparam(str(resource_name)):
-            resource_name = sanitize_k8s_name(resource_name)
-        snapshot_metadata = V1ObjectMeta(
-            name="{{workflow.name}}-%s" % resource_name,
-            annotations=annotations
+    if "k8s_resource" in kwargs:
+      if resource_name or pvc or snapshot_class or annotations or volume:
+        raise ValueError(
+            "You cannot provide k8s_resource along with "
+            "other arguments."
         )
-        k8s_resource = {
-            "apiVersion": "snapshot.storage.k8s.io/v1alpha1",
-            "kind": "VolumeSnapshot",
-            "metadata": snapshot_metadata,
-            "spec": {"source": source}
+      # TODO: Check if is VolumeSnapshot
+      super().__init__(**kwargs)
+      self.snapshot = V1TypedLocalObjectReference(
+          api_group="snapshot.storage.k8s.io",
+          kind="VolumeSnapshot",
+          name=self.outputs["name"]
+      )
+      return
+
+    if not (pvc or volume):
+      raise ValueError("You must provide a pvc or a volume.")
+    elif pvc and volume:
+      raise ValueError("You can't provide both pvc and volume.")
+
+    source = None
+    deps = []
+    if pvc:
+      source = V1TypedLocalObjectReference(
+          kind="PersistentVolumeClaim", name=pvc
+      )
+    else:
+      if not hasattr(volume, "persistent_volume_claim"):
+        raise ValueError("The volume must be referencing a PVC.")
+      if hasattr(volume, "dependent_names"):  #TODO: Replace with type check
+        deps = list(volume.dependent_names)
+      source = V1TypedLocalObjectReference(
+          kind="PersistentVolumeClaim",
+          name=volume.persistent_volume_claim.claim_name
+      )
+
+    # Set the k8s_resource
+    # TODO: Use VolumeSnapshot
+    if not match_serialized_pipelineparam(str(resource_name)):
+      resource_name = sanitize_k8s_name(resource_name)
+    snapshot_metadata = V1ObjectMeta(
+        name="{{workflow.name}}-%s" % resource_name, annotations=annotations
+    )
+    k8s_resource = {
+        "apiVersion": "snapshot.storage.k8s.io/v1alpha1",
+        "kind": "VolumeSnapshot",
+        "metadata": snapshot_metadata,
+        "spec": {
+            "source": source
         }
-        if snapshot_class:
-            k8s_resource["spec"]["snapshotClassName"] = snapshot_class
+    }
+    if snapshot_class:
+      k8s_resource["spec"]["snapshotClassName"] = snapshot_class
 
-        super().__init__(
-            k8s_resource=k8s_resource,
-            **kwargs
-        )
-        self.dependent_names.extend(deps)
-        self.snapshot = V1TypedLocalObjectReference(
-            api_group="snapshot.storage.k8s.io",
-            kind="VolumeSnapshot",
-            name=self.outputs["name"]
-        )
+    super().__init__(k8s_resource=k8s_resource, **kwargs)
+    self.dependent_names.extend(deps)
+    self.snapshot = V1TypedLocalObjectReference(
+        api_group="snapshot.storage.k8s.io",
+        kind="VolumeSnapshot",
+        name=self.outputs["name"]
+    )

--- a/sdk/python/kfp/dsl/types.py
+++ b/sdk/python/kfp/dsl/types.py
@@ -17,187 +17,215 @@ import warnings
 
 
 class BaseType:
-	'''MetaType is a base type for all scalar and artifact types.
-	'''
-	pass
+  """MetaType is a base type for all scalar and artifact types."""
+  pass
+
 
 # Primitive Types
 class Integer(BaseType):
-	def __init__(self):
-		self.openapi_schema_validator = {
-			"type": "integer"
-		}
+
+  def __init__(self):
+    self.openapi_schema_validator = {"type": "integer"}
+
 
 class String(BaseType):
-	def __init__(self):
-		self.openapi_schema_validator = {
-			"type": "string"
-		}
+
+  def __init__(self):
+    self.openapi_schema_validator = {"type": "string"}
+
 
 class Float(BaseType):
-	def __init__(self):
-		self.openapi_schema_validator = {
-			"type": "number"
-		}
+
+  def __init__(self):
+    self.openapi_schema_validator = {"type": "number"}
+
 
 class Bool(BaseType):
-	def __init__(self):
-		self.openapi_schema_validator = {
-			"type": "boolean"
-		}
+
+  def __init__(self):
+    self.openapi_schema_validator = {"type": "boolean"}
+
 
 class List(BaseType):
-	def __init__(self):
-		self.openapi_schema_validator = {
-			"type": "array"
-		}
+
+  def __init__(self):
+    self.openapi_schema_validator = {"type": "array"}
+
 
 class Dict(BaseType):
-	def __init__(self):
-		self.openapi_schema_validator = {
-			"type": "object",
-		}
+
+  def __init__(self):
+    self.openapi_schema_validator = {
+        "type": "object",
+    }
+
 
 # GCP Types
 class GCSPath(BaseType):
-	def __init__(self):
-		self.openapi_schema_validator = {
-			"type": "string",
-			"pattern": "^gs://.*$"
-		}
+
+  def __init__(self):
+    self.openapi_schema_validator = {"type": "string", "pattern": "^gs://.*$"}
+
 
 class GCRPath(BaseType):
-	def __init__(self):
-		self.openapi_schema_validator = {
-			"type": "string",
-			"pattern": "^.*gcr\\.io/.*$"
-		}
+
+  def __init__(self):
+    self.openapi_schema_validator = {
+        "type": "string",
+        "pattern": "^.*gcr\\.io/.*$"
+    }
+
 
 class GCPRegion(BaseType):
-	def __init__(self):
-		self.openapi_schema_validator = {
-			"type": "string"
-		}
+
+  def __init__(self):
+    self.openapi_schema_validator = {"type": "string"}
+
 
 class GCPProjectID(BaseType):
-	'''MetaGCPProjectID: GCP project id'''
-	def __init__(self):
-		self.openapi_schema_validator = {
-			"type": "string"
-		}
+  '''MetaGCPProjectID: GCP project id'''
+
+  def __init__(self):
+    self.openapi_schema_validator = {"type": "string"}
+
 
 # General Types
 class LocalPath(BaseType):
-	#TODO: add restriction to path
-	def __init__(self):
-		self.openapi_schema_validator = {
-			"type": "string"
-		}
+  #TODO: add restriction to path
+  def __init__(self):
+    self.openapi_schema_validator = {"type": "string"}
+
 
 class InconsistentTypeException(Exception):
-	'''InconsistencyTypeException is raised when two types are not consistent'''
-	pass
+  """InconsistencyTypeException is raised when two types are not consistent."""
+  pass
 
 
 class InconsistentTypeWarning(Warning):
-	'''InconsistentTypeWarning is issued when two types are not consistent'''
-	pass
+  """InconsistentTypeWarning is issued when two types are not consistent."""
+  pass
 
 
 TypeSpecType = Union[str, Dict]
 
 
-def verify_type_compatibility(given_type: TypeSpecType, expected_type: TypeSpecType, error_message_prefix : str = ''):
-	'''verify_type_compatibility verifies that the given argument type is compatible with the expected input type.
-	Args:
-		given_type (str/dict): The type of the argument passed to the input
-		expected_type (str/dict): The declared type of the input
-	'''
-	if given_type is None or expected_type is None:
-		return True # Missing types are treated as being compatible with any types
+def verify_type_compatibility(
+    given_type: TypeSpecType,
+    expected_type: TypeSpecType,
+    error_message_prefix: str = ''
+):
+  """verify_type_compatibility verifies that the given argument type is
+  compatible with the expected input type.
 
-	types_are_compatible = check_types(given_type, expected_type)
+  Args:
+          given_type (str/dict): The type of the argument passed to the input
+          expected_type (str/dict): The declared type of the input
 
-	if not types_are_compatible:
-		error_text = error_message_prefix + 'Argument type "{}" is incompatible with the input type "{}"'.format(str(given_type), str(expected_type))
-		import kfp
-		if kfp.TYPE_CHECK:
-			raise InconsistentTypeException(error_text)
-		else:
-			warnings.warn(InconsistentTypeWarning(error_text))
-	return types_are_compatible
+  """
+  if given_type is None or expected_type is None:
+    return True  # Missing types are treated as being compatible with any types
+
+  types_are_compatible = check_types(given_type, expected_type)
+
+  if not types_are_compatible:
+    error_text = error_message_prefix + 'Argument type "{}" is incompatible with the input type "{}"'.format(
+        str(given_type), str(expected_type)
+    )
+    import kfp
+    if kfp.TYPE_CHECK:
+      raise InconsistentTypeException(error_text)
+    else:
+      warnings.warn(InconsistentTypeWarning(error_text))
+  return types_are_compatible
 
 
 def check_types(checked_type, expected_type):
-	'''check_types checks the type consistency.
-	For each of the attribute in checked_type, there is the same attribute in expected_type with the same value.
-	However, expected_type could contain more attributes that checked_type does not contain.
-	Args:
-		checked_type (BaseType/str/dict): it describes a type from the upstream component output
-		expected_type (BaseType/str/dict): it describes a type from the downstream component input
-		'''
-	if isinstance(checked_type, BaseType):
-		checked_type = _instance_to_dict(checked_type)
-	elif isinstance(checked_type, str):
-		checked_type = {checked_type: {}}
-	if isinstance(expected_type, BaseType):
-		expected_type = _instance_to_dict(expected_type)
-	elif isinstance(expected_type, str):
-		expected_type = {expected_type: {}}
-	return _check_dict_types(checked_type, expected_type)
+  """check_types checks the type consistency.
+
+  For each of the attribute in checked_type, there is the same attribute in expected_type with the same value.
+  However, expected_type could contain more attributes that checked_type does not contain.
+  Args:
+          checked_type (BaseType/str/dict): it describes a type from the upstream component output
+          expected_type (BaseType/str/dict): it describes a type from the downstream component input
+
+  """
+  if isinstance(checked_type, BaseType):
+    checked_type = _instance_to_dict(checked_type)
+  elif isinstance(checked_type, str):
+    checked_type = {checked_type: {}}
+  if isinstance(expected_type, BaseType):
+    expected_type = _instance_to_dict(expected_type)
+  elif isinstance(expected_type, str):
+    expected_type = {expected_type: {}}
+  return _check_dict_types(checked_type, expected_type)
+
 
 def _check_valid_type_dict(payload):
-	'''_check_valid_type_dict checks whether a dict is a correct serialization of a type
+  '''_check_valid_type_dict checks whether a dict is a correct serialization of a type
 	Args:
 		payload(dict)
 	'''
-	if not isinstance(payload, dict) or len(payload) != 1:
-		return False
-	for type_name in payload:
-		if not isinstance(payload[type_name], dict):
-			return False
-		property_types = (int, str, float, bool)
-		property_value_types = (int, str, float, bool, dict)
-		for property_name in payload[type_name]:
-			if not isinstance(property_name, property_types) or not isinstance(payload[type_name][property_name], property_value_types):
-				return False
-	return True
+  if not isinstance(payload, dict) or len(payload) != 1:
+    return False
+  for type_name in payload:
+    if not isinstance(payload[type_name], dict):
+      return False
+    property_types = (int, str, float, bool)
+    property_value_types = (int, str, float, bool, dict)
+    for property_name in payload[type_name]:
+      if not isinstance(property_name, property_types) or not isinstance(
+          payload[type_name][property_name], property_value_types):
+        return False
+  return True
+
 
 def _instance_to_dict(instance):
-	'''_instance_to_dict serializes the type instance into a python dictionary
+  '''_instance_to_dict serializes the type instance into a python dictionary
 	Args:
 		instance(BaseType): An instance that describes a type
 
 	Return:
 		dict
 	'''
-	return {type(instance).__name__: instance.__dict__}
+  return {type(instance).__name__: instance.__dict__}
+
 
 def _check_dict_types(checked_type, expected_type):
-	'''_check_dict_types checks the type consistency.
-	Args:
-  	checked_type (dict): A dict that describes a type from the upstream component output
-  	expected_type (dict): A dict that describes a type from the downstream component input
-	'''
-	if not checked_type or not expected_type:
-		# If the type is empty, it matches any types
-		return True
-	checked_type_name,_ = list(checked_type.items())[0]
-	expected_type_name,_ = list(expected_type.items())[0]
-	if checked_type_name == '' or expected_type_name == '':
-		# If the type name is empty, it matches any types
-		return True
-	if checked_type_name != expected_type_name:
-		print('type name ' + str(checked_type_name) + ' is different from expected: ' + str(expected_type_name))
-		return False
-	type_name = checked_type_name
-	for type_property in checked_type[type_name]:
-		if type_property not in expected_type[type_name]:
-			print(type_name + ' has a property ' + str(type_property) + ' that the latter does not.')
-			return False
-		if checked_type[type_name][type_property] != expected_type[type_name][type_property]:
-			print(type_name + ' has a property ' + str(type_property) + ' with value: ' +
-						str(checked_type[type_name][type_property]) + ' and ' +
-						str(expected_type[type_name][type_property]))
-			return False
-	return True
+  """_check_dict_types checks the type consistency.
+
+  Args:
+  checked_type (dict): A dict that describes a type from the upstream component output
+  expected_type (dict): A dict that describes a type from the downstream component input
+
+  """
+  if not checked_type or not expected_type:
+    # If the type is empty, it matches any types
+    return True
+  checked_type_name, _ = list(checked_type.items())[0]
+  expected_type_name, _ = list(expected_type.items())[0]
+  if checked_type_name == '' or expected_type_name == '':
+    # If the type name is empty, it matches any types
+    return True
+  if checked_type_name != expected_type_name:
+    print(
+        'type name ' + str(checked_type_name) +
+        ' is different from expected: ' + str(expected_type_name)
+    )
+    return False
+  type_name = checked_type_name
+  for type_property in checked_type[type_name]:
+    if type_property not in expected_type[type_name]:
+      print(
+          type_name + ' has a property ' + str(type_property) +
+          ' that the latter does not.'
+      )
+      return False
+    if checked_type[type_name][type_property] != expected_type[type_name
+                                                              ][type_property]:
+      print(
+          type_name + ' has a property ' + str(type_property) +
+          ' with value: ' + str(checked_type[type_name][type_property]) +
+          ' and ' + str(expected_type[type_name][type_property])
+      )
+      return False
+  return True


### PR DESCRIPTION
This is the auto-lint change made by yapf with configuration in `.style.yapf` and running `docformatter --in-place --wrap-summaries 80 --wrap-descriptions 80 --blank dsl/*.py` to lint the docstring. Please see #2442 for some background.

It seems like docformatter is not very aggressive in wrapping long lines to comply with length limit, but I think overall the readability is preserved well. Maybe some manual adjustment could make it looks better.

Please let me know how does it look. @neuromage @IronPan @hongye-sun @gaoning777 @gaoning777 @SinaChavoshi @elikatsis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2498)
<!-- Reviewable:end -->
