### PR TITLE
SDK - Components - Fixed handling collection return values

### DIFF
--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
@@ -31,9 +31,6 @@ spec:
               
               _outputs = consume(**_parsed_args)
               
-              if not hasattr(_outputs, '__getitem__') or isinstance(_outputs, str):
-                  _outputs = [_outputs]
-              
               _output_serializers = [
               
               ]
@@ -75,9 +72,6 @@ spec:
               _output_files = _parsed_args.pop("_output_paths", [])
               
               _outputs = consume(**_parsed_args)
-              
-              if not hasattr(_outputs, '__getitem__') or isinstance(_outputs, str):
-                  _outputs = [_outputs]
               
               _output_serializers = [
               
@@ -121,9 +115,6 @@ spec:
               
               _outputs = consume(**_parsed_args)
               
-              if not hasattr(_outputs, '__getitem__') or isinstance(_outputs, str):
-                  _outputs = [_outputs]
-              
               _output_serializers = [
               
               ]
@@ -165,9 +156,6 @@ spec:
               _output_files = _parsed_args.pop("_output_paths", [])
               
               _outputs = consume(**_parsed_args)
-              
-              if not hasattr(_outputs, '__getitem__') or isinstance(_outputs, str):
-                  _outputs = [_outputs]
               
               _output_serializers = [
               
@@ -211,9 +199,6 @@ spec:
               
               _outputs = consume(**_parsed_args)
               
-              if not hasattr(_outputs, '__getitem__') or isinstance(_outputs, str):
-                  _outputs = [_outputs]
-              
               _output_serializers = [
               
               ]
@@ -256,9 +241,6 @@ spec:
               
               _outputs = consume(**_parsed_args)
               
-              if not hasattr(_outputs, '__getitem__') or isinstance(_outputs, str):
-                  _outputs = [_outputs]
-              
               _output_serializers = [
               
               ]
@@ -300,9 +282,6 @@ spec:
               _output_files = _parsed_args.pop("_output_paths", [])
               
               _outputs = consume(**_parsed_args)
-              
-              if not hasattr(_outputs, '__getitem__') or isinstance(_outputs, str):
-                  _outputs = [_outputs]
               
               _output_serializers = [
               
@@ -507,8 +486,7 @@ spec:
               
               _outputs = produce_list_of_dicts(**_parsed_args)
               
-              if not hasattr(_outputs, '__getitem__') or isinstance(_outputs, str):
-                  _outputs = [_outputs]
+              _outputs = [_outputs]
               
               _output_serializers = [
                   _serialize_json,
@@ -570,8 +548,7 @@ spec:
               
               _outputs = produce_list_of_ints(**_parsed_args)
               
-              if not hasattr(_outputs, '__getitem__') or isinstance(_outputs, str):
-                  _outputs = [_outputs]
+              _outputs = [_outputs]
               
               _output_serializers = [
                   _serialize_json,
@@ -633,8 +610,7 @@ spec:
               
               _outputs = produce_list_of_strings(**_parsed_args)
               
-              if not hasattr(_outputs, '__getitem__') or isinstance(_outputs, str):
-                  _outputs = [_outputs]
+              _outputs = [_outputs]
               
               _output_serializers = [
                   _serialize_json,
@@ -690,8 +666,7 @@ spec:
               
               _outputs = produce_str(**_parsed_args)
               
-              if not hasattr(_outputs, '__getitem__') or isinstance(_outputs, str):
-                  _outputs = [_outputs]
+              _outputs = [_outputs]
               
               _output_serializers = [
                   _serialize_str,

--- a/sdk/python/tests/components/test_python_op.py
+++ b/sdk/python/tests/components/test_python_op.py
@@ -554,7 +554,7 @@ class PythonOpTestCase(unittest.TestCase):
 
     def test_handling_list_dict_output_values(self):
         def produce_list() -> list:
-            return (["string", 1, 2.2, True, False, None, [3, 4], {'s': 5}], )
+            return ["string", 1, 2.2, True, False, None, [3, 4], {'s': 5}]
         
         # ! JSON map keys are always strings. Python converts all keys to strings without warnings
         task_factory = comp.func_to_container_op(produce_list)


### PR DESCRIPTION
Problem: Python components with single unnamed collection outputs are handled incorrectly.

Fixes https://github.com/kubeflow/pipelines/issues/3262

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3263)
<!-- Reviewable:end -->
