### PR TITLE
Clean up metric columns

### DIFF
--- a/frontend/src/pages/AllRunsList.tsx
+++ b/frontend/src/pages/AllRunsList.tsx
@@ -65,6 +65,7 @@ class AllRunsList extends Page<{}, AllRunsListState> {
           onSelectionChange={this._selectionChanged.bind(this)}
           ref={this._runlistRef}
           storageState={RunStorageState.AVAILABLE}
+          hideMetricMetadata={true}
           {...this.props}
         />
       </div>

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -62,6 +62,7 @@ export interface RunListProps extends RouteComponentProps {
   disableSorting?: boolean;
   experimentIdMask?: string;
   hideExperimentColumn?: boolean;
+  hideMetricMetadata?: boolean;
   noFilterBox?: boolean;
   onError: (message: string, error: Error) => void;
   onSelectionChange?: (selectedRunIds: string[]) => void;
@@ -112,7 +113,7 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
       });
     }
 
-    if (metricMetadata.length) {
+    if (metricMetadata.length && !this.props.hideMetricMetadata) {
       // This is a column of empty cells with a left border to separate the metrics from the other
       // columns.
       columns.push({
@@ -158,7 +159,7 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
       if (!this.props.hideExperimentColumn) {
         row.otherFields.splice(3, 0, r.experiment);
       }
-      if (displayMetrics.length) {
+      if (displayMetrics.length && !this.props.hideMetricMetadata) {
         row.otherFields.push(''); // Metric buffer column
         row.otherFields.push(...(displayMetrics as any));
       }

--- a/frontend/src/pages/__snapshots__/AllRunsList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/AllRunsList.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`AllRunsList renders all runs 1`] = `
   className="page"
 >
   <RunList
+    hideMetricMetadata={true}
     history={
       Object {
         "push": [MockFunction],


### PR DESCRIPTION
Internal bug thread b/135048320, reporting the metric columns of some runs are  missing when displayed in RunList. This is not actually a bug but because the runs of the list are not required to have the same set of metrics and we currently show metric columns based on the first run in the list.

Reasoning: 
1. Given the fact that the main intention of displaying metric columns in a run list is for comparing these metrics across runs, we can conclude that the metric columns in run list make sense if the runs under comparison have the same set of metrics. On the other hand, in AllRun list, the runs are from *all* runs of *unrelated* pipelines in the system, and their metric sets have no inherent connection or comparison need. Therefore, in the AllRun list, we disable metric columns display. 

2. Meanwhile, e.g., if our users want to compare metric columns of runs from a same pipeline and hence having same metric columns, it is still available. They can leverage our "Experiment" feature. I.e., if they group runs of same metrics to a single experiment, our run list of a same experiment has the metric columns displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2964)
<!-- Reviewable:end -->
