### PR TITLE
SDK - Fix SDK on Python 3.8

### DIFF
--- a/sdk/python/kfp/components/_dynamic.py
+++ b/sdk/python/kfp/components/_dynamic.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Mapping, Sequence
+import sys
 import types
+from typing import Any, Callable, Mapping, Sequence
 from inspect import Parameter, Signature
 
 
@@ -44,21 +45,31 @@ def create_function_from_parameters(func: Callable[[Mapping[str, Any]], Any], pa
         mod_co_filename = code.co_filename
         mod_co_firstlineno = code.co_firstlineno
 
-    modified_code = types.CodeType(
-        mod_co_argcount,
-        code.co_kwonlyargcount,
-        mod_co_nlocals,
-        code.co_stacksize,
-        code.co_flags,
-        code.co_code,
-        code.co_consts,
-        code.co_names,
-        mod_co_varnames,
-        mod_co_filename,
-        mod_co_name,
-        mod_co_firstlineno,
-        code.co_lnotab
-    )
+    if sys.version_info >= (3, 8):
+        modified_code = (code
+            .replace(co_argcount=mod_co_argcount)
+            .replace(co_nlocals=mod_co_nlocals)
+            .replace(co_varnames=mod_co_varnames)
+            .replace(co_filename=mod_co_filename)
+            .replace(co_name=mod_co_name)
+            .replace(co_firstlineno=mod_co_firstlineno)
+        )
+    else:
+        modified_code = types.CodeType(
+            mod_co_argcount,
+            code.co_kwonlyargcount,
+            mod_co_nlocals,
+            code.co_stacksize,
+            code.co_flags,
+            code.co_code,
+            code.co_consts,
+            code.co_names,
+            mod_co_varnames,
+            mod_co_filename,
+            mod_co_name,
+            mod_co_firstlineno,
+            code.co_lnotab
+        )
 
     default_arg_values = tuple( p.default for p in parameters if p.default != Parameter.empty ) #!argdefs "starts from the right"/"is right-aligned"
     modified_func = types.FunctionType(modified_code, {'dict_func': func, 'locals': locals}, name=func_name, argdefs=default_arg_values)

--- a/sdk/python/kfp/components/_dynamic.py
+++ b/sdk/python/kfp/components/_dynamic.py
@@ -46,13 +46,13 @@ def create_function_from_parameters(func: Callable[[Mapping[str, Any]], Any], pa
         mod_co_firstlineno = code.co_firstlineno
 
     if sys.version_info >= (3, 8):
-        modified_code = (code
-            .replace(co_argcount=mod_co_argcount)
-            .replace(co_nlocals=mod_co_nlocals)
-            .replace(co_varnames=mod_co_varnames)
-            .replace(co_filename=mod_co_filename)
-            .replace(co_name=mod_co_name)
-            .replace(co_firstlineno=mod_co_firstlineno)
+        modified_code = code.replace(
+            co_argcount=mod_co_argcount,
+            co_nlocals=mod_co_nlocals,
+            co_varnames=mod_co_varnames,
+            co_filename=mod_co_filename,
+            co_name=mod_co_name,
+            co_firstlineno=mod_co_firstlineno,
         )
     else:
         modified_code = types.CodeType(


### PR DESCRIPTION
Fixes the follwoing error: "TypeError: code() takes at least 14 arguments (13 given)".

The cause of the issue is a breaking change in CodeType constructor in Python 3.8.
https://bugs.python.org/issue37221
This should have been fixed by https://github.com/python/cpython/pull/13959 and https://github.com/python/cpython/pull/14505, but the code still fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3126)
<!-- Reviewable:end -->
