### PR TITLE
Pin TFT to 0.21.0

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,7 +28,7 @@ FROM python:3.5 as compiler
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y -q default-jdk python3-setuptools python3-dev
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
-RUN python3 -m pip install tfx==0.21.0
+RUN python3 -m pip install tfx==0.21.1
 
 WORKDIR /go/src/github.com/kubeflow/pipelines
 COPY sdk sdk

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,7 +28,7 @@ FROM python:3.5 as compiler
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y -q default-jdk python3-setuptools python3-dev
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
-RUN python3 -m pip install tfx==0.21.1 tensorflow_transform==0.21.0
+RUN python3 -m pip install tfx==0.21.0 tensorflow_transform==0.21.0
 
 WORKDIR /go/src/github.com/kubeflow/pipelines
 COPY sdk sdk

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,7 +28,7 @@ FROM python:3.5 as compiler
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y -q default-jdk python3-setuptools python3-dev
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
-RUN python3 -m pip install tfx==0.21.1
+RUN python3 -m pip install tfx==0.21.1 tensorflow_transform==0.21.0
 
 WORKDIR /go/src/github.com/kubeflow/pipelines
 COPY sdk sdk

--- a/test/sample-test/Dockerfile
+++ b/test/sample-test/Dockerfile
@@ -19,7 +19,7 @@ RUN pip3 install google-api-python-client==1.7.0
 RUN pip3 install google-cloud-storage==1.17.0
 RUN pip3 install fire==0.2.1
 RUN pip3 install yamale==2.0
-RUN pip3 install tfx==0.21.0
+RUN pip3 install tfx==0.21.1
 
 # Install python client, including DSL compiler.
 COPY ./sdk/python /sdk/python

--- a/test/sample-test/Dockerfile
+++ b/test/sample-test/Dockerfile
@@ -19,7 +19,7 @@ RUN pip3 install google-api-python-client==1.7.0
 RUN pip3 install google-cloud-storage==1.17.0
 RUN pip3 install fire==0.2.1
 RUN pip3 install yamale==2.0
-RUN pip3 install tfx==0.21.1
+RUN pip3 install tfx==0.21.0 tensorflow_transform==0.21.0
 
 # Install python client, including DSL compiler.
 COPY ./sdk/python /sdk/python


### PR DESCRIPTION
Currently TFX team are during their releasing process, causing a dependency discrepancy. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3209)
<!-- Reviewable:end -->
