### PR TITLE
Fix config fieldname `PipelineFolder` to `PipelinePath`

### DIFF
--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -328,7 +328,7 @@ func initMinioClient(initConnectionTimeout time.Duration) storage.ObjectStoreInt
 	accessKey := common.GetStringConfigWithDefault("ObjectStoreConfig.AccessKey", "")
 	secretKey := common.GetStringConfigWithDefault("ObjectStoreConfig.SecretAccessKey", "")
 	bucketName := common.GetStringConfigWithDefault("ObjectStoreConfig.BucketName", os.Getenv(pipelineBucketName))
-	pipelinePath := common.GetStringConfigWithDefault("ObjectStoreConfig.PipelineFolder", os.Getenv(pipelinePath))
+	pipelinePath := common.GetStringConfigWithDefault("ObjectStoreConfig.PipelinePath", os.Getenv(pipelinePath))
 	disableMultipart := common.GetBoolConfigWithDefault("ObjectStoreConfig.Multipart.Disable", true)
 
 	minioClient := client.CreateMinioClientOrFatal(minioServiceHost, minioServicePort, accessKey,

--- a/backend/src/apiserver/config/config.json
+++ b/backend/src/apiserver/config/config.json
@@ -9,7 +9,7 @@
     "AccessKey": "minio",
     "SecretAccessKey": "minio123",
     "BucketName": "mlpipeline",
-    "PipelineFolder": "pipelines"
+    "PipelinePath": "pipelines"
   },
   "InitConnectionTimeout": "6m",
   "DefaultPipelineRunnerServiceAccount": "pipeline-runner"


### PR DESCRIPTION
With reference to PR #2080 :

param to customize the pipeline path to save the pipeline templates (`PipelineFolder`) was supposed to be renamed to `PipelinePath`. However, the `config.json` as well as the config field was not renamed. 

This PR fix this oversight - i.e. rename the config field to `PipelinePath`, and updates the `config.json`.

cc: @Jeffwan

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3056)
<!-- Reviewable:end -->
