### PR TITLE
SDK - Client - Fixed client on Windows

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -140,7 +140,7 @@ class Client(object):
       return config
 
     if config.host:
-      config.host = os.path.join(config.host, Client.KUBE_PROXY_PATH.format(namespace))
+      config.host = config.host + '/' + Client.KUBE_PROXY_PATH.format(namespace)
     return config
 
   def _is_iap_host(self, host, client_id):


### PR DESCRIPTION

URLs joining should not depend on OS path separator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2524)
<!-- Reviewable:end -->
