### PR TITLE
[UI] Get execution name from name field

### DIFF
--- a/frontend/src/pages/ExecutionList.tsx
+++ b/frontend/src/pages/ExecutionList.tsx
@@ -219,7 +219,8 @@ class ExecutionList extends Page<{}, ExecutionListState> {
               getResourceProperty(execution, ExecutionProperties.PIPELINE_NAME) ||
                 getResourceProperty(execution, ExecutionCustomProperties.WORKSPACE, true) ||
                 getResourceProperty(execution, ExecutionCustomProperties.RUN_ID, true),
-              getResourceProperty(execution, ExecutionProperties.COMPONENT_ID) ||
+              getResourceProperty(execution, ExecutionProperties.NAME) ||
+                getResourceProperty(execution, ExecutionProperties.COMPONENT_ID) ||
                 getResourceProperty(execution, ExecutionCustomProperties.TASK_ID, true),
               getResourceProperty(execution, ExecutionProperties.STATE),
               execution.getId(),


### PR DESCRIPTION
/area frontend

The execution name field was not populated by tfx, so I didn't show it in previous implementation.
Fixes https://github.com/kubeflow/pipelines/issues/3109
![3c7fuHKd69d](https://user-images.githubusercontent.com/4957653/75639851-a94fee80-5c6d-11ea-8bca-f3dffb9aae80.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3196)
<!-- Reviewable:end -->

