### PR TITLE
[SDK] Use new released kfp-server-api package

### DIFF
--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -10,7 +10,7 @@ cryptography>=2.4.2
 google-auth>=1.6.1
 requests_toolbelt>=0.8.0
 cloudpickle==1.1.1
-kfp-server-api >= 0.1.18, < 0.1.19
+kfp-server-api==0.2.5
 argo-models == 2.2.1a
 jsonschema >= 3.0.1
 tabulate == 0.8.3

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -32,7 +32,7 @@ REQUIRES = [
     'google-auth>=1.6.1',
     'requests_toolbelt>=0.8.0',
     'cloudpickle==1.1.1',
-    'kfp-server-api >= 0.1.18, <= 0.2.5',  #Update the upper version whenever a new version of the kfp-server-api package is released. Update the lower version when there is a breaking change in kfp-server-api.
+    'kfp-server-api >= 0.2.5, <= 0.2.5',  #Update the upper version whenever a new version of the kfp-server-api package is released. Update the lower version when there is a breaking change in kfp-server-api, or kfp sdk depends on new api changes in kfp-server-api.
     'argo-models == 2.2.1a',  #2.2.1a is equivalent to argo 2.2.1
     'jsonschema >= 3.0.1',
     'tabulate == 0.8.3',

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -32,7 +32,7 @@ REQUIRES = [
     'google-auth>=1.6.1',
     'requests_toolbelt>=0.8.0',
     'cloudpickle==1.1.1',
-    'kfp-server-api >= 0.2.5, <= 0.2.5',  #Update the upper version whenever a new version of the kfp-server-api package is released. Update the lower version when there is a breaking change in kfp-server-api, or kfp sdk depends on new api changes in kfp-server-api.
+    'kfp-server-api==0.2.5',  #Update the upper version whenever a new version of the kfp-server-api package is released. Update the lower version when there is a breaking change in kfp-server-api, or kfp sdk depends on new api changes in kfp-server-api.
     'argo-models == 2.2.1a',  #2.2.1a is equivalent to argo 2.2.1
     'jsonschema >= 3.0.1',
     'tabulate == 0.8.3',

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -32,7 +32,7 @@ REQUIRES = [
     'google-auth>=1.6.1',
     'requests_toolbelt>=0.8.0',
     'cloudpickle==1.1.1',
-    'kfp-server-api >= 0.1.18, <= 0.1.40',  #Update the upper version whenever a new version of the kfp-server-api package is released. Update the lower version when there is a breaking change in kfp-server-api.
+    'kfp-server-api >= 0.1.18, <= 0.2.5',  #Update the upper version whenever a new version of the kfp-server-api package is released. Update the lower version when there is a breaking change in kfp-server-api.
     'argo-models == 2.2.1a',  #2.2.1a is equivalent to argo 2.2.1
     'jsonschema >= 3.0.1',
     'tabulate == 0.8.3',


### PR DESCRIPTION
/assign @numerology

We should release a patched kfp shortly after then.
Context: https://github.com/kubeflow/pipelines/issues/2977#issuecomment-595598865
We should change kfp package dependency when releasing a new kfp-server-api package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3224)
<!-- Reviewable:end -->
