### PR TITLE
[MLMD][Lineage] Navigate to ArtifactDetails Overview on row click

### DIFF
--- a/frontend/src/pages/ArtifactDetails.tsx
+++ b/frontend/src/pages/ArtifactDetails.tsx
@@ -26,7 +26,7 @@ import {
   LineageResource,
 } from '@kubeflow/frontend';
 import * as React from 'react';
-import { Page } from './Page';
+import { Page, PageProps } from './Page';
 import { ToolbarProps } from '../components/Toolbar';
 import { RoutePage, RoutePageFactory, RouteParams } from '../components/Router';
 import { classes } from 'typestyle';
@@ -93,6 +93,23 @@ export default class ArtifactDetails extends Page<{}, ArtifactDetailsState> {
 
   public async componentDidMount(): Promise<void> {
     return this.load();
+  }
+
+  public componentDidUpdate(
+    prevProps: Readonly<{} & PageProps>,
+    prevState: Readonly<ArtifactDetailsState>,
+    snapshot?: any): void {
+    if (this.props.match.params[RouteParams.ID] === prevProps.match.params[RouteParams.ID]
+      && prevState.selectedTab !== ArtifactDetailsTab.LINEAGE_EXPLORER) {
+      return;
+    }
+
+    // Switch the tab to Overview when the route changes due to LineageView link click.
+    this.setState({
+      artifact: undefined,
+      selectedTab: ArtifactDetailsTab.OVERVIEW,
+    });
+    this.load();
   }
 
   public render(): JSX.Element {

--- a/frontend/src/pages/ArtifactDetails.tsx
+++ b/frontend/src/pages/ArtifactDetails.tsx
@@ -98,9 +98,12 @@ export default class ArtifactDetails extends Page<{}, ArtifactDetailsState> {
   public componentDidUpdate(
     prevProps: Readonly<{} & PageProps>,
     prevState: Readonly<ArtifactDetailsState>,
-    snapshot?: any): void {
-    if (this.props.match.params[RouteParams.ID] === prevProps.match.params[RouteParams.ID]
-      && prevState.selectedTab !== ArtifactDetailsTab.LINEAGE_EXPLORER) {
+    snapshot?: any,
+  ): void {
+    if (
+      this.props.match.params[RouteParams.ID] === prevProps.match.params[RouteParams.ID] &&
+      prevState.selectedTab !== ArtifactDetailsTab.LINEAGE_EXPLORER
+    ) {
       return;
     }
 


### PR DESCRIPTION
/priority p0
/area front-end
/assign @kwasi 
/cc @Bobgy 

## Description

Fixes an issue where clicking on an Artifact title in the LineageView doesn't cause a page load because the LineageView and Overview tab are both within the same route on the ArtifactDetails page. This isn't an issue for Executions because their overview tab in on the ExecutionDetails page. 

The long term solution for this issue should be to add support for deep links for each tab so that the LineageView routes all point to a new page.

## Validation

Screencast: https://screencast.googleplex.com/cast/NDc2OTQ4OTE1MTMyODI1NnxhNWQyNDlhNy1iNA
Deployment: https://6d1629804d56a867-dot-us-central2.pipelines.googleusercontent.com/#/artifact_types/Examples/artifacts/2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3137)
<!-- Reviewable:end -->
