### PR TITLE
Adding missing kfp.cli.diagnose_me package to setup.py Fixes #2609

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -64,6 +64,7 @@ setup(
     packages=[
         'kfp',
         'kfp.cli',
+        'kfp.cli.diagnose_me',
         'kfp.compiler',
         'kfp.components',
         'kfp.components.structures',


### PR DESCRIPTION
The `kfp.cli.diagnose_me` package was missing from the setup.py packages list and so wasn't included in the latest release pushed to pypi.org.

This package is required to run the `kfp` CLI - it raises a "Module Not Found" exception if not present
Fixes #2609

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2610)
<!-- Reviewable:end -->
