### PR TITLE
[Tutorial] - Fixed lightweight component tutorial with bad metadata usage

### DIFF
--- a/samples/tutorials/mnist/00_Kubeflow_Cluster_Setup.ipynb
+++ b/samples/tutorials/mnist/00_Kubeflow_Cluster_Setup.ipynb
@@ -114,6 +114,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**If you are using AI Platform Notebooks**, your environment is already authenticated. Skip the following cell."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/samples/tutorials/mnist/01_Lightweight_Python_Components.ipynb
+++ b/samples/tutorials/mnist/01_Lightweight_Python_Components.ipynb
@@ -186,9 +186,10 @@
     "from typing import NamedTuple\n",
     "\n",
     "def my_divmod(dividend: float, \n",
-    "              divisor: float, \n",
-    "              output_dir: str = './'\n",
-    "             ) -> NamedTuple('MyDivmodOutput', [('quotient', float), ('remainder', float)]):\n",
+    "              divisor: float,\n",
+    "             ) -> NamedTuple('MyDivmodOutput', [('quotient', float), ('remainder', float), \n",
+    "                                                ('mlpipeline_ui_metadata', 'UI_metadata'), \n",
+    "                                                ('mlpipeline_metrics', 'Metrics')]):\n",
     "    \n",
     "    '''Divides two numbers and calculate  the quotient and remainder'''\n",
     "    \n",
@@ -201,7 +202,6 @@
     "\n",
     "    (quotient, remainder) = divmod_helper(dividend, divisor)\n",
     "\n",
-    "    from tensorflow.python.lib.io import file_io\n",
     "    import json\n",
     "    \n",
     "    # Exports a sample tensorboard:\n",
@@ -211,8 +211,6 @@
     "        'source': 'gs://ml-pipeline-dataset/tensorboard-train',\n",
     "      }]\n",
     "    }\n",
-    "    with open(output_dir + 'mlpipeline-ui-metadata.json', 'w') as f:\n",
-    "        json.dump(metadata, f)\n",
     "\n",
     "    # Exports two sample metrics:\n",
     "    metrics = {\n",
@@ -224,12 +222,10 @@
     "          'numberValue':  float(remainder),\n",
     "        }]}\n",
     "\n",
-    "    with file_io.FileIO(output_dir + 'mlpipeline-metrics.json', 'w') as f:\n",
-    "        json.dump(metrics, f)\n",
-    "\n",
     "    from collections import namedtuple\n",
-    "    divmod_output = namedtuple('MyDivmodOutput', ['quotient', 'remainder'])\n",
-    "    return divmod_output(quotient, remainder)"
+    "    divmod_output = namedtuple('MyDivmodOutput', \n",
+    "                               ['quotient', 'remainder', 'mlpipeline_ui_metadata', 'mlpipeline_metrics'])\n",
+    "    return divmod_output(quotient, remainder, json.dumps(metadata), json.dumps(metrics))"
    ]
   },
   {
@@ -247,7 +243,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "divmod_op = comp.func_to_container_op(my_divmod)"
+    "divmod_op = comp.func_to_container_op(func=my_divmod, \n",
+    "                                      base_image=\"tensorflow/tensorflow:1.15.0-py3\")"
    ]
   },
   {
@@ -278,38 +275,10 @@
     "    \n",
     "    #Passing a task output reference as operation arguments\n",
     "    #For an operation with a single return value, the output reference can be accessed using `task.output` or `task.outputs['output_name']` syntax\n",
-    "    divmod_task = divmod_op(add_task.output, b, '/')\n",
+    "    divmod_task = divmod_op(add_task.output, b)\n",
     "\n",
     "    #For an operation with a multiple return values, the output references can be accessed using `task.outputs['output_name']` syntax\n",
     "    result_task = add_op(divmod_task.outputs['quotient'], c)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Compile the pipeline"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pipeline_func = calc_pipeline\n",
-    "pipeline_filename = pipeline_func.__name__ + '.pipeline.zip'\n",
-    "import kfp.compiler as compiler\n",
-    "compiler.Compiler().compile(pipeline_func, pipeline_filename)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! ls ."
    ]
   },
   {
@@ -325,14 +294,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "pipeline_func = calc_pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "experiment_name = 'python-functions'\n",
+    "\n",
     "#Specify pipeline argument values\n",
     "arguments = {'a': '7', 'b': '8'}\n",
     "\n",
-    "experiment = client.create_experiment('python-functions')\n",
-    "\n",
-    "#Submit a pipeline run\n",
     "run_name = pipeline_func.__name__ + ' run'\n",
-    "run_result = client.run_pipeline(experiment.id, run_name, pipeline_filename, arguments)"
+    "\n",
+    "# Submit pipeline directly from pipeline function\n",
+    "run_result = client.create_run_from_pipeline_func(pipeline_func, \n",
+    "                                                  experiment_name=experiment_name, \n",
+    "                                                  run_name=run_name, \n",
+    "                                                  arguments=arguments)"
    ]
   },
   {


### PR DESCRIPTION
- The way of sending metadata output was not updated in https://github.com/kubeflow/pipelines/blob/master/samples/tutorials/mnist/01_Lightweight_Python_Components.ipynb
- Also add an instruction to avoid running "gcloud auth application-default login" on AI Platform notebooks in  https://github.com/kubeflow/pipelines/blob/master/samples/tutorials/mnist/00_Kubeflow_Cluster_Setup.ipynb

Fixes #3182

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3186)
<!-- Reviewable:end -->
