### PR TITLE
Update Pipelines version used in README.md under pipelines/manifests/kustomize

### DIFF
--- a/manifests/kustomize/README.md
+++ b/manifests/kustomize/README.md
@@ -6,7 +6,7 @@ This folder contains Kubeflow Pipelines Kustomize manifests for a light weight d
 
 Deploy latest version of Kubeflow Pipelines
 ```
-export PIPELINE_VERSION=0.1.40
+export PIPELINE_VERSION=0.2.0
 kubectl apply -f https://storage.googleapis.com/ml-pipeline/pipeline-lite/$PIPELINE_VERSION/crd.yaml
 kubectl wait --for condition=established --timeout=60s crd/applications.app.k8s.io
 kubectl apply -f https://storage.googleapis.com/ml-pipeline/pipeline-lite/$PIPELINE_VERSION/namespaced-install.yaml


### PR DESCRIPTION
The version 0.1.40 of crd.yaml no longer exists. Update to the current latest version (i.e. 0.2.0). This is just to make it work and it's definitely better to use a smarter way to retrieve the latest version instead of having it hard-coded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2926)
<!-- Reviewable:end -->
