### PR TITLE
Fix missing run and pipeline id when buttons are clicked before content load

### DIFF
--- a/frontend/mock-backend/mock-api-middleware.ts
+++ b/frontend/mock-backend/mock-api-middleware.ts
@@ -175,7 +175,7 @@ export default (app: express.Application) => {
   app.post(v1beta1Prefix + '/experiments', (req, res) => {
     const experiment: ApiExperiment = req.body;
     if (fixedData.experiments.find(e => e.name!.toLowerCase() === experiment.name!.toLowerCase())) {
-      res.status(404).send('An experiment with teh same name already exists');
+      res.status(404).send('An experiment with the same name already exists');
       return;
     }
     experiment.id = 'new-experiment-' + (fixedData.experiments.length + 1);

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -118,8 +118,8 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
   public getInitialToolbarState(): ToolbarProps {
     const buttons = new Buttons(this.props, this.refresh.bind(this));
     const fromRunId = new URLParser(this.props).get(QUERY_PARAMS.fromRunId);
+    const pipelineIdFromParams = this.props.match.params[RouteParams.pipelineId];
     buttons.newRunFromPipeline(() => {
-      const pipelineIdFromParams = this.props.match.params[RouteParams.pipelineId];
       return this.state.pipeline
         ? this.state.pipeline.id!
         : pipelineIdFromParams
@@ -141,9 +141,20 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
     } else {
       // Add buttons for creating experiment and deleting pipeline
       buttons
-        .newExperiment(() => (this.state.pipeline ? this.state.pipeline.id! : ''))
+        .newExperiment(() =>
+          this.state.pipeline
+            ? this.state.pipeline.id!
+            : pipelineIdFromParams
+            ? pipelineIdFromParams
+            : '',
+        )
         .delete(
-          () => (this.state.pipeline ? [this.state.pipeline.id!] : []),
+          () =>
+            this.state.pipeline
+              ? [this.state.pipeline.id!]
+              : pipelineIdFromParams
+              ? [pipelineIdFromParams]
+              : [],
           'pipeline',
           this._deleteCallback.bind(this),
           true /* useCurrentResource */,

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -168,14 +168,35 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
 
   public getInitialToolbarState(): ToolbarProps {
     const buttons = new Buttons(this.props, this.refresh.bind(this));
+    const runIdFromParams = this.props.match.params[RouteParams.runId];
     return {
       actions: buttons
-        .retryRun(() => (this.state.runMetadata ? [this.state.runMetadata!.id!] : []), true, () =>
-          this.retry(),
+        .retryRun(
+          () =>
+            this.state.runMetadata
+              ? [this.state.runMetadata!.id!]
+              : runIdFromParams
+              ? [runIdFromParams]
+              : [],
+          true,
+          () => this.retry(),
         )
-        .cloneRun(() => (this.state.runMetadata ? [this.state.runMetadata!.id!] : []), true)
+        .cloneRun(
+          () =>
+            this.state.runMetadata
+              ? [this.state.runMetadata!.id!]
+              : runIdFromParams
+              ? [runIdFromParams]
+              : [],
+          true,
+        )
         .terminateRun(
-          () => (this.state.runMetadata ? [this.state.runMetadata!.id!] : []),
+          () =>
+            this.state.runMetadata
+              ? [this.state.runMetadata!.id!]
+              : runIdFromParams
+              ? [runIdFromParams]
+              : [],
           true,
           () => this.refresh(),
         )


### PR DESCRIPTION
Fixes an issue related to [#2488](https://github.com/kubeflow/pipelines/issues/2488).
If you click certain buttons before the full page has loaded then there will be adverse results due to no pipeline/run id being specified. An example is clicking the "Delete" button on the pipeline details page before the page has fully loaded will result in receiving a popup saying "Delete succeeded for this pipeline", but nothing will be deleted.

In the pipeline details page the "Create Experiment" and "Delete" buttons were changed to include the pipeline id.
In the run details page the "Retry", "Clone Run", and "Terminate" buttons were changed to include the run id.

My only concern is that I am not sure if the api is fail safe in regards to being asked to terminate a run for a run id which is already finished running. This is possible because the Terminate button is enabled on page load and now also has the run id on page load. If this is undesirable the Terminate button can be disabled until the page loads.

This also fixes a small typo in the mock-api

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2573)
<!-- Reviewable:end -->
