### PR TITLE
[UI] Adding Troubleshooting guide link to Error / Warning Banner

### DIFF
--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -69,7 +69,6 @@ export const css = stylesheet({
     fontWeight: 'bold',
     textDecoration: 'none',
   },
-
 });
 
 export interface BannerProps {

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -54,6 +54,22 @@ export const css = stylesheet({
   refreshButton: {
     backgroundColor: color.background,
   },
+  troubleShootingLink: {
+    $nest: {
+      '&:hover': {
+        color: color.theme,
+        textDecoration: 'underline',
+      },
+    },
+    alignItems: 'center',
+    color: color.secondaryText,
+    cursor: 'pointer',
+    display: 'flex !important',
+    flexShrink: 0,
+    fontWeight: 'bold',
+    textDecoration: 'none',
+  },
+
 });
 
 export interface BannerProps {
@@ -111,6 +127,7 @@ class Banner extends React.Component<BannerProps, BannerState> {
           {this.props.message}
         </div>
         <div className={commonCss.flex}>
+        <a className={css.troubleShootingLink} href="https://www.kubeflow.org/docs/pipelines/troubleshooting">Troubleshooting guide</a>
           {this.props.additionalInfo && (
             <Button className={css.button} onClick={this._showAdditionalInfo.bind(this)}>
               Details

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -60,12 +60,8 @@ export const css = stylesheet({
   troubleShootingLink: {
     alignItems: 'center',
     color: color.theme,
-    cursor: 'pointer',
-    display: 'flex !important',
-    flexShrink: 0,
     fontWeight: 'bold',
     padding: spacing.units(-4),
-    textDecoration: 'underline',
   },
 });
 

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -42,6 +42,9 @@ export const css = stylesheet({
     maxHeight: '32px',
     minWidth: '75px',
   },
+  detailsButton: {
+    backgroundColor: color.background,
+  },  
   icon: {
     height: '18px',
     padding: spacing.units(-4),
@@ -55,19 +58,14 @@ export const css = stylesheet({
     backgroundColor: color.background,
   },
   troubleShootingLink: {
-    $nest: {
-      '&:hover': {
-        color: color.theme,
-        textDecoration: 'underline',
-      },
-    },
     alignItems: 'center',
-    color: color.secondaryText,
+    color: color.theme,
     cursor: 'pointer',
     display: 'flex !important',
     flexShrink: 0,
     fontWeight: 'bold',
-    textDecoration: 'none',
+    padding: spacing.units(-4),
+    textDecoration: 'underline',
   },
 });
 
@@ -128,7 +126,7 @@ class Banner extends React.Component<BannerProps, BannerState> {
         <div className={commonCss.flex}>
         <a className={css.troubleShootingLink} href="https://www.kubeflow.org/docs/pipelines/troubleshooting">Troubleshooting guide</a>
           {this.props.additionalInfo && (
-            <Button className={css.button} onClick={this._showAdditionalInfo.bind(this)}>
+            <Button className={classes(css.button, css.detailsButton)} onClick={this._showAdditionalInfo.bind(this)}>
               Details
             </Button>
           )}

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -44,7 +44,7 @@ export const css = stylesheet({
   },
   detailsButton: {
     backgroundColor: color.background,
-  },  
+  },
   icon: {
     height: '18px',
     padding: spacing.units(-4),
@@ -124,9 +124,17 @@ class Banner extends React.Component<BannerProps, BannerState> {
           {this.props.message}
         </div>
         <div className={commonCss.flex}>
-        <a className={css.troubleShootingLink} href="https://www.kubeflow.org/docs/pipelines/troubleshooting">Troubleshooting guide</a>
+          <a
+            className={css.troubleShootingLink}
+            href='https://www.kubeflow.org/docs/pipelines/troubleshooting'
+          >
+            Troubleshooting guide
+          </a>
           {this.props.additionalInfo && (
-            <Button className={classes(css.button, css.detailsButton)} onClick={this._showAdditionalInfo.bind(this)}>
+            <Button
+              className={classes(css.button, css.detailsButton)}
+              onClick={this._showAdditionalInfo.bind(this)}
+            >
               Details
             </Button>
           )}

--- a/frontend/src/components/__snapshots__/Banner.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Banner.test.tsx.snap
@@ -14,7 +14,14 @@ exports[`Banner defaults to error mode 1`] = `
   </div>
   <div
     className="flex"
-  />
+  >
+    <a
+      className="troubleShootingLink"
+      href="https://www.kubeflow.org/docs/pipelines/troubleshooting"
+    >
+      Troubleshooting guide
+    </a>
+  </div>
 </div>
 `;
 
@@ -33,6 +40,12 @@ exports[`Banner shows "Details" button and has dialog when there is additional i
   <div
     className="flex"
   >
+    <a
+      className="troubleShootingLink"
+      href="https://www.kubeflow.org/docs/pipelines/troubleshooting"
+    >
+      Troubleshooting guide
+    </a>
     <WithStyles(Button)
       className="button"
       onClick={[Function]}
@@ -79,6 +92,12 @@ exports[`Banner shows "Refresh" button when passed a refresh function 1`] = `
   <div
     className="flex"
   >
+    <a
+      className="troubleShootingLink"
+      href="https://www.kubeflow.org/docs/pipelines/troubleshooting"
+    >
+      Troubleshooting guide
+    </a>
     <WithStyles(Button)
       className="button refreshButton"
       onClick={[Function]}
@@ -103,7 +122,14 @@ exports[`Banner uses error mode when instructed 1`] = `
   </div>
   <div
     className="flex"
-  />
+  >
+    <a
+      className="troubleShootingLink"
+      href="https://www.kubeflow.org/docs/pipelines/troubleshooting"
+    >
+      Troubleshooting guide
+    </a>
+  </div>
 </div>
 `;
 
@@ -121,6 +147,13 @@ exports[`Banner uses warning mode when instructed 1`] = `
   </div>
   <div
     className="flex"
-  />
+  >
+    <a
+      className="troubleShootingLink"
+      href="https://www.kubeflow.org/docs/pipelines/troubleshooting"
+    >
+      Troubleshooting guide
+    </a>
+  </div>
 </div>
 `;

--- a/frontend/src/components/__snapshots__/Banner.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Banner.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`Banner shows "Details" button and has dialog when there is additional i
       Troubleshooting guide
     </a>
     <WithStyles(Button)
-      className="button"
+      className="button detailsButton"
       onClick={[Function]}
     >
       Details

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -275,7 +275,7 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
                         {!!selectedNodeDetails && (
                           <React.Fragment>
                             {!!selectedNodeDetails.phaseMessage && (
-                              <Banner mode='warning' message={selectedNodeDetails.phaseMessage}/>
+                              <Banner mode='warning' message={selectedNodeDetails.phaseMessage} />
                             )}
                             <div className={commonCss.page}>
                               <MD2Tabs

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -275,7 +275,11 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
                         {!!selectedNodeDetails && (
                           <React.Fragment>
                             {!!selectedNodeDetails.phaseMessage && (
-                              <Banner mode='warning' message={selectedNodeDetails.phaseMessage} />
+                              <div>
+                                <Banner mode='warning' message={selectedNodeDetails.phaseMessage}/>
+                                <a className={classes(commonCss.link,padding(70,'lr'))} href="https://www.kubeflow.org/docs/pipelines/troubleshooting"> Learn more about troubleshooting Pipelines and environment configurations here.</a>
+                                <br/><br/>
+                              </div>
                             )}
                             <div className={commonCss.page}>
                               <MD2Tabs

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -275,11 +275,7 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
                         {!!selectedNodeDetails && (
                           <React.Fragment>
                             {!!selectedNodeDetails.phaseMessage && (
-                              <div>
-                                <Banner mode='warning' message={selectedNodeDetails.phaseMessage}/>
-                                <a className={classes(commonCss.link,padding(70,'lr'))} href="https://www.kubeflow.org/docs/pipelines/troubleshooting"> Learn more about troubleshooting Pipelines and environment configurations here.</a>
-                                <br/><br/>
-                              </div>
+                              <Banner mode='warning' message={selectedNodeDetails.phaseMessage}/>
                             )}
                             <div className={commonCss.page}>
                               <MD2Tabs


### PR DESCRIPTION
Adding a UI link to FAQ / Trouble shooting guide when pipelines fail. This is WIP posting for early feedback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2930)
<!-- Reviewable:end -->
