### PR TITLE
Fix third party license

### DIFF
--- a/backend/src/apiserver/visualization/third_party_licenses.csv
+++ b/backend/src/apiserver/visualization/third_party_licenses.csv
@@ -134,4 +134,5 @@ pygobject,https://raw.githubusercontent.com/GNOME/pygobject/mainline/COPYING,LGP
 pyxdg,https://cgit.freedesktop.org/xdg/pyxdg/plain/COPYING,LGPL
 SecretStorage,https://raw.githubusercontent.com/mitya57/secretstorage/master/LICENSE,BSD-3
 Mako,https://raw.githubusercontent.com/sqlalchemy/mako/master/LICENSE,MIT
+typing-extensions,https://raw.githubusercontent.com/python/typing/master/typing_extensions/LICENSE,Python Software Foundation License
 

--- a/backend/src/apiserver/visualization/third_party_licenses.csv
+++ b/backend/src/apiserver/visualization/third_party_licenses.csv
@@ -134,5 +134,6 @@ pygobject,https://raw.githubusercontent.com/GNOME/pygobject/mainline/COPYING,LGP
 pyxdg,https://cgit.freedesktop.org/xdg/pyxdg/plain/COPYING,LGPL
 SecretStorage,https://raw.githubusercontent.com/mitya57/secretstorage/master/LICENSE,BSD-3
 Mako,https://raw.githubusercontent.com/sqlalchemy/mako/master/LICENSE,MIT
+typing,https://raw.githubusercontent.com/python/typing/master/typing_extensions/LICENSE,Python Software Foundation License
 typing-extensions,https://raw.githubusercontent.com/python/typing/master/typing_extensions/LICENSE,Python Software Foundation License
 

--- a/components/third_party_licenses.csv
+++ b/components/third_party_licenses.csv
@@ -209,3 +209,4 @@ pycrypto,https://raw.githubusercontent.com/dlitz/pycrypto/master/COPYRIGHT,Publi
 pygobject,https://raw.githubusercontent.com/GNOME/pygobject/mainline/COPYING,LGPL
 pyxdg,https://cgit.freedesktop.org/xdg/pyxdg/plain/COPYING,LGPL
 SecretStorage,https://raw.githubusercontent.com/mitya57/secretstorage/master/LICENSE,BSD-3
+typing-extensions,https://raw.githubusercontent.com/python/typing/master/typing_extensions/LICENSE,Python Software Foundation License

--- a/components/third_party_licenses.csv
+++ b/components/third_party_licenses.csv
@@ -209,4 +209,3 @@ pycrypto,https://raw.githubusercontent.com/dlitz/pycrypto/master/COPYRIGHT,Publi
 pygobject,https://raw.githubusercontent.com/GNOME/pygobject/mainline/COPYING,LGPL
 pyxdg,https://cgit.freedesktop.org/xdg/pyxdg/plain/COPYING,LGPL
 SecretStorage,https://raw.githubusercontent.com/mitya57/secretstorage/master/LICENSE,BSD-3
-typing-extensions,https://raw.githubusercontent.com/python/typing/master/typing_extensions/LICENSE,Python Software Foundation License


### PR DESCRIPTION
Currently cloud build is failing at:
```
The following packages are not found for licenses tracking.
Please add an entry in /ml/third_party_licenses.csv for each of them.
typing-extensions
The command '/bin/sh -c mkdir /usr/licenses &&     /ml/license.sh /ml/third_party_licenses.csv /usr/licenses' returned a non-zero code: 1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2972)
<!-- Reviewable:end -->
