### PR TITLE
Remove iap host cloud enpdoint url pattern check

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -155,9 +155,10 @@ class Client(object):
 
   def _is_iap_host(self, host, client_id):
     if host and client_id:
-      if re.match(r'\S+.endpoints.\S+.cloud.goog/{0,1}$', host):
+      if host.endswith('/pipeline'):
+        return True
+      else:
         warnings.warn('Suffix /pipeline is not ignorable for IAP host.')
-      return re.match(r'\S+.endpoints.\S+.cloud.goog/pipeline', host)
     return False
 
   def _is_inverse_proxy_host(self, host):


### PR DESCRIPTION
Not sure we need to assume that iap hostname is generated by google cloud endpoints here. 

This PR tries to address issue https://github.com/kubeflow/pipelines/issues/2244  @IronPan @chensun 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/2997)
<!-- Reviewable:end -->
