### PR TITLE
[Testing] Describe unhealthy pods when tests clean up.

### DIFF
--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -32,7 +32,7 @@ function clean_up {
   for POD_NAME in "${UNHEALTHY_PODS[@]}"; do
     echo ""
     echo "For pod $POD_NAME:"
-    describe pod $POD_NAME -n $NAMESPACE
+    kubectl describe pod $POD_NAME -n $NAMESPACE
   done
   echo "============================================================="
   echo "The above is output of describing pods with unhealthy status."

--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -27,6 +27,17 @@ SHOULD_CLEANUP_CLUSTER=false
 function clean_up {
   set +e # the following clean up commands shouldn't exit on error
 
+  echo "Describe pods with unhealthy status:"
+  UNHEALTHY_PODS=($(kubectl get pods --field-selector=status.phase!=Running,status.phase!=Succeeded -o=custom-columns=:metadata.name -n $NAMESPACE))
+  for POD_NAME in "${UNHEALTHY_PODS[@]}"; do
+    echo ""
+    echo "For pod $POD_NAME:"
+    describe pod $POD_NAME -n $NAMESPACE
+  done
+  echo "============================================================="
+  echo "The above is output of describing pods with unhealthy status."
+  echo "============================================================="
+
   echo "Status of pods before clean up:"
   kubectl get pods --all-namespaces
 


### PR DESCRIPTION
For debugging postsubmit test failure: pod with image pull back off.

Related reference:
* https://cheatsheet.dennyzhang.com/cheatsheet-kubernetes-a4
* The approach we use won't work with CrashLooPBackOff, https://github.com/kubernetes/kubernetes/issues/49387#issuecomment-504405180

However, I don't want to workaround kubectl limitations. This one is good enough. We can improve when we actually see crash loop back off issue.

/assign @jingzhang36 
/area testing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2554)
<!-- Reviewable:end -->
