### PR TITLE
[Frontend] Fix the TFMA/TFDV viz behavior when caching is used.

### DIFF
--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -472,7 +472,7 @@ async function getExecutionInContextWithPodName(
     return undefined; // Not found, this is expected to happen normally when there's no mlmd data.
   }
   const state = foundExecution.getPropertiesMap().get('state');
-  if (!state || state.getStringValue() !== 'complete') {
+  if (!state || (state.getStringValue() !== 'complete' && state.getStringValue() !== 'cached')) {
     return undefined; // Execution doesn't have a valid state, or it has not finished.
   }
   return foundExecution;

--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -473,7 +473,7 @@ async function getExecutionInContextWithPodName(
   }
   const state = foundExecution.getPropertiesMap().get('state');
   // Both complete and cached executions are considered valid.
-  if (['complete', 'cached'].includes(state?.getStringValue()) {
+  if (['complete', 'cached'].includes(state?.getStringValue())) {
     return foundExecution;
   }
   // No valid execution found.

--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -473,7 +473,7 @@ async function getExecutionInContextWithPodName(
   }
   const state = foundExecution.getPropertiesMap().get('state');
   // Both complete and cached executions are considered valid.
-  if (['complete', 'cached'].includes(state?.getStringValue())) {
+  if (state && ['complete', 'cached'].includes(state.getStringValue())) {
     return foundExecution;
   }
   // No valid execution found.

--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -473,7 +473,7 @@ async function getExecutionInContextWithPodName(
   }
   const state = foundExecution.getPropertiesMap().get('state');
   if (state && (state.getStringValue() === 'complete' || state.getStringValue() === 'cached')) {
-    return foundExecution
+    return foundExecution;
   }
   // No valid execution found.
   return undefined;

--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -472,7 +472,7 @@ async function getExecutionInContextWithPodName(
     return undefined; // Not found, this is expected to happen normally when there's no mlmd data.
   }
   const state = foundExecution.getPropertiesMap().get('state');
-  if (state && state.getStringValue() === 'complete' || state.getStringValue() === 'cached')) {
+  if (state && (state.getStringValue() === 'complete' || state.getStringValue() === 'cached')) {
     return foundExecution
   }
   // No valid execution found.

--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -472,7 +472,8 @@ async function getExecutionInContextWithPodName(
     return undefined; // Not found, this is expected to happen normally when there's no mlmd data.
   }
   const state = foundExecution.getPropertiesMap().get('state');
-  if (state && (state.getStringValue() === 'complete' || state.getStringValue() === 'cached')) {
+  // Both complete and cached executions are considered valid.
+  if (['complete', 'cached'].includes(state?.getStringValue()) {
     return foundExecution;
   }
   // No valid execution found.

--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -472,10 +472,11 @@ async function getExecutionInContextWithPodName(
     return undefined; // Not found, this is expected to happen normally when there's no mlmd data.
   }
   const state = foundExecution.getPropertiesMap().get('state');
-  if (!state || (state.getStringValue() !== 'complete' && state.getStringValue() !== 'cached')) {
-    return undefined; // Execution doesn't have a valid state, or it has not finished.
+  if (state && state.getStringValue() === 'complete' || state.getStringValue() === 'cached')) {
+    return foundExecution
   }
-  return foundExecution;
+  // No valid execution found.
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
Reason:

Currently for output artifact resolution we only consider executions with COMPLETE status. However, when cache is used, the current execution with the right argo pod name will be published with CACHED status [1]. Those should also be considered.

[1] https://github.com/tensorflow/tfx/blob/29349c9bd0196af3a7c0336a5339897406cbfdb3/tfx/components/base/base_driver.py#L263

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3228)
<!-- Reviewable:end -->
