### PR TITLE
SDK - Fixed the broken kfp.gcp.use_preemptible_nodepool extension

### DIFF
--- a/sdk/python/kfp/gcp.py
+++ b/sdk/python/kfp/gcp.py
@@ -112,9 +112,10 @@ def use_preemptible_nodepool(toleration: V1Toleration = V1Toleration(effect='NoS
       node_affinity = V1NodeAffinity(required_during_scheduling_ignored_during_execution=
                         V1NodeSelector(node_selector_terms=[node_selector_term]))
     else:
-      node_affinity = V1NodeAffinity(preferred_during_scheduling_ignored_during_execution=
+      node_affinity = V1NodeAffinity(preferred_during_scheduling_ignored_during_execution=[
                         V1PreferredSchedulingTerm(preference=node_selector_term,
-                                                  weight=50))
+                                                  weight=50)
+      ])
     affinity = V1Affinity(node_affinity=node_affinity)
     task.add_affinity(affinity=affinity)
     return task

--- a/sdk/python/tests/compiler/testdata/preemptible_tpu_gpu.yaml
+++ b/sdk/python/tests/compiler/testdata/preemptible_tpu_gpu.yaml
@@ -13,7 +13,7 @@ spec:
     - affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            preference:
+          - preference:
               matchExpressions:
                 - key: cloud.google.com/gke-preemptible
                   operator: In


### PR DESCRIPTION
It was generating broken Kubernetes structures that made the workflow fail at submission time.

Fixes https://github.com/kubeflow/pipelines/issues/2847

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3091)
<!-- Reviewable:end -->
