### PR TITLE
SDK - Components - Fixed dict-style type annotations

### DIFF
--- a/sdk/python/kfp/components/_components.py
+++ b/sdk/python/kfp/components/_components.py
@@ -26,7 +26,7 @@ from typing import Any, List, Mapping, NamedTuple, Sequence, Union
 from ._naming import _sanitize_file_name, _sanitize_python_function_name, generate_unique_name_conversion_table
 from ._yaml_utils import load_yaml
 from .structures import *
-from ._data_passing import serialize_value, type_name_to_type
+from ._data_passing import serialize_value, get_canonical_type_for_type_struct
 
 
 _default_component_name = 'Component'
@@ -313,7 +313,7 @@ def _create_task_factory_from_component_spec(component_spec:ComponentSpec, compo
     input_parameters = [
         _dynamic.KwParameter(
             input_name_to_pythonic[port.name],
-            annotation=(type_name_to_type.get(str(port.type), str(port.type)) if port.type else inspect.Parameter.empty),
+            annotation=(get_canonical_type_for_type_struct(str(port.type)) or str(port.type) if port.type else inspect.Parameter.empty),
             default=component_default_to_func_default(port.default, port.optional),
         )
         for port in reordered_input_list

--- a/sdk/python/kfp/components/_data_passing.py
+++ b/sdk/python/kfp/components/_data_passing.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 __all__ = [
-    'type_to_type_name',
-    'type_name_to_type',
-    'type_to_deserializer',
-    'type_name_to_deserializer',
-    'type_name_to_serializer',
+    'get_canonical_type_struct_for_type',
+    'get_canonical_type_for_type_struct',
+    'get_deserializer_code_for_type',
+    'get_deserializer_code_for_type_struct',
+    'get_serializer_func_for_type_struct',
 ]
 
 
@@ -121,6 +121,41 @@ type_name_to_type = {type_name: converter.types[0] for converter in _converters 
 type_to_deserializer = {typ: (converter.deserializer_code, converter.definitions) for converter in _converters for typ in converter.types}
 type_name_to_deserializer = {type_name: (converter.deserializer_code, converter.definitions) for converter in _converters for type_name in converter.type_names}
 type_name_to_serializer = {type_name: converter.serializer for converter in _converters for type_name in converter.type_names}
+
+
+def get_canonical_type_struct_for_type(typ) -> str:
+    try:
+        return type_to_type_name.get(typ, None)
+    except:
+        return None
+
+
+def get_canonical_type_for_type_struct(type_struct) -> str:
+    try:
+        return type_name_to_type.get(type_struct, None)
+    except:
+        return None
+
+
+def get_deserializer_code_for_type(typ) -> str:
+    try:
+        return type_name_to_deserializer.get(get_canonical_type_struct_for_type[typ], None)
+    except:
+        return None
+
+
+def get_deserializer_code_for_type_struct(type_struct) -> str:
+    try:
+        return type_name_to_deserializer.get(type_struct, None)
+    except:
+        return None
+
+
+def get_serializer_func_for_type_struct(type_struct) -> str:
+    try:
+        return type_name_to_serializer.get(type_struct, None)
+    except:
+        return None
 
 
 def serialize_value(value, type_name: str) -> str:

--- a/sdk/python/tests/components/test_python_op.py
+++ b/sdk/python/tests/components/test_python_op.py
@@ -286,7 +286,8 @@ class PythonOpTestCase(unittest.TestCase):
             bool_param : bool = True,
             none_param = None,
             custom_type_param: 'Custom type' = None,
-            ) -> NamedTuple('DummyName', [
+            custom_struct_type_param: {'CustomType': {'param1': 'value1', 'param2': 'value2'}} = None,
+        ) -> NamedTuple('DummyName', [
                 #('required_param',), # All typing.NamedTuple fields must have types
                 ('int_param', int),
                 ('float_param', float),
@@ -294,6 +295,7 @@ class PythonOpTestCase(unittest.TestCase):
                 ('bool_param', bool),
                 #('custom_type_param', 'Custom type'), #SyntaxError: Forward reference must be an expression -- got 'Custom type'
                 ('custom_type_param', 'CustomType'),
+                #('custom_struct_type_param', {'CustomType': {'param1': 'value1', 'param2': 'value2'}}), # TypeError: NamedTuple('Name', [(f0, t0), (f1, t1), ...]); each t must be a type Got {'CustomType': {'param1': 'value1', 'param2': 'value2'}}
             ]
         ):
             '''Function docstring'''
@@ -312,6 +314,7 @@ class PythonOpTestCase(unittest.TestCase):
                 InputSpec(name='bool_param', type='Boolean', default='True', optional=True),
                 InputSpec(name='none_param', optional=True), # No default='None'
                 InputSpec(name='custom_type_param', type='Custom type', optional=True),
+                InputSpec(name='custom_struct_type_param', type={'CustomType': {'param1': 'value1', 'param2': 'value2'}}, optional=True),
             ]
         )
         self.assertEqual(
@@ -323,6 +326,7 @@ class PythonOpTestCase(unittest.TestCase):
                 OutputSpec(name='bool_param', type='Boolean'),
                 #OutputSpec(name='custom_type_param', type='Custom type', default='None'),
                 OutputSpec(name='custom_type_param', type='CustomType'),
+                #OutputSpec(name='custom_struct_type_param', type={'CustomType': {'param1': 'value1', 'param2': 'value2'}}, optional=True),
             ]
         )
 
@@ -340,6 +344,7 @@ class PythonOpTestCase(unittest.TestCase):
                     {'name': 'bool_param', 'type': 'Boolean', 'default': 'True', 'optional': True},
                     {'name': 'none_param', 'optional': True}, # No default='None'
                     {'name': 'custom_type_param', 'type': 'Custom type', 'optional': True},
+                    {'name': 'custom_struct_type_param', 'type': {'CustomType': {'param1': 'value1', 'param2': 'value2'}}, 'optional': True},
                 ],
                 'outputs': [
                     {'name': 'int_param', 'type': 'Integer'},
@@ -347,6 +352,7 @@ class PythonOpTestCase(unittest.TestCase):
                     {'name': 'str_param', 'type': 'String'},
                     {'name': 'bool_param', 'type': 'Boolean'},
                     {'name': 'custom_type_param', 'type': 'CustomType'},
+                    #{'name': 'custom_struct_type_param', 'type': {'CustomType': {'param1': 'value1', 'param2': 'value2'}}, 'optional': True},
                 ]
             }
         )


### PR DESCRIPTION
Refactored `_data_passing.py` interface to expose functions instead of dictionaries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3107)
<!-- Reviewable:end -->
