### PR TITLE
Manifests/Kustomize: Add metadata-writer to images

### DIFF
--- a/manifests/kustomize/base/kustomization.yaml
+++ b/manifests/kustomize/base/kustomization.yaml
@@ -26,3 +26,5 @@ images:
   newTag: 0.2.0
 - name: gcr.io/ml-pipeline/visualization-server
   newTag: 0.2.0
+- name: gcr.io/ml-pipeline/metadata-writer
+  newTag: 0.2.0


### PR DESCRIPTION
It looks like `metadata-writer`'s image reference is missing from `kustomization.yaml`, so the generated manifests point to `gcr.io/ml-pipeline/metadata-writer:0.1.40` as that deployment's image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2882)
<!-- Reviewable:end -->
