### PR TITLE
updating links and service account message

### DIFF
--- a/components/diagnostics/diagnose_me/component.py
+++ b/components/diagnostics/diagnose_me/component.py
@@ -65,7 +65,7 @@ def run_diagnose_me(
         auth_project_id = project_config.parsed_output['core']['project']
         print('GCP credentials are configured with access to project: %s ...\n' % (project_id))
         print('Following account(s) are active under this pipeline:\n')
-        subprocess.run(['gcloud', 'auth', 'list'])
+        subprocess.run(['gcloud', 'auth', 'list','--format','json'])
         print('\n')
     else:
         print(
@@ -133,7 +133,7 @@ def run_diagnose_me(
             api_check_results = False
             print(
                 'API \"%s\" is not accessible or not enabled. To enable this api go to ' % (api) +
-                'https://pantheon.corp.google.com/apis/library/%s?project=%s' %
+                'https://console.cloud.google.com/apis/library/%s?project=%s' %
                 (api, project_id),file=sys.stderr)
             config_error_observed = True
 

--- a/components/diagnostics/diagnose_me/component.yaml
+++ b/components/diagnostics/diagnose_me/component.yaml
@@ -61,7 +61,7 @@ implementation:
               auth_project_id = project_config.parsed_output['core']['project']
               print('GCP credentials are configured with access to project: %s ...\n' % (project_id))
               print('Following account(s) are active under this pipeline:\n')
-              subprocess.run(['gcloud', 'auth', 'list'])
+              subprocess.run(['gcloud', 'auth', 'list','--format','json'])
               print('\n')
           else:
               print(
@@ -129,7 +129,7 @@ implementation:
                   api_check_results = False
                   print(
                       'API \"%s\" is not accessible or not enabled. To enable this api go to ' % (api) +
-                      'https://pantheon.corp.google.com/apis/library/%s?project=%s' %
+                      'https://console.cloud.google.com/apis/library/%s?project=%s' %
                       (api, project_id),file=sys.stderr)
                   config_error_observed = True
 


### PR DESCRIPTION
Updating the API update links to point to cloud.console 
also changing the service account message to remove confusing around possible action items when users see : 
```
To set the active account, run:
    $ gcloud config set account `ACCOUNT`
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3044)
<!-- Reviewable:end -->
