### PR TITLE
SDK - Moved _dsl_bridge to dsl

### DIFF
--- a/sdk/python/kfp/dsl/_component_bridge.py
+++ b/sdk/python/kfp/dsl/_component_bridge.py
@@ -14,8 +14,9 @@
 
 import copy
 from typing import Any, Mapping
-from .structures import ComponentSpec, ComponentReference
-from ._components import _default_component_name, _resolve_command_line_and_paths
+from ..components.structures import ComponentSpec, ComponentReference
+from ..components._components import _default_component_name, _resolve_command_line_and_paths
+from ..components._naming import _sanitize_python_function_name, generate_unique_name_conversion_table
 from .. import dsl
 
 
@@ -40,7 +41,6 @@ def _create_container_op_from_component_and_arguments(
     )
 
     #Renaming outputs to conform with ContainerOp/Argo
-    from ._naming import _sanitize_python_function_name, generate_unique_name_conversion_table
     output_names = (resolved_cmd.output_paths or {}).keys()
     output_name_to_python = generate_unique_name_conversion_table(output_names, _sanitize_python_function_name)
     output_paths_for_container_op = {output_name_to_python[name]: path for name, path in resolved_cmd.output_paths.items()}

--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -16,8 +16,9 @@
 from . import _container_op
 from . import _resource_op
 from . import _ops_group
+from ._component_bridge import _create_container_op_from_component_and_arguments
+from ..components import _components
 from ..components._naming import _make_name_unique_by_adding_index
-from ..components import _dsl_bridge, _components
 import sys
 
 
@@ -191,7 +192,7 @@ class Pipeline():
 
     Pipeline._default_pipeline = self
     self._old_container_task_constructor = _components._container_task_constructor
-    _components._container_task_constructor = _dsl_bridge._create_container_op_from_component_and_arguments
+    _components._container_task_constructor = _create_container_op_from_component_and_arguments
 
     def register_op_and_generate_id(op):
       return self.add_op(op, op.is_exit_handler)

--- a/sdk/python/tests/dsl/component_bridge_tests.py
+++ b/sdk/python/tests/dsl/component_bridge_tests.py
@@ -24,7 +24,7 @@ class TestComponentBridge(unittest.TestCase):
     # Alternatively, we could use kfp.dsl.Pipleine().__enter__ and __exit__
     def setUp(self):
         self.old_container_task_constructor = kfp.components._components._container_task_constructor
-        kfp.components._components._container_task_constructor = kfp.components._dsl_bridge._create_container_op_from_component_and_arguments
+        kfp.components._components._container_task_constructor = kfp.dsl._component_bridge._create_container_op_from_component_and_arguments
 
     def tearDown(self):
         kfp.components._components._container_task_constructor = self.old_container_task_constructor


### PR DESCRIPTION
This is a pure refactoring change.
The components library should not have any dependencies on the DSL library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3267)
<!-- Reviewable:end -->
