### PR TITLE
Make created_at value follows RFC3339 time format.

### DIFF
--- a/.cloudbuild.yaml
+++ b/.cloudbuild.yaml
@@ -95,6 +95,14 @@ steps:
          '/workspace/backend/metadata_writer/Dockerfile', '/workspace']
   waitFor: ["-"]
 
+# Build marketplace deployer
+- id: 'buildMarketplaceDeployer'
+  name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/deployer:$COMMIT_SHA',
+         '--build-arg', 'COMMIT_HASH=$COMMIT_SHA', '-f',
+         '/workspace/manifests/gcp_marketplace/deployer/Dockerfile', '/workspace/manifests/gcp_marketplace']
+  waitFor: ["-"]
+
 # Build the Kubeflow-based pipeline component images
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/ml-pipeline-kubeflow-deployer:$COMMIT_SHA',
@@ -184,6 +192,9 @@ images:
 - 'gcr.io/$PROJECT_ID/inverse-proxy-agent:$COMMIT_SHA'
 - 'gcr.io/$PROJECT_ID/visualization-server:$COMMIT_SHA'
 - 'gcr.io/$PROJECT_ID/metadata-writer:$COMMIT_SHA'
+
+# Images for Marketplace
+- 'gcr.io/$PROJECT_ID/deployer:$COMMIT_SHA'
 
 # Images for the Kubeflow-based pipeline components
 - 'gcr.io/$PROJECT_ID/ml-pipeline-kubeflow-deployer:$COMMIT_SHA'

--- a/backend/src/apiserver/server/pipeline_upload_server.go
+++ b/backend/src/apiserver/server/pipeline_upload_server.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/golang/glog"
+	"github.com/golang/protobuf/jsonpb"
 	api "github.com/kubeflow/pipelines/backend/api/go_client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
@@ -76,25 +76,13 @@ func (s *PipelineUploadServer) UploadPipeline(w http.ResponseWriter, r *http.Req
 		s.writeErrorToResponse(w, http.StatusInternalServerError, util.Wrap(err, "Error creating pipeline"))
 		return
 	}
-	apiPipeline := ToApiPipeline(newPipeline)
-	createdAt := time.Unix(apiPipeline.CreatedAt.Seconds, int64(apiPipeline.CreatedAt.Nanos)).UTC().Format(time.RFC3339)
-	apiPipeline.CreatedAt = nil
-	// Create an anonymous struct to stream time conforming RFC3339 format "1970-01-01T00:00:01Z"
-	// Otherwise it returns "created_at":{"seconds":1}
-	pipeline := struct {
-		api.Pipeline
-		CreatedAtDateTime string `json:"created_at"`
-	}{
-		*apiPipeline,
-		createdAt,
-	}
-	pipelineJson, err := json.Marshal(pipeline)
+
+	w.Header().Set("Content-Type", "application/json")
+	err = (&jsonpb.Marshaler{OrigName:true}).Marshal(w, ToApiPipeline(newPipeline))
 	if err != nil {
 		s.writeErrorToResponse(w, http.StatusInternalServerError, util.Wrap(err, "Error creating pipeline"))
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(pipelineJson)
 }
 
 func (s *PipelineUploadServer) writeErrorToResponse(w http.ResponseWriter, code int, err error) {

--- a/backend/src/apiserver/server/pipeline_upload_server.go
+++ b/backend/src/apiserver/server/pipeline_upload_server.go
@@ -78,7 +78,8 @@ func (s *PipelineUploadServer) UploadPipeline(w http.ResponseWriter, r *http.Req
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	err = (&jsonpb.Marshaler{OrigName:true}).Marshal(w, ToApiPipeline(newPipeline))
+	marshaler := &jsonpb.Marshaler{EnumsAsInts: true, OrigName: true}
+	err = marshaler.Marshal(w, ToApiPipeline(newPipeline))
 	if err != nil {
 		s.writeErrorToResponse(w, http.StatusInternalServerError, util.Wrap(err, "Error creating pipeline"))
 		return

--- a/backend/src/apiserver/server/pipeline_upload_server_test.go
+++ b/backend/src/apiserver/server/pipeline_upload_server_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"io"
@@ -51,8 +52,10 @@ func TestUploadPipeline_YAML(t *testing.T) {
 	handler := http.HandlerFunc(server.UploadPipeline)
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, 200, rr.Code)
-	// Verify time format is RFC3339
-	assert.Contains(t, rr.Body.String(), `"created_at":"1970-01-01T00:00:01Z"`)
+	// Verify time format is RFC3339. There should be two created_at,
+	// one for pipeline and one for the default version. It means that we should
+	// get 3 if we split the output with the expected expression.
+	assert.Equal(t, 3, len(strings.Split(rr.Body.String(), `"created_at":"1970-01-01T00:00:01Z"`)))
 
 	// Verify stored in object store
 	template, err := clientManager.ObjectStore().GetFile(storage.CreatePipelinePath(resource.DefaultFakeUUID))

--- a/backend/src/apiserver/server/pipeline_upload_server_test.go
+++ b/backend/src/apiserver/server/pipeline_upload_server_test.go
@@ -52,10 +52,10 @@ func TestUploadPipeline_YAML(t *testing.T) {
 	assert.Equal(t, 200, rr.Code)
 	// Verify time format is RFC3339.
 	parsedResponse := struct {
-		CreatedAt string	 `json:"created_at"`
+		CreatedAt      string `json:"created_at"`
 		DefaultVersion struct {
-			CreatedAt string	`json:"created_at"`
-		}	`json:"default_version"`
+			CreatedAt string `json:"created_at"`
+		} `json:"default_version"`
 	}{}
 	json.Unmarshal(rr.Body.Bytes(), &parsedResponse)
 	assert.Equal(t, "1970-01-01T00:00:01Z", parsedResponse.CreatedAt)


### PR DESCRIPTION
Make created_at value of default_version in UploadPiplineResponse follow RFC3339 time format.

It returned `created_at` value as a json dictionary, for example
`"created_at":{"seconds":1576824474}`, and broke SDK parser.  `jsonpb`
will be used to take care of all json marshaling including time format
conversion.

See https://github.com/kubeflow/pipelines/issues/2764 for the detail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2876)
<!-- Reviewable:end -->
