### PR TITLE
SDK/CLI: Implement CLI delete run command

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -440,6 +440,18 @@ class Client(object):
     """
     return self._run_api.get_run(run_id=run_id)
 
+  def delete_run(self, run_id):
+    """Delete run.
+    Args:
+      id of the run.
+    Returns:
+      Object. If the method is called asynchronously,
+      returns the request thread.
+    Throws:
+      Exception if run is not found.
+    """
+    return self._run_api.delete_run(id=run_id)
+
   def wait_for_run_completion(self, run_id, timeout):
     """Wait for a run to complete.
     Args:

--- a/sdk/python/kfp/cli/run.py
+++ b/sdk/python/kfp/cli/run.py
@@ -75,6 +75,15 @@ def get(ctx, watch, run_id):
     namespace = ctx.obj['namespace']
     _display_run(client, namespace, run_id, watch)
 
+@run.command()
+@click.argument("run-id")
+@click.pass_context
+def delete(ctx, run_id):
+    """delete an uploaded KFP run"""
+    client = ctx.obj["client"]
+    client.delete_run(run_id)
+    print(f"{run_id} is deleted")
+
 def _display_run(client, namespace, run_id, watch):
     run = client.get_run(run_id).run
     _print_runs([run])


### PR DESCRIPTION
## Summary
- Implementation of `delete` run command
- Check local environment like below 

## Check
```
❯ kfp run list
+--------------------------------------+------------------------------------------+-----------+---------------------------+
| run id                               | name                                     | status    | created at                |
+======================================+==========================================+===========+===========================+
| 095cfbaf-2b28-4c4a-ad8f-0235eb68cbf2 | hello_world_pipeline run                 | Succeeded | 2020-01-22T10:10:57+00:00 |
+--------------------------------------+------------------------------------------+-----------+---------------------------+
| c004079a-f54d-4bb2-b3dd-b312ef6ce79f | hello_world_pipeline run                 | Succeeded | 2020-01-22T10:06:14+00:00 |
+--------------------------------------+------------------------------------------+-----------+---------------------------+

```

Then, run delete command.

```
❯ kfp run delete 095cfbaf-2b28-4c4a-ad8f-0235eb68cbf2
095cfbaf-2b28-4c4a-ad8f-0235eb68cbf2 is deleted
```

Finally, it was confirmed to delete the run correctly 

```
❯ kfp run list
+--------------------------------------+------------------------------------------+-----------+---------------------------+
| run id                               | name                                     | status    | created at                |
+======================================+==========================================+===========+===========================+
| c004079a-f54d-4bb2-b3dd-b312ef6ce79f | hello_world_pipeline run                 | Succeeded | 2020-01-22T10:06:14+00:00 |
+--------------------------------------+------------------------------------------+-----------+---------------------------+
```

## Comment
`_run_api.delete_run`  has `id` argument.
But other similiar commands like create_run, list_run, etc.. have `run_id` argument.

It may derive from the interface of backend api.
https://github.com/kubeflow/pipelines/blob/master/backend/api/go_client/run.pb.go#L478

So, I suggest that refactering is necessary for other PR for consistency.


## PR Status
Reviewable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2898)
<!-- Reviewable:end -->
