### PR TITLE
Upload pipeline version return a response with enum as string

### DIFF
--- a/backend/src/apiserver/server/pipeline_upload_server.go
+++ b/backend/src/apiserver/server/pipeline_upload_server.go
@@ -81,7 +81,7 @@ func (s *PipelineUploadServer) UploadPipeline(w http.ResponseWriter, r *http.Req
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	marshaler := &jsonpb.Marshaler{EnumsAsInts: true, OrigName: true}
+	marshaler := &jsonpb.Marshaler{EnumsAsInts: false, OrigName: true}
 	err = marshaler.Marshal(w, ToApiPipeline(newPipeline))
 	if err != nil {
 		s.writeErrorToResponse(w, http.StatusInternalServerError, util.Wrap(err, "Error creating pipeline"))
@@ -143,7 +143,7 @@ func (s *PipelineUploadServer) UploadPipelineVersion(w http.ResponseWriter, r *h
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	marshaler := &jsonpb.Marshaler{EnumsAsInts: true, OrigName: true}
+	marshaler := &jsonpb.Marshaler{EnumsAsInts: false, OrigName: true}
 	createdPipelineVersion, err := ToApiPipelineVersion(newPipelineVersion)
 	if err != nil {
 		s.writeErrorToResponse(w, http.StatusInternalServerError, util.Wrap(err, "Error creating pipeline version"))


### PR DESCRIPTION
Our api client assumes the enum being string e.g. https://github.com/kubeflow/pipelines/blob/master/backend/api/go_http_client/pipeline_upload_model/api_resource_type.go
So when we populate the response, we need to treat enum as string instead of int, in order for our api client to parse it correctly.

Needed to unblock another PR at https://github.com/kubeflow/pipelines/pull/3174

Tested on my own KFP instance with latest image at https://pantheon.corp.google.com/kubernetes/deployment/us-central1-a/kubeflow-pipelines-standalone/kubeflow/ml-pipeline?project=jingzhangjz-project&organizationId=433637338589&tab=overview&deployment_overview_active_revisions_tablesize=50&duration=PT1H&pod_summary_list_tablesize=20&service_list_datatablesize=20

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3171)
<!-- Reviewable:end -->
