### PR TITLE
Enable inverse proxy to access host network

### DIFF
--- a/manifests/kustomize/base/proxy/proxy-deployment.yaml
+++ b/manifests/kustomize/base/proxy/proxy-deployment.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: proxy-agent
     spec:
+      hostNetwork: true
       containers:
       - image: gcr.io/ml-pipeline/inverse-proxy-agent:0.1.20
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
When switching to GKE workload identity, the pods can't access to metadata server anymore by default due to metadata concealment. 
This can be unlocked by explicitly enable hostnetwork for the pod. 
https://cloud.google.com/kubernetes-engine/docs/how-to/protecting-cluster-metadata#concealment

This should be OK as proxy is an optional component. In any case when user feel this not a secure option he/she could opt out it.

/assign @Bobgy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2614)
<!-- Reviewable:end -->
