### PR TITLE
[Backend][Multi-user] Add namespace to Experiment API implementation

### DIFF
--- a/backend/src/apiserver/resource/BUILD.bazel
+++ b/backend/src/apiserver/resource/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//backend/src/crd/pkg/apis/scheduledworkflow/v1beta1:go_default_library",
         "@com_github_argoproj_argo//pkg/apis/workflow/v1alpha1:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_spf13_viper//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",

--- a/backend/src/apiserver/resource/model_converter.go
+++ b/backend/src/apiserver/resource/model_converter.go
@@ -24,6 +24,24 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 )
 
+func (r *ResourceManager) ToModelExperiment(apiExperiment *api.Experiment) (*model.Experiment, error) {
+	namespace := ""
+	if common.IsMultiUserMode() {
+		resourceReferences := apiExperiment.GetResourceReferences()
+		if len(resourceReferences) != 1 ||
+			resourceReferences[0].Key.Type != api.ResourceType_NAMESPACE ||
+			resourceReferences[0].Relationship != api.Relationship_OWNER {
+			return nil, util.NewInvalidInputError("Invalid resource references for experiment: %v", resourceReferences)
+		}
+		namespace = resourceReferences[0].Key.Id
+	}
+	return &model.Experiment{
+		Name:        apiExperiment.Name,
+		Description: apiExperiment.Description,
+		Namespace:   namespace,
+	}, nil
+}
+
 func (r *ResourceManager) ToModelRunMetric(metric *api.RunMetric, runUUID string) *model.RunMetric {
 	return &model.RunMetric{
 		RunUUID:     runUUID,

--- a/backend/src/apiserver/resource/model_converter.go
+++ b/backend/src/apiserver/resource/model_converter.go
@@ -22,16 +22,17 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/pkg/errors"
 )
 
 func (r *ResourceManager) ToModelExperiment(apiExperiment *api.Experiment) (*model.Experiment, error) {
 	namespace := ""
-	if common.IsMultiUserMode() {
-		resourceReferences := apiExperiment.GetResourceReferences()
+	resourceReferences := apiExperiment.GetResourceReferences()
+	if resourceReferences != nil {
 		if len(resourceReferences) != 1 ||
 			resourceReferences[0].Key.Type != api.ResourceType_NAMESPACE ||
 			resourceReferences[0].Relationship != api.Relationship_OWNER {
-			return nil, util.NewInvalidInputError("Invalid resource references for experiment: %v", resourceReferences)
+			return nil, util.NewInternalServerError(errors.New("Invalid resource references for experiment"), "Unable to convert to model experiment.")
 		}
 		namespace = resourceReferences[0].Key.Id
 	}

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -88,8 +88,8 @@ func initWithExperiment(t *testing.T) (*FakeClientManager, *ResourceManager, *mo
 	initEnvVars()
 	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
 	manager := NewResourceManager(store)
-	experiment := &model.Experiment{Name: "e1"}
-	experiment, err := manager.CreateExperiment(experiment)
+	apiExperiment := &api.Experiment{Name: "e1"}
+	experiment, err := manager.CreateExperiment(apiExperiment)
 	assert.Nil(t, err)
 	return store, manager, experiment
 }
@@ -98,8 +98,8 @@ func initWithExperimentAndPipeline(t *testing.T) (*FakeClientManager, *ResourceM
 	initEnvVars()
 	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
 	manager := NewResourceManager(store)
-	experiment := &model.Experiment{Name: "e1"}
-	experiment, err := manager.CreateExperiment(experiment)
+	apiExperiment := &api.Experiment{Name: "e1"}
+	experiment, err := manager.CreateExperiment(apiExperiment)
 	assert.Nil(t, err)
 	pipeline, err := manager.CreatePipeline("p1", "", []byte(testWorkflow.ToStringForStore()))
 	assert.Nil(t, err)
@@ -307,8 +307,8 @@ func TestGetPipelineTemplate_PipelineFileNotFound(t *testing.T) {
 func TestCreateRun_ThroughPipelineID(t *testing.T) {
 	store, manager, p := initWithPipeline(t)
 	defer store.Close()
-	experiment := &model.Experiment{Name: "e1"}
-	experiment, err := manager.CreateExperiment(experiment)
+	apiExperiment := &api.Experiment{Name: "e1"}
+	experiment, err := manager.CreateExperiment(apiExperiment)
 	assert.Nil(t, err)
 	apiRun := &api.Run{
 		Name: "run1",
@@ -898,8 +898,8 @@ func TestCreateJob_ThroughWorkflowSpec(t *testing.T) {
 func TestCreateJob_ThroughPipelineID(t *testing.T) {
 	store, manager, pipeline := initWithPipeline(t)
 	defer store.Close()
-	experiment := &model.Experiment{Name: "e1"}
-	experiment, err := manager.CreateExperiment(experiment)
+	apiExperiment := &api.Experiment{Name: "e1"}
+	experiment, err := manager.CreateExperiment(apiExperiment)
 	job := &api.Job{
 		Name:    "j1",
 		Enabled: true,

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -2290,3 +2290,46 @@ func TestDeletePipelineVersion_FileError(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, version)
 }
+
+func TestCreateDefaultExperiment(t *testing.T) {
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	defer store.Close()
+	manager := NewResourceManager(store)
+
+	experimentID, err := manager.CreateDefaultExperiment()
+	assert.Nil(t, err)
+	experiment, err := manager.GetExperiment(experimentID)
+	assert.Nil(t, err)
+
+	expectedExperiment := &model.Experiment{
+		UUID:           DefaultFakeUUID,
+		CreatedAtInSec: 1,
+		Name:           "Default",
+		Description:    "All runs created without specifying an experiment will be grouped here.",
+		Namespace:      "",
+	}
+	assert.Equal(t, expectedExperiment, experiment)
+}
+
+func TestCreateDefaultExperiment_MultiUser(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	defer store.Close()
+	manager := NewResourceManager(store)
+
+	experimentID, err := manager.CreateDefaultExperiment()
+	assert.Nil(t, err)
+	experiment, err := manager.GetExperiment(experimentID)
+	assert.Nil(t, err)
+
+	expectedExperiment := &model.Experiment{
+		UUID:           DefaultFakeUUID,
+		CreatedAtInSec: 1,
+		Name:           "Default",
+		Description:    "All runs created without specifying an experiment will be grouped here.",
+		Namespace:      "",
+	}
+	assert.Equal(t, expectedExperiment, experiment)
+}

--- a/backend/src/apiserver/server/api_converter.go
+++ b/backend/src/apiserver/server/api_converter.go
@@ -26,6 +26,23 @@ import (
 )
 
 func ToApiExperiment(experiment *model.Experiment) *api.Experiment {
+	if common.IsMultiUserMode() {
+		return &api.Experiment{
+			Id:          experiment.UUID,
+			Name:        experiment.Name,
+			Description: experiment.Description,
+			CreatedAt:   &timestamp.Timestamp{Seconds: experiment.CreatedAtInSec},
+			ResourceReferences: []*api.ResourceReference{
+				&api.ResourceReference{
+					Key: &api.ResourceKey{
+						Type: api.ResourceType_NAMESPACE,
+						Id:   experiment.Namespace,
+					},
+					Relationship: api.Relationship_OWNER,
+				},
+			},
+		}
+	}
 	return &api.Experiment{
 		Id:          experiment.UUID,
 		Name:        experiment.Name,
@@ -40,13 +57,6 @@ func ToApiExperiments(experiments []*model.Experiment) []*api.Experiment {
 		apiExperiments = append(apiExperiments, ToApiExperiment(experiment))
 	}
 	return apiExperiments
-}
-
-func ToModelExperiment(experiment *api.Experiment) *model.Experiment {
-	return &model.Experiment{
-		Name:        experiment.Name,
-		Description: experiment.Description,
-	}
 }
 
 func ToApiPipeline(pipeline *model.Pipeline) *api.Pipeline {

--- a/backend/src/apiserver/server/api_converter.go
+++ b/backend/src/apiserver/server/api_converter.go
@@ -26,28 +26,24 @@ import (
 )
 
 func ToApiExperiment(experiment *model.Experiment) *api.Experiment {
+	resourceReferences := []*api.ResourceReference(nil)
 	if common.IsMultiUserMode() {
-		return &api.Experiment{
-			Id:          experiment.UUID,
-			Name:        experiment.Name,
-			Description: experiment.Description,
-			CreatedAt:   &timestamp.Timestamp{Seconds: experiment.CreatedAtInSec},
-			ResourceReferences: []*api.ResourceReference{
-				&api.ResourceReference{
-					Key: &api.ResourceKey{
-						Type: api.ResourceType_NAMESPACE,
-						Id:   experiment.Namespace,
-					},
-					Relationship: api.Relationship_OWNER,
+		resourceReferences = []*api.ResourceReference{
+			&api.ResourceReference{
+				Key: &api.ResourceKey{
+					Type: api.ResourceType_NAMESPACE,
+					Id:   experiment.Namespace,
 				},
+				Relationship: api.Relationship_OWNER,
 			},
 		}
 	}
 	return &api.Experiment{
-		Id:          experiment.UUID,
-		Name:        experiment.Name,
-		Description: experiment.Description,
-		CreatedAt:   &timestamp.Timestamp{Seconds: experiment.CreatedAtInSec},
+		Id:                 experiment.UUID,
+		Name:               experiment.Name,
+		Description:        experiment.Description,
+		CreatedAt:          &timestamp.Timestamp{Seconds: experiment.CreatedAtInSec},
+		ResourceReferences: resourceReferences,
 	}
 }
 

--- a/backend/src/apiserver/server/experiment_server.go
+++ b/backend/src/apiserver/server/experiment_server.go
@@ -122,6 +122,7 @@ func ValidateCreateExperimentRequest(request *api.CreateExperimentRequest) error
 	return nil
 }
 
+// TODO(chensun): consider refactoring the code to get rid of double-query of experiment.
 func (s *ExperimentServer) canAccessExperiment(ctx context.Context, experimentID string) error {
 	if !common.IsMultiUserMode() {
 		// Skip authorization if not multi-user mode.

--- a/backend/src/apiserver/server/experiment_server.go
+++ b/backend/src/apiserver/server/experiment_server.go
@@ -5,9 +5,11 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	api "github.com/kubeflow/pipelines/backend/api/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/pkg/errors"
 )
 
 type ExperimentServer struct {
@@ -20,7 +22,13 @@ func (s *ExperimentServer) CreateExperiment(ctx context.Context, request *api.Cr
 	if err != nil {
 		return nil, util.Wrap(err, "Validate experiment request failed.")
 	}
-	newExperiment, err := s.resourceManager.CreateExperiment(ToModelExperiment(request.Experiment))
+
+	err = CanAccessNamespaceInResourceReferences(s.resourceManager, ctx, request.Experiment.ResourceReferences)
+	if err != nil {
+		return nil, util.Wrap(err, "Failed to authorize the requests.")
+	}
+
+	newExperiment, err := s.resourceManager.CreateExperiment(request.Experiment)
 	if err != nil {
 		return nil, util.Wrap(err, "Create experiment failed.")
 	}
@@ -29,6 +37,11 @@ func (s *ExperimentServer) CreateExperiment(ctx context.Context, request *api.Cr
 
 func (s *ExperimentServer) GetExperiment(ctx context.Context, request *api.GetExperimentRequest) (
 	*api.Experiment, error) {
+	err := s.canAccessExperiment(ctx, request.Id)
+	if err != nil {
+		return nil, util.Wrap(err, "Failed to authorize the requests.")
+	}
+
 	experiment, err := s.resourceManager.GetExperiment(request.Id)
 	if err != nil {
 		return nil, util.Wrap(err, "Get experiment failed.")
@@ -44,7 +57,17 @@ func (s *ExperimentServer) ListExperiment(ctx context.Context, request *api.List
 		return nil, util.Wrap(err, "Failed to create list options")
 	}
 
-	experiments, total_size, nextPageToken, err := s.resourceManager.ListExperiments(opts)
+	filterContext, err := ValidateFilter(request.ResourceReferenceKey)
+	if err != nil {
+		return nil, util.Wrap(err, "Validating filter failed.")
+	}
+
+	refKey := filterContext.ReferenceKey
+	if refKey != nil && refKey.Type != common.Namespace {
+		return nil, util.NewInvalidInputError("List experiment only supports filtering by namespace.")
+	}
+
+	experiments, total_size, nextPageToken, err := s.resourceManager.ListExperiments(filterContext, opts)
 	if err != nil {
 		return nil, util.Wrap(err, "List experiments failed.")
 	}
@@ -56,7 +79,12 @@ func (s *ExperimentServer) ListExperiment(ctx context.Context, request *api.List
 }
 
 func (s *ExperimentServer) DeleteExperiment(ctx context.Context, request *api.DeleteExperimentRequest) (*empty.Empty, error) {
-	err := s.resourceManager.DeleteExperiment(request.Id)
+	err := s.canAccessExperiment(ctx, request.Id)
+	if err != nil {
+		return nil, util.Wrap(err, "Failed to authorize the requests.")
+	}
+
+	err = s.resourceManager.DeleteExperiment(request.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -66,6 +94,36 @@ func (s *ExperimentServer) DeleteExperiment(ctx context.Context, request *api.De
 func ValidateCreateExperimentRequest(request *api.CreateExperimentRequest) error {
 	if request.Experiment == nil || request.Experiment.Name == "" {
 		return util.NewInvalidInputError("Experiment name is empty. Please specify a valid experiment name.")
+	}
+
+	if common.IsMultiUserMode() {
+		if len(request.Experiment.ResourceReferences) != 1 {
+			return util.NewInvalidInputError("Experiment should specify one and only one resource reference.")
+		}
+		namespace := common.GetNamespaceFromAPIResourceReferences(request.Experiment.ResourceReferences)
+		if len(namespace) == 0 {
+			return util.NewInvalidInputError("Experiment should specify namespace.")
+		}
+	}
+	return nil
+}
+
+func (s *ExperimentServer) canAccessExperiment(ctx context.Context, experimentID string) error {
+	if !common.IsMultiUserMode() {
+		// Skip authorization if not multi-user mode.
+		return nil
+	}
+	namespace, err := s.resourceManager.GetNamespaceFromExperimentID(experimentID)
+	if err != nil {
+		return util.Wrap(err, "Failed to authorize with the experiment ID.")
+	}
+	if len(namespace) == 0 {
+		return util.NewInternalServerError(errors.New("There is no namespace found"), "There is no namespace found")
+	}
+
+	err = isAuthorized(s.resourceManager, ctx, namespace)
+	if err != nil {
+		return util.Wrap(err, "Failed to authorize with API resource references")
 	}
 	return nil
 }

--- a/backend/src/apiserver/server/experiment_server_test.go
+++ b/backend/src/apiserver/server/experiment_server_test.go
@@ -284,7 +284,7 @@ func TestValidateCreateExperimentRequest_Multiuser(t *testing.T) {
 				ResourceReferences: []*api.ResourceReference{},
 			},
 			true,
-			"Experiment should specify one and only one resource reference",
+			"Invalid resource references for experiment.",
 		},
 		{
 			"Multiple namespace",
@@ -303,7 +303,7 @@ func TestValidateCreateExperimentRequest_Multiuser(t *testing.T) {
 				},
 			},
 			true,
-			"Experiment should specify one and only one resource reference",
+			"Invalid resource references for experiment.",
 		},
 		{
 			"Invalid resource type",
@@ -318,7 +318,7 @@ func TestValidateCreateExperimentRequest_Multiuser(t *testing.T) {
 				},
 			},
 			true,
-			"Experiment should specify namespace",
+			"Invalid resource references for experiment.",
 		},
 	}
 

--- a/backend/src/apiserver/server/experiment_server_test.go
+++ b/backend/src/apiserver/server/experiment_server_test.go
@@ -1,13 +1,18 @@
 package server
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
 	api "github.com/kubeflow/pipelines/backend/api/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestCreateExperiment(t *testing.T) {
@@ -36,6 +41,39 @@ func TestCreateExperiment_Failed(t *testing.T) {
 	_, err := server.CreateExperiment(nil, &api.CreateExperimentRequest{Experiment: experiment})
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Create experiment failed.")
+}
+
+func TestCreateExperiment_Multiuser(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	resourceManager := resource.NewResourceManager(clientManager)
+	server := ExperimentServer{resourceManager: resourceManager}
+	resourceReferences := []*api.ResourceReference{
+		{
+			Key:          &api.ResourceKey{Type: api.ResourceType_NAMESPACE, Id: "ns1"},
+			Relationship: api.Relationship_OWNER,
+		},
+	}
+	experiment := &api.Experiment{
+		Name:               "exp1",
+		Description:        "first experiment",
+		ResourceReferences: resourceReferences,
+	}
+
+	result, err := server.CreateExperiment(ctx, &api.CreateExperimentRequest{Experiment: experiment})
+	assert.Nil(t, err)
+	expectedExperiment := &api.Experiment{
+		Id:                 resource.DefaultFakeUUID,
+		Name:               "exp1",
+		Description:        "first experiment",
+		CreatedAt:          &timestamp.Timestamp{Seconds: 1},
+		ResourceReferences: resourceReferences,
+	}
+	assert.Equal(t, expectedExperiment, result)
 }
 
 func TestGetExperiment(t *testing.T) {
@@ -70,6 +108,40 @@ func TestGetExperiment_Failed(t *testing.T) {
 	assert.Contains(t, err.Error(), "Get experiment failed.")
 }
 
+func TestGetExperiment_Multiuser(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	resourceManager := resource.NewResourceManager(clientManager)
+	server := ExperimentServer{resourceManager: resourceManager}
+	resourceReferences := []*api.ResourceReference{
+		{
+			Key:          &api.ResourceKey{Type: api.ResourceType_NAMESPACE, Id: "ns1"},
+			Relationship: api.Relationship_OWNER,
+		},
+	}
+	experiment := &api.Experiment{
+		Name:               "exp1",
+		Description:        "first experiment",
+		ResourceReferences: resourceReferences,
+	}
+
+	createResult, err := server.CreateExperiment(ctx, &api.CreateExperimentRequest{Experiment: experiment})
+	assert.Nil(t, err)
+	result, err := server.GetExperiment(ctx, &api.GetExperimentRequest{Id: createResult.Id})
+	expectedExperiment := &api.Experiment{
+		Id:                 createResult.Id,
+		Name:               "exp1",
+		Description:        "first experiment",
+		CreatedAt:          &timestamp.Timestamp{Seconds: 1},
+		ResourceReferences: resourceReferences,
+	}
+	assert.Equal(t, expectedExperiment, result)
+}
+
 func TestListExperiment(t *testing.T) {
 	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
 	resourceManager := resource.NewResourceManager(clientManager)
@@ -102,9 +174,165 @@ func TestListExperiment_Failed(t *testing.T) {
 	assert.Contains(t, err.Error(), "List experiments failed.")
 }
 
-func TestValidateCreateExperimentRequest_EmptyName(t *testing.T) {
-	experiment := &api.Experiment{Description: "first experiment"}
-	err := ValidateCreateExperimentRequest(&api.CreateExperimentRequest{Experiment: experiment})
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "name is empty")
+func TestListExperiment_Multiuser(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	resourceManager := resource.NewResourceManager(clientManager)
+	server := ExperimentServer{resourceManager: resourceManager}
+	referenceKey := &api.ResourceKey{Type: api.ResourceType_NAMESPACE, Id: "ns1"}
+	resourceReferences := []*api.ResourceReference{
+		{
+			Key:          referenceKey,
+			Relationship: api.Relationship_OWNER,
+		},
+	}
+	experiment := &api.Experiment{
+		Name:               "exp1",
+		Description:        "first experiment",
+		ResourceReferences: resourceReferences,
+	}
+
+	createResult, err := server.CreateExperiment(ctx, &api.CreateExperimentRequest{Experiment: experiment})
+	assert.Nil(t, err)
+
+	result, err := server.ListExperiment(ctx, &api.ListExperimentsRequest{ResourceReferenceKey: referenceKey})
+	assert.Nil(t, err)
+	expectedExperiment := []*api.Experiment{{
+		Id:                 createResult.Id,
+		Name:               "exp1",
+		Description:        "first experiment",
+		CreatedAt:          &timestamp.Timestamp{Seconds: 1},
+		ResourceReferences: resourceReferences,
+	}}
+	assert.Equal(t, expectedExperiment, result.Experiments)
+
+	result, err = server.ListExperiment(ctx, &api.ListExperimentsRequest{ResourceReferenceKey: &api.ResourceKey{Type: api.ResourceType_NAMESPACE, Id: "ns2"}})
+	assert.Nil(t, err)
+	expectedExperiment = []*api.Experiment{}
+	assert.Equal(t, expectedExperiment, result.Experiments)
+}
+
+func TestValidateCreateExperimentRequest(t *testing.T) {
+	tests := []struct {
+		name         string
+		experiment   *api.Experiment
+		wantError    bool
+		errorMessage string
+	}{
+		{
+			"Valid",
+			&api.Experiment{Name: "exp1", Description: "first experiment"},
+			false,
+			"",
+		},
+		{
+			"Empty name",
+			&api.Experiment{Description: "first experiment"},
+			true,
+			"name is empty",
+		},
+	}
+
+	for _, tc := range tests {
+		err := ValidateCreateExperimentRequest(&api.CreateExperimentRequest{Experiment: tc.experiment})
+		if !tc.wantError && err != nil {
+			t.Errorf("TestValidateCreateExperimentRequest(%v) expect no error but got %v", tc.name, err)
+		}
+		if tc.wantError {
+			if err == nil {
+				t.Errorf("TestValidateCreateExperimentRequest(%v) expect error but got nil", tc.name)
+			} else if !strings.Contains(err.Error(), tc.errorMessage) {
+				t.Errorf("TestValidateCreateExperimentRequest(%v) expect error containing: %v, but got: %v", tc.name, tc.errorMessage, err)
+			}
+		}
+	}
+}
+
+func TestValidateCreateExperimentRequest_Multiuser(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	tests := []struct {
+		name         string
+		experiment   *api.Experiment
+		wantError    bool
+		errorMessage string
+	}{
+		{
+			"Valid",
+			&api.Experiment{
+				Name:        "exp1",
+				Description: "first experiment",
+				ResourceReferences: []*api.ResourceReference{
+					{
+						Key:          &api.ResourceKey{Type: api.ResourceType_NAMESPACE, Id: "ns1"},
+						Relationship: api.Relationship_OWNER,
+					},
+				},
+			},
+			false,
+			"",
+		},
+		{
+			"Missing namespace",
+			&api.Experiment{
+				Name:               "exp1",
+				Description:        "first experiment",
+				ResourceReferences: []*api.ResourceReference{},
+			},
+			true,
+			"Experiment should specify one and only one resource reference",
+		},
+		{
+			"Multiple namespace",
+			&api.Experiment{
+				Name:        "exp1",
+				Description: "first experiment",
+				ResourceReferences: []*api.ResourceReference{
+					{
+						Key:          &api.ResourceKey{Type: api.ResourceType_NAMESPACE, Id: "ns1"},
+						Relationship: api.Relationship_OWNER,
+					},
+					{
+						Key:          &api.ResourceKey{Type: api.ResourceType_NAMESPACE, Id: "ns2"},
+						Relationship: api.Relationship_OWNER,
+					},
+				},
+			},
+			true,
+			"Experiment should specify one and only one resource reference",
+		},
+		{
+			"Invalid resource type",
+			&api.Experiment{
+				Name:        "exp1",
+				Description: "first experiment",
+				ResourceReferences: []*api.ResourceReference{
+					{
+						Key:          &api.ResourceKey{Type: api.ResourceType_EXPERIMENT, Id: "exp2"},
+						Relationship: api.Relationship_OWNER,
+					},
+				},
+			},
+			true,
+			"Experiment should specify namespace",
+		},
+	}
+
+	for _, tc := range tests {
+		err := ValidateCreateExperimentRequest(&api.CreateExperimentRequest{Experiment: tc.experiment})
+		if !tc.wantError && err != nil {
+			t.Errorf("TestValidateCreateExperimentRequest(%v) expect no error but got %v", tc.name, err)
+		}
+		if tc.wantError {
+			if err == nil {
+				t.Errorf("TestValidateCreateExperimentRequest(%v) expect error but got nil", tc.name)
+			} else if !strings.Contains(err.Error(), tc.errorMessage) {
+				t.Errorf("TestValidateCreateExperimentRequest(%v) expect error containing: %v, but got: %v", tc.name, tc.errorMessage, err)
+			}
+		}
+	}
 }

--- a/backend/src/apiserver/server/run_server_test.go
+++ b/backend/src/apiserver/server/run_server_test.go
@@ -377,10 +377,13 @@ func TestReportRunMetrics_PartialFailures(t *testing.T) {
 }
 
 func TestCanAccessRun_Unauthorized(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+
 	clients, manager, experiment := initWithExperiment_KFAM_Unauthorized(t)
 	defer clients.Close()
 	runServer := RunServer{resourceManager: manager}
-	viper.Set(common.MultiUserMode, "true")
+
 	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
@@ -410,10 +413,13 @@ func TestCanAccessRun_Unauthorized(t *testing.T) {
 }
 
 func TestCanAccessRun_Authorized(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+
 	clients, manager, experiment := initWithExperiment(t)
 	defer clients.Close()
 	runServer := RunServer{resourceManager: manager}
-	viper.Set(common.MultiUserMode, "true")
+
 	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 

--- a/backend/src/apiserver/server/test_util.go
+++ b/backend/src/apiserver/server/test_util.go
@@ -82,8 +82,19 @@ func initWithExperiment(t *testing.T) (*resource.FakeClientManager, *resource.Re
 	initEnvVars()
 	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
 	resourceManager := resource.NewResourceManager(clientManager)
-	experiment := &model.Experiment{Name: "123"}
-	experiment, err := resourceManager.CreateExperiment(experiment)
+	apiExperiment := &api.Experiment{Name: "123"}
+	if common.IsMultiUserMode() {
+		apiExperiment = &api.Experiment{
+			Name: "123",
+			ResourceReferences: []*api.ResourceReference{
+				{
+					Key:          &api.ResourceKey{Type: api.ResourceType_NAMESPACE, Id: "ns1"},
+					Relationship: api.Relationship_OWNER,
+				},
+			},
+		}
+	}
+	experiment, err := resourceManager.CreateExperiment(apiExperiment)
 	assert.Nil(t, err)
 	return clientManager, resourceManager, experiment
 }
@@ -93,8 +104,19 @@ func initWithExperiment_KFAM_Unauthorized(t *testing.T) (*resource.FakeClientMan
 	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
 	clientManager.KfamClientFake = client.NewFakeKFAMClientUnauthorized()
 	resourceManager := resource.NewResourceManager(clientManager)
-	experiment := &model.Experiment{Name: "123"}
-	experiment, err := resourceManager.CreateExperiment(experiment)
+	apiExperiment := &api.Experiment{Name: "123"}
+	if common.IsMultiUserMode() {
+		apiExperiment = &api.Experiment{
+			Name: "123",
+			ResourceReferences: []*api.ResourceReference{
+				{
+					Key:          &api.ResourceKey{Type: api.ResourceType_NAMESPACE, Id: "ns1"},
+					Relationship: api.Relationship_OWNER,
+				},
+			},
+		}
+	}
+	experiment, err := resourceManager.CreateExperiment(apiExperiment)
 	assert.Nil(t, err)
 	return clientManager, resourceManager, experiment
 }
@@ -105,8 +127,8 @@ func initWithExperimentAndPipelineVersion(t *testing.T) (*resource.FakeClientMan
 	resourceManager := resource.NewResourceManager(clientManager)
 
 	// Create an experiment.
-	experiment := &model.Experiment{Name: "123"}
-	experiment, err := resourceManager.CreateExperiment(experiment)
+	apiExperiment := &api.Experiment{Name: "123"}
+	experiment, err := resourceManager.CreateExperiment(apiExperiment)
 	assert.Nil(t, err)
 
 	// Create a pipeline and then a pipeline version.

--- a/backend/src/apiserver/server/util_test.go
+++ b/backend/src/apiserver/server/util_test.go
@@ -346,9 +346,12 @@ func TestGetUserIdentity(t *testing.T) {
 }
 
 func TestCanAccessNamespaceInResourceReferencesUnauthorized(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+
 	clients, manager, _ := initWithExperiment_KFAM_Unauthorized(t)
 	defer clients.Close()
-	viper.Set(common.MultiUserMode, "true")
+
 	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	references := []*api.ResourceReference{
@@ -363,9 +366,12 @@ func TestCanAccessNamespaceInResourceReferencesUnauthorized(t *testing.T) {
 }
 
 func TestCanAccessNamespaceInResourceReferences_Authorized(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+
 	clients, manager, _ := initWithExperiment(t)
 	defer clients.Close()
-	viper.Set(common.MultiUserMode, "true")
+
 	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	references := []*api.ResourceReference{

--- a/backend/src/apiserver/storage/experiment_store_test.go
+++ b/backend/src/apiserver/storage/experiment_store_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	api "github.com/kubeflow/pipelines/backend/api/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/list"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
@@ -60,7 +61,7 @@ func TestListExperiments_Pagination(t *testing.T) {
 	opts, err := list.NewOptions(&model.Experiment{}, 2, "name", nil)
 	assert.Nil(t, err)
 
-	experiments, total_size, nextPageToken, err := experimentStore.ListExperiments(opts)
+	experiments, total_size, nextPageToken, err := experimentStore.ListExperiments(&common.FilterContext{}, opts)
 
 	assert.Nil(t, err)
 	assert.NotEmpty(t, nextPageToken)
@@ -84,7 +85,7 @@ func TestListExperiments_Pagination(t *testing.T) {
 	opts, err = list.NewOptionsFromToken(nextPageToken, 2)
 	assert.Nil(t, err)
 
-	experiments, total_size, nextPageToken, err = experimentStore.ListExperiments(opts)
+	experiments, total_size, nextPageToken, err = experimentStore.ListExperiments(&common.FilterContext{}, opts)
 	assert.Nil(t, err)
 	assert.Empty(t, nextPageToken)
 	assert.Equal(t, 4, total_size)
@@ -119,7 +120,7 @@ func TestListExperiments_Pagination_Descend(t *testing.T) {
 
 	opts, err := list.NewOptions(&model.Experiment{}, 2, "name desc", nil)
 	assert.Nil(t, err)
-	experiments, total_size, nextPageToken, err := experimentStore.ListExperiments(opts)
+	experiments, total_size, nextPageToken, err := experimentStore.ListExperiments(&common.FilterContext{}, opts)
 
 	assert.Nil(t, err)
 	assert.NotEmpty(t, nextPageToken)
@@ -143,7 +144,7 @@ func TestListExperiments_Pagination_Descend(t *testing.T) {
 	opts, err = list.NewOptionsFromToken(nextPageToken, 2)
 	assert.Nil(t, err)
 
-	experiments, total_size, nextPageToken, err = experimentStore.ListExperiments(opts)
+	experiments, total_size, nextPageToken, err = experimentStore.ListExperiments(&common.FilterContext{}, opts)
 	assert.Nil(t, err)
 	assert.Empty(t, nextPageToken)
 	assert.Equal(t, 4, total_size)
@@ -166,7 +167,7 @@ func TestListExperiments_Pagination_LessThanPageSize(t *testing.T) {
 	opts, err := list.NewOptions(&model.Experiment{}, 2, "", nil)
 	assert.Nil(t, err)
 
-	experiments, total_size, nextPageToken, err := experimentStore.ListExperiments(opts)
+	experiments, total_size, nextPageToken, err := experimentStore.ListExperiments(&common.FilterContext{}, opts)
 	assert.Nil(t, err)
 	assert.Equal(t, "", nextPageToken)
 	assert.Equal(t, 1, total_size)
@@ -181,7 +182,7 @@ func TestListExperimentsError(t *testing.T) {
 
 	opts, err := list.NewOptions(&model.Experiment{}, 2, "", nil)
 	assert.Nil(t, err)
-	_, _, _, err = experimentStore.ListExperiments(opts)
+	_, _, _, err = experimentStore.ListExperiments(&common.FilterContext{}, opts)
 	assert.Equal(t, codes.Internal, err.(*util.UserError).ExternalStatusCode())
 }
 
@@ -368,7 +369,7 @@ func TestListExperiments_Filtering(t *testing.T) {
 
 	opts, err := list.NewOptions(&model.Experiment{}, 2, "id", filterProto)
 	assert.Nil(t, err)
-	experiments, total_size, nextPageToken, err := experimentStore.ListExperiments(opts)
+	experiments, total_size, nextPageToken, err := experimentStore.ListExperiments(&common.FilterContext{}, opts)
 
 	expected := []*model.Experiment{
 		&model.Experiment{
@@ -394,7 +395,7 @@ func TestListExperiments_Filtering(t *testing.T) {
 	opts, err = list.NewOptionsFromToken(nextPageToken, 2)
 	assert.Nil(t, err)
 
-	experiments, total_size, nextPageToken, err = experimentStore.ListExperiments(opts)
+	experiments, total_size, nextPageToken, err = experimentStore.ListExperiments(&common.FilterContext{}, opts)
 
 	expected = []*model.Experiment{
 		&model.Experiment{


### PR DESCRIPTION
Conduct user authorization on namespace for the following experiment APIs:
* CreateExperiment
* GetExperiment
* ListExperiment
* DeleteExperiment

/cc @IronPan @Bobgy

Image for testing: gcr.io/chesu-dev/api-server:pr3243

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3243)
<!-- Reviewable:end -->
