### PR TITLE
TFMA auto-visualization for TFX components in KFP

### DIFF
--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -319,6 +319,9 @@ export class OutputArtifactLoader {
     viewers = viewers.concat(
       EvaluatorArtifactUris.map(uri => {
         const configFilePath = uri + '/eval_config.json';
+        // The visualization of TFMA inside KFP UI depends a hack of TFMA widget js
+        // For context and future improvement, please refer to
+        // https://github.com/tensorflow/model-analysis/issues/10#issuecomment-587422929
         const script = [
           `import io`,
           `import json`,

--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -319,24 +319,24 @@ export class OutputArtifactLoader {
     const EvaluatorArtifactUris = filterArtifactUrisByType('ModelEvaluation', artifactTypes, artifacts);
     viewers = viewers.concat(
       EvaluatorArtifactUris.map(uri => {
-        const config_file_path = uri + '/eval_config.json';
+        const configFilePath = uri + '/eval_config.json';
         const script = [
-          `
-          import json
-          import tensorflow as tf
-          import tensorflow_model_analysis as tfma
-          from ipywidgets.embed import embed_minimal_html
-          from IPython.core.display import display, HTML
-          config_file=tf.io.gfile.GFile('${config_file_path}', 'r')
-          config=json.loads(config_file.read())
-          featureKeys=list(filter(lambda x: 'featureKeys' in x, config['evalConfig']['slicingSpecs']))
-          columns=[] if len(featureKeys) == 0 else featureKeys[0]['featureKeys']
-          slicing_spec = tfma.slicer.SingleSliceSpec(columns=columns)
-          eval_result = tfma.load_eval_result('${uri}')
-          slicing_metrics_view = tfma.view.render_slicing_metrics(eval_result, slicing_spec=slicing_spec)
-          embed_minimal_html('tfma_export.html', views=[slicing_metrics_view], title='Slicing Metrics')
-          with open('tfma_export.html', 'r') as view: display(HTML(view.read()))
-          `
+          `import json`,
+          `import tensorflow as tf`,
+          `import tensorflow_model_analysis as tfma`,
+          `from ipywidgets.embed import embed_minimal_html`,
+          `from IPython.core.display import display, HTML`,
+          `config_file=tf.io.gfile.GFile('${configFilePath}', 'r')`,
+          `config=json.loads(config_file.read())`,
+          `featureKeys=list(filter(lambda x: 'featureKeys' in x, config['evalConfig']['slicingSpecs']))`,
+          `columns=[] if len(featureKeys) == 0 else featureKeys[0]['featureKeys']`,
+          `slicing_spec = tfma.slicer.SingleSliceSpec(columns=columns)`,
+          `eval_result = tfma.load_eval_result('${uri}')`,
+          `slicing_metrics_view = tfma.view.render_slicing_metrics(eval_result, slicing_spec=slicing_spec)`,
+          `embed_minimal_html('tfma_export.html', views=[slicing_metrics_view], title='Slicing Metrics')`,
+          `with open('tfma_export.html', 'r') as view: view_html = view.read()`,
+          `res_html = view_html.replace('dist/embed-amd.js" crossorigin="anonymous"></script>', 'dist/embed-amd.js" crossorigin="anonymous" data-jupyter-widgets-cdn="https://cdn.jsdelivr.net/gh/Bobgy/model-analysis@kfp/tensorflow_model_analysis/notebook/jupyter/js/dist/" crossorigin="anonymous"></script>')`,
+          `display(HTML(res_html))`
         ];
         return buildArtifactViewer(script);
       }),

--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -316,6 +316,20 @@ export class OutputArtifactLoader {
         return buildArtifactViewer(script);
       }),
     );
+    const EvaluatorArtifactUris = filterArtifactUrisByType('ModelEvaluation', artifactTypes, artifacts);
+    viewers = viewers.concat(
+      EvaluatorArtifactUris.map(uri => {
+        const script = [
+          'import tensorflow_model_analysis as tfma',
+          'from ipywidgets.embed import embed_minimal_html',
+          `eval_res = tfma.load_eval_result('${uri}')`,
+          'slicing_metrics_view = tfma.view.render_slicing_metrics(eval_res)',
+          `embed_minimal_html('tfma_export.html', views=[slicing_metrics_view], title='Slicing Metrics')`,
+          `with open('tfma_export.html', 'r') as view: print(view.read())`,
+        ];
+        return buildArtifactViewer(script);
+      }),
+    );
     return Promise.all(viewers);
   }
 

--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -311,7 +311,11 @@ export class OutputArtifactLoader {
         return buildArtifactViewer(script);
       }),
     );
-    const EvaluatorArtifactUris = filterArtifactUrisByType('ModelEvaluation', artifactTypes, artifacts);
+    const EvaluatorArtifactUris = filterArtifactUrisByType(
+      'ModelEvaluation',
+      artifactTypes,
+      artifacts,
+    );
     viewers = viewers.concat(
       EvaluatorArtifactUris.map(uri => {
         const configFilePath = uri + '/eval_config.json';
@@ -332,7 +336,7 @@ export class OutputArtifactLoader {
           `view_html=None`,
           `with open('tfma_export.html', 'r') as view: view_html = view.read()`,
           `res_html = view_html.replace('dist/embed-amd.js" crossorigin="anonymous"></script>', 'dist/embed-amd.js" crossorigin="anonymous" data-jupyter-widgets-cdn="https://cdn.jsdelivr.net/gh/Bobgy/model-analysis@kfp/tensorflow_model_analysis/notebook/jupyter/js/dist/" crossorigin="anonymous"></script>')`,
-          `display(HTML(res_html))`
+          `display(HTML(res_html))`,
         ];
         return buildArtifactViewer(script);
       }),

--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -334,6 +334,7 @@ export class OutputArtifactLoader {
           `eval_result = tfma.load_eval_result('${uri}')`,
           `slicing_metrics_view = tfma.view.render_slicing_metrics(eval_result, slicing_spec=slicing_spec)`,
           `embed_minimal_html('tfma_export.html', views=[slicing_metrics_view], title='Slicing Metrics')`,
+          `view_html=None`,
           `with open('tfma_export.html', 'r') as view: view_html = view.read()`,
           `res_html = view_html.replace('dist/embed-amd.js" crossorigin="anonymous"></script>', 'dist/embed-amd.js" crossorigin="anonymous" data-jupyter-widgets-cdn="https://cdn.jsdelivr.net/gh/Bobgy/model-analysis@kfp/tensorflow_model_analysis/notebook/jupyter/js/dist/" crossorigin="anonymous"></script>')`,
           `display(HTML(res_html))`
@@ -562,45 +563,3 @@ async function buildArtifactViewer(script: string[]): Promise<HTMLViewerConfig> 
     type: PlotType.WEB_APP,
   };
 }
-
-// TODO: add tfma back
-// function filterTfmaArtifactsPaths(
-//   artifactTypes: ArtifactType[],
-//   artifacts: Artifact[],
-// ): string[] {
-//   const tfmaArtifactTypeIds = artifactTypes
-//     .filter(artifactType => artifactType.getName() === 'ModelEvaluation')
-//     .map(artifactType => artifactType.getId());
-//   const tfmaArtifacts = artifacts.filter(artifact =>
-//     tfmaArtifactTypeIds.includes(artifact.getTypeId()),
-//   );
-
-//   const tfmaArtifactPaths = tfmaArtifacts.map(artifact => artifact.getUri()).filter(uri => uri); // uri not empty
-//   return tfmaArtifactPaths;
-// }
-
-// async function getTfmaArtifactViewers(
-//   tfmaArtifactPaths: string[],
-// ): Array<Promise<HTMLViewerConfig>> {
-//   return tfmaArtifactPaths.map(async artifactPath => {
-//     const script = [
-//       'import tensorflow_model_analysis as tfma',
-//       `tfma_result = tfma.load_eval_result('${artifactPath}')`,
-//       'tfma.view.render_slicing_metrics(tfma_result)',
-//     ];
-//     const visualizationData: ApiVisualization = {
-//       arguments: JSON.stringify({ code: script }),
-//       source: '',
-//       type: ApiVisualizationType.CUSTOM,
-//     };
-//     const visualization = await Apis.buildPythonVisualizationConfig(visualizationData);
-//     if (!visualization.htmlContent) {
-//       // TODO: Improve error message with details.
-//       throw new Error('Failed to build TFMA artifact visualization');
-//     }
-//     return {
-//       htmlContent: visualization.htmlContent,
-//       type: PlotType.WEB_APP,
-//     };
-//   });
-// }

--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -344,6 +344,7 @@ export class OutputArtifactLoader {
         return buildArtifactViewer(script);
       }),
     );
+    // TODO(jingzhang36): maybe move the above built-in scripts to visualization server.
 
     return Promise.all(viewers);
   }

--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -320,6 +320,7 @@ export class OutputArtifactLoader {
       EvaluatorArtifactUris.map(uri => {
         const configFilePath = uri + '/eval_config.json';
         const script = [
+          `import io`,
           `import json`,
           `import tensorflow as tf`,
           `import tensorflow_model_analysis as tfma`,
@@ -332,11 +333,10 @@ export class OutputArtifactLoader {
           `slicing_spec = tfma.slicer.SingleSliceSpec(columns=columns)`,
           `eval_result = tfma.load_eval_result('${uri}')`,
           `slicing_metrics_view = tfma.view.render_slicing_metrics(eval_result, slicing_spec=slicing_spec)`,
-          `embed_minimal_html('tfma_export.html', views=[slicing_metrics_view], title='Slicing Metrics')`,
-          `view_html=None`,
-          `with open('tfma_export.html', 'r') as view: view_html = view.read()`,
-          `res_html = view_html.replace('dist/embed-amd.js" crossorigin="anonymous"></script>', 'dist/embed-amd.js" crossorigin="anonymous" data-jupyter-widgets-cdn="https://cdn.jsdelivr.net/gh/Bobgy/model-analysis@kfp/tensorflow_model_analysis/notebook/jupyter/js/dist/" crossorigin="anonymous"></script>')`,
-          `display(HTML(res_html))`,
+          `view = io.StringIO()`,
+          `embed_minimal_html(view, views=[slicing_metrics_view], title='Slicing Metrics')`,
+          `html = view.getvalue().replace('dist/embed-amd.js" crossorigin="anonymous"></script>', 'dist/embed-amd.js" crossorigin="anonymous" data-jupyter-widgets-cdn="https://cdn.jsdelivr.net/gh/Bobgy/model-analysis@kfp/tensorflow_model_analysis/notebook/jupyter/js/dist/" crossorigin="anonymous"></script>')`,
+          `display(HTML(html))`,
         ];
         return buildArtifactViewer(script);
       }),


### PR DESCRIPTION
We add TFMA auto-visualization for TFX components in KFP. 

Note: Widgets in TFMA visualization depend on tfma_widget_js file, which unfortunately doesn't work outside Notebook (as of now). So this PR depends on the work of @Bobgy https://cdn.jsdelivr.net/gh/Bobgy/model-analysis@kfp/tensorflow_model_analysis/notebook/jupyter/js/dist/, which provides a bundle of js files that can support TFMA widgets to work in KFP context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3111)
<!-- Reviewable:end -->
