### PR TITLE
[Doc] Minor fix to MKP secret setup guide

### DIFF
--- a/manifests/gcp_marketplace/guide.md
+++ b/manifests/gcp_marketplace/guide.md
@@ -59,11 +59,8 @@ and store the service account credential as a Kubernetes secret `user-gcp-sa` in
 # Create credential for the service account
 gcloud iam service-accounts keys create application_default_credentials.json --iam-account $SA_NAME@$PROJECT_ID.iam.gserviceaccount.com
 
-# Make sure the secret is created under the correct namespace.
-kubectl config set-context --current --namespace=$NAMESPACE
-
 # Attempt to create a k8s secret. If already exists, override.
-kubectl create secret generic user-gcp-sa \
+kubectl create secret generic user-gcp-sa -n $NAMESPACE\
   --from-file=user-gcp-sa.json=application_default_credentials.json \
   --dry-run -o yaml  |  kubectl apply -f -
 ```

--- a/manifests/gcp_marketplace/guide.md
+++ b/manifests/gcp_marketplace/guide.md
@@ -60,9 +60,9 @@ and store the service account credential as a Kubernetes secret `user-gcp-sa` in
 gcloud iam service-accounts keys create application_default_credentials.json --iam-account $SA_NAME@$PROJECT_ID.iam.gserviceaccount.com
 
 # Attempt to create a k8s secret. If already exists, override.
-kubectl create secret generic user-gcp-sa -n $NAMESPACE\
+kubectl create secret generic user-gcp-sa \
   --from-file=user-gcp-sa.json=application_default_credentials.json \
-  --dry-run -o yaml  |  kubectl apply -f -
+  -n $NAMESPACE --dry-run -o yaml  |  kubectl apply -f -
 ```
 Remove the private key file if needed
 ```

--- a/manifests/gcp_marketplace/guide.md
+++ b/manifests/gcp_marketplace/guide.md
@@ -38,7 +38,8 @@ Then you can create a service account with the necessary IAM permissions
 export SA_NAME=<my-account>
 export NAMESPACE=<namespace-where-kfp-was-installed>
 # Create service account
-gcloud iam service-accounts create $SA_NAME --display-name $SA_NAME --project "$PROJECT_ID"
+gcloud iam service-accounts create $SA_NAME \
+  --display-name $SA_NAME --project "$PROJECT_ID"
 # Grant permissions to the service account by binding roles
 gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member=serviceAccount:$SA_NAME@$PROJECT_ID.iam.gserviceaccount.com \


### PR DESCRIPTION
Change the way of specifying namespace.

Sometimes `--current` option might not work for gcloud in MacOS, causing empty secret and permission issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2576)
<!-- Reviewable:end -->
