### PR TITLE
SKL - DSL - Stabilized the PipelineVolume names

### DIFF
--- a/sdk/python/tests/dsl/pipeline_volume_tests.py
+++ b/sdk/python/tests/dsl/pipeline_volume_tests.py
@@ -70,8 +70,7 @@ class TestPipelineVolume(unittest.TestCase):
         def my_pipeline(param='foo'):
             vol1 = PipelineVolume(pvc="foo")
             vol2 = PipelineVolume(name="provided", pvc="foo")
-            name1 = ("pvolume-127ac63cf2013e9b95c192eb6a2c7d5a023ebeb51f6a1144"
-                     "86e3121")
+            name1 = ("pvolume-4cf668b8c7be134cfcbd7758d1eef9643d1bd7ed9925a98e707635b")
             name2 = "provided"
             self.assertEqual(vol1.name, name1)
             self.assertEqual(vol2.name, name2)


### PR DESCRIPTION
The name no longer depends on unset parameters or the version of the Kubernetes package.
Needed for https://github.com/kubeflow/pipelines/pull/2780
Fixes  https://travis-ci.com/kubeflow/pipelines/jobs/270786161

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2794)
<!-- Reviewable:end -->
