### PR TITLE
Add readable step id for test cloudbuild steps

### DIFF
--- a/test/cloudbuild/api_server.yaml
+++ b/test/cloudbuild/api_server.yaml
@@ -1,5 +1,6 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
+  id: "api-server"
   args: [ 'build', '-t', '$_GCR_BASE/api-server', '-f', 'backend/Dockerfile', '.' ]
 timeout: 1800s # 30min
 options:

--- a/test/cloudbuild/batch_build.yaml
+++ b/test/cloudbuild/batch_build.yaml
@@ -1,25 +1,31 @@
 steps:
   - name: "gcr.io/cloud-builders/docker"
+    id: "persistenceagent"
     args:
       ["build", "-t", "$_GCR_BASE/persistenceagent", "-f", "backend/Dockerfile.persistenceagent", "."]
     waitFor: ["-"]
   - name: "gcr.io/cloud-builders/docker"
+    id: "scheduledworkflow"
     args:
       ["build", "-t", "$_GCR_BASE/scheduledworkflow", "-f", "backend/Dockerfile.scheduledworkflow", "."]
     waitFor: ["-"]
   - name: "gcr.io/cloud-builders/docker"
+    id: "frontend"
     args:
       ["build", "-t", "$_GCR_BASE/frontend", "-f", "frontend/Dockerfile", "."]
     waitFor: ["-"]
   - name: "gcr.io/cloud-builders/docker"
+    id: "viewer-crd-controller"
     args:
       ["build", "-t", "$_GCR_BASE/viewer-crd-controller", "-f", "backend/Dockerfile.viewercontroller", "."]
     waitFor: ["-"]
   - name: "gcr.io/cloud-builders/docker"
+    id: "visualization-server"
     args:
       ["build", "-t", "$_GCR_BASE/visualization-server", "-f", "backend/Dockerfile.visualization", "."]
     waitFor: ["-"]
   - name: "gcr.io/cloud-builders/docker"
+    id: "inverse-proxy-agent"
     args:
       ["build", "-t", "$_GCR_BASE/inverse-proxy-agent", "-f", "proxy/Dockerfile", "./proxy"]
     waitFor: ["-"]


### PR DESCRIPTION
This should make reading cloudbuild error message a lot easier

Build log looks like the following now, it's clear which step is building which image
```
Starting Step #5 - "inverse-proxy-agent"
Starting Step #1 - "scheduledworkflow"
Starting Step #3 - "viewer-crd-controller"
Starting Step #0 - "persistenceagent"
Starting Step #2 - "frontend"
Starting Step #4 - "visualization-server"
Step #5 - "inverse-proxy-agent": Already have image (with digest): gcr.io/cloud-builders/docker
Step #1 - "scheduledworkflow": Already have image (with digest): gcr.io/cloud-builders/docker
Step #0 - "persistenceagent": Already have image (with digest): gcr.io/cloud-builders/docker
Step #3 - "viewer-crd-controller": Already have image (with digest): gcr.io/cloud-builders/docker
Step #4 - "visualization-server": Already have image (with digest): gcr.io/cloud-builders/docker
Step #2 - "frontend": Already have image (with digest): gcr.io/cloud-builders/docker
Step #5 - "inverse-proxy-agent": Sending build context to Docker daemon  15.36kB

Step #5 - "inverse-proxy-agent": Step 1/14 : FROM gcr.io/inverting-proxy/agent@sha256:d0a06a247bb443f9528356a1341cadfa4c4479a034097ef9ed8cf200c6383ec0
Step #5 - "inverse-proxy-agent": sha256:d0a06a247bb443f9528356a1341cadfa4c4479a034097ef9ed8cf200c6383ec0: Pulling from inverting-proxy/agent
Step #5 - "inverse-proxy-agent": cd8eada9c7bb: Pulling fs layer
Step #5 - "inverse-proxy-agent": 1d86f9372c1c: Pulling fs layer
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2673)
<!-- Reviewable:end -->
