### PR TITLE
Fix combined unique keys

### DIFF
--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -189,16 +189,6 @@ func initDBClient(initConnectionTimeout time.Duration) *storage.DB {
 		}
 	}
 
-	// If the old unique index idx_pipeline_version_uuid_name on pipeline_versions exists, remove it.
-	rows, err := db.Raw(`show index from pipeline_versions where Key_name="idx_pipeline_version_uuid_name"`).Rows()
-	if err != nil {
-		glog.Fatalf("Failed to query pipeline_version table's indices. Error: %s", err)
-	}
-	if rows.Next() {
-		db.Exec(`drop index idx_pipeline_version_uuid_name on pipeline_versions`)
-	}
-	rows.Close()
-
 	// Create table
 	response := db.AutoMigrate(
 		&model.Experiment{},
@@ -241,6 +231,16 @@ func initDBClient(initConnectionTimeout time.Duration) *storage.DB {
 	if response.Error != nil {
 		glog.Fatalf("Failed to update pipeline description type. Error: %s", response.Error)
 	}
+
+	// If the old unique index idx_pipeline_version_uuid_name on pipeline_versions exists, remove it.
+	rows, err := db.Raw(`show index from pipeline_versions where Key_name="idx_pipeline_version_uuid_name"`).Rows()
+	if err != nil {
+		glog.Fatalf("Failed to query pipeline_version table's indices. Error: %s", err)
+	}
+	if rows.Next() {
+		db.Exec(`drop index idx_pipeline_version_uuid_name on pipeline_versions`)
+	}
+	rows.Close()
 
 	return storage.NewDB(db.DB(), storage.NewMySQLDialect())
 }

--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -189,6 +189,16 @@ func initDBClient(initConnectionTimeout time.Duration) *storage.DB {
 		}
 	}
 
+	// If the old unique index idx_pipeline_version_uuid_name on pipeline_versions exists, remove it.
+	rows, err := db.Raw(`show index from pipeline_versions where Key_name="idx_pipeline_version_uuid_name"`).Rows()
+	if err != nil {
+		glog.Fatalf("Failed to query pipeline_version table's indices. Error: %s", err)
+	}
+	if rows.Next() {
+		db.Exec(`drop index idx_pipeline_version_uuid_name on pipeline_versions`)
+	}
+	rows.Close()
+
 	// Create table
 	response := db.AutoMigrate(
 		&model.Experiment{},

--- a/backend/src/apiserver/model/pipeline_version.go
+++ b/backend/src/apiserver/model/pipeline_version.go
@@ -31,14 +31,14 @@ const (
 type PipelineVersion struct {
 	UUID           string `gorm:"column:UUID; not null; primary_key"`
 	CreatedAtInSec int64  `gorm:"column:CreatedAtInSec; not null; index"`
-	Name           string `gorm:"column:Name; not null; unique_index:idx_pipeline_version_uuid_name"`
+	Name           string `gorm:"column:Name; not null; unique_index:idx_pipelineid_name"`
 	// Set size to 65535 so it will be stored as longtext.
 	// https://dev.mysql.com/doc/refman/8.0/en/column-count-limit.html
 	Parameters string `gorm:"column:Parameters; not null; size:65535"`
 	// PipelineVersion belongs to Pipeline. If a pipeline with a specific UUID
 	// is deleted from Pipeline table, all this pipeline's versions will be
 	// deleted from PipelineVersion table.
-	PipelineId string                `gorm:"column:PipelineId; not null;index;"`
+	PipelineId string                `gorm:"column:PipelineId; not null;index; unique_index:idx_pipelineid_name"`
 	Status     PipelineVersionStatus `gorm:"column:Status; not null"`
 	// Code source url links to the pipeline version's definition in repo.
 	CodeSourceUrl string `gorm:"column:CodeSourceUrl;"`


### PR DESCRIPTION
The current implementation of combined unique key is not working. The unique_index should be defined on the two columns (name and pipeline id) in order for those two columns to be combined unique key. So remove the old (not-working) index and add the new combined unique keys. (BTW, the current implementation makes the name globally unique)

Test: manual test with a deployment of KFP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2712)
<!-- Reviewable:end -->
