### PR TITLE
[Testing] Upgrade gcp sdk version to reduce flakiness of workload identity

### DIFF
--- a/test/deploy-pipeline-lite.sh
+++ b/test/deploy-pipeline-lite.sh
@@ -73,7 +73,6 @@ if [ "$ENABLE_WORKLOAD_IDENTITY" = true ]; then
 
   source "$DIR/../manifests/kustomize/wi-utils.sh"
   verify_workload_identity_binding "pipeline-runner" $NAMESPACE
-  sleep 60
 fi
 
 popd

--- a/test/deploy-pipeline-lite.sh
+++ b/test/deploy-pipeline-lite.sh
@@ -73,6 +73,7 @@ if [ "$ENABLE_WORKLOAD_IDENTITY" = true ]; then
 
   source "$DIR/../manifests/kustomize/wi-utils.sh"
   verify_workload_identity_binding "pipeline-runner" $NAMESPACE
+  sleep 60
 fi
 
 popd

--- a/test/sample-test/Dockerfile
+++ b/test/sample-test/Dockerfile
@@ -1,6 +1,5 @@
 # This image has the script to kick off the ML pipeline sample e2e test,
 
-# TODO: use google/cloud-sdk:272.0.0, currently some python dependencies break if we use the new version
 FROM google/cloud-sdk:272.0.0
 
 RUN apt-get update -y && \

--- a/test/sample-test/Dockerfile
+++ b/test/sample-test/Dockerfile
@@ -1,7 +1,7 @@
 # This image has the script to kick off the ML pipeline sample e2e test,
 
 # TODO: use google/cloud-sdk:272.0.0, currently some python dependencies break if we use the new version
-FROM google/cloud-sdk:236.0.0
+FROM google/cloud-sdk:272.0.0
 
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y -q default-jdk python3-setuptools python3-dev && \


### PR DESCRIPTION
Currently presubmit tests seem to be flaky because of old sdk version not working well with workload identity.

Follow up on flakiness from https://github.com/kubeflow/pipelines/pull/2619

/assign @numerology 
Can you help me review?

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2744)
<!-- Reviewable:end -->
