### PR TITLE
[Backend] Report workflow should use its namespace

### DIFF
--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -295,6 +295,11 @@ func initMysql(driverName string, initConnectionTimeout time.Duration) string {
 
 	util.TerminateIfError(err)
 	mysqlConfig.DBName = dbName
+	// When updating, return rows matched instead of rows affected. This counts rows that are being
+	// set as the same values as before. If updating using a primary key and rows matched is 0, then
+	// it means this row is not found.
+	// Config reference: https://github.com/go-sql-driver/mysql#clientfoundrows
+	mysqlConfig.ClientFoundRows = true
 	return mysqlConfig.FormatDSN()
 }
 

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -600,7 +600,7 @@ func (r *ResourceManager) ReportWorkflowResource(workflow *util.Workflow) error 
 
 	if workflow.PersistedFinalState() {
 		// If workflow's final state has being persisted, the workflow should be garbage collected.
-		err := r.getWorkflowClient("").Delete(workflow.Name, &v1.DeleteOptions{})
+		err := r.getWorkflowClient(workflow.Namespace).Delete(workflow.Name, &v1.DeleteOptions{})
 		if err != nil {
 			return util.NewInternalServerError(err, "Failed to delete the completed workflow for run %s", runId)
 		}
@@ -668,7 +668,7 @@ func (r *ResourceManager) ReportWorkflowResource(workflow *util.Workflow) error 
 	}
 
 	if workflow.IsInFinalState() {
-		err := AddWorkflowLabel(r.getWorkflowClient(""), workflow.Name, util.LabelKeyWorkflowPersistedFinalState, "true")
+		err := AddWorkflowLabel(r.getWorkflowClient(workflow.Namespace), workflow.Name, util.LabelKeyWorkflowPersistedFinalState, "true")
 		if err != nil {
 			return util.Wrap(err, "Failed to add PersistedFinalState label to workflow")
 		}


### PR DESCRIPTION
/assign @gaoning777 
/kind bug

There are two different problems:
<details>
<summary>error log 1</summary>
<pre>
I0107 09:03:28.062672       1 interceptor.go:29] /api.ReportService/ReportWorkflow handler starting
I0107 09:03:28.103541       1 error.go:218] Failed to update run
github.com/kubeflow/pipelines/backend/src/apiserver/storage.(*RunStore).UpdateRun
	backend/src/apiserver/storage/run_store.go:405
github.com/kubeflow/pipelines/backend/src/apiserver/resource.(*ResourceManager).ReportWorkflowResource
	backend/src/apiserver/resource/resource_manager.go:613
github.com/kubeflow/pipelines/backend/src/apiserver/server.(*ReportServer).ReportWorkflow
	backend/src/apiserver/server/report_server.go:39
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler.func1
	bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:174
main.apiServerInterceptor
	backend/src/apiserver/interceptor.go:30
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler
	bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:176
google.golang.org/grpc.(*Server).processUnaryRPC
	external/org_golang_google_grpc/server.go:966
google.golang.org/grpc.(*Server).handleStream
	external/org_golang_google_grpc/server.go:1245
google.golang.org/grpc.(*Server).serveStreams.func1.1
	external/org_golang_google_grpc/server.go:685
runtime.goexit
	GOROOT/src/runtime/asm_amd64.s:1333
<b>InternalServerError: Failed to update run 6fd49a99-f198-495f-b91b-6614f3e45079. Row not found</b>
github.com/kubeflow/pipelines/backend/src/common/util.NewInternalServerError
	backend/src/common/util/error.go:142
github.com/kubeflow/pipelines/backend/src/apiserver/storage.(*RunStore).UpdateRun
	backend/src/apiserver/storage/run_store.go:405
github.com/kubeflow/pipelines/backend/src/apiserver/resource.(*ResourceManager).ReportWorkflowResource
	backend/src/apiserver/resource/resource_manager.go:613
github.com/kubeflow/pipelines/backend/src/apiserver/server.(*ReportServer).ReportWorkflow
	backend/src/apiserver/server/report_server.go:39
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler.func1
	bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:174
main.apiServerInterceptor
	backend/src/apiserver/interceptor.go:30
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler
	bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:176
google.golang.org/grpc.(*Server).processUnaryRPC
	external/org_golang_google_grpc/server.go:966
google.golang.org/grpc.(*Server).handleStream
	external/org_golang_google_grpc/server.go:1245
google.golang.org/grpc.(*Server).serveStreams.func1.1
	external/org_golang_google_grpc/server.go:685
runtime.goexit
	GOROOT/src/runtime/asm_amd64.s:1333
Failed to update the run.
github.com/kubeflow/pipelines/backend/src/common/util.(*UserError).wrap
	backend/src/common/util/error.go:211
github.com/kubeflow/pipelines/backend/src/common/util.Wrap
	backend/src/common/util/error.go:244
github.com/kubeflow/pipelines/backend/src/apiserver/resource.(*ResourceManager).ReportWorkflowResource
	backend/src/apiserver/resource/resource_manager.go:615
github.com/kubeflow/pipelines/backend/src/apiserver/server.(*ReportServer).ReportWorkflow
	backend/src/apiserver/server/report_server.go:39
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler.func1
	bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:174
main.apiServerInterceptor
	backend/src/apiserver/interceptor.go:30
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler
	bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:176
google.golang.org/grpc.(*Server).processUnaryRPC
	external/org_golang_google_grpc/server.go:966
google.golang.org/grpc.(*Server).handleStream
	external/org_golang_google_grpc/server.go:1245
google.golang.org/grpc.(*Server).serveStreams.func1.1
	external/org_golang_google_grpc/server.go:685
runtime.goexit
	GOROOT/src/runtime/asm_amd64.s:1333
Report workflow failed.
github.com/kubeflow/pipelines/backend/src/common/util.(*UserError).wrap
	backend/src/common/util/error.go:211
github.com/kubeflow/pipelines/backend/src/common/util.Wrap
	backend/src/common/util/error.go:244
github.com/kubeflow/pipelines/backend/src/apiserver/server.(*ReportServer).ReportWorkflow
	backend/src/apiserver/server/report_server.go:41
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler.func1
	bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:174
main.apiServerInterceptor
	backend/src/apiserver/interceptor.go:30
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler
	bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:176
google.golang.org/grpc.(*Server).processUnaryRPC
	external/org_golang_google_grpc/server.go:966
google.golang.org/grpc.(*Server).handleStream
	external/org_golang_google_grpc/server.go:1245
google.golang.org/grpc.(*Server).serveStreams.func1.1
	external/org_golang_google_grpc/server.go:685
runtime.goexit
	GOROOT/src/runtime/asm_amd64.s:1333
/api.ReportService/ReportWorkflow call failed
github.com/kubeflow/pipelines/backend/src/common/util.(*UserError).wrapf
	backend/src/common/util/error.go:206
github.com/kubeflow/pipelines/backend/src/common/util.Wrapf
	backend/src/common/util/error.go:231
main.apiServerInterceptor
	backend/src/apiserver/interceptor.go:32
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler
	bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:176
google.golang.org/grpc.(*Server).processUnaryRPC
	external/org_golang_google_grpc/server.go:966
google.golang.org/grpc.(*Server).handleStream
	external/org_golang_google_grpc/server.go:1245
google.golang.org/grpc.(*Server).serveStreams.func1.1
	external/org_golang_google_grpc/server.go:685
runtime.goexit
	GOROOT/src/runtime/asm_amd64.s:1333
</pre>
</details>
<details>
<summary>error log 2</summary>
<pre>
I0107 10:55:38.115884       1 interceptor.go:29] /api.ReportService/ReportWorkflow handler starting
<b>E0107 10:55:38.330257       1 error.go:256] InternalError: workflows.argoproj.io "conditional-execution-pipeline-x4v6v" not found</b>
Failed to add PersistedFinalState label to workflow
github.com/kubeflow/pipelines/backend/src/common/util.Wrap
        backend/src/common/util/error.go:246
github.com/kubeflow/pipelines/backend/src/apiserver/resource.(*ResourceManager).ReportWorkflowResource
        backend/src/apiserver/resource/resource_manager.go:673
github.com/kubeflow/pipelines/backend/src/apiserver/server.(*ReportServer).ReportWorkflow
        backend/src/apiserver/server/report_server.go:39
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler.func1
        bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:174
main.apiServerInterceptor
        backend/src/apiserver/interceptor.go:30
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler
        bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:176
google.golang.org/grpc.(*Server).processUnaryRPC
        external/org_golang_google_grpc/server.go:966
google.golang.org/grpc.(*Server).handleStream
        external/org_golang_google_grpc/server.go:1245
google.golang.org/grpc.(*Server).serveStreams.func1.1
        external/org_golang_google_grpc/server.go:685
runtime.goexit
        GOROOT/src/runtime/asm_amd64.s:1333
Report workflow failed.
github.com/kubeflow/pipelines/backend/src/common/util.Wrap
        backend/src/common/util/error.go:246
github.com/kubeflow/pipelines/backend/src/apiserver/server.(*ReportServer).ReportWorkflow
        backend/src/apiserver/server/report_server.go:41
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler.func1
        bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:174
main.apiServerInterceptor
        backend/src/apiserver/interceptor.go:30
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler
        bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:176
google.golang.org/grpc.(*Server).processUnaryRPC
        external/org_golang_google_grpc/server.go:966
google.golang.org/grpc.(*Server).handleStream
        external/org_golang_google_grpc/server.go:1245
google.golang.org/grpc.(*Server).serveStreams.func1.1
        external/org_golang_google_grpc/server.go:685
runtime.goexit
        GOROOT/src/runtime/asm_amd64.s:1333
/api.ReportService/ReportWorkflow call failed
github.com/kubeflow/pipelines/backend/src/common/util.Wrapf
        backend/src/common/util/error.go:233
main.apiServerInterceptor
        backend/src/apiserver/interceptor.go:32
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler
        bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:176
google.golang.org/grpc.(*Server).processUnaryRPC
        external/org_golang_google_grpc/server.go:966
google.golang.org/grpc.(*Server).handleStream
        external/org_golang_google_grpc/server.go:1245
google.golang.org/grpc.(*Server).serveStreams.func1.1
        external/org_golang_google_grpc/server.go:685
runtime.goexit
        GOROOT/src/runtime/asm_amd64.s:1333
</pre>
</details>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2815)
<!-- Reviewable:end -->
