### PR TITLE
Fixes test flakiness caused by "unsupported operand type(s) for -=: 'Retry' and 'int'"

### DIFF
--- a/test/sample-test/Dockerfile
+++ b/test/sample-test/Dockerfile
@@ -3,8 +3,10 @@
 FROM google/cloud-sdk:236.0.0
 
 RUN apt-get update -y && \
-    apt-get install --no-install-recommends -y -q python3-pip default-jdk python3-setuptools python3-dev && \
+    apt-get install --no-install-recommends -y -q default-jdk python3-setuptools python3-dev && \
     apt-get install --no-install-recommends -y -q libssl-dev libffi-dev wget ssh
+
+RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
 
 RUN pip3 install wheel
 RUN pip3 install junit-xml


### PR DESCRIPTION
I want to first test if this fix actually help.
part of https://github.com/kubeflow/pipelines/issues/2556
The fix come from https://stackoverflow.com/a/37531821

/kind bug

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2563)
<!-- Reviewable:end -->
