### PR TITLE
Remove UI metadata parameter from Bigquery Query component

### DIFF
--- a/components/gcp/bigquery/query/component.yaml
+++ b/components/gcp/bigquery/query/component.yaml
@@ -55,13 +55,10 @@ outputs:
   - name: output_gcs_path
     description: 'The path to the Cloud Storage bucket containing the query output in CSV format.'
     type: GCSPath
-  - name: MLPipeline UI metadata
-    type: UI metadata
 implementation:
   container:
     image: gcr.io/ml-pipeline/ml-pipeline-gcp:bae654dc5cf407359ac5f822d03833768739c4c1
     args: [
-      --ui_metadata_path, {outputPath: MLPipeline UI metadata},
       kfp_component.google.bigquery, query,
       --query, {inputValue: query},
       --project_id, {inputValue: project_id},


### PR DESCRIPTION
I tried this sample.

https://github.com/kubeflow/pipelines/blob/master/components/gcp/bigquery/query/sample.ipynb

But `wait` container failed with the error log:

```
time="2020-01-27T09:31:01Z" level=error msg="`[sh -c docker cp -a 932c01e5f0fe1f09182a6cf05a09db31d76ff5086afb9cc4e34fe6b207818502:/outputs/MLPipeline_UI_metadata/data - | tar -ax -O]` stderr:\nError: No such container:path: 932c01e5f0fe1f09182a6cf05a09db31d76ff5086afb9cc4e34fe6b207818502:/outputs/MLPipeline_UI_metadata/data\ntar: This does not look like a tar archive\ntar: Exiting with failure status due to previous errors\n"
""
```

This component doesn't make any ui-metadata, right?
So I removed information related to UI metadata from component.yaml.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2917)
<!-- Reviewable:end -->
