### PR TITLE
[UI] Succeed snackbar shouldn't show when there is an error

### DIFF
--- a/frontend/src/lib/Buttons.ts
+++ b/frontend/src/lib/Buttons.ts
@@ -563,7 +563,7 @@ export default class Buttons {
       );
 
       const successfulOps = selectedIds.length - unsuccessfulIds.length;
-      if (useCurrentResource || successfulOps > 0) {
+      if (successfulOps > 0) {
         this._props.updateSnackbar({
           message: `${actionName} succeeded for ${
             useCurrentResource ? 'this' : successfulOps

--- a/frontend/src/pages/RunDetails.test.tsx
+++ b/frontend/src/pages/RunDetails.test.tsx
@@ -27,7 +27,7 @@ import { PageProps } from './Page';
 import { PlotType } from '../components/viewers/Viewer';
 import { RouteParams, RoutePage, QUERY_PARAMS } from '../components/Router';
 import { Workflow } from 'third_party/argo-ui/argo_template';
-import { shallow, ShallowWrapper } from 'enzyme';
+import { shallow, ShallowWrapper, mount, ReactWrapper } from 'enzyme';
 import { ButtonKeys } from '../lib/Buttons';
 
 describe('RunDetails', () => {
@@ -52,7 +52,7 @@ describe('RunDetails', () => {
   const formatDateStringSpy = jest.spyOn(Utils, 'formatDateString');
 
   let testRun: ApiRunDetail = {};
-  let tree: ShallowWrapper;
+  let tree: ShallowWrapper | ReactWrapper;
 
   function generateProps(): PageProps {
     const pageProps: PageProps = {
@@ -216,6 +216,26 @@ describe('RunDetails', () => {
     await confirmBtn.onClick();
     expect(retryRunSpy).toHaveBeenCalledTimes(1);
     expect(retryRunSpy).toHaveBeenLastCalledWith(testRun.run!.id);
+  });
+
+  it('shows an error dialog when retry API fails', async () => {
+    retryRunSpy.mockImplementation(() => Promise.reject('mocked error'));
+
+    tree = mount(<RunDetails {...generateProps()} />);
+    await TestUtils.flushPromises();
+    const instance = tree.instance() as RunDetails;
+    const retryBtn = instance.getInitialToolbarState().actions[ButtonKeys.RETRY];
+    await retryBtn!.action();
+    const call = updateDialogSpy.mock.calls[0][0];
+    const confirmBtn = call.buttons.find((b: any) => b.text === 'Retry');
+    await confirmBtn.onClick();
+    expect(updateDialogSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        content: 'Failed to retry run: test-run-id with error: ""mocked error""',
+      }),
+    );
+    // There shouldn't be a snackbar on error.
+    expect(updateSnackbarSpy).not.toHaveBeenCalled();
   });
 
   it('has a terminate button', async () => {


### PR DESCRIPTION
/kind bug
/area frontend
/assign @jingzhang36

Bug behavior: error dialog and success snackbar shows together.
![localhost_3000_ (5)](https://user-images.githubusercontent.com/4957653/71345122-64d61180-259f-11ea-942b-d7ef6f78c421.png)
After fix: only error dialog shows
![localhost_3000_ (6)](https://user-images.githubusercontent.com/4957653/71345172-8f27cf00-259f-11ea-8d2e-da77425c9f01.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2766)
<!-- Reviewable:end -->
