### PR TITLE
Fix metadata_writer service connection to a proper GRPC server

### DIFF
--- a/backend/metadata_writer/src/metadata_helpers.py
+++ b/backend/metadata_writer/src/metadata_helpers.py
@@ -12,17 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import os
 import sys
-import ml_metadata
 from time import sleep
-from ml_metadata.proto import metadata_store_pb2
+
+import ml_metadata
 from ml_metadata.metadata_store import metadata_store
+from ml_metadata.proto import metadata_store_pb2
 
 
 def connect_to_mlmd() -> metadata_store.MetadataStore:
-    metadata_service_host = os.environ.get('METADATA_SERVICE_SERVICE_HOST', 'metadata-service')
-    metadata_service_port = int(os.environ.get('METADATA_SERVICE_SERVICE_PORT', 8080))
+    metadata_service_host = os.environ.get('METADATA_GRPC_SERVICE_SERVICE_HOST', 'metadata-grpc-service')
+    metadata_service_port = int(os.environ.get('METADATA_GRPC_SERVICE_SERVICE_PORT', 8080))
 
     mlmd_connection_config = metadata_store_pb2.MetadataStoreClientConfig(
         host=metadata_service_host,
@@ -150,7 +152,6 @@ def create_context_with_type(
     return context
 
 
-import functools
 @functools.lru_cache(maxsize=128)
 def get_context_by_name(
     store,


### PR DESCRIPTION
Metadata service uses ml_metadata python API but tries to connect to kubeflow metadata service instead of TFX metadata service hence it fails to connect with the error:

## Expected behavior:

Should connect to metadata server without any errors

## Actual behavior before this PR:

Pod fails with the following error in logs:

```
Failed to access the Metadata store. Exception: "Trying to connect an http1.x server"
```

## How to test

1. build the service and push to a docker registry with the tag `metadata_writer:latest`
2. make a deployment with the following YAML:
```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/component: pipelines
    app.kubernetes.io/instance: metadata-writer
    app.kubernetes.io/managed-by: wla
    app.kubernetes.io/name: metadata-writer-deployment
    app.kubernetes.io/part-of: kubeflow
    app.kubernetes.io/version: 0.2.1
    component: server
  name: metadata-writer
  namespace: kubeflow
spec:
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app.kubernetes.io/component: pipelines
      app.kubernetes.io/instance: metadata-writer
      app.kubernetes.io/managed-by: wla
      app.kubernetes.io/name: metadata-writer
      app.kubernetes.io/part-of: kubeflow
      app.kubernetes.io/version: 0.2.1
      component: server
  template:
    metadata:
      labels:
        app.kubernetes.io/component: pipelines
        app.kubernetes.io/instance: metadata-writer
        app.kubernetes.io/managed-by: wla
        app.kubernetes.io/name: metadata-writer
        app.kubernetes.io/part-of: kubeflow
        app.kubernetes.io/version: 0.2.1
        component: server
        kustomize.component: metadata
    spec:
      serviceAccountName: metadata-writer-sa
      containers:
      - envFrom:
        - configMapRef:
            name: metadata-db-parameters
        - secretRef:
            name: metadata-db-secrets
        image: metadata_writer:latest
        imagePullPolicy: IfNotPresent
        name: container
        env:
        - name: NAMESPACE_TO_WATCH
          value: kubeflow
---
apiVersion: v1
kind: ServiceAccount
metadata:
  namespace: kubeflow
  name: metadata-writer-sa
---
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: Role
metadata:
  namespace: kubeflow
  name: metadata-writer-role
rules:
- apiGroups: [""]
  resources: ["pods"]
  verbs: ["get", "list", "watch", "patch"]
---
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: RoleBinding
metadata:
  namespace: kubeflow
  name: metadata-writer-rb
roleRef:
  kind: Role
  name: metadata-writer-role
  apiGroup: rbac.authorization.k8s.io
subjects:
 - kind: ServiceAccount
   name: metadata-writer-sa
   namespace: kubeflow
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3087)
<!-- Reviewable:end -->
