### PR TITLE
[Frontend] GKE metadata endpoint should fail when fetched response is not ok

### DIFF
--- a/frontend/mock-backend/mock-api-middleware.ts
+++ b/frontend/mock-backend/mock-api-middleware.ts
@@ -605,6 +605,20 @@ export default (app: express.Application) => {
     res.send(true);
   });
 
+  // Uncomment this instead to test 404 endpoints.
+  // app.get('/system/cluster-name', (_, res) => {
+  //   res.status(404).send('404 Not Found');
+  // });
+  // app.get('/system/project-id', (_, res) => {
+  //   res.status(404).send('404 Not Found');
+  // });
+  app.get('/system/cluster-name', (_, res) => {
+    res.send('mock-cluster-name');
+  });
+  app.get('/system/project-id', (_, res) => {
+    res.send('mock-project-id');
+  });
+
   app.all(v1beta1Prefix + '*', (req, res) => {
     res.status(404).send('Bad request endpoint.');
   });

--- a/frontend/server/handlers/gke-metadata.ts
+++ b/frontend/server/handlers/gke-metadata.ts
@@ -37,6 +37,10 @@ const clusterNameHandler: Handler = async (_, res) => {
     'http://metadata/computeMetadata/v1/instance/attributes/cluster-name',
     { headers: { 'Metadata-Flavor': 'Google' } },
   );
+  if (!response.ok) {
+    res.status(500).send('Failed fetching GKE cluster name');
+    return;
+  }
   res.send(await response.text());
 };
 
@@ -56,5 +60,9 @@ const projectIdHandler: Handler = async (_, res) => {
   const response = await fetch('http://metadata/computeMetadata/v1/project/project-id', {
     headers: { 'Metadata-Flavor': 'Google' },
   });
+  if (!response.ok) {
+    res.status(500).send('Failed fetching GKE project id');
+    return;
+  }
   res.send(await response.text());
 };


### PR DESCRIPTION
/area frontend
/kind bug

This also fixes the issue mentioned in https://github.com/kubeflow/kubeflow/issues/4829.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3218)
<!-- Reviewable:end -->
