### PR TITLE
Tests - Fixed presubmit tests

### DIFF
--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -69,7 +69,7 @@ else
   NODE_POOL_CONFIG_ARG="--num-nodes=2 --machine-type=n1-standard-8 \
     --enable-autoscaling --max-nodes=8 --min-nodes=2"
   # Use new kubernetes master to improve workload identity stability.
-  KUBERNETES_VERSION_ARG="--cluster-version=1.14.8-gke.17"
+  KUBERNETES_VERSION_ARG="--cluster-version=1.14.8-gke.33"
   if [ "$ENABLE_WORKLOAD_IDENTITY" = true ]; then
     WI_ARG="--identity-namespace=$PROJECT.svc.id.goog"
     SCOPE_ARG=


### PR DESCRIPTION
1.14.8-gke.17 is no longer supported while 1.14.10-gke.17 and 1.14.9-gke.23 have broken Workflow Identity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2912)
<!-- Reviewable:end -->
