### PR TITLE
casting job_config to QueryJobConfig if supplied by user

### DIFF
--- a/components/gcp/container/component_sdk/python/kfp_component/google/bigquery/_query.py
+++ b/components/gcp/container/component_sdk/python/kfp_component/google/bigquery/_query.py
@@ -48,6 +48,8 @@ def query(query, project_id, dataset_id=None, table_id=None,
         job_config = bigquery.QueryJobConfig()
         job_config.create_disposition = bigquery.job.CreateDisposition.CREATE_IF_NEEDED
         job_config.write_disposition = bigquery.job.WriteDisposition.WRITE_TRUNCATE
+    else:
+        job_config = bigquery.QueryJobConfig.from_api_repr(job_config)
     job_id = None
     def cancel():
         if job_id:


### PR DESCRIPTION
Small fix for #2612 by constructing a QueryJobConfig object from the `job_config` dict if it is given.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2616)
<!-- Reviewable:end -->
