### PR TITLE
Frontend server: add feature flag for kubeflow deployment

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -25,7 +25,7 @@
     <title>Kubeflow Pipelines</title>
     <script>
       window.KFP_FLAGS={};
-      window.KFP_FLAGS.MULTI_USER=0;
+      window.KFP_FLAGS.DEPLOYMENT=null;
     </script>
   </head>
   <body>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -23,6 +23,10 @@
     <link rel="manifest" href="%PUBLIC_URL%/static/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/static/favicon.ico">
     <title>Kubeflow Pipelines</title>
+    <script>
+      window.KFP_FLAGS={};
+      window.KFP_FLAGS.MULTI_USER=0;
+    </script>
   </head>
   <body>
     <noscript>

--- a/frontend/server/server.ts
+++ b/frontend/server/server.ts
@@ -410,17 +410,24 @@ function modifyFeatureFlags(indexHtml: string): string {
   }
 }
 
-// TODO: cache index html if latency is important
+// Read index html on start up.
+let indexHtml = null;
+fs.readFile(path.resolve(staticDir, 'index.html'), (err, data) => {
+  if (err) {
+    console.error('Failed to load index.html.');
+    process.exit(1);
+  } else {
+    indexHtml = data.toString();
+  }
+});
+
 function handleIndexHtml(req, res) {
-  fs.readFile(path.resolve(staticDir, 'index.html'), (err, data) => {
-    if (err) {
-      res.send(404);
-    } else {
-      res.contentType('text/html');
-      const html = modifyFeatureFlags(data.toString());
-      res.send(html);
-    }
-  });
+  if (indexHtml) {
+    res.contentType('text/html');
+    res.send(modifyFeatureFlags(indexHtml));
+  } else {
+    res.send(404);
+  }
 }
 
 // These pathes can be matched by static handler. Putting them before it to

--- a/frontend/server/server.ts
+++ b/frontend/server/server.ts
@@ -412,7 +412,7 @@ app.all(BASEPATH  + '/' + v1beta1Prefix + '/*', proxy({
 const DEFAULT_FLAG = 'window.KFP_FLAGS.DEPLOYMENT=null';
 function modifyFeatureFlags(indexHtml: string): string {
   if (DEPLOYMENT === Deployments.KUBEFLOW) {
-    return indexHtml.replace(DEFAULT_FLAG, 'window.KFP_FLAGS.MULTI_USER="KUBEFLOW"');
+    return indexHtml.replace(DEFAULT_FLAG, 'window.KFP_FLAGS.DEPLOYMENT="KUBEFLOW"');
   } else {
     return indexHtml;
   }


### PR DESCRIPTION
/assign @gaoning777

Pipeline UI pod will pass this feature flag to client: "DEPLOYMENT=KUBEFLOW".
In browser UI code, the flag can be accessed as `window.KFP_FLAGS.DEPLOYMENT`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2631)
<!-- Reviewable:end -->
