### PR TITLE
SDK - Fixed the capitalization in _python_function_name_to_component_name

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -115,7 +115,8 @@ def set_default_base_image(image_or_factory: Union[str, Callable[[], str]]):
 
 def _python_function_name_to_component_name(name):
     import re
-    return re.sub(' +', ' ', name.replace('_', ' ')).strip(' ').capitalize()
+    name_with_spaces = re.sub(' +', ' ', name.replace('_', ' ')).strip(' ')
+    return name_with_spaces[0].upper() + name_with_spaces[1:]
 
 
 def _capture_function_code_using_cloudpickle(func, modules_to_capture: List[str] = None) -> str:


### PR DESCRIPTION
When auto-creating components from functions I want the generated component names to look "human". For example "def do_something()" should result in "Do something".
I thought that `capitalize` was doing exactly what I want, but it turned out that its behavior is different. It lowers the case of all subsequent characters, transforming "CsvExampleGen" to "Csvexamplegen". 
This PR fixes that issue and only changes the first character.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2688)
<!-- Reviewable:end -->
