### PR TITLE
[SDK] kfp client should not silently fail using gcloud

### DIFF
--- a/sdk/python/kfp/_auth.py
+++ b/sdk/python/kfp/_auth.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+import subprocess
 import google.auth
 import google.auth.app_engine
 import google.auth.compute_engine.credentials
@@ -35,8 +36,8 @@ def get_gcp_access_token():
     Credentials. If not set, returns None. For more information, see
     https://cloud.google.com/sdk/gcloud/reference/auth/application-default/print-access-token
     """
-    with os.popen('gcloud auth print-access-token') as token:
-        return token.read().rstrip()
+    args = ['gcloud', 'auth', 'print-access-token']
+    return subprocess.check_output(args).rstrip()
 
 def get_auth_token(client_id, other_client_id, other_client_secret):
     """Gets auth token from default service account or user account."""


### PR DESCRIPTION
/assign @Ark-kun 
/cc @IronPan 

There was a recent report that kfp client doesn't work in cloud functions. After long troubleshooting from multiple engineers. We found os.popen is hiding underneath error that gcloud doesn't exist in cloud functions.

This PR addresses the silent error issue first.
`os.popen` is already deprecated in doc: https://docs.python.org/2/library/os.html#os.popen because it silently hides internal errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2896)
<!-- Reviewable:end -->
