### PR TITLE
Frontend - Added support for https artifact links

### DIFF
--- a/frontend/src/components/ArtifactLink.tsx
+++ b/frontend/src/components/ArtifactLink.tsx
@@ -4,16 +4,16 @@ import { generateGcsConsoleUri } from '../lib/Utils';
 /**
  * A component that renders an artifact URL as clickable link if URL is correct
   */
-export const GcsLink: React.FC<{ gcsUri?: string }> = ({ gcsUri }) => {
+export const ArtifactLink: React.FC<{ artifactUri?: string }> = ({ artifactUri }) => {
   let clickableUrl: string | undefined = undefined;
-  if (gcsUri) {
-    if (gcsUri.startsWith('gs:')) {
-      const gcsConsoleUrl = generateGcsConsoleUri(gcsUri);
+  if (artifactUri) {
+    if (artifactUri.startsWith('gs:')) {
+      const gcsConsoleUrl = generateGcsConsoleUri(artifactUri);
       if (gcsConsoleUrl) {
         clickableUrl = gcsConsoleUrl;
       }
-    } else if (gcsUri.startsWith('http:') || gcsUri.startsWith('https:')) {
-      clickableUrl = gcsUri;
+    } else if (artifactUri.startsWith('http:') || artifactUri.startsWith('https:')) {
+      clickableUrl = artifactUri;
     }
   }
 
@@ -21,10 +21,10 @@ export const GcsLink: React.FC<{ gcsUri?: string }> = ({ gcsUri }) => {
     // Opens in new window safely
     return (
       <a href={clickableUrl} target={'_blank'} rel={'noreferrer noopener'}>
-        {gcsUri}
+        {artifactUri}
       </a>
     );
   } else {
-    return <>{gcsUri}</>;
+    return <>{artifactUri}</>;
   }
 };

--- a/frontend/src/components/ArtifactLink.tsx
+++ b/frontend/src/components/ArtifactLink.tsx
@@ -3,9 +3,9 @@ import { generateGcsConsoleUri } from '../lib/Utils';
 
 /**
  * A component that renders an artifact URL as clickable link if URL is correct
-  */
+ */
 export const ArtifactLink: React.FC<{ artifactUri?: string }> = ({ artifactUri }) => {
-  let clickableUrl: string | undefined = undefined;
+  let clickableUrl: string | undefined;
   if (artifactUri) {
     if (artifactUri.startsWith('gs:')) {
       const gcsConsoleUrl = generateGcsConsoleUri(artifactUri);

--- a/frontend/src/components/GcsLink.tsx
+++ b/frontend/src/components/GcsLink.tsx
@@ -2,19 +2,18 @@ import * as React from 'react';
 import { generateGcsConsoleUri } from '../lib/Utils';
 
 /**
- * A component that renders a gcs console link when gcsUri is gs:// and pure
- * text if it is not a valid gs:// uri.
- */
+ * A component that renders an artifact URL as clickable link if URL is correct
+  */
 export const GcsLink: React.FC<{ gcsUri?: string }> = ({ gcsUri }) => {
-  var clickableUrl: string | undefined = undefined
+  let clickableUrl: string | undefined = undefined;
   if (gcsUri) {
     if (gcsUri.startsWith('gs:')) {
-      var gcsConsoleUrl = generateGcsConsoleUri(gcsUri)
+      const gcsConsoleUrl = generateGcsConsoleUri(gcsUri);
       if (gcsConsoleUrl) {
-        clickableUrl = gcsConsoleUrl
+        clickableUrl = gcsConsoleUrl;
       }
     } else if (gcsUri.startsWith('http:') || gcsUri.startsWith('https:')) {
-      clickableUrl = gcsUri
+      clickableUrl = gcsUri;
     }
   }
 

--- a/frontend/src/components/GcsLink.tsx
+++ b/frontend/src/components/GcsLink.tsx
@@ -6,11 +6,22 @@ import { generateGcsConsoleUri } from '../lib/Utils';
  * text if it is not a valid gs:// uri.
  */
 export const GcsLink: React.FC<{ gcsUri?: string }> = ({ gcsUri }) => {
-  const gcsConsoleUri = gcsUri ? generateGcsConsoleUri(gcsUri) : undefined;
-  if (gcsConsoleUri) {
+  var clickableUrl: string | undefined = undefined
+  if (gcsUri) {
+    if (gcsUri.startsWith('gs:')) {
+      var gcsConsoleUrl = generateGcsConsoleUri(gcsUri)
+      if (gcsConsoleUrl) {
+        clickableUrl = gcsConsoleUrl
+      }
+    } else if (gcsUri.startsWith('http:') || gcsUri.startsWith('https:')) {
+      clickableUrl = gcsUri
+    }
+  }
+
+  if (clickableUrl) {
     // Opens in new window safely
     return (
-      <a href={gcsConsoleUri} target={'_blank'} rel={'noreferrer noopener'}>
+      <a href={clickableUrl} target={'_blank'} rel={'noreferrer noopener'}>
         {gcsUri}
       </a>
     );

--- a/frontend/src/components/ResourceInfo.tsx
+++ b/frontend/src/components/ResourceInfo.tsx
@@ -18,7 +18,7 @@ import { stylesheet } from 'typestyle';
 import { color, commonCss } from '../Css';
 import { getMetadataValue } from '../lib/Utils';
 import { Artifact, Execution } from '../generated/src/apis/metadata/metadata_store_pb';
-import { GcsLink } from './GcsLink';
+import { ArtifactLink } from './ArtifactLink';
 
 export const css = stylesheet({
   field: {
@@ -77,7 +77,7 @@ export class ResourceInfo extends React.Component<ResourceInfoProps, {}> {
               <>
                 <dt className={css.term}>URI</dt>
                 <dd className={css.value}>
-                  <GcsLink gcsUri={this.props.resource.getUri()} />
+                  <ArtifactLink artifactUri={this.props.resource.getUri()} />
                 </dd>
               </>
             );

--- a/frontend/src/pages/ArtifactList.tsx
+++ b/frontend/src/pages/ArtifactList.tsx
@@ -42,7 +42,7 @@ import {
   GetArtifactsRequest,
 } from '../generated/src/apis/metadata/metadata_store_service_pb';
 import { getArtifactCreationTime } from '../lib/MetadataUtils';
-import { GcsLink } from '../components/GcsLink';
+import { ArtifactLink } from '../components/ArtifactLink';
 
 interface ArtifactListState {
   artifacts: Artifact[];
@@ -154,7 +154,7 @@ class ArtifactList extends Page<{}, ArtifactListState> {
   };
 
   private uriCustomRenderer: React.FC<CustomRendererProps<string>> = ({ value }) => (
-    <GcsLink gcsUri={value} />
+    <ArtifactLink artifactUri={value} />
   );
 
   /**


### PR DESCRIPTION
Currently the Artifacts list makes artifact URLs clickable only when they are 'gs://'.
This commit adds support for https: links.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2517)
<!-- Reviewable:end -->
