### PR TITLE
[Backend] Refactor integration tests, facilitate local testing

### DIFF
--- a/backend/test/integration/README.md
+++ b/backend/test/integration/README.md
@@ -6,4 +6,6 @@
 ### How to run
 
 1. Configure kubectl to connect to your kfp cluster.
-2. Run: `NAMESPACE=<kfp-namespace> ./run_tests_locally.sh`.
+2. Run the following for all integration tests: `NAMESPACE=<kfp-namespace> ./run_tests_locally.sh`.
+3. Or run the following to select certain tests: `NAMESPACE=<kfp-namespace> ./run_tests_locally.sh -testify.m Job`.
+   Reference: https://stackoverflow.com/a/43312451

--- a/backend/test/integration/README.md
+++ b/backend/test/integration/README.md
@@ -1,0 +1,6 @@
+## Api Server Integration Tests
+
+### How to run
+
+1. Configure kubectl to connect to your kfp cluster.
+2. Run: `NAMESPACE=<kfp-namespace> ./run_tests_locally.sh`.

--- a/backend/test/integration/README.md
+++ b/backend/test/integration/README.md
@@ -1,5 +1,8 @@
 ## Api Server Integration Tests
 
+### WARNING
+**These integration tests will delete all the data in your KFP instance, please only use a test cluster to run these.**
+
 ### How to run
 
 1. Configure kubectl to connect to your kfp cluster.

--- a/backend/test/integration/experiment_api_test.go
+++ b/backend/test/integration/experiment_api_test.go
@@ -28,12 +28,15 @@ func (s *ExperimentApiTest) SetupTest() {
 		return
 	}
 
-	err := test.WaitForReady(*namespace, *initializeTimeout)
-	if err != nil {
-		glog.Exitf("Failed to initialize test. Error: %v", err)
+	if !*skipWaitForCluster {
+		err := test.WaitForReady(*namespace, *initializeTimeout)
+		if err != nil {
+			glog.Exitf("Failed to initialize test. Error: %v", err)
+		}
 	}
 	s.namespace = *namespace
 	clientConfig := test.GetClientConfig(*namespace)
+	var err error
 	s.experimentClient, err = api_server.NewExperimentClient(clientConfig, false)
 	if err != nil {
 		glog.Exitf("Failed to get experiment client. Error: %v", err)

--- a/backend/test/integration/experiment_api_test.go
+++ b/backend/test/integration/experiment_api_test.go
@@ -41,6 +41,9 @@ func (s *ExperimentApiTest) SetupTest() {
 	if err != nil {
 		glog.Exitf("Failed to get experiment client. Error: %v", err)
 	}
+
+	/* ---------- Clean up ---------- */
+	test.DeleteAllExperiments(s.experimentClient, s.T())
 }
 
 func (s *ExperimentApiTest) TestExperimentAPI() {
@@ -157,9 +160,6 @@ func (s *ExperimentApiTest) TestExperimentAPI() {
 	experiment, err = s.experimentClient.Get(&params.GetExperimentParams{ID: trainingExperiment.ID})
 	assert.Nil(t, err)
 	assert.Equal(t, expectedTrainingExperiment, experiment)
-
-	/* ---------- Clean up ---------- */
-	test.DeleteAllExperiments(s.experimentClient, t)
 }
 
 func TestExperimentAPI(t *testing.T) {

--- a/backend/test/integration/experiment_api_test.go
+++ b/backend/test/integration/experiment_api_test.go
@@ -166,8 +166,10 @@ func TestExperimentAPI(t *testing.T) {
 }
 
 func (s *ExperimentApiTest) TearDownSuite() {
-	if !*isDevMode {
-		s.cleanUp()
+	if *runIntegrationTests {
+		if !*isDevMode {
+			s.cleanUp()
+		}
 	}
 }
 

--- a/backend/test/integration/experiment_api_test.go
+++ b/backend/test/integration/experiment_api_test.go
@@ -28,7 +28,7 @@ func (s *ExperimentApiTest) SetupTest() {
 		return
 	}
 
-	if !*skipWaitForCluster {
+	if !*isDevMode {
 		err := test.WaitForReady(*namespace, *initializeTimeout)
 		if err != nil {
 			glog.Exitf("Failed to initialize test. Error: %v", err)
@@ -42,8 +42,7 @@ func (s *ExperimentApiTest) SetupTest() {
 		glog.Exitf("Failed to get experiment client. Error: %v", err)
 	}
 
-	/* ---------- Clean up ---------- */
-	test.DeleteAllExperiments(s.experimentClient, s.T())
+	s.cleanUp()
 }
 
 func (s *ExperimentApiTest) TestExperimentAPI() {
@@ -164,4 +163,14 @@ func (s *ExperimentApiTest) TestExperimentAPI() {
 
 func TestExperimentAPI(t *testing.T) {
 	suite.Run(t, new(ExperimentApiTest))
+}
+
+func (s *ExperimentApiTest) TearDownSuite() {
+	if !*isDevMode {
+		s.cleanUp()
+	}
+}
+
+func (s *ExperimentApiTest) cleanUp() {
+	test.DeleteAllExperiments(s.experimentClient, s.T())
 }

--- a/backend/test/integration/flags.go
+++ b/backend/test/integration/flags.go
@@ -8,4 +8,10 @@ import (
 var namespace = flag.String("namespace", "kubeflow", "The namespace ml pipeline deployed to")
 var initializeTimeout = flag.Duration("initializeTimeout", 2*time.Minute, "Duration to wait for test initialization")
 var runIntegrationTests = flag.Bool("runIntegrationTests", false, "Whether to also run integration tests that call the service")
-var skipWaitForCluster = flag.Bool("skipWaitForCluster", false, "Whether we wait for cluster to come up, set this to true when testing locally")
+
+/**
+ * Differences in dev mode:
+ * 1. Resources are not cleaned up when a test finishes, so that developer can debug manually.
+ * 2. One step that doesn't work locally is skipped.
+ */
+var isDevMode = flag.Bool("isDevMode", false, "Dev mode helps local development of integration tests")

--- a/backend/test/integration/flags.go
+++ b/backend/test/integration/flags.go
@@ -8,3 +8,4 @@ import (
 var namespace = flag.String("namespace", "kubeflow", "The namespace ml pipeline deployed to")
 var initializeTimeout = flag.Duration("initializeTimeout", 2*time.Minute, "Duration to wait for test initialization")
 var runIntegrationTests = flag.Bool("runIntegrationTests", false, "Whether to also run integration tests that call the service")
+var skipWaitForCluster = flag.Bool("skipWaitForCluster", false, "Whether we wait for cluster to come up, set this to true when testing locally")

--- a/backend/test/integration/job_api_test.go
+++ b/backend/test/integration/job_api_test.go
@@ -41,7 +41,7 @@ func (s *JobApiTestSuite) SetupTest() {
 		return
 	}
 
-	if !*skipWaitForCluster {
+	if !*isDevMode {
 		err := test.WaitForReady(*namespace, *initializeTimeout)
 		if err != nil {
 			glog.Exitf("Failed to initialize test. Error: %s", err.Error())
@@ -71,11 +71,7 @@ func (s *JobApiTestSuite) SetupTest() {
 		glog.Exitf("Failed to get job client. Error: %s", err.Error())
 	}
 
-	/* ---------- Clean up ---------- */
-	test.DeleteAllExperiments(s.experimentClient, s.T())
-	test.DeleteAllPipelines(s.pipelineClient, s.T())
-	test.DeleteAllJobs(s.jobClient, s.T())
-	test.DeleteAllRuns(s.runClient, s.T())
+	s.cleanUp()
 }
 
 func (s *JobApiTestSuite) TestJobApis() {
@@ -315,3 +311,16 @@ func TestJobApi(t *testing.T) {
 }
 
 // TODO(jingzhang36): include UploadPipelineVersion in integration test
+
+func (s *JobApiTestSuite) TearDownSuite() {
+	if !*isDevMode {
+		s.cleanUp()
+	}
+}
+
+func (s *JobApiTestSuite) cleanUp() {
+	test.DeleteAllExperiments(s.experimentClient, s.T())
+	test.DeleteAllPipelines(s.pipelineClient, s.T())
+	test.DeleteAllJobs(s.jobClient, s.T())
+	test.DeleteAllRuns(s.runClient, s.T())
+}

--- a/backend/test/integration/job_api_test.go
+++ b/backend/test/integration/job_api_test.go
@@ -70,6 +70,12 @@ func (s *JobApiTestSuite) SetupTest() {
 	if err != nil {
 		glog.Exitf("Failed to get job client. Error: %s", err.Error())
 	}
+
+	/* ---------- Clean up ---------- */
+	test.DeleteAllExperiments(s.experimentClient, s.T())
+	test.DeleteAllPipelines(s.pipelineClient, s.T())
+	test.DeleteAllJobs(s.jobClient, s.T())
+	test.DeleteAllRuns(s.runClient, s.T())
 }
 
 func (s *JobApiTestSuite) TestJobApis() {
@@ -210,12 +216,6 @@ func (s *JobApiTestSuite) TestJobApis() {
 	assert.Equal(t, 1, totalSize)
 	argParamsRun := runs[0]
 	s.checkArgParamsRun(t, argParamsRun, argParamsExperiment.ID, argParamsExperiment.Name, argParamsJob.ID, argParamsJob.Name)
-
-	/* ---------- Clean up ---------- */
-	test.DeleteAllExperiments(s.experimentClient, t)
-	test.DeleteAllPipelines(s.pipelineClient, t)
-	test.DeleteAllJobs(s.jobClient, t)
-	test.DeleteAllRuns(s.runClient, t)
 }
 
 func (s *JobApiTestSuite) checkHelloWorldJob(t *testing.T, job *job_model.APIJob, experimentID string, experimentName string, pipelineID string) {

--- a/backend/test/integration/job_api_test.go
+++ b/backend/test/integration/job_api_test.go
@@ -41,12 +41,15 @@ func (s *JobApiTestSuite) SetupTest() {
 		return
 	}
 
-	err := test.WaitForReady(*namespace, *initializeTimeout)
-	if err != nil {
-		glog.Exitf("Failed to initialize test. Error: %s", err.Error())
+	if !*skipWaitForCluster {
+		err := test.WaitForReady(*namespace, *initializeTimeout)
+		if err != nil {
+			glog.Exitf("Failed to initialize test. Error: %s", err.Error())
+		}
 	}
 	s.namespace = *namespace
 	clientConfig := test.GetClientConfig(*namespace)
+	var err error
 	s.experimentClient, err = api_server.NewExperimentClient(clientConfig, false)
 	if err != nil {
 		glog.Exitf("Failed to get pipeline upload client. Error: %s", err.Error())

--- a/backend/test/integration/job_api_test.go
+++ b/backend/test/integration/job_api_test.go
@@ -313,8 +313,10 @@ func TestJobApi(t *testing.T) {
 // TODO(jingzhang36): include UploadPipelineVersion in integration test
 
 func (s *JobApiTestSuite) TearDownSuite() {
-	if !*isDevMode {
-		s.cleanUp()
+	if *runIntegrationTests {
+		if !*isDevMode {
+			s.cleanUp()
+		}
 	}
 }
 

--- a/backend/test/integration/pipeline_api_test.go
+++ b/backend/test/integration/pipeline_api_test.go
@@ -221,8 +221,10 @@ func TestPipelineAPI(t *testing.T) {
 // TODO(jingzhang36): include UploadPipelineVersion in integration test
 
 func (s *PipelineApiTest) TearDownSuite() {
-	if !*isDevMode {
-		s.cleanUp()
+	if *runIntegrationTests {
+		if !*isDevMode {
+			s.cleanUp()
+		}
 	}
 }
 

--- a/backend/test/integration/pipeline_api_test.go
+++ b/backend/test/integration/pipeline_api_test.go
@@ -55,6 +55,9 @@ func (s *PipelineApiTest) SetupTest() {
 	if err != nil {
 		glog.Exitf("Failed to get pipeline client. Error: %s", err.Error())
 	}
+
+	/* ---------- Clean up ---------- */
+	test.DeleteAllPipelines(s.pipelineClient, s.T())
 }
 
 func (s *PipelineApiTest) TestPipelineAPI() {
@@ -182,9 +185,6 @@ func (s *PipelineApiTest) TestPipelineAPI() {
 	var expectedWorkflow v1alpha1.Workflow
 	err = yaml.Unmarshal(expected, &expectedWorkflow)
 	assert.Equal(t, expectedWorkflow, *template)
-
-	/* ---------- Clean up ---------- */
-	test.DeleteAllPipelines(s.pipelineClient, t)
 }
 
 func verifyPipeline(t *testing.T, pipeline *model.APIPipeline) {

--- a/backend/test/integration/pipeline_api_test.go
+++ b/backend/test/integration/pipeline_api_test.go
@@ -39,7 +39,7 @@ func (s *PipelineApiTest) SetupTest() {
 		return
 	}
 
-	if !*skipWaitForCluster {
+	if !*isDevMode {
 		err := test.WaitForReady(*namespace, *initializeTimeout)
 		if err != nil {
 			glog.Exitf("Failed to initialize test. Error: %s", err.Error())
@@ -56,8 +56,7 @@ func (s *PipelineApiTest) SetupTest() {
 		glog.Exitf("Failed to get pipeline client. Error: %s", err.Error())
 	}
 
-	/* ---------- Clean up ---------- */
-	test.DeleteAllPipelines(s.pipelineClient, s.T())
+	s.cleanUp()
 }
 
 func (s *PipelineApiTest) TestPipelineAPI() {
@@ -220,3 +219,13 @@ func TestPipelineAPI(t *testing.T) {
 }
 
 // TODO(jingzhang36): include UploadPipelineVersion in integration test
+
+func (s *PipelineApiTest) TearDownSuite() {
+	if !*isDevMode {
+		s.cleanUp()
+	}
+}
+
+func (s *PipelineApiTest) cleanUp() {
+	test.DeleteAllPipelines(s.pipelineClient, s.T())
+}

--- a/backend/test/integration/pipeline_api_test.go
+++ b/backend/test/integration/pipeline_api_test.go
@@ -39,11 +39,14 @@ func (s *PipelineApiTest) SetupTest() {
 		return
 	}
 
-	err := test.WaitForReady(*namespace, *initializeTimeout)
-	if err != nil {
-		glog.Exitf("Failed to initialize test. Error: %s", err.Error())
+	if !*skipWaitForCluster {
+		err := test.WaitForReady(*namespace, *initializeTimeout)
+		if err != nil {
+			glog.Exitf("Failed to initialize test. Error: %s", err.Error())
+		}
 	}
 	clientConfig := test.GetClientConfig(*namespace)
+	var err error
 	s.pipelineUploadClient, err = api_server.NewPipelineUploadClient(clientConfig, false)
 	if err != nil {
 		glog.Exitf("Failed to get pipeline upload client. Error: %s", err.Error())

--- a/backend/test/integration/run_api_test.go
+++ b/backend/test/integration/run_api_test.go
@@ -36,7 +36,7 @@ func (s *RunApiTestSuite) SetupTest() {
 		return
 	}
 
-	if !*skipWaitForCluster {
+	if !*isDevMode {
 		err := test.WaitForReady(*namespace, *initializeTimeout)
 		if err != nil {
 			glog.Exitf("Failed to initialize test. Error: %s", err.Error())
@@ -62,10 +62,7 @@ func (s *RunApiTestSuite) SetupTest() {
 		glog.Exitf("Failed to get run client. Error: %s", err.Error())
 	}
 
-	/* ---------- Clean up ---------- */
-	test.DeleteAllExperiments(s.experimentClient, s.T())
-	test.DeleteAllPipelines(s.pipelineClient, s.T())
-	test.DeleteAllRuns(s.runClient, s.T())
+	s.cleanUp()
 }
 
 func (s *RunApiTestSuite) TestRunApis() {
@@ -317,3 +314,16 @@ func TestRunApi(t *testing.T) {
 }
 
 // TODO(jingzhang36): include UploadPipelineVersion in integration test
+
+func (s *RunApiTestSuite) TearDownSuite() {
+	if !*isDevMode {
+		s.cleanUp()
+	}
+}
+
+func (s *RunApiTestSuite) cleanUp() {
+	/* ---------- Clean up ---------- */
+	test.DeleteAllExperiments(s.experimentClient, s.T())
+	test.DeleteAllPipelines(s.pipelineClient, s.T())
+	test.DeleteAllRuns(s.runClient, s.T())
+}

--- a/backend/test/integration/run_api_test.go
+++ b/backend/test/integration/run_api_test.go
@@ -61,6 +61,11 @@ func (s *RunApiTestSuite) SetupTest() {
 	if err != nil {
 		glog.Exitf("Failed to get run client. Error: %s", err.Error())
 	}
+
+	/* ---------- Clean up ---------- */
+	test.DeleteAllExperiments(s.experimentClient, s.T())
+	test.DeleteAllPipelines(s.pipelineClient, s.T())
+	test.DeleteAllRuns(s.runClient, s.T())
 }
 
 func (s *RunApiTestSuite) TestRunApis() {
@@ -218,11 +223,6 @@ func (s *RunApiTestSuite) TestRunApis() {
 	longRunningRunDetail, _, err = s.runClient.Get(&runparams.GetRunParams{RunID: longRunningRunDetail.Run.ID})
 	assert.Nil(t, err)
 	s.checkTerminatedRunDetail(t, longRunningRunDetail, helloWorldExperiment.ID, helloWorldExperiment.Name, longRunningPipeline.ID)
-
-	/* ---------- Clean up ---------- */
-	test.DeleteAllExperiments(s.experimentClient, t)
-	test.DeleteAllPipelines(s.pipelineClient, t)
-	test.DeleteAllRuns(s.runClient, t)
 }
 
 func (s *RunApiTestSuite) checkTerminatedRunDetail(t *testing.T, runDetail *run_model.APIRunDetail, experimentId string, experimentName string, pipelineId string) {

--- a/backend/test/integration/run_api_test.go
+++ b/backend/test/integration/run_api_test.go
@@ -316,8 +316,10 @@ func TestRunApi(t *testing.T) {
 // TODO(jingzhang36): include UploadPipelineVersion in integration test
 
 func (s *RunApiTestSuite) TearDownSuite() {
-	if !*isDevMode {
-		s.cleanUp()
+	if *runIntegrationTests {
+		if !*isDevMode {
+			s.cleanUp()
+		}
 	}
 }
 

--- a/backend/test/integration/run_api_test.go
+++ b/backend/test/integration/run_api_test.go
@@ -36,12 +36,15 @@ func (s *RunApiTestSuite) SetupTest() {
 		return
 	}
 
-	err := test.WaitForReady(*namespace, *initializeTimeout)
-	if err != nil {
-		glog.Exitf("Failed to initialize test. Error: %s", err.Error())
+	if !*skipWaitForCluster {
+		err := test.WaitForReady(*namespace, *initializeTimeout)
+		if err != nil {
+			glog.Exitf("Failed to initialize test. Error: %s", err.Error())
+		}
 	}
 	s.namespace = *namespace
 	clientConfig := test.GetClientConfig(*namespace)
+	var err error
 	s.experimentClient, err = api_server.NewExperimentClient(clientConfig, false)
 	if err != nil {
 		glog.Exitf("Failed to get pipeline upload client. Error: %s", err.Error())

--- a/backend/test/integration/run_tests_locally.sh
+++ b/backend/test/integration/run_tests_locally.sh
@@ -20,4 +20,6 @@ case "$response" in
 esac
 
 echo "Starting integration tests..."
-go test -v ./... -namespace ${NAMESPACE} -args -runIntegrationTests=true -isDevMode=true
+command="go test -v ./... -namespace ${NAMESPACE} -args -runIntegrationTests=true -isDevMode=true"
+echo $command "$@"
+$command "$@"

--- a/backend/test/integration/run_tests_locally.sh
+++ b/backend/test/integration/run_tests_locally.sh
@@ -2,13 +2,22 @@
 
 set -e
 
-echo "The tests run against the cluster your kubectl communicates to.";
-echo "It's currently '$(kubectl config current-context)'."
-
 if [ -z "${NAMESPACE}" ]; then
     echo "NAMESPACE env var is not provided, please set it to your KFP namespace"
     exit
 fi
+
+echo "The api integration tests run against the cluster your kubectl communicates to.";
+echo "It's currently '$(kubectl config current-context)'."
+echo "WARNING: this will clear up all existing KFP data in this cluster."
+read -r -p "Are you sure? [y/N] " response
+case "$response" in
+    [yY][eE][sS]|[yY])
+        ;;
+    *)
+        exit
+        ;;
+esac
 
 echo "Starting integration tests..."
 go test -v ./... -namespace ${NAMESPACE} -args -runIntegrationTests=true -skipWaitForCluster=true

--- a/backend/test/integration/run_tests_locally.sh
+++ b/backend/test/integration/run_tests_locally.sh
@@ -20,4 +20,4 @@ case "$response" in
 esac
 
 echo "Starting integration tests..."
-go test -v ./... -namespace ${NAMESPACE} -args -runIntegrationTests=true -skipWaitForCluster=true
+go test -v ./... -namespace ${NAMESPACE} -args -runIntegrationTests=true -isDevMode=true

--- a/backend/test/integration/run_tests_locally.sh
+++ b/backend/test/integration/run_tests_locally.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+echo "The tests run against the cluster your kubectl communicates to.";
+echo "It's currently '$(kubectl config current-context)'."
+
+if [ -z "${NAMESPACE}" ]; then
+    echo "NAMESPACE env var is not provided, please set it to your KFP namespace"
+    exit
+fi
+
+echo "Starting integration tests..."
+go test -v ./... -namespace ${NAMESPACE} -args -runIntegrationTests=true -skipWaitForCluster=true

--- a/backend/test/integration/visualization_api_test.go
+++ b/backend/test/integration/visualization_api_test.go
@@ -25,7 +25,7 @@ func (s *VisualizationApiTest) SetupTest() {
 		return
 	}
 
-	if !*skipWaitForCluster {
+	if !*isDevMode {
 		err := test.WaitForReady(*namespace, *initializeTimeout)
 		if err != nil {
 			glog.Exitf("Failed to initialize test. Error: %v", err)

--- a/backend/test/integration/visualization_api_test.go
+++ b/backend/test/integration/visualization_api_test.go
@@ -14,7 +14,7 @@ import (
 
 type VisualizationApiTest struct {
 	suite.Suite
-	namespace        string
+	namespace           string
 	visualizationClient *api_server.VisualizationClient
 }
 
@@ -25,12 +25,15 @@ func (s *VisualizationApiTest) SetupTest() {
 		return
 	}
 
-	err := test.WaitForReady(*namespace, *initializeTimeout)
-	if err != nil {
-		glog.Exitf("Failed to initialize test. Error: %v", err)
+	if !*skipWaitForCluster {
+		err := test.WaitForReady(*namespace, *initializeTimeout)
+		if err != nil {
+			glog.Exitf("Failed to initialize test. Error: %v", err)
+		}
 	}
 	s.namespace = *namespace
 	clientConfig := test.GetClientConfig(*namespace)
+	var err error
 	s.visualizationClient, err = api_server.NewVisualizationClient(clientConfig, false)
 	if err != nil {
 		glog.Exitf("Failed to get experiment client. Error: %v", err)
@@ -43,7 +46,7 @@ func (s *VisualizationApiTest) TestVisualizationAPI() {
 	/* ---------- Generate custom visualization --------- */
 	visualization := &visualization_model.APIVisualization{
 		Arguments: `{"code": ["print(2)"]}`,
-		Type: visualization_model.APIVisualizationTypeCUSTOM,
+		Type:      visualization_model.APIVisualizationTypeCUSTOM,
 	}
 	customVisualization, err := s.visualizationClient.Create(&params.CreateVisualizationParams{
 		Body: visualization,


### PR DESCRIPTION
Add README and script to help run backend integration tests locally.

Also moved cleanup steps to test setup stage, so that
* each test doesn't depend on cluster initial state, e.g. if you halt your test in the middle, rerunning the test would fail because of the cluster being in an intermediate state. With this change, test will just pass.
* dev can debug manually after a test fails

UPDATE: tests will clean up both before and after it runs, to unblock frontend-integration-test which depends on the cluster being empty, but clean up after test is disabled in dev mode

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3138)
<!-- Reviewable:end -->
