### PR TITLE
[Backend] Fix parameter patching

### DIFF
--- a/backend/src/apiserver/resource/resource_manager_util.go
+++ b/backend/src/apiserver/resource/resource_manager_util.go
@@ -24,6 +24,7 @@ import (
 	"github.com/argoproj/argo/workflow/common"
 	api "github.com/kubeflow/pipelines/backend/api/go_client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/client"
+	servercommon "github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	scheduledworkflow "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
@@ -180,4 +181,20 @@ func deletePods(k8sCoreClient client.KubernetesCoreInterface, podsToDelete []str
 		}
 	}
 	return nil
+}
+
+// Mutate default values of specified pipeline spec.
+// Args:
+//  text: (part of) pipeline file in string.
+func PatchPipelineDefaultParameter(text string) (string, error) {
+	defaultBucket := servercommon.GetStringConfig(DefaultBucketNameEnvVar)
+	projectId := servercommon.GetStringConfig(ProjectIDEnvVar)
+	toPatch := map[string]string{
+		"{{kfp-default-bucket}}": defaultBucket,
+		"{{kfp-project-id}}":     projectId,
+	}
+	for key, value := range toPatch {
+		text = strings.Replace(text, key, value, -1)
+	}
+	return text, nil
 }

--- a/backend/src/apiserver/server/run_server.go
+++ b/backend/src/apiserver/server/run_server.go
@@ -16,7 +16,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	api "github.com/kubeflow/pipelines/backend/api/go_client"
@@ -31,23 +30,7 @@ type RunServer struct {
 	resourceManager *resource.ResourceManager
 }
 
-const (
-	HasDefaultBucketEnvVar  = "HAS_DEFAULT_BUCKET"
-	ProjectIDEnvVar         = "PROJECT_ID"
-	DefaultBucketNameEnvVar = "BUCKET_NAME"
-)
-
 func (s *RunServer) CreateRun(ctx context.Context, request *api.CreateRunRequest) (*api.RunDetail, error) {
-	// Patch default values
-	for _, param := range request.Run.PipelineSpec.Parameters {
-		if common.GetBoolConfigWithDefault(HasDefaultBucketEnvVar, false) {
-			var err error
-			param.Value, err = PatchPipelineDefaultParameter(param.Value)
-			if err != nil {
-				return nil, fmt.Errorf("failed to patch default value to pipeline. Error: %v", err)
-			}
-		}
-	}
 	err := s.validateCreateRunRequest(request)
 	if err != nil {
 		return nil, util.Wrap(err, "Validate create run request failed.")

--- a/backend/src/apiserver/server/run_server_test.go
+++ b/backend/src/apiserver/server/run_server_test.go
@@ -64,9 +64,6 @@ func TestCreateRun(t *testing.T) {
 
 func TestCreateRunPatch(t *testing.T) {
 	clients, manager, experiment := initWithExperiment(t)
-	viper.Set(HasDefaultBucketEnvVar, "true")
-	viper.Set(ProjectIDEnvVar, "test-project-id")
-	viper.Set(DefaultBucketNameEnvVar, "test-default-bucket")
 	defer clients.Close()
 	server := NewRunServer(manager)
 	run := &api.Run{
@@ -75,8 +72,8 @@ func TestCreateRunPatch(t *testing.T) {
 		PipelineSpec: &api.PipelineSpec{
 			WorkflowManifest: testWorkflowPatch.ToStringForStore(),
 			Parameters: []*api.Parameter{
-				{Name: "param1", Value: "{{kfp-default-bucket}}"},
-				{Name: "param2", Value: "{{kfp-project-id}}"}},
+				{Name: "param1", Value: "test-default-bucket"},
+				{Name: "param2", Value: "test-project-id"}},
 		},
 	}
 	runDetail, err := server.CreateRun(nil, &api.CreateRunRequest{Run: run})

--- a/backend/src/apiserver/server/util.go
+++ b/backend/src/apiserver/server/util.go
@@ -182,22 +182,6 @@ func ReadPipelineFile(fileName string, fileReader io.Reader, maxFileLength int) 
 	return processedFile, nil
 }
 
-// Mutate default values of specified pipeline spec.
-// Args:
-//  text: (part of) pipeline file in string.
-func PatchPipelineDefaultParameter(text string) (string, error) {
-	defaultBucket := common.GetStringConfig(DefaultBucketNameEnvVar)
-	projectId := common.GetStringConfig(ProjectIDEnvVar)
-	toPatch := map[string]string{
-		"{{kfp-default-bucket}}": defaultBucket,
-		"{{kfp-project-id}}":     projectId,
-	}
-	for key, value := range toPatch {
-		text = strings.Replace(text, key, value, -1)
-	}
-	return text, nil
-}
-
 func printParameters(params []*api.Parameter) string {
 	var s strings.Builder
 	for _, p := range params {

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -15,6 +15,8 @@
 package util
 
 import (
+	"strings"
+
 	workflowapi "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	"github.com/golang/glog"
 	swfregister "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow"
@@ -22,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
-	"strings"
 )
 
 // Workflow is a type to help manipulate Workflow objects.


### PR DESCRIPTION
Previous patching does not work for the following codepath:

In SDK use placeholder in parameter default value → In SDK create_run_from_pipeline_func/package → Run triggered and failed 

Change to patch RunDetail and WorkflowSpec in resource manager.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3145)
<!-- Reviewable:end -->
