### PR TITLE
remove the magic which update codes only when building a docker image…

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,10 +11,6 @@ COPY . .
 
 WORKDIR ./frontend
 
-# Pin getting started page links to the commit that built the frontend image
-RUN sed -E "s#/(blob|tree)/master/#/\1/${COMMIT_HASH}/#g" -i src/pages/GettingStarted.tsx && \
-    sed -E "s#/(blob|tree)/master/#/\1/${COMMIT_HASH}/#g" -i src/pages/GettingStarted.test.tsx
-
 RUN npm ci && npm run postinstall
 RUN npm run build
 


### PR DESCRIPTION
remove the magic which update codes only when building a docker image with a commit callback

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3188)
<!-- Reviewable:end -->
