### PR TITLE
enlarge timeout to 45m to avoid flakyness

### DIFF
--- a/test/presubmit-tests-with-pipeline-deployment.sh
+++ b/test/presubmit-tests-with-pipeline-deployment.sh
@@ -31,7 +31,7 @@ usage()
 PLATFORM=gcp
 PROJECT=ml-pipeline-test
 TEST_RESULT_BUCKET=ml-pipeline-test
-TIMEOUT_SECONDS=1800 # 30 minutes
+TIMEOUT_SECONDS=2700 # 45 minutes
 NAMESPACE=kubeflow
 ENABLE_WORKLOAD_IDENTITY=true
 

--- a/test/sample-test/configs/default.config.yaml
+++ b/test/sample-test/configs/default.config.yaml
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 test_name: default_sample_test
-test_timeout: 1200
+test_timeout: 2700
 run_pipeline: True


### PR DESCRIPTION
enlarge timeout to 45m to avoid flakyness

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2875)
<!-- Reviewable:end -->
