### PR TITLE
[Backend][Multi-user] Add 'Namespace' to Experiment data model

### DIFF
--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -214,6 +214,11 @@ func initDBClient(initConnectionTimeout time.Duration) *storage.DB {
 		glog.Fatalf("Failed to initialize the databases.")
 	}
 
+	response = db.Model(&model.Experiment{}).RemoveIndex("Name")
+	if response.Error != nil {
+		glog.Fatalf("Failed to drop unique key on experiment name. Error: %s", response.Error)
+	}
+
 	response = db.Model(&model.ResourceReference{}).ModifyColumn("Payload", "longtext not null")
 	if response.Error != nil {
 		glog.Fatalf("Failed to update the resource reference payload type. Error: %s", response.Error)

--- a/backend/src/apiserver/model/experiment.go
+++ b/backend/src/apiserver/model/experiment.go
@@ -2,9 +2,10 @@ package model
 
 type Experiment struct {
 	UUID           string `gorm:"column:UUID; not null; primary_key"`
-	Name           string `gorm:"column:Name; not null; unique"`
+	Name           string `gorm:"column:Name; not null; unique_index:idx_name_namespace"`
 	Description    string `gorm:"column:Description; not null"`
 	CreatedAtInSec int64  `gorm:"column:CreatedAtInSec; not null"`
+	Namespace      string `gorm:"column:Namespace; not null; unique_index:idx_name_namespace"`
 }
 
 func (e Experiment) GetValueOfPrimaryKey() string {
@@ -30,6 +31,7 @@ var experimentAPIToModelFieldMap = map[string]string{
 	"name":        "Name",
 	"created_at":  "CreatedAtInSec",
 	"description": "Description",
+	"namespace":   "Namespace",
 }
 
 // APIToModelFieldMap returns a map from API names to field names for model

--- a/backend/src/apiserver/storage/experiment_store.go
+++ b/backend/src/apiserver/storage/experiment_store.go
@@ -123,17 +123,18 @@ func (s *ExperimentStore) GetExperiment(uuid string) (*model.Experiment, error) 
 func (s *ExperimentStore) scanRows(rows *sql.Rows) ([]*model.Experiment, error) {
 	var experiments []*model.Experiment
 	for rows.Next() {
-		var uuid, name, description string
+		var uuid, name, description, namespace string
 		var createdAtInSec int64
-		err := rows.Scan(&uuid, &name, &description, &createdAtInSec)
+		err := rows.Scan(&uuid, &name, &description, &createdAtInSec, &namespace)
 		if err != nil {
-			return experiments, nil
+			return experiments, err
 		}
 		experiments = append(experiments, &model.Experiment{
 			UUID:           uuid,
 			Name:           name,
 			Description:    description,
 			CreatedAtInSec: createdAtInSec,
+			Namespace:      namespace,
 		})
 	}
 	return experiments, nil
@@ -150,12 +151,13 @@ func (s *ExperimentStore) CreateExperiment(experiment *model.Experiment) (*model
 	newExperiment.UUID = id.String()
 	sql, args, err := sq.
 		Insert("experiments").
-		SetMap(
-			sq.Eq{
-				"UUID":           newExperiment.UUID,
-				"CreatedAtInSec": newExperiment.CreatedAtInSec,
-				"Name":           newExperiment.Name,
-				"Description":    newExperiment.Description}).
+		SetMap(sq.Eq{
+			"UUID":           newExperiment.UUID,
+			"CreatedAtInSec": newExperiment.CreatedAtInSec,
+			"Name":           newExperiment.Name,
+			"Description":    newExperiment.Description,
+			"Namespace":      newExperiment.Namespace,
+		}).
 		ToSql()
 	if err != nil {
 		return nil, util.NewInternalServerError(err, "Failed to create query to insert experiment to experiment table: %v",
@@ -165,7 +167,7 @@ func (s *ExperimentStore) CreateExperiment(experiment *model.Experiment) (*model
 	if err != nil {
 		if s.db.IsDuplicateError(err) {
 			return nil, util.NewInvalidInputError(
-				"Failed to create a new experiment. The name %v already exist. Please specify a new name.", experiment.Name)
+				"Failed to create a new experiment. The name %v already exists. Please specify a new name.", experiment.Name)
 		}
 		return nil, util.NewInternalServerError(err, "Failed to add experiment to experiment table: %v",
 			err.Error())
@@ -209,9 +211,9 @@ func (s *ExperimentStore) DeleteExperiment(id string) error {
 // factory function for experiment store
 func NewExperimentStore(db *DB, time util.TimeInterface, uuid util.UUIDGeneratorInterface) *ExperimentStore {
 	return &ExperimentStore{
-		db:   db,
-		time: time,
-		uuid: uuid,
+		db:                     db,
+		time:                   time,
+		uuid:                   uuid,
 		resourceReferenceStore: NewResourceReferenceStore(db),
 		defaultExperimentStore: NewDefaultExperimentStore(db),
 	}


### PR DESCRIPTION
Experiment data model changes:

* Add `Namespace` column to `experiments` table.
* Change experiment `Name` from globally unique to unique within a namespace.
* Fix a bug where errors weren't propagated from ExperimentStore scanRows method.

/cc @IronPan @Bobgy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3184)
<!-- Reviewable:end -->
