### PR TITLE
fix panic in Viewer cleanup

### DIFF
--- a/backend/src/crd/controller/viewer/reconciler/reconciler.go
+++ b/backend/src/crd/controller/viewer/reconciler/reconciler.go
@@ -288,5 +288,5 @@ func (r *Reconciler) maybeDeleteOldestViewer(t viewerV1beta1.ViewerType, namespa
 		}
 	}
 
-	return r.Client.Delete(context.Background(), oldest, nil)
+	return r.Client.Delete(context.Background(), oldest)
 }


### PR DESCRIPTION
addresses issue #2253. Passing `nil` as an argument to the varargs `...DeleteOption` parameter of `client.Delete()` will panic since client-go will iterate over the DeleteOption array and invoke each (since DeleteOption is defined as `type DeleteOptionFunc func(*DeleteOptions)`.