### PR TITLE
Frontend format check should be before linting.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,7 +57,7 @@
     "test": "react-scripts-ts test --env=jsdom",
     "test:coverage": "npm test -- --env=jsdom --coverage",
     "test:coveralls": "npm run test:coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
-    "test:ci": "npm run lint && npm run format:check && npm run test:coveralls",
+    "test:ci": "npm run format:check && npm run lint && npm run test:coveralls",
     "vr-approve": "backstop approve",
     "vr-test": "ts-node -O '{\"module\": \"commonjs\"}' backstop.ts"
   },


### PR DESCRIPTION
Format check should happen before linting, because format is easier to fix and some of lint errors can be fixed by format.

/area front-end
/assign @jingzhang36 
/approve

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2525)
<!-- Reviewable:end -->
