### PR TITLE
[Testing] Recycle upgrade- clusters and reduce time lapse

### DIFF
--- a/test/tools/project-cleaner/resource_spec.yaml
+++ b/test/tools/project-cleaner/resource_spec.yaml
@@ -20,4 +20,5 @@ resources:
     name-prefixes:
       - e2e-
       - sample-
-    time-lapse-hours: 24
+      - upgrade-
+    time-lapse-hours: 2


### PR DESCRIPTION
Two changes:
1. also recycle clusters with `upgrade-` prefix
2. Recycle clusters earlier, 2 hours after test finish can reduce some test flakiness caused by too many clusters in the project

/assign @dushyanthsc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3282)
<!-- Reviewable:end -->
