### PR TITLE
Pin tensorboard version to 1.13.2

### DIFF
--- a/backend/src/crd/controller/viewer/reconciler/reconciler.go
+++ b/backend/src/crd/controller/viewer/reconciler/reconciler.go
@@ -170,7 +170,9 @@ func setPodSpecForTensorboard(view *viewerV1beta1.Viewer, s *corev1.PodSpec) {
 		"tensorboard",
 		fmt.Sprintf("--logdir=%s", view.Spec.TensorboardSpec.LogDir),
 		fmt.Sprintf("--path_prefix=/tensorboard/%s/", view.Name),
-// 		"--bind_all",
+		// This is needed for tf 2.0. We need to optionally add it
+		// when https://github.com/kubeflow/pipelines/issues/2514 is done
+		// "--bind_all",
 	}
 	c.Ports = []corev1.ContainerPort{
 		corev1.ContainerPort{ContainerPort: viewerTargetPort},

--- a/backend/src/crd/controller/viewer/reconciler/reconciler.go
+++ b/backend/src/crd/controller/viewer/reconciler/reconciler.go
@@ -165,7 +165,7 @@ func setPodSpecForTensorboard(view *viewerV1beta1.Viewer, s *corev1.PodSpec) {
 
 	c := &s.Containers[0]
 	c.Name = view.Name + "-pod"
-	c.Image = "tensorflow/tensorflow"
+	c.Image = "tensorflow/tensorflow:1.13.2"
 	c.Args = []string{
 		"tensorboard",
 		fmt.Sprintf("--logdir=%s", view.Spec.TensorboardSpec.LogDir),

--- a/backend/src/crd/controller/viewer/reconciler/reconciler.go
+++ b/backend/src/crd/controller/viewer/reconciler/reconciler.go
@@ -170,7 +170,7 @@ func setPodSpecForTensorboard(view *viewerV1beta1.Viewer, s *corev1.PodSpec) {
 		"tensorboard",
 		fmt.Sprintf("--logdir=%s", view.Spec.TensorboardSpec.LogDir),
 		fmt.Sprintf("--path_prefix=/tensorboard/%s/", view.Name),
-		"--bind_all",
+// 		"--bind_all",
 	}
 	c.Ports = []corev1.ContainerPort{
 		corev1.ContainerPort{ContainerPort: viewerTargetPort},

--- a/backend/src/crd/controller/viewer/reconciler/reconciler_test.go
+++ b/backend/src/crd/controller/viewer/reconciler/reconciler_test.go
@@ -174,7 +174,7 @@ func TestReconcile_EachViewerCreatesADeployment(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:  "viewer-123-pod",
-						Image: "tensorflow/tensorflow",
+						Image: "tensorflow/tensorflow:1.13.2",
 						Args: []string{
 							"tensorboard",
 							"--logdir=gs://tensorboard/logdir",
@@ -271,7 +271,7 @@ func TestReconcile_ViewerUsesSpecifiedVolumeMountsForDeployment(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:  "viewer-123-pod",
-						Image: "tensorflow/tensorflow",
+						Image: "tensorflow/tensorflow:1.13.2",
 						Args: []string{
 							"tensorboard",
 							"--logdir=gs://tensorboard/logdir",

--- a/backend/src/crd/controller/viewer/reconciler/reconciler_test.go
+++ b/backend/src/crd/controller/viewer/reconciler/reconciler_test.go
@@ -178,8 +178,7 @@ func TestReconcile_EachViewerCreatesADeployment(t *testing.T) {
 						Args: []string{
 							"tensorboard",
 							"--logdir=gs://tensorboard/logdir",
-							"--path_prefix=/tensorboard/viewer-123/",
-							"--bind_all"},
+							"--path_prefix=/tensorboard/viewer-123/"},
 						Ports: []corev1.ContainerPort{{ContainerPort: 6006}},
 					}}}}}}}
 
@@ -276,8 +275,7 @@ func TestReconcile_ViewerUsesSpecifiedVolumeMountsForDeployment(t *testing.T) {
 						Args: []string{
 							"tensorboard",
 							"--logdir=gs://tensorboard/logdir",
-							"--path_prefix=/tensorboard/viewer-123/",
-							"--bind_all"},
+							"--path_prefix=/tensorboard/viewer-123/"},
 						Ports: []corev1.ContainerPort{{ContainerPort: 6006}},
 						VolumeMounts: []v1.VolumeMount{
 							{Name: "/volume-mount-name", MountPath: "/mount/path"},


### PR DESCRIPTION
Using latest causes various uncertainties due to tensorflow backward incompatibility especially new 2.0.
In long term we should allow user specify the tensorboard image version. 
/assign @numerology 
cc @jingzhang36

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2513)
<!-- Reviewable:end -->
