### PR TITLE
[frontend]: Use Promise.all to fetch clusterName and projectId

### DIFF
--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -766,8 +766,10 @@ class RunDetails extends Page<RunDetailsProps, RunDetailsState> {
       });
     } catch (err) {
       try {
-        const projectId = await Apis.getProjectId();
-        const clusterName = await Apis.getClusterName();
+        const [clusterName, projectId] = await Promise.all([
+          Apis.getClusterName(),
+          Apis.getProjectId(),
+        ]);
         this.setStateSafe({
           legacyStackdriverUrl: `https://console.cloud.google.com/logs/viewer?project=${projectId}&interval=NO_LIMIT&advancedFilter=resource.type%3D"container"%0Aresource.labels.cluster_name:"${clusterName}"%0Aresource.labels.pod_id:"${selectedNodeDetails.id}"`,
           logsBannerMessage:


### PR DESCRIPTION
Parallelizing async API calls using Promise.all instead of using two awaits.

#### Issue in focus
There are no issues related to this. It is a minor performance related improvement and makes the code consistent across the repository for fetching `clusterName` and `projectId` - For example, the same format is followed [here](https://github.com/kubeflow/pipelines/blob/b90040a00fe53129f699a5d8c1ec0dcace02d041/frontend/src/components/SideNav.tsx#L232) in `/frontend/src/components/SideNav.tsx`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3140)
<!-- Reviewable:end -->
