### PR TITLE
Fix inverse proxy agent in e2e tests

### DIFF
--- a/test/cloudbuild/batch_build.yaml
+++ b/test/cloudbuild/batch_build.yaml
@@ -26,9 +26,10 @@ steps:
 options:
   machineType: N1_HIGHCPU_8 # use a fast machine to build because there a lot of work
 images:
-  - "$_GCR_BASE/frontend"
-  - "$_GCR_BASE/scheduledworkflow"
   - "$_GCR_BASE/persistenceagent"
+  - "$_GCR_BASE/scheduledworkflow"
+  - "$_GCR_BASE/frontend"
   - "$_GCR_BASE/viewer-crd-controller"
   - "$_GCR_BASE/visualization-server"
+  - "$_GCR_BASE/inverse-proxy-agent"
 timeout: 1800s # 30min


### PR DESCRIPTION
Even in a successful test, we can see inverse proxy is in ImagePullBackOff state. It's not used in any e2e tests, so it doesn't break presubmit.
example log: https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kubeflow_pipelines/2563/kubeflow-pipeline-e2e-test/1192300433008234496#1:build-log.txt%3A1426

However, this issue breaks image caching. Inverse proxy agent is always not in gcr because we didn't push it there. This PR fixes the issue.

Benefit of the fix: rerunning tests will skip the image building step.

/assign @jingzhang36

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2566)
<!-- Reviewable:end -->
