### PR TITLE
minio: Set secure=true to enable TLS by default

### DIFF
--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -324,7 +324,7 @@ func initMinioClient(initConnectionTimeout time.Duration) storage.ObjectStoreInt
 	minioServiceRegion := common.GetStringConfigWithDefault(
 		"ObjectStoreConfig.Region", os.Getenv(minioServiceRegion))
 	minioServiceSecure := common.GetBoolConfigWithDefault(
-		"ObjectStoreConfig.Secure", common.GetBoolFromStringWithDefault(os.Getenv(minioServiceSecure), false))
+		"ObjectStoreConfig.Secure", common.GetBoolFromStringWithDefault(os.Getenv(minioServiceSecure), true))
 	accessKey := common.GetStringConfigWithDefault("ObjectStoreConfig.AccessKey", "")
 	secretKey := common.GetStringConfigWithDefault("ObjectStoreConfig.SecretAccessKey", "")
 	bucketName := common.GetStringConfigWithDefault("ObjectStoreConfig.BucketName", os.Getenv(pipelineBucketName))

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
@@ -666,6 +666,8 @@ spec:
             {{ if .Values.managedstorage.enabled }}
             - name: OBJECTSTORECONFIG_BUCKETNAME
               value: '{{ tpl .Values.managedstorage.gcsBucketName . }}'
+            - name: OBJECTSTORECONFIG_SECURE
+              value: "false"
             - name: DBCONFIG_DBNAME
               {{ if .Values.managedstorage.databaseNamePrefix }}
               value: '{{ .Values.managedstorage.databaseNamePrefix }}_pipeline'

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -19,6 +19,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: OBJECTSTORECONFIG_SECURE
+          value: "false"
         image: gcr.io/ml-pipeline/api-server:0.1.27
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-api-server


### PR DESCRIPTION
Not using TLS is a security concern, especially if using cloud storage
like S3. This should be set to secure to avoid people unknowingly not
using TLS.

To make the bundled minio still work, I've submitted
https://github.com/kubeflow/manifests/pull/950 to set secure=false in
this case explicitly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3168)
<!-- Reviewable:end -->
