### PR TITLE
[Frontend]: Fix SideNav auto collapse logic

### DIFF
--- a/frontend/src/components/SideNav.test.tsx
+++ b/frontend/src/components/SideNav.test.tsx
@@ -219,6 +219,8 @@ describe('SideNav', () => {
     (window as any).innerWidth = narrowWidth;
     const resizeEvent = new Event('resize');
     window.dispatchEvent(resizeEvent);
+
+    await TestUtils.flushPromises();
     expect(isCollapsed(tree)).toBe(true);
   });
 

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -35,7 +35,7 @@ import GitHubIcon from '../icons/GitHub-Mark-120px-plus.png';
 import PipelinesIcon from '../icons/pipelines';
 import { Apis } from '../lib/Apis';
 import { Deployments, KFP_FLAGS } from '../lib/Flags';
-import { LocalStorage, LocalStorageKey } from '../lib/LocalStorage';
+import { LocalStorage } from '../lib/LocalStorage';
 import { logger } from '../lib/Utils';
 import { GkeMetadataContext, GkeMetadata } from 'src/lib/GkeMetadata';
 
@@ -207,7 +207,7 @@ export class SideNav extends React.Component<SideNavInternalProps, SideNavState>
       collapsed,
       // Set jupyterHubAvailable to false so UI don't show Jupyter Hub link
       jupyterHubAvailable: false,
-      manualCollapseState: LocalStorage.hasKey(LocalStorageKey.navbarCollapsed),
+      manualCollapseState: collapsed,
     };
   }
 
@@ -579,7 +579,7 @@ export class SideNav extends React.Component<SideNavInternalProps, SideNavState>
     this.setStateSafe(
       {
         collapsed: !this.state.collapsed,
-        manualCollapseState: true,
+        manualCollapseState: !this.state.collapsed,
       },
       () => LocalStorage.saveNavbarCollapsed(this.state.collapsed),
     );


### PR DESCRIPTION
The previous logic didn't auto collapse SideNav component because the flag remained true always irrespective of whether the user decided to collapse/expand the SideNav.
This breaks the UI when resizing to smaller viewports like that of mobile phones.
This commit fixes the logic by making the auto collapse follow the collapsed state. If the user has decided to collapse the SideNav, it continues to remain collapse but once expanded, it will auto collapse on window resizing.

#### Issue in focus
There are currently no issues related to this. I found out this behavior while playing around with the UI.

#### Visualizing Changes
* Window sized to the infliction point
![Imgur](https://i.imgur.com/pIRG62e.png)
* **Previously** - SideNav doesn't collapse even after reducing the viewport width 
![Imgur](https://i.imgur.com/eVKKCSa.png)
* **After Changes** -SideNav collapses if it's expanded and the window is resized
![Imgur](https://i.imgur.com/oifvv3K.png)

In case there are changes required, please leave a comment and I'll address them asap!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3195)
<!-- Reviewable:end -->
