### PR TITLE
[UI] Fix firefox compatibility

### DIFF
--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -12,12 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as portableFetch from 'portable-fetch';
 import { HTMLViewerConfig } from 'src/components/viewers/HTMLViewer';
-import { ExperimentServiceApi } from '../apis/experiment';
-import { JobServiceApi } from '../apis/job';
-import { ApiPipeline, PipelineServiceApi } from '../apis/pipeline';
-import { RunServiceApi } from '../apis/run';
-import { ApiVisualization, VisualizationServiceApi } from '../apis/visualization';
+import {
+  Configuration as ExperimentApiConfig,
+  ExperimentServiceApi,
+  FetchAPI,
+} from '../apis/experiment';
+import { Configuration as JobApiConfig, JobServiceApi } from '../apis/job';
+import {
+  ApiPipeline,
+  Configuration as PipelineApiConfig,
+  PipelineServiceApi,
+} from '../apis/pipeline';
+import { Configuration as RunApiConfig, RunServiceApi } from '../apis/run';
+import {
+  ApiVisualization,
+  Configuration as VisualizationApiConfig,
+  VisualizationServiceApi,
+} from '../apis/visualization';
 import { PlotType } from '../components/viewers/Viewer';
 import {
   MetadataStoreServiceClient,
@@ -121,6 +134,42 @@ const metadataServicePromiseClient = {
   ),
 };
 
+// For cross browser support, fetch should use 'same-origin' as default. This fixes firefox auth issues.
+// Refrence: https://github.com/github/fetch#sending-cookies
+const crossBrowserFetch: FetchAPI = (url, init) =>
+  portableFetch(url, { credentials: 'same-origin', ...init });
+
+// There's no better way to do this, ref: https://github.com/swagger-api/swagger-codegen/pull/4038#issuecomment-257844811
+class ExperimentServiceApiPatch extends ExperimentServiceApi {
+  constructor(configuration?: ExperimentApiConfig) {
+    super(configuration, undefined, crossBrowserFetch);
+  }
+}
+
+class JobServiceApiPatch extends JobServiceApi {
+  constructor(configuration?: JobApiConfig) {
+    super(configuration, undefined, crossBrowserFetch);
+  }
+}
+
+class RunServiceApiPatch extends RunServiceApi {
+  constructor(configuration?: RunApiConfig) {
+    super(configuration, undefined, crossBrowserFetch);
+  }
+}
+
+class VisualizationServiceApiPatch extends VisualizationServiceApi {
+  constructor(configuration?: VisualizationApiConfig) {
+    super(configuration, undefined, crossBrowserFetch);
+  }
+}
+
+class PipelineServiceApiPatch extends PipelineServiceApi {
+  constructor(configuration?: PipelineApiConfig) {
+    super(configuration, undefined, crossBrowserFetch);
+  }
+}
+
 export class Apis {
   public static async areCustomVisualizationsAllowed(): Promise<boolean> {
     // Result is cached to prevent excessive network calls for simple request.
@@ -171,35 +220,35 @@ export class Apis {
 
   public static get experimentServiceApi(): ExperimentServiceApi {
     if (!this._experimentServiceApi) {
-      this._experimentServiceApi = new ExperimentServiceApi({ basePath: this.basePath });
+      this._experimentServiceApi = new ExperimentServiceApiPatch({ basePath: this.basePath });
     }
     return this._experimentServiceApi;
   }
 
   public static get jobServiceApi(): JobServiceApi {
     if (!this._jobServiceApi) {
-      this._jobServiceApi = new JobServiceApi({ basePath: this.basePath });
+      this._jobServiceApi = new JobServiceApiPatch({ basePath: this.basePath });
     }
     return this._jobServiceApi;
   }
 
   public static get pipelineServiceApi(): PipelineServiceApi {
     if (!this._pipelineServiceApi) {
-      this._pipelineServiceApi = new PipelineServiceApi({ basePath: this.basePath });
+      this._pipelineServiceApi = new PipelineServiceApiPatch({ basePath: this.basePath });
     }
     return this._pipelineServiceApi;
   }
 
   public static get runServiceApi(): RunServiceApi {
     if (!this._runServiceApi) {
-      this._runServiceApi = new RunServiceApi({ basePath: this.basePath });
+      this._runServiceApi = new RunServiceApiPatch({ basePath: this.basePath });
     }
     return this._runServiceApi;
   }
 
   public static get visualizationServiceApi(): VisualizationServiceApi {
     if (!this._visualizationServiceApi) {
-      this._visualizationServiceApi = new VisualizationServiceApi({ basePath: this.basePath });
+      this._visualizationServiceApi = new VisualizationServiceApiPatch({ basePath: this.basePath });
     }
     return this._visualizationServiceApi;
   }


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/1572#issuecomment-510264328

Before fix:
All api requests fail in Firefox because cookie is not sent by default.

After fix:
Cookies are sent with 'credentials: same-origin' policy. All the UI work properly in Firefox.

Verification
Built a new image locally and swaps into a marketplace deployed cluster, verified firefox can now use the UI properly.

/assign @jingzhang36

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2580)
<!-- Reviewable:end -->
