### PR TITLE
SDK/DSL: Enable the deletion of a resource via ResourceOp method

### DIFF
--- a/sdk/python/kfp/dsl/_resource_op.py
+++ b/sdk/python/kfp/dsl/_resource_op.py
@@ -158,3 +158,21 @@ class ResourceOp(BaseOp):
         `io.argoproj.workflow.v1alpha1.Template`.
         """
         return self._resource
+
+    def delete(self):
+        """Returns a ResourceOp which deletes the resource."""
+        if self.resource.action == "delete":
+            raise ValueError("This operation is already a resource deletion.")
+
+        k8s_resource = dict()
+        if isinstance(self.k8s_resource, dict):
+            k8s_resource["apiVersion"] = self.k8s_resource["apiVersion"]
+            k8s_resource["kind"] = self.k8s_resource["kind"]
+        else:
+            k8s_resource["apiVersion"] = self.k8s_resource.api_version
+            k8s_resource["kind"] = self.k8s_resource.kind
+        k8s_resource["metadata"] = {"name": self.outputs["name"]}
+
+        return ResourceOp(name="del-%s" % self.name,
+                          action="delete",
+                          k8s_resource=k8s_resource)

--- a/sdk/python/kfp/dsl/_resource_op.py
+++ b/sdk/python/kfp/dsl/_resource_op.py
@@ -101,14 +101,14 @@ class ResourceOp(BaseOp):
         ])
 
         if k8s_resource is None:
-            ValueError("You need to provide a k8s_resource.")
+            raise ValueError("You need to provide a k8s_resource.")
 
         if merge_strategy and action != "apply":
-            ValueError("You can't set merge_strategy when action != 'apply'")
+            raise ValueError("You can't set merge_strategy when action != 'apply'")
         
         # if action is delete, there should not be any outputs, success_condition, and failure_condition
         if action == "delete" and (success_condition or failure_condition or attribute_outputs):
-            ValueError("You can't set success_condition, failure_condition, or attribute_outputs when action == 'delete'")
+            raise ValueError("You can't set success_condition, failure_condition, or attribute_outputs when action == 'delete'")
 
         init_resource = {
             "action": action,

--- a/sdk/python/tests/dsl/resource_op_tests.py
+++ b/sdk/python/tests/dsl/resource_op_tests.py
@@ -69,3 +69,30 @@ class TestResourceOp(unittest.TestCase):
             self.assertEqual(res.dependent_names, [])
 
         kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def test_delete(self):
+        """Test delete method."""
+        param = PipelineParam("param")
+        k8s_resource = {"apiVersion": "version",
+                        "kind": "CustomResource",
+                        "metadata": {"name": "my-resource"}}
+        res = ResourceOp(name="resource",
+                         k8s_resource=k8s_resource,
+                         success_condition=param,
+                         attribute_outputs={"test": "attr"})
+
+        delete_res = res.delete()
+
+        self.assertEqual(delete_res.resource.action, "delete")
+        self.assertEqual(delete_res.attribute_outputs, {})
+        self.assertEqual(delete_res.outputs, {})
+        self.assertEqual(delete_res.output, None)
+
+        expected_res_name = PipelineParam(name="name", op_name=res.name)
+        expected_res_resource = {"apiVersion": "version",
+                                 "kind": "CustomResource",
+                                 "metadata": {"name": expected_res_name}}
+        self.assertEqual(delete_res.k8s_resource, expected_res_resource)
+
+        with self.assertRaises(ValueError):
+            delete_res.delete()

--- a/sdk/python/tests/dsl/volume_op_tests.py
+++ b/sdk/python/tests/dsl/volume_op_tests.py
@@ -66,3 +66,22 @@ class TestVolumeOp(unittest.TestCase):
             )
         
         kfp.compiler.Compiler()._compile(my_pipeline)
+
+    def test_delete(self):
+        """Test delete method."""
+        vop = VolumeOp(name="vop", resource_name="vop", size="1Gi")
+
+        delete_vop = vop.delete()
+
+        self.assertEqual(delete_vop.resource.action, "delete")
+        self.assertEqual(delete_vop.attribute_outputs, {})
+        self.assertEqual(delete_vop.outputs, {})
+        self.assertEqual(delete_vop.output, None)
+        expected_name = PipelineParam(name="name", op_name=vop.name)
+        expected_resource = {"apiVersion": "v1",
+                             "kind": "PersistentVolumeClaim",
+                             "metadata": {"name": expected_name}}
+        self.assertEqual(delete_vop.k8s_resource, expected_resource)
+
+        with self.assertRaises(ValueError):
+            delete_vop.delete()


### PR DESCRIPTION
Related to #1779.

This PR enables performing the `delete` action on a resource that's highly connected to the workflow (e.g., a PVC created using a `VolumeOp`).

The approach of #3194 is aligned to this one, but is a subset of it. I decided to submit this PR to have a generic `delete()` method that would work out of the box with any `ResourceOp` (or subclass).

cc @PatrickXYS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3213)
<!-- Reviewable:end -->
