### PR TITLE
[Frontend] Update deps to bring optional chaining js language feature

### DIFF
--- a/frontend/.eslintrc.yaml
+++ b/frontend/.eslintrc.yaml
@@ -1,10 +1,9 @@
-extends: react-app
+extends:
+    - react-app
 ignorePatterns:
     - node_modules/
     - src/apis # these are generated api clients
     - '*.test.ts'
     - '*.test.tsx'
-
 rules:
     react/jsx-no-target-blank: ['error', { "allowReferrer": true }]
-

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27160,9 +27160,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
     "typestyle": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19661,9 +19661,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "pretty-error": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -93,7 +93,7 @@
     "ts-node": "^7.0.1",
     "ts-node-dev": "^1.0.0-pre.30",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.6.4",
+    "typescript": "^3.7.5",
     "webpack": "4.41.5",
     "webpack-bundle-analyzer": "^3.6.0"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,7 +84,7 @@
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.15.1",
     "enzyme-to-json": "^3.3.4",
-    "prettier": "^1.19.1",
+    "prettier": "1.19.1",
     "react-router-test-context": "^0.1.0",
     "react-scripts": "^3.4.0",
     "react-test-renderer": "^16.5.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,7 +84,7 @@
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.15.1",
     "enzyme-to-json": "^3.3.4",
-    "prettier": "1.18.2",
+    "prettier": "^1.19.1",
     "react-router-test-context": "^0.1.0",
     "react-scripts": "^3.4.0",
     "react-test-renderer": "^16.5.2",

--- a/frontend/src/apis/run/api.ts
+++ b/frontend/src/apis/run/api.ts
@@ -1486,10 +1486,12 @@ export const RunServiceApiFactory = function(
      * @throws {RequiredError}
      */
     readArtifact(run_id: string, node_id: string, artifact_name: string, options?: any) {
-      return RunServiceApiFp(configuration).readArtifact(run_id, node_id, artifact_name, options)(
-        fetch,
-        basePath,
-      );
+      return RunServiceApiFp(configuration).readArtifact(
+        run_id,
+        node_id,
+        artifact_name,
+        options,
+      )(fetch, basePath);
     },
     /**
      *
@@ -1500,10 +1502,11 @@ export const RunServiceApiFactory = function(
      * @throws {RequiredError}
      */
     reportRunMetrics(run_id: string, body: ApiReportRunMetricsRequest, options?: any) {
-      return RunServiceApiFp(configuration).reportRunMetrics(run_id, body, options)(
-        fetch,
-        basePath,
-      );
+      return RunServiceApiFp(configuration).reportRunMetrics(
+        run_id,
+        body,
+        options,
+      )(fetch, basePath);
     },
     /**
      *
@@ -1661,10 +1664,11 @@ export class RunServiceApi extends BaseAPI {
    * @memberof RunServiceApi
    */
   public reportRunMetrics(run_id: string, body: ApiReportRunMetricsRequest, options?: any) {
-    return RunServiceApiFp(this.configuration).reportRunMetrics(run_id, body, options)(
-      this.fetch,
-      this.basePath,
-    );
+    return RunServiceApiFp(this.configuration).reportRunMetrics(
+      run_id,
+      body,
+      options,
+    )(this.fetch, this.basePath);
   }
 
   /**

--- a/frontend/src/atoms/ExternalLink.tsx
+++ b/frontend/src/atoms/ExternalLink.tsx
@@ -14,16 +14,18 @@ const css = stylesheet({
   },
 });
 
-export const ExternalLink: React.FC<
-  DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>
-> = props => (
+export const ExternalLink: React.FC<DetailedHTMLProps<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  HTMLAnchorElement
+>> = props => (
   // eslint-disable-next-line jsx-a11y/anchor-has-content
   <a {...props} className={css.link} target='_blank' rel='noopener' />
 );
 
-export const AutoLink: React.FC<
-  DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>
-> = props =>
+export const AutoLink: React.FC<DetailedHTMLProps<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  HTMLAnchorElement
+>> = props =>
   props.href && props.href.startsWith('#') ? (
     // eslint-disable-next-line jsx-a11y/anchor-has-content
     <a {...props} className={css.link} />

--- a/frontend/src/components/CompareTable.test.tsx
+++ b/frontend/src/components/CompareTable.test.tsx
@@ -37,7 +37,11 @@ describe('CompareTable', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  const rows = [['1', '2', '3'], ['4', '5', '6'], ['cell7', 'cell8', 'cell9']];
+  const rows = [
+    ['1', '2', '3'],
+    ['4', '5', '6'],
+    ['cell7', 'cell8', 'cell9'],
+  ];
   const xLabels = ['col1', 'col2', 'col3'];
   const yLabels = ['row1', 'row2', 'row3'];
 

--- a/frontend/src/components/CustomTableRow.test.tsx
+++ b/frontend/src/components/CustomTableRow.test.tsx
@@ -43,7 +43,7 @@ describe('CustomTable', () => {
   };
 
   it('renders some rows using a custom renderer', async () => {
-    columns[0].customRenderer = () => <span>this is custom output</span> as any;
+    columns[0].customRenderer = () => (<span>this is custom output</span>) as any;
     const tree = shallow(<CustomTableRow {...props} row={row} columns={columns} />);
     await TestUtils.flushPromises();
     expect(tree).toMatchSnapshot();

--- a/frontend/src/components/DetailsTable.test.tsx
+++ b/frontend/src/components/DetailsTable.test.tsx
@@ -95,7 +95,14 @@ describe('DetailsTable', () => {
   });
 
   it('does not render booleans as JSON', () => {
-    const tree = shallow(<DetailsTable fields={[['key1', 'true'], ['key2', 'false']]} />);
+    const tree = shallow(
+      <DetailsTable
+        fields={[
+          ['key1', 'true'],
+          ['key2', 'false'],
+        ]}
+      />,
+    );
     expect(tree).toMatchSnapshot();
   });
 

--- a/frontend/src/components/viewers/ConfusionMatrix.test.tsx
+++ b/frontend/src/components/viewers/ConfusionMatrix.test.tsx
@@ -25,7 +25,11 @@ describe('ConfusionMatrix', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  const data = [[0, 1, 2], [3, 4, 5], [6, 7, 8]];
+  const data = [
+    [0, 1, 2],
+    [3, 4, 5],
+    [6, 7, 8],
+  ];
   const config: ConfusionMatrixConfig = {
     axes: ['test x axis', 'test y axis'],
     data,

--- a/frontend/src/components/viewers/PagedTable.test.tsx
+++ b/frontend/src/components/viewers/PagedTable.test.tsx
@@ -30,7 +30,10 @@ describe('PagedTable', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  const data = [['col1', 'col2', 'col3'], ['col4', 'col5', 'col6']];
+  const data = [
+    ['col1', 'col2', 'col3'],
+    ['col4', 'col5', 'col6'],
+  ];
   const labels = ['field1', 'field2', 'field3'];
 
   it('renders simple data', () => {

--- a/frontend/src/lib/CompareUtils.test.ts
+++ b/frontend/src/lib/CompareUtils.test.ts
@@ -266,7 +266,10 @@ describe('CompareUtils', () => {
         } as ApiRun,
       ];
       expect(CompareUtils.multiRunMetricsCompareProps(runs)).toEqual({
-        rows: [['0.330', ''], ['', '0.660']],
+        rows: [
+          ['0.330', ''],
+          ['', '0.660'],
+        ],
         xLabels: ['run1', 'run2'],
         yLabels: ['some-metric', 'another-metric'],
       });
@@ -396,7 +399,10 @@ describe('CompareUtils', () => {
         name: 'run1',
       } as ApiRun;
       expect(CompareUtils.singleRunToMetricsCompareProps(run)).toEqual({
-        rows: [['0.230', ''], ['', '0.540']],
+        rows: [
+          ['0.230', ''],
+          ['', '0.540'],
+        ],
         xLabels: ['some-metric-name', 'another-metric-name'],
         yLabels: ['someNodeId', 'anotherNodeId'],
       });

--- a/frontend/src/lib/OutputArtifactLoader.test.ts
+++ b/frontend/src/lib/OutputArtifactLoader.test.ts
@@ -168,7 +168,10 @@ describe('OutputArtifactLoader', () => {
       const result = await OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any);
       expect(result).toEqual({
         axes: ['field1', 'field2'],
-        data: [[0, 0], [0, 0]],
+        data: [
+          [0, 0],
+          [0, 0],
+        ],
         labels: ['field1', 'field2'],
         type: PlotType.CONFUSION_MATRIX,
       } as ConfusionMatrixConfig);
@@ -372,7 +375,11 @@ describe('OutputArtifactLoader', () => {
         6,7,8
       `;
       expect(await OutputArtifactLoader.buildRocCurveConfig(metadata as any)).toEqual({
-        data: [{ label: '2', x: 0, y: 1 }, { label: '5', x: 3, y: 4 }, { label: '8', x: 6, y: 7 }],
+        data: [
+          { label: '2', x: 0, y: 1 },
+          { label: '5', x: 3, y: 4 },
+          { label: '8', x: 6, y: 7 },
+        ],
         type: PlotType.ROC,
       } as ROCCurveConfig);
     });
@@ -388,7 +395,11 @@ describe('OutputArtifactLoader', () => {
         6,7,8
       `;
       expect(await OutputArtifactLoader.buildRocCurveConfig(metadata as any)).toEqual({
-        data: [{ label: '0', x: 2, y: 1 }, { label: '3', x: 5, y: 4 }, { label: '6', x: 8, y: 7 }],
+        data: [
+          { label: '0', x: 2, y: 1 },
+          { label: '3', x: 5, y: 4 },
+          { label: '6', x: 8, y: 7 },
+        ],
         type: PlotType.ROC,
       } as ROCCurveConfig);
     });
@@ -404,7 +415,11 @@ describe('OutputArtifactLoader', () => {
         6,7,8
       `;
       expect(await OutputArtifactLoader.buildRocCurveConfig(metadata as any)).toEqual({
-        data: [{ label: '2', x: 0, y: 1 }, { label: '5', x: 3, y: 4 }, { label: '8', x: 6, y: 7 }],
+        data: [
+          { label: '2', x: 0, y: 1 },
+          { label: '5', x: 3, y: 4 },
+          { label: '8', x: 6, y: 7 },
+        ],
         type: PlotType.ROC,
       } as ROCCurveConfig);
     });

--- a/frontend/src/lib/StaticGraphParser.test.ts
+++ b/frontend/src/lib/StaticGraphParser.test.ts
@@ -593,13 +593,19 @@ describe('StaticGraphParser', () => {
         container: {},
         dag: [],
         inputs: {
-          parameters: [{ name: 'param1', value: 'val1' }, { name: 'param2', value: 'val2' }],
+          parameters: [
+            { name: 'param1', value: 'val1' },
+            { name: 'param2', value: 'val2' },
+          ],
         },
         name: 'template-1',
       } as any;
       const nodeInfo = _populateInfoFromTemplate(new SelectedNodeInfo(), template);
       expect(nodeInfo.nodeType).toEqual('container');
-      expect(nodeInfo.inputs).toEqual([['param1', 'val1'], ['param2', 'val2']]);
+      expect(nodeInfo.inputs).toEqual([
+        ['param1', 'val1'],
+        ['param2', 'val2'],
+      ]);
     });
 
     it('returns nodeInfo of a container with empty strings for inputs with no specified value', () => {
@@ -613,7 +619,10 @@ describe('StaticGraphParser', () => {
       } as any;
       const nodeInfo = _populateInfoFromTemplate(new SelectedNodeInfo(), template);
       expect(nodeInfo.nodeType).toEqual('container');
-      expect(nodeInfo.inputs).toEqual([['param1', ''], ['param2', '']]);
+      expect(nodeInfo.inputs).toEqual([
+        ['param1', ''],
+        ['param2', ''],
+      ]);
     });
 
     it('returns nodeInfo containing container outputs as list of name/value tuples, pulling from valueFrom if necessary', () => {
@@ -651,7 +660,10 @@ describe('StaticGraphParser', () => {
       } as any;
       const nodeInfo = _populateInfoFromTemplate(new SelectedNodeInfo(), template);
       expect(nodeInfo.nodeType).toEqual('container');
-      expect(nodeInfo.outputs).toEqual([['param1', ''], ['param2', '']]);
+      expect(nodeInfo.outputs).toEqual([
+        ['param1', ''],
+        ['param2', ''],
+      ]);
     });
 
     it('returns nodeInfo of a resource with empty values if template does not have inputs and/or outputs', () => {
@@ -672,14 +684,20 @@ describe('StaticGraphParser', () => {
       const template = {
         dag: [],
         inputs: {
-          parameters: [{ name: 'param1', value: 'val1' }, { name: 'param2', value: 'val2' }],
+          parameters: [
+            { name: 'param1', value: 'val1' },
+            { name: 'param2', value: 'val2' },
+          ],
         },
         name: 'template-1',
         resource: {},
       } as any;
       const nodeInfo = _populateInfoFromTemplate(new SelectedNodeInfo(), template);
       expect(nodeInfo.nodeType).toEqual('resource');
-      expect(nodeInfo.inputs).toEqual([['param1', 'val1'], ['param2', 'val2']]);
+      expect(nodeInfo.inputs).toEqual([
+        ['param1', 'val1'],
+        ['param2', 'val2'],
+      ]);
     });
 
     it('returns nodeInfo of a resource with empty strings for inputs with no specified value', () => {
@@ -693,7 +711,10 @@ describe('StaticGraphParser', () => {
       } as any;
       const nodeInfo = _populateInfoFromTemplate(new SelectedNodeInfo(), template);
       expect(nodeInfo.nodeType).toEqual('resource');
-      expect(nodeInfo.inputs).toEqual([['param1', ''], ['param2', '']]);
+      expect(nodeInfo.inputs).toEqual([
+        ['param1', ''],
+        ['param2', ''],
+      ]);
     });
 
     it('returns nodeInfo containing resource outputs as list of name/value tuples, pulling from valueFrom if necessary', () => {
@@ -731,7 +752,10 @@ describe('StaticGraphParser', () => {
       } as any;
       const nodeInfo = _populateInfoFromTemplate(new SelectedNodeInfo(), template);
       expect(nodeInfo.nodeType).toEqual('resource');
-      expect(nodeInfo.outputs).toEqual([['param1', ''], ['param2', '']]);
+      expect(nodeInfo.outputs).toEqual([
+        ['param1', ''],
+        ['param2', ''],
+      ]);
     });
   });
 });

--- a/frontend/src/pages/AllRunsList.tsx
+++ b/frontend/src/pages/AllRunsList.tsx
@@ -46,8 +46,10 @@ class AllRunsList extends Page<{}, AllRunsListState> {
         .newExperiment()
         .compareRuns(() => this.state.selectedIds)
         .cloneRun(() => this.state.selectedIds, false)
-        .archive(() => this.state.selectedIds, false, selectedIds =>
-          this._selectionChanged(selectedIds),
+        .archive(
+          () => this.state.selectedIds,
+          false,
+          selectedIds => this._selectionChanged(selectedIds),
         )
         .refresh(this.refresh.bind(this))
         .getToolbarActionMap(),

--- a/frontend/src/pages/Compare.test.tsx
+++ b/frontend/src/pages/Compare.test.tsx
@@ -242,7 +242,10 @@ describe('Compare', () => {
     const workflow = {
       spec: {
         arguments: {
-          parameters: [{ name: 'param1', value: 'value1' }, { name: 'param2', value: 'value2' }],
+          parameters: [
+            { name: 'param1', value: 'value1' },
+            { name: 'param2', value: 'value2' },
+          ],
         },
       },
     } as Workflow;

--- a/frontend/src/pages/ExperimentDetails.test.tsx
+++ b/frontend/src/pages/ExperimentDetails.test.tsx
@@ -369,7 +369,10 @@ describe('ExperimentDetails', () => {
   });
 
   it('navigates to the compare runs page', async () => {
-    const runs = [{ id: 'run-1-id', name: 'run-1' }, { id: 'run-2-id', name: 'run-2' }];
+    const runs = [
+      { id: 'run-1-id', name: 'run-1' },
+      { id: 'run-2-id', name: 'run-2' },
+    ];
     listRunsSpy.mockImplementation(() => ({ runs }));
     await listRunsSpy;
 

--- a/frontend/src/pages/ExperimentDetails.tsx
+++ b/frontend/src/pages/ExperimentDetails.tsx
@@ -123,7 +123,11 @@ class ExperimentDetails extends Page<{}, ExperimentDetailsState> {
           .newRecurringRun(this.props.match.params[RouteParams.experimentId])
           .compareRuns(() => this.state.selectedIds)
           .cloneRun(() => this.state.selectedIds, false)
-          .archive(() => this.state.selectedIds, false, ids => this._selectionChanged(ids))
+          .archive(
+            () => this.state.selectedIds,
+            false,
+            ids => this._selectionChanged(ids),
+          )
           .getToolbarActionMap(),
         breadcrumbs: [],
         pageTitle: 'Runs',

--- a/frontend/src/pages/ExperimentList.tsx
+++ b/frontend/src/pages/ExperimentList.tsx
@@ -72,7 +72,11 @@ class ExperimentList extends Page<{}, ExperimentListState> {
         .newExperiment()
         .compareRuns(() => this.state.selectedIds)
         .cloneRun(() => this.state.selectedIds, false)
-        .archive(() => this.state.selectedIds, false, ids => this._selectionChanged(ids))
+        .archive(
+          () => this.state.selectedIds,
+          false,
+          ids => this._selectionChanged(ids),
+        )
         .refresh(this.refresh.bind(this))
         .getToolbarActionMap(),
       breadcrumbs: [],

--- a/frontend/src/pages/GettingStarted.tsx
+++ b/frontend/src/pages/GettingStarted.tsx
@@ -129,14 +129,11 @@ export class GettingStarted extends Page<{}, { links: string[] }> {
           .listPipelines(undefined, 10, undefined, createAndEncodeFilter(name))
           .then(pipelineList => {
             const pipelines = pipelineList.pipelines;
-            if (!pipelines || pipelines.length !== 1) {
+            if (pipelines?.length !== 1) {
+              // This should be accurate, do not accept ambiguous results.
               return '';
             }
-            const pipeline = pipelines[0];
-            if (!pipeline.id) {
-              return '';
-            }
-            return pipeline.id;
+            return pipelines[0].id || '';
           })
           .catch(() => ''),
       ),

--- a/frontend/src/pages/NewPipelineVersion.tsx
+++ b/frontend/src/pages/NewPipelineVersion.tsx
@@ -532,17 +532,21 @@ class NewPipelineVersion extends Page<{}, NewPipelineVersionState> {
         // (3) new pipeline version (under an existing pipeline) from url
         const response =
           this.state.newPipeline && this.state.importMethod === ImportMethod.LOCAL
-            ? (await Apis.uploadPipeline(
-                this.state.pipelineName!,
-                this.state.pipelineDescription,
-                this.state.file!,
-              )).default_version!
+            ? (
+                await Apis.uploadPipeline(
+                  this.state.pipelineName!,
+                  this.state.pipelineDescription,
+                  this.state.file!,
+                )
+              ).default_version!
             : this.state.newPipeline && this.state.importMethod === ImportMethod.URL
-            ? (await Apis.pipelineServiceApi.createPipeline({
-                description: this.state.pipelineDescription,
-                name: this.state.pipelineName!,
-                url: { pipeline_url: this.state.packageUrl },
-              })).default_version!
+            ? (
+                await Apis.pipelineServiceApi.createPipeline({
+                  description: this.state.pipelineDescription,
+                  name: this.state.pipelineName!,
+                  url: { pipeline_url: this.state.packageUrl },
+                })
+              ).default_version!
             : await this._createPipelineVersion();
 
         // If success, go to pipeline details page of the new version

--- a/frontend/src/pages/PipelineDetails.test.tsx
+++ b/frontend/src/pages/PipelineDetails.test.tsx
@@ -618,8 +618,14 @@ describe('PipelineDetails', () => {
     info.command = ['test command', 'test command 2'];
     info.condition = 'test condition';
     info.image = 'test image';
-    info.inputs = [['key1', 'val1'], ['key2', 'val2']];
-    info.outputs = [['key3', 'val3'], ['key4', 'val4']];
+    info.inputs = [
+      ['key1', 'val1'],
+      ['key2', 'val2'],
+    ];
+    info.outputs = [
+      ['key3', 'val3'],
+      ['key4', 'val4'],
+    ];
     info.nodeType = 'container';
     g.setNode('node1', { info, label: 'node1' });
     createGraphSpy.mockImplementation(() => g);

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -482,13 +482,15 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
           // TODO(jingzhang36): pagination not proper here. so if many versions,
           // the page size value should be?
           versions =
-            (await Apis.pipelineServiceApi.listPipelineVersions(
-              'PIPELINE',
-              pipelineId,
-              50,
-              undefined,
-              'created_at desc',
-            )).versions || [];
+            (
+              await Apis.pipelineServiceApi.listPipelineVersions(
+                'PIPELINE',
+                pipelineId,
+                50,
+                undefined,
+                'created_at desc',
+              )
+            ).versions || [];
         } catch (err) {
           await this.showPageError('Cannot retrieve pipeline versions.', err);
           logger.error('Cannot retrieve pipeline versions.', err);

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -925,14 +925,16 @@ const ArtifactsTabContent: React.FC<{
       };
 
       // Load the viewer configurations from the output paths
-      const builtConfigs = (await Promise.all([
-        OutputArtifactLoader.buildTFXArtifactViewerConfig(nodeId, reportProgress).catch(
-          reportErrorAndReturnEmpty,
-        ),
-        ...outputPaths.map(path =>
-          OutputArtifactLoader.load(path).catch(reportErrorAndReturnEmpty),
-        ),
-      ])).flatMap(configs => configs);
+      const builtConfigs = (
+        await Promise.all([
+          OutputArtifactLoader.buildTFXArtifactViewerConfig(nodeId, reportProgress).catch(
+            reportErrorAndReturnEmpty,
+          ),
+          ...outputPaths.map(path =>
+            OutputArtifactLoader.load(path).catch(reportErrorAndReturnEmpty),
+          ),
+        ])
+      ).flatMap(configs => configs);
       if (aborted) {
         return;
       }

--- a/frontend/src/pages/RunList.test.tsx
+++ b/frontend/src/pages/RunList.test.tsx
@@ -366,7 +366,10 @@ describe('RunList', () => {
   it('adds metrics columns', async () => {
     mockNRuns(2, {
       run: {
-        metrics: [{ name: 'metric1', number_value: 5 }, { name: 'metric2', number_value: 10 }],
+        metrics: [
+          { name: 'metric1', number_value: 5 },
+          { name: 'metric2', number_value: 10 },
+        ],
         status: 'Succeeded',
       },
     });

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "build/dist",
     "module": "esnext",
     "target": "es5",
-    "lib": ["es6", "dom", "es2019"],
+    "lib": ["es6", "dom", "es2020"],
     "sourceMap": true,
     "allowJs": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
/area frontend
/assign @Bobgy

Part of https://github.com/kubeflow/pipelines/issues/2407

UPDATE: I cannot fix the test configs, it seems this is also blocked by https://github.com/kubeflow/pipelines/issues/2432, because create-react-app-ts has restriction on which jest and ts-jest version to use.
UPDATE2: After #2432 fixed, also upgraded typescript, this works now.

Optional chaining example usage: https://github.com/kubeflow/pipelines/pull/3154/files#diff-1e8357336f0f74b158fbf0751ac2d9da

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3154)
<!-- Reviewable:end -->
