### PR TITLE
[UI] fix artifact handler query parameter key

### DIFF
--- a/frontend/server/app.test.ts
+++ b/frontend/server/app.test.ts
@@ -171,7 +171,7 @@ describe('UIServer apis', () => {
 
       const request = requests(app.start());
       request
-        .get('/artifacts/get?source=minio&bucket=ml-pipeline&encodedKey=hello%2Fworld.txt')
+        .get('/artifacts/get?source=minio&bucket=ml-pipeline&key=hello%2Fworld.txt')
         .expect(200, artifactContent, err => {
           expect(mockedMinioClient).toBeCalledWith({
             accessKey: 'minio',
@@ -205,7 +205,7 @@ describe('UIServer apis', () => {
 
       const request = requests(app.start());
       request
-        .get('/artifacts/get?source=s3&bucket=ml-pipeline&encodedKey=hello%2Fworld.txt')
+        .get('/artifacts/get?source=s3&bucket=ml-pipeline&key=hello%2Fworld.txt')
         .expect(200, artifactContent, err => {
           expect(mockedMinioClient).toBeCalledWith({
             accessKey: 'aws123',
@@ -237,7 +237,7 @@ describe('UIServer apis', () => {
 
       const request = requests(app.start());
       request
-        .get('/artifacts/get?source=s3&bucket=ml-pipeline&encodedKey=hello%2Fworld.txt')
+        .get('/artifacts/get?source=s3&bucket=ml-pipeline&key=hello%2Fworld.txt')
         .expect(200, artifactContent, err => {
           expect(mockedMinioClient).toBeCalledWith({
             accessKey: 'aws123',
@@ -263,7 +263,7 @@ describe('UIServer apis', () => {
 
       const request = requests(app.start());
       request
-        .get('/artifacts/get?source=http&bucket=ml-pipeline&encodedKey=hello%2Fworld.txt')
+        .get('/artifacts/get?source=http&bucket=ml-pipeline&key=hello%2Fworld.txt')
         .expect(200, artifactContent, err => {
           expect(mockedFetch).toBeCalledWith('http://foo.bar/ml-pipeline/hello/world.txt', {
             headers: {},
@@ -290,7 +290,7 @@ describe('UIServer apis', () => {
 
       const request = requests(app.start());
       request
-        .get('/artifacts/get?source=https&bucket=ml-pipeline&encodedKey=hello%2Fworld.txt')
+        .get('/artifacts/get?source=https&bucket=ml-pipeline&key=hello%2Fworld.txt')
         .expect(200, artifactContent, err => {
           expect(mockedFetch).toBeCalledWith('https://foo.bar/ml-pipeline/hello/world.txt', {
             headers: {
@@ -317,7 +317,7 @@ describe('UIServer apis', () => {
 
       const request = requests(app.start());
       request
-        .get('/artifacts/get?source=https&bucket=ml-pipeline&encodedKey=hello%2Fworld.txt')
+        .get('/artifacts/get?source=https&bucket=ml-pipeline&key=hello%2Fworld.txt')
         .set('Authorization', 'inheritedToken')
         .expect(200, artifactContent, err => {
           expect(mockedFetch).toBeCalledWith('https://foo.bar/ml-pipeline/hello/world.txt', {
@@ -346,7 +346,7 @@ describe('UIServer apis', () => {
 
       const request = requests(app.start());
       request
-        .get('/artifacts/get?source=gcs&bucket=ml-pipeline&encodedKey=hello%2Fworld.txt')
+        .get('/artifacts/get?source=gcs&bucket=ml-pipeline&key=hello%2Fworld.txt')
         .expect(200, artifactContent + '\n', done);
     });
   });

--- a/frontend/server/aws-helper.ts
+++ b/frontend/server/aws-helper.ts
@@ -103,7 +103,7 @@ class AWSInstanceProfileCredentials {
   /**
    * Get the AWS metadata store session credentials.
    */
-  async getCredentials(): Promise<AWSMetadataCredentials> {
+  async getCredentials(): Promise<AWSMetadataCredentials | undefined> {
     // query for credentials if going to expire or no credentials yet
     if (Date.now() + 10 >= this._expiration || !this._credentials) {
       this._credentials = await this._fetchCredentials();

--- a/frontend/server/configs.ts
+++ b/frontend/server/configs.ts
@@ -96,9 +96,9 @@ export function loadConfigs(
     },
     artifacts: {
       aws: {
-        accessKey: AWS_ACCESS_KEY_ID,
+        accessKey: AWS_ACCESS_KEY_ID || '',
         endPoint: 's3.amazonaws.com',
-        secretKey: AWS_SECRET_ACCESS_KEY,
+        secretKey: AWS_SECRET_ACCESS_KEY || '',
       },
       http: {
         auth: {
@@ -140,7 +140,7 @@ export function loadConfigs(
     },
     viewer: {
       tensorboard: {
-        podTemplateSpec: loadJSON<object | undefined>(VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH),
+        podTemplateSpec: loadJSON<object>(VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH),
       },
     },
     visualizations: {

--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -29,7 +29,7 @@ interface ArtifactsQueryStrings {
   /** bucket name. */
   bucket: string;
   /** artifact key/path that is uri encoded.  */
-  encodedKey: string;
+  key: string;
 }
 
 /**
@@ -44,7 +44,7 @@ export function getArtifactsHandler(artifactsConfigs: {
 }): Handler {
   const { aws, http, minio } = artifactsConfigs;
   return async (req, res) => {
-    const { source, bucket, encodedKey } = req.query as Partial<ArtifactsQueryStrings>;
+    const { source, bucket, key: encodedKey } = req.query as Partial<ArtifactsQueryStrings>;
     if (!source) {
       res.status(500).send('Storage source is missing from artifact request');
       return;

--- a/frontend/server/k8s-helper.ts
+++ b/frontend/server/k8s-helper.ts
@@ -238,6 +238,10 @@ export async function getArgoWorkflow(workflowName: string): Promise<PartialArgo
     workflowName,
   );
 
+  if (res.response.statusCode == null) {
+    throw new Error(`Unable to query workflow:${workflowName}: No status code present.`);
+  }
+
   if (res.response.statusCode >= 400) {
     throw new Error(`Unable to query workflow:${workflowName}: Access denied.`);
   }

--- a/frontend/server/minio-helper.ts
+++ b/frontend/server/minio-helper.ts
@@ -59,7 +59,8 @@ export function getTarObjectAsString({ bucket, key, client }: MinioRequestConfig
     try {
       const stream = await getObjectStream({ bucket, key, client });
       let contents = '';
-      stream.pipe(new tar.Parse()).on('entry', (entry: Stream) => {
+      // TODO: fix tar.Parse typing problem
+      stream.pipe(new (tar.Parse as any)()).on('entry', (entry: Stream) => {
         entry.on('data', buffer => (contents += buffer.toString()));
       });
       stream.on('end', () => {

--- a/frontend/server/package-lock.json
+++ b/frontend/server/package-lock.json
@@ -593,6 +593,12 @@
       "integrity": "sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==",
       "dev": true
     },
+    "@types/crypto-js": {
+      "version": "3.1.43",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-3.1.43.tgz",
+      "integrity": "sha512-EHe/YKctU3IYNBsDmSOPX/7jLHPRlx8WaiDKSY9JCTnJ8XJeM4c0ZJvx+9Gxmr2s2ihI92R+3U/gNL1sq5oRuQ==",
+      "dev": true
+    },
     "@types/express": {
       "version": "4.16.1",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz",
@@ -668,6 +674,15 @@
         "@types/node": "*"
       }
     },
+    "@types/minipass": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/minipass/-/minipass-2.2.0.tgz",
+      "integrity": "sha512-wuzZksN4w4kyfoOv/dlpov4NOunwutLA/q7uc00xU02ZyUY+aoM5PWIXEKBMnm0NHd4a+N71BMjq+x7+2Af1fg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "10.17.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.11.tgz",
@@ -732,6 +747,16 @@
       "dev": true,
       "requires": {
         "@types/superagent": "*"
+      }
+    },
+    "@types/tar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-4.0.3.tgz",
+      "integrity": "sha512-Z7AVMMlkI8NTWF0qGhC4QIX0zkV/+y0J8x7b/RsHrN0310+YNjoJd8UrApCiGBCWtKjxS9QhNqLi2UJNToh5hA==",
+      "dev": true,
+      "requires": {
+        "@types/minipass": "*",
+        "@types/node": "*"
       }
     },
     "@types/tough-cookie": {
@@ -1319,9 +1344,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
     },
     "ci-info": {
       "version": "2.0.0",
@@ -4589,20 +4614,20 @@
       }
     },
     "minipass": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.6.5.tgz",
-      "integrity": "sha512-ewSKOPFH9blOLXx0YSE+mbrNMBFPS+11a2b03QZ+P4LVrUHW/GAlqeYC7DBknDyMWkHzrzTpDhUvy7MUxqyrPA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
       }
     },
     "minizlib": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.2.tgz",
-      "integrity": "sha512-hR3At21uSrsjjDTWrbu0IMLTpnkpv8IIMFDFaoz43Tmu4LkmAXfH44vNNzpTnf+OAQQCHrb91y/wc2J4x5XgSQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "^2.9.0"
       }
     },
     "mixin-deep": {
@@ -5916,13 +5941,13 @@
       "dev": true
     },
     "tar": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.11.tgz",
-      "integrity": "sha512-iI4zh3ktLJKaDNZKZc+fUONiQrSn9HkCFzamtb7k8FFmVilHVob7QsLX/VySAW8lAviMzMbFw4QtFb4errwgYA==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
-        "minipass": "^2.6.4",
+        "minipass": "^2.8.6",
         "minizlib": "^1.2.1",
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",

--- a/frontend/server/package.json
+++ b/frontend/server/package.json
@@ -11,15 +11,17 @@
     "lodash": ">=4.17.13",
     "minio": "^7.0.0",
     "node-fetch": "^2.1.2",
-    "tar": "^4.4.11"
+    "tar": "^4.4.13"
   },
   "devDependencies": {
+    "@types/crypto-js": "^3.1.43",
     "@types/express": "^4.11.1",
     "@types/jest": "^24.0.23",
     "@types/minio": "^7.0.3",
     "@types/node": "^10.17.11",
     "@types/node-fetch": "^2.1.2",
     "@types/supertest": "^2.0.8",
+    "@types/tar": "^4.0.3",
     "jest": "^24.9.0",
     "supertest": "^4.0.2",
     "ts-jest": "^24.2.0",

--- a/frontend/server/utils.ts
+++ b/frontend/server/utils.ts
@@ -51,7 +51,7 @@ export function generateRandomString(length: number): string {
   return str;
 }
 
-export function loadJSON<T>(filepath: string, defaultValue?: T): T {
+export function loadJSON<T>(filepath?: string, defaultValue?: T): T | undefined {
   if (!filepath) {
     return defaultValue;
   }

--- a/frontend/server/workflow-helper.ts
+++ b/frontend/server/workflow-helper.ts
@@ -159,18 +159,18 @@ export async function getPodLogsMinioRequestConfigfromWorkflow(
     throw new Error(`Unable to retrieve workflow status: ${err}.`);
   }
 
+  let artifacts: ArtifactRecord[] | undefined;
   // check if required fields are available
-  if (
-    !workflow.status ||
-    !workflow.status.nodes ||
-    !workflow.status.nodes[podName] ||
-    !workflow.status.nodes[podName].outputs ||
-    !workflow.status.nodes[podName].outputs.artifacts
-  ) {
+  if (workflow.status && workflow.status.nodes) {
+    const node = workflow.status.nodes[podName];
+    if (node && node.outputs && node.outputs.artifacts) {
+      artifacts = node.outputs.artifacts;
+    }
+  }
+  if (!artifacts) {
     throw new Error('Unable to find pod info in workflow status to retrieve logs.');
   }
 
-  const artifacts: ArtifactRecord[] = workflow.status.nodes[podName].outputs.artifacts;
   const archiveLogs: ArtifactRecord[] = artifacts.filter((artifact: any) => artifact.archiveLogs);
 
   if (archiveLogs.length === 0) {


### PR DESCRIPTION
Error message when getting artifact:
```
Storage key is missing from artifact request
```

The bug was introduced in https://github.com/kubeflow/pipelines/pull/2745/files#diff-ac560cff381b58853d96359ba19782e9L179.
The query parameter should be "key", but it was renamed to "encodedKey".

/cc @eterna2

This PR depends on https://github.com/kubeflow/pipelines/pull/2807.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2809)
<!-- Reviewable:end -->
