### PR TITLE
Fix wrong example with container_op

### DIFF
--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -769,9 +769,9 @@ class BaseOp(object):
           from kfp.gcp import use_gcp_secret
           task = (
             train_op(...)
-              .set_memory_request('1GB')
+              .set_memory_request('1G')
               .apply(use_gcp_secret('user-gcp-sa'))
-              .set_memory_limit('2GB')
+              .set_memory_limit('2G')
           )
         """
         return mod_func(self) or self


### PR DESCRIPTION
Hi

I've fix some example codes.

when I ran latest dsl-compile with your current example code, I got error as below

```
Traceback (most recent call last):
  File "c:\programdata\miniconda3\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\programdata\miniconda3\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\ProgramData\Miniconda3\Scripts\dsl-compile.exe\__main__.py", line 7, in <module>
  File "c:\programdata\miniconda3\lib\site-packages\kfp\compiler\main.py", line 123, in main
    compile_pyfile(args.py, args.function, args.output, not args.disable_type_check)
  File "c:\programdata\miniconda3\lib\site-packages\kfp\compiler\main.py", line 112, in compile_pyfile
    _compile_pipeline_function(pipeline_funcs, function_name, output_path, type_check)
  File "c:\programdata\miniconda3\lib\site-packages\kfp\compiler\main.py", line 71, in _compile_pipeline_function
    kfp.compiler.Compiler().compile(pipeline_func, output_path, type_check)
  File "c:\programdata\miniconda3\lib\site-packages\kfp\compiler\compiler.py", line 879, in compile
    package_path=package_path)
  File "c:\programdata\miniconda3\lib\site-packages\kfp\compiler\compiler.py", line 941, in _create_and_write_workflow
    pipeline_conf)
  File "c:\programdata\miniconda3\lib\site-packages\kfp\compiler\compiler.py", line 785, in _create_workflow
    pipeline_func(*args_list)
  File ".\pipeline.py", line 16, in pipeline
    .set_memory_limit('1GB')
  File "c:\programdata\miniconda3\lib\site-packages\kfp\dsl\_container_op.py", line 46, in _wrapped
    return func(*args, **kwargs)
  File "c:\programdata\miniconda3\lib\site-packages\kfp\dsl\_container_op.py", line 1056, in _decorated
    ret = getattr(self._container, proxy_attr)(*args, **kwargs)
  File "c:\programdata\miniconda3\lib\site-packages\kfp\dsl\_container_op.py", line 263, in set_memory_limit
    self._validate_memory_string(memory)
  File "c:\programdata\miniconda3\lib\site-packages\kfp\dsl\_container_op.py", line 179, in _validate_memory_string
    'Invalid memory string. Should be an integer, or integer followed '
ValueError: Invalid memory string. Should be an integer, or integer followed by one of "E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki"
```

so I've changed `GB` to `G`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2838)
<!-- Reviewable:end -->
