### PR TITLE
Add new Ops to Azure Databricks for KFP: secretscope, workspaceitem & dbfsblock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ frontend/test/ui/visual-regression/screenshots/screen
 .idea/
 .ijwb/
 *.iml
+.history/*
 
 # Merge files
 *.orig

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ frontend/test/ui/visual-regression/screenshots/screen
 .idea/
 .ijwb/
 *.iml
-.history/*
 
 # Merge files
 *.orig

--- a/samples/contrib/azure-samples/databricks-pipelines/README.md
+++ b/samples/contrib/azure-samples/databricks-pipelines/README.md
@@ -11,13 +11,18 @@ resources using the [Azure Databricks for Kubeflow Pipelines](
     https://docs.microsoft.com/en-us/azure/databricks/getting-started/try-databricks?toc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fazure-databricks%2FTOC.json&bc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#--step-2-create-an-azure-databricks-workspace)
 2) [Deploy the Azure Databricks Operator for Kubernetes](
     https://github.com/microsoft/azure-databricks-operator/blob/master/docs/deploy.md)
-3) All these samples reference 'sparkpi.jar' library. This library can be found here: [Create and run a 
+3) Some samples reference 'sparkpi.jar' library. This library can be found here: [Create and run a 
 jar job](https://docs.databricks.com/dev-tools/api/latest/examples.html#create-and-run-a-jar-job). 
 Upload it to [Databricks File System](
 https://docs.microsoft.com/en-us/azure/databricks/data/databricks-file-system) using e.g. [DBFS 
 CLI](https://docs.microsoft.com/en-us/azure/databricks/dev-tools/databricks-cli#dbfs-cli).
-4) [Install the Kubeflow Pipelines SDK](https://www.kubeflow.org/docs/pipelines/sdk/install-sdk/)
-5) Install Azure Databricks for Kubeflow Pipelines package:
+4) Some samples that use CreateSecretScopeOp reference a secret in Kubernetes. This secret must be
+created before running these pipelines. For example:
+```bash
+kubectl create secret generic -n kubeflow mysecret --from-literal=username=alex 
+```
+5) [Install the Kubeflow Pipelines SDK](https://www.kubeflow.org/docs/pipelines/sdk/install-sdk/)
+6) Install Azure Databricks for Kubeflow Pipelines package:
 ```
 pip install -e "git+https://github.com/kubeflow/pipelines#egg=kfp-azure-databricks&subdirectory=samples/contrib/azure-samples/kfp-azure-databricks" --upgrade
 ```

--- a/samples/contrib/azure-samples/databricks-pipelines/databricks_cluster_pipeline.py
+++ b/samples/contrib/azure-samples/databricks-pipelines/databricks_cluster_pipeline.py
@@ -52,4 +52,6 @@ def calc_pipeline(cluster_name="test-cluster", run_name="test-run", parameter="1
     delete_cluster_task.after(delete_run_task)
 
 if __name__ == "__main__":
-    compiler.Compiler().compile(calc_pipeline, __file__ + ".tar.gz")
+    compiler.Compiler()._create_and_write_workflow(
+        pipeline_func=calc_pipeline,
+        package_path=__file__ + ".tar.gz")

--- a/samples/contrib/azure-samples/databricks-pipelines/databricks_job_pipeline.py
+++ b/samples/contrib/azure-samples/databricks-pipelines/databricks_job_pipeline.py
@@ -39,7 +39,7 @@ def delete_job(job_name):
     )
 
 @dsl.pipeline(
-    name="DatabricksRun",
+    name="DatabricksJob",
     description="A toy pipeline that computes an approximation to pi with Azure Databricks."
 )
 def calc_pipeline(job_name="test-job", run_name="test-job-run", parameter="10"):

--- a/samples/contrib/azure-samples/databricks-pipelines/databricks_job_pipeline.py
+++ b/samples/contrib/azure-samples/databricks-pipelines/databricks_job_pipeline.py
@@ -52,4 +52,6 @@ def calc_pipeline(job_name="test-job", run_name="test-job-run", parameter="10"):
     delete_job_task.after(delete_run_task)
 
 if __name__ == "__main__":
-    compiler.Compiler().compile(calc_pipeline, __file__ + ".tar.gz")
+    compiler.Compiler()._create_and_write_workflow(
+        pipeline_func=calc_pipeline,
+        package_path=__file__ + ".tar.gz")

--- a/samples/contrib/azure-samples/databricks-pipelines/databricks_notebook_pipeline.py
+++ b/samples/contrib/azure-samples/databricks-pipelines/databricks_notebook_pipeline.py
@@ -8,29 +8,11 @@ import kfp.compiler as compiler
 import databricks
 
 def create_dbfsblock(block_name):
-    # Op not implemented in Azure Databricks for KFP yet
-    return dsl.ResourceOp(
+    return databricks.CreateDbfsBlockOp(
         name="createdbfsblock",
-        k8s_resource={
-            "apiVersion": "databricks.microsoft.com/v1alpha1",
-            "kind": "DbfsBlock",
-            "metadata": {
-                "name":block_name
-            },
-            "spec":{
-                "path": "/data/foo.txt",
-                "data": "QWxlamFuZHJvIENhbXBvcyBNYWdlbmNpbw=="
-            }
-        },
-        action="create",
-        success_condition="status.file_hash",
-        attribute_outputs={
-            "name": "{.metadata.name}",
-            "file_info_path": "{.status.file_info.path}",
-            "file_info_is_dir": "{.status.file_info.is_dir}",
-            "file_info_file_size": "{.status.file_info.file_size}",
-            "file_hash": "{.status.file_hash}"
-        }
+        block_name=block_name,
+        data="QWxlamFuZHJvIENhbXBvcyBNYWdlbmNpbw==",
+        path="/data/foo.txt"
     )
 
 def create_secretscope(scope_name):
@@ -137,17 +119,9 @@ def delete_secretscope(scope_name):
     )
 
 def delete_dbfsblock(block_name):
-    # Op not implemented in Azure Databricks for KFP yet
-    return dsl.ResourceOp(
+    return databricks.DeleteDbfsBlockOp(
         name="deletedbfsblock",
-        k8s_resource={
-            "apiVersion": "databricks.microsoft.com/v1alpha1",
-            "kind": "DbfsBlock",
-            "metadata": {
-                "name":block_name
-            }
-        },
-        action="delete"
+        block_name=block_name
     )
 
 @dsl.pipeline(

--- a/samples/contrib/azure-samples/databricks-pipelines/databricks_notebook_pipeline.py
+++ b/samples/contrib/azure-samples/databricks-pipelines/databricks_notebook_pipeline.py
@@ -41,7 +41,7 @@ def create_secretscope(scope_name):
         ]
     )
 
-def import_workspace_item(item_name):
+def import_workspace_item(item_name, user):
     current_path = Path(__file__).parent
     notebook_file_name = current_path.joinpath("notebooks", "ScalaExampleNotebook")
     notebook = open(notebook_file_name).read().encode("utf-8")
@@ -50,7 +50,7 @@ def import_workspace_item(item_name):
         name="importworkspaceitem",
         item_name=item_name,
         content=notebook_base64,
-        path="/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+        path=f"/Users/{user}/ScalaExampleNotebook",
         language="SCALA",
         file_format="SOURCE"
     )
@@ -67,13 +67,13 @@ def create_cluster(cluster_name):
         num_workers=2
     )
 
-def create_job(job_name, cluster_id):
+def create_job(job_name, cluster_id, user):
     return databricks.CreateJobOp(
         name="createjob",
         job_name=job_name,
         existing_cluster_id=cluster_id,
         notebook_task={
-            "notebook_path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook"
+            "notebook_path": f"/Users/{user}/ScalaExampleNotebook"
         }
     )
 
@@ -135,13 +135,14 @@ def calc_pipeline(
         cluster_name="test-cluster",
         job_name="test-job",
         run_name="test-run",
+        user="user@foo.com",
         parameter1="38",
         parameter2="43"):
     create_dbfsblock_task = create_dbfsblock(dbfsblock_name)
     create_secretscope_task = create_secretscope(secretescope_name)
-    import_workspace_item_task = import_workspace_item(workspaceitem_name)
+    import_workspace_item_task = import_workspace_item(workspaceitem_name, user)
     create_cluster_task = create_cluster(cluster_name)
-    create_job_task = create_job(job_name, create_cluster_task.outputs["cluster_id"])
+    create_job_task = create_job(job_name, create_cluster_task.outputs["cluster_id"], user)
     submit_run_task = submit_run(run_name, job_name, parameter1, parameter2)
     submit_run_task.after(create_dbfsblock_task)
     submit_run_task.after(create_secretscope_task)

--- a/samples/contrib/azure-samples/databricks-pipelines/databricks_notebook_pipeline.py
+++ b/samples/contrib/azure-samples/databricks-pipelines/databricks_notebook_pipeline.py
@@ -1,0 +1,190 @@
+"""Import a notebook into a Databricks workspace and submit a job run to execute it in a cluster.
+Notebook will accept some parameters and access a file in DBFS and some secrets in a secret scope.
+"""
+from pathlib import Path
+import base64
+import kfp.dsl as dsl
+import kfp.compiler as compiler
+import databricks
+
+def create_dbfsblock(block_name):
+    # Op not implemented in Azure Databricks for KFP yet
+    return dsl.ResourceOp(
+        name="createdbfsblock",
+        k8s_resource={
+            "apiVersion": "databricks.microsoft.com/v1alpha1",
+            "kind": "DbfsBlock",
+            "metadata": {
+                "name":block_name
+            },
+            "spec":{
+                "path": "/data/foo.txt",
+                "data": "QWxlamFuZHJvIENhbXBvcyBNYWdlbmNpbw=="
+            }
+        },
+        action="create",
+        success_condition="status.file_hash",
+        attribute_outputs={
+            "name": "{.metadata.name}",
+            "file_info_path": "{.status.file_info.path}",
+            "file_info_is_dir": "{.status.file_info.is_dir}",
+            "file_info_file_size": "{.status.file_info.file_size}",
+            "file_hash": "{.status.file_hash}"
+        }
+    )
+
+def create_secretscope(scope_name):
+    return databricks.CreateSecretScopeOp(
+        name="createsecretscope",
+        scope_name=scope_name,
+        initial_manage_principal="users",
+        secrets=[
+            {
+                "key": "string-secret",
+                "string_value": "helloworld"
+            },
+            {
+                "key": "byte-secret",
+                "byte_value": "aGVsbG93b3JsZA=="
+            },
+            {
+                "key": "ref-secret",
+                "value_from": {
+                    "secret_key_ref": {
+                        "name": "mysecret",
+                        "key": "username"
+                    }
+                }
+            }
+        ]
+    )
+
+def import_workspace_item(item_name):
+    current_path = Path(__file__).parent
+    notebook_file_name = current_path.joinpath("notebooks", "ScalaExampleNotebook")
+    notebook = open(notebook_file_name).read().encode("utf-8")
+    notebook_base64 = base64.b64encode(notebook)
+    return databricks.ImportWorkspaceItemOp(
+        name="importworkspaceitem",
+        item_name=item_name,
+        content=notebook_base64,
+        path="/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+        language="SCALA",
+        file_format="SOURCE"
+    )
+
+def create_cluster(cluster_name):
+    return databricks.CreateClusterOp(
+        name="createcluster",
+        cluster_name=cluster_name,
+        spark_version="5.3.x-scala2.11",
+        node_type_id="Standard_D3_v2",
+        spark_conf={
+            "spark.speculation": "true"
+        },
+        num_workers=2
+    )
+
+def create_job(job_name, cluster_id):
+    return databricks.CreateJobOp(
+        name="createjob",
+        job_name=job_name,
+        existing_cluster_id=cluster_id,
+        notebook_task={
+            "notebook_path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook"
+        }
+    )
+
+def submit_run(run_name, job_name, parameter1, parameter2):
+    return databricks.SubmitRunOp(
+        name="submitrun",
+        run_name=run_name,
+        job_name=job_name,
+        notebook_params={
+            "param1": parameter1,
+            "param2": parameter2
+        }
+    )
+
+def delete_run(run_name):
+    return databricks.DeleteRunOp(
+        name="deleterun",
+        run_name=run_name
+    )
+
+def delete_job(job_name):
+    return databricks.DeleteJobOp(
+        name="deletejob",
+        job_name=job_name
+    )
+
+def delete_cluster(cluster_name):
+    return databricks.DeleteClusterOp(
+        name="deletecluster",
+        cluster_name=cluster_name
+    )
+
+def delete_workspace_item(item_name):
+    return databricks.DeleteWorkspaceItemOp(
+        name="deleteworkspaceitem",
+        item_name=item_name
+    )
+
+def delete_secretscope(scope_name):
+    return databricks.DeleteSecretScopeOp(
+        name="deletesecretscope",
+        scope_name=scope_name
+    )
+
+def delete_dbfsblock(block_name):
+    # Op not implemented in Azure Databricks for KFP yet
+    return dsl.ResourceOp(
+        name="deletedbfsblock",
+        k8s_resource={
+            "apiVersion": "databricks.microsoft.com/v1alpha1",
+            "kind": "DbfsBlock",
+            "metadata": {
+                "name":block_name
+            }
+        },
+        action="delete"
+    )
+
+@dsl.pipeline(
+    name="Databrick",
+    description="A toy pipeline that runs a sample notebook in a Databricks cluster."
+)
+def calc_pipeline(
+        dbfsblock_name="test-block",
+        secretescope_name="test-scope",
+        workspaceitem_name="test-item",
+        cluster_name="test-cluster",
+        job_name="test-job",
+        run_name="test-run",
+        parameter1="38",
+        parameter2="43"):
+    create_dbfsblock_task = create_dbfsblock(dbfsblock_name)
+    create_secretscope_task = create_secretscope(secretescope_name)
+    import_workspace_item_task = import_workspace_item(workspaceitem_name)
+    create_cluster_task = create_cluster(cluster_name)
+    create_job_task = create_job(job_name, create_cluster_task.outputs["cluster_id"])
+    submit_run_task = submit_run(run_name, job_name, parameter1, parameter2)
+    submit_run_task.after(create_dbfsblock_task)
+    submit_run_task.after(create_secretscope_task)
+    submit_run_task.after(import_workspace_item_task)
+    submit_run_task.after(create_job_task)
+    delete_run_task = delete_run(run_name)
+    delete_run_task.after(submit_run_task)
+    delete_job_task = delete_job(job_name)
+    delete_job_task.after(delete_run_task)
+    delete_cluster_task = delete_cluster(cluster_name)
+    delete_cluster_task.after(delete_job_task)
+    delete_workspace_item_task = delete_workspace_item(workspaceitem_name)
+    delete_workspace_item_task.after(submit_run_task)
+    delete_secretscope_task = delete_secretscope(secretescope_name)
+    delete_secretscope_task.after(submit_run_task)
+    delete_dbfsblock_task = delete_dbfsblock(dbfsblock_name)
+    delete_dbfsblock_task.after(submit_run_task)
+
+if __name__ == "__main__":
+    compiler.Compiler().compile(calc_pipeline, __file__ + ".tar.gz")

--- a/samples/contrib/azure-samples/databricks-pipelines/databricks_notebook_pipeline.py
+++ b/samples/contrib/azure-samples/databricks-pipelines/databricks_notebook_pipeline.py
@@ -162,4 +162,6 @@ def calc_pipeline(
     delete_dbfsblock_task.after(submit_run_task)
 
 if __name__ == "__main__":
-    compiler.Compiler().compile(calc_pipeline, __file__ + ".tar.gz")
+    compiler.Compiler()._create_and_write_workflow(
+        pipeline_func=calc_pipeline,
+        package_path=__file__ + ".tar.gz")

--- a/samples/contrib/azure-samples/databricks-pipelines/databricks_run_pipeline.py
+++ b/samples/contrib/azure-samples/databricks-pipelines/databricks_run_pipeline.py
@@ -35,4 +35,6 @@ def calc_pipeline(run_name="test-run", parameter="10"):
     delete_run_task.after(submit_run_task)
 
 if __name__ == "__main__":
-    compiler.Compiler().compile(calc_pipeline, __file__ + ".tar.gz")
+    compiler.Compiler()._create_and_write_workflow(
+        pipeline_func=calc_pipeline,
+        package_path=__file__ + ".tar.gz")

--- a/samples/contrib/azure-samples/databricks-pipelines/databricks_secretscope_pipeline.py
+++ b/samples/contrib/azure-samples/databricks-pipelines/databricks_secretscope_pipeline.py
@@ -1,0 +1,73 @@
+"""Create a new secret scope in Databricks."""
+import kfp.dsl as dsl
+import kfp.compiler as compiler
+import databricks
+
+def create_secretscope(
+        scope_name,
+        string_secret,
+        byte_secret,
+        ref_secret_name,
+        ref_secret_key,
+        principal_name):
+    return databricks.CreateSecretScopeOp(
+        name="createsecretscope",
+        scope_name=scope_name,
+        initial_manage_principal="users",
+        secrets=[
+            {
+                "key": "string-secret",
+                "string_value": string_secret
+            },
+            {
+                "key": "byte-secret",
+                "byte_value": byte_secret
+            },
+            {
+                "key": "ref-secret",
+                "value_from": {
+                    "secret_key_ref": {
+                        "name": ref_secret_name,
+                        "key": ref_secret_key
+                    }
+                }
+            }
+        ],
+        acls=[
+            {
+                "principal": principal_name,
+                "permission": "READ"
+            }
+        ]
+    )
+
+def delete_secretscope(scope_name):
+    return databricks.DeleteSecretScopeOp(
+        name="deletesecretscope",
+        scope_name=scope_name
+    )
+
+@dsl.pipeline(
+    name="DatabricksSecretScope",
+    description="A toy pipeline that sets some secrets and acls in an Azure Databricks Secret Scope."
+)
+def calc_pipeline(
+        scope_name="test-secretscope",
+        string_secret="helloworld",
+        byte_secret="aGVsbG93b3JsZA==",
+        ref_secret_name="mysecret",
+        ref_secret_key="username",
+        principal_name="alejacma@microsoft.com"
+    ):
+    create_secretscope_task = create_secretscope(
+        scope_name,
+        string_secret,
+        byte_secret,
+        ref_secret_name,
+        ref_secret_key,
+        principal_name)
+    delete_secretscope_task = delete_secretscope(scope_name)
+    delete_secretscope_task.after(create_secretscope_task)
+
+if __name__ == "__main__":
+    compiler.Compiler().compile(calc_pipeline, __file__ + ".tar.gz")

--- a/samples/contrib/azure-samples/databricks-pipelines/databricks_secretscope_pipeline.py
+++ b/samples/contrib/azure-samples/databricks-pipelines/databricks_secretscope_pipeline.py
@@ -70,4 +70,6 @@ def calc_pipeline(
     delete_secretscope_task.after(create_secretscope_task)
 
 if __name__ == "__main__":
-    compiler.Compiler().compile(calc_pipeline, __file__ + ".tar.gz")
+    compiler.Compiler()._create_and_write_workflow(
+        pipeline_func=calc_pipeline,
+        package_path=__file__ + ".tar.gz")

--- a/samples/contrib/azure-samples/databricks-pipelines/databricks_secretscope_pipeline.py
+++ b/samples/contrib/azure-samples/databricks-pipelines/databricks_secretscope_pipeline.py
@@ -57,7 +57,7 @@ def calc_pipeline(
         byte_secret="aGVsbG93b3JsZA==",
         ref_secret_name="mysecret",
         ref_secret_key="username",
-        principal_name="alejacma@microsoft.com"
+        principal_name="user@foo.com"
     ):
     create_secretscope_task = create_secretscope(
         scope_name,

--- a/samples/contrib/azure-samples/databricks-pipelines/databricks_workspaceitem_pipeline.py
+++ b/samples/contrib/azure-samples/databricks-pipelines/databricks_workspaceitem_pipeline.py
@@ -29,4 +29,6 @@ def calc_pipeline(item_name="test-item", user="user@foo.com"):
     delete_workspace_item_task.after(import_workspace_item_task)
 
 if __name__ == "__main__":
-    compiler.Compiler().compile(calc_pipeline, __file__ + ".tar.gz")
+    compiler.Compiler()._create_and_write_workflow(
+        pipeline_func=calc_pipeline,
+        package_path=__file__ + ".tar.gz")

--- a/samples/contrib/azure-samples/databricks-pipelines/databricks_workspaceitem_pipeline.py
+++ b/samples/contrib/azure-samples/databricks-pipelines/databricks_workspaceitem_pipeline.py
@@ -3,12 +3,12 @@ import kfp.dsl as dsl
 import kfp.compiler as compiler
 import databricks
 
-def import_workspace_item(item_name):
+def import_workspace_item(item_name, user):
     return databricks.ImportWorkspaceItemOp(
         name="importworkspaceitem",
         item_name=item_name,
         content="cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
-        path="/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+        path=f"/Users/{user}/ScalaExampleNotebook",
         language="SCALA",
         file_format="SOURCE"
     )
@@ -23,8 +23,8 @@ def delete_workspace_item(item_name):
     name="DatabricksWorkspaceItem",
     description="A toy pipeline that imports some source code into a Databricks Workspace."
 )
-def calc_pipeline(item_name="test-item"):
-    import_workspace_item_task = import_workspace_item(item_name)
+def calc_pipeline(item_name="test-item", user="user@foo.com"):
+    import_workspace_item_task = import_workspace_item(item_name, user)
     delete_workspace_item_task = delete_workspace_item(item_name)
     delete_workspace_item_task.after(import_workspace_item_task)
 

--- a/samples/contrib/azure-samples/databricks-pipelines/databricks_workspaceitem_pipeline.py
+++ b/samples/contrib/azure-samples/databricks-pipelines/databricks_workspaceitem_pipeline.py
@@ -1,0 +1,32 @@
+"""Import an item into a Databricks Workspace."""
+import kfp.dsl as dsl
+import kfp.compiler as compiler
+import databricks
+
+def import_workspace_item(item_name):
+    return databricks.ImportWorkspaceItemOp(
+        name="importworkspaceitem",
+        item_name=item_name,
+        content="cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+        path="/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+        language="SCALA",
+        file_format="SOURCE"
+    )
+
+def delete_workspace_item(item_name):
+    return databricks.DeleteWorkspaceItemOp(
+        name="deleteworkspaceitem",
+        item_name=item_name
+    )
+
+@dsl.pipeline(
+    name="DatabricksWorkspaceItem",
+    description="A toy pipeline that imports some source code into a Databricks Workspace."
+)
+def calc_pipeline(item_name="test-item"):
+    import_workspace_item_task = import_workspace_item(item_name)
+    delete_workspace_item_task = delete_workspace_item(item_name)
+    delete_workspace_item_task.after(import_workspace_item_task)
+
+if __name__ == "__main__":
+    compiler.Compiler().compile(calc_pipeline, __file__ + ".tar.gz")

--- a/samples/contrib/azure-samples/databricks-pipelines/notebooks/ScalaExampleNotebook
+++ b/samples/contrib/azure-samples/databricks-pipelines/notebooks/ScalaExampleNotebook
@@ -1,0 +1,23 @@
+val param1 = dbutils.widgets.get("param1")
+val param2 = dbutils.widgets.get("param2")
+var output = s"param1 = $param1, param2 = $param2"
+
+val txt = dbutils.fs.head("/data/foo.txt")
+output = s"$output, foo.txt exists and contains '$txt'"
+
+val string_secret = dbutils.secrets.get(scope = "test-scope", key = "string-secret")
+if (string_secret == "helloworld") {
+  output = s"$output, string-secret is correct"
+}
+
+val byte_secret = dbutils.secrets.get(scope = "test-scope", key = "byte-secret")
+if (byte_secret == "helloworld") {
+  output = s"$output, byte-secret is correct"
+}
+
+val ref_secret = dbutils.secrets.get(scope = "test-scope", key = "ref-secret")
+if (ref_secret == "alex") {
+  output = s"$output, ref-secret is correct"
+}
+
+dbutils.notebook.exit(output)

--- a/samples/contrib/azure-samples/kfp-azure-databricks/README.md
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/README.md
@@ -8,18 +8,22 @@ and less error prone, than using the [ResourceOp](
 https://www.kubeflow.org/docs/pipelines/sdk/manipulate-resources/#resourceop) to manipulate
 these Databricks resources.
 
-These are the supported Ops up to date:
+## Supported Ops
 
 - CreateClusterOp, to create a cluster in Databricks.
-- DeleteClusterOp, to delete an existing cluster from Databricks.
-- CreateJobOp, to create a Spark Job in Databricks.
-- DeleteJobOp, to delete an existing Spark Job from Databricks.
-- SubmitRunOp, to submit a Job Run in Databricks.
-- DeleteRunOp, to delete an existing Run.
+- DeleteClusterOp, to delete a cluster created with CreateClusterOp.
+- CreateJobOp, to create a Spark job in Databricks.
+- DeleteJobOp, to delete a job created with CreateJobOp.
+- SubmitRunOp, to submit a job run in Databricks.
+- DeleteRunOp, to delete a run submitted with SubmitRunOp.
+- CreateSecretScopeOp, to create a secret scope in Databricks.
+- DeleteSecretScopeOp, to delete a secret scope created with CreateSecretScopeOp.
+- ImportWorkspaceItemOp, to import an item into a Databricks Workspace.
+- DeleteWorkspaceItemOp, to delete an item imported with ImportWorkspaceItemOp.
 
 For each of these there are two ways a Kubeflow user can create the Ops:
-1) By passing the complete Databricks spec for the Op within a Python Dictionary
-2) By using named parameters
+1) By passing the complete Databricks spec for the Op within a Python Dictionary.
+2) By using named parameters.
 
 ## Setup
 
@@ -169,3 +173,7 @@ Ops:
     https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/jobs)
 - Run Ops: [Azure Databricks Jobs API - Runs Submit](
     https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/jobs#--runs-submit)
+- Secret Scope Ops: [Azure Databricks Secrets API](
+    https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/secrets)
+- Workspace Item Ops: [Azure Databricks Workspace API](
+    https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/workspace)

--- a/samples/contrib/azure-samples/kfp-azure-databricks/README.md
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/README.md
@@ -20,6 +20,8 @@ these Databricks resources.
 - DeleteSecretScopeOp, to delete a secret scope created with CreateSecretScopeOp.
 - ImportWorkspaceItemOp, to import an item into a Databricks Workspace.
 - DeleteWorkspaceItemOp, to delete an item imported with ImportWorkspaceItemOp.
+- CreateDbfsBlockOp, to create Dbfs Block in Databricks.
+- DeleteDbfsBlockOp, to delete Dbfs Block created with CreateDbfsBlockOp.
 
 For each of these there are two ways a Kubeflow user can create the Ops:
 1) By passing the complete Databricks spec for the Op within a Python Dictionary.
@@ -177,3 +179,6 @@ Ops:
     https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/secrets)
 - Workspace Item Ops: [Azure Databricks Workspace API](
     https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/workspace)
+- DbfsBlock Ops: [Azure Databricks DBFS API](
+    https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/dbfs)
+

--- a/samples/contrib/azure-samples/kfp-azure-databricks/databricks/__init__.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/databricks/__init__.py
@@ -3,5 +3,5 @@ from ._run_op import SubmitRunOp, DeleteRunOp
 from ._cluster_op import CreateClusterOp, DeleteClusterOp
 from ._secretscope_op import CreateSecretScopeOp, DeleteSecretScopeOp
 from ._workspaceitem_op import ImportWorkspaceItemOp, DeleteWorkspaceItemOp
-
+from ._dbfsblocks_op import  CreateDbfsBlockOp, DeleteDbfsBlockOp
 __version__ = "0.2.0"

--- a/samples/contrib/azure-samples/kfp-azure-databricks/databricks/__init__.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/databricks/__init__.py
@@ -1,5 +1,7 @@
 from ._job_op import CreateJobOp, DeleteJobOp
 from ._run_op import SubmitRunOp, DeleteRunOp
 from ._cluster_op import CreateClusterOp, DeleteClusterOp
+from ._secretscope_op import CreateSecretScopeOp, DeleteSecretScopeOp
+from ._workspaceitem_op import ImportWorkspaceItemOp, DeleteWorkspaceItemOp
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_cluster_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_cluster_op.py
@@ -7,7 +7,7 @@ class CreateClusterOp(ResourceOp):
 
     Examples:
 
-        import kfp.dsl.databricks as databricks
+        import databricks
 
         databricks.CreateClusterOp(
             name="createcluster",
@@ -219,7 +219,7 @@ class DeleteClusterOp(ResourceOp):
 
     Example:
 
-        import kfp.dsl.databricks as databricks
+        import databricks
 
         databricks.DeleteClusterOp(
             name="deletecluster",

--- a/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_cluster_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_cluster_op.py
@@ -203,7 +203,8 @@ class CreateClusterOp(ResourceOp):
             ValueError: if the file name doesn't exist.
         """
 
-        spec = json.loads(open(file_name).read())
+        with open(file_name) as json_file:
+            spec = json.loads(json_file.read())
         return cls(name=name, k8s_name=k8s_name, cluster_name=cluster_name, spec=spec)
 
     @property

--- a/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_dbfsblocks_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_dbfsblocks_op.py
@@ -1,0 +1,208 @@
+import json
+from kfp.dsl import ResourceOp
+
+class CreateDbfsBlockOp(ResourceOp):
+    """Represents an Op which will be translated into a Databricks DbfsBlock  Create
+    resource template.
+
+    Example:
+
+        import databricks
+
+        databricks.CreateDbfsBlockOp(
+            name="createdbfsblock",
+            block_name="test-item",
+            spec={
+                "data": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+                "path": "/data/foo.txt",
+            }
+        )
+
+        databricks.CreateDbfsBlockOp(
+            name="createdbfsblock",
+            block_name="test-item",
+            data="cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+            path="/data/foo.txt",
+        )
+    """
+
+    def __init__(self,
+                 name: str = None,
+                 k8s_name: str = None,
+                 block_name: str = None,
+                 spec: {} = None,
+                 path: str = None,
+                 data: str = None):
+        """Create a new instance of CreateDbfsBlockOp.
+
+        Args:
+            name: The name of the pipeline Op.
+                It does not have to be unique within a pipeline
+                because the pipeline will generate a new unique name in case of a conflict.
+            k8s_name = The name of the k8s resource which will be submitted to the cluster.
+                If no k8s_name is provided, block_name will be used as the resource name.
+                This name is DNS-1123 subdomain name and must consist of lower case alphanumeric
+                characters, '-' or '.', and must start and end with an alphanumeric character.
+            block_name: A name for the DbfsBlock.
+                If k8s_name is provided, this will be ignored.
+            data: The base64-encoded content.
+                This has a limit of 10 MB.
+            path: The absolute path of the file.
+                Importing directory is only support for DBC format.
+
+        Raises:
+
+            ValueError: If no k8s resource name or DbfsBlock name are provided.
+        """
+
+        if not spec:
+            spec = {}      
+        if path:
+            spec["path"] = path
+        if data:
+            spec["data"] = data
+
+        k8s_name = k8s_name or block_name
+        if not k8s_name:
+            raise ValueError("You need to provide a k8s_name or a block_name.")
+
+        super().__init__(
+            k8s_resource={
+                "apiVersion": "databricks.microsoft.com/v1alpha1",
+                "kind": "DbfsBlock",
+                "metadata": {
+                    "name": k8s_name
+                },
+                "spec": spec
+            },
+            action="create",
+            success_condition="status.file_hash",
+            attribute_outputs={
+                "name": "{.metadata.name}",
+                "file_info_path": "{.status.file_info.path}",
+                "file_info_is_dir": "{.status.file_info.is_dir}",
+                "file_info_file_size": "{.status.file_info.file_size}",
+                "file_hash": "{.status.file_hash}"
+            },
+            name=name)
+
+    @classmethod
+    def from_json_spec(cls,
+                       name: str = None,
+                       k8s_name: str = None,
+                       block_name: str = None,
+                       json_spec: str = None):
+        """Create a new instance of CreateDbfsBlockOp from a json specification.
+
+        Args:
+
+            name: The name of the pipeline Op.
+                It does not have to be unique within a pipeline
+                because the pipeline will generate a new unique name in case of a conflict.
+            k8s_name = The name of the k8s resource which will be submitted to the cluster.
+                If no k8s_name is provided, block_name will be used as the resource name.
+                This name is DNS-1123 subdomain name and must consist of lower case alphanumeric
+                characters, '-' or '.', and must start and end with an alphanumeric character.
+            block_name: A name for the DbfsBlock Item.
+                If k8s_name is provided, this will be ignored.
+            json_spec: Full specification of the DbfsBlock Item to import in json format.
+        """
+
+        spec = json.loads(json_spec)
+        return cls(name=name, k8s_name=k8s_name, block_name=block_name, spec=spec)
+
+    @classmethod
+    def from_file_name(cls,
+                       name: str = None,
+                       k8s_name: str = None,
+                       block_name: str = None,
+                       file_name: str = None):
+        """Create a new instance of CreateDbfsBlockOp from a file with json specification.
+
+        Args:
+
+            name: The name of the pipeline Op.
+                It does not have to be unique within a pipeline
+                because the pipeline will generate a new unique name in case of a conflict.
+            k8s_name = The name of the k8s resource which will be submitted to the cluster.
+                If no k8s_name is provided, block_name will be used as the resource name.
+                This name is DNS-1123 subdomain name and must consist of lower case alphanumeric
+                characters, '-' or '.', and must start and end with an alphanumeric character.
+            block_name: A name for the DbfsBlock Item.
+                If k8s_name is provided, this will be ignored.
+            json_spec: Name of the file containing the full specification of the DbfsBlock Item to
+                import in json format.
+
+        Raises:
+
+            ValueError: if the file name doesn't exist.
+        """
+
+        spec = json.loads(open(file_name).read())
+        return cls(name=name, k8s_name=k8s_name, block_name=block_name, spec=spec)
+
+    @property
+    def resource(self):
+        """`Resource` object that represents the `resource` property in
+        `io.argoproj.workflow.v1alpha1.Template`.
+        """
+        return self._resource
+
+class DeleteDbfsBlockOp(ResourceOp):
+    """Represents an Op which will be translated into a Databricks DbfsBlock Item deletion
+    resource template.
+
+    Example:
+
+        import databricks
+
+        databricks.DeleteDbfsBlockOp(
+            name="deletedbfsblock",
+            block_name="test-item"
+        )
+    """
+
+    def __init__(self,
+                 name: str = None,
+                 k8s_name: str = None,
+                 block_name: str = None):
+        """Create a new instance of DeleteDbfsBlockOp.
+
+        Args:
+
+            name: The name of the pipeline Op.
+                It does not have to be unique within a pipeline
+                because the pipeline will generate a new unique name in case of a conflict.
+            k8s_name = The name of the k8s resource which will be submitted to the cluster.
+                If no k8s_name is provided, block_name will be used as the resource name.
+                This name is DNS-1123 subdomain name and must consist of lower case alphanumeric
+                characters, '-' or '.', and must start and end with an alphanumeric character.
+            block_name: The name of the DbfsBlock Item.
+                If k8s_name is provided, this will be ignored.
+
+        Raises:
+
+            ValueError: If no k8s resource name or Dbfs Item name are provided.
+        """
+
+        k8s_name = k8s_name or block_name
+        if not k8s_name:
+            raise ValueError("You need to provide a k8s_name or a block_name.")
+
+        super().__init__(
+            k8s_resource={
+                "apiVersion": "databricks.microsoft.com/v1alpha1",
+                "kind": "DbfsBlock",
+                "metadata": {
+                    "name": k8s_name
+                }
+            },
+            action="delete",
+            name=name)
+
+    @property
+    def resource(self):
+        """`Resource` object that represents the `resource` property in
+        `io.argoproj.workflow.v1alpha1.Template`.
+        """
+        return self._resource

--- a/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_dbfsblocks_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_dbfsblocks_op.py
@@ -138,7 +138,8 @@ class CreateDbfsBlockOp(ResourceOp):
             ValueError: if the file name doesn't exist.
         """
 
-        spec = json.loads(open(file_name).read())
+        with open(file_name) as json_file:
+            spec = json.loads(json_file.read())
         return cls(name=name, k8s_name=k8s_name, block_name=block_name, spec=spec)
 
     @property

--- a/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_job_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_job_op.py
@@ -7,7 +7,7 @@ class CreateJobOp(ResourceOp):
 
     Example:
 
-        import kfp.dsl.databricks as databricks
+        import databricks
 
         databricks.CreateJobOp(
             name="createjob",
@@ -257,7 +257,7 @@ class DeleteJobOp(ResourceOp):
 
     Example:
 
-        import kfp.dsl.databricks as databricks
+        import databricks
 
         databricks.DeleteJobOp(
             name = "deletejob",

--- a/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_job_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_job_op.py
@@ -241,7 +241,8 @@ class CreateJobOp(ResourceOp):
             ValueError: if the file name doesn't exist.
         """
 
-        spec = json.loads(open(file_name).read())
+        with open(file_name) as json_file:
+            spec = json.loads(json_file.read())
         return cls(name=name, k8s_name=k8s_name, job_name=job_name, spec=spec)
 
     @property

--- a/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_run_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_run_op.py
@@ -7,7 +7,7 @@ class SubmitRunOp(ResourceOp):
 
     Examples:
 
-        import kfp.dsl.databricks as databricks
+        import databricks
 
         databricks.SubmitRunOp(
             name="submitrun",
@@ -259,7 +259,7 @@ class DeleteRunOp(ResourceOp):
 
     Example:
 
-        import kfp.dsl.databricks as databricks
+        import databricks
 
         databricks.DeleteRunOp(
             name="deleterun",

--- a/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_run_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_run_op.py
@@ -243,7 +243,8 @@ class SubmitRunOp(ResourceOp):
             ValueError: if the file name doesn't exist.
         """
 
-        spec = json.loads(open(file_name).read())
+        with open(file_name) as json_file:
+            spec = json.loads(json_file.read())
         return cls(name=name, k8s_name=k8s_name, run_name=run_name, spec=spec)
 
     @property

--- a/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_secretscope_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_secretscope_op.py
@@ -35,7 +35,7 @@ class CreateSecretScopeOp(ResourceOp):
                 ],
                 "acls": [
                     {
-                        "principal": "alejacma@microsoft.com",
+                        "principal": "user@foo.com",
                         "permission": "READ"
                     }
                 ]
@@ -67,7 +67,7 @@ class CreateSecretScopeOp(ResourceOp):
             ],
             acls=[
                 {
-                    "principal": "alejacma@microsoft.com",
+                    "principal": "user@foo.com",
                     "permission": "READ"
                 }
             ]

--- a/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_secretscope_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_secretscope_op.py
@@ -1,0 +1,260 @@
+import json
+from kfp.dsl import ResourceOp
+
+class CreateSecretScopeOp(ResourceOp):
+    """Represents an Op which will be translated into a Databricks Secret Scope creation
+    resource template.
+
+    Example:
+
+        import databricks
+
+        databricks.CreateSecretScopeOp(
+            name="createsecretscope",
+            scope_name="test-secretscope",
+            spec={
+                "initial_manage_permission": "users",
+                "secrets": [
+                    {
+                        "key": "string-secret",
+                        "string_value": "helloworld"
+                    },
+                    {
+                        "key": "byte-secret",
+                        "byte_value": "aGVsbG93b3JsZA=="
+                    },
+                    {
+                        "key": "ref-secret",
+                        "value_from": {
+                            "secret_key_ref": {
+                                "name": "mysecret",
+                                "key": "username"
+                            }
+                        }
+                    }
+                ],
+                "acls": [
+                    {
+                        "principal": "alejacma@microsoft.com",
+                        "permission": "READ"
+                    }
+                ]
+            }
+        )
+
+        databricks.CreateSecretScopeOp(
+            name="createsecretscope",
+            scope_name="test-secretscope",
+            initial_manage_permission="users",
+            secrets=[
+                {
+                    "key": "string-secret",
+                    "string_value": "helloworld"
+                },
+                {
+                    "key": "byte-secret",
+                    "byte_value": "aGVsbG93b3JsZA=="
+                },
+                {
+                    "key": "ref-secret",
+                    "value_from": {
+                        "secret_key_ref": {
+                            "name": "mysecret",
+                            "key": "username"
+                        }
+                    }
+                }
+            ],
+            acls=[
+                {
+                    "principal": "alejacma@microsoft.com",
+                    "permission": "READ"
+                }
+            ]
+        )
+    """
+
+    def __init__(self,
+                 name: str = None,
+                 k8s_name: str = None,
+                 scope_name: str = None,
+                 spec: {} = None,
+                 initial_manage_principal: str = None,
+                 secrets: {} = None,
+                 acls: {} = None):
+        """Create a new instance of CreateSecretScopeOp.
+
+        Args:
+            name: The name of the pipeline Op.
+                It does not have to be unique within a pipeline
+                because the pipeline will generate a new unique name in case of a conflict.
+            k8s_name = The name of the k8s resource which will be submitted to the cluster.
+                If no k8s_name is provided, scope_name will be used as the resource name.
+                This name is DNS-1123 subdomain name and must consist of lower case alphanumeric
+                characters, '-' or '.', and must start and end with an alphanumeric character.
+            scope_name: A name for the Secret Scope.
+                If k8s_name is provided, this will be ignored.
+            spec: Full specification of the Secret Scope to create.
+            initial_manage_principal: The principal that is initially granted MANAGE permission to
+                the created scope.
+            secrets: Secrets that will be stored at this scope.
+            acls: ACLs that will be set on this scope.
+
+        Raises:
+
+            ValueError: If no k8s resource name or Secret Scope name are provided.
+        """
+
+        if not spec:
+            spec = {}
+
+        if initial_manage_principal:
+            spec["initial_manage_permission"] = initial_manage_principal
+        if secrets:
+            spec["secrets"] = secrets
+        if acls:
+            spec["acls"] = acls
+
+        k8s_name = k8s_name or scope_name
+        if not k8s_name:
+            raise ValueError("You need to provide a k8s_name or a scope_name.")
+
+        super().__init__(
+            k8s_resource={
+                "apiVersion": "databricks.microsoft.com/v1alpha1",
+                "kind": "SecretScope",
+                "metadata": {
+                    "name": k8s_name
+                },
+                "spec": spec
+            },
+            action="create",
+            success_condition="status.secretscope.name",
+            attribute_outputs={
+                "name": "{.metadata.name}",
+                "secretscope_name": "{.status.secretscope.name}",
+                "secretscope_backend_type": "{.status.secretscope.backend_type}",
+                "secret_in_cluster_available": "{.status.secretinclusteravailable}"
+            },
+            name=name)
+
+    @classmethod
+    def from_json_spec(cls,
+                       name: str = None,
+                       k8s_name: str = None,
+                       scope_name: str = None,
+                       json_spec: str = None):
+        """Create a new instance of CreateSecretScopeOp from a json specification.
+
+        Args:
+
+            name: The name of the pipeline Op.
+                It does not have to be unique within a pipeline
+                because the pipeline will generate a new unique name in case of a conflict.
+            k8s_name = The name of the k8s resource which will be submitted to the cluster.
+                If no k8s_name is provided, scope_name will be used as the resource name.
+                This name is DNS-1123 subdomain name and must consist of lower case alphanumeric
+                characters, '-' or '.', and must start and end with an alphanumeric character.
+            scope_name: A name for the Secret Scope.
+                If k8s_name is provided, this will be ignored.
+            json_spec: Full specification of the Secret Scope to create in json format.
+        """
+
+        spec = json.loads(json_spec)
+        return cls(name=name, k8s_name=k8s_name, scope_name=scope_name, spec=spec)
+
+    @classmethod
+    def from_file_name(cls,
+                       name: str = None,
+                       k8s_name: str = None,
+                       scope_name: str = None,
+                       file_name: str = None):
+        """Create a new instance of CreateSecretScopeOp from a file with json specification.
+
+        Args:
+
+            name: The name of the pipeline Op.
+                It does not have to be unique within a pipeline
+                because the pipeline will generate a new unique name in case of a conflict.
+            k8s_name = The name of the k8s resource which will be submitted to the cluster.
+                If no k8s_name is provided, scope_name will be used as the resource name.
+                This name is DNS-1123 subdomain name and must consist of lower case alphanumeric
+                characters, '-' or '.', and must start and end with an alphanumeric character.
+            scope_name: A name for the Secret Scope.
+                If k8s_name is provided, this will be ignored.
+            json_spec_file_name: Name of the file containing the full specification of the Secret
+                Scope to create in json format.
+
+        Raises:
+
+            ValueError: if the file name doesn't exist.
+        """
+
+        spec = json.loads(open(file_name).read())
+        return cls(name=name, k8s_name=k8s_name, scope_name=scope_name, spec=spec)
+
+    @property
+    def resource(self):
+        """`Resource` object that represents the `resource` property in
+        `io.argoproj.workflow.v1alpha1.Template`.
+        """
+        return self._resource
+
+class DeleteSecretScopeOp(ResourceOp):
+    """Represents an Op which will be translated into a Databricks Secret Scope deletion
+    resource template.
+
+    Example:
+
+        import databricks
+
+        databricks.DeleteSecretScopeOp(
+            name = "deletesecretscope",
+            scope_name = "test-secretscope"
+        )
+    """
+
+    def __init__(self,
+                 name: str = None,
+                 k8s_name: str = None,
+                 scope_name: str = None):
+        """Create a new instance of DeleteSecretScopeOp.
+
+        Args:
+
+            name: The name of the pipeline Op.
+                It does not have to be unique within a pipeline
+                because the pipeline will generate a new unique name in case of a conflict.
+            k8s_name = The name of the k8s resource which will be submitted to the cluster.
+                If no k8s_name is provided, scope_name will be used as the resource name.
+                This name is DNS-1123 subdomain name and must consist of lower case alphanumeric
+                characters, '-' or '.', and must start and end with an alphanumeric character.
+            scope_name: The name of the Secret Scope.
+                If k8s_name is provided, this will be ignored.
+
+        Raises:
+
+            ValueError: If no k8s resource name or Secret Scope name are provided.
+        """
+
+        k8s_name = k8s_name or scope_name
+        if not k8s_name:
+            raise ValueError("You need to provide a k8s_name or a scope_name.")
+
+        super().__init__(
+            k8s_resource={
+                "apiVersion": "databricks.microsoft.com/v1alpha1",
+                "kind": "SecretScope",
+                "metadata": {
+                    "name": k8s_name
+                }
+            },
+            action="delete",
+            name=name)
+
+    @property
+    def resource(self):
+        """`Resource` object that represents the `resource` property in
+        `io.argoproj.workflow.v1alpha1.Template`.
+        """
+        return self._resource

--- a/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_secretscope_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_secretscope_op.py
@@ -190,7 +190,8 @@ class CreateSecretScopeOp(ResourceOp):
             ValueError: if the file name doesn't exist.
         """
 
-        spec = json.loads(open(file_name).read())
+        with open(file_name) as json_file:
+            spec = json.loads(json_file.read())
         return cls(name=name, k8s_name=k8s_name, scope_name=scope_name, spec=spec)
 
     @property

--- a/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_workspaceitem_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_workspaceitem_op.py
@@ -1,0 +1,225 @@
+import json
+from kfp.dsl import ResourceOp
+
+class ImportWorkspaceItemOp(ResourceOp):
+    """Represents an Op which will be translated into a Databricks Workspace Item import
+    resource template.
+
+    Example:
+
+        import databricks
+
+        databricks.ImportWorkspaceItemOp(
+            name="importworkspaceitem",
+            item_name="test-item",
+            spec={
+                "content": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+                "language": "SCALA",
+                "format": "SOURCE"
+            }
+        )
+
+        databricks.ImportWorkspaceItemOp(
+            name="importworkspaceitem",
+            item_name="test-item",
+            content="cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+            path="/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+            language="SCALA",
+            file_format="SOURCE"
+        )
+    """
+
+    def __init__(self,
+                 name: str = None,
+                 k8s_name: str = None,
+                 item_name: str = None,
+                 spec: {} = None,
+                 content: str = None,
+                 path: str = None,
+                 language: str = None,
+                 file_format: str = None):
+        """Create a new instance of ImportWorkspaceItemOp.
+
+        Args:
+            name: The name of the pipeline Op.
+                It does not have to be unique within a pipeline
+                because the pipeline will generate a new unique name in case of a conflict.
+            k8s_name = The name of the k8s resource which will be submitted to the cluster.
+                If no k8s_name is provided, item_name will be used as the resource name.
+                This name is DNS-1123 subdomain name and must consist of lower case alphanumeric
+                characters, '-' or '.', and must start and end with an alphanumeric character.
+            item_name: A name for the Workspace Item.
+                If k8s_name is provided, this will be ignored.
+            spec: Full specification of the Workspace Item to import.
+            content: The base64-encoded content.
+                This has a limit of 10 MB.
+            path: The absolute path of the notebook or directory.
+                Importing directory is only support for DBC format.
+            language: The language.
+                If format is set to SOURCE, this field is required; otherwise, it will be ignored.
+            file_format: This specifies the format of the file to be imported.
+                By default, this is SOURCE. However it may be one of: SOURCE, HTML, JUPYTER, DBC.
+                The value is case sensitive.
+
+        Raises:
+
+            ValueError: If no k8s resource name or Workspace Item name are provided.
+        """
+
+        if not spec:
+            spec = {}
+
+        if content:
+            spec["content"] = content
+        if path:
+            spec["path"] = path
+        if language:
+            spec["language"] = language
+        if file_format:
+            spec["format"] = file_format
+
+        k8s_name = k8s_name or item_name
+        if not k8s_name:
+            raise ValueError("You need to provide a k8s_name or a item_name.")
+
+        super().__init__(
+            k8s_resource={
+                "apiVersion": "databricks.microsoft.com/v1alpha1",
+                "kind": "WorkspaceItem",
+                "metadata": {
+                    "name": k8s_name
+                },
+                "spec": spec
+            },
+            action="create",
+            success_condition="status.object_hash",
+            attribute_outputs={
+                "name": "{.metadata.name}",
+                "object_hash": "{.status.object_hash}",
+                "object_language": "{.status.object_info.language}",
+                "object_type": "{.status.object_info.object_type}",
+                "object_path": "{.status.object_info.path}"
+            },
+            name=name)
+
+    @classmethod
+    def from_json_spec(cls,
+                       name: str = None,
+                       k8s_name: str = None,
+                       item_name: str = None,
+                       json_spec: str = None):
+        """Create a new instance of ImportWorkspaceItemOp from a json specification.
+
+        Args:
+
+            name: The name of the pipeline Op.
+                It does not have to be unique within a pipeline
+                because the pipeline will generate a new unique name in case of a conflict.
+            k8s_name = The name of the k8s resource which will be submitted to the cluster.
+                If no k8s_name is provided, item_name will be used as the resource name.
+                This name is DNS-1123 subdomain name and must consist of lower case alphanumeric
+                characters, '-' or '.', and must start and end with an alphanumeric character.
+            item_name: A name for the Workspace Item.
+                If k8s_name is provided, this will be ignored.
+            json_spec: Full specification of the Workspace Item to import in json format.
+        """
+
+        spec = json.loads(json_spec)
+        return cls(name=name, k8s_name=k8s_name, item_name=item_name, spec=spec)
+
+    @classmethod
+    def from_file_name(cls,
+                       name: str = None,
+                       k8s_name: str = None,
+                       item_name: str = None,
+                       file_name: str = None):
+        """Create a new instance of ImportWorkspaceItemOp from a file with json specification.
+
+        Args:
+
+            name: The name of the pipeline Op.
+                It does not have to be unique within a pipeline
+                because the pipeline will generate a new unique name in case of a conflict.
+            k8s_name = The name of the k8s resource which will be submitted to the cluster.
+                If no k8s_name is provided, item_name will be used as the resource name.
+                This name is DNS-1123 subdomain name and must consist of lower case alphanumeric
+                characters, '-' or '.', and must start and end with an alphanumeric character.
+            item_name: A name for the Workspace Item.
+                If k8s_name is provided, this will be ignored.
+            json_spec: Name of the file containing the full specification of the Workspace Item to
+                import in json format.
+
+        Raises:
+
+            ValueError: if the file name doesn't exist.
+        """
+
+        spec = json.loads(open(file_name).read())
+        return cls(name=name, k8s_name=k8s_name, item_name=item_name, spec=spec)
+
+    @property
+    def resource(self):
+        """`Resource` object that represents the `resource` property in
+        `io.argoproj.workflow.v1alpha1.Template`.
+        """
+        return self._resource
+
+class DeleteWorkspaceItemOp(ResourceOp):
+    """Represents an Op which will be translated into a Databricks Workspace Item deletion
+    resource template.
+
+    Example:
+
+        import databricks
+
+        databricks.DeleteWorkspaceItemOp(
+            name="deleteworkspaceitem",
+            item_name="test-item"
+        )
+    """
+
+    def __init__(self,
+                 name: str = None,
+                 k8s_name: str = None,
+                 item_name: str = None):
+        """Create a new instance of DeleteWorkspaceItemOp.
+
+        Args:
+
+            name: The name of the pipeline Op.
+                It does not have to be unique within a pipeline
+                because the pipeline will generate a new unique name in case of a conflict.
+            k8s_name = The name of the k8s resource which will be submitted to the cluster.
+                If no k8s_name is provided, item_name will be used as the resource name.
+                This name is DNS-1123 subdomain name and must consist of lower case alphanumeric
+                characters, '-' or '.', and must start and end with an alphanumeric character.
+            item_name: The name of the Workspace Item.
+                If k8s_name is provided, this will be ignored.
+
+        Raises:
+
+            ValueError: If no k8s resource name or Workspace Item name are provided.
+        """
+
+        k8s_name = k8s_name or item_name
+        if not k8s_name:
+            raise ValueError("You need to provide a k8s_name or a item_name.")
+
+        super().__init__(
+            k8s_resource={
+                "apiVersion": "databricks.microsoft.com/v1alpha1",
+                "kind": "WorkspaceItem",
+                "metadata": {
+                    "name": k8s_name
+                }
+            },
+            action="delete",
+            name=name)
+
+    @property
+    def resource(self):
+        """`Resource` object that represents the `resource` property in
+        `io.argoproj.workflow.v1alpha1.Template`.
+        """
+        return self._resource

--- a/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_workspaceitem_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_workspaceitem_op.py
@@ -155,7 +155,8 @@ class ImportWorkspaceItemOp(ResourceOp):
             ValueError: if the file name doesn't exist.
         """
 
-        spec = json.loads(open(file_name).read())
+        with open(file_name) as json_file:
+            spec = json.loads(json_file.read())
         return cls(name=name, k8s_name=k8s_name, item_name=item_name, spec=spec)
 
     @property

--- a/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_workspaceitem_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/databricks/_workspaceitem_op.py
@@ -14,7 +14,7 @@ class ImportWorkspaceItemOp(ResourceOp):
             item_name="test-item",
             spec={
                 "content": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
-                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+                "path": "/Users/user@foo.com/ScalaExampleNotebook",
                 "language": "SCALA",
                 "format": "SOURCE"
             }
@@ -24,7 +24,7 @@ class ImportWorkspaceItemOp(ResourceOp):
             name="importworkspaceitem",
             item_name="test-item",
             content="cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
-            path="/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+            path="/Users/user@foo.com/ScalaExampleNotebook",
             language="SCALA",
             file_format="SOURCE"
         )

--- a/samples/contrib/azure-samples/kfp-azure-databricks/setup.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='kfp-azure-databricks',
-    version='0.1.0',
+    version='0.2.0',
     description='Python package to manage Azure Databricks on Kubeflow Pipelines using Azure Databricks operator for Kubernetes',
     url='https://github.com/kubeflow/pipelines/tree/master/samples/contrib/azure-samples/kfp-azure-databricks',
     packages=['databricks']

--- a/samples/contrib/azure-samples/kfp-azure-databricks/setup.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/setup.py
@@ -1,8 +1,9 @@
 from setuptools import setup
+import databricks
 
 setup(
     name='kfp-azure-databricks',
-    version='0.2.0',
+    version=databricks.__version__,
     description='Python package to manage Azure Databricks on Kubeflow Pipelines using Azure Databricks operator for Kubernetes',
     url='https://github.com/kubeflow/pipelines/tree/master/samples/contrib/azure-samples/kfp-azure-databricks',
     packages=['databricks']

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/dbfsblock_spec.json
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/dbfsblock_spec.json
@@ -1,0 +1,4 @@
+{
+    "data": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+    "path": "/data/foo.txt"
+}

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/run_tests.sh
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/run_tests.sh
@@ -1,2 +1,4 @@
 pip install --upgrade ..
-python3 -m unittest discover --verbose
+pip install coverage
+coverage run -m unittest discover --verbose
+coverage report

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/secretscope_spec.json
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/secretscope_spec.json
@@ -1,0 +1,28 @@
+{
+    "initial_manage_permission": "users",
+    "secrets": [
+        {
+            "key": "string-secret",
+            "string_value": "helloworld"
+        },
+        {
+            "key": "byte-secret",
+            "byte_value": "aGVsbG93b3JsZA=="
+        },
+        {
+            "key": "ref-secret",
+            "value_from": {
+                "secret_key_ref": {
+                    "name": "mysecret",
+                    "key": "username"
+                }
+            }
+        }
+    ],
+    "acls": [
+        {
+            "principal": "alejacma@microsoft.com",
+            "permission": "READ"
+        }
+    ]
+}

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/secretscope_spec.json
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/secretscope_spec.json
@@ -21,7 +21,7 @@
     ],
     "acls": [
         {
-            "principal": "alejacma@microsoft.com",
+            "principal": "user@foo.com",
             "permission": "READ"
         }
     ]

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_cluster_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_cluster_op.py
@@ -18,7 +18,7 @@ class TestCreateClusterOp(unittest.TestCase):
                 num_workers=2
             )
 
-        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._create_workflow(my_pipeline))
 
     def test_databricks_create_cluster(self):
         def my_pipeline():
@@ -49,7 +49,7 @@ class TestCreateClusterOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_create_autoscaling_cluster(self):
         def my_pipeline():
@@ -78,7 +78,7 @@ class TestCreateClusterOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_create_cluster_with_spec(self):
         def my_pipeline():
@@ -99,7 +99,7 @@ class TestCreateClusterOp(unittest.TestCase):
 
             self.assert_res(res, spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_create_cluster_with_spec_and_extra_args(self):
         def my_pipeline():
@@ -130,7 +130,7 @@ class TestCreateClusterOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)        
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)        
 
     def test_databricks_create_cluster_with_json_spec(self):
         def my_pipeline():
@@ -164,7 +164,7 @@ class TestCreateClusterOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_create_cluster_with_json_file_spec(self):
         def my_pipeline():
@@ -190,7 +190,7 @@ class TestCreateClusterOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def assert_res(self, res, expected_spec):
         self.assertEqual(res.name, "createcluster")
@@ -234,7 +234,7 @@ class TestDeleteClusterOp(unittest.TestCase):
                 name="deletecluster"
             )
 
-        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._create_workflow(my_pipeline))
 
     def test_databricks_delete_cluster(self):
         def my_pipeline():
@@ -256,7 +256,7 @@ class TestDeleteClusterOp(unittest.TestCase):
             self.assertEqual(res.k8s_resource["kind"], "Dcluster")
             self.assertEqual(res.k8s_resource["metadata"]["name"], "test-cluster")
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
 if __name__ == '__main__':
     unittest.main()

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_dbfsblock_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_dbfsblock_op.py
@@ -1,0 +1,196 @@
+import unittest
+from pathlib import Path
+import kfp
+from kfp.dsl import PipelineParam
+from databricks import CreateDbfsBlockOp, DeleteDbfsBlockOp
+
+class TestCreateDbfsBlockOp(unittest.TestCase):
+
+    def test_databricks_createdbfsblock_without_k8s_or_block_name(self):
+        def my_pipeline():
+            CreateDbfsBlockOp(
+                name="createdbfsitem",
+                data="cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+                path="/Users/alejacma@microsoft.com/ScalaExampleNotebook"
+            )
+
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+
+    def test_databricks_createdbfsblock(self):
+        def my_pipeline():
+            block_name = "createdbfsitem"
+            data = "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK"
+            path = "/Users/alejacma@microsoft.com/ScalaExampleNotebook"
+            
+
+            expected_spec = {
+                "path": path,
+                "data": data
+            }
+
+            res = CreateDbfsBlockOp(
+                name="createdbfsitem",
+                block_name=block_name,
+                path=path,
+                data=data
+            )
+            
+            self.assert_res(res, expected_spec)
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def test_databricks_createdbfsblock_with_spec(self):
+        def my_pipeline():
+            block_name = "createdbfsitem"
+            spec = {
+                "data": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook"          
+            }
+
+            res = CreateDbfsBlockOp(
+                name="createdbfsitem",
+                block_name=block_name,
+                spec=spec
+            )
+
+            self.assert_res(res, spec)
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def test_databricks_createdbfsblock_with_spec_and_extra_args(self):
+        def my_pipeline():
+            block_name = "createdbfsitem"
+            data = "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK"
+            spec = {
+                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook"
+            }
+
+            expected_spec = {
+                "data": data,
+                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook"
+            }
+
+            res = CreateDbfsBlockOp(
+                name="createdbfsitem",
+                block_name=block_name,
+                data=data,
+                spec=spec
+            )
+
+            self.assert_res(res, expected_spec)
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def test_databricks_createdbfsblock_with_json_spec(self):
+        def my_pipeline():
+            block_name = "createdbfsitem"
+            json_spec = """
+            {
+                "data": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook"
+            }
+            """
+
+            expected_spec = {
+                "data": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook"
+            }
+
+            res = CreateDbfsBlockOp.from_json_spec(
+                name="createdbfsitem",
+                block_name=block_name,
+                json_spec=json_spec
+            )
+
+            self.assert_res(res, expected_spec)
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def test_databricks_createdbfsblock_with_json_file_spec(self):
+        def my_pipeline():
+            block_name = "createdbfsitem"
+            current_path = Path(__file__).parent
+            json_spec_file_name = current_path.joinpath("dbfsblock_spec.json")
+
+            expected_spec = {
+                "data": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+                "path": "/data/foo.txt"
+            }
+
+            res = CreateDbfsBlockOp.from_file_name(
+                name="createdbfsitem",
+                block_name=block_name,
+                file_name=json_spec_file_name
+            )
+
+            self.assert_res(res, expected_spec)
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def assert_res(self, res, expected_spec):
+        self.assertEqual(res.name, "createdbfsitem")
+        self.assertEqual(res.resource.action, "create")
+        self.assertEqual(res.resource.success_condition, "status.file_hash")
+        self.assertEqual(res.resource.failure_condition, None)
+        self.assertEqual(res.resource.manifest, None)
+        expected_attribute_outputs = {
+            "name": "{.metadata.name}",
+            "file_info_path": "{.status.file_info.path}",
+            "file_info_is_dir": "{.status.file_info.is_dir}",
+            "file_info_file_size": "{.status.file_info.file_size}",
+            "file_hash": "{.status.file_hash}",
+            "manifest": "{}"
+        }                
+        self.assertEqual(res.attribute_outputs, expected_attribute_outputs)
+        expected_outputs = {
+            "name": PipelineParam(name="name", op_name=res.name),
+            "file_info_path": PipelineParam(name="file_info_path", op_name=res.name),
+            "file_info_is_dir": PipelineParam(name="file_info_is_dir", op_name=res.name),
+            "file_info_file_size": PipelineParam(name="file_info_file_size", op_name=res.name),
+            "file_hash": PipelineParam(name="file_hash", op_name=res.name),
+            "manifest": PipelineParam(name="manifest", op_name=res.name)
+        }
+        self.assertEqual(res.outputs, expected_outputs)
+        self.assertEqual(
+            res.output,
+            PipelineParam(name="name", op_name=res.name)
+        )
+        self.assertEqual(res.dependent_names, [])
+        self.assertEqual(res.k8s_resource["kind"], "DbfsBlock")
+        self.assertEqual(res.k8s_resource["metadata"]["name"], "createdbfsitem")
+        self.assertEqual(res.k8s_resource["spec"], expected_spec)
+
+class TestDeletedbfsblockOp(unittest.TestCase):
+
+    def test_databricks_delete_dbfsblock_without_k8s_or_block_name(self):
+        def my_pipeline():
+            DeleteDbfsBlockOp(
+                name="deletedbfsblock"
+            )
+
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+
+    def test_databricks_delete_dbfsblock(self):
+        def my_pipeline():
+
+            res = DeleteDbfsBlockOp(
+                name="deletedbfsblock",
+                block_name="createdbfsitem"
+            )
+
+            self.assertEqual(res.name, "deletedbfsblock")
+            self.assertEqual(res.resource.action, "delete")
+            self.assertEqual(res.resource.success_condition, None)
+            self.assertEqual(res.resource.failure_condition, None)
+            self.assertEqual(res.resource.manifest, None)
+            self.assertEqual(res.attribute_outputs, {})
+            self.assertEqual(res.outputs, {})
+            self.assertEqual(res.output, None)
+            self.assertEqual(res.dependent_names, [])
+            self.assertEqual(res.k8s_resource["kind"], "DbfsBlock")
+            self.assertEqual(res.k8s_resource["metadata"]["name"], "createdbfsitem")
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_dbfsblock_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_dbfsblock_op.py
@@ -11,7 +11,7 @@ class TestCreateDbfsBlockOp(unittest.TestCase):
             CreateDbfsBlockOp(
                 name="createdbfsitem",
                 data="cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
-                path="/Users/alejacma@microsoft.com/ScalaExampleNotebook"
+                path="/Users/user@foo.com/ScalaExampleNotebook"
             )
 
         self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
@@ -20,7 +20,7 @@ class TestCreateDbfsBlockOp(unittest.TestCase):
         def my_pipeline():
             block_name = "createdbfsitem"
             data = "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK"
-            path = "/Users/alejacma@microsoft.com/ScalaExampleNotebook"
+            path = "/Users/user@foo.com/ScalaExampleNotebook"
             
 
             expected_spec = {
@@ -44,7 +44,7 @@ class TestCreateDbfsBlockOp(unittest.TestCase):
             block_name = "createdbfsitem"
             spec = {
                 "data": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
-                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook"          
+                "path": "/Users/user@foo.com/ScalaExampleNotebook"
             }
 
             res = CreateDbfsBlockOp(
@@ -62,12 +62,12 @@ class TestCreateDbfsBlockOp(unittest.TestCase):
             block_name = "createdbfsitem"
             data = "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK"
             spec = {
-                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook"
+                "path": "/Users/user@foo.com/ScalaExampleNotebook"
             }
 
             expected_spec = {
                 "data": data,
-                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook"
+                "path": "/Users/user@foo.com/ScalaExampleNotebook"
             }
 
             res = CreateDbfsBlockOp(
@@ -87,13 +87,13 @@ class TestCreateDbfsBlockOp(unittest.TestCase):
             json_spec = """
             {
                 "data": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
-                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook"
+                "path": "/Users/user@foo.com/ScalaExampleNotebook"
             }
             """
 
             expected_spec = {
                 "data": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
-                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook"
+                "path": "/Users/user@foo.com/ScalaExampleNotebook"
             }
 
             res = CreateDbfsBlockOp.from_json_spec(

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_dbfsblock_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_dbfsblock_op.py
@@ -14,7 +14,7 @@ class TestCreateDbfsBlockOp(unittest.TestCase):
                 path="/Users/user@foo.com/ScalaExampleNotebook"
             )
 
-        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._create_workflow(my_pipeline))
 
     def test_databricks_createdbfsblock(self):
         def my_pipeline():
@@ -37,7 +37,7 @@ class TestCreateDbfsBlockOp(unittest.TestCase):
             
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_createdbfsblock_with_spec(self):
         def my_pipeline():
@@ -55,7 +55,7 @@ class TestCreateDbfsBlockOp(unittest.TestCase):
 
             self.assert_res(res, spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_createdbfsblock_with_spec_and_extra_args(self):
         def my_pipeline():
@@ -79,7 +79,7 @@ class TestCreateDbfsBlockOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_createdbfsblock_with_json_spec(self):
         def my_pipeline():
@@ -104,7 +104,7 @@ class TestCreateDbfsBlockOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_createdbfsblock_with_json_file_spec(self):
         def my_pipeline():
@@ -125,7 +125,7 @@ class TestCreateDbfsBlockOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def assert_res(self, res, expected_spec):
         self.assertEqual(res.name, "createdbfsitem")
@@ -168,7 +168,7 @@ class TestDeletedbfsblockOp(unittest.TestCase):
                 name="deletedbfsblock"
             )
 
-        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._create_workflow(my_pipeline))
 
     def test_databricks_delete_dbfsblock(self):
         def my_pipeline():
@@ -190,7 +190,7 @@ class TestDeletedbfsblockOp(unittest.TestCase):
             self.assertEqual(res.k8s_resource["kind"], "DbfsBlock")
             self.assertEqual(res.k8s_resource["metadata"]["name"], "createdbfsitem")
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
 if __name__ == '__main__':
     unittest.main()

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_job_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_job_op.py
@@ -36,7 +36,7 @@ class TestCreateJobOp(unittest.TestCase):
                 }
             )
 
-        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._create_workflow(my_pipeline))
 
     def test_databricks_create_job_with_new_cluster_and_spark_jar_task(self):
         def my_pipeline():
@@ -89,7 +89,7 @@ class TestCreateJobOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_create_job_with_new_cluster_and_spark_python_task(self):
         def my_pipeline():
@@ -138,7 +138,7 @@ class TestCreateJobOp(unittest.TestCase):
             )
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_create_job_with_new_cluster_and_spark_submit_task(self):
         def my_pipeline():
@@ -178,7 +178,7 @@ class TestCreateJobOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_create_job_with_existing_cluster_and_notebook_task(self):
         def my_pipeline():
@@ -212,7 +212,7 @@ class TestCreateJobOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_create_job_with_spec(self):
         def my_pipeline():
@@ -251,7 +251,7 @@ class TestCreateJobOp(unittest.TestCase):
 
             self.assert_res(res, spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_create_job_with_spec_and_extra_args(self):
         def my_pipeline():
@@ -310,7 +310,7 @@ class TestCreateJobOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_create_job_with_json_spec(self):
         def my_pipeline():
@@ -380,7 +380,7 @@ class TestCreateJobOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_create_job_with_json_file_spec(self):
         def my_pipeline():
@@ -424,7 +424,7 @@ class TestCreateJobOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def assert_res(self, res, expected_spec):
         self.assertEqual(res.name, "createjob")
@@ -466,7 +466,7 @@ class TestDeleteJobOp(unittest.TestCase):
                 name="deletejob"
             )
 
-        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._create_workflow(my_pipeline))
 
     def test_databricks_delete_job(self):
         def my_pipeline():
@@ -488,7 +488,7 @@ class TestDeleteJobOp(unittest.TestCase):
             self.assertEqual(res.k8s_resource["kind"], "Djob")
             self.assertEqual(res.k8s_resource["metadata"]["name"], "test-job")
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
 if __name__ == '__main__':
     unittest.main()

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_run_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_run_op.py
@@ -24,7 +24,7 @@ class TestSubmitRunOp(unittest.TestCase):
                 }
             )
 
-        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._create_workflow(my_pipeline))
 
     def test_databricks_submit_run_with_job_name_and_jar_params(self):
         def my_pipeline():
@@ -47,7 +47,7 @@ class TestSubmitRunOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_submit_run_with_job_name_and_python_params(self):
         def my_pipeline():
@@ -70,7 +70,7 @@ class TestSubmitRunOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_submit_run_with_job_name_and_spark_submit_params(self):
         def my_pipeline():
@@ -93,7 +93,7 @@ class TestSubmitRunOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_submit_run_with_job_name_and_notebook_params(self):
         def my_pipeline():
@@ -119,7 +119,7 @@ class TestSubmitRunOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_submit_run_with_new_cluster_and_spark_jar_task(self):
         def my_pipeline():
@@ -154,7 +154,7 @@ class TestSubmitRunOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_submit_run_with_new_cluster_and_spark_python_task(self):
         def my_pipeline():
@@ -186,7 +186,7 @@ class TestSubmitRunOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_submit_run_with_new_cluster_and_spark_submit_task(self):
         def my_pipeline():
@@ -220,7 +220,7 @@ class TestSubmitRunOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_submit_run_with_existing_cluster_and_notebook_task(self):
         def my_pipeline():
@@ -248,7 +248,7 @@ class TestSubmitRunOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_submit_run_with_spec(self):
         def my_pipeline():
@@ -276,7 +276,7 @@ class TestSubmitRunOp(unittest.TestCase):
 
             self.assert_res(res, spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_submit_run_with_spec_and_extra_args(self):
         def my_pipeline():
@@ -327,7 +327,7 @@ class TestSubmitRunOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_submit_run_with_json_spec(self):
         def my_pipeline():
@@ -375,7 +375,7 @@ class TestSubmitRunOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_submit_run_with_json_file_spec(self):
         def my_pipeline():
@@ -408,7 +408,7 @@ class TestSubmitRunOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def assert_res(self, res, expected_spec):
         self.assertEqual(res.name, "submitrun")
@@ -466,7 +466,7 @@ class TestDeleteRunOp(unittest.TestCase):
                 name="deleterun"
             )
 
-        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._create_workflow(my_pipeline))
 
     def test_databricks_delete_run(self):
         def my_pipeline():
@@ -488,7 +488,7 @@ class TestDeleteRunOp(unittest.TestCase):
             self.assertEqual(res.k8s_resource["kind"], "Run")
             self.assertEqual(res.k8s_resource["metadata"]["name"], "test-run")
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
 if __name__ == '__main__':
     unittest.main()

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_secretscope_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_secretscope_op.py
@@ -1,0 +1,388 @@
+import unittest
+from pathlib import Path
+import kfp
+from kfp.dsl import PipelineParam
+from databricks import CreateSecretScopeOp, DeleteSecretScopeOp
+
+class TestCreateSecretScopeOp(unittest.TestCase):
+
+    def test_databricks_create_secretscope_without_k8s_or_scope_name(self):
+        def my_pipeline():
+            CreateSecretScopeOp(
+                name="createsecretscope",
+                initial_manage_principal="users",
+                secrets=[
+                    {
+                        "key": "string-secret",
+                        "string_value": "helloworld"
+                    },
+                    {
+                        "key": "byte-secret",
+                        "byte_value": "aGVsbG93b3JsZA=="
+                    },
+                    {
+                        "key": "ref-secret",
+                        "value_from": {
+                            "secret_key_ref": {
+                                "name": "mysecret",
+                                "key": "username"
+                            }
+                        }
+                    }
+                ],
+                acls=[
+                    {
+                        "principal": "alejacma@microsoft.com",
+                        "permission": "READ"
+                    }
+                ]
+            )
+
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+
+    def test_databricks_create_secretscope(self):
+        def my_pipeline():
+            scope_name = "test-secretscope"
+            initial_manage_principal = "users"
+            secrets = [
+                {
+                    "key": "string-secret",
+                    "string_value": "helloworld"
+                },
+                {
+                    "key": "byte-secret",
+                    "byte_value": "aGVsbG93b3JsZA=="
+                },
+                {
+                    "key": "ref-secret",
+                    "value_from": {
+                        "secret_key_ref": {
+                            "name": "mysecret",
+                            "key": "username"
+                        }
+                    }
+                }
+            ]
+            acls = [
+                {
+                    "principal": "alejacma@microsoft.com",
+                    "permission": "READ"
+                }
+            ]
+
+            expected_spec = {
+                "initial_manage_permission": initial_manage_principal,
+                "secrets": secrets,
+                "acls": acls
+            }
+
+            res = CreateSecretScopeOp(
+                name="createsecretscope",
+                scope_name=scope_name,
+                initial_manage_principal=initial_manage_principal,
+                secrets=secrets,
+                acls=acls
+            )
+            
+            self.assert_res(res, expected_spec)
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def test_databricks_create_secretscope_with_spec(self):
+        def my_pipeline():
+            scope_name = "test-secretscope"
+            spec = {
+                "initial_manage_permission": "users",
+                "secrets": [
+                    {
+                        "key": "string-secret",
+                        "string_value": "helloworld"
+                    },
+                    {
+                        "key": "byte-secret",
+                        "byte_value": "aGVsbG93b3JsZA=="
+                    },
+                    {
+                        "key": "ref-secret",
+                        "value_from": {
+                            "secret_key_ref": {
+                                "name": "mysecret",
+                                "key": "username"
+                            }
+                        }
+                    }
+                ],
+                "acls": [
+                    {
+                        "principal": "alejacma@microsoft.com",
+                        "permission": "READ"
+                    }
+                ]
+            }
+
+            res = CreateSecretScopeOp(
+                name="createsecretscope",
+                scope_name=scope_name,
+                spec=spec
+            )
+
+            self.assert_res(res, spec)
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def test_databricks_create_secretscope_with_spec_and_extra_args(self):
+        def my_pipeline():
+            scope_name = "test-secretscope"
+            acls = [
+                {
+                    "principal": "alejacma@microsoft.com",
+                    "permission": "READ"
+                }
+            ]
+            spec = {
+                "initial_manage_permission": "users",
+                "secrets": [
+                    {
+                        "key": "string-secret",
+                        "string_value": "helloworld"
+                    },
+                    {
+                        "key": "byte-secret",
+                        "byte_value": "aGVsbG93b3JsZA=="
+                    },
+                    {
+                        "key": "ref-secret",
+                        "value_from": {
+                            "secret_key_ref": {
+                                "name": "mysecret",
+                                "key": "username"
+                            }
+                        }
+                    }
+                ]
+            }
+
+            expected_spec = {
+                "initial_manage_permission": "users",
+                "secrets": [
+                    {
+                        "key": "string-secret",
+                        "string_value": "helloworld"
+                    },
+                    {
+                        "key": "byte-secret",
+                        "byte_value": "aGVsbG93b3JsZA=="
+                    },
+                    {
+                        "key": "ref-secret",
+                        "value_from": {
+                            "secret_key_ref": {
+                                "name": "mysecret",
+                                "key": "username"
+                            }
+                        }
+                    }
+                ],
+                "acls": acls
+            }
+
+            res = CreateSecretScopeOp(
+                name="createsecretscope",
+                scope_name=scope_name,
+                spec=spec,
+                acls=acls
+            )
+
+            self.assert_res(res, expected_spec)
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def test_databricks_create_secretscope_with_json_spec(self):
+        def my_pipeline():
+            scope_name = "test-secretscope"
+            json_spec = """
+            {
+                "initial_manage_permission": "users",
+                "secrets": [
+                    {
+                        "key": "string-secret",
+                        "string_value": "helloworld"
+                    },
+                    {
+                        "key": "byte-secret",
+                        "byte_value": "aGVsbG93b3JsZA=="
+                    },
+                    {
+                        "key": "ref-secret",
+                        "value_from": {
+                            "secret_key_ref": {
+                                "name": "mysecret",
+                                "key": "username"
+                            }
+                        }
+                    }
+                ],
+                "acls": [
+                    {
+                        "principal": "alejacma@microsoft.com",
+                        "permission": "READ"
+                    }
+                ]
+            }
+            """
+
+            expected_spec = {
+                "initial_manage_permission": "users",
+                "secrets": [
+                    {
+                        "key": "string-secret",
+                        "string_value": "helloworld"
+                    },
+                    {
+                        "key": "byte-secret",
+                        "byte_value": "aGVsbG93b3JsZA=="
+                    },
+                    {
+                        "key": "ref-secret",
+                        "value_from": {
+                            "secret_key_ref": {
+                                "name": "mysecret",
+                                "key": "username"
+                            }
+                        }
+                    }
+                ],
+                "acls": [
+                    {
+                        "principal": "alejacma@microsoft.com",
+                        "permission": "READ"
+                    }
+                ]
+            }
+
+            res = CreateSecretScopeOp.from_json_spec(
+                name="createsecretscope",
+                scope_name=scope_name,
+                json_spec=json_spec
+            )
+
+            self.assert_res(res, expected_spec)
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def test_databricks_create_secretscope_with_json_file_spec(self):
+        def my_pipeline():
+            scope_name = "test-secretscope"
+            current_path = Path(__file__).parent
+            json_spec_file_name = current_path.joinpath("secretscope_spec.json")
+
+            expected_spec = {
+                "initial_manage_permission": "users",
+                "secrets": [
+                    {
+                        "key": "string-secret",
+                        "string_value": "helloworld"
+                    },
+                    {
+                        "key": "byte-secret",
+                        "byte_value": "aGVsbG93b3JsZA=="
+                    },
+                    {
+                        "key": "ref-secret",
+                        "value_from": {
+                            "secret_key_ref": {
+                                "name": "mysecret",
+                                "key": "username"
+                            }
+                        }
+                    }
+                ],
+                "acls": [
+                    {
+                        "principal": "alejacma@microsoft.com",
+                        "permission": "READ"
+                    }
+                ]
+            }
+
+            res = CreateSecretScopeOp.from_file_name(
+                name="createsecretscope",
+                scope_name=scope_name,
+                file_name=json_spec_file_name
+            )
+
+            self.assert_res(res, expected_spec)
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def assert_res(self, res, expected_spec):
+        self.assertEqual(res.name, "createsecretscope")
+        self.assertEqual(res.resource.action, "create")
+        self.assertEqual(
+            res.resource.success_condition,
+            "status.secretscope.name"
+        )
+        self.assertEqual(res.resource.failure_condition, None)
+        self.assertEqual(res.resource.manifest, None)
+        expected_attribute_outputs = {
+            "name": "{.metadata.name}",
+            "secretscope_name": "{.status.secretscope.name}",
+            "secretscope_backend_type": "{.status.secretscope.backend_type}",
+            "secret_in_cluster_available": "{.status.secretinclusteravailable}",
+            "manifest": "{}"
+        }
+        self.assertEqual(res.attribute_outputs, expected_attribute_outputs)
+        expected_outputs = {
+            "name": PipelineParam(name="name", op_name=res.name),
+            "secretscope_name":
+                PipelineParam(name="secretscope_name", op_name=res.name),
+            "secretscope_backend_type":
+                PipelineParam(name="secretscope_backend_type", op_name=res.name),
+            "secret_in_cluster_available":
+                PipelineParam(name="secret_in_cluster_available", op_name=res.name),
+            "manifest": PipelineParam(name="manifest", op_name=res.name)
+        }
+        self.assertEqual(res.outputs, expected_outputs)
+        self.assertEqual(
+            res.output,
+            PipelineParam(name="name", op_name=res.name)
+        )
+        self.assertEqual(res.dependent_names, [])
+        self.assertEqual(res.k8s_resource["kind"], "SecretScope")
+        self.assertEqual(res.k8s_resource["metadata"]["name"], "test-secretscope")
+        self.assertEqual(res.k8s_resource["spec"], expected_spec)
+
+class TestDeleteSecretScopeOp(unittest.TestCase):
+
+    def test_databricks_delete_secretscope_without_k8s_or_scope_name(self):
+        def my_pipeline():
+            DeleteSecretScopeOp(
+                name="deletesecretscope"
+            )
+
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+
+    def test_databricks_delete_secretscope(self):
+        def my_pipeline():
+
+            res = DeleteSecretScopeOp(
+                name="deletesecretscope",
+                scope_name="test-secretscope"
+            )
+
+            self.assertEqual(res.name, "deletesecretscope")
+            self.assertEqual(res.resource.action, "delete")
+            self.assertEqual(res.resource.success_condition, None)
+            self.assertEqual(res.resource.failure_condition, None)
+            self.assertEqual(res.resource.manifest, None)
+            self.assertEqual(res.attribute_outputs, {})
+            self.assertEqual(res.outputs, {})
+            self.assertEqual(res.output, None)
+            self.assertEqual(res.dependent_names, [])
+            self.assertEqual(res.k8s_resource["kind"], "SecretScope")
+            self.assertEqual(res.k8s_resource["metadata"]["name"], "test-secretscope")
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_secretscope_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_secretscope_op.py
@@ -32,7 +32,7 @@ class TestCreateSecretScopeOp(unittest.TestCase):
                 ],
                 acls=[
                     {
-                        "principal": "alejacma@microsoft.com",
+                        "principal": "user@foo.com",
                         "permission": "READ"
                     }
                 ]
@@ -65,7 +65,7 @@ class TestCreateSecretScopeOp(unittest.TestCase):
             ]
             acls = [
                 {
-                    "principal": "alejacma@microsoft.com",
+                    "principal": "user@foo.com",
                     "permission": "READ"
                 }
             ]
@@ -114,7 +114,7 @@ class TestCreateSecretScopeOp(unittest.TestCase):
                 ],
                 "acls": [
                     {
-                        "principal": "alejacma@microsoft.com",
+                        "principal": "user@foo.com",
                         "permission": "READ"
                     }
                 ]
@@ -135,7 +135,7 @@ class TestCreateSecretScopeOp(unittest.TestCase):
             scope_name = "test-secretscope"
             acls = [
                 {
-                    "principal": "alejacma@microsoft.com",
+                    "principal": "user@foo.com",
                     "permission": "READ"
                 }
             ]
@@ -224,7 +224,7 @@ class TestCreateSecretScopeOp(unittest.TestCase):
                 ],
                 "acls": [
                     {
-                        "principal": "alejacma@microsoft.com",
+                        "principal": "user@foo.com",
                         "permission": "READ"
                     }
                 ]
@@ -254,7 +254,7 @@ class TestCreateSecretScopeOp(unittest.TestCase):
                 ],
                 "acls": [
                     {
-                        "principal": "alejacma@microsoft.com",
+                        "principal": "user@foo.com",
                         "permission": "READ"
                     }
                 ]
@@ -299,7 +299,7 @@ class TestCreateSecretScopeOp(unittest.TestCase):
                 ],
                 "acls": [
                     {
-                        "principal": "alejacma@microsoft.com",
+                        "principal": "user@foo.com",
                         "permission": "READ"
                     }
                 ]

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_secretscope_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_secretscope_op.py
@@ -38,7 +38,7 @@ class TestCreateSecretScopeOp(unittest.TestCase):
                 ]
             )
 
-        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._create_workflow(my_pipeline))
 
     def test_databricks_create_secretscope(self):
         def my_pipeline():
@@ -86,7 +86,7 @@ class TestCreateSecretScopeOp(unittest.TestCase):
             
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_create_secretscope_with_spec(self):
         def my_pipeline():
@@ -128,7 +128,7 @@ class TestCreateSecretScopeOp(unittest.TestCase):
 
             self.assert_res(res, spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_create_secretscope_with_spec_and_extra_args(self):
         def my_pipeline():
@@ -195,7 +195,7 @@ class TestCreateSecretScopeOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_create_secretscope_with_json_spec(self):
         def my_pipeline():
@@ -268,7 +268,7 @@ class TestCreateSecretScopeOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_create_secretscope_with_json_file_spec(self):
         def my_pipeline():
@@ -313,7 +313,7 @@ class TestCreateSecretScopeOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def assert_res(self, res, expected_spec):
         self.assertEqual(res.name, "createsecretscope")
@@ -360,7 +360,7 @@ class TestDeleteSecretScopeOp(unittest.TestCase):
                 name="deletesecretscope"
             )
 
-        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._create_workflow(my_pipeline))
 
     def test_databricks_delete_secretscope(self):
         def my_pipeline():
@@ -382,7 +382,7 @@ class TestDeleteSecretScopeOp(unittest.TestCase):
             self.assertEqual(res.k8s_resource["kind"], "SecretScope")
             self.assertEqual(res.k8s_resource["metadata"]["name"], "test-secretscope")
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
 if __name__ == '__main__':
     unittest.main()

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_workspaceitem_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_workspaceitem_op.py
@@ -1,0 +1,215 @@
+import unittest
+from pathlib import Path
+import kfp
+from kfp.dsl import PipelineParam
+from databricks import ImportWorkspaceItemOp, DeleteWorkspaceItemOp
+
+class TestImportWorkspaceItemOp(unittest.TestCase):
+
+    def test_databricks_import_workspaceitem_without_k8s_or_item_name(self):
+        def my_pipeline():
+            ImportWorkspaceItemOp(
+                name="importworkspaceitem",
+                content="cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+                path="/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+                language="SCALA",
+                file_format="SOURCE"
+            )
+
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+
+    def test_databricks_import_workspaceitem(self):
+        def my_pipeline():
+            item_name = "test-item"
+            content = "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK"
+            path = "/Users/alejacma@microsoft.com/ScalaExampleNotebook"
+            language = "SCALA"
+            file_format = "SOURCE"
+
+            expected_spec = {
+                "content": content,
+                "path": path,
+                "language": language,
+                "format": file_format
+            }
+
+            res = ImportWorkspaceItemOp(
+                name="importworkspaceitem",
+                item_name=item_name,
+                content=content,
+                path=path,
+                language=language,
+                file_format=file_format
+            )
+            
+            self.assert_res(res, expected_spec)
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def test_databricks_import_workspaceitem_with_spec(self):
+        def my_pipeline():
+            item_name = "test-item"
+            spec = {
+                "content": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+                "language": "SCALA",
+                "format": "SOURCE"
+            }
+
+            res = ImportWorkspaceItemOp(
+                name="importworkspaceitem",
+                item_name=item_name,
+                spec=spec
+            )
+
+            self.assert_res(res, spec)
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def test_databricks_import_workspaceitem_with_spec_and_extra_args(self):
+        def my_pipeline():
+            item_name = "test-item"
+            content = "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK"
+            spec = {
+                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+                "language": "SCALA",
+                "format": "SOURCE"
+            }
+
+            expected_spec = {
+                "content": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+                "language": "SCALA",
+                "format": "SOURCE"
+            }
+
+            res = ImportWorkspaceItemOp(
+                name="importworkspaceitem",
+                item_name=item_name,
+                spec=spec,
+                content=content
+            )
+
+            self.assert_res(res, expected_spec)
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def test_databricks_import_workspaceitem_with_json_spec(self):
+        def my_pipeline():
+            item_name = "test-item"
+            json_spec = """
+            {
+                "content": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+                "language": "SCALA",
+                "format": "SOURCE"
+            }
+            """
+
+            expected_spec = {
+                "content": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+                "language": "SCALA",
+                "format": "SOURCE"
+            }
+
+            res = ImportWorkspaceItemOp.from_json_spec(
+                name="importworkspaceitem",
+                item_name=item_name,
+                json_spec=json_spec
+            )
+
+            self.assert_res(res, expected_spec)
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def test_databricks_import_workspaceitem_with_json_file_spec(self):
+        def my_pipeline():
+            item_name = "test-item"
+            current_path = Path(__file__).parent
+            json_spec_file_name = current_path.joinpath("workspaceitem_spec.json")
+
+            expected_spec = {
+                "content": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+                "language": "SCALA",
+                "format": "SOURCE"
+            }
+
+            res = ImportWorkspaceItemOp.from_file_name(
+                name="importworkspaceitem",
+                item_name=item_name,
+                file_name=json_spec_file_name
+            )
+
+            self.assert_res(res, expected_spec)
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def assert_res(self, res, expected_spec):
+        self.assertEqual(res.name, "importworkspaceitem")
+        self.assertEqual(res.resource.action, "create")
+        self.assertEqual(res.resource.success_condition, "status.object_hash")
+        self.assertEqual(res.resource.failure_condition, None)
+        self.assertEqual(res.resource.manifest, None)
+        expected_attribute_outputs = {
+            "name": "{.metadata.name}",
+            "object_hash": "{.status.object_hash}",
+            "object_language": "{.status.object_info.language}",
+            "object_type": "{.status.object_info.object_type}",
+            "object_path": "{.status.object_info.path}",
+            "manifest": "{}"
+        }                
+        self.assertEqual(res.attribute_outputs, expected_attribute_outputs)
+        expected_outputs = {
+            "name": PipelineParam(name="name", op_name=res.name),
+            "object_hash": PipelineParam(name="object_hash", op_name=res.name),
+            "object_language": PipelineParam(name="object_language", op_name=res.name),
+            "object_type": PipelineParam(name="object_type", op_name=res.name),
+            "object_path": PipelineParam(name="object_path", op_name=res.name),
+            "manifest": PipelineParam(name="manifest", op_name=res.name)
+        }
+        self.assertEqual(res.outputs, expected_outputs)
+        self.assertEqual(
+            res.output,
+            PipelineParam(name="name", op_name=res.name)
+        )
+        self.assertEqual(res.dependent_names, [])
+        self.assertEqual(res.k8s_resource["kind"], "WorkspaceItem")
+        self.assertEqual(res.k8s_resource["metadata"]["name"], "test-item")
+        self.assertEqual(res.k8s_resource["spec"], expected_spec)
+
+class TestDeleteWorkspaceItemOp(unittest.TestCase):
+
+    def test_databricks_delete_workspaceitem_without_k8s_or_item_name(self):
+        def my_pipeline():
+            DeleteWorkspaceItemOp(
+                name="deleteworkspaceitem"
+            )
+
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+
+    def test_databricks_delete_workspaceitem(self):
+        def my_pipeline():
+
+            res = DeleteWorkspaceItemOp(
+                name="deleteworkspaceitem",
+                item_name="test-item"
+            )
+
+            self.assertEqual(res.name, "deleteworkspaceitem")
+            self.assertEqual(res.resource.action, "delete")
+            self.assertEqual(res.resource.success_condition, None)
+            self.assertEqual(res.resource.failure_condition, None)
+            self.assertEqual(res.resource.manifest, None)
+            self.assertEqual(res.attribute_outputs, {})
+            self.assertEqual(res.outputs, {})
+            self.assertEqual(res.output, None)
+            self.assertEqual(res.dependent_names, [])
+            self.assertEqual(res.k8s_resource["kind"], "WorkspaceItem")
+            self.assertEqual(res.k8s_resource["metadata"]["name"], "test-item")
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_workspaceitem_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_workspaceitem_op.py
@@ -16,7 +16,7 @@ class TestImportWorkspaceItemOp(unittest.TestCase):
                 file_format="SOURCE"
             )
 
-        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._create_workflow(my_pipeline))
 
     def test_databricks_import_workspaceitem(self):
         def my_pipeline():
@@ -44,7 +44,7 @@ class TestImportWorkspaceItemOp(unittest.TestCase):
             
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_import_workspaceitem_with_spec(self):
         def my_pipeline():
@@ -64,7 +64,7 @@ class TestImportWorkspaceItemOp(unittest.TestCase):
 
             self.assert_res(res, spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_import_workspaceitem_with_spec_and_extra_args(self):
         def my_pipeline():
@@ -92,7 +92,7 @@ class TestImportWorkspaceItemOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_import_workspaceitem_with_json_spec(self):
         def my_pipeline():
@@ -121,7 +121,7 @@ class TestImportWorkspaceItemOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def test_databricks_import_workspaceitem_with_json_file_spec(self):
         def my_pipeline():
@@ -144,7 +144,7 @@ class TestImportWorkspaceItemOp(unittest.TestCase):
 
             self.assert_res(res, expected_spec)
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
     def assert_res(self, res, expected_spec):
         self.assertEqual(res.name, "importworkspaceitem")
@@ -187,7 +187,7 @@ class TestDeleteWorkspaceItemOp(unittest.TestCase):
                 name="deleteworkspaceitem"
             )
 
-        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._compile(my_pipeline))
+        self.assertRaises(ValueError, lambda: kfp.compiler.Compiler()._create_workflow(my_pipeline))
 
     def test_databricks_delete_workspaceitem(self):
         def my_pipeline():
@@ -209,7 +209,7 @@ class TestDeleteWorkspaceItemOp(unittest.TestCase):
             self.assertEqual(res.k8s_resource["kind"], "WorkspaceItem")
             self.assertEqual(res.k8s_resource["metadata"]["name"], "test-item")
 
-        kfp.compiler.Compiler()._compile(my_pipeline)
+        kfp.compiler.Compiler()._create_workflow(my_pipeline)
 
 if __name__ == '__main__':
     unittest.main()

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_workspaceitem_op.py
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/test_workspaceitem_op.py
@@ -11,7 +11,7 @@ class TestImportWorkspaceItemOp(unittest.TestCase):
             ImportWorkspaceItemOp(
                 name="importworkspaceitem",
                 content="cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
-                path="/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+                path="/Users/user@foo.com/ScalaExampleNotebook",
                 language="SCALA",
                 file_format="SOURCE"
             )
@@ -22,7 +22,7 @@ class TestImportWorkspaceItemOp(unittest.TestCase):
         def my_pipeline():
             item_name = "test-item"
             content = "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK"
-            path = "/Users/alejacma@microsoft.com/ScalaExampleNotebook"
+            path = "/Users/user@foo.com/ScalaExampleNotebook"
             language = "SCALA"
             file_format = "SOURCE"
 
@@ -51,7 +51,7 @@ class TestImportWorkspaceItemOp(unittest.TestCase):
             item_name = "test-item"
             spec = {
                 "content": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
-                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+                "path": "/Users/user@foo.com/ScalaExampleNotebook",
                 "language": "SCALA",
                 "format": "SOURCE"
             }
@@ -71,14 +71,14 @@ class TestImportWorkspaceItemOp(unittest.TestCase):
             item_name = "test-item"
             content = "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK"
             spec = {
-                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+                "path": "/Users/user@foo.com/ScalaExampleNotebook",
                 "language": "SCALA",
                 "format": "SOURCE"
             }
 
             expected_spec = {
                 "content": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
-                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+                "path": "/Users/user@foo.com/ScalaExampleNotebook",
                 "language": "SCALA",
                 "format": "SOURCE"
             }
@@ -100,7 +100,7 @@ class TestImportWorkspaceItemOp(unittest.TestCase):
             json_spec = """
             {
                 "content": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
-                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+                "path": "/Users/user@foo.com/ScalaExampleNotebook",
                 "language": "SCALA",
                 "format": "SOURCE"
             }
@@ -108,7 +108,7 @@ class TestImportWorkspaceItemOp(unittest.TestCase):
 
             expected_spec = {
                 "content": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
-                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+                "path": "/Users/user@foo.com/ScalaExampleNotebook",
                 "language": "SCALA",
                 "format": "SOURCE"
             }
@@ -131,7 +131,7 @@ class TestImportWorkspaceItemOp(unittest.TestCase):
 
             expected_spec = {
                 "content": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
-                "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+                "path": "/Users/user@foo.com/ScalaExampleNotebook",
                 "language": "SCALA",
                 "format": "SOURCE"
             }

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/workspaceitem_spec.json
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/workspaceitem_spec.json
@@ -1,0 +1,6 @@
+{
+    "content": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
+    "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+    "language": "SCALA",
+    "format": "SOURCE"
+}

--- a/samples/contrib/azure-samples/kfp-azure-databricks/tests/workspaceitem_spec.json
+++ b/samples/contrib/azure-samples/kfp-azure-databricks/tests/workspaceitem_spec.json
@@ -1,6 +1,6 @@
 {
     "content": "cHJpbnQoImhlbGxvLCB3b3JsZCIpCgoK",
-    "path": "/Users/alejacma@microsoft.com/ScalaExampleNotebook",
+    "path": "/Users/user@foo.com/ScalaExampleNotebook",
     "language": "SCALA",
     "format": "SOURCE"
 }


### PR DESCRIPTION
Adds new Ops to Azure Databricks for Kubeflow Pipelines:
* CreateSecretScopeOp, to create a secret scope in Databricks.
* DeleteSecretScopeOp, to delete a secret scope created with CreateSecretScopeOp.
* ImportWorkspaceItemOp, to import an item into a Databricks Workspace.
* DeleteWorkspaceItemOp, to delete an item imported with ImportWorkspaceItemOp.
* CreateDbfsBlockOp, to create Dbfs block in Databricks.
* DeleteDbfsBlockOp, to delete Dbfs block created with CreateDbfsBlockOp.

Adds new pipeline samples to show the usage of these new Ops.

Fixes some typos in existing Ops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2817)
<!-- Reviewable:end -->
