### PR TITLE
[Testing] Save pod desc text and stackdriver link as artifacts

### DIFF
--- a/test/check-argo-status.sh
+++ b/test/check-argo-status.sh
@@ -16,7 +16,6 @@
 
 set -e
 
-ARTIFACT_DIR=$WORKSPACE/_artifacts
 WORKFLOW_COMPLETE_KEYWORD="completed=true"
 WORKFLOW_FAILED_KEYWORD="phase=Failed"
 PULL_ARGO_WORKFLOW_STATUS_MAX_ATTEMPT=$(expr $TIMEOUT_SECONDS / 20 )
@@ -70,8 +69,7 @@ fi
 echo "Argo workflow finished successfully."
 if [[ -n "$TEST_RESULT_FOLDER" ]]; then
   echo "Copy test result"
-  mkdir -p "$ARTIFACT_DIR"
-  gsutil cp -r "${TEST_RESULTS_GCS_DIR}"/* "${ARTIFACT_DIR}" || true
+  gsutil cp -r "${TEST_RESULTS_GCS_DIR}"/* "${ARTIFACTS}" || true
 fi
 
 echo "=========Main workflow=============="

--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -32,12 +32,15 @@ function clean_up {
   kubectl get pods --all-namespaces
 
   echo "Dumping all pods info as artifacts..."
+  POD_INFO_DIR="$ARTIFACTS/pods_info"
+  mkdir -p "$POD_INFO_DIR"
   # Refer to https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables
   ALL_PODS=($(kubectl get pods -o=custom-columns=:metadata.name -n $NAMESPACE))
   for POD_NAME in "${ALL_PODS[@]}"; do
-    kubectl describe pod $POD_NAME -n $NAMESPACE > "$ARTIFACTS/pod_desc_$POD_NAME.txt"
-    echo "https://console.cloud.google.com/logs/viewer?project=$PROJECT&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22$PROJECT%22%0Aresource.labels.location%3D%22us-east1-b%22%0Aresource.labels.cluster_name%3D%22${TEST_CLUSTER}%22%0Aresource.labels.namespace_name%3D%22$NAMESPACE%22%0Aresource.labels.pod_name%3D%22$POD_NAME%22" \
-      >> "$ARTIFACTS/pod_stackdriver_links.txt"
+    pod_info_file="$POD_INFO_DIR/$POD_NAME.txt"
+    kubectl describe pod $POD_NAME -n $NAMESPACE > "$pod_info_file"
+    echo "Detailed logs: https://console.cloud.google.com/logs/viewer?project=$PROJECT&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22$PROJECT%22%0Aresource.labels.location%3D%22us-east1-b%22%0Aresource.labels.cluster_name%3D%22${TEST_CLUSTER}%22%0Aresource.labels.namespace_name%3D%22$NAMESPACE%22%0Aresource.labels.pod_name%3D%22$POD_NAME%22" \
+      >> "$pod_info_file"
   done
 
   echo "Clean up..."

--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -24,7 +24,6 @@ TEST_CLUSTER_DEFAULT=$(echo $TEST_CLUSTER_PREFIX | cut -d _ -f 1)-${COMMIT_SHA:0
 TEST_CLUSTER=${TEST_CLUSTER:-${TEST_CLUSTER_DEFAULT}}
 ENABLE_WORKLOAD_IDENTITY=${ENABLE_WORKLOAD_IDENTITY:-false}
 SHOULD_CLEANUP_CLUSTER=false
-ARTIFACT_DIR="$WORKSPACE/_artifacts"
 
 function clean_up {
   set +e # the following clean up commands shouldn't exit on error
@@ -33,12 +32,12 @@ function clean_up {
   kubectl get pods --all-namespaces
 
   echo "Dumping all pods info as artifacts..."
-  mkdir -p $ARTIFACT_DIR
+  # Refer to https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables
   ALL_PODS=($(kubectl get pods -o=custom-columns=:metadata.name -n $NAMESPACE))
   for POD_NAME in "${ALL_PODS[@]}"; do
-    kubectl describe pod $POD_NAME -n $NAMESPACE > "$ARTIFACT_DIR/pod_desc_$POD_NAME.txt"
+    kubectl describe pod $POD_NAME -n $NAMESPACE > "$ARTIFACTS/pod_desc_$POD_NAME.txt"
     echo "https://console.cloud.google.com/logs/viewer?project=$PROJECT&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22$PROJECT%22%0Aresource.labels.location%3D%22us-east1-b%22%0Aresource.labels.cluster_name%3D%22${TEST_CLUSTER}%22%0Aresource.labels.namespace_name%3D%22$NAMESPACE%22%0Aresource.labels.pod_name%3D%22$POD_NAME%22" \
-      >> "$ARTIFACT_DIR/pod_stackdriver_links.txt"
+      >> "$ARTIFACTS/pod_stackdriver_links.txt"
   done
 
   echo "Clean up..."

--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -24,23 +24,22 @@ TEST_CLUSTER_DEFAULT=$(echo $TEST_CLUSTER_PREFIX | cut -d _ -f 1)-${COMMIT_SHA:0
 TEST_CLUSTER=${TEST_CLUSTER:-${TEST_CLUSTER_DEFAULT}}
 ENABLE_WORKLOAD_IDENTITY=${ENABLE_WORKLOAD_IDENTITY:-false}
 SHOULD_CLEANUP_CLUSTER=false
+ARTIFACT_DIR="$WORKSPACE/_artifacts"
 
 function clean_up {
   set +e # the following clean up commands shouldn't exit on error
 
-  echo "Describe pods with unhealthy status:"
-  UNHEALTHY_PODS=($(kubectl get pods --field-selector=status.phase!=Running,status.phase!=Succeeded -o=custom-columns=:metadata.name -n $NAMESPACE))
-  for POD_NAME in "${UNHEALTHY_PODS[@]}"; do
-    echo ""
-    echo "For pod $POD_NAME:"
-    kubectl describe pod $POD_NAME -n $NAMESPACE
-  done
-  echo "============================================================="
-  echo "The above is output of describing pods with unhealthy status."
-  echo "============================================================="
-
   echo "Status of pods before clean up:"
   kubectl get pods --all-namespaces
+
+  echo "Dumping all pods info as artifacts..."
+  mkdir -p $ARTIFACT_DIR
+  ALL_PODS=($(kubectl get pods -o=custom-columns=:metadata.name -n $NAMESPACE))
+  for POD_NAME in "${ALL_PODS[@]}"; do
+    kubectl describe pod $POD_NAME -n $NAMESPACE > "$ARTIFACT_DIR/pod_desc_$POD_NAME.txt"
+    echo "https://console.cloud.google.com/logs/viewer?project=$PROJECT&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22$PROJECT%22%0Aresource.labels.location%3D%22us-east1-b%22%0Aresource.labels.cluster_name%3D%22${TEST_CLUSTER}%22%0Aresource.labels.namespace_name%3D%22$NAMESPACE%22%0Aresource.labels.pod_name%3D%22$POD_NAME%22" \
+      >> "$ARTIFACT_DIR/pod_stackdriver_links.txt"
+  done
 
   echo "Clean up..."
   if [ $SHOULD_CLEANUP_CLUSTER == true ]; then

--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -38,9 +38,13 @@ function clean_up {
   ALL_PODS=($(kubectl get pods -o=custom-columns=:metadata.name -n $NAMESPACE))
   for POD_NAME in "${ALL_PODS[@]}"; do
     pod_info_file="$POD_INFO_DIR/$POD_NAME.txt"
-    kubectl describe pod $POD_NAME -n $NAMESPACE > "$pod_info_file"
+    echo "Pod name: $POD_NAME" >> "$pod_info_file"
     echo "Detailed logs: https://console.cloud.google.com/logs/viewer?project=$PROJECT&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22$PROJECT%22%0Aresource.labels.location%3D%22us-east1-b%22%0Aresource.labels.cluster_name%3D%22${TEST_CLUSTER}%22%0Aresource.labels.namespace_name%3D%22$NAMESPACE%22%0Aresource.labels.pod_name%3D%22$POD_NAME%22" \
       >> "$pod_info_file"
+    echo "--------" >> "$pod_info_file"
+    kubectl describe pod $POD_NAME -n $NAMESPACE >> "$pod_info_file"
+    echo "--------" >> "$pod_info_file"
+    kubectl get pod $POD_NAME -n $NAMESPACE -o yaml >> "$pod_info_file"
   done
 
   echo "Clean up..."


### PR DESCRIPTION
## Existing problem
Unhealthy pod description is usually too long and very distracting. e.g. https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kubeflow_pipelines/2786/kubeflow-pipeline-sample-test/1211813796222341120#1:build-log.txt%3A7345 the description section is too long that it's hard to find which steps passed.
But they are usually not even enough, we also need pod logs to identify the issue.

## Proposed solution
Save information related to each pod in a text file in artifacts.
Each file contains:
1. pod yaml
2. pod description
3. pod logs link

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2791)
<!-- Reviewable:end -->
