### PR TITLE
[UI] Scheduled workflow catchup=false option

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,12 +2,13 @@
 
 ## Develop
 
-You need `npm`, install dependencies using `npm install`.
+You need `npm`, install dependencies using `npm ci` (`npm ci` makes sure your
+installed dependencies have the exact same version as others).
 
 If you made any changes to protos (see backend/README), you'll need to
 regenerate the Typescript client library from swagger. We use
 swagger-codegen-cli@2.4.7, which you can get
-[here](http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.7/swagger-codegen-cli-2.4.7.jar).
+[here](https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.7/).
 Make sure the jar file is somewhere on your path with the name
 swagger-codegen-cli.jar, then run `npm run apis`.
 

--- a/frontend/src/apis/job/api.ts
+++ b/frontend/src/apis/job/api.ts
@@ -191,6 +191,12 @@ export interface ApiJob {
    * @memberof ApiJob
    */
   enabled?: boolean;
+  /**
+   * Optional input field. Whether the job should catch up if behind schedule. If true, the job will only schedule the latest interval if behind schedule. If false, the job will catch up on each past interval.
+   * @type {boolean}
+   * @memberof ApiJob
+   */
+  no_catchup?: boolean;
 }
 
 /**
@@ -558,7 +564,7 @@ export const JobServiceApiFetchParamCreator = function(configuration?: Configura
     },
     /**
      *
-     * @summary Disable a job.
+     * @summary Stops a job and all its associated runs. The job is not deleted.
      * @param {string} id The ID of the job to be disabled
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -606,7 +612,7 @@ export const JobServiceApiFetchParamCreator = function(configuration?: Configura
     },
     /**
      *
-     * @summary Enable a job.
+     * @summary Restarts a job that was previously stopped. All runs associated with the job will continue.
      * @param {string} id The ID of the job to be enabled
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -839,7 +845,7 @@ export const JobServiceApiFp = function(configuration?: Configuration) {
     },
     /**
      *
-     * @summary Disable a job.
+     * @summary Stops a job and all its associated runs. The job is not deleted.
      * @param {string} id The ID of the job to be disabled
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -861,7 +867,7 @@ export const JobServiceApiFp = function(configuration?: Configuration) {
     },
     /**
      *
-     * @summary Enable a job.
+     * @summary Restarts a job that was previously stopped. All runs associated with the job will continue.
      * @param {string} id The ID of the job to be enabled
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -981,7 +987,7 @@ export const JobServiceApiFactory = function(
     },
     /**
      *
-     * @summary Disable a job.
+     * @summary Stops a job and all its associated runs. The job is not deleted.
      * @param {string} id The ID of the job to be disabled
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -991,7 +997,7 @@ export const JobServiceApiFactory = function(
     },
     /**
      *
-     * @summary Enable a job.
+     * @summary Restarts a job that was previously stopped. All runs associated with the job will continue.
      * @param {string} id The ID of the job to be enabled
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -1082,7 +1088,7 @@ export class JobServiceApi extends BaseAPI {
 
   /**
    *
-   * @summary Disable a job.
+   * @summary Stops a job and all its associated runs. The job is not deleted.
    * @param {string} id The ID of the job to be disabled
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
@@ -1094,7 +1100,7 @@ export class JobServiceApi extends BaseAPI {
 
   /**
    *
-   * @summary Enable a job.
+   * @summary Restarts a job that was previously stopped. All runs associated with the job will continue.
    * @param {string} id The ID of the job to be enabled
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}

--- a/frontend/src/atoms/HelpButton.tsx
+++ b/frontend/src/atoms/HelpButton.tsx
@@ -1,0 +1,40 @@
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import IconButton from '@material-ui/core/IconButton';
+import { withStyles } from '@material-ui/core/styles';
+import Tooltip from '@material-ui/core/Tooltip';
+import HelpIcon from '@material-ui/icons/Help';
+import React, { ReactNode } from 'react';
+import { color, fontsize } from 'src/Css';
+
+const NostyleTooltip = withStyles({
+  tooltip: {
+    backgroundColor: 'transparent',
+    maxWidth: 220,
+    fontSize: fontsize.base,
+    color: color.secondaryText,
+    border: '0 none',
+  },
+})(Tooltip);
+
+interface HelpButtonProps {
+  helpText?: ReactNode;
+}
+export const HelpButton: React.FC<HelpButtonProps> = ({ helpText }) => {
+  return (
+    <NostyleTooltip
+      title={
+        <Card>
+          <CardContent>{helpText}</CardContent>
+        </Card>
+      }
+      interactive
+      leaveDelay={400}
+      placement='top'
+    >
+      <IconButton>
+        <HelpIcon />
+      </IconButton>
+    </NostyleTooltip>
+  );
+};

--- a/frontend/src/atoms/HelpButton.tsx
+++ b/frontend/src/atoms/HelpButton.tsx
@@ -5,15 +5,15 @@ import { withStyles } from '@material-ui/core/styles';
 import Tooltip from '@material-ui/core/Tooltip';
 import HelpIcon from '@material-ui/icons/Help';
 import React, { ReactNode } from 'react';
-import { color, fontsize } from 'src/Css';
+import { color, fontsize } from '../Css';
 
 const NostyleTooltip = withStyles({
   tooltip: {
     backgroundColor: 'transparent',
-    maxWidth: 220,
-    fontSize: fontsize.base,
-    color: color.secondaryText,
     border: '0 none',
+    color: color.secondaryText,
+    fontSize: fontsize.base,
+    maxWidth: 220,
   },
 })(Tooltip);
 
@@ -28,7 +28,7 @@ export const HelpButton: React.FC<HelpButtonProps> = ({ helpText }) => {
           <CardContent>{helpText}</CardContent>
         </Card>
       }
-      interactive
+      interactive={true}
       leaveDelay={400}
       placement='top'
     >

--- a/frontend/src/components/Trigger.test.tsx
+++ b/frontend/src/components/Trigger.test.tsx
@@ -19,6 +19,17 @@ import Trigger from './Trigger';
 import { shallow } from 'enzyme';
 import { TriggerType, PeriodicInterval } from '../lib/TriggerUtils';
 
+const PARAMS_DEFAULT = {
+  catchup: true,
+  maxConcurrentRuns: '10',
+};
+const PERIODIC_DEFAULT = {
+  end_time: undefined,
+  interval_second: '60',
+  start_time: undefined,
+};
+const CRON_DEFAULT = { cron: '0 * * * * ?', end_time: undefined, start_time: undefined };
+
 describe('Trigger', () => {
   // tslint:disable-next-line:variable-name
   const RealDate = Date;
@@ -82,12 +93,12 @@ describe('Trigger', () => {
       (tree.instance() as Trigger).handleChange('type')({
         target: { value: TriggerType.INTERVALED },
       });
-      expect(spy).toHaveBeenLastCalledWith(
-        {
-          periodic_schedule: { end_time: undefined, interval_second: '60', start_time: undefined },
+      expect(spy).toHaveBeenLastCalledWith({
+        ...PARAMS_DEFAULT,
+        trigger: {
+          periodic_schedule: PERIODIC_DEFAULT,
         },
-        '10',
-      );
+      });
     });
 
     it('builds trigger with a start time if the checkbox is checked', () => {
@@ -99,10 +110,12 @@ describe('Trigger', () => {
       (tree.instance() as Trigger).handleChange('hasStartDate')({
         target: { type: 'checkbox', checked: true },
       });
-      expect(spy).toHaveBeenLastCalledWith(
-        { periodic_schedule: { end_time: undefined, interval_second: '60', start_time: testDate } },
-        '10',
-      );
+      expect(spy).toHaveBeenLastCalledWith({
+        ...PARAMS_DEFAULT,
+        trigger: {
+          periodic_schedule: { ...PERIODIC_DEFAULT, start_time: testDate },
+        },
+      });
     });
 
     it('builds trigger with the entered start date/time', () => {
@@ -116,16 +129,15 @@ describe('Trigger', () => {
       });
       (tree.instance() as Trigger).handleChange('startDate')({ target: { value: '2018-11-23' } });
       (tree.instance() as Trigger).handleChange('endTime')({ target: { value: '08:35' } });
-      expect(spy).toHaveBeenLastCalledWith(
-        {
+      expect(spy).toHaveBeenLastCalledWith({
+        ...PARAMS_DEFAULT,
+        trigger: {
           periodic_schedule: {
-            end_time: undefined,
-            interval_second: '60',
+            ...PERIODIC_DEFAULT,
             start_time: new Date(2018, 10, 23, 8, 35),
           },
         },
-        '10',
-      );
+      });
     });
 
     it('builds trigger without the entered start date if no time is entered', () => {
@@ -139,16 +151,12 @@ describe('Trigger', () => {
       });
       (tree.instance() as Trigger).handleChange('startDate')({ target: { value: '2018-11-23' } });
       (tree.instance() as Trigger).handleChange('startTime')({ target: { value: '' } });
-      expect(spy).toHaveBeenLastCalledWith(
-        {
-          periodic_schedule: {
-            end_time: undefined,
-            interval_second: '60',
-            start_time: undefined,
-          },
+      expect(spy).toHaveBeenLastCalledWith({
+        ...PARAMS_DEFAULT,
+        trigger: {
+          periodic_schedule: PERIODIC_DEFAULT,
         },
-        '10',
-      );
+      });
     });
 
     it('builds trigger without the entered start time if no date is entered', () => {
@@ -162,16 +170,12 @@ describe('Trigger', () => {
       });
       (tree.instance() as Trigger).handleChange('startDate')({ target: { value: '' } });
       (tree.instance() as Trigger).handleChange('startTime')({ target: { value: '11:33' } });
-      expect(spy).toHaveBeenLastCalledWith(
-        {
-          periodic_schedule: {
-            end_time: undefined,
-            interval_second: '60',
-            start_time: undefined,
-          },
+      expect(spy).toHaveBeenLastCalledWith({
+        ...PARAMS_DEFAULT,
+        trigger: {
+          periodic_schedule: PERIODIC_DEFAULT,
         },
-        '10',
-      );
+      });
     });
 
     it('builds trigger with a date if both start and end checkboxes are checked', () => {
@@ -186,10 +190,12 @@ describe('Trigger', () => {
       (tree.instance() as Trigger).handleChange('hasEndDate')({
         target: { type: 'checkbox', checked: true },
       });
-      expect(spy).toHaveBeenLastCalledWith(
-        { periodic_schedule: { end_time: testDate, interval_second: '60', start_time: testDate } },
-        '10',
-      );
+      expect(spy).toHaveBeenLastCalledWith({
+        ...PARAMS_DEFAULT,
+        trigger: {
+          periodic_schedule: { ...PERIODIC_DEFAULT, end_time: testDate, start_time: testDate },
+        },
+      });
     });
 
     it('resets trigger to no start date if it is added then removed', () => {
@@ -204,12 +210,12 @@ describe('Trigger', () => {
       (tree.instance() as Trigger).handleChange('hasStartDate')({
         target: { type: 'checkbox', checked: false },
       });
-      expect(spy).toHaveBeenLastCalledWith(
-        {
-          periodic_schedule: { end_time: undefined, interval_second: '60', start_time: undefined },
+      expect(spy).toHaveBeenLastCalledWith({
+        ...PARAMS_DEFAULT,
+        trigger: {
+          periodic_schedule: PERIODIC_DEFAULT,
         },
-        '10',
-      );
+      });
     });
 
     it('builds trigger with a weekly interval', () => {
@@ -221,16 +227,15 @@ describe('Trigger', () => {
       (tree.instance() as Trigger).handleChange('intervalCategory')({
         target: { value: PeriodicInterval.WEEK },
       });
-      expect(spy).toHaveBeenLastCalledWith(
-        {
+      expect(spy).toHaveBeenLastCalledWith({
+        ...PARAMS_DEFAULT,
+        trigger: {
           periodic_schedule: {
-            end_time: undefined,
+            ...PERIODIC_DEFAULT,
             interval_second: (7 * 24 * 60 * 60).toString(),
-            start_time: undefined,
           },
         },
-        '10',
-      );
+      });
     });
 
     it('builds trigger with an every-three-months interval', () => {
@@ -243,16 +248,15 @@ describe('Trigger', () => {
         target: { value: PeriodicInterval.MONTH },
       });
       (tree.instance() as Trigger).handleChange('intervalValue')({ target: { value: 3 } });
-      expect(spy).toHaveBeenLastCalledWith(
-        {
+      expect(spy).toHaveBeenLastCalledWith({
+        ...PARAMS_DEFAULT,
+        trigger: {
           periodic_schedule: {
-            end_time: undefined,
+            ...PERIODIC_DEFAULT,
             interval_second: (3 * 30 * 24 * 60 * 60).toString(),
-            start_time: undefined,
           },
         },
-        '10',
-      );
+      });
     });
 
     it('builds trigger with the specified max concurrency setting', () => {
@@ -262,16 +266,31 @@ describe('Trigger', () => {
         target: { value: TriggerType.INTERVALED },
       });
       (tree.instance() as Trigger).handleChange('maxConcurrentRuns')({ target: { value: '3' } });
-      expect(spy).toHaveBeenLastCalledWith(
-        {
-          periodic_schedule: {
-            end_time: undefined,
-            interval_second: '60',
-            start_time: undefined,
-          },
+      expect(spy).toHaveBeenLastCalledWith({
+        ...PARAMS_DEFAULT,
+        maxConcurrentRuns: '3',
+        trigger: {
+          periodic_schedule: PERIODIC_DEFAULT,
         },
-        '3',
-      );
+      });
+    });
+
+    it('builds trigger with the specified catchup setting', () => {
+      const spy = jest.fn();
+      const tree = shallow(<Trigger onChange={spy} />);
+      (tree.instance() as Trigger).handleChange('type')({
+        target: { value: TriggerType.INTERVALED },
+      });
+      (tree.instance() as Trigger).handleChange('catchup')({
+        target: { type: 'checkbox', checked: false },
+      });
+      expect(spy).toHaveBeenLastCalledWith({
+        ...PARAMS_DEFAULT,
+        catchup: false,
+        trigger: {
+          periodic_schedule: PERIODIC_DEFAULT,
+        },
+      });
     });
   });
 
@@ -280,10 +299,12 @@ describe('Trigger', () => {
       const spy = jest.fn();
       const tree = shallow(<Trigger onChange={spy} />);
       (tree.instance() as Trigger).handleChange('type')({ target: { value: TriggerType.CRON } });
-      expect(spy).toHaveBeenLastCalledWith(
-        { cron_schedule: { cron: '0 * * * * ?', end_time: undefined, start_time: undefined } },
-        '10',
-      );
+      expect(spy).toHaveBeenLastCalledWith({
+        ...PARAMS_DEFAULT,
+        trigger: {
+          cron_schedule: CRON_DEFAULT,
+        },
+      });
     });
 
     it('builds a 1-minute cron trigger with specified start date', () => {
@@ -294,10 +315,12 @@ describe('Trigger', () => {
         target: { type: 'checkbox', checked: true },
       });
       (tree.instance() as Trigger).handleChange('startDate')({ target: { value: '2018-03-23' } });
-      expect(spy).toHaveBeenLastCalledWith(
-        { cron_schedule: { cron: '0 * * * * ?', end_time: undefined, start_time: testDate } },
-        '10',
-      );
+      expect(spy).toHaveBeenLastCalledWith({
+        ...PARAMS_DEFAULT,
+        trigger: {
+          cron_schedule: { ...CRON_DEFAULT, start_time: testDate },
+        },
+      });
     });
 
     it('builds a daily cron trigger with specified end date/time', () => {
@@ -310,10 +333,12 @@ describe('Trigger', () => {
       (tree.instance() as Trigger).handleChange('intervalCategory')({
         target: { value: PeriodicInterval.DAY },
       });
-      expect(spy).toHaveBeenLastCalledWith(
-        { cron_schedule: { cron: '0 0 0 * * ?', end_time: testDate, start_time: undefined } },
-        '10',
-      );
+      expect(spy).toHaveBeenLastCalledWith({
+        ...PARAMS_DEFAULT,
+        trigger: {
+          cron_schedule: { ...CRON_DEFAULT, end_time: testDate, cron: '0 0 0 * * ?' },
+        },
+      });
     });
 
     it('builds a weekly cron trigger that runs every Monday, Friday, and Saturday', () => {
@@ -327,10 +352,12 @@ describe('Trigger', () => {
       (tree.instance() as any)._toggleDay(1);
       (tree.instance() as any)._toggleDay(5);
       (tree.instance() as any)._toggleDay(6);
-      expect(spy).toHaveBeenLastCalledWith(
-        { cron_schedule: { cron: '0 0 0 ? * 1,5,6', end_time: undefined, start_time: undefined } },
-        '10',
-      );
+      expect(spy).toHaveBeenLastCalledWith({
+        ...PARAMS_DEFAULT,
+        trigger: {
+          cron_schedule: { ...CRON_DEFAULT, cron: '0 0 0 ? * 1,5,6' },
+        },
+      });
     });
 
     it('builds a cron with the manually specified cron string, even if days are toggled', () => {
@@ -350,16 +377,12 @@ describe('Trigger', () => {
       (tree.instance() as Trigger).handleChange('cron')({
         target: { value: 'oops this will break!' },
       });
-      expect(spy).toHaveBeenLastCalledWith(
-        {
-          cron_schedule: {
-            cron: 'oops this will break!',
-            end_time: undefined,
-            start_time: undefined,
-          },
+      expect(spy).toHaveBeenLastCalledWith({
+        ...PARAMS_DEFAULT,
+        trigger: {
+          cron_schedule: { ...CRON_DEFAULT, cron: 'oops this will break!' },
         },
-        '10',
-      );
+      });
     });
   });
 });

--- a/frontend/src/components/Trigger.tsx
+++ b/frontend/src/components/Trigger.tsx
@@ -14,25 +14,26 @@
  * limitations under the License.
  */
 
-import * as React from 'react';
 import Button from '@material-ui/core/Button';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Input from '../atoms/Input';
 import MenuItem from '@material-ui/core/MenuItem';
+import * as React from 'react';
+import { stylesheet } from 'typestyle';
+import { ApiTrigger } from '../apis/job';
+import { HelpButton } from '../atoms/HelpButton';
+import Input from '../atoms/Input';
 import Separator from '../atoms/Separator';
 import { commonCss } from '../Css';
-import { dateToPickerFormat } from '../lib/TriggerUtils';
 import {
-  PeriodicInterval,
-  TriggerType,
-  triggers,
   buildCron,
-  pickersToDate,
   buildTrigger,
+  dateToPickerFormat,
+  PeriodicInterval,
+  pickersToDate,
+  triggers,
+  TriggerType,
 } from '../lib/TriggerUtils';
-import { ApiTrigger } from '../apis/job';
-import { stylesheet } from 'typestyle';
 
 interface TriggerProps {
   onChange?: (config: {
@@ -224,6 +225,24 @@ export default class Trigger extends React.Component<TriggerProps, TriggerState>
                 />
               }
               label='Catchup'
+            />
+            <HelpButton
+              helpText={
+                <div>
+                  <p>
+                    Whether the recurring run should catch up if behind schedule. Defaults to true.
+                  </p>
+                  <p>
+                    For example, if the recurring run is paused for a while and re-enabled
+                    afterwards. If catchup=true, the scheduler will catch up on (backfill) each
+                    missed interval. Otherwise, it only schedules the latest interval.
+                  </p>
+                  <p>
+                    Usually, if your pipeline handles backfill internally, you should turn catchup
+                    off to avoid duplicate work.
+                  </p>
+                </div>
+              }
             />
           </span>
 

--- a/frontend/src/components/Trigger.tsx
+++ b/frontend/src/components/Trigger.tsx
@@ -80,6 +80,7 @@ export default class Trigger extends React.Component<TriggerProps, TriggerState>
     const [endDate, endTime] = dateToPickerFormat(inAWeek);
 
     return {
+      catchup: true,
       cron: '',
       editCron: false,
       endDate,
@@ -93,7 +94,6 @@ export default class Trigger extends React.Component<TriggerProps, TriggerState>
       startDate,
       startTime,
       type: TriggerType.INTERVALED,
-      catchup: true,
     };
   })();
 
@@ -401,9 +401,9 @@ export default class Trigger extends React.Component<TriggerProps, TriggerState>
 
         if (this.props.onChange) {
           this.props.onChange({
-            trigger,
-            maxConcurrentRuns: trigger ? this.state.maxConcurrentRuns : undefined,
             catchup,
+            maxConcurrentRuns: trigger ? this.state.maxConcurrentRuns : undefined,
+            trigger,
           });
         }
       },

--- a/frontend/src/components/__snapshots__/Trigger.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Trigger.test.tsx.snap
@@ -148,6 +148,35 @@ exports[`Trigger enables a single day on click 1`] = `
     <span
       className="flex"
     >
+      <WithStyles(WithFormControlContext(FormControlLabel))
+        control={
+          <WithStyles(Checkbox)
+            checked={true}
+            color="primary"
+            onClick={[Function]}
+          />
+        }
+        label="Catchup"
+      />
+      <Component
+        helpText={
+          <div>
+            <p>
+              Whether the recurring run should catch up if behind schedule. Defaults to true.
+            </p>
+            <p>
+              For example, if the recurring run is paused for a while and re-enabled afterwards. If catchup=true, the scheduler will catch up on (backfill) each missed interval. Otherwise, it only schedules the latest interval.
+            </p>
+            <p>
+              Usually, if your pipeline handles backfill internally, you should turn catchup off to avoid duplicate work.
+            </p>
+          </div>
+        }
+      />
+    </span>
+    <span
+      className="flex"
+    >
       Run every
       <Component />
       <Component
@@ -457,6 +486,35 @@ exports[`Trigger renders all week days enabled 1`] = `
         width={120}
       />
     </div>
+    <span
+      className="flex"
+    >
+      <WithStyles(WithFormControlContext(FormControlLabel))
+        control={
+          <WithStyles(Checkbox)
+            checked={true}
+            color="primary"
+            onClick={[Function]}
+          />
+        }
+        label="Catchup"
+      />
+      <Component
+        helpText={
+          <div>
+            <p>
+              Whether the recurring run should catch up if behind schedule. Defaults to true.
+            </p>
+            <p>
+              For example, if the recurring run is paused for a while and re-enabled afterwards. If catchup=true, the scheduler will catch up on (backfill) each missed interval. Otherwise, it only schedules the latest interval.
+            </p>
+            <p>
+              Usually, if your pipeline handles backfill internally, you should turn catchup off to avoid duplicate work.
+            </p>
+          </div>
+        }
+      />
+    </span>
     <span
       className="flex"
     >
@@ -772,6 +830,35 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
     <span
       className="flex"
     >
+      <WithStyles(WithFormControlContext(FormControlLabel))
+        control={
+          <WithStyles(Checkbox)
+            checked={true}
+            color="primary"
+            onClick={[Function]}
+          />
+        }
+        label="Catchup"
+      />
+      <Component
+        helpText={
+          <div>
+            <p>
+              Whether the recurring run should catch up if behind schedule. Defaults to true.
+            </p>
+            <p>
+              For example, if the recurring run is paused for a while and re-enabled afterwards. If catchup=true, the scheduler will catch up on (backfill) each missed interval. Otherwise, it only schedules the latest interval.
+            </p>
+            <p>
+              Usually, if your pipeline handles backfill internally, you should turn catchup off to avoid duplicate work.
+            </p>
+          </div>
+        }
+      />
+    </span>
+    <span
+      className="flex"
+    >
       Run every
       <div
         className="flex"
@@ -979,6 +1066,35 @@ exports[`Trigger renders periodic schedule controls if the trigger type is CRON 
         width={120}
       />
     </div>
+    <span
+      className="flex"
+    >
+      <WithStyles(WithFormControlContext(FormControlLabel))
+        control={
+          <WithStyles(Checkbox)
+            checked={true}
+            color="primary"
+            onClick={[Function]}
+          />
+        }
+        label="Catchup"
+      />
+      <Component
+        helpText={
+          <div>
+            <p>
+              Whether the recurring run should catch up if behind schedule. Defaults to true.
+            </p>
+            <p>
+              For example, if the recurring run is paused for a while and re-enabled afterwards. If catchup=true, the scheduler will catch up on (backfill) each missed interval. Otherwise, it only schedules the latest interval.
+            </p>
+            <p>
+              Usually, if your pipeline handles backfill internally, you should turn catchup off to avoid duplicate work.
+            </p>
+          </div>
+        }
+      />
+    </span>
     <span
       className="flex"
     >
@@ -1212,6 +1328,35 @@ exports[`Trigger renders week days if the trigger type is CRON and interval is w
         width={120}
       />
     </div>
+    <span
+      className="flex"
+    >
+      <WithStyles(WithFormControlContext(FormControlLabel))
+        control={
+          <WithStyles(Checkbox)
+            checked={true}
+            color="primary"
+            onClick={[Function]}
+          />
+        }
+        label="Catchup"
+      />
+      <Component
+        helpText={
+          <div>
+            <p>
+              Whether the recurring run should catch up if behind schedule. Defaults to true.
+            </p>
+            <p>
+              For example, if the recurring run is paused for a while and re-enabled afterwards. If catchup=true, the scheduler will catch up on (backfill) each missed interval. Otherwise, it only schedules the latest interval.
+            </p>
+            <p>
+              Usually, if your pipeline handles backfill internally, you should turn catchup off to avoid duplicate work.
+            </p>
+          </div>
+        }
+      />
+    </span>
     <span
       className="flex"
     >

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as portableFetch from 'portable-fetch';
-import { HTMLViewerConfig } from 'src/components/viewers/HTMLViewer';
+import { HTMLViewerConfig } from '../components/viewers/HTMLViewer';
 import { ExperimentServiceApi, FetchAPI } from '../apis/experiment';
 import { JobServiceApi } from '../apis/job';
 import { ApiPipeline, PipelineServiceApi, ApiPipelineVersion } from '../apis/pipeline';

--- a/frontend/src/lib/RunUtils.ts
+++ b/frontend/src/lib/RunUtils.ts
@@ -15,7 +15,7 @@
  */
 
 import { orderBy } from 'lodash';
-import { ApiParameter, ApiPipelineVersion } from 'src/apis/pipeline';
+import { ApiParameter, ApiPipelineVersion } from '../apis/pipeline';
 import { Workflow } from 'third_party/argo-ui/argo_template';
 import { ApiJob } from '../apis/job';
 import {

--- a/frontend/src/pages/GettingStarted.test.tsx
+++ b/frontend/src/pages/GettingStarted.test.tsx
@@ -4,7 +4,7 @@ import TestUtils, { formatHTML } from '../TestUtils';
 import { render } from '@testing-library/react';
 import { PageProps } from './Page';
 import { Apis } from '../lib/Apis';
-import { ApiListPipelinesResponse } from 'src/apis/pipeline/api';
+import { ApiListPipelinesResponse } from '../apis/pipeline/api';
 import snapshotDiff from 'snapshot-diff';
 
 const PATH_BACKEND_CONFIG = '../../../backend/src/apiserver/config/sample_config.json';

--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -1649,6 +1649,7 @@ describe('NewRun', () => {
         enabled: true,
         max_concurrency: '10',
         name: 'test run name',
+        no_catchup: false,
         pipeline_spec: {
           parameters: MOCK_PIPELINE.parameters,
         },

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -68,6 +68,7 @@ interface NewRunState {
   isFirstRunInExperiment: boolean;
   isRecurringRun: boolean;
   maxConcurrentRuns?: string;
+  catchup: boolean;
   parameters: ApiParameter[];
   pipeline?: ApiPipeline;
   pipelineVersion?: ApiPipelineVersion;
@@ -142,29 +143,26 @@ class NewRun extends Page<{}, NewRunState> {
     { label: 'Created at', flex: 1, sortKey: ExperimentSortKeys.CREATED_AT },
   ];
 
-  constructor(props: any) {
-    super(props);
-
-    this.state = {
-      description: '',
-      errorMessage: '',
-      experimentName: '',
-      experimentSelectorOpen: false,
-      isBeingStarted: false,
-      isClone: false,
-      isFirstRunInExperiment: false,
-      isRecurringRun: false,
-      parameters: [],
-      pipelineName: '',
-      pipelineSelectorOpen: false,
-      pipelineVersionName: '',
-      pipelineVersionSelectorOpen: false,
-      runName: '',
-      uploadDialogOpen: false,
-      usePipelineFromRunLabel: 'Using pipeline from cloned run',
-      useWorkflowFromRun: false,
-    };
-  }
+  public state: NewRunState = {
+    description: '',
+    errorMessage: '',
+    experimentName: '',
+    experimentSelectorOpen: false,
+    isBeingStarted: false,
+    isClone: false,
+    isFirstRunInExperiment: false,
+    isRecurringRun: false,
+    parameters: [],
+    pipelineName: '',
+    pipelineSelectorOpen: false,
+    pipelineVersionName: '',
+    pipelineVersionSelectorOpen: false,
+    runName: '',
+    uploadDialogOpen: false,
+    usePipelineFromRunLabel: 'Using pipeline from cloned run',
+    useWorkflowFromRun: false,
+    catchup: true, // defaults to true
+  };
 
   public getInitialToolbarState(): ToolbarProps {
     return {
@@ -507,11 +505,12 @@ class NewRun extends Page<{}, NewRunState> {
               <div>Choose a method by which new runs will be triggered</div>
 
               <Trigger
-                onChange={(trigger, maxConcurrentRuns) =>
+                onChange={({ trigger, maxConcurrentRuns, catchup }) =>
                   this.setStateSafe(
                     {
                       maxConcurrentRuns,
                       trigger,
+                      catchup,
                     },
                     this._validate.bind(this),
                   )
@@ -1037,6 +1036,7 @@ class NewRun extends Page<{}, NewRunState> {
         enabled: true,
         max_concurrency: this.state.maxConcurrentRuns || '1',
         trigger: this.state.trigger,
+        no_catchup: !this.state.catchup,
       });
     }
 

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -113,6 +113,27 @@ class NewRun extends Page<{}, NewRunState> {
   static contextType = NamespaceContext;
   context!: React.ContextType<typeof NamespaceContext>;
 
+  public state: NewRunState = {
+    catchup: true,
+    description: '',
+    errorMessage: '',
+    experimentName: '',
+    experimentSelectorOpen: false,
+    isBeingStarted: false,
+    isClone: false,
+    isFirstRunInExperiment: false,
+    isRecurringRun: false,
+    parameters: [],
+    pipelineName: '',
+    pipelineSelectorOpen: false,
+    pipelineVersionName: '',
+    pipelineVersionSelectorOpen: false,
+    runName: '',
+    uploadDialogOpen: false,
+    usePipelineFromRunLabel: 'Using pipeline from cloned run',
+    useWorkflowFromRun: false,
+  };
+
   private pipelineSelectorColumns = [
     {
       customRenderer: NameWithTooltip,
@@ -142,27 +163,6 @@ class NewRun extends Page<{}, NewRunState> {
     { label: 'Description', flex: 2 },
     { label: 'Created at', flex: 1, sortKey: ExperimentSortKeys.CREATED_AT },
   ];
-
-  public state: NewRunState = {
-    description: '',
-    errorMessage: '',
-    experimentName: '',
-    experimentSelectorOpen: false,
-    isBeingStarted: false,
-    isClone: false,
-    isFirstRunInExperiment: false,
-    isRecurringRun: false,
-    parameters: [],
-    pipelineName: '',
-    pipelineSelectorOpen: false,
-    pipelineVersionName: '',
-    pipelineVersionSelectorOpen: false,
-    runName: '',
-    uploadDialogOpen: false,
-    usePipelineFromRunLabel: 'Using pipeline from cloned run',
-    useWorkflowFromRun: false,
-    catchup: true,
-  };
 
   public getInitialToolbarState(): ToolbarProps {
     return {
@@ -508,9 +508,9 @@ class NewRun extends Page<{}, NewRunState> {
                 onChange={({ trigger, maxConcurrentRuns, catchup }) =>
                   this.setStateSafe(
                     {
+                      catchup,
                       maxConcurrentRuns,
                       trigger,
-                      catchup,
                     },
                     this._validate.bind(this),
                   )
@@ -1035,8 +1035,8 @@ class NewRun extends Page<{}, NewRunState> {
       newRun = Object.assign(newRun, {
         enabled: true,
         max_concurrency: this.state.maxConcurrentRuns || '1',
-        trigger: this.state.trigger,
         no_catchup: !this.state.catchup,
+        trigger: this.state.trigger,
       });
     }
 

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -161,7 +161,7 @@ class NewRun extends Page<{}, NewRunState> {
     uploadDialogOpen: false,
     usePipelineFromRunLabel: 'Using pipeline from cloned run',
     useWorkflowFromRun: false,
-    catchup: true, // defaults to true
+    catchup: true,
   };
 
   public getInitialToolbarState(): ToolbarProps {

--- a/frontend/src/pages/RecurringRunDetails.test.tsx
+++ b/frontend/src/pages/RecurringRunDetails.test.tsx
@@ -66,6 +66,7 @@ describe('RecurringRunDetails', () => {
       enabled: true,
       id: 'test-job-id',
       max_concurrency: '50',
+      no_catchup: true,
       name: 'test job',
       pipeline_spec: {
         parameters: [{ name: 'param1', value: 'value1' }],
@@ -80,21 +81,12 @@ describe('RecurringRunDetails', () => {
       },
     } as ApiJob;
 
-    historyPushSpy.mockClear();
-    updateBannerSpy.mockClear();
-    updateDialogSpy.mockClear();
-    updateSnackbarSpy.mockClear();
-    updateToolbarSpy.mockClear();
+    jest.clearAllMocks();
     getJobSpy.mockImplementation(() => fullTestJob);
-    getJobSpy.mockClear();
-    deleteJobSpy.mockClear();
     deleteJobSpy.mockImplementation();
-    enableJobSpy.mockClear();
     enableJobSpy.mockImplementation();
-    disableJobSpy.mockClear();
     disableJobSpy.mockImplementation();
     getExperimentSpy.mockImplementation();
-    getExperimentSpy.mockClear();
   });
 
   afterEach(() => tree.unmount());
@@ -106,13 +98,18 @@ describe('RecurringRunDetails', () => {
   });
 
   it('renders a recurring run with cron schedule', async () => {
-    fullTestJob.trigger = {
-      cron_schedule: {
-        cron: '* * * 0 0 !',
-        end_time: new Date(2018, 10, 9, 8, 7, 6),
-        start_time: new Date(2018, 9, 8, 7, 6),
+    const cronTestJob = {
+      ...fullTestJob,
+      no_catchup: undefined, // in api requests, it's undefined when false
+      trigger: {
+        cron_schedule: {
+          cron: '* * * 0 0 !',
+          end_time: new Date(2018, 10, 9, 8, 7, 6),
+          start_time: new Date(2018, 9, 8, 7, 6),
+        },
       },
     };
+    getJobSpy.mockImplementation(() => cronTestJob);
     tree = shallow(<RecurringRunDetails {...generateProps()} />);
     await TestUtils.flushPromises();
     expect(tree).toMatchSnapshot();

--- a/frontend/src/pages/RecurringRunDetails.tsx
+++ b/frontend/src/pages/RecurringRunDetails.tsx
@@ -85,6 +85,7 @@ class RecurringRunDetails extends Page<{}, RecurringRunConfigState> {
         if (run.max_concurrency) {
           triggerDetails.push(['Max. concurrent runs', run.max_concurrency]);
         }
+        triggerDetails.push(['Catchup', `${run.no_catchup || false}`]);
         if (run.trigger.cron_schedule && run.trigger.cron_schedule.start_time) {
           triggerDetails.push([
             'Start time',
@@ -103,9 +104,6 @@ class RecurringRunDetails extends Page<{}, RecurringRunConfigState> {
             'End time',
             formatDateString(run.trigger.periodic_schedule.end_time),
           ]);
-        }
-        if (run.no_catchup != null) {
-          triggerDetails.push(['Catchup', `${run.no_catchup}`]);
         }
       }
     }

--- a/frontend/src/pages/RecurringRunDetails.tsx
+++ b/frontend/src/pages/RecurringRunDetails.tsx
@@ -104,6 +104,9 @@ class RecurringRunDetails extends Page<{}, RecurringRunConfigState> {
             formatDateString(run.trigger.periodic_schedule.end_time),
           ]);
         }
+        if (run.no_catchup != null) {
+          triggerDetails.push(['Catchup', `${run.no_catchup}`]);
+        }
       }
     }
 

--- a/frontend/src/pages/RecurringRunDetails.tsx
+++ b/frontend/src/pages/RecurringRunDetails.tsx
@@ -85,7 +85,7 @@ class RecurringRunDetails extends Page<{}, RecurringRunConfigState> {
         if (run.max_concurrency) {
           triggerDetails.push(['Max. concurrent runs', run.max_concurrency]);
         }
-        triggerDetails.push(['Catchup', `${run.no_catchup || false}`]);
+        triggerDetails.push(['Catchup', `${!run.no_catchup}`]);
         if (run.trigger.cron_schedule && run.trigger.cron_schedule.start_time) {
           triggerDetails.push([
             'Start time',

--- a/frontend/src/pages/__snapshots__/RecurringRunDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RecurringRunDetails.test.tsx.snap
@@ -38,6 +38,10 @@ exports[`RecurringRunDetails renders a recurring run with cron schedule 1`] = `
             "50",
           ],
           Array [
+            "Catchup",
+            "true",
+          ],
+          Array [
             "Start time",
             "10/8/2018, 7:06:00 AM",
           ],
@@ -100,6 +104,10 @@ exports[`RecurringRunDetails renders a recurring run with periodic schedule 1`] 
           Array [
             "Max. concurrent runs",
             "50",
+          ],
+          Array [
+            "Catchup",
+            "false",
           ],
           Array [
             "Start time",


### PR DESCRIPTION
Demo: https://youtu.be/33ZoXJHq3jA
/area frontend
Part of https://github.com/kubeflow/pipelines/issues/3055

## Verification
The feature works e2e:
All the four recurring runs have past start date and end date of from 10:00am to 10:02am and interval of 1 minute. Those with catchup = false has only one run, those with catchup = true has two runs.
![tgYrrS87FuP](https://user-images.githubusercontent.com/4957653/75000509-78b3cc00-5499-11ea-9a0d-a4471483ecd5.png)

Recurring run details page also shows catchup field.
![uBAeUo9Tee7](https://user-images.githubusercontent.com/4957653/75000575-b1ec3c00-5499-11ea-91dd-7e1c04bf2abf.png)


/assign @jingzhang36

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3131)
<!-- Reviewable:end -->
