### PR TITLE
Fix postsubmit test which times out

### DIFF
--- a/test/component_test.yaml
+++ b/test/component_test.yaml
@@ -56,7 +56,7 @@ spec:
             value: test/sample-test/Dockerfile
           - name: image-name
             value: "{{inputs.parameters.target-image-prefix}}{{inputs.parameters.sample-tests-image-suffix}}"
-      - name: run-xgboost-tests
+    - - name: run-xgboost-tests
         template: run-sample-tests
         arguments:
           parameters:


### PR DESCRIPTION
These two steps should be sequential, but they are written as parallel.
Reference: https://github.com/argoproj/argo/blob/master/examples/steps.yaml

The issue this bug caused:
If image failed to build in postsubmit tests, the test will timeout in 2 hours instead of failing with error message right away, because the second step will be stuck in ImagePullBackOff, and it never stops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2557)
<!-- Reviewable:end -->
