### PR TITLE
SDK - Components - Make component structures hashable

### DIFF
--- a/sdk/python/kfp/components/modelbase.py
+++ b/sdk/python/kfp/components/modelbase.py
@@ -286,3 +286,6 @@ class ModelBase:
 
     def __ne__(self, other):
         return not self == other
+
+    def __hash__(self):
+        return hash(repr(self))


### PR DESCRIPTION
This commit makes it possiblt to put TaskSpec or InputSpec into python set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3258)
<!-- Reviewable:end -->
