### PR TITLE
[UI] Fix metadata tabs loading state

### DIFF
--- a/frontend/mock-backend/mock-api-server.ts
+++ b/frontend/mock-backend/mock-api-server.ts
@@ -18,6 +18,9 @@ import mockApiMiddleware from './mock-api-middleware';
 const app = express();
 const port = process.argv[2] || 3001;
 
+// Uncomment the following line to get 1000ms delay to all requests
+// app.use((req, res, next) => { setTimeout(next, 1000); });
+
 app.use((_, res, next) => {
   res.header('Access-Control-Allow-Origin', '*');
   res.header('Access-Control-Allow-Headers', 'X-Requested-With, content-type');

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -102,6 +102,7 @@ const metadataServicePromiseClient = {
   getArtifactTypes: makePromiseApi(
     metadataServiceClient.getArtifactTypes.bind(metadataServiceClient),
   ),
+  getArtifacts: makePromiseApi(metadataServiceClient.getArtifacts.bind(metadataServiceClient)),
   getArtifactsByID: makePromiseApi(
     metadataServiceClient.getArtifactsByID.bind(metadataServiceClient),
   ),

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -112,6 +112,10 @@ const metadataServicePromiseClient = {
   getEventsByExecutionIDs: makePromiseApi(
     metadataServiceClient.getEventsByExecutionIDs.bind(metadataServiceClient),
   ),
+  getExecutionTypes: makePromiseApi(
+    metadataServiceClient.getExecutionTypes.bind(metadataServiceClient),
+  ),
+  getExecutions: makePromiseApi(metadataServiceClient.getExecutions.bind(metadataServiceClient)),
   getExecutionsByID: makePromiseApi(
     metadataServiceClient.getExecutionsByID.bind(metadataServiceClient),
   ),

--- a/frontend/src/pages/ArtifactList.tsx
+++ b/frontend/src/pages/ArtifactList.tsx
@@ -120,18 +120,20 @@ class ArtifactList extends Page<{}, ArtifactListState> {
   }
 
   private async reload(request: ListRequest): Promise<string> {
-    Apis.getMetadataServiceClient().getArtifacts(new GetArtifactsRequest(), (err, res) => {
-      // Code === 5 means no record found in backend. This is a temporary workaround.
-      // TODO: remove err.code !== 5 check when backend is fixed.
-      if (err && err.code !== 5) {
-        this.showPageError(serviceErrorToString(err));
-        return;
-      }
+    const { response, error } = await Apis.getMetadataServicePromiseClient().getArtifacts(
+      new GetArtifactsRequest(),
+    );
 
-      const artifacts = (res && res.getArtifactsList()) || [];
-      this.getRowsFromArtifacts(request, artifacts);
-      this.clearBanner();
-    });
+    // Code === 5 means no record found in backend. This is a temporary workaround.
+    // TODO: remove err.code !== 5 check when backend is fixed.
+    if (error && error.code !== 5) {
+      this.showPageError(serviceErrorToString(error));
+      return '';
+    }
+
+    const artifacts = (response && response.getArtifactsList()) || [];
+    await this.getRowsFromArtifacts(request, artifacts);
+    this.clearBanner();
     return '';
   }
 
@@ -160,77 +162,78 @@ class ArtifactList extends Page<{}, ArtifactListState> {
    * TODO: Replace once https://github.com/kubeflow/metadata/issues/73 is done.
    * @param request
    */
-  private getRowsFromArtifacts(request: ListRequest, artifacts: Artifact[]): void {
+  private async getRowsFromArtifacts(request: ListRequest, artifacts: Artifact[]): Promise<void> {
     const artifactTypesMap = new Map<number, ArtifactType>();
     // TODO: Consider making an Api method for returning and caching types
-    Apis.getMetadataServiceClient().getArtifactTypes(
+    const {
+      response: res,
+      error: err,
+    } = await Apis.getMetadataServicePromiseClient().getArtifactTypes(
       new GetArtifactTypesRequest(),
-      async (err, res) => {
-        if (err) {
-          this.showPageError(serviceErrorToString(err));
-          return;
-        }
-
-        ((res && res.getArtifactTypesList()) || []).forEach(artifactType => {
-          artifactTypesMap.set(artifactType.getId()!, artifactType);
-        });
-
-        try {
-          // TODO: When backend supports sending creation time back when we list
-          // artifacts, let's use it directly.
-          const artifactsWithCreationTimes = await Promise.all(
-            artifacts.map(async artifact => {
-              const artifactId = artifact.getId();
-              if (!artifactId) {
-                return { artifact };
-              }
-
-              return {
-                artifact,
-                creationTime: await getArtifactCreationTime(artifactId),
-              };
-            }),
-          );
-
-          const collapsedAndExpandedRows = groupRows(
-            artifactsWithCreationTimes
-              .map(({ artifact, creationTime }) => {
-                const typeId = artifact.getTypeId();
-                const type =
-                  typeId && artifactTypesMap && artifactTypesMap.get(typeId)
-                    ? artifactTypesMap.get(typeId)!.getName()
-                    : typeId;
-                return {
-                  id: `${type}:${artifact.getId()}`, // Join with colon so we can build the link
-                  otherFields: [
-                    getResourceProperty(artifact, ArtifactProperties.PIPELINE_NAME) ||
-                      getResourceProperty(artifact, ArtifactCustomProperties.WORKSPACE, true),
-                    getResourceProperty(artifact, ArtifactProperties.NAME),
-                    artifact.getId(),
-                    type,
-                    artifact.getUri(),
-                    creationTime || '',
-                  ],
-                } as Row;
-              })
-              .filter(rowFilterFn(request))
-              .sort(rowCompareFn(request, this.state.columns)),
-          );
-
-          this.setState({
-            artifacts,
-            expandedRows: collapsedAndExpandedRows.expandedRows,
-            rows: collapsedAndExpandedRows.collapsedRows,
-          });
-        } catch (err) {
-          if (err.message) {
-            this.showPageError(err.message, err);
-          } else {
-            this.showPageError('Unknown error', err);
-          }
-        }
-      },
     );
+    if (err) {
+      this.showPageError(serviceErrorToString(err));
+      return;
+    }
+
+    ((res && res.getArtifactTypesList()) || []).forEach(artifactType => {
+      artifactTypesMap.set(artifactType.getId()!, artifactType);
+    });
+
+    try {
+      // TODO: When backend supports sending creation time back when we list
+      // artifacts, let's use it directly.
+      const artifactsWithCreationTimes = await Promise.all(
+        artifacts.map(async artifact => {
+          const artifactId = artifact.getId();
+          if (!artifactId) {
+            return { artifact };
+          }
+
+          return {
+            artifact,
+            creationTime: await getArtifactCreationTime(artifactId),
+          };
+        }),
+      );
+
+      const collapsedAndExpandedRows = groupRows(
+        artifactsWithCreationTimes
+          .map(({ artifact, creationTime }) => {
+            const typeId = artifact.getTypeId();
+            const type =
+              typeId && artifactTypesMap && artifactTypesMap.get(typeId)
+                ? artifactTypesMap.get(typeId)!.getName()
+                : typeId;
+            return {
+              id: `${type}:${artifact.getId()}`, // Join with colon so we can build the link
+              otherFields: [
+                getResourceProperty(artifact, ArtifactProperties.PIPELINE_NAME) ||
+                  getResourceProperty(artifact, ArtifactCustomProperties.WORKSPACE, true),
+                getResourceProperty(artifact, ArtifactProperties.NAME),
+                artifact.getId(),
+                type,
+                artifact.getUri(),
+                creationTime || '',
+              ],
+            } as Row;
+          })
+          .filter(rowFilterFn(request))
+          .sort(rowCompareFn(request, this.state.columns)),
+      );
+
+      this.setState({
+        artifacts,
+        expandedRows: collapsedAndExpandedRows.expandedRows,
+        rows: collapsedAndExpandedRows.collapsedRows,
+      });
+    } catch (err) {
+      if (err.message) {
+        this.showPageError(err.message, err);
+      } else {
+        this.showPageError('Unknown error', err);
+      }
+    }
   }
 
   /**

--- a/frontend/src/pages/ArtifactList.tsx
+++ b/frontend/src/pages/ArtifactList.tsx
@@ -120,20 +120,21 @@ class ArtifactList extends Page<{}, ArtifactListState> {
   }
 
   private async reload(request: ListRequest): Promise<string> {
-    const { response, error } = await Apis.getMetadataServicePromiseClient().getArtifacts(
+    const { response: res, error: err } = await Apis.getMetadataServicePromiseClient().getArtifacts(
       new GetArtifactsRequest(),
     );
 
-    // Code === 5 means no record found in backend. This is a temporary workaround.
-    // TODO: remove err.code !== 5 check when backend is fixed.
-    if (error && error.code !== 5) {
-      this.showPageError(serviceErrorToString(error));
+    if (err) {
+      // Code === 5 means no record found in backend. This is a temporary workaround.
+      // TODO: remove err.code !== 5 check when backend is fixed.
+      if (err.code !== 5) {
+        this.showPageError(serviceErrorToString(err));
+      }
       return '';
     }
 
-    const artifacts = (response && response.getArtifactsList()) || [];
+    const artifacts = (res && res.getArtifactsList()) || [];
     await this.getRowsFromArtifacts(request, artifacts);
-    this.clearBanner();
     return '';
   }
 


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/2504

Change summary:
metadata UI didn't respect returning a promise when data is ready. I refactored it to use promise now. Therefore, now `CustomTable` can correctly know when loading finishes based on the promise.

Screencast: https://drive.google.com/file/d/1Bd4uqh_Da39mEGEvW_Z-gCgTEJqk9agA/view
/cc @numerology 
/assign @rmgogogo 
/area front-end
/kind bug

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2508)
<!-- Reviewable:end -->
