### PR TITLE
[UI] Separate page state for each page instance

### DIFF
--- a/frontend/mock-backend/mock-api-server.ts
+++ b/frontend/mock-backend/mock-api-server.ts
@@ -19,9 +19,7 @@ const app = express();
 const port = process.argv[2] || 3001;
 
 // Uncomment the following line to get 1000ms delay to all requests
-app.use((req, res, next) => {
-  setTimeout(next, 1000);
-});
+// app.use((req, res, next) => { setTimeout(next, 1000); });
 
 app.use((_, res, next) => {
   res.header('Access-Control-Allow-Origin', '*');

--- a/frontend/mock-backend/mock-api-server.ts
+++ b/frontend/mock-backend/mock-api-server.ts
@@ -19,7 +19,9 @@ const app = express();
 const port = process.argv[2] || 3001;
 
 // Uncomment the following line to get 1000ms delay to all requests
-// app.use((req, res, next) => { setTimeout(next, 1000); });
+app.use((req, res, next) => {
+  setTimeout(next, 1000);
+});
 
 app.use((_, res, next) => {
   res.header('Access-Control-Allow-Origin', '*');

--- a/frontend/src/components/Router.test.tsx
+++ b/frontend/src/components/Router.test.tsx
@@ -16,12 +16,60 @@
 
 import * as React from 'react';
 
-import { shallow } from 'enzyme';
-import Router from './Router';
+import { shallow, mount } from 'enzyme';
+import Router, { RouteConfig } from './Router';
+import { Router as ReactRouter } from 'react-router';
+import { Page } from '../pages/Page';
+import { ToolbarProps } from './Toolbar';
+import { createMemoryHistory } from 'history';
 
 describe('Router', () => {
   it('initial render', () => {
     const tree = shallow(<Router />);
     expect(tree).toMatchSnapshot();
+  });
+
+  it('does not share state between pages', () => {
+    class ApplePage extends Page<{}, {}> {
+      getInitialToolbarState(): ToolbarProps {
+        return {
+          pageTitle: 'Apple',
+          actions: {},
+          breadcrumbs: [],
+        };
+      }
+      async refresh() {}
+      render() {
+        return <div>apple</div>;
+      }
+    }
+    const configs: RouteConfig[] = [
+      {
+        path: '/apple',
+        Component: ApplePage,
+      },
+      {
+        path: '/pear',
+        Component: () => {
+          return <div>pear</div>;
+        },
+      },
+    ];
+    const history = createMemoryHistory({
+      initialEntries: ['/apple'],
+    });
+    const tree = mount(
+      <ReactRouter history={history}>
+        <Router configs={configs} />
+      </ReactRouter>,
+    );
+    expect(tree.getDOMNode().querySelector('[data-testid=page-title]')!.textContent).toEqual(
+      'Apple',
+    );
+    // When visiting the second page, page title should be reset automatically, but it remains.
+    history.push('/pear');
+    expect(tree.getDOMNode().querySelector('[data-testid=page-title]')!.textContent).toEqual(
+      'Apple',
+    );
   });
 });

--- a/frontend/src/components/Router.test.tsx
+++ b/frontend/src/components/Router.test.tsx
@@ -66,10 +66,8 @@ describe('Router', () => {
     expect(tree.getDOMNode().querySelector('[data-testid=page-title]')!.textContent).toEqual(
       'Apple',
     );
-    // When visiting the second page, page title should be reset automatically, but it remains.
+    // When visiting the second page, page title should be reset automatically.
     history.push('/pear');
-    expect(tree.getDOMNode().querySelector('[data-testid=page-title]')!.textContent).toEqual(
-      'Apple',
-    );
+    expect(tree.getDOMNode().querySelector('[data-testid=page-title]')!.textContent).toEqual('');
   });
 });

--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -135,8 +135,8 @@ export interface RouterProps {
 }
 
 // This component is made as a wrapper to separate toolbar state for different pages.
-const Router: React.FC<RouterProps> = props => {
-  const routes: RouteConfig[] = props.configs || [
+const Router: React.FC<RouterProps> = ({ configs }) => {
+  const routes: RouteConfig[] = configs || [
     { path: RoutePage.ARCHIVE, Component: Archive },
     { path: RoutePage.ARTIFACTS, Component: ArtifactList },
     { path: RoutePage.ARTIFACT_DETAILS, Component: ArtifactDetails },
@@ -178,7 +178,7 @@ const Router: React.FC<RouterProps> = props => {
             exact={true}
             path={path}
             render={props => <RoutedPage key={props.location.key} route={route} />}
-          ></Route>
+          />
         );
       })}
 

--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -177,7 +177,7 @@ const Router: React.FC<RouterProps> = props => {
             key={i}
             exact={true}
             path={path}
-            render={props => <RouterImp key={props.location.key} configs={routes} />}
+            render={props => <RoutedPage key={props.location.key} route={route} />}
           ></Route>
         );
       })}
@@ -185,14 +185,14 @@ const Router: React.FC<RouterProps> = props => {
       {/* 404 */}
       {
         <Route>
-          <RouterImp configs={routes} />
+          <RoutedPage />
         </Route>
       }
     </Switch>
   );
 };
 
-class RouterImp extends React.Component<{ configs: RouteConfig[] }, RouteComponentState> {
+class RoutedPage extends React.Component<{ route?: RouteConfig }, RouteComponentState> {
   constructor(props: any) {
     super(props);
 
@@ -212,6 +212,7 @@ class RouterImp extends React.Component<{ configs: RouteConfig[] }, RouteCompone
       updateSnackbar: this._updateSnackbar.bind(this),
       updateToolbar: this._updateToolbar.bind(this),
     };
+    const route = this.props.route;
 
     return (
       <div className={commonCss.page}>
@@ -228,22 +229,24 @@ class RouterImp extends React.Component<{ configs: RouteConfig[] }, RouteCompone
               />
             )}
             <Switch>
-              {this.props.configs.map((route, i) => {
-                const { path, Component, ...otherProps } = { ...route };
-                return (
-                  <Route
-                    key={i}
-                    exact={true}
-                    path={path}
-                    render={({ ...props }) => (
-                      <Component {...props} {...childProps} {...otherProps} />
-                    )}
-                  />
-                );
-              })}
+              {route &&
+                (() => {
+                  const { path, Component, ...otherProps } = { ...route };
+                  return (
+                    <Route
+                      exact={true}
+                      path={path}
+                      render={({ ...props }) => (
+                        <Component {...props} {...childProps} {...otherProps} />
+                      )}
+                    />
+                  );
+                })()}
 
               {/* 404 */}
-              {<Route render={({ ...props }) => <Page404 {...props} {...childProps} />} />}
+              {!!route && (
+                <Route render={({ ...props }) => <Page404 {...props} {...childProps} />} />
+              )}
             </Switch>
 
             <Snackbar

--- a/frontend/src/components/Toolbar.tsx
+++ b/frontend/src/components/Toolbar.tsx
@@ -168,7 +168,11 @@ class Toolbar extends React.Component<ToolbarProps> {
               </Tooltip>
             )}
             {/* Resource Name */}
-            <span className={classes(css.pageName, commonCss.ellipsis)} title={pageTitleTooltip}>
+            <span
+              className={classes(css.pageName, commonCss.ellipsis)}
+              title={pageTitleTooltip}
+              data-testid='page-title' // TODO: use a proper h1 tag for page titles and let tests query this by h1.
+            >
               {pageTitle}
             </span>
           </div>

--- a/frontend/src/components/__snapshots__/Router.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Router.test.tsx.snap
@@ -1,139 +1,137 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Router initial render 1`] = `
-<HashRouter>
+<div
+  className="page"
+>
   <div
-    className="page"
+    className="flexGrow"
   >
+    <Route
+      render={[Function]}
+    />
     <div
-      className="flexGrow"
+      className="page"
     >
       <Route
         render={[Function]}
       />
-      <div
-        className="page"
-      >
+      <Switch>
+        <Route
+          exact={true}
+          path="/"
+          render={[Function]}
+        />
+        <Route
+          exact={true}
+          key="0"
+          path="/archive"
+          render={[Function]}
+        />
+        <Route
+          exact={true}
+          key="1"
+          path="/artifacts"
+          render={[Function]}
+        />
+        <Route
+          exact={true}
+          key="2"
+          path="/artifact_types/:artifactType+/artifacts/:id"
+          render={[Function]}
+        />
+        <Route
+          exact={true}
+          key="3"
+          path="/executions"
+          render={[Function]}
+        />
+        <Route
+          exact={true}
+          key="4"
+          path="/execution_types/:executionType+/executions/:id"
+          render={[Function]}
+        />
+        <Route
+          exact={true}
+          key="5"
+          path="/experiments"
+          render={[Function]}
+        />
+        <Route
+          exact={true}
+          key="6"
+          path="/experiments/details/:eid"
+          render={[Function]}
+        />
+        <Route
+          exact={true}
+          key="7"
+          path="/experiments/new"
+          render={[Function]}
+        />
+        <Route
+          exact={true}
+          key="8"
+          path="/runs/new"
+          render={[Function]}
+        />
+        <Route
+          exact={true}
+          key="9"
+          path="/pipelines"
+          render={[Function]}
+        />
+        <Route
+          exact={true}
+          key="10"
+          path="/pipelines/details/:pid?"
+          render={[Function]}
+        />
+        <Route
+          exact={true}
+          key="11"
+          path="/runs"
+          render={[Function]}
+        />
+        <Route
+          exact={true}
+          key="12"
+          path="/recurringrun/details/:rid"
+          render={[Function]}
+        />
+        <Route
+          exact={true}
+          key="13"
+          path="/runs/details/:rid"
+          render={[Function]}
+        />
+        <Route
+          exact={true}
+          key="14"
+          path="/compare"
+          render={[Function]}
+        />
         <Route
           render={[Function]}
         />
-        <Switch>
-          <Route
-            exact={true}
-            path="/"
-            render={[Function]}
-          />
-          <Route
-            exact={true}
-            key="0"
-            path="/archive"
-            render={[Function]}
-          />
-          <Route
-            exact={true}
-            key="1"
-            path="/artifacts"
-            render={[Function]}
-          />
-          <Route
-            exact={true}
-            key="2"
-            path="/artifact_types/:artifactType+/artifacts/:id"
-            render={[Function]}
-          />
-          <Route
-            exact={true}
-            key="3"
-            path="/executions"
-            render={[Function]}
-          />
-          <Route
-            exact={true}
-            key="4"
-            path="/execution_types/:executionType+/executions/:id"
-            render={[Function]}
-          />
-          <Route
-            exact={true}
-            key="5"
-            path="/experiments"
-            render={[Function]}
-          />
-          <Route
-            exact={true}
-            key="6"
-            path="/experiments/details/:eid"
-            render={[Function]}
-          />
-          <Route
-            exact={true}
-            key="7"
-            path="/experiments/new"
-            render={[Function]}
-          />
-          <Route
-            exact={true}
-            key="8"
-            path="/runs/new"
-            render={[Function]}
-          />
-          <Route
-            exact={true}
-            key="9"
-            path="/pipelines"
-            render={[Function]}
-          />
-          <Route
-            exact={true}
-            key="10"
-            path="/pipelines/details/:pid?"
-            render={[Function]}
-          />
-          <Route
-            exact={true}
-            key="11"
-            path="/runs"
-            render={[Function]}
-          />
-          <Route
-            exact={true}
-            key="12"
-            path="/recurringrun/details/:rid"
-            render={[Function]}
-          />
-          <Route
-            exact={true}
-            key="13"
-            path="/runs/details/:rid"
-            render={[Function]}
-          />
-          <Route
-            exact={true}
-            key="14"
-            path="/compare"
-            render={[Function]}
-          />
-          <Route
-            render={[Function]}
-          />
-        </Switch>
-        <WithStyles(Snackbar)
-          autoHideDuration={5000}
-          onClose={[Function]}
-          open={false}
-        />
-      </div>
+      </Switch>
+      <WithStyles(Snackbar)
+        autoHideDuration={5000}
+        onClose={[Function]}
+        open={false}
+      />
     </div>
-    <WithStyles(Dialog)
-      className="dialog"
-      classes={
-        Object {
-          "paper": "dialog",
-        }
-      }
-      onClose={[Function]}
-      open={false}
-    />
   </div>
-</HashRouter>
+  <WithStyles(Dialog)
+    className="dialog"
+    classes={
+      Object {
+        "paper": "dialog",
+      }
+    }
+    onClose={[Function]}
+    open={false}
+  />
+</div>
 `;

--- a/frontend/src/components/__snapshots__/Router.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Router.test.tsx.snap
@@ -98,74 +98,7 @@ exports[`Router initial render 1`] = `
     render={[Function]}
   />
   <Route>
-    <RouterImp
-      configs={
-        Array [
-          Object {
-            "Component": [Function],
-            "path": "/archive",
-          },
-          Object {
-            "Component": [Function],
-            "path": "/artifacts",
-          },
-          Object {
-            "Component": [Function],
-            "path": "/artifact_types/:artifactType+/artifacts/:id",
-          },
-          Object {
-            "Component": [Function],
-            "path": "/executions",
-          },
-          Object {
-            "Component": [Function],
-            "path": "/execution_types/:executionType+/executions/:id",
-          },
-          Object {
-            "Component": [Function],
-            "path": "/experiments",
-            "view": 0,
-          },
-          Object {
-            "Component": [Function],
-            "path": "/experiments/details/:eid",
-          },
-          Object {
-            "Component": [Function],
-            "path": "/experiments/new",
-          },
-          Object {
-            "Component": [Function],
-            "path": "/runs/new",
-          },
-          Object {
-            "Component": [Function],
-            "path": "/pipelines",
-          },
-          Object {
-            "Component": [Function],
-            "path": "/pipelines/details/:pid?",
-          },
-          Object {
-            "Component": [Function],
-            "path": "/runs",
-            "view": 1,
-          },
-          Object {
-            "Component": [Function],
-            "path": "/recurringrun/details/:rid",
-          },
-          Object {
-            "Component": [Function],
-            "path": "/runs/details/:rid",
-          },
-          Object {
-            "Component": [Function],
-            "path": "/compare",
-          },
-        ]
-      }
-    />
+    <RoutedPage />
   </Route>
 </Switch>
 `;

--- a/frontend/src/components/__snapshots__/Router.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Router.test.tsx.snap
@@ -1,137 +1,171 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Router initial render 1`] = `
-<div
-  className="page"
->
-  <div
-    className="flexGrow"
-  >
-    <Route
-      render={[Function]}
-    />
-    <div
-      className="page"
-    >
-      <Route
-        render={[Function]}
-      />
-      <Switch>
-        <Route
-          exact={true}
-          path="/"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          key="0"
-          path="/archive"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          key="1"
-          path="/artifacts"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          key="2"
-          path="/artifact_types/:artifactType+/artifacts/:id"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          key="3"
-          path="/executions"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          key="4"
-          path="/execution_types/:executionType+/executions/:id"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          key="5"
-          path="/experiments"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          key="6"
-          path="/experiments/details/:eid"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          key="7"
-          path="/experiments/new"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          key="8"
-          path="/runs/new"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          key="9"
-          path="/pipelines"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          key="10"
-          path="/pipelines/details/:pid?"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          key="11"
-          path="/runs"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          key="12"
-          path="/recurringrun/details/:rid"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          key="13"
-          path="/runs/details/:rid"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          key="14"
-          path="/compare"
-          render={[Function]}
-        />
-        <Route
-          render={[Function]}
-        />
-      </Switch>
-      <WithStyles(Snackbar)
-        autoHideDuration={5000}
-        onClose={[Function]}
-        open={false}
-      />
-    </div>
-  </div>
-  <WithStyles(Dialog)
-    className="dialog"
-    classes={
-      Object {
-        "paper": "dialog",
-      }
-    }
-    onClose={[Function]}
-    open={false}
+<Switch>
+  <Route
+    exact={true}
+    path="/"
+    render={[Function]}
   />
-</div>
+  <Route
+    exact={true}
+    key="0"
+    path="/archive"
+    render={[Function]}
+  />
+  <Route
+    exact={true}
+    key="1"
+    path="/artifacts"
+    render={[Function]}
+  />
+  <Route
+    exact={true}
+    key="2"
+    path="/artifact_types/:artifactType+/artifacts/:id"
+    render={[Function]}
+  />
+  <Route
+    exact={true}
+    key="3"
+    path="/executions"
+    render={[Function]}
+  />
+  <Route
+    exact={true}
+    key="4"
+    path="/execution_types/:executionType+/executions/:id"
+    render={[Function]}
+  />
+  <Route
+    exact={true}
+    key="5"
+    path="/experiments"
+    render={[Function]}
+  />
+  <Route
+    exact={true}
+    key="6"
+    path="/experiments/details/:eid"
+    render={[Function]}
+  />
+  <Route
+    exact={true}
+    key="7"
+    path="/experiments/new"
+    render={[Function]}
+  />
+  <Route
+    exact={true}
+    key="8"
+    path="/runs/new"
+    render={[Function]}
+  />
+  <Route
+    exact={true}
+    key="9"
+    path="/pipelines"
+    render={[Function]}
+  />
+  <Route
+    exact={true}
+    key="10"
+    path="/pipelines/details/:pid?"
+    render={[Function]}
+  />
+  <Route
+    exact={true}
+    key="11"
+    path="/runs"
+    render={[Function]}
+  />
+  <Route
+    exact={true}
+    key="12"
+    path="/recurringrun/details/:rid"
+    render={[Function]}
+  />
+  <Route
+    exact={true}
+    key="13"
+    path="/runs/details/:rid"
+    render={[Function]}
+  />
+  <Route
+    exact={true}
+    key="14"
+    path="/compare"
+    render={[Function]}
+  />
+  <Route>
+    <RouterImp
+      configs={
+        Array [
+          Object {
+            "Component": [Function],
+            "path": "/archive",
+          },
+          Object {
+            "Component": [Function],
+            "path": "/artifacts",
+          },
+          Object {
+            "Component": [Function],
+            "path": "/artifact_types/:artifactType+/artifacts/:id",
+          },
+          Object {
+            "Component": [Function],
+            "path": "/executions",
+          },
+          Object {
+            "Component": [Function],
+            "path": "/execution_types/:executionType+/executions/:id",
+          },
+          Object {
+            "Component": [Function],
+            "path": "/experiments",
+            "view": 0,
+          },
+          Object {
+            "Component": [Function],
+            "path": "/experiments/details/:eid",
+          },
+          Object {
+            "Component": [Function],
+            "path": "/experiments/new",
+          },
+          Object {
+            "Component": [Function],
+            "path": "/runs/new",
+          },
+          Object {
+            "Component": [Function],
+            "path": "/pipelines",
+          },
+          Object {
+            "Component": [Function],
+            "path": "/pipelines/details/:pid?",
+          },
+          Object {
+            "Component": [Function],
+            "path": "/runs",
+            "view": 1,
+          },
+          Object {
+            "Component": [Function],
+            "path": "/recurringrun/details/:rid",
+          },
+          Object {
+            "Component": [Function],
+            "path": "/runs/details/:rid",
+          },
+          Object {
+            "Component": [Function],
+            "path": "/compare",
+          },
+        ]
+      }
+    />
+  </Route>
+</Switch>
 `;

--- a/frontend/src/components/__snapshots__/Toolbar.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Toolbar.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`Toolbar disables the back button when there is no browser history 1`] =
       </WithStyles(Tooltip)>
       <span
         className="pageName ellipsis"
+        data-testid="page-title"
       />
     </div>
   </div>
@@ -181,6 +182,7 @@ exports[`Toolbar renders outlined action buttons 1`] = `
       </WithStyles(Tooltip)>
       <span
         className="pageName ellipsis"
+        data-testid="page-title"
       />
     </div>
   </div>
@@ -274,6 +276,7 @@ exports[`Toolbar renders primary action buttons 1`] = `
       </WithStyles(Tooltip)>
       <span
         className="pageName ellipsis"
+        data-testid="page-title"
       />
     </div>
   </div>
@@ -367,6 +370,7 @@ exports[`Toolbar renders primary action buttons without outline, even if outline
       </WithStyles(Tooltip)>
       <span
         className="pageName ellipsis"
+        data-testid="page-title"
       />
     </div>
   </div>
@@ -460,6 +464,7 @@ exports[`Toolbar renders with two breadcrumbs and two actions 1`] = `
       </WithStyles(Tooltip)>
       <span
         className="pageName ellipsis"
+        data-testid="page-title"
       />
     </div>
   </div>
@@ -557,6 +562,7 @@ exports[`Toolbar renders without actions and one breadcrumb 1`] = `
       </WithStyles(Tooltip)>
       <span
         className="pageName ellipsis"
+        data-testid="page-title"
       >
         test page title
       </span>
@@ -618,6 +624,7 @@ exports[`Toolbar renders without actions, one breadcrumb, and a page name 1`] = 
       </WithStyles(Tooltip)>
       <span
         className="pageName ellipsis"
+        data-testid="page-title"
       >
         test page title
       </span>
@@ -648,6 +655,7 @@ exports[`Toolbar renders without breadcrumbs and a component page title 1`] = `
     >
       <span
         className="pageName ellipsis"
+        data-testid="page-title"
       >
         <div
           id="myComponent"
@@ -720,6 +728,7 @@ exports[`Toolbar renders without breadcrumbs and a string page title 1`] = `
     >
       <span
         className="pageName ellipsis"
+        data-testid="page-title"
       >
         test page title
       </span>
@@ -788,6 +797,7 @@ exports[`Toolbar renders without breadcrumbs and one action 1`] = `
     >
       <span
         className="pageName ellipsis"
+        data-testid="page-title"
       >
         test page title
       </span>
@@ -837,6 +847,7 @@ exports[`Toolbar renders without breadcrumbs and two actions 1`] = `
     >
       <span
         className="pageName ellipsis"
+        data-testid="page-title"
       >
         test page title
       </span>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -21,6 +21,7 @@ import MuiThemeProvider from '@material-ui/core/styles/MuiThemeProvider';
 import Router from './components/Router';
 import { cssRule } from 'typestyle';
 import { theme, fonts } from './Css';
+import { HashRouter } from 'react-router-dom';
 
 // TODO: license headers
 
@@ -36,7 +37,9 @@ cssRule('html, body, #root', {
 
 ReactDOM.render(
   <MuiThemeProvider theme={theme}>
-    <Router />
+    <HashRouter>
+      <Router />
+    </HashRouter>
   </MuiThemeProvider>,
   document.getElementById('root'),
 );

--- a/frontend/tslint.json
+++ b/frontend/tslint.json
@@ -10,12 +10,15 @@
       "backstop_data/**/*.js",
       "generated/**",
       "src/api/*.ts",
-      "scripts/**"
+      "scripts/**",
+      "src/**/*.test.ts",
+      "src/**/*.test.tsx"
     ],
     "format": "verbose"
   },
   "rules": {
     "interface-name": [true, "never-prefix"],
+    "interface-over-type-literal": false,
     "jsx-no-bind": false,
     "jsx-no-lambda": false,
     "max-classes-per-file": false,


### PR DESCRIPTION
Toolbar, title, ... state used to get shared between pages. This caused unpredictable behavior when dangling network requests come back. It was reported in https://github.com/kubeflow/pipelines/issues/2590.

For review, [this file](https://github.com/kubeflow/pipelines/pull/2622/commits/2feaf2d3f73cb351cc4bc4c72abb2ff0b39ed575#diff-49667469ed86eeaa60660982d608ef4e
) contains all the major changes.

Changes in this PR:
* Refactor related components to facilitate testing.
* Add a failing test to reflect this bug.
* Fix the bug and verify the test passes now.
* Disable lint errors for test files.

Videos: https://github.com/kubeflow/pipelines/issues/2590#issuecomment-554897861

Fixes https://github.com/kubeflow/pipelines/issues/2590

/assign @rmgogogo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2622)
<!-- Reviewable:end -->
