### PR TITLE
[chore] Ignore built pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ _artifacts
 # Generated Python SDK documentation
 docs/_build
 
+# Pipeline Built Outputs
+*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -67,4 +67,4 @@ _artifacts
 docs/_build
 
 # Pipeline Built Outputs
-*.tar.gz
+samples/**/*.tar.gz


### PR DESCRIPTION
I prefer ignoring built pipelines so they don't pollute `git status` output.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2638)
<!-- Reviewable:end -->
