### PR TITLE
apiserver: Close rows before reusing tx

### DIFF
--- a/backend/src/apiserver/storage/db_status_store.go
+++ b/backend/src/apiserver/storage/db_status_store.go
@@ -47,7 +47,7 @@ func (s *DBStatusStore) InitializeDBStatusTable() error {
 		return util.NewInternalServerError(err, "Failed to load database status.")
 	}
 	next := rows.Next()
-	rows.Close()
+	rows.Close() // "rows" shouldn't be used after this point.
 
 	// The table is not initialized
 	if !next {

--- a/backend/src/apiserver/storage/db_status_store.go
+++ b/backend/src/apiserver/storage/db_status_store.go
@@ -46,10 +46,11 @@ func (s *DBStatusStore) InitializeDBStatusTable() error {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to load database status.")
 	}
-	defer rows.Close()
+	next := rows.Next()
+	rows.Close()
 
 	// The table is not initialized
-	if !rows.Next() {
+	if !next {
 		sql, args, queryErr := sq.
 			Insert("db_statuses").
 			SetMap(defaultDBStatus).

--- a/backend/src/apiserver/storage/default_experiment_store.go
+++ b/backend/src/apiserver/storage/default_experiment_store.go
@@ -48,10 +48,11 @@ func (s *DefaultExperimentStore) initializeDefaultExperimentTable() error {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to get default experiment.")
 	}
-	defer rows.Close()
+	next := rows.Next()
+	rows.Close()
 
 	// If the table is not initialized, then set the default value.
-	if !rows.Next() {
+	if !next {
 		sql, args, queryErr := sq.
 			Insert("default_experiments").
 			SetMap(defaultExperimentDBValue).


### PR DESCRIPTION
Reusing tx before closing rows (might) result in the following error:

[mysql] 2020/02/17 11:55:38 packets.go:427: busy buffer

This closes #3098

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3099)
<!-- Reviewable:end -->
