### PR TITLE
SDK - Components - Fixed YAML formatting for some components

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -483,6 +483,8 @@ def _func_to_component_spec(func, extra_code='', base_image : str = None, packag
         '_output_files = _parsed_args.pop("_output_paths", [])',
     ])
 
+    output_serialization_code = ''.join('    ' + s + ',' + '\n' for s in output_serialization_expression_strings)
+
     full_source = \
 '''\
 {pre_func_code}
@@ -499,7 +501,7 @@ if not hasattr(_outputs, '__getitem__') or isinstance(_outputs, str):
     _outputs = [_outputs]
 
 _output_serializers = [
-    {output_serialization_code}
+{output_serialization_code}
 ]
 
 import os
@@ -516,7 +518,7 @@ for idx, output_file in enumerate(_output_files):
         pre_func_code=pre_func_code,
         extra_code=extra_code,
         arg_parse_code='\n'.join(arg_parse_code_lines),
-        output_serialization_code=',\n    '.join(output_serialization_expression_strings),
+        output_serialization_code=output_serialization_code,
     )
 
     #Removing consecutive blank lines

--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -483,7 +483,7 @@ def _func_to_component_spec(func, extra_code='', base_image : str = None, packag
         '_output_files = _parsed_args.pop("_output_paths", [])',
     ])
 
-    output_serialization_code = ''.join('    ' + s + ',' + '\n' for s in output_serialization_expression_strings)
+    output_serialization_code = ''.join('    {},\n'.format(s) for s in output_serialization_expression_strings)
 
     full_source = \
 '''\


### PR DESCRIPTION
This fixes formatting for components where function does not have a return annotation.
The low-level cause of issue: Trailing whitespace when there are no serializers.
Trailing whitespace triggers ugly YAML string formatting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2529)
<!-- Reviewable:end -->
