### PR TITLE
add support for AWS S3 in minio client

### DIFF
--- a/backend/src/apiserver/client/minio.go
+++ b/backend/src/apiserver/client/minio.go
@@ -24,22 +24,22 @@ import (
 	"github.com/pkg/errors"
 )
 
-func CreateMinioClient(minioServiceHost string, minioServicePort string,
+func CreateMinioClient(minioServiceUrl string, ssl bool,
 	accessKey string, secretKey string) (*minio.Client, error) {
-	minioClient, err := minio.New(fmt.Sprintf("%s:%s", minioServiceHost, minioServicePort),
-		accessKey, secretKey, false /* Secure connection */)
+	minioClient, err := minio.New(minioServiceUrl,
+		accessKey, secretKey, ssl)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error while creating minio client: %+v", err)
 	}
 	return minioClient, nil
 }
 
-func CreateMinioClientOrFatal(minioServiceHost string, minioServicePort string,
+func CreateMinioClientOrFatal(minioServiceUrl string, ssl bool,
 	accessKey string, secretKey string, initConnectionTimeout time.Duration) *minio.Client {
 	var minioClient *minio.Client
 	var err error
 	var operation = func() error {
-		minioClient, err = CreateMinioClient(minioServiceHost, minioServicePort,
+		minioClient, err = CreateMinioClient(minioServiceUrl, ssl,
 			accessKey, secretKey)
 		if err != nil {
 			return err

--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -37,8 +37,7 @@ import (
 )
 
 const (
-	minioServiceHost       = "MINIO_SERVICE_SERVICE_HOST"
-	minioServicePort       = "MINIO_SERVICE_SERVICE_PORT"
+	minioServiceUrl        = "MINIO_SERVICE_SERVICE_URL"
 	mysqlServiceHost       = "DBConfig.Host"
 	mysqlServicePort       = "DBConfig.Port"
 	mysqlUser              = "DBConfig.User"
@@ -303,16 +302,15 @@ func initMysql(driverName string, initConnectionTimeout time.Duration) string {
 
 func initMinioClient(initConnectionTimeout time.Duration) storage.ObjectStoreInterface {
 	// Create minio client.
-	minioServiceHost := common.GetStringConfigWithDefault(
-		"ObjectStoreConfig.Host", os.Getenv(minioServiceHost))
-	minioServicePort := common.GetStringConfigWithDefault(
-		"ObjectStoreConfig.Port", os.Getenv(minioServicePort))
+	minioServiceUrl := common.GetStringConfigWithDefault(
+		"ObjectStoreConfig.Url", os.Getenv(minioServiceUrl))
+	ssl := common.GetStringConfigWithDefault("ObjectStoreConfig.Ssl")
 	accessKey := common.GetStringConfig("ObjectStoreConfig.AccessKey")
 	secretKey := common.GetStringConfig("ObjectStoreConfig.SecretAccessKey")
 	bucketName := common.GetStringConfig("ObjectStoreConfig.BucketName")
 	disableMultipart := common.GetBoolConfigWithDefault("ObjectStoreConfig.Multipart.Disable", true)
 
-	minioClient := client.CreateMinioClientOrFatal(minioServiceHost, minioServicePort, accessKey,
+	minioClient := client.CreateMinioClientOrFatal(minioServiceUrl, ssl, accessKey,
 		secretKey, initConnectionTimeout)
 	createMinioBucket(minioClient, bucketName)
 


### PR DESCRIPTION
Hello,
There is a pull request but without any activity since april : https://github.com/kubeflow/pipelines/pull/766

To be able to put Kubeflow in production we need to extract the persistent data, like the mysql and minio.

Here is a pull request to be able to use a AWS S3 instead of the minio server included in Kubeflow.

Don't hesitate to comment.

Thanks !

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2720)
<!-- Reviewable:end -->
