### PR TITLE
[Sample] CI Sample: mnist

### DIFF
--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/README.md
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/README.md
@@ -1,0 +1,30 @@
+# Mnist CI Pipeline
+
+## What you can learn in this sample
+* CI process of a simple but general ML pipeline.
+* Launch a tensorboard as one pipeline step
+* Data passing between steps
+
+
+## What needs to be done before run
+* Create a secret following the troubleshooting parts in [https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize]()
+* Set up a trigger in cloud build, and link it to your github repo
+* Substitute the 'substitution' field in cloudbuild.yaml:
+
+`_GCR_PATH`: '[YOUR CLOUD REGISTRY], for example: gcr.io/my-project' \
+`_GS_BUCKET`: '[YOUR GS BUCKET TO STORE PIPELINE AND LAUNCH TENSORBOARD], for example: gs://my-bucket'\
+`_PIPELINE_ID`: '[PIPELINE ID TO CREATE A VERSION ON], get it on kfp UI' \
+`_HOST_NAME`: '[EXTERNAL HOST NAME OF ml-pipeline service], read README.md for more info.'
+
+For the constant **_HOST_NAME**, you need to expose the 'ml-pipeline' service to external network so that the cloud build can create a http request to the kfp server to create a pipeline or its new version. You can achieve this by:
+- Enter **pantheon -> kubernetes engine -> workloads**
+- Find 'ml-pipeline' deployment
+- Click into the deployment. Click into the pod. Expose the pod and choose 'Load balancer' in the field 'service type'.
+- Wait for a seconds. Get the endpoints in 'Exposing services'. This will be the _HOST_NAME to put in the cloudbuild.yaml file.
+
+* Set your container registy public
+* Set the gs bucket public to view, so that cloud build can access it
+* Try a commit to your repo, then you can observe the build process triggered automatically 
+
+
+

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/README.md
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/README.md
@@ -9,21 +9,16 @@
 ## What needs to be done before run
 * Create a secret following the troubleshooting parts in [https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize]()
 * Set up a trigger in cloud build, and link it to your github repo
+* Enable "Kubernetes Engine Developer" in cloud build setting
+* Replace the CLOUDSDK_COMPUTE_ZONE, CLOUDSDK_CONTAINER_CLUSTER in cloudbuild.yaml with your own zone and cluster
 * Substitute the 'substitution' field in cloudbuild.yaml:
 
 `_GCR_PATH`: '[YOUR CLOUD REGISTRY], for example: gcr.io/my-project' \
 `_GS_BUCKET`: '[YOUR GS BUCKET TO STORE PIPELINE AND LAUNCH TENSORBOARD], for example: gs://my-bucket'\
 `_PIPELINE_ID`: '[PIPELINE ID TO CREATE A VERSION ON], get it on kfp UI' \
-`_HOST_NAME`: '[EXTERNAL HOST NAME OF ml-pipeline service], read README.md for more info.'
 
-For the constant **_HOST_NAME**, you need to expose the 'ml-pipeline' service to external network so that the cloud build can create a http request to the kfp server to create a pipeline or its new version. You can achieve this by:
-- Enter **pantheon -> kubernetes engine -> workloads**
-- Find 'ml-pipeline' deployment
-- Click into the deployment. Click into the pod. Expose the pod and choose 'Load balancer' in the field 'service type'.
-- Wait for a seconds. Get the endpoints in 'Exposing services'. This will be the _HOST_NAME to put in the cloudbuild.yaml file.
-
-* Set your container registy public
-* Set the gs bucket public to view, so that cloud build can access it
+* Set your container registy public or grant cloud registry access to cloud build and kubeflow pipeline
+* Set your gs bucket public or grant cloud storage access to cloud build and kubeflow pipeline
 * Try a commit to your repo, then you can observe the build process triggered automatically 
 
 

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/README.md
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/README.md
@@ -4,7 +4,7 @@
 
 This sample uses cloud build to implement the continuous integration process of a basic machine learning pipeline that trains and visualizes model in tensorboard. Once all set up, you can push your code to github repo, then the build process in cloud build will be triggered automatically, then a run will be created in kubeflow pipeline. You can view your pipeline and the run in kubeflow pipelines. 
 
-We use *Kubeflow Pipeline(KFP) SDK** to interact with kubeflow pipeline to create a new version and a run in this sample.
+We use **Kubeflow Pipeline(KFP) SDK** to interact with kubeflow pipeline to create a new version and a run in this sample.
 
 ## What you can learn in this sample
 * CI process of a simple but general ML pipeline.
@@ -13,7 +13,7 @@ We use *Kubeflow Pipeline(KFP) SDK** to interact with kubeflow pipeline to creat
 
 
 ## What needs to be done before run
-* Create a secret following the troubleshooting parts in [https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize]()
+* Create a secret following the troubleshooting parts in [KFP Repo](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize)
 * Set up a trigger in cloud build, and link it to your github repo
 * Enable "Kubernetes Engine Developer" in cloud build setting
 * Replace the CLOUDSDK_COMPUTE_ZONE, CLOUDSDK_CONTAINER_CLUSTER in cloudbuild.yaml with your own zone and cluster

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/README.md
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/README.md
@@ -1,4 +1,10 @@
-# Mnist CI Pipeline
+# Mnist Continuous Integration(CI) Pipeline
+
+## ## Overview
+
+This sample uses cloud build to implement the continuous integration process of a basic machine learning pipeline that trains and visualizes model in tensorboard. Once all set up, you can push your code to github repo, then the build process in cloud build will be triggered automatically, then a run will be created in kubeflow pipeline. You can view your pipeline and the run in kubeflow pipelines. 
+
+We use *Kubeflow Pipeline(KFP) SDK** to interact with kubeflow pipeline to create a new version and a run in this sample.
 
 ## What you can learn in this sample
 * CI process of a simple but general ML pipeline.

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/README.md
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/README.md
@@ -1,6 +1,6 @@
 # Mnist Continuous Integration(CI) Pipeline
 
-## ## Overview
+## Overview
 
 This sample uses cloud build to implement the continuous integration process of a basic machine learning pipeline that trains and visualizes model in tensorboard. Once all set up, you can push your code to github repo, then the build process in cloud build will be triggered automatically, then a run will be created in kubeflow pipeline. You can view your pipeline and the run in kubeflow pipelines. 
 
@@ -13,7 +13,7 @@ We use **Kubeflow Pipeline(KFP) SDK** to interact with kubeflow pipeline to crea
 
 
 ## What needs to be done before run
-* Create a secret following the troubleshooting parts in [KFP Repo](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize)
+* Authenticate to gcp services by either: Create a "user-gcp-sa" secret following the troubleshooting parts in [KFP Repo](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize), or configure workload identity as instructed in [this guide](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity). This sample uses the first method, but this will soon be deprecated. Please refer to the second method to replace the use of "user-gcp-sa" service account.
 * Set up a trigger in cloud build, and link it to your github repo
 * Enable "Kubernetes Engine Developer" in cloud build setting
 * Replace the CLOUDSDK_COMPUTE_ZONE, CLOUDSDK_CONTAINER_CLUSTER in cloudbuild.yaml with your own zone and cluster

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/cloudbuild.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/cloudbuild.yaml
@@ -35,6 +35,8 @@ steps:
         "cd ${_CODE_PATH};
         pip3 install cffi==1.12.3 --upgrade;
         pip3 install kfp==0.1.37;
+        sed -i s/image: train_image_location/image: ${_GCR_PATH}/mnist_train:$COMMIT_SHA/g ./train/component.yaml;
+        sed -i s/image: tensorboard_image_location/image: ${_GCR_PATH}/mnist_tensorboard:$COMMIT_SHA/g ./tensorboard/component.yaml;
         python pipeline.py --gcr_address ${_GCR_PATH};
         cp pipeline.py.zip /workspace/pipeline.zip",
       ]
@@ -83,5 +85,5 @@ substitutions:
   _NAMESPACE: kubeflow
   _GCR_PATH: gcr.io/alert-ability-264507
   _GS_BUCKET: gs://dldaisy-test-bucket
-  _PIPELINE_ID: f6f8558a-6eec-4ef4-b343-a650473ee613
+  _PIPELINE_ID: f6f8558a-6eec-4ef4-b343-a650473ee613]
 

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/cloudbuild.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/cloudbuild.yaml
@@ -52,8 +52,8 @@ steps:
         "cd ${_CODE_PATH};
         pip3 install cffi==1.12.3 --upgrade;
         pip3 install kfp==0.1.37;
-        sed -i 's|image: train_image_location|image: ${_GCR_PATH}/mnist_train:latest|g' ./train/component.yaml;
-        sed -i 's|image: tensorboard_image_location|image: ${_GCR_PATH}/mnist_tensorboard:latest|g' ./tensorboard/component.yaml;
+        sed -i 's|image: train_image_location|image: ${_GCR_PATH}/mnist_train:$COMMIT_SHA|g' ./train/component.yaml;
+        sed -i 's|image: tensorboard_image_location|image: ${_GCR_PATH}/mnist_tensorboard:$COMMIT_SHA|g' ./tensorboard/component.yaml;
         python pipeline.py --gcr_address ${_GCR_PATH};
         cp pipeline.py.zip /workspace/pipeline.zip",
       ]
@@ -87,8 +87,8 @@ steps:
         --pipeline_id ${_PIPELINE_ID}"
       ]
     env:
-      - "CLOUDSDK_COMPUTE_ZONE=us-central1-a"
-      - "CLOUDSDK_CONTAINER_CLUSTER=sample"
+      - "CLOUDSDK_COMPUTE_ZONE=[Your cluster zone, for example: us-central1-a]"
+      - "CLOUDSDK_CONTAINER_CLUSTER=[Your cluster name, for example: my-cluster]"
     id: "MnistCreatePipelineVersionAndRun"
 
 images:
@@ -98,7 +98,8 @@ images:
 substitutions:
   _CODE_PATH: /workspace/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample
   _NAMESPACE: kubeflow
-  _GCR_PATH: gcr.io/alert-ability-264507
-  _GS_BUCKET: gs://dldaisy-test-bucket
-  _PIPELINE_ID: f6f8558a-6eec-4ef4-b343-a650473ee613
+  _GCR_PATH: [Your cloud registry path. For example, gcr.io/my-project-id]
+  _GS_BUCKET: [Name of your cloud storage bucket. For example, gs://my-project-bucket]
+  _PIPELINE_ID: [Your kubeflow pipeline id to create a version on. Get it from Kubeflow Pipeline UI.
+                 For example, f6f8558a-6eec-4ef4-b343-a650473ee613]
 

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/cloudbuild.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/cloudbuild.yaml
@@ -54,6 +54,7 @@ steps:
         pip3 install kfp==0.1.37;
         sed -i 's|image: train_image_location|image: ${_GCR_PATH}/mnist_train:$COMMIT_SHA|g' ./train/component.yaml;
         sed -i 's|image: tensorboard_image_location|image: ${_GCR_PATH}/mnist_tensorboard:$COMMIT_SHA|g' ./tensorboard/component.yaml;
+        sed -i 's|ui_metadata_path|${_UI_METADATA_PATH}|g' ./tensorboard/component.yaml;
         python pipeline.py --gcr_address ${_GCR_PATH};
         cp pipeline.py.zip /workspace/pipeline.zip",
       ]
@@ -84,7 +85,8 @@ steps:
         python3 create_pipeline_version_and_run.py 
         --bucket_name ${_GS_BUCKET}
         --commit_sha $COMMIT_SHA
-        --pipeline_id ${_PIPELINE_ID}"
+        --pipeline_id ${_PIPELINE_ID}
+        --output_path ${_UI_METADATA_PATH}"
       ]
     env:
       - "CLOUDSDK_COMPUTE_ZONE=[Your cluster zone, for example: us-central1-a]"
@@ -102,4 +104,4 @@ substitutions:
   _GS_BUCKET: [Name of your cloud storage bucket. For example, gs://my-project-bucket]
   _PIPELINE_ID: [Your kubeflow pipeline id to create a version on. Get it from Kubeflow Pipeline UI.
                  For example, f6f8558a-6eec-4ef4-b343-a650473ee613]
-
+  _UI_METADATA_PATH: [Path to the file which specifies where your metadata is located. For example, /mlpipeline-ui-metadata.json ]

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/cloudbuild.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/cloudbuild.yaml
@@ -16,6 +16,15 @@ steps:
   - name: "gcr.io/cloud-builders/docker"
     args:
       [
+        "push",
+        "${_GCR_PATH}/mnist_train:$COMMIT_SHA",
+      ]
+    id: "MnistPushFirstImage"
+    waitFor: ["MnistBuildFirstImage"]
+
+  - name: "gcr.io/cloud-builders/docker"
+    args:
+      [
         "build",
         "-t",
         "${_GCR_PATH}/mnist_tensorboard:$COMMIT_SHA",
@@ -27,6 +36,14 @@ steps:
       ]
     id: "MnistBuildSecondImage"
 
+  - name: "gcr.io/cloud-builders/docker"
+    args:
+      [
+        "push",
+        "${_GCR_PATH}/mnist_tensorboard:$COMMIT_SHA",
+      ]
+    id: "MnistPushSecondImage"
+    waitFor: ["MnistBuildSecondImage"]
 
   - name: "python:3.7-slim"
     entrypoint: "/bin/sh"
@@ -75,9 +92,7 @@ steps:
     id: "MnistCreatePipelineVersionAndRun"
 
 images:
-  - "${_GCR_PATH}/mnist_train:$COMMIT_SHA"
   - "${_GCR_PATH}/mnist_train:latest"
-  - "${_GCR_PATH}/mnist_tensorboard:$COMMIT_SHA"
   - "${_GCR_PATH}/mnist_tensorboard:latest"
 
 substitutions:
@@ -85,5 +100,5 @@ substitutions:
   _NAMESPACE: kubeflow
   _GCR_PATH: gcr.io/alert-ability-264507
   _GS_BUCKET: gs://dldaisy-test-bucket
-  _PIPELINE_ID: f6f8558a-6eec-4ef4-b343-a650473ee613]
+  _PIPELINE_ID: f6f8558a-6eec-4ef4-b343-a650473ee613
 

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/cloudbuild.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/cloudbuild.yaml
@@ -35,8 +35,8 @@ steps:
         "cd ${_CODE_PATH};
         pip3 install cffi==1.12.3 --upgrade;
         pip3 install kfp==0.1.37;
-        sed -i s/image: train_image_location/image: ${_GCR_PATH}/mnist_train:$COMMIT_SHA/g ./train/component.yaml;
-        sed -i s/image: tensorboard_image_location/image: ${_GCR_PATH}/mnist_tensorboard:$COMMIT_SHA/g ./tensorboard/component.yaml;
+        sed -i 's|image: train_image_location|image: ${_GCR_PATH}/mnist_train:$COMMIT_SHA|g' ./train/component.yaml;
+        sed -i 's|image: tensorboard_image_location|image: ${_GCR_PATH}/mnist_tensorboard:$COMMIT_SHA|g' ./tensorboard/component.yaml;
         python pipeline.py --gcr_address ${_GCR_PATH};
         cp pipeline.py.zip /workspace/pipeline.zip",
       ]

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/cloudbuild.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/cloudbuild.yaml
@@ -35,8 +35,8 @@ steps:
         "cd ${_CODE_PATH};
         pip3 install cffi==1.12.3 --upgrade;
         pip3 install kfp==0.1.37;
-        sed -i 's|image: train_image_location|image: ${_GCR_PATH}/mnist_train:$COMMIT_SHA|g' ./train/component.yaml;
-        sed -i 's|image: tensorboard_image_location|image: ${_GCR_PATH}/mnist_tensorboard:$COMMIT_SHA|g' ./tensorboard/component.yaml;
+        sed -i 's|image: train_image_location|image: ${_GCR_PATH}/mnist_train:latest|g' ./train/component.yaml;
+        sed -i 's|image: tensorboard_image_location|image: ${_GCR_PATH}/mnist_tensorboard:latest|g' ./tensorboard/component.yaml;
         python pipeline.py --gcr_address ${_GCR_PATH};
         cp pipeline.py.zip /workspace/pipeline.zip",
       ]

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/cloudbuild.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/cloudbuild.yaml
@@ -1,0 +1,87 @@
+steps:
+  - name: "gcr.io/cloud-builders/docker"
+    args:
+      [
+        "build",
+        "-t",
+        "${_GCR_PATH}/mnist_train:$COMMIT_SHA",
+        "-t",
+        "${_GCR_PATH}/mnist_train:latest",
+        "${_CODE_PATH}/train",
+        "-f",
+        "${_CODE_PATH}/train/Dockerfile",
+      ]
+    id: "MnistBuildFirstImage"
+
+  - name: "gcr.io/cloud-builders/docker"
+    args:
+      [
+        "build",
+        "-t",
+        "${_GCR_PATH}/mnist_tensorboard:$COMMIT_SHA",
+        "-t",
+        "${_GCR_PATH}/mnist_tensorboard:latest",
+        "${_CODE_PATH}/tensorboard",
+        "-f",
+        "${_CODE_PATH}/tensorboard/Dockerfile",
+      ]
+    id: "MnistBuildSecondImage"
+
+
+  - name: "python:3.7-slim"
+    entrypoint: "/bin/sh"
+    args: [
+        "-c",
+        "cd ${_CODE_PATH};
+        pip3 install cffi==1.12.3 --upgrade;
+        pip3 install kfp==0.1.37;
+        python pipeline.py --gcr_address ${_GCR_PATH};
+        cp pipeline.py.zip /workspace/pipeline.zip",
+      ]
+    id: "MnistPackagePipeline"
+
+  - name: "gcr.io/cloud-builders/gsutil"
+    args:
+      [
+        "cp",
+        "/workspace/pipeline.zip",
+        "${_GS_BUCKET}/$COMMIT_SHA/pipeline.zip"
+      ]
+    id: "MnistUploadPipeline"
+    waitFor: ["MnistPackagePipeline"]
+
+
+  - name: "gcr.io/cloud-builders/kubectl"
+    entrypoint: "/bin/sh"
+    args: [
+        "-c",
+        "cd ${_CODE_PATH};
+        apt-get update;
+        apt-get install -y python3-pip;
+        apt-get install -y libssl-dev libffi-dev;
+        /builder/kubectl.bash;
+        pip3 install kfp==0.1.37;
+        pip3 install kubernetes;
+        python3 create_pipeline_version_and_run.py 
+        --bucket_name ${_GS_BUCKET}
+        --commit_sha $COMMIT_SHA
+        --pipeline_id ${_PIPELINE_ID}"
+      ]
+    env:
+      - "CLOUDSDK_COMPUTE_ZONE=us-central1-a"
+      - "CLOUDSDK_CONTAINER_CLUSTER=sample"
+    id: "MnistCreatePipelineVersionAndRun"
+
+images:
+  - "${_GCR_PATH}/mnist_train:$COMMIT_SHA"
+  - "${_GCR_PATH}/mnist_train:latest"
+  - "${_GCR_PATH}/mnist_tensorboard:$COMMIT_SHA"
+  - "${_GCR_PATH}/mnist_tensorboard:latest"
+
+substitutions:
+  _CODE_PATH: /workspace/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample
+  _NAMESPACE: kubeflow
+  _GCR_PATH: gcr.io/alert-ability-264507
+  _GS_BUCKET: gs://dldaisy-test-bucket
+  _PIPELINE_ID: f6f8558a-6eec-4ef4-b343-a650473ee613
+

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/create_pipeline_version_and_run.py
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/create_pipeline_version_and_run.py
@@ -5,6 +5,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--bucket_name', help='Required. gs bucket to store tensorboard', type=str)
 parser.add_argument('--commit_sha', help='Required. Name of the new version. Must be unique.', type=str)
 parser.add_argument('--pipeline_id', help = 'Required. pipeline id',type=str)
+parser.add_argument('--output_path', help = 'Required. Path to UI metadata.',type=str)
 parser.add_argument('--host', help='Host address of kfp.Client. Will be get from cluster automatically', type=str, default='')
 parser.add_argument('--run_name', help='name of the new run.', type=str, default='')
 parser.add_argument('--experiment_id', help = 'experiment id',type=str)
@@ -31,7 +32,12 @@ resource_references = [{"key": {"id": version_id, "type":4}, "relationship":2}]
 if args.experiment_id:
     resource_references.append({"key": {"id": args.experiment_id, "type":1}, "relationship": 1})
 run_body={"name":run_name,
-          "pipeline_spec":{"parameters": [{"name": "storage_bucket", "value": args.bucket_name}]},
+          "pipeline_spec":{
+            "parameters": [
+              {"name": "storage_bucket", "value": args.bucket_name},
+              {"name": "output_path", "value": args.output_path}
+            ]
+            },
           "resource_references": resource_references}
 try:
     client.runs.create_run(run_body)

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/create_pipeline_version_and_run.py
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/create_pipeline_version_and_run.py
@@ -1,0 +1,48 @@
+import kfp
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--bucket_name', help='Required. gs bucket to store tensorboard', type=str)
+parser.add_argument('--commit_sha', help='Required. Name of the new version. Must be unique.', type=str)
+parser.add_argument('--pipeline_id', help = 'Required. pipeline id',type=str)
+parser.add_argument('--host', help='Host address of kfp.Client. Will be get from cluster automatically', type=str, default='')
+parser.add_argument('--run_name', help='name of the new run.', type=str, default='')
+parser.add_argument('--experiment_id', help = 'experiment id',type=str)
+parser.add_argument('--code_source_url', help = 'url of source code', type=str, default='')
+args = parser.parse_args()
+
+if args.host:
+    client = kfp.Client(host=args.host)
+else:
+    client = kfp.Client()
+import os
+package_url = os.path.join('https://storage.googleapis.com', args.bucket_name.lstrip('gs://'), args.commit_sha, 'pipeline.zip')
+#create version
+version_body = {"name": args.commit_sha, \
+"code_source_url": args.code_source_url, \
+"package_url": {"pipeline_url": package_url}, \
+"resource_references": [{"key": {"id": args.pipeline_id, "type":3}, "relationship":1}]}
+print('version body: {}'.format(version_body))
+response = client.pipelines.create_pipeline_version(version_body)
+
+print('args are: {}'.format(args))
+print('Now start to create a run...')
+version_id = response.id
+# create run
+print('version response: {}'.format(response))
+run_name = args.run_name if args.run_name else 'run' + version_id
+resource_references = [{"key": {"id": version_id, "type":4}, "relationship":2}]
+if args.experiment_id:
+    resource_references.append({"key": {"id": args.experiment_id, "type":1}, "relationship": 1})
+run_body={"name":run_name,
+          "pipeline_spec":{"parameters": [{"name": "storage_bucket", "value": args.bucket_name}]},
+          "resource_references": resource_references}
+print('run body is :{}'.format(run_body))
+try:
+    client.runs.create_run(run_body)
+except:
+    print('Error Creating Run...')
+
+
+
+    

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/create_pipeline_version_and_run.py
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/create_pipeline_version_and_run.py
@@ -22,14 +22,10 @@ version_body = {"name": args.commit_sha, \
 "code_source_url": args.code_source_url, \
 "package_url": {"pipeline_url": package_url}, \
 "resource_references": [{"key": {"id": args.pipeline_id, "type":3}, "relationship":1}]}
-print('version body: {}'.format(version_body))
 response = client.pipelines.create_pipeline_version(version_body)
 
-print('args are: {}'.format(args))
-print('Now start to create a run...')
 version_id = response.id
 # create run
-print('version response: {}'.format(response))
 run_name = args.run_name if args.run_name else 'run' + version_id
 resource_references = [{"key": {"id": version_id, "type":4}, "relationship":2}]
 if args.experiment_id:
@@ -37,7 +33,6 @@ if args.experiment_id:
 run_body={"name":run_name,
           "pipeline_spec":{"parameters": [{"name": "storage_bucket", "value": args.bucket_name}]},
           "resource_references": resource_references}
-print('run body is :{}'.format(run_body))
 try:
     client.runs.create_run(run_body)
 except:

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/pipeline.py
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/pipeline.py
@@ -8,13 +8,17 @@ from kfp.gcp import use_gcp_secret
 )
 def mnist_pipeline(
    storage_bucket: str,
+   output_path: str,
    ):
    import os
    train_op = components.load_component_from_file('./train/component.yaml')
    train_step = train_op(storage_bucket=storage_bucket).apply(use_gcp_secret('user-gcp-sa'))
 
    visualize_op = components.load_component_from_file('./tensorboard/component.yaml')
-   visualize_step = visualize_op(logdir='%s' % train_step.outputs['logdir']).apply(use_gcp_secret('user-gcp-sa'))
+   visualize_step = visualize_op(
+     logdir='%s' % train_step.outputs['logdir'],
+     output_path=output_path
+   ).apply(use_gcp_secret('user-gcp-sa'))
 
 if __name__ == '__main__':
    import argparse

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/pipeline.py
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/pipeline.py
@@ -19,7 +19,7 @@ def mnist_pipeline(
    ).apply(use_gcp_secret('user-gcp-sa'))
 
    visualize_op = components.load_component_from_file('./tensorboard/component.yaml')
-   visualize_step = visualize_op(tensorboard_image='gcr.io/alert-ability-264507/mnist_tensorboard:latest', logdir=train_step.outputs['logdir']).apply(use_gcp_secret('user-gcp-sa'))
+   visualize_step = visualize_op(tensorboard_image='gcr.io/alert-ability-264507/mnist_tensorboard:latest', logdir='%s' % train_step.outputs['logdir']).apply(use_gcp_secret('user-gcp-sa'))
 
 if __name__ == '__main__':
    import argparse

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/pipeline.py
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/pipeline.py
@@ -1,0 +1,31 @@
+import kfp.dsl as dsl
+import kfp.components as components
+from kfp.gcp import use_gcp_secret
+
+@dsl.pipeline(
+   name='mnist pipeline',
+   description='A pipeline to train a model on mnist dataset and start a tensorboard.'
+)
+def mnist_pipeline(
+   storage_bucket: str,
+   ):
+   import os
+   train_step = dsl.ContainerOp(
+       name='train mnist model',
+       image = os.path.join(args.gcr_address, 'mnist_train:latest'),
+       command = ['python', '/mnist.py'],
+       arguments = ['--storage_bucket', storage_bucket],
+       file_outputs = {'logdir': '/logdir.txt'},
+   ).apply(use_gcp_secret('user-gcp-sa'))
+
+   visualize_op = components.load_component_from_file('./tensorboard/component.yaml')
+   visualize_step = visualize_op(tensorboard_image='gcr.io/alert-ability-264507/mnist_tensorboard:latest', logdir=train_step.outputs['logdir']).apply(use_gcp_secret('user-gcp-sa'))
+
+if __name__ == '__main__':
+   import argparse
+   parser = argparse.ArgumentParser()
+   parser.add_argument('--gcr_address', type = str)
+   args = parser.parse_args()
+   
+   import kfp.compiler as compiler
+   compiler.Compiler().compile(mnist_pipeline, __file__ + '.zip')

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/pipeline.py
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/pipeline.py
@@ -19,7 +19,7 @@ def mnist_pipeline(
    ).apply(use_gcp_secret('user-gcp-sa'))
 
    visualize_op = components.load_component_from_file('./tensorboard/component.yaml')
-   visualize_step = visualize_op(tensorboard_image='gcr.io/alert-ability-264507/mnist_tensorboard:latest', logdir='%s' % train_step.outputs['logdir']).apply(use_gcp_secret('user-gcp-sa'))
+   visualize_step = visualize_op(logdir='%s' % train_step.outputs['logdir']).apply(use_gcp_secret('user-gcp-sa'))
 
 if __name__ == '__main__':
    import argparse

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/pipeline.py
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/pipeline.py
@@ -10,13 +10,8 @@ def mnist_pipeline(
    storage_bucket: str,
    ):
    import os
-   train_step = dsl.ContainerOp(
-       name='train mnist model',
-       image = os.path.join(args.gcr_address, 'mnist_train:latest'),
-       command = ['python', '/mnist.py'],
-       arguments = ['--storage_bucket', storage_bucket],
-       file_outputs = {'logdir': '/logdir.txt'},
-   ).apply(use_gcp_secret('user-gcp-sa'))
+   train_op = components.load_component_from_file('./train/component.yaml')
+   train_step = train_op(storage_bucket=storage_bucket).apply(use_gcp_secret('user-gcp-sa'))
 
    visualize_op = components.load_component_from_file('./tensorboard/component.yaml')
    visualize_step = visualize_op(logdir='%s' % train_step.outputs['logdir']).apply(use_gcp_secret('user-gcp-sa'))

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/Dockerfile
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.7-slim
+COPY tensorboard.py .
+CMD ["python", "./tensorboard.py"]

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/component.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/component.yaml
@@ -1,9 +1,12 @@
 name: tensorboard visualization
 description: visualize training in tensorboard
+outputs:
+  - {name: MLPipeline UI metadata, type: UI metadata}
 implementation:
   container:
     image: gcr.io/alert-ability-264507/mnist_tensorboard:latest
     command: ['python', '/tensorboard.py']
     args: ['--logdir', {inputValue: logdir}]
-    fileOutputs: {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'}
+    fileOutputs: 
+      MLPipeline UI metadata: /mlpipeline-ui-metadata.json
     

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/component.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/component.yaml
@@ -1,5 +1,7 @@
 name: tensorboard visualization
 description: visualize training in tensorboard
+inputs:
+  - {name: logdir, type: string}
 outputs:
   - {name: MLPipeline UI metadata, type: UI metadata}
 implementation:

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/component.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/component.yaml
@@ -2,13 +2,15 @@ name: tensorboard visualization
 description: visualize training in tensorboard
 inputs:
   - {name: logdir, type: string}
+  - {name: output_path, type: string}
 outputs:
   - {name: MLPipeline UI metadata, type: UI metadata}
 implementation:
   container:
     image: tensorboard_image_location
     command: ['python', '/tensorboard.py']
-    args: ['--logdir', {inputValue: logdir}]
+    args: ['--logdir', {inputValue: logdir},
+           '--output_path', {inputValue: output_path}]
     fileOutputs: 
-      MLPipeline UI metadata: /mlpipeline-ui-metadata.json
+      MLPipeline UI metadata: ui_metadata_path
     

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/component.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/component.yaml
@@ -2,8 +2,8 @@ name: tensorboard visualization
 description: visualize training in tensorboard
 implementation:
   container:
-    image: {inputValue: tensorboard_image},
-    command: ['python', '/tensorboard.py'],
-    args: ['--logdir', {inputValue: logdir}],
+    image: {inputValue: tensorboard_image}
+    command: ['python', '/tensorboard.py']
+    args: ['--logdir', {inputValue: logdir}]
     file_outputs: {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'}
     

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/component.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/component.yaml
@@ -1,0 +1,9 @@
+name: tensorboard visualization
+description: visualize training in tensorboard
+implementation:
+  container:
+    image: {inputValue: tensorboard_image},
+    command: ['python', '/tensorboard.py'],
+    args: ['--logdir', {inputValue: logdir}],
+    file_outputs: {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'}
+    

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/component.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/component.yaml
@@ -6,7 +6,7 @@ outputs:
   - {name: MLPipeline UI metadata, type: UI metadata}
 implementation:
   container:
-    image: gcr.io/alert-ability-264507/mnist_tensorboard:latest
+    image: tensorboard_image_location
     command: ['python', '/tensorboard.py']
     args: ['--logdir', {inputValue: logdir}]
     fileOutputs: 

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/component.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/component.yaml
@@ -2,7 +2,7 @@ name: tensorboard visualization
 description: visualize training in tensorboard
 implementation:
   container:
-    image: {inputValue: tensorboard_image}
+    image: gcr.io/alert-ability-264507/mnist_tensorboard:latest
     command: ['python', '/tensorboard.py']
     args: ['--logdir', {inputValue: logdir}]
     file_outputs: {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'}

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/component.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/component.yaml
@@ -5,5 +5,5 @@ implementation:
     image: gcr.io/alert-ability-264507/mnist_tensorboard:latest
     command: ['python', '/tensorboard.py']
     args: ['--logdir', {inputValue: logdir}]
-    file_outputs: {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'}
+    fileOutputs: {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'}
     

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/tensorboard.py
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/tensorboard.py
@@ -1,0 +1,18 @@
+if __name__ == '__main__':
+    import json
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--logdir', type=str)
+    parser.add_argument('--output_path', type=str, default='/')
+
+    args = parser.parse_args()
+
+    metadata = {
+      'outputs' : [{
+        'type': 'tensorboard',
+        'source': args.logdir,
+      }]
+    }
+    with open(args.output_path+'mlpipeline-ui-metadata.json', 'w') as f:
+      json.dump(metadata, f)

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/tensorboard.py
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/tensorboard/tensorboard.py
@@ -4,7 +4,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--logdir', type=str)
-    parser.add_argument('--output_path', type=str, default='/')
+    parser.add_argument('--output_path', type=str, default='/mlpipeline-ui-metadata.json')
 
     args = parser.parse_args()
 
@@ -14,5 +14,5 @@ if __name__ == '__main__':
         'source': args.logdir,
       }]
     }
-    with open(args.output_path+'mlpipeline-ui-metadata.json', 'w') as f:
+    with open(args.output_path, 'w') as f:
       json.dump(metadata, f)

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/train/Dockerfile
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/train/Dockerfile
@@ -1,0 +1,3 @@
+FROM tensorflow/tensorflow:2.0.0-py3
+COPY mnist.py .
+CMD ["python", "./mnist.py"]

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/train/component.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/train/component.yaml
@@ -1,0 +1,13 @@
+name: train mnist model
+description: train mnist model
+inputs:
+  - {name: storage_bucket, type: GCSPath}
+outputs:
+  - {name: logdir, type: string}
+implementation:
+  container:
+    image: gcr.io/alert-ability-264507/mnist_tensorboard:latest
+    command: ['python', '/mnist.py']
+    args: ['--storage_bucket', {inputValue: storage_bucket}]
+    fileOutputs: 
+      logdir: /logdir.txt

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/train/component.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/train/component.yaml
@@ -6,7 +6,7 @@ outputs:
   - {name: logdir, type: string}
 implementation:
   container:
-    image: gcr.io/alert-ability-264507/mnist_tensorboard:latest
+    image: gcr.io/alert-ability-264507/mnist_train:latest
     command: ['python', '/mnist.py']
     args: ['--storage_bucket', {inputValue: storage_bucket}]
     fileOutputs: 

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/train/component.yaml
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/train/component.yaml
@@ -6,7 +6,7 @@ outputs:
   - {name: logdir, type: string}
 implementation:
   container:
-    image: gcr.io/alert-ability-264507/mnist_train:latest
+    image: train_image_location
     command: ['python', '/mnist.py']
     args: ['--storage_bucket', {inputValue: storage_bucket}]
     fileOutputs: 

--- a/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/train/mnist.py
+++ b/samples/contrib/versioned-pipeline-ci-samples/mnist-ci-sample/train/mnist.py
@@ -1,0 +1,41 @@
+def mnisttrain(storage_bucket:str):
+    import tensorflow as tf
+    import json
+    mnist = tf.keras.datasets.mnist
+    (x_train,y_train), (x_test, y_test) = mnist.load_data()
+    x_train, x_test = x_train/255.0, x_test/255.0
+
+    def create_model():
+        return tf.keras.models.Sequential([
+            tf.keras.layers.Flatten(input_shape = (28,28)),
+            tf.keras.layers.Dense(512, activation = 'relu'),
+            tf.keras.layers.Dropout(0.2),
+            tf.keras.layers.Dense(10, activation = 'softmax')
+        ])
+    model = create_model()
+    model.compile(optimizer='adam',
+                  loss='sparse_categorical_crossentropy',
+                  metrics=['accuracy'])
+    import datetime
+    import os
+    log_dir = os.path.join(storage_bucket, datetime.datetime.now().strftime("%Y%m%d-%H%M%S"))
+    tensorboard_callback = tf.keras.callbacks.TensorBoard(log_dir=log_dir, histogram_freq=1)
+
+    model.fit(x=x_train, 
+              y=y_train, 
+              epochs=5, 
+              validation_data=(x_test, y_test), 
+              callbacks=[tensorboard_callback])
+
+    print('At least tensorboard callbacks are correct')
+    with open('/logdir.txt', 'w') as f:
+      f.write(log_dir)
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--storage_bucket', type=str)
+
+    args = parser.parse_args()
+    mnisttrain(args.storage_bucket)


### PR DESCRIPTION
#2 piece for CI samples:
<To make the repo more easily reviewable, pr 2784(#2784) will be broken into smaller prs>
This sample is the mnist sample for versioned pipeline CI. Data scientists can make the least effort to migrate their original code to implement KFP CI by wrapping the whole training code in one step and other adds-on like visualizations in other steps.

- Use cloudbuild for CI process
- Use KFP SDK to connect to KFP API server

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3013)
<!-- Reviewable:end -->
