### PR TITLE
ml_engine component READMEs incorrect

### DIFF
--- a/components/gcp/ml_engine/batch_predict/README.md
+++ b/components/gcp/ml_engine/batch_predict/README.md
@@ -49,7 +49,6 @@ The component accepts the following as input:
 Name | Description | Type
 :--- | :---------- | :---
 job_id | The ID of the created batch job. | String
-output_path | The output path of the batch prediction job | GCSPath
 
 
 ## Cautions & requirements

--- a/components/gcp/ml_engine/deploy/README.md
+++ b/components/gcp/ml_engine/deploy/README.md
@@ -59,10 +59,11 @@ The accepted file formats are:
 `model_uri` can also be an [Estimator export base directory, ](https://www.tensorflow.org/guide/saved_model#perform_the_export)which contains a list of subdirectories named by timestamp. The directory with the latest timestamp is used to load the trained model file.
 
 ## Output
-| Name    | Description                 | Type      |
-|:------- |:----                        | :---      |
-| job_id  | The ID of the created job.  |  String   |
-| job_dir | The Cloud Storage path that contains the trained model output files. |  GCSPath  |
+Name | Description | Type
+:--- | :---------- | :---
+| model_uri | The Cloud Storage URI of the trained model.  |  GCSPath |
+| model_name | The name of the deployed model. |  String  |
+| version_name | The name of the deployed version. |  String  |
 
 
 ## Cautions & requirements


### PR DESCRIPTION
The output sections of the deploy and batch_prediction component's READMEs are
incorrect. Updated to reflect the actual outputs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3103)
<!-- Reviewable:end -->
