### PR TITLE
[UI] Pass namespace to experiment api calls

### DIFF
--- a/frontend/src/apis/experiment/api.ts
+++ b/frontend/src/apis/experiment/api.ts
@@ -111,6 +111,12 @@ export interface ApiExperiment {
    * @memberof ApiExperiment
    */
   created_at?: Date;
+  /**
+   * Optional input field. Specify which resource this run belongs to. For Experiment, the only valid resource reference is a single Namespace.
+   * @type {Array<ApiResourceReference>}
+   * @memberof ApiExperiment
+   */
+  resource_references?: Array<ApiResourceReference>;
 }
 
 /**
@@ -137,6 +143,77 @@ export interface ApiListExperimentsResponse {
    * @memberof ApiListExperimentsResponse
    */
   next_page_token?: string;
+}
+
+/**
+ *
+ * @export
+ * @enum {string}
+ */
+export enum ApiRelationship {
+  UNKNOWNRELATIONSHIP = <any>'UNKNOWN_RELATIONSHIP',
+  OWNER = <any>'OWNER',
+  CREATOR = <any>'CREATOR',
+}
+
+/**
+ *
+ * @export
+ * @interface ApiResourceKey
+ */
+export interface ApiResourceKey {
+  /**
+   * The type of the resource that referred to.
+   * @type {ApiResourceType}
+   * @memberof ApiResourceKey
+   */
+  type?: ApiResourceType;
+  /**
+   * The ID of the resource that referred to.
+   * @type {string}
+   * @memberof ApiResourceKey
+   */
+  id?: string;
+}
+
+/**
+ *
+ * @export
+ * @interface ApiResourceReference
+ */
+export interface ApiResourceReference {
+  /**
+   *
+   * @type {ApiResourceKey}
+   * @memberof ApiResourceReference
+   */
+  key?: ApiResourceKey;
+  /**
+   * The name of the resource that referred to.
+   * @type {string}
+   * @memberof ApiResourceReference
+   */
+  name?: string;
+  /**
+   * Required field. The relationship from referred resource to the object.
+   * @type {ApiRelationship}
+   * @memberof ApiResourceReference
+   */
+  relationship?: ApiRelationship;
+}
+
+/**
+ *
+ * @export
+ * @enum {string}
+ */
+export enum ApiResourceType {
+  UNKNOWNRESOURCETYPE = <any>'UNKNOWN_RESOURCE_TYPE',
+  EXPERIMENT = <any>'EXPERIMENT',
+  JOB = <any>'JOB',
+  PIPELINE = <any>'PIPELINE',
+  PIPELINEVERSION = <any>'PIPELINE_VERSION',
+  NAMESPACE = <any>'NAMESPACE',
 }
 
 /**
@@ -345,6 +422,8 @@ export const ExperimentServiceApiFetchParamCreator = function(configuration?: Co
      * @param {number} [page_size]
      * @param {string} [sort_by] Can be format of \&quot;field_name\&quot;, \&quot;field_name asc\&quot; or \&quot;field_name des\&quot; Ascending by default.
      * @param {string} [filter] A url-encoded, JSON-serialized Filter protocol buffer (see [filter.proto](https://github.com/kubeflow/pipelines/ blob/master/backend/api/filter.proto)).
+     * @param {'UNKNOWN_RESOURCE_TYPE' | 'EXPERIMENT' | 'JOB' | 'PIPELINE' | 'PIPELINE_VERSION' | 'NAMESPACE'} [resource_reference_key_type] The type of the resource that referred to.
+     * @param {string} [resource_reference_key_id] The ID of the resource that referred to.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -353,6 +432,14 @@ export const ExperimentServiceApiFetchParamCreator = function(configuration?: Co
       page_size?: number,
       sort_by?: string,
       filter?: string,
+      resource_reference_key_type?:
+        | 'UNKNOWN_RESOURCE_TYPE'
+        | 'EXPERIMENT'
+        | 'JOB'
+        | 'PIPELINE'
+        | 'PIPELINE_VERSION'
+        | 'NAMESPACE',
+      resource_reference_key_id?: string,
       options: any = {},
     ): FetchArgs {
       const localVarPath = `/apis/v1beta1/experiments`;
@@ -384,6 +471,14 @@ export const ExperimentServiceApiFetchParamCreator = function(configuration?: Co
 
       if (filter !== undefined) {
         localVarQueryParameter['filter'] = filter;
+      }
+
+      if (resource_reference_key_type !== undefined) {
+        localVarQueryParameter['resource_reference_key.type'] = resource_reference_key_type;
+      }
+
+      if (resource_reference_key_id !== undefined) {
+        localVarQueryParameter['resource_reference_key.id'] = resource_reference_key_id;
       }
 
       localVarUrlObj.query = Object.assign(
@@ -490,6 +585,8 @@ export const ExperimentServiceApiFp = function(configuration?: Configuration) {
      * @param {number} [page_size]
      * @param {string} [sort_by] Can be format of \&quot;field_name\&quot;, \&quot;field_name asc\&quot; or \&quot;field_name des\&quot; Ascending by default.
      * @param {string} [filter] A url-encoded, JSON-serialized Filter protocol buffer (see [filter.proto](https://github.com/kubeflow/pipelines/ blob/master/backend/api/filter.proto)).
+     * @param {'UNKNOWN_RESOURCE_TYPE' | 'EXPERIMENT' | 'JOB' | 'PIPELINE' | 'PIPELINE_VERSION' | 'NAMESPACE'} [resource_reference_key_type] The type of the resource that referred to.
+     * @param {string} [resource_reference_key_id] The ID of the resource that referred to.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -498,6 +595,14 @@ export const ExperimentServiceApiFp = function(configuration?: Configuration) {
       page_size?: number,
       sort_by?: string,
       filter?: string,
+      resource_reference_key_type?:
+        | 'UNKNOWN_RESOURCE_TYPE'
+        | 'EXPERIMENT'
+        | 'JOB'
+        | 'PIPELINE'
+        | 'PIPELINE_VERSION'
+        | 'NAMESPACE',
+      resource_reference_key_id?: string,
       options?: any,
     ): (fetch?: FetchAPI, basePath?: string) => Promise<ApiListExperimentsResponse> {
       const localVarFetchArgs = ExperimentServiceApiFetchParamCreator(configuration).listExperiment(
@@ -505,6 +610,8 @@ export const ExperimentServiceApiFp = function(configuration?: Configuration) {
         page_size,
         sort_by,
         filter,
+        resource_reference_key_type,
+        resource_reference_key_id,
         options,
       );
       return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
@@ -567,6 +674,8 @@ export const ExperimentServiceApiFactory = function(
      * @param {number} [page_size]
      * @param {string} [sort_by] Can be format of \&quot;field_name\&quot;, \&quot;field_name asc\&quot; or \&quot;field_name des\&quot; Ascending by default.
      * @param {string} [filter] A url-encoded, JSON-serialized Filter protocol buffer (see [filter.proto](https://github.com/kubeflow/pipelines/ blob/master/backend/api/filter.proto)).
+     * @param {'UNKNOWN_RESOURCE_TYPE' | 'EXPERIMENT' | 'JOB' | 'PIPELINE' | 'PIPELINE_VERSION' | 'NAMESPACE'} [resource_reference_key_type] The type of the resource that referred to.
+     * @param {string} [resource_reference_key_id] The ID of the resource that referred to.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -575,6 +684,14 @@ export const ExperimentServiceApiFactory = function(
       page_size?: number,
       sort_by?: string,
       filter?: string,
+      resource_reference_key_type?:
+        | 'UNKNOWN_RESOURCE_TYPE'
+        | 'EXPERIMENT'
+        | 'JOB'
+        | 'PIPELINE'
+        | 'PIPELINE_VERSION'
+        | 'NAMESPACE',
+      resource_reference_key_id?: string,
       options?: any,
     ) {
       return ExperimentServiceApiFp(configuration).listExperiment(
@@ -582,6 +699,8 @@ export const ExperimentServiceApiFactory = function(
         page_size,
         sort_by,
         filter,
+        resource_reference_key_type,
+        resource_reference_key_id,
         options,
       )(fetch, basePath);
     },
@@ -647,6 +766,8 @@ export class ExperimentServiceApi extends BaseAPI {
    * @param {number} [page_size]
    * @param {string} [sort_by] Can be format of \&quot;field_name\&quot;, \&quot;field_name asc\&quot; or \&quot;field_name des\&quot; Ascending by default.
    * @param {string} [filter] A url-encoded, JSON-serialized Filter protocol buffer (see [filter.proto](https://github.com/kubeflow/pipelines/ blob/master/backend/api/filter.proto)).
+   * @param {'UNKNOWN_RESOURCE_TYPE' | 'EXPERIMENT' | 'JOB' | 'PIPELINE' | 'PIPELINE_VERSION' | 'NAMESPACE'} [resource_reference_key_type] The type of the resource that referred to.
+   * @param {string} [resource_reference_key_id] The ID of the resource that referred to.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof ExperimentServiceApi
@@ -656,6 +777,14 @@ export class ExperimentServiceApi extends BaseAPI {
     page_size?: number,
     sort_by?: string,
     filter?: string,
+    resource_reference_key_type?:
+      | 'UNKNOWN_RESOURCE_TYPE'
+      | 'EXPERIMENT'
+      | 'JOB'
+      | 'PIPELINE'
+      | 'PIPELINE_VERSION'
+      | 'NAMESPACE',
+    resource_reference_key_id?: string,
     options?: any,
   ) {
     return ExperimentServiceApiFp(this.configuration).listExperiment(
@@ -663,6 +792,8 @@ export class ExperimentServiceApi extends BaseAPI {
       page_size,
       sort_by,
       filter,
+      resource_reference_key_type,
+      resource_reference_key_id,
       options,
     )(this.fetch, this.basePath);
   }

--- a/frontend/src/pages/ExperimentList.tsx
+++ b/frontend/src/pages/ExperimentList.tsx
@@ -30,7 +30,7 @@ import { ApiRun, RunStorageState } from '../apis/run';
 import { Apis, ExperimentSortKeys, ListRequest, RunSortKeys } from '../lib/Apis';
 import { Link } from 'react-router-dom';
 import { NodePhase } from '../lib/StatusUtils';
-import { Page } from './Page';
+import { Page, PageProps } from './Page';
 import { RoutePage, RouteParams } from '../components/Router';
 import { ToolbarProps } from '../components/Toolbar';
 import { classes } from 'typestyle';
@@ -38,6 +38,7 @@ import { commonCss, padding } from '../Css';
 import { logger } from '../lib/Utils';
 import { statusToIcon } from './Status';
 import Tooltip from '@material-ui/core/Tooltip';
+import { NamespaceContext } from 'src/lib/KubeflowClient';
 
 interface DisplayExperiment extends ApiExperiment {
   last5Runs?: ApiRun[];
@@ -51,7 +52,7 @@ interface ExperimentListState {
   selectedTab: number;
 }
 
-class ExperimentList extends Page<{}, ExperimentListState> {
+export class ExperimentList extends Page<{ namespace?: string }, ExperimentListState> {
   private _tableRef = React.createRef<CustomTable>();
 
   constructor(props: any) {
@@ -181,6 +182,8 @@ class ExperimentList extends Page<{}, ExperimentListState> {
         request.pageSize,
         request.sortBy,
         request.filter,
+        this.props.namespace ? 'NAMESPACE' : undefined,
+        this.props.namespace || undefined,
       );
       displayExperiments = response.experiments || [];
       displayExperiments.forEach(exp => (exp.expandState = ExpandState.COLLAPSED));
@@ -267,4 +270,9 @@ class ExperimentList extends Page<{}, ExperimentListState> {
   }
 }
 
-export default ExperimentList;
+const EnhancedExperimentList: React.FC<PageProps> = props => {
+  const namespace = React.useContext(NamespaceContext);
+  return <ExperimentList {...props} namespace={namespace} />;
+};
+
+export default EnhancedExperimentList;

--- a/frontend/src/pages/NewExperiment.tsx
+++ b/frontend/src/pages/NewExperiment.tsx
@@ -18,9 +18,9 @@ import * as React from 'react';
 import BusyButton from '../atoms/BusyButton';
 import Button from '@material-ui/core/Button';
 import Input from '../atoms/Input';
-import { ApiExperiment } from '../apis/experiment';
+import { ApiExperiment, ApiResourceType, ApiRelationship } from '../apis/experiment';
 import { Apis } from '../lib/Apis';
-import { Page } from './Page';
+import { Page, PageProps } from './Page';
 import { RoutePage, QUERY_PARAMS } from '../components/Router';
 import { TextFieldProps } from '@material-ui/core/TextField';
 import { ToolbarProps } from '../components/Toolbar';
@@ -28,6 +28,7 @@ import { URLParser } from '../lib/URLParser';
 import { classes, stylesheet } from 'typestyle';
 import { commonCss, padding, fontsize } from '../Css';
 import { logger, errorToMessage } from '../lib/Utils';
+import { NamespaceContext } from 'src/lib/KubeflowClient';
 
 interface NewExperimentState {
   description: string;
@@ -47,7 +48,7 @@ const css = stylesheet({
   },
 });
 
-class NewExperiment extends Page<{}, NewExperimentState> {
+export class NewExperiment extends Page<{ namespace?: string }, NewExperimentState> {
   private _experimentNameRef = React.createRef<HTMLInputElement>();
 
   constructor(props: any) {
@@ -146,6 +147,17 @@ class NewExperiment extends Page<{}, NewExperimentState> {
     const newExperiment: ApiExperiment = {
       description: this.state.description,
       name: this.state.experimentName,
+      resource_references: this.props.namespace
+        ? [
+            {
+              key: {
+                id: this.props.namespace,
+                type: ApiResourceType.NAMESPACE,
+              },
+              relationship: ApiRelationship.OWNER,
+            },
+          ]
+        : undefined,
     };
 
     this.setState({ isbeingCreated: true }, async () => {
@@ -193,4 +205,9 @@ class NewExperiment extends Page<{}, NewExperimentState> {
   }
 }
 
-export default NewExperiment;
+const EnhancedNewExperiment: React.FC<PageProps> = props => {
+  const namespace = React.useContext(NamespaceContext);
+  return <NewExperiment {...props} namespace={namespace} />;
+};
+
+export default EnhancedNewExperiment;

--- a/frontend/src/pages/__snapshots__/ExperimentsAndRuns.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ExperimentsAndRuns.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`ExperimentsAndRuns renders experiments page 1`] = `
       ]
     }
   />
-  <ExperimentList
+  <EnhancedExperimentList
     history={Object {}}
     location=""
     match=""


### PR DESCRIPTION
/assign @chensun 
/area frontend

Fixes https://github.com/kubeflow/pipelines/issues/3291

Pass namespace to all experiment api calls:
* listExperiment
* createExperiment

@chensun I built UI image that you can try first: gcr.io/gongyuan-pipeline-test/dev/frontend@sha256:f6d3ac5de4994cb3a9ed92e773544e580ec515435502ac5162f69b7f8108504a
I verified the image works, please have a try.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3252)
<!-- Reviewable:end -->
