### PR TITLE
[Frontend] snapshot diff setup

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -100,13 +100,16 @@ To understand more what prettier is: [What is Prettier](https://prettier.io/docs
   this project's config automatically.
   Recommend setting the following in [settings.json](https://code.visualstudio.com/docs/getstarted/settings#_settings-file-locations) for vscode to autoformat on save.
   ```
-  "[typescript]": {
-      "editor.formatOnSave": true,
+    "[typescript]": {
+    "editor.formatOnSave": true,
+    "files.trimTrailingWhitespace": false,
   },
   "[typescriptreact]": {
-      "editor.formatOnSave": true,
+    "editor.formatOnSave": true,
+    "files.trimTrailingWhitespace": false,
   },
   ```
+  Also, vscode builtin trailing whitespace [conflicts with jest inline snapshot](https://github.com/Microsoft/vscode/issues/52711), so recommend disabling it.
 - For others, refer to https://prettier.io/docs/en/editors.html
 
 ### Format Code Manually

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -110,6 +110,7 @@
     ],
     "snapshotSerializers": [
       "./src/__serializers__/mock-function",
+      "snapshot-diff/serializer.js",
       "enzyme-to-json/serializer"
     ]
   },

--- a/frontend/src/TestUtils.tsx
+++ b/frontend/src/TestUtils.tsx
@@ -26,6 +26,7 @@ import { match } from 'react-router';
 import { mount, ReactWrapper } from 'enzyme';
 import { object } from 'prop-types';
 import { format } from 'prettier';
+import snapshotDiff from 'snapshot-diff';
 
 export default class TestUtils {
   /**
@@ -109,4 +110,44 @@ export default class TestUtils {
 
 export function formatHTML(html: string): string {
   return format(html, { parser: 'html' });
+}
+
+/**
+ * Generate diff text for two HTML strings.
+ * Recommend providing base and update annotations to clarify context in the diff directly.
+ */
+export function diffHTML({
+  base,
+  update,
+  baseAnnotation,
+  updateAnnotation,
+}: {
+  base: string;
+  baseAnnotation?: string;
+  update: string;
+  updateAnnotation?: string;
+}) {
+  return snapshotDiff(formatHTML(base), formatHTML(update), {
+    stablePatchmarks: true, // Avoid line numbers in diff, so that diffs are stable against irrelevant changes
+    aAnnotation: baseAnnotation,
+    bAnnotation: updateAnnotation,
+  });
+}
+
+export function diffShallow({
+  base,
+  update,
+  baseAnnotation,
+  updateAnnotation,
+}: {
+  base: string;
+  baseAnnotation?: string;
+  update: string;
+  updateAnnotation?: string;
+}) {
+  return snapshotDiff(base, update, {
+    stablePatchmarks: true, // Avoid line numbers in diff, so that diffs are stable against irrelevant changes
+    aAnnotation: baseAnnotation,
+    bAnnotation: updateAnnotation,
+  });
 }

--- a/frontend/src/TestUtils.tsx
+++ b/frontend/src/TestUtils.tsx
@@ -127,14 +127,15 @@ export function diffHTML({
   update: string;
   updateAnnotation?: string;
 }) {
-  return snapshotDiff(formatHTML(base), formatHTML(update), {
-    stablePatchmarks: true, // Avoid line numbers in diff, so that diffs are stable against irrelevant changes
-    aAnnotation: baseAnnotation,
-    bAnnotation: updateAnnotation,
+  return diff({
+    base: formatHTML(base),
+    update: formatHTML(update),
+    baseAnnotation,
+    updateAnnotation,
   });
 }
 
-export function diffShallow({
+export function diff({
   base,
   update,
   baseAnnotation,

--- a/frontend/src/components/SideNav.test.tsx
+++ b/frontend/src/components/SideNav.test.tsx
@@ -17,13 +17,12 @@
 import * as React from 'react';
 
 import SideNav, { css } from './SideNav';
-import TestUtils from '../TestUtils';
+import TestUtils, { diffShallow } from '../TestUtils';
 import { Apis } from '../lib/Apis';
 import { LocalStorage } from '../lib/LocalStorage';
 import { ReactWrapper, ShallowWrapper, shallow } from 'enzyme';
 import { RoutePage } from './Router';
 import { RouterProps } from 'react-router';
-import snapshotDiff from 'snapshot-diff';
 
 const wideWidth = 1000;
 const narrowWidth = 200;
@@ -259,10 +258,36 @@ describe('SideNav', () => {
     buildInfoSpy.mockImplementationOnce(() => Promise.reject('Error when fetching build info'));
 
     tree = shallow(<SideNav page={RoutePage.PIPELINES} {...routerProps} />);
-    const baseTree = tree.debug();
+    const base = tree.debug();
     await TestUtils.flushPromises();
     tree.update();
-    expect(snapshotDiff(baseTree, tree.debug())).toMatchSnapshot();
+    expect(diffShallow({ base, update: tree.debug() })).toMatchInlineSnapshot(`
+      Snapshot Diff:
+      - Expected
+      + Received
+
+      @@ --- --- @@
+            <WithStyles(IconButton) className="chevron" onClick={[Function: bound _toggleNavClicked]}>
+              <pure(ChevronLeftIcon) />
+            </WithStyles(IconButton)>
+          </div>
+          <div className="infoVisible">
+      +     <WithStyles(Tooltip) title="Cluster name: some-cluster-name, Project ID: some-project-id" enterDelay={300} placement="top-start">
+      +       <div className="envMetadata">
+      +         <span>
+      +           Cluster name: 
+      +         </span>
+      +         <a href="https://console.cloud.google.com/kubernetes/list?project=some-project-id&filter=name:some-cluster-name" className="link unstyled" rel="noopener" target="_blank">
+      +           some-cluster-name
+      +         </a>
+      +       </div>
+      +     </WithStyles(Tooltip)>
+            <WithStyles(Tooltip) title="Report an Issue" enterDelay={300} placement="top-start">
+              <div className="envMetadata">
+                <a href="https://github.com/kubeflow/pipelines/issues/new?template=BUG_REPORT.md" className="link unstyled" rel="noopener" target="_blank">
+                  Report an Issue
+                </a>
+    `);
   });
 
   it('displays the frontend commit hash if the api server hash is not returned', async () => {

--- a/frontend/src/components/SideNav.test.tsx
+++ b/frontend/src/components/SideNav.test.tsx
@@ -275,7 +275,7 @@ describe('SideNav', () => {
       +     <WithStyles(Tooltip) title="Cluster name: some-cluster-name, Project ID: some-project-id" enterDelay={300} placement="top-start">
       +       <div className="envMetadata">
       +         <span>
-      +           Cluster name:
+      +           Cluster name: 
       +         </span>
       +         <a href="https://console.cloud.google.com/kubernetes/list?project=some-project-id&filter=name:some-cluster-name" className="link unstyled" rel="noopener" target="_blank">
       +           some-cluster-name

--- a/frontend/src/components/SideNav.test.tsx
+++ b/frontend/src/components/SideNav.test.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 
 import SideNav, { css } from './SideNav';
-import TestUtils, { diffShallow } from '../TestUtils';
+import TestUtils, { diff } from '../TestUtils';
 import { Apis } from '../lib/Apis';
 import { LocalStorage } from '../lib/LocalStorage';
 import { ReactWrapper, ShallowWrapper, shallow } from 'enzyme';
@@ -261,7 +261,7 @@ describe('SideNav', () => {
     const base = tree.debug();
     await TestUtils.flushPromises();
     tree.update();
-    expect(diffShallow({ base, update: tree.debug() })).toMatchInlineSnapshot(`
+    expect(diff({ base, update: tree.debug() })).toMatchInlineSnapshot(`
       Snapshot Diff:
       - Expected
       + Received
@@ -275,7 +275,7 @@ describe('SideNav', () => {
       +     <WithStyles(Tooltip) title="Cluster name: some-cluster-name, Project ID: some-project-id" enterDelay={300} placement="top-start">
       +       <div className="envMetadata">
       +         <span>
-      +           Cluster name: 
+      +           Cluster name:
       +         </span>
       +         <a href="https://console.cloud.google.com/kubernetes/list?project=some-project-id&filter=name:some-cluster-name" className="link unstyled" rel="noopener" target="_blank">
       +           some-cluster-name

--- a/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
@@ -1,33 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SideNav populates the cluster information using the response from the system endpoints 1`] = `
-"Snapshot Diff:
-- First value
-+ Second value
-
-@@ -64,10 +64,20 @@
-      <WithStyles(IconButton) className=\\"chevron\\" onClick={[Function: bound _toggleNavClicked]}>
-        <pure(ChevronLeftIcon) />
-      </WithStyles(IconButton)>
-    </div>
-    <div className=\\"infoVisible\\">
-+     <WithStyles(Tooltip) title=\\"Cluster name: some-cluster-name, Project ID: some-project-id\\" enterDelay={300} placement=\\"top-start\\">
-+       <div className=\\"envMetadata\\">
-+         <span>
-+           Cluster name: 
-+         </span>
-+         <a href=\\"https://console.cloud.google.com/kubernetes/list?project=some-project-id&filter=name:some-cluster-name\\" className=\\"link unstyled\\" rel=\\"noopener\\" target=\\"_blank\\">
-+           some-cluster-name
-+         </a>
-+       </div>
-+     </WithStyles(Tooltip)>
-      <WithStyles(Tooltip) title=\\"Report an Issue\\" enterDelay={300} placement=\\"top-start\\">
-        <div className=\\"envMetadata\\">
-          <a href=\\"https://github.com/kubeflow/pipelines/issues/new?template=BUG_REPORT.md\\" className=\\"link unstyled\\" rel=\\"noopener\\" target=\\"_blank\\">
-            Report an Issue
-          </a>"
-`;
-
 exports[`SideNav populates the display build information using the response from the healthz endpoint 1`] = `
 <div
   className="root flexColumn noShrink"

--- a/frontend/src/components/viewers/Tensorboard.test.tsx
+++ b/frontend/src/components/viewers/Tensorboard.test.tsx
@@ -16,11 +16,10 @@
 
 import * as React from 'react';
 import TensorboardViewer from './Tensorboard';
-import TestUtils from '../../TestUtils';
+import TestUtils, { diffShallow } from '../../TestUtils';
 import { Apis } from '../../lib/Apis';
 import { PlotType } from './Viewer';
 import { ReactWrapper, ShallowWrapper, shallow, mount } from 'enzyme';
-import snapshotDiff from 'snapshot-diff';
 
 describe('Tensorboard', () => {
   let tree: ReactWrapper | ShallowWrapper;
@@ -50,10 +49,26 @@ describe('Tensorboard', () => {
     const getAppMock = () => Promise.resolve({ podAddress: '', tfVersion: '' });
     jest.spyOn(Apis, 'getTensorboardApp').mockImplementation(getAppMock);
     tree = shallow(<TensorboardViewer configs={[]} />);
-    const baseTree = tree.debug();
+    const base = tree.debug();
 
     await TestUtils.flushPromises();
-    expect(snapshotDiff(tree.debug(), baseTree)).toMatchSnapshot();
+    expect(diffShallow({ base, update: tree.debug() })).toMatchInlineSnapshot(`
+      Snapshot Diff:
+      - Expected
+      + Received
+
+      @@ --- --- @@
+                  </WithStyles(MenuItem)>
+                </WithStyles(WithFormControlContext(Select))>
+              </WithStyles(FormControl)>
+            </div>
+            <div>
+      -       <BusyButton className="buttonAction" disabled={false} onClick={[Function]} busy={true} title="Start Tensorboard" />
+      +       <BusyButton className="buttonAction" disabled={false} onClick={[Function]} busy={false} title="Start Tensorboard" />
+            </div>
+          </div>
+        </div>
+    `);
   });
 
   it('does not break on empty data', async () => {
@@ -61,10 +76,26 @@ describe('Tensorboard', () => {
     jest.spyOn(Apis, 'getTensorboardApp').mockImplementation(getAppMock);
     const config = { type: PlotType.TENSORBOARD, url: '' };
     tree = shallow(<TensorboardViewer configs={[config]} />);
-    const baseTree = tree.debug();
+    const base = tree.debug();
 
     await TestUtils.flushPromises();
-    expect(snapshotDiff(tree.debug(), baseTree)).toMatchSnapshot();
+    expect(diffShallow({ base, update: tree.debug() })).toMatchInlineSnapshot(`
+      Snapshot Diff:
+      - Expected
+      + Received
+
+      @@ --- --- @@
+                  </WithStyles(MenuItem)>
+                </WithStyles(WithFormControlContext(Select))>
+              </WithStyles(FormControl)>
+            </div>
+            <div>
+      -       <BusyButton className="buttonAction" disabled={false} onClick={[Function]} busy={true} title="Start Tensorboard" />
+      +       <BusyButton className="buttonAction" disabled={false} onClick={[Function]} busy={false} title="Start Tensorboard" />
+            </div>
+          </div>
+        </div>
+    `);
   });
 
   it('shows a link to the tensorboard instance if exists', async () => {
@@ -82,10 +113,26 @@ describe('Tensorboard', () => {
     const getAppMock = () => Promise.resolve({ podAddress: '', tfVersion: '' });
     const spy = jest.spyOn(Apis, 'getTensorboardApp').mockImplementation(getAppMock);
     tree = shallow(<TensorboardViewer configs={[config]} />);
-    const baseTree = tree.debug();
+    const base = tree.debug();
 
     await TestUtils.flushPromises();
-    expect(snapshotDiff(tree.debug(), baseTree)).toMatchSnapshot();
+    expect(diffShallow({ base, update: tree.debug() })).toMatchInlineSnapshot(`
+      Snapshot Diff:
+      - Expected
+      + Received
+
+      @@ --- --- @@
+                  </WithStyles(MenuItem)>
+                </WithStyles(WithFormControlContext(Select))>
+              </WithStyles(FormControl)>
+            </div>
+            <div>
+      -       <BusyButton className="buttonAction" disabled={false} onClick={[Function]} busy={true} title="Start Tensorboard" />
+      +       <BusyButton className="buttonAction" disabled={false} onClick={[Function]} busy={false} title="Start Tensorboard" />
+            </div>
+          </div>
+        </div>
+    `);
     expect(spy).toHaveBeenCalledWith(config.url);
   });
 

--- a/frontend/src/components/viewers/Tensorboard.test.tsx
+++ b/frontend/src/components/viewers/Tensorboard.test.tsx
@@ -16,7 +16,7 @@
 
 import * as React from 'react';
 import TensorboardViewer from './Tensorboard';
-import TestUtils, { diffShallow } from '../../TestUtils';
+import TestUtils, { diff } from '../../TestUtils';
 import { Apis } from '../../lib/Apis';
 import { PlotType } from './Viewer';
 import { ReactWrapper, ShallowWrapper, shallow, mount } from 'enzyme';
@@ -52,7 +52,7 @@ describe('Tensorboard', () => {
     const base = tree.debug();
 
     await TestUtils.flushPromises();
-    expect(diffShallow({ base, update: tree.debug() })).toMatchInlineSnapshot(`
+    expect(diff({ base, update: tree.debug() })).toMatchInlineSnapshot(`
       Snapshot Diff:
       - Expected
       + Received
@@ -79,7 +79,7 @@ describe('Tensorboard', () => {
     const base = tree.debug();
 
     await TestUtils.flushPromises();
-    expect(diffShallow({ base, update: tree.debug() })).toMatchInlineSnapshot(`
+    expect(diff({ base, update: tree.debug() })).toMatchInlineSnapshot(`
       Snapshot Diff:
       - Expected
       + Received
@@ -116,7 +116,7 @@ describe('Tensorboard', () => {
     const base = tree.debug();
 
     await TestUtils.flushPromises();
-    expect(diffShallow({ base, update: tree.debug() })).toMatchInlineSnapshot(`
+    expect(diff({ base, update: tree.debug() })).toMatchInlineSnapshot(`
       Snapshot Diff:
       - Expected
       + Received

--- a/frontend/src/components/viewers/__snapshots__/Tensorboard.test.tsx.snap
+++ b/frontend/src/components/viewers/__snapshots__/Tensorboard.test.tsx.snap
@@ -111,42 +111,6 @@ exports[`Tensorboard base component snapshot 1`] = `
 </div>
 `;
 
-exports[`Tensorboard does not break on empty data 1`] = `
-"Snapshot Diff:
-- First value
-+ Second value
-
-@@ -53,9 +53,9 @@
-            </WithStyles(MenuItem)>
-          </WithStyles(WithFormControlContext(Select))>
-        </WithStyles(FormControl)>
-      </div>
-      <div>
--       <BusyButton className=\\"buttonAction\\" disabled={false} onClick={[Function]} busy={false} title=\\"Start Tensorboard\\" />
-+       <BusyButton className=\\"buttonAction\\" disabled={false} onClick={[Function]} busy={true} title=\\"Start Tensorboard\\" />
-      </div>
-    </div>
-  </div>"
-`;
-
-exports[`Tensorboard does not break on no config 1`] = `
-"Snapshot Diff:
-- First value
-+ Second value
-
-@@ -53,9 +53,9 @@
-            </WithStyles(MenuItem)>
-          </WithStyles(WithFormControlContext(Select))>
-        </WithStyles(FormControl)>
-      </div>
-      <div>
--       <BusyButton className=\\"buttonAction\\" disabled={false} onClick={[Function]} busy={false} title=\\"Start Tensorboard\\" />
-+       <BusyButton className=\\"buttonAction\\" disabled={false} onClick={[Function]} busy={true} title=\\"Start Tensorboard\\" />
-      </div>
-    </div>
-  </div>"
-`;
-
 exports[`Tensorboard shows a link to the tensorboard instance if exists 1`] = `
 <div>
   <div>
@@ -217,22 +181,4 @@ exports[`Tensorboard shows a link to the tensorboard instance if exists 1`] = `
     </div>
   </div>
 </div>
-`;
-
-exports[`Tensorboard shows start button if no instance exists 1`] = `
-"Snapshot Diff:
-- First value
-+ Second value
-
-@@ -53,9 +53,9 @@
-            </WithStyles(MenuItem)>
-          </WithStyles(WithFormControlContext(Select))>
-        </WithStyles(FormControl)>
-      </div>
-      <div>
--       <BusyButton className=\\"buttonAction\\" disabled={false} onClick={[Function]} busy={false} title=\\"Start Tensorboard\\" />
-+       <BusyButton className=\\"buttonAction\\" disabled={false} onClick={[Function]} busy={true} title=\\"Start Tensorboard\\" />
-      </div>
-    </div>
-  </div>"
 `;

--- a/frontend/src/pages/GettingStarted.test.tsx
+++ b/frontend/src/pages/GettingStarted.test.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { GettingStarted } from './GettingStarted';
-import TestUtils, { formatHTML } from '../TestUtils';
+import TestUtils, { diffHTML } from '../TestUtils';
 import { render } from '@testing-library/react';
 import { PageProps } from './Page';
 import { Apis } from '../lib/Apis';
 import { ApiListPipelinesResponse } from '../apis/pipeline/api';
-import snapshotDiff from 'snapshot-diff';
 
 const PATH_BACKEND_CONFIG = '../../../backend/src/apiserver/config/sample_config.json';
 const PATH_FRONTEND_CONFIG = '../config/sample_config_from_backend.json';
@@ -60,12 +59,75 @@ describe('GettingStarted page', () => {
       return Promise.resolve(response);
     });
     const { container } = render(<GettingStarted {...generateProps()} />);
-    const initialHtml = container.innerHTML;
+    const base = container.innerHTML;
     await TestUtils.flushPromises();
     expect(pipelineListSpy.mock.calls).toMatchSnapshot();
-    expect(
-      snapshotDiff(formatHTML(initialHtml), formatHTML(container.innerHTML)),
-    ).toMatchSnapshot();
+    expect(diffHTML({ base, update: container.innerHTML })).toMatchInlineSnapshot(`
+      Snapshot Diff:
+      - Expected
+      + Received
+
+      @@ --- --- @@
+            <h2 id="demonstrations-and-tutorials">Demonstrations and Tutorials</h2>
+            <p>This section contains demo and tutorial pipelines.</p>
+            <p><strong>Demos</strong> - Try an end-to-end demonstration pipeline.</p>
+            <ul>
+              <li>
+      -         <a href="#/pipelines" class="link">TFX pipeline demo</a>
+      +         <a href="#/pipelines/details/pipeline-id-2?" class="link"
+      +           >TFX pipeline demo</a
+      +         >
+                <ul>
+                  <li>
+                    Classification pipeline with model analysis, based on a public
+                    BigQuery dataset of taxicab trips.
+                    <a
+      @@ --- --- @@
+                    >
+                  </li>
+                </ul>
+              </li>
+              <li>
+      -         <a href="#/pipelines" class="link">XGBoost Pipeline demo</a>
+      +         <a href="#/pipelines/details/pipeline-id-1?" class="link"
+      +           >XGBoost Pipeline demo</a
+      +         >
+                <ul>
+                  <li>
+                    An example of end-to-end distributed training for an XGBoost model.
+                    <a
+                      href="https://github.com/kubeflow/pipelines/tree/master/samples/core/xgboost_training_cm"
+      @@ --- --- @@
+              <strong>Tutorials</strong> - Learn pipeline concepts by following a
+              tutorial.
+            </p>
+            <ul>
+              <li>
+      -         <a href="#/pipelines" class="link">Data passing in python components</a>
+      +         <a href="#/pipelines/details/pipeline-id-3?" class="link"
+      +           >Data passing in python components</a
+      +         >
+                <ul>
+                  <li>
+                    Shows how to pass data between python components.
+                    <a
+                      href="https://github.com/kubeflow/pipelines/tree/master/samples/tutorials/Data%20passing%20in%20python%20components"
+      @@ --- --- @@
+                    >
+                  </li>
+                </ul>
+              </li>
+              <li>
+      -         <a href="#/pipelines" class="link">DSL - Control structures</a>
+      +         <a href="#/pipelines/details/pipeline-id-4?" class="link"
+      +           >DSL - Control structures</a
+      +         >
+                <ul>
+                  <li>
+                    Shows how to use conditional execution and exit handlers.
+                    <a
+                      href="https://github.com/kubeflow/pipelines/tree/master/samples/tutorials/DSL%20-%20Control%20structures"
+    `);
   });
 
   it('fallbacks to show pipeline list page if request failed', async () => {
@@ -89,10 +151,28 @@ describe('GettingStarted page', () => {
       },
     );
     const { container } = render(<GettingStarted {...generateProps()} />);
-    const initialHtml = container.innerHTML;
+    const base = container.innerHTML;
     await TestUtils.flushPromises();
-    expect(
-      snapshotDiff(formatHTML(initialHtml), formatHTML(container.innerHTML)),
-    ).toMatchSnapshot();
+    expect(diffHTML({ base, update: container.innerHTML })).toMatchInlineSnapshot(`
+      Snapshot Diff:
+      - Expected
+      + Received
+
+      @@ --- --- @@
+                    >
+                  </li>
+                </ul>
+              </li>
+              <li>
+      -         <a href="#/pipelines" class="link">DSL - Control structures</a>
+      +         <a href="#/pipelines/details/pipeline-id-4?" class="link"
+      +           >DSL - Control structures</a
+      +         >
+                <ul>
+                  <li>
+                    Shows how to use conditional execution and exit handlers.
+                    <a
+                      href="https://github.com/kubeflow/pipelines/tree/master/samples/tutorials/DSL%20-%20Control%20structures"
+    `);
   });
 });

--- a/frontend/src/pages/__snapshots__/GettingStarted.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/GettingStarted.test.tsx.snap
@@ -1,27 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GettingStarted page fallbacks to show pipeline list page if request failed 1`] = `
-"Snapshot Diff:
-- First value
-+ Second value
-
-@@ -70,11 +70,13 @@
-              >
-            </li>
-          </ul>
-        </li>
-        <li>
--         <a href=\\"#/pipelines\\" class=\\"link\\">DSL - Control structures</a>
-+         <a href=\\"#/pipelines/details/pipeline-id-4?\\" class=\\"link\\"
-+           >DSL - Control structures</a
-+         >
-          <ul>
-            <li>
-              Shows how to use conditional execution and exit handlers.
-              <a
-                href=\\"https://github.com/kubeflow/pipelines/tree/master/samples/tutorials/DSL%20-%20Control%20structures\\""
-`;
-
 exports[`GettingStarted page initially renders documentation 1`] = `
 <div>
   <div
@@ -253,71 +231,4 @@ Array [
     "%7B%22predicates%22%3A%5B%7B%22key%22%3A%22name%22%2C%22op%22%3A%22EQUALS%22%2C%22string_value%22%3A%22%5BTutorial%5D%20DSL%20-%20Control%20structures%22%7D%5D%7D",
   ],
 ]
-`;
-
-exports[`GettingStarted page renders documentation with pipeline deep link after querying demo pipelines 2`] = `
-"Snapshot Diff:
-- First value
-+ Second value
-
-@@ -17,11 +17,13 @@
-      <h2 id=\\"demonstrations-and-tutorials\\">Demonstrations and Tutorials</h2>
-      <p>This section contains demo and tutorial pipelines.</p>
-      <p><strong>Demos</strong> - Try an end-to-end demonstration pipeline.</p>
-      <ul>
-        <li>
--         <a href=\\"#/pipelines\\" class=\\"link\\">TFX pipeline demo</a>
-+         <a href=\\"#/pipelines/details/pipeline-id-2?\\" class=\\"link\\"
-+           >TFX pipeline demo</a
-+         >
-          <ul>
-            <li>
-              Classification pipeline with model analysis, based on a public
-              BigQuery dataset of taxicab trips.
-              <a
-@@ -33,11 +35,13 @@
-              >
-            </li>
-          </ul>
-        </li>
-        <li>
--         <a href=\\"#/pipelines\\" class=\\"link\\">XGBoost Pipeline demo</a>
-+         <a href=\\"#/pipelines/details/pipeline-id-1?\\" class=\\"link\\"
-+           >XGBoost Pipeline demo</a
-+         >
-          <ul>
-            <li>
-              An example of end-to-end distributed training for an XGBoost model.
-              <a
-                href=\\"https://github.com/kubeflow/pipelines/tree/master/samples/core/xgboost_training_cm\\"
-@@ -55,11 +59,13 @@
-        <strong>Tutorials</strong> - Learn pipeline concepts by following a
-        tutorial.
-      </p>
-      <ul>
-        <li>
--         <a href=\\"#/pipelines\\" class=\\"link\\">Data passing in python components</a>
-+         <a href=\\"#/pipelines/details/pipeline-id-3?\\" class=\\"link\\"
-+           >Data passing in python components</a
-+         >
-          <ul>
-            <li>
-              Shows how to pass data between python components.
-              <a
-                href=\\"https://github.com/kubeflow/pipelines/tree/master/samples/tutorials/Data%20passing%20in%20python%20components\\"
-@@ -70,11 +76,13 @@
-              >
-            </li>
-          </ul>
-        </li>
-        <li>
--         <a href=\\"#/pipelines\\" class=\\"link\\">DSL - Control structures</a>
-+         <a href=\\"#/pipelines/details/pipeline-id-4?\\" class=\\"link\\"
-+           >DSL - Control structures</a
-+         >
-          <ul>
-            <li>
-              Shows how to use conditional execution and exit handlers.
-              <a
-                href=\\"https://github.com/kubeflow/pipelines/tree/master/samples/tutorials/DSL%20-%20Control%20structures\\""
 `;


### PR DESCRIPTION
Changes:
1. Use inline snapshots
2. Configure snapshot-diff to remove line number
3. Configure snapshot-diff to remove escaped characters
4. Common test utils for diffing HTML and shallow

Best practices:
1. Only use inline snapshots (this makes snapshots easier to read when reading tests, also it's clear when a snapshot is too long)
2. Avoid long snapshots, use snapshot diff or non-snapshot testing instead

This PR is aligned with https://kentcdodds.com/blog/effective-snapshot-testing/

/area frontend
/area engprod
Part of #2407 
Unblocks https://github.com/kubeflow/pipelines/issues/2652

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3166)
<!-- Reviewable:end -->
