### PR TITLE
[Sample] Align preload TFX sample with TFX head

### DIFF
--- a/samples/contrib/parameterized_tfx_oss/README.md
+++ b/samples/contrib/parameterized_tfx_oss/README.md
@@ -11,7 +11,7 @@ Please refer to inline comments for the purpose of each step.
 In order to successfully compile this sample, you'll need to have a TFX installation at HEAD.
 First, you can clone their repo and run `python setup.py install` from `tfx/`. 
 The image used in the pipeline is specified as `tfx_image` in the 
-`KubeflowDagRunnerConfig`. Currently we're using our own patched version of TFX image containing visualization support.
+`KubeflowDagRunnerConfig`. Please make sure you use the latest TFX build so that visualization support is included.
 List of officially released nightly build image available can be found [here](https://hub.docker.com/r/tensorflow/tfx/tags)).
 
 After that, running 

--- a/samples/contrib/parameterized_tfx_oss/parameterized_tfx_oss.py
+++ b/samples/contrib/parameterized_tfx_oss/parameterized_tfx_oss.py
@@ -131,7 +131,7 @@ if __name__ == '__main__':
     enable_cache=enable_cache)
   config = kubeflow_dag_runner.KubeflowDagRunnerConfig(
     kubeflow_metadata_config=kubeflow_dag_runner.get_default_kubeflow_metadata_config(),
-    tfx_image='gcr.io/ml-pipeline/patched-tfx:0.1.32')
+    tfx_image='tensorflow/tfx:0.16.0.dev20191101')
   kfp_runner = kubeflow_dag_runner.KubeflowDagRunner(config=config)
   # Make sure kfp_runner recognizes those parameters.
   kfp_runner._params.extend([_data_root_param, _taxi_module_file_param])


### PR DESCRIPTION
Sample background: 

There is a breaking change introduced in TFX side in [this PR](https://github.com/tensorflow/tfx/commit/9b79f8af839ff01bdde079c873e3f9d3225d3209#diff-93a4c8b6e41081e9ae98c006808a0bb6), adding a required argument `component_config` to `container_entrypoint.py`. As a result, if a user compile this uDSL file using TFX head but try to run it against our `patched-tfx:0.1.32` image, it will fail due to missing argument. 

I think it would a reasonable fix if we align this sample with TFX for now. After this change, when the user compile this sample from TFX head, a pipeline using latest TFX nightly build would be returned, which is consistent with the yaml spec. Though the generated yaml spec is slightly different from what we baked into our backend server, which I think is fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2526)
<!-- Reviewable:end -->
