### PR TITLE
SDK/DSL: Fix PipelineVolume name length

### DIFF
--- a/sdk/python/kfp/dsl/_pipeline_volume.py
+++ b/sdk/python/kfp/dsl/_pipeline_volume.py
@@ -75,13 +75,8 @@ class PipelineVolume(V1Volume):
             hash_value = hashlib.sha256(bytes(json.dumps(self.to_dict(),
                                                          sort_keys=True),
                                               "utf-8")).hexdigest()
-            name_prefix = "pvolume-"
-            # Name must be no more than 63 characters, so we will keep the last
-            # chars of the hash value
-            hash_len = 63 - len(name_prefix)
-            self.name = (name_prefix + hash_value[len(hash_value)-hash_len:]
-                         if len(hash_value) > hash_len
-                         else name_prefix + hash_value)
+            name = "pvolume-{}".format(hash_value)
+            self.name = name[0:63] if len(name) > 63 else name
         self.dependent_names = []
 
     def after(self, *ops):

--- a/sdk/python/tests/dsl/pipeline_volume_tests.py
+++ b/sdk/python/tests/dsl/pipeline_volume_tests.py
@@ -70,8 +70,8 @@ class TestPipelineVolume(unittest.TestCase):
         def my_pipeline(param='foo'):
             vol1 = PipelineVolume(pvc="foo")
             vol2 = PipelineVolume(name="provided", pvc="foo")
-            name1 = ("pvolume-2013e9b95c192eb6a2c7d5a023ebeb51f6a114486e31216e"
-                     "083a563")
+            name1 = ("pvolume-127ac63cf2013e9b95c192eb6a2c7d5a023ebeb51f6a1144"
+                     "86e3121")
             name2 = "provided"
             self.assertEqual(vol1.name, name1)
             self.assertEqual(vol2.name, name2)

--- a/sdk/python/tests/dsl/pipeline_volume_tests.py
+++ b/sdk/python/tests/dsl/pipeline_volume_tests.py
@@ -70,8 +70,8 @@ class TestPipelineVolume(unittest.TestCase):
         def my_pipeline(param='foo'):
             vol1 = PipelineVolume(pvc="foo")
             vol2 = PipelineVolume(name="provided", pvc="foo")
-            name1 = ("pvolume-127ac63cf2013e9b95c192eb6a2c7d5a023ebeb51f6a114486e3"
-                     "1216e083a563")
+            name1 = ("pvolume-2013e9b95c192eb6a2c7d5a023ebeb51f6a114486e31216e"
+                     "083a563")
             name2 = "provided"
             self.assertEqual(vol1.name, name1)
             self.assertEqual(vol2.name, name2)


### PR DESCRIPTION
Volume name must be no more than 63 characters

Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>

---

Example of faulty behavior mentioned in kubeflow-kale/kale#30:
```
This step is in Error state with this message: Pod "rwx-test2-et0i4-tkphz-2706597555" is invalid: [spec.volumes[2].name: Invalid value: "pvolume-ca6c4cec0854efe7746ed49b8661abc2a924aef77f23218ad5c43fc8258b0dfe": must be no more than 63 characters, spec.containers[0].volumeMounts[2].name: Not found: "pvolume-ca6c4cec0854efe7746ed49b8661abc2a924aef77f23218ad5c43fc8258b0dfe", spec.containers[1].volumeMounts[0].name: Not found: "pvolume-ca6c4cec0854efe7746ed49b8661abc2a924aef77f23218ad5c43fc8258b0dfe"]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2739)
<!-- Reviewable:end -->
