### PR TITLE
[Frontend] Unpin notebook permalink when release

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 WORKDIR ./frontend
 
 # Pin getting started page links to the commit that built the frontend image
-RUN sed -E "s#/(blob|tree)/master/#/\1/${COMMIT_HASH}/#g" -i src/pages/GettingStarted.tsx
+RUN sed -E "s#/(blob|tree)/master/#/\1/${COMMIT_HASH}/#g" -i src/pages/GettingStarted.tsx && \
     sed -E "s#/(blob|tree)/master/#/\1/${COMMIT_HASH}/#g" -i src/pages/GettingStarted.test.tsx
 
 RUN npm ci && npm run postinstall

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,10 +12,8 @@ COPY . .
 WORKDIR ./frontend
 
 # Pin getting started page links to the commit that built the frontend image
-RUN sed -E "s#/(blob|tree)/master/#/\1/${COMMIT_HASH}/#g" -i src/pages/GettingStarted.tsx && \
-    sed -E "s/%252Fmaster/%252F${COMMIT_HASH}/#g" -i src/pages/GettingStarted.tsx && \
-    sed -E "s#/(blob|tree)/master/#/\1/${COMMIT_HASH}/#g" -i src/pages/GettingStarted.test.tsx && \
-    sed -E "s/%252Fmaster/%252F${COMMIT_HASH}/#g" -i src/pages/GettingStarted.test.tsx
+RUN sed -E "s#/(blob|tree)/master/#/\1/${COMMIT_HASH}/#g" -i src/pages/GettingStarted.tsx
+    sed -E "s#/(blob|tree)/master/#/\1/${COMMIT_HASH}/#g" -i src/pages/GettingStarted.test.tsx
 
 RUN npm ci && npm run postinstall
 RUN npm run build


### PR DESCRIPTION
Previously we pin the link due to the existence of the TFX demo notebook, which located in KFP's repo. 

However, it's actually redundant and problematic now b/c we no longer use that anymore, and it mistakenly replace the link for the TFX template notebook, causing 404 when CAIP notebook attempting to load it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3183)
<!-- Reviewable:end -->
