### PR TITLE
[UI] Visualization only loads on completed nodes

### DIFF
--- a/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
@@ -1391,30 +1391,19 @@ exports[`RunDetails opens side panel when graph node is clicked 1`] = `
               >
                 <ArtifactsTabContent
                   generatedVisualizations={Array []}
-                  onError={[Function]}
-                  selectedNodeDetails={
+                  nodeId="node1"
+                  nodeStatus={
                     Object {
                       "id": "node1",
-                      "phaseMessage": undefined,
                     }
                   }
+                  onError={[Function]}
                   visualizationCreatorConfig={
                     Object {
                       "allowCustomVisualizations": false,
                       "isBusy": false,
                       "onGenerate": [Function],
                       "type": "visualization-creator",
-                    }
-                  }
-                  workflow={
-                    Object {
-                      "status": Object {
-                        "nodes": Object {
-                          "node1": Object {
-                            "id": "node1",
-                          },
-                        },
-                      },
                     }
                   }
                 />
@@ -1643,32 +1632,21 @@ exports[`RunDetails shows clicked node message in side panel 1`] = `
               >
                 <ArtifactsTabContent
                   generatedVisualizations={Array []}
-                  onError={[Function]}
-                  selectedNodeDetails={
+                  nodeId="node1"
+                  nodeStatus={
                     Object {
                       "id": "node1",
-                      "phaseMessage": "This step is in Succeeded state with this message: some test message",
+                      "message": "some test message",
+                      "phase": "Succeeded",
                     }
                   }
+                  onError={[Function]}
                   visualizationCreatorConfig={
                     Object {
                       "allowCustomVisualizations": false,
                       "isBusy": false,
                       "onGenerate": [Function],
                       "type": "visualization-creator",
-                    }
-                  }
-                  workflow={
-                    Object {
-                      "status": Object {
-                        "nodes": Object {
-                          "node1": Object {
-                            "id": "node1",
-                            "message": "some test message",
-                            "phase": "Succeeded",
-                          },
-                        },
-                      },
                     }
                   }
                 />


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/3080

Changes: this fixes the bug by only refetching data when selected node phase changes to completed.

/area frontend
/kind bug

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3082)
<!-- Reviewable:end -->
