### PR TITLE
Configure jest to hide noisy message about no coverage data on .d.ts files

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,6 +99,7 @@
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}",
+      "!src/**/*.d.ts",
       "!src/apis/**/*.ts",
       "!src/icons/*.tsx",
       "!src/third_party/*",


### PR DESCRIPTION
/area frontend
/kind bug

Fixes error messages like the following when running `npm run test:coverage` during presubmit tests
```
Failed to collect coverage from /home/prow/go/src/github.com/kubeflow/pipelines/frontend/src/generated/src/apis/metadata/metadata_store_service_pb_service.d.ts
ERROR: Debug Failure. Output generation failed
STACK: Error: Debug Failure. Output generation failed
    at Object.transpileModule (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/typescript/lib/typescript.js:112350:29)
    at Object.process (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/ts-jest/dist/preprocessor.js:20:28)
    at ScriptTransformer.transformSource (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest-runtime/build/script_transformer.js:247:35)
    at exports.default (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest/node_modules/jest-cli/build/generate_empty_coverage.js:16:105)
    at Object.worker (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest/node_modules/jest-cli/build/reporters/coverage_worker.js:48:84)
    at execMethod (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest-worker/build/child.js:83:29)
    at process.<anonymous> (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest-worker/build/child.js:40:7)
    at process.emit (events.js:210:5)
    at emit (internal/child_process.js:876:12)
    at processTicksAndRejections (internal/process/task_queues.js:81:21)
Failed to collect coverage from /home/prow/go/src/github.com/kubeflow/pipelines/frontend/src/assets.d.ts
ERROR: Debug Failure. Output generation failed
STACK: Error: Debug Failure. Output generation failed
    at Object.transpileModule (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/typescript/lib/typescript.js:112350:29)
    at Object.process (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/ts-jest/dist/preprocessor.js:20:28)
    at ScriptTransformer.transformSource (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest-runtime/build/script_transformer.js:247:35)
    at exports.default (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest/node_modules/jest-cli/build/generate_empty_coverage.js:16:105)
    at Object.worker (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest/node_modules/jest-cli/build/reporters/coverage_worker.js:48:84)
    at execMethod (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest-worker/build/child.js:83:29)
    at process.<anonymous> (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest-worker/build/child.js:40:7)
    at process.emit (events.js:210:5)
    at emit (internal/child_process.js:876:12)
    at processTicksAndRejections (internal/process/task_queues.js:81:21)
Failed to collect coverage from /home/prow/go/src/github.com/kubeflow/pipelines/frontend/src/generated/src/apis/metadata/metadata_store_pb_service.d.ts
ERROR: Debug Failure. Output generation failed
STACK: Error: Debug Failure. Output generation failed
    at Object.transpileModule (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/typescript/lib/typescript.js:112350:29)
    at Object.process (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/ts-jest/dist/preprocessor.js:20:28)
    at ScriptTransformer.transformSource (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest-runtime/build/script_transformer.js:247:35)
    at exports.default (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest/node_modules/jest-cli/build/generate_empty_coverage.js:16:105)
    at Object.worker (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest/node_modules/jest-cli/build/reporters/coverage_worker.js:48:84)
    at execMethod (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest-worker/build/child.js:83:29)
    at process.<anonymous> (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest-worker/build/child.js:40:7)
    at process.emit (events.js:210:5)
    at emit (internal/child_process.js:876:12)
    at processTicksAndRejections (internal/process/task_queues.js:81:21)
Failed to collect coverage from /home/prow/go/src/github.com/kubeflow/pipelines/frontend/src/generated/src/apis/metadata/metadata_store_pb.d.ts
ERROR: Debug Failure. Output generation failed
STACK: Error: Debug Failure. Output generation failed
    at Object.transpileModule (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/typescript/lib/typescript.js:112350:29)
    at Object.process (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/ts-jest/dist/preprocessor.js:20:28)
    at ScriptTransformer.transformSource (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest-runtime/build/script_transformer.js:247:35)
    at exports.default (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest/node_modules/jest-cli/build/generate_empty_coverage.js:16:105)
    at Object.worker (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest/node_modules/jest-cli/build/reporters/coverage_worker.js:48:84)
    at execMethod (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest-worker/build/child.js:83:29)
    at process.<anonymous> (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest-worker/build/child.js:40:7)
    at process.emit (events.js:210:5)
    at emit (internal/child_process.js:876:12)
    at processTicksAndRejections (internal/process/task_queues.js:81:21)
Failed to collect coverage from /home/prow/go/src/github.com/kubeflow/pipelines/frontend/src/generated/src/apis/metadata/metadata_store_service_pb.d.ts
ERROR: Debug Failure. Output generation failed
STACK: Error: Debug Failure. Output generation failed
    at Object.transpileModule (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/typescript/lib/typescript.js:112350:29)
    at Object.process (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/ts-jest/dist/preprocessor.js:20:28)
    at ScriptTransformer.transformSource (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest-runtime/build/script_transformer.js:247:35)
    at exports.default (/home/prow/go/src/github.com/kubeflow/pipelines/frontend/node_modules/jest/node_modules/jest-cli/build/generate_empty_coverage.js:16:105)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2672)
<!-- Reviewable:end -->
