### PR TITLE
Metadata: Adding metadata-grpc config map

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/metadata.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/metadata.yaml
@@ -58,18 +58,18 @@ spec:
         - name: MYSQL_DATABASE
           valueFrom:
             configMapKeyRef:
-              name: metadata-configmap
-              key: mysql_database
+              name: metadata-mysql-configmap
+              key: MYSQL_DATABASE
         - name: MYSQL_HOST
           valueFrom:
             configMapKeyRef:
-              name: metadata-configmap
-              key: mysql_host
+              name: metadata-mysql-configmap
+              key: MYSQL_HOST
         - name: MYSQL_PORT
           valueFrom:
             configMapKeyRef:
-              name: metadata-configmap
-              key: mysql_port
+              name: metadata-mysql-configmap
+              key: MYSQL_PORT
         command: ["/bin/metadata_store_server"]
         args: ["--grpc_port=8080",
                  "--mysql_config_database=$(MYSQL_DATABASE)",
@@ -140,3 +140,30 @@ data:
   mysql_port: "3306"
   username: "root"
   password: ""
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metadata-mysql-configmap
+  labels:
+    component: metadata-server
+data:
+  {{ if .Values.managedstorage.databaseNamePrefix }}
+  MYSQL_DATABASE: '{{ .Values.managedstorage.databaseNamePrefix }}_metadata'
+  {{ else }}
+  mysql_database: '{{ .Release.Name | replace "-" "_" | replace "." "_"}}_metadata'
+  {{ end }}
+  MYSQL_HOST: "mysql"
+  MYSQL_PORT: "3306"
+  username: "root"
+  password: ""
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metadata-grpc-configmap
+  labels:
+    component: metadata-server
+data:
+  METADATA_GRPC_SERVICE_HOST: "metadata-service"
+  METADATA_GRPC_SERVICE_PORT: "8080"

--- a/manifests/kustomize/base/metadata/metadata-configmap.yaml
+++ b/manifests/kustomize/base/metadata/metadata-configmap.yaml
@@ -1,3 +1,4 @@
+# metadata-config is retained for backward compatibility reasons.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,3 +9,24 @@ data:
   mysql_database: "metadb"
   mysql_host: "mysql"
   mysql_port: "3306"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metadata-mysql-configmap
+  labels:
+    component: metadata-server
+data:
+  MYSQL_DATABASE: "metadb"
+  MYSQL_HOST: "mysql"
+  MYSQL_PORT: "3306"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metadata-grpc-configmap
+  labels:
+    component: metadata-server
+data:
+  METADATA_GRPC_SERVICE_HOST: "metadata-service"
+  METADATA_GRPC_SERVICE_PORT: "8080"

--- a/manifests/kustomize/base/metadata/metadata-deployment.yaml
+++ b/manifests/kustomize/base/metadata/metadata-deployment.yaml
@@ -31,18 +31,18 @@ spec:
         - name: MYSQL_DATABASE
           valueFrom:
             configMapKeyRef:
-              name: metadata-configmap
-              key: mysql_database
+              name: metadata-mysql-configmap
+              key: MYSQL_DATABASE
         - name: MYSQL_HOST
           valueFrom:
             configMapKeyRef:
-              name: metadata-configmap
-              key: mysql_host
+              name: metadata-mysql-configmap
+              key: MYSQL_HOST
         - name: MYSQL_PORT
           valueFrom:
             configMapKeyRef:
-              name: metadata-configmap
-              key: mysql_port
+              name: metadata-mysql-configmap
+              key: MYSQL_PORT
         command: ["/bin/metadata_store_server"]
         args: ["--grpc_port=8080",
                "--mysql_config_database=$(MYSQL_DATABASE)",


### PR DESCRIPTION
This change adds the necessary config-map related to gRPC MLMD server.

To make the names more clear, this change also modifies the existing 'metadata-configmap' which provides mysql configurations to 'metadata-mysql-configmap'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2723)
<!-- Reviewable:end -->
