### PR TITLE
api resource type conversion needs to convert pipeline version type

### DIFF
--- a/backend/src/apiserver/server/api_converter.go
+++ b/backend/src/apiserver/server/api_converter.go
@@ -266,6 +266,8 @@ func toApiResourceType(modelType common.ResourceType) api.ResourceType {
 		return api.ResourceType_EXPERIMENT
 	case common.Job:
 		return api.ResourceType_JOB
+	case common.PipelineVersion:
+		return api.ResourceType_PIPELINE_VERSION
 	default:
 		return api.ResourceType_UNKNOWN_RESOURCE_TYPE
 	}

--- a/backend/src/apiserver/server/api_converter_test.go
+++ b/backend/src/apiserver/server/api_converter_test.go
@@ -509,12 +509,16 @@ func TestToApiResourceReferences(t *testing.T) {
 			ReferenceName: "e1", ReferenceType: common.Experiment, Relationship: common.Owner},
 		{ResourceUUID: "run1", ResourceType: common.Run, ReferenceUUID: "job1",
 			ReferenceName: "j1", ReferenceType: common.Job, Relationship: common.Owner},
+		{ResourceUUID: "run1", ResourceType: common.Run, ReferenceUUID: "pipelineversion1",
+			ReferenceName: "k1", ReferenceType: common.PipelineVersion, Relationship: common.Owner},
 	}
 	expectedApiResourceReferences := []*api.ResourceReference{
 		{Key: &api.ResourceKey{Type: api.ResourceType_EXPERIMENT, Id: "experiment1"},
 			Name: "e1", Relationship: api.Relationship_OWNER},
 		{Key: &api.ResourceKey{Type: api.ResourceType_JOB, Id: "job1"},
 			Name: "j1", Relationship: api.Relationship_OWNER},
+		{Key: &api.ResourceKey{Type: api.ResourceType_PIPELINE_VERSION, Id: "pipelineversion1"},
+			Name: "k1", Relationship: api.Relationship_OWNER},
 	}
 	assert.Equal(t, expectedApiResourceReferences, toApiResourceReferences(resourceReferences))
 }


### PR DESCRIPTION
Api resource type conversion needs to convert pipeline version type, since now pipeline version shows as a type of resource reference in run

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2648)
<!-- Reviewable:end -->
