### PR TITLE
Implement filtering in ListPipelines

### DIFF
--- a/backend/src/apiserver/list/list.go
+++ b/backend/src/apiserver/list/list.go
@@ -155,7 +155,7 @@ func NewOptions(listable Listable, pageSize int, sortBy string, filterProto *api
 
 	// Filtering.
 	if filterProto != nil {
-		f, err := filter.NewWithKeyMap(filterProto, listable.APIToModelFieldMap())
+		f, err := filter.NewWithKeyMap(filterProto, listable.APIToModelFieldMap(), listable.GetModelName())
 		if err != nil {
 			return nil, err
 		}

--- a/backend/src/apiserver/storage/pipeline_store.go
+++ b/backend/src/apiserver/storage/pipeline_store.go
@@ -88,7 +88,7 @@ func (s *PipelineStore) ListPipelines(opts *list.Options) ([]*model.Pipeline, in
 	}
 
 	buildQuery := func(sqlBuilder sq.SelectBuilder) sq.SelectBuilder {
-		return sqlBuilder.
+		return opts.AddFilterToSelect(sqlBuilder).
 			From("pipelines").
 			LeftJoin("pipeline_versions ON pipelines.DefaultVersionId = pipeline_versions.UUID").
 			Where(sq.Eq{"pipelines.Status": model.PipelineReady})


### PR DESCRIPTION
This PR fixes issue #2945 by adding filter to the `ListPipelines` API. 

Because `ListPipelines` joins table `pipelines` and `pipeline_versions`, and they both have a column `name`, we need to fully qualify the column in `NewWithKeyMap` to avoid "ambiguous column name" error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3040)
<!-- Reviewable:end -->
