### PR TITLE
Let frontend pass pipeline description when upload a local file

### DIFF
--- a/backend/src/apiserver/server/pipeline_upload_server.go
+++ b/backend/src/apiserver/server/pipeline_upload_server.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/golang/glog"
@@ -28,8 +29,9 @@ import (
 
 // These are valid conditions of a ScheduledWorkflow.
 const (
-	FormFileKey        = "uploadfile"
-	NameQueryStringKey = "name"
+	FormFileKey               = "uploadfile"
+	NameQueryStringKey        = "name"
+	DescriptionQueryStringKey = "description"
 )
 
 type PipelineUploadServer struct {
@@ -59,11 +61,16 @@ func (s *PipelineUploadServer) UploadPipeline(w http.ResponseWriter, r *http.Req
 
 	fileNameQueryString := r.URL.Query().Get(NameQueryStringKey)
 	pipelineName, err := GetPipelineName(fileNameQueryString, header.Filename)
+	pipelineDescription, err := url.QueryUnescape(r.URL.Query().Get(DescriptionQueryStringKey))
+	if err != nil {
+		s.writeErrorToResponse(w, http.StatusBadRequest, util.Wrap(err, "Error read pipeline description."))
+		return
+	}
 	if err != nil {
 		s.writeErrorToResponse(w, http.StatusBadRequest, util.Wrap(err, "Invalid pipeline name."))
 		return
 	}
-	newPipeline, err := s.resourceManager.CreatePipeline(pipelineName, "", pipelineFile)
+	newPipeline, err := s.resourceManager.CreatePipeline(pipelineName, pipelineDescription, pipelineFile)
 	if err != nil {
 		s.writeErrorToResponse(w, http.StatusInternalServerError, util.Wrap(err, "Error creating pipeline"))
 		return

--- a/backend/src/apiserver/server/pipeline_upload_server.go
+++ b/backend/src/apiserver/server/pipeline_upload_server.go
@@ -65,6 +65,7 @@ func (s *PipelineUploadServer) UploadPipeline(w http.ResponseWriter, r *http.Req
 		s.writeErrorToResponse(w, http.StatusBadRequest, util.Wrap(err, "Invalid pipeline name."))
 		return
 	}
+	// We don't set a max length for pipeline description here, since in our DB the description type is longtext.
 	pipelineDescription, err := url.QueryUnescape(r.URL.Query().Get(DescriptionQueryStringKey))
 	if err != nil {
 		s.writeErrorToResponse(w, http.StatusBadRequest, util.Wrap(err, "Error read pipeline description."))

--- a/backend/src/apiserver/server/pipeline_upload_server.go
+++ b/backend/src/apiserver/server/pipeline_upload_server.go
@@ -61,13 +61,13 @@ func (s *PipelineUploadServer) UploadPipeline(w http.ResponseWriter, r *http.Req
 
 	fileNameQueryString := r.URL.Query().Get(NameQueryStringKey)
 	pipelineName, err := GetPipelineName(fileNameQueryString, header.Filename)
+	if err != nil {
+		s.writeErrorToResponse(w, http.StatusBadRequest, util.Wrap(err, "Invalid pipeline name."))
+		return
+	}
 	pipelineDescription, err := url.QueryUnescape(r.URL.Query().Get(DescriptionQueryStringKey))
 	if err != nil {
 		s.writeErrorToResponse(w, http.StatusBadRequest, util.Wrap(err, "Error read pipeline description."))
-		return
-	}
-	if err != nil {
-		s.writeErrorToResponse(w, http.StatusBadRequest, util.Wrap(err, "Invalid pipeline name."))
 		return
 	}
 	newPipeline, err := s.resourceManager.CreatePipeline(pipelineName, pipelineDescription, pipelineFile)

--- a/frontend/src/lib/Apis.test.ts
+++ b/frontend/src/lib/Apis.test.ts
@@ -163,10 +163,10 @@ describe('Apis', () => {
 
   it('uploadPipeline', async () => {
     const spy = fetchSpy(JSON.stringify({ name: 'resultName' }));
-    const result = await Apis.uploadPipeline('test pipeline name', new File([], 'test name'));
+    const result = await Apis.uploadPipeline('test pipeline name', 'test description', new File([], 'test name'));
     expect(result).toEqual({ name: 'resultName' });
     expect(spy).toHaveBeenCalledWith(
-      'apis/v1beta1/pipelines/upload?name=' + encodeURIComponent('test pipeline name'),
+      'apis/v1beta1/pipelines/upload?name=' + encodeURIComponent('test pipeline name') + '&description=' + encodeURIComponent('test description'),
       {
         body: expect.anything(),
         cache: 'no-cache',

--- a/frontend/src/lib/Apis.test.ts
+++ b/frontend/src/lib/Apis.test.ts
@@ -163,10 +163,17 @@ describe('Apis', () => {
 
   it('uploadPipeline', async () => {
     const spy = fetchSpy(JSON.stringify({ name: 'resultName' }));
-    const result = await Apis.uploadPipeline('test pipeline name', 'test description', new File([], 'test name'));
+    const result = await Apis.uploadPipeline(
+      'test pipeline name',
+      'test description',
+      new File([], 'test name'),
+    );
     expect(result).toEqual({ name: 'resultName' });
     expect(spy).toHaveBeenCalledWith(
-      'apis/v1beta1/pipelines/upload?name=' + encodeURIComponent('test pipeline name') + '&description=' + encodeURIComponent('test description'),
+      'apis/v1beta1/pipelines/upload?name=' +
+        encodeURIComponent('test pipeline name') +
+        '&description=' +
+        encodeURIComponent('test description'),
       {
         body: expect.anything(),
         cache: 'no-cache',

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -302,6 +302,7 @@ export class Apis {
    */
   public static async uploadPipeline(
     pipelineName: string,
+    pipelineDescription: string,
     pipelineData: File,
   ): Promise<ApiPipeline> {
     const fd = new FormData();
@@ -309,7 +310,7 @@ export class Apis {
     return await this._fetchAndParse<ApiPipeline>(
       '/pipelines/upload',
       v1beta1Prefix,
-      `name=${encodeURIComponent(pipelineName)}`,
+      `name=${encodeURIComponent(pipelineName)}&description=${encodeURIComponent(pipelineDescription)}`,
       {
         body: fd,
         cache: 'no-cache',

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -310,7 +310,9 @@ export class Apis {
     return await this._fetchAndParse<ApiPipeline>(
       '/pipelines/upload',
       v1beta1Prefix,
-      `name=${encodeURIComponent(pipelineName)}&description=${encodeURIComponent(pipelineDescription)}`,
+      `name=${encodeURIComponent(pipelineName)}&description=${encodeURIComponent(
+        pipelineDescription,
+      )}`,
       {
         body: fd,
         cache: 'no-cache',

--- a/frontend/src/pages/NewPipelineVersion.test.tsx
+++ b/frontend/src/pages/NewPipelineVersion.test.tsx
@@ -316,10 +316,13 @@ describe('NewPipelineVersion', () => {
     it('creates pipeline from local file', async () => {
       tree = shallow(<NewPipelineVersion {...generateProps()} />);
 
-      // Set local file, pipeline name and click create
+      // Set local file, pipeline name, pipeline description and click create
       tree.find('#localPackageBtn').simulate('change');
       (tree.instance() as TestNewPipelineVersion).handleChange('pipelineName')({
         target: { value: 'test pipeline name' },
+      });
+      (tree.instance() as TestNewPipelineVersion).handleChange('pipelineDescription')({
+        target: { value: 'test pipeline description' },
       });
       const file = new File(['file contents'], 'file_name', { type: 'text/plain' });
       (tree.instance() as TestNewPipelineVersion)._onDropForTest([file]);
@@ -329,7 +332,7 @@ describe('NewPipelineVersion', () => {
       await TestUtils.flushPromises();
 
       expect(tree.state('importMethod')).toBe(ImportMethod.LOCAL);
-      expect(uploadPipelineSpy).toHaveBeenLastCalledWith('test pipeline name', file);
+      expect(uploadPipelineSpy).toHaveBeenLastCalledWith('test pipeline name', 'test pipeline description', file);
       expect(createPipelineSpy).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/pages/NewPipelineVersion.test.tsx
+++ b/frontend/src/pages/NewPipelineVersion.test.tsx
@@ -332,7 +332,11 @@ describe('NewPipelineVersion', () => {
       await TestUtils.flushPromises();
 
       expect(tree.state('importMethod')).toBe(ImportMethod.LOCAL);
-      expect(uploadPipelineSpy).toHaveBeenLastCalledWith('test pipeline name', 'test pipeline description', file);
+      expect(uploadPipelineSpy).toHaveBeenLastCalledWith(
+        'test pipeline name',
+        'test pipeline description',
+        file,
+      );
       expect(createPipelineSpy).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/pages/NewPipelineVersion.tsx
+++ b/frontend/src/pages/NewPipelineVersion.tsx
@@ -551,7 +551,7 @@ class NewPipelineVersion extends Page<{}, NewPipelineVersionState> {
         // (3) new pipeline version (under an existing pipeline) from url
         const response =
           this.state.newPipeline && this.state.importMethod === ImportMethod.LOCAL
-            ? (await Apis.uploadPipeline(this.state.pipelineName!, this.state.file!))
+            ? (await Apis.uploadPipeline(this.state.pipelineName!, this.state.pipelineDescription, this.state.file!))
                 .default_version!
             : this.state.newPipeline && this.state.importMethod === ImportMethod.URL
             ? (await Apis.pipelineServiceApi.createPipeline({

--- a/frontend/src/pages/NewPipelineVersion.tsx
+++ b/frontend/src/pages/NewPipelineVersion.tsx
@@ -551,8 +551,11 @@ class NewPipelineVersion extends Page<{}, NewPipelineVersionState> {
         // (3) new pipeline version (under an existing pipeline) from url
         const response =
           this.state.newPipeline && this.state.importMethod === ImportMethod.LOCAL
-            ? (await Apis.uploadPipeline(this.state.pipelineName!, this.state.pipelineDescription, this.state.file!))
-                .default_version!
+            ? (await Apis.uploadPipeline(
+                this.state.pipelineName!,
+                this.state.pipelineDescription,
+                this.state.file!,
+              )).default_version!
             : this.state.newPipeline && this.state.importMethod === ImportMethod.URL
             ? (await Apis.pipelineServiceApi.createPipeline({
                 description: this.state.pipelineDescription,

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -798,7 +798,7 @@ class NewRun extends Page<{}, NewRunState> {
     try {
       const uploadedPipeline =
         method === ImportMethod.LOCAL
-          ? await Apis.uploadPipeline(name, file!)
+          ? await Apis.uploadPipeline(name, description || "", file!)
           : await Apis.pipelineServiceApi.createPipeline({ name, url: { pipeline_url: url } });
       this.setStateSafe(
         {

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -798,7 +798,7 @@ class NewRun extends Page<{}, NewRunState> {
     try {
       const uploadedPipeline =
         method === ImportMethod.LOCAL
-          ? await Apis.uploadPipeline(name, description || "", file!)
+          ? await Apis.uploadPipeline(name, description || '', file!)
           : await Apis.pipelineServiceApi.createPipeline({ name, url: { pipeline_url: url } });
       this.setStateSafe(
         {

--- a/frontend/src/pages/PipelineList.tsx
+++ b/frontend/src/pages/PipelineList.tsx
@@ -244,7 +244,7 @@ class PipelineList extends Page<{}, PipelineListState> {
 
     try {
       method === ImportMethod.LOCAL
-        ? await Apis.uploadPipeline(name, file!)
+        ? await Apis.uploadPipeline(name, description || "", file!)
         : await Apis.pipelineServiceApi.createPipeline({ name, url: { pipeline_url: url } });
       this.setStateSafe({ uploadDialogOpen: false });
       this.refresh();

--- a/frontend/src/pages/PipelineList.tsx
+++ b/frontend/src/pages/PipelineList.tsx
@@ -244,7 +244,7 @@ class PipelineList extends Page<{}, PipelineListState> {
 
     try {
       method === ImportMethod.LOCAL
-        ? await Apis.uploadPipeline(name, description || "", file!)
+        ? await Apis.uploadPipeline(name, description || '', file!)
         : await Apis.pipelineServiceApi.createPipeline({ name, url: { pipeline_url: url } });
       this.setStateSafe({ uploadDialogOpen: false });
       this.refresh();


### PR DESCRIPTION
When we create pipeline using a local file (instead of using a url) from UI, the description specified in the text box in UI is not actually passed to backend's pipeline_upload_server; and pipeline_upload_server.go simply uses "" as description. This change lets frontend passes the description to backend and let backend uses the received description. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2783)
<!-- Reviewable:end -->
