### PR TITLE
[Testing] Fix travis error: "virtualenv 20.0.1 has requirement six<2,>=1.12.0, but you'll have six 1.11.0 which is incompatible."

### DIFF
--- a/components/gcp/container/component_sdk/python/run_test.sh
+++ b/components/gcp/container/component_sdk/python/run_test.sh
@@ -1,2 +1,3 @@
-pip install -U tox virtualenv
+# six>=1.12.0 is required by virtualenv
+pip install -U six>=1.12.0 tox virtualenv
 tox "$@"

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -1,5 +1,5 @@
 urllib3>=1.15,<1.25 #Fixing the version conflict with the "requests" package caused by the kubernetes package
-six>=1.10
+six>=1.12
 certifi
 python-dateutil
 PyYAML


### PR DESCRIPTION
/cc @numerology 
This is blocking all presubmit tests.
/priority p0
/kind bug

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3039)
<!-- Reviewable:end -->
