### PR TITLE
SDK - Components - Made it easier to access component spec classes

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -28,7 +28,7 @@ from ._k8s_helper import convert_k8s_obj_to_json, sanitize_k8s_name
 from ._op_to_template import _op_to_template
 from ._default_transformers import add_pod_env
 
-from ..components._structures import InputSpec
+from ..components.structures import InputSpec
 from ..dsl._metadata import _extract_pipeline_metadata
 from ..dsl._ops_group import OpsGroup
 

--- a/sdk/python/kfp/components/_component_store.py
+++ b/sdk/python/kfp/components/_component_store.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import requests
 from typing import Callable
 from . import _components as comp
-from ._structures import ComponentReference
+from .structures import ComponentReference
 
 class ComponentStore:
     def __init__(self, local_search_paths=None, url_search_prefixes=None):

--- a/sdk/python/kfp/components/_components.py
+++ b/sdk/python/kfp/components/_components.py
@@ -25,8 +25,7 @@ from collections import OrderedDict
 from typing import Any, List, Mapping, NamedTuple, Sequence, Union
 from ._naming import _sanitize_file_name, _sanitize_python_function_name, generate_unique_name_conversion_table
 from ._yaml_utils import load_yaml
-from ._structures import ComponentSpec
-from ._structures import *
+from .structures import *
 from ._data_passing import serialize_value, type_name_to_type
 
 

--- a/sdk/python/kfp/components/_dsl_bridge.py
+++ b/sdk/python/kfp/components/_dsl_bridge.py
@@ -14,7 +14,7 @@
 
 import copy
 from typing import Any, Mapping
-from ._structures import ComponentSpec, ComponentReference
+from .structures import ComponentSpec, ComponentReference
 from ._components import _default_component_name, _resolve_command_line_and_paths
 from .. import dsl
 

--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -31,7 +31,7 @@ from ._yaml_utils import dump_yaml
 from ._components import _create_task_factory_from_component_spec
 from ._data_passing import serialize_value, type_name_to_deserializer, type_name_to_serializer, type_to_type_name
 from ._naming import _make_name_unique_by_adding_index
-from ._structures import *
+from .structures import *
 
 import inspect
 from pathlib import Path

--- a/sdk/python/kfp/components/structures/__init__.py
+++ b/sdk/python/kfp/components/structures/__init__.py
@@ -1,0 +1,1 @@
+from .._structures import *

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -25,7 +25,7 @@ from kubernetes.client.models import (
 )
 
 from . import _pipeline_param
-from ..components._structures import ComponentSpec
+from ..components.structures import ComponentSpec
 
 # generics
 T = TypeVar('T')

--- a/sdk/python/kfp/dsl/_metadata.py
+++ b/sdk/python/kfp/dsl/_metadata.py
@@ -15,7 +15,7 @@
 import warnings
 from .types import BaseType, _check_valid_type_dict
 from ..components._data_passing import serialize_value
-from ..components._structures import ComponentSpec, InputSpec, OutputSpec
+from ..components.structures import ComponentSpec, InputSpec, OutputSpec
 
 
 def _annotation_to_typemeta(annotation):

--- a/sdk/python/tests/components/test_components.py
+++ b/sdk/python/tests/components/test_components.py
@@ -111,7 +111,7 @@ implementation:
         actual_component_spec = task_factory1.component_spec
         actual_component_spec_dict = actual_component_spec.to_dict()
         expected_component_spec_dict = load_yaml(component_text)
-        expected_component_spec = kfp.components._structures.ComponentSpec.from_dict(expected_component_spec_dict)
+        expected_component_spec = kfp.components.structures.ComponentSpec.from_dict(expected_component_spec_dict)
         self.assertEqual(expected_component_spec_dict, actual_component_spec_dict)
         self.assertEqual(expected_component_spec, task_factory1.component_spec)
 

--- a/sdk/python/tests/components/test_graph_components.py
+++ b/sdk/python/tests/components/test_graph_components.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 
 import kfp.components as comp
-from kfp.components._structures import ComponentReference, ComponentSpec, ContainerSpec, GraphInputReference, GraphSpec, InputSpec, InputValuePlaceholder, GraphImplementation, OutputPathPlaceholder, OutputSpec, TaskOutputArgument, TaskSpec
+from kfp.components.structures import ComponentReference, ComponentSpec, ContainerSpec, GraphInputReference, GraphSpec, InputSpec, InputValuePlaceholder, GraphImplementation, OutputPathPlaceholder, OutputSpec, TaskOutputArgument, TaskSpec
 
 from kfp.components._yaml_utils import load_yaml
 

--- a/sdk/python/tests/components/test_python_op.py
+++ b/sdk/python/tests/components/test_python_op.py
@@ -301,7 +301,7 @@ class PythonOpTestCase(unittest.TestCase):
 
         component_spec = comp._python_op._extract_component_interface(my_func)
 
-        from kfp.components._structures import InputSpec, OutputSpec
+        from kfp.components.structures import InputSpec, OutputSpec
         self.assertEqual(
             component_spec.inputs,
             [

--- a/sdk/python/tests/dsl/component_tests.py
+++ b/sdk/python/tests/dsl/component_tests.py
@@ -17,7 +17,7 @@ import kfp.dsl as dsl
 from kfp.dsl import component, graph_component
 from kfp.dsl.types import Integer, GCSPath, InconsistentTypeException
 from kfp.dsl import ContainerOp, Pipeline, PipelineParam
-from kfp.components._structures import ComponentSpec, InputSpec, OutputSpec
+from kfp.components.structures import ComponentSpec, InputSpec, OutputSpec
 import unittest
 
 class TestPythonComponent(unittest.TestCase):

--- a/sdk/python/tests/dsl/metadata_tests.py
+++ b/sdk/python/tests/dsl/metadata_tests.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kfp.components._structures import ComponentSpec, InputSpec, OutputSpec
+from kfp.components.structures import ComponentSpec, InputSpec, OutputSpec
 import unittest
 
 

--- a/sdk/python/tests/dsl/pipeline_tests.py
+++ b/sdk/python/tests/dsl/pipeline_tests.py
@@ -16,7 +16,7 @@ import kfp
 from kfp.dsl import Pipeline, PipelineParam, ContainerOp, pipeline
 from kfp.dsl._metadata import _extract_pipeline_metadata
 from kfp.dsl.types import GCSPath, Integer
-from kfp.components._structures import ComponentSpec, InputSpec
+from kfp.components.structures import ComponentSpec, InputSpec
 import unittest
 
 


### PR DESCRIPTION
Make the classes like `ComponentSpec` accessible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2860)
<!-- Reviewable:end -->
