### PR TITLE
Suspense resume feature - Python SDK part

### DIFF
--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -225,6 +225,17 @@ def _op_to_template(op: BaseOp):
                 processed_op.resource
             )
         }
+    elif isinstance(op, dsl.SuspendOp):
+        # no output artifacts
+        output_artifacts = []
+
+        # workflow template
+        template = {
+            'name': processed_op.name,
+            'suspend': convert_k8s_obj_to_json(
+                op.suspend
+            )
+        }
 
     # inputs
     input_artifact_paths = processed_op.input_artifact_paths if isinstance(processed_op, dsl.ContainerOp) else None
@@ -238,6 +249,9 @@ def _op_to_template(op: BaseOp):
         param_outputs = processed_op.file_outputs
     elif isinstance(op, dsl.ResourceOp):
         param_outputs = processed_op.attribute_outputs
+    elif isinstance(op, dsl.SuspendOp):
+        param_outputs = processed_op.outputs
+
     outputs_dict = _outputs_to_json(op, processed_op.outputs, param_outputs, output_artifacts)
     if outputs_dict:
         template['outputs'] = outputs_dict

--- a/sdk/python/kfp/dsl/__init__.py
+++ b/sdk/python/kfp/dsl/__init__.py
@@ -17,6 +17,7 @@ from ._pipeline_param import PipelineParam, match_serialized_pipelineparam
 from ._pipeline import Pipeline, pipeline, get_pipeline_conf, PipelineConf
 from ._container_op import ContainerOp, InputArgumentPath, UserContainer, Sidecar
 from ._resource_op import ResourceOp
+from ._suspend_op import SuspendOp
 from ._volume_op import (
     VolumeOp, VOLUME_MODE_RWO, VOLUME_MODE_RWM, VOLUME_MODE_ROM
 )

--- a/sdk/python/kfp/dsl/_suspend_op.py
+++ b/sdk/python/kfp/dsl/_suspend_op.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sdk/python/kfp/dsl/_suspend_op.py
+++ b/sdk/python/kfp/dsl/_suspend_op.py
@@ -1,0 +1,91 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Dict, Optional
+
+from ._container_op import BaseOp
+from . import _pipeline_param
+
+
+class Suspend(object):
+    """
+    A wrapper over Argo SuspendTemplate definition object
+    (io.argoproj.workflow.v1alpha1.SuspendTemplate)
+    which is used to represent the `suspend` property in argo's workflow
+    template (io.argoproj.workflow.v1alpha1.Template).
+    """
+    """
+    Attributes:
+      swagger_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    swagger_types = {
+        "duration": "str"
+    }
+    attribute_map = {
+        "duration": "duration"
+    }
+
+    def __init__(self,
+                 duration: str = None):
+        """Create a new instance of Suspend"""
+        self.duration = duration
+
+
+class SuspendOp(BaseOp):
+    """Represents an op which will be translated into a suspend template"""
+
+    def __init__(self,
+                 duration: Optional[int] = None,
+                 **kwargs):
+        """Create a new instance of SuspendOp.
+
+        Args:
+            duration: Amount of time in seconds to wait until automtically resume the workflow.
+                In case of None it will wait for manual resume.
+            kwargs: name, sidecars. See BaseOp definition
+        Raises:
+        ValueError: if not inside a pipeline
+                    if the name is an invalid string
+                    if the duration is set and is not an integer
+        """
+
+        super().__init__(**kwargs)
+        self.attrs_with_pipelineparams = list(self.attrs_with_pipelineparams)
+        self.attrs_with_pipelineparams.extend([
+            "_suspend"
+        ])
+
+        if duration and not isinstance(duration, int):
+            raise ValueError("Duration must be an integer or None.")
+
+        init_suspend = {
+            "duration": str(duration) if duration else ''
+        }
+        # `suspend` prop in `io.argoproj.workflow.v1alpha1.Template`
+        self._suspend = Suspend(**init_suspend)
+
+        self.attribute_outputs = {}
+        self.outputs = {}
+        self.output = None
+
+    @property
+    def suspend(self):
+        """`Suspend` object that represents the `suspend` property in
+        `io.argoproj.workflow.v1alpha1.Template`.
+        """
+        return self._suspend

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -72,6 +72,10 @@ class TestCompiler(unittest.TestCase):
         ),
         attribute_outputs={"out": json}
       )
+      suspend_op = dsl.SuspendOp(
+        name="test-suspend",
+        duration=10
+      )
       golden_output = {
         'container': {
           'image': 'image',
@@ -148,11 +152,18 @@ class TestCompiler(unittest.TestCase):
           )
         }
       }
+      suspend_output = {
+        'name': 'test-suspend',
+        'suspend': {
+          'duration': '10'
+        }
+      }
 
       self.maxDiff = None
       self.assertEqual(golden_output, compiler._op_to_template._op_to_template(op))
       self.assertEqual(res_output, compiler._op_to_template._op_to_template(res))
-    
+      self.assertEqual(suspend_output, compiler._op_to_template._op_to_template(suspend_op))
+
     kfp.compiler.Compiler()._compile(my_pipeline)
 
   def _get_yaml_from_zip(self, zip_file):

--- a/sdk/python/tests/dsl/suspend_op_tests.py
+++ b/sdk/python/tests/dsl/suspend_op_tests.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sdk/python/tests/dsl/suspend_op_tests.py
+++ b/sdk/python/tests/dsl/suspend_op_tests.py
@@ -1,0 +1,43 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import kfp
+from kfp.dsl import SuspendOp
+import unittest
+
+
+class TestSuspendOp(unittest.TestCase):
+
+    def test_basic(self):
+        """Test basic usage."""
+        def my_pipeline(param):
+            res = SuspendOp(name="suspend")
+
+            self.assertEqual(res.name, "suspend")
+            self.assertEqual(
+                res.suspend.duration,
+                ''
+            )
+            self.assertEqual(res.dependent_names, [])
+
+        kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def test_duration_validation(self):
+        """Test bad duration value."""
+        def my_pipeline(param):
+            res = SuspendOp(name="suspend", duration="bad input")
+
+        with self.assertRaises(ValueError):
+            kfp.compiler.Compiler()._compile(my_pipeline)


### PR DESCRIPTION
**This PR is part of the "pipeline suspense and resume" feature**

Added SuspendOp to the python DSL in order to have a suspense step (including setting a specific duration)

Fixes #3101

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3203)
<!-- Reviewable:end -->
