### PR TITLE
[Standalone] Fix GCP cloudsql manifest

### DIFF
--- a/manifests/kustomize/env/gcp/gcp-configurations-patch.yaml
+++ b/manifests/kustomize/env/gcp/gcp-configurations-patch.yaml
@@ -28,3 +28,31 @@ spec:
             - name: CLOUD_SQL_INSTANCE_CONNECTION_NAME
               # E.g. project-id:us-central1:instance-name
               value: ''
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workflow-controller-configmap
+data:
+  config: |
+    {
+    namespace: $(NAMESPACE),
+    executorImage: gcr.io/ml-pipeline/argoexec:v2.3.0-license-compliance,
+    artifactRepository:
+    {
+        s3: {
+            bucket: '', # Replace this with the same bucket as OBJECTSTORECONFIG_BUCKETNAME.
+            keyPrefix: artifacts,
+            endpoint: minio-service.$(NAMESPACE):9000,
+            insecure: true,
+            accessKeySecret: {
+                name: mlpipeline-minio-artifact,
+                key: accesskey
+            },
+            secretKeySecret: {
+                name: mlpipeline-minio-artifact,
+                key: secretkey
+            }
+        }
+    }
+    }


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/2719

## Decisions
* I wanted to patch only related entries in the JSON configmap, but this isn't currently supported by kustomize: https://github.com/kubernetes-sigs/kustomize/issues/680, we can only duplicate it.

## Verification
```
$ kubectl kustomize env/gcp/ | grep workflow-controller-configmap -C 30
    component: metadata-server
  name: metadata-mysql-configmap
  namespace: kubeflow
---
apiVersion: v1
data:
  config: |
    {
    namespace: kubeflow,
    executorImage: gcr.io/ml-pipeline/argoexec:v2.3.0-license-compliance,
    artifactRepository:
    {
        s3: {
            bucket: '', # Replace this with the same bucket as OBJECTSTORECONFIG_BUCKETNAME.
            keyPrefix: artifacts,
            endpoint: minio-service.kubeflow:9000,
            insecure: true,
            accessKeySecret: {
                name: mlpipeline-minio-artifact,
                key: accesskey
            },
            secretKeySecret: {
                name: mlpipeline-minio-artifact,
                key: secretkey
            }
        }
    }
    }
kind: ConfigMap
metadata:
  name: workflow-controller-configmap
  namespace: kubeflow
---
```
namespace replacement works well too

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2772)
<!-- Reviewable:end -->
