### PR TITLE
Fix inverse-proxy test cloudbuild yaml

### DIFF
--- a/test/cloudbuild/batch_build.yaml
+++ b/test/cloudbuild/batch_build.yaml
@@ -21,7 +21,7 @@ steps:
     waitFor: ["-"]
   - name: "gcr.io/cloud-builders/docker"
     args:
-      ["build", "-t", "$_GCR_BASE/inverse-proxy-agent", "-f", "proxy/Dockerfile", "."]
+      ["build", "-t", "$_GCR_BASE/inverse-proxy-agent", "-f", "proxy/Dockerfile", "./proxy"]
     waitFor: ["-"]
 options:
   machineType: N1_HIGHCPU_8 # use a fast machine to build because there a lot of work


### PR DESCRIPTION
This dockerfile assumes it is called in its containing dir as workspace. It's different from most other dockerfiles which assumes project root.

/assign @rmgogogo 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2568)
<!-- Reviewable:end -->
