### PR TITLE
[Frontend] Fix run id not populated in NewRun page when clicked too fast bug

### DIFF
--- a/frontend/src/pages/PipelineDetails.test.tsx
+++ b/frontend/src/pages/PipelineDetails.test.tsx
@@ -416,6 +416,20 @@ describe('PipelineDetails', () => {
     );
   });
 
+  it('clicking new run button when viewing half-loaded page navigates to the new run page with run ID', async () => {
+    tree = shallow(<PipelineDetails {...generateProps(false)} />);
+    // Intentionally don't wait until all network requests finish.
+    const instance = tree.instance() as PipelineDetails;
+    const newRunFromPipelineBtn = instance.getInitialToolbarState().actions[
+      ButtonKeys.NEW_RUN_FROM_PIPELINE
+    ];
+    newRunFromPipelineBtn.action();
+    expect(historyPushSpy).toHaveBeenCalledTimes(1);
+    expect(historyPushSpy).toHaveBeenLastCalledWith(
+      RoutePage.NEW_RUN + `?${QUERY_PARAMS.pipelineId}=${testPipeline.id}`,
+    );
+  });
+
   it('clicking new experiment button navigates to new experiment page', async () => {
     tree = shallow(<PipelineDetails {...generateProps()} />);
     await getTemplateSpy;

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -118,7 +118,14 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
   public getInitialToolbarState(): ToolbarProps {
     const buttons = new Buttons(this.props, this.refresh.bind(this));
     const fromRunId = new URLParser(this.props).get(QUERY_PARAMS.fromRunId);
-    buttons.newRunFromPipeline(() => (this.state.pipeline ? this.state.pipeline.id! : ''));
+    buttons.newRunFromPipeline(() => {
+      const pipelineIdFromParams = this.props.match.params[RouteParams.pipelineId];
+      return this.state.pipeline
+        ? this.state.pipeline.id!
+        : pipelineIdFromParams
+        ? pipelineIdFromParams
+        : '';
+    });
 
     if (fromRunId) {
       return {


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/2488

/area front-end
/kind bug
/cc @Ark-kun 
/assign @rmgogogo 