### PR TITLE
fix slow query when get runs

### DIFF
--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -210,7 +210,7 @@ func (s *RunStore) addMetricsAndResourceReferences(filteredSelectBuilder sq.Sele
 		Select("subq.*", resourceRefConcatQuery+" AS refs").
 		FromSelect(subQ, "subq").
 		// Append all the resource references for the run as a json column
-		LeftJoin("(select * from resource_references where ResourceType='Run') AS r ON subq.UUID=r.ResourceUUID").
+		LeftJoin("resource_references AS r ON r.ResourceType='Run' AND subq.UUID=r.ResourceUUID").
 		GroupBy("subq.UUID")
 }
 


### PR DESCRIPTION
the current sql for runs list as below:
```
explain SELECT subq.*, CONCAT("[",GROUP_CONCAT(r.Payload SEPARATOR ","),"]") AS refs FROM (SELECT rd.*, CONCAT("[",GROUP_CONCAT(m.Payload SEPARATOR ","),"]") AS metrics FROM (SELECT UUID, DisplayName, Name, StorageState, Namespace, Description, CreatedAtInSec, ScheduledAtInSec, FinishedAtInSec, Conditions, PipelineId, PipelineName, PipelineSpecManifest, WorkflowSpecManifest, Parameters, pipelineRuntimeManifest, WorkflowRuntimeManifest FROM run_details WHERE UUID in (SELECT ResourceUUID FROM resource_references as rf WHERE (rf.ResourceType = 'Run' AND rf.ReferenceUUID = 'xxxx-177b4751-xxxx-xxxx-xxxx-xxxx' AND rf.ReferenceType = 'Experiment')) AND StorageState <> 'STORAGESTATE_ARCHIVED' ORDER BY CreatedAtInSec DESC, UUID DESC LIMIT 11) AS rd LEFT JOIN run_metrics AS m ON rd.UUID=m.RunUUID GROUP BY rd.UUID) AS subq LEFT JOIN (select * from resource_references where ResourceType='Run') AS r ON subq.UUID=r.ResourceUUID GROUP BY subq.UUID ORDER BY CreatedAtInSec DESC, UUID DESC;
+----+-------------+---------------------+--------+-------------------------+-----------------+---------+----------------------------+------+-----------------------------------------------------------+
| id | select_type | table               | type   | possible_keys           | key             | key_len | ref                        | rows | Extra                                                     |
+----+-------------+---------------------+--------+-------------------------+-----------------+---------+----------------------------+------+-----------------------------------------------------------+
|  1 | PRIMARY     | <derived2>          | ALL    | NULL                    | NULL            | NULL    | NULL                       |   11 | Using temporary; Using filesort                           |
|  1 | PRIMARY     | <derived5>          | ref    | <auto_key0>             | <auto_key0>     | 257     | subq.UUID                  |   30 | NULL                                                      |
|  5 | DERIVED     | resource_references | ref    | referencefilter         | referencefilter | 257     | const                      | 3047 | Using index condition                                     |
|  2 | DERIVED     | <derived3>          | ALL    | NULL                    | NULL            | NULL    | NULL                       |   11 | Using temporary; Using filesort                           |
|  2 | DERIVED     | m                   | ALL    | PRIMARY                 | NULL            | NULL    | NULL                       |    1 | Using where; Using join buffer (Block Nested Loop)        |
|  3 | DERIVED     | rf                  | ref    | PRIMARY,referencefilter | referencefilter | 771     | const,const,const          |  302 | Using where; Using index; Using temporary; Using filesort |
|  3 | DERIVED     | run_details         | eq_ref | PRIMARY                 | PRIMARY         | 257     | mlpipeline.rf.ResourceUUID |    1 | Using where                                               |
+----+-------------+---------------------+--------+-------------------------+-----------------+---------+----------------------------+------+-----------------------------------------------------------+
```

the union index as below:
```
mysql> show index from resource_references;
+---------------------+------------+-----------------+--------------+---------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| Table               | Non_unique | Key_name        | Seq_in_index | Column_name   | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment |
+---------------------+------------+-----------------+--------------+---------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| resource_references |          0 | PRIMARY         |            1 | ResourceUUID  | A         |        6095 |     NULL | NULL   |      | BTREE      |         |               |
| resource_references |          0 | PRIMARY         |            2 | ResourceType  | A         |        6095 |     NULL | NULL   |      | BTREE      |         |               |
| resource_references |          0 | PRIMARY         |            3 | ReferenceType | A         |        6095 |     NULL | NULL   |      | BTREE      |         |               |
| resource_references |          1 | referencefilter |            1 | ResourceType  | A         |           4 |     NULL | NULL   |      | BTREE      |         |               |
| resource_references |          1 | referencefilter |            2 | ReferenceUUID | A         |          64 |     NULL | NULL   |      | BTREE      |         |               |
| resource_references |          1 | referencefilter |            3 | ReferenceType | A         |          64 |     NULL | NULL   |      | BTREE      |         |               |
+---------------------+------------+-----------------+--------------+---------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
```

the left join query as below, the union index doesn't work
```
subq LEFT JOIN (select * from resource_references where ResourceType='Run') AS r ON subq.UUID=r.ResourceUUID
```

change the left join as below:
```
subq LEFT JOIN resource_references AS r ON r.ResourceType='Run' AND subq.UUID=r.ResourceUUID
```

the result as below:
```
mysql> explain SELECT subq.*, CONCAT("[",GROUP_CONCAT(r.Payload SEPARATOR ","),"]") AS refs FROM (SELECT rd.*, CONCAT("[",GROUP_CONCAT(m.Payload SEPARATOR ","),"]") AS metrics FROM (SELECT UUID, DisplayName, Name, StorageState, Namespace, Description, CreatedAtInSec, ScheduledAtInSec, FinishedAtInSec, Conditions, PipelineId, PipelineName, PipelineSpecManifest, WorkflowSpecManifest, Parameters, pipelineRuntimeManifest, WorkflowRuntimeManifest FROM run_details WHERE UUID in (SELECT ResourceUUID FROM resource_references as rf WHERE (rf.ResourceType = 'Run' AND rf.ReferenceUUID = 'xxxx-177b4751-xxxx-xxxx' AND rf.ReferenceType = 'Experiment')) AND StorageState <> 'STORAGESTATE_ARCHIVED' ORDER BY CreatedAtInSec DESC, UUID DESC LIMIT 11) AS rd LEFT JOIN run_metrics AS m ON rd.UUID=m.RunUUID GROUP BY rd.UUID) AS subq LEFT JOIN resource_references AS r ON r.ResourceType='Run' AND subq.UUID=r.ResourceUUID GROUP BY subq.UUID ORDER BY CreatedAtInSec DESC, UUI
+----+-------------+-------------+--------+-------------------------+-----------------+---------+----------------------------+------+-----------------------------------------------------------+
| id | select_type | table       | type   | possible_keys           | key             | key_len | ref                        | rows | Extra                                                     |
+----+-------------+-------------+--------+-------------------------+-----------------+---------+----------------------------+------+-----------------------------------------------------------+
|  1 | PRIMARY     | <derived2>  | ALL    | NULL                    | NULL            | NULL    | NULL                       |   11 | Using temporary; Using filesort                           |
|  1 | PRIMARY     | r           | ref    | PRIMARY,referencefilter | PRIMARY         | 514     | subq.UUID,const            |    1 | Using where                                               |
|  2 | DERIVED     | <derived3>  | ALL    | NULL                    | NULL            | NULL    | NULL                       |   11 | Using temporary; Using filesort                           |
|  2 | DERIVED     | m           | ALL    | PRIMARY                 | NULL            | NULL    | NULL                       |    1 | Using where; Using join buffer (Block Nested Loop)        |
|  3 | DERIVED     | rf          | ref    | PRIMARY,referencefilter | referencefilter | 771     | const,const,const          |  302 | Using where; Using index; Using temporary; Using filesort |
|  3 | DERIVED     | run_details | eq_ref | PRIMARY                 | PRIMARY         | 257     | mlpipeline.rf.ResourceUUID |    1 | Using where                                               |
+----+-------------+-------------+--------+-------------------------+-----------------+---------+----------------------------+------+-----------------------------------------------------------+
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2558)
<!-- Reviewable:end -->
