### PR TITLE
[fix] default yaml.dump to block style

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -868,7 +868,7 @@ class Compiler(object):
         will be returned.
     """
     yaml.Dumper.ignore_aliases = lambda *args : True
-    yaml_text = yaml.dump(workflow, default_flow_style=False)
+    yaml_text = yaml.dump(workflow, default_flow_style=False, default_style='>')
 
     if '{{pipelineparam' in yaml_text:
       raise RuntimeError(

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -868,7 +868,7 @@ class Compiler(object):
         will be returned.
     """
     yaml.Dumper.ignore_aliases = lambda *args : True
-    yaml_text = yaml.dump(workflow, default_flow_style=False, default_style='I')
+    yaml_text = yaml.dump(workflow, default_flow_style=False, default_style='|')
 
     if '{{pipelineparam' in yaml_text:
       raise RuntimeError(

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -868,7 +868,7 @@ class Compiler(object):
         will be returned.
     """
     yaml.Dumper.ignore_aliases = lambda *args : True
-    yaml_text = yaml.dump(workflow, default_flow_style=False, default_style='>')
+    yaml_text = yaml.dump(workflow, default_flow_style=False, default_style='I')
 
     if '{{pipelineparam' in yaml_text:
       raise RuntimeError(


### PR DESCRIPTION
As issue raised in https://github.com/kubeflow/pipelines/issues/2495

The output from yaml.dump does not work well with golang's backend causing the pipeline to return 500 when triggered due to yaml parsing error

Maybe it's better to detect when the string is too long and apply block style accordingly than applying for every field, that's up to the maintainer, but this fixes the 500 as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2591)
<!-- Reviewable:end -->
