### PR TITLE
place holder for diagnose entry

### DIFF
--- a/tools/diagnose/OWNERS
+++ b/tools/diagnose/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - SinaChavoshi
+  - rmgogogo
+reviewers:
+  - SinaChavoshi
+  - rmgogogo

--- a/tools/diagnose/kfp.sh
+++ b/tools/diagnose/kfp.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This bash launches diagnose steps.
+
+project=''
+cluster=''
+region=''
+namespace=''
+
+print_usage() {
+  printf "Usage: $0 -p project -c cluster -r region -n namespace\n"
+}
+
+while getopts ':p:c:r:n:' flag; do
+  case "${flag}" in
+    p) project=${OPTARG} ;;
+    c) cluster=${OPTARG} ;;
+    r) region="${OPTARG}" ;;
+    n) namespace="${OPTARG}" ;;
+    *) print_usage
+       exit 1 ;;
+  esac
+done
+
+if [ -z "${project}" ] || [ -z "${cluster}" ] || [ -z "${region}" ] || [ -z "${namespace}" ]; then
+  print_usage
+  exit 1
+fi
+
+echo "This tool helps you diagnose your KubeFlow Pipelines and provide configure suggestions."
+echo "Start checking [project: ${project}, cluster: ${cluster}, region: ${region}, namespace: ${namespace}]"
+
+# Do anything here
+
+echo "Done"


### PR DESCRIPTION
- It's to be launched from Cloud Shell or any CLI.
- It may still reuse existing diagnose tool inside KFP SDK, so bash will install KFP
- Or it may directly run gcloud and kubectl to do checking or all a golang/python script if bash is hard to handle complex logics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3028)
<!-- Reviewable:end -->
