### PR TITLE
[UI] Fix SideNav too tall when collapsed

### DIFF
--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -136,11 +136,15 @@ export const css = stylesheet({
     opacity: 0,
     transition: 'opacity 0s',
     transitionDelay: '0s',
+    // guarantees info doesn't affect layout when hidden
+    overflow: 'hidden',
+    height: 0,
   },
   infoVisible: {
     opacity: 'initial',
     transition: 'opacity 0.2s',
     transitionDelay: '0.3s',
+    overflow: 'hidden',
   },
   label: {
     fontSize: fontsize.base,


### PR DESCRIPTION
/area frontend
/kind bug

Context: the bug has been like this since the very beginning, but after some recent changes to add more info in the env info section, the bug can be easily triggered now.

Before the fix: when sidenav collapsed, the page grows tall and overflows the screen (notice the scrollbar on the right).
![OCoO3fzPLOi](https://user-images.githubusercontent.com/4957653/76190616-5dc2b500-6218-11ea-953e-dccc3667578c.png)
After the fix: it is the same height as expanded state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3239)
<!-- Reviewable:end -->
