### PR TITLE
[UI] Show corresponding GKE cluster name

### DIFF
--- a/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SideNav populates the cluster information using the response from the system endpoints 1`] = `
+"Snapshot Diff:
+- First value
++ Second value
+
+@@ -63,7 +63,18 @@
+      <hr className=\\"separator\\" />
+      <WithStyles(IconButton) className=\\"chevron\\" onClick={[Function: bound ]}>
+        <pure(ChevronLeftIcon) />
+      </WithStyles(IconButton)>
+    </div>
+-   <div className=\\"infoVisible\\" />
++   <div className=\\"infoVisible\\">
++     <WithStyles(Tooltip) title=\\"Cluster name: some-cluster-name, Project ID: some-project-id\\" enterDelay={300} placement=\\"top-start\\">
++       <div className=\\"envMetadata\\">
++         <span>
++           Cluster name: 
++         </span>
++         <a href=\\"https://console.cloud.google.com/kubernetes/list?project=some-project-id&filter=name:some-cluster-name\\" className=\\"link unstyled\\" target=\\"_blank\\">
++           some-cluster-name
++         </a>
++       </div>
++     </WithStyles(Tooltip)>
++   </div>
+  </div>"
+`;
+
 exports[`SideNav populates the display build information using the response from the healthz endpoint 1`] = `
 <div
   className="root flexColumn noShrink"
@@ -211,7 +238,7 @@ exports[`SideNav populates the display build information using the response from
       title="Build date: 10/23/2018"
     >
       <div
-        className="buildInfo"
+        className="envMetadata"
       >
         <span>
           Build commit: 

--- a/frontend/src/components/viewers/Tensorboard.test.tsx
+++ b/frontend/src/components/viewers/Tensorboard.test.tsx
@@ -20,10 +20,9 @@ import TestUtils from '../../TestUtils';
 import { Apis } from '../../lib/Apis';
 import { PlotType } from './Viewer';
 import { ReactWrapper, ShallowWrapper, shallow, mount } from 'enzyme';
+import snapshotDiff from 'snapshot-diff';
 
 describe('Tensorboard', () => {
-  const snapshotDiff = require('snapshot-diff');
-
   let tree: ReactWrapper | ShallowWrapper;
   beforeEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
Changes:
1. Shows cluster name
2. Provides a tooltip and a link to show the cluster in GCP UI

![download (25)](https://user-images.githubusercontent.com/4957653/71656091-eafb1080-2d74-11ea-8d3d-872a0b95b3ea.png)
![localhost_3000_ (11)](https://user-images.githubusercontent.com/4957653/71656111-07974880-2d75-11ea-8c94-fb2cfaa278fd.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2789)
<!-- Reviewable:end -->
