### PR TITLE
Coverage reporting for frontend server

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,10 +55,10 @@
     "start:proxy-standalone-and-server": "./start-proxy-standalone-and-server.sh",
     "start": "react-scripts-ts start",
     "test": "react-scripts-ts test --env=jsdom",
-    "test:server": "cd ./server && npm test && cd ..",
-    "test:coverage": "npm test -- --env=jsdom --coverage",
+    "test:server:coverage": "cd ./server && npm test -- --coverage && cd ..",
+    "test:coverage": "npm test -- --coverage && npm run test:server:coverage",
     "test:ci": "npm run format:check && npm run lint && npm run test:coverage",
-    "test:ci:prow": "npm set unsafe-perm true && npm ci && npm run test:ci && ./scripts/report-coveralls.sh && npm run test:server",
+    "test:ci:prow": "npm set unsafe-perm true && npm ci && npm run test:ci && ./scripts/report-coveralls.sh",
     "vr-approve": "backstop approve",
     "vr-test": "ts-node -O '{\"module\": \"commonjs\"}' backstop.ts"
   },

--- a/frontend/scripts/report-coveralls.sh
+++ b/frontend/scripts/report-coveralls.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 
+set -e
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-export COVERALLS_REPO_TOKEN=$(node $DIR/get-coveralls-repo-token.js)
-export COVERALLS_SERVICE_NAME="prow"
 # Prow env reference: https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md
-export COVERALLS_SERVICE_JOB_ID=$PROW_JOB_ID
+export COVERALLS_REPO_TOKEN=$(node $DIR/get-coveralls-repo-token.js)
 REPO_BASE="https://github.com/kubeflow/pipelines"
 export CI_PULL_REQUEST="$REPO_BASE/pull/$PULL_NUMBER"
+
+export COVERALLS_SERVICE_JOB_ID="${PROW_JOB_ID}-frontend"
+export COVERALLS_SERVICE_NAME="prow-frontend"
 cat ./coverage/lcov.info | npx coveralls
+
+export COVERALLS_SERVICE_JOB_ID="${PROW_JOB_ID}-frontend-server"
+export COVERALLS_SERVICE_NAME="prow-frontend-server"
+cat ./server/coverage/lcov.info | npx coveralls


### PR DESCRIPTION
This is part of https://github.com/kubeflow/pipelines/issues/2215

Some investigation:
Ideally, I'd want to merge both coverage reports into one report in coveralls: https://docs.coveralls.io/parallel-build-webhook, but it's not well supported for now: https://github.com/nickmerwin/node-coveralls/issues/134.

Decided to not try to fix that, this simply submits two entries for each build.

/area frontend
/assign @Bobgy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2877)
<!-- Reviewable:end -->
