### PR TITLE
[UI] Auto refresh/redirect experiment list/detail page when user selects a different namespace

### DIFF
--- a/frontend/src/pages/ExperimentDetails.tsx
+++ b/frontend/src/pages/ExperimentDetails.tsx
@@ -28,12 +28,14 @@ import Toolbar, { ToolbarProps } from '../components/Toolbar';
 import Tooltip from '@material-ui/core/Tooltip';
 import { ApiExperiment } from '../apis/experiment';
 import { Apis } from '../lib/Apis';
-import { Page } from './Page';
+import { Page, PageProps } from './Page';
 import { RoutePage, RouteParams } from '../components/Router';
 import { RunStorageState } from '../apis/run';
 import { classes, stylesheet } from 'typestyle';
 import { color, commonCss, padding } from '../Css';
 import { logger } from '../lib/Utils';
+import { NamespaceContext } from 'src/lib/KubeflowClient';
+import { Redirect } from 'react-router-dom';
 
 const css = stylesheet({
   card: {
@@ -106,7 +108,7 @@ interface ExperimentDetailsState {
   runListToolbarProps: ToolbarProps;
 }
 
-class ExperimentDetails extends Page<{}, ExperimentDetailsState> {
+export class ExperimentDetails extends Page<{}, ExperimentDetailsState> {
   private _runlistRef = React.createRef<RunList>();
 
   constructor(props: any) {
@@ -343,4 +345,17 @@ class ExperimentDetails extends Page<{}, ExperimentDetailsState> {
   }
 }
 
-export default ExperimentDetails;
+const EnhancedExperimentDetails: React.FC<PageProps> = props => {
+  const namespace = React.useContext(NamespaceContext);
+  const [initialNamespace] = React.useState(namespace);
+
+  // When namespace changes, this experiment no longer belongs to new namespace.
+  // So we redirect to experiment list page instead.
+  if (namespace !== initialNamespace) {
+    return <Redirect to={RoutePage.EXPERIMENTS} />;
+  }
+
+  return <ExperimentDetails {...props} />;
+};
+
+export default EnhancedExperimentDetails;

--- a/frontend/src/pages/ExperimentList.test.tsx
+++ b/frontend/src/pages/ExperimentList.test.tsx
@@ -31,7 +31,15 @@ import { ButtonKeys } from '../lib/Buttons';
 import { NamespaceContext } from 'src/lib/KubeflowClient';
 import { render } from '@testing-library/react';
 
-const LIST_EXPERIMENT_DEFAULTS = ['', 10, 'created_at desc', '', undefined, undefined];
+// Default arguments for Apis.experimentServiceApi.listExperiment.
+const LIST_EXPERIMENT_DEFAULTS = [
+  '', // page token
+  10, // page size
+  'created_at desc', // sort by
+  '', // filter
+  undefined, // resource_reference_key_type
+  undefined, // resource_reference_key_id
+];
 
 describe('ExperimentList', () => {
   let tree: ShallowWrapper | ReactWrapper;

--- a/frontend/src/pages/ExperimentList.test.tsx
+++ b/frontend/src/pages/ExperimentList.test.tsx
@@ -16,7 +16,7 @@
 
 import * as React from 'react';
 import * as Utils from '../lib/Utils';
-import { ExperimentList } from './ExperimentList';
+import EnhancedExperimentList, { ExperimentList } from './ExperimentList';
 import TestUtils from '../TestUtils';
 import { ApiFilter, PredicateOp } from '../apis/filter';
 import { RunStorageState } from '../apis/run';
@@ -28,6 +28,10 @@ import { ReactWrapper, ShallowWrapper, shallow } from 'enzyme';
 import { RoutePage, QUERY_PARAMS } from '../components/Router';
 import { range } from 'lodash';
 import { ButtonKeys } from '../lib/Buttons';
+import { NamespaceContext } from 'src/lib/KubeflowClient';
+import { render } from '@testing-library/react';
+
+const LIST_EXPERIMENT_DEFAULTS = ['', 10, 'created_at desc', '', undefined, undefined];
 
 describe('ExperimentList', () => {
   let tree: ShallowWrapper | ReactWrapper;
@@ -82,7 +86,9 @@ describe('ExperimentList', () => {
   afterEach(() => {
     jest.resetAllMocks();
     jest.clearAllMocks();
-    tree.unmount();
+    if (tree.exists()) {
+      tree.unmount();
+    }
   });
 
   it('renders an empty list with empty state message', () => {
@@ -140,14 +146,7 @@ describe('ExperimentList', () => {
 
   it('calls Apis to list experiments, sorted by creation time in descending order', async () => {
     await mountWithNExperiments(1, 1);
-    expect(listExperimentsSpy).toHaveBeenLastCalledWith(
-      '',
-      10,
-      'created_at desc',
-      '',
-      undefined,
-      undefined,
-    );
+    expect(listExperimentsSpy).toHaveBeenLastCalledWith(...LIST_EXPERIMENT_DEFAULTS);
     expect(listRunsSpy).toHaveBeenLastCalledWith(
       undefined,
       5,
@@ -179,10 +178,7 @@ describe('ExperimentList', () => {
   it('calls Apis to list experiments with namespace when available', async () => {
     await mountWithNExperiments(1, 1, { namespace: 'test-ns' });
     expect(listExperimentsSpy).toHaveBeenLastCalledWith(
-      '',
-      10,
-      'created_at desc',
-      '',
+      ...LIST_EXPERIMENT_DEFAULTS.slice(0, 4),
       'NAMESPACE',
       'test-ns',
     );
@@ -196,14 +192,7 @@ describe('ExperimentList', () => {
     expect(refreshBtn).toBeDefined();
     await refreshBtn!.action();
     expect(listExperimentsSpy.mock.calls.length).toBe(2);
-    expect(listExperimentsSpy).toHaveBeenLastCalledWith(
-      '',
-      10,
-      'created_at desc',
-      '',
-      undefined,
-      undefined,
-    );
+    expect(listExperimentsSpy).toHaveBeenLastCalledWith(...LIST_EXPERIMENT_DEFAULTS);
     expect(updateBannerSpy).toHaveBeenLastCalledWith({});
   });
 
@@ -248,14 +237,7 @@ describe('ExperimentList', () => {
     TestUtils.makeErrorResponseOnce(listExperimentsSpy, 'bad stuff happened');
     await refreshBtn!.action();
     expect(listExperimentsSpy.mock.calls.length).toBe(2);
-    expect(listExperimentsSpy).toHaveBeenLastCalledWith(
-      '',
-      10,
-      'created_at desc',
-      '',
-      undefined,
-      undefined,
-    );
+    expect(listExperimentsSpy).toHaveBeenLastCalledWith(...LIST_EXPERIMENT_DEFAULTS);
     expect(updateBannerSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
         additionalInfo: 'bad stuff happened',
@@ -437,5 +419,50 @@ describe('ExperimentList', () => {
         ],
       }),
     ).toMatchSnapshot();
+  });
+
+  describe('EnhancedExperimentList', () => {
+    it('defaults to no namespace', () => {
+      render(<EnhancedExperimentList {...generateProps()} />);
+      expect(listExperimentsSpy).toHaveBeenLastCalledWith(...LIST_EXPERIMENT_DEFAULTS);
+    });
+
+    it('gets namespace from context', () => {
+      render(
+        <NamespaceContext.Provider value='test-ns'>
+          <EnhancedExperimentList {...generateProps()} />
+        </NamespaceContext.Provider>,
+      );
+      expect(listExperimentsSpy).toHaveBeenLastCalledWith(
+        ...LIST_EXPERIMENT_DEFAULTS.slice(0, 4),
+        'NAMESPACE',
+        'test-ns',
+      );
+    });
+
+    it('auto refreshes list when namespace changes', () => {
+      const { rerender } = render(
+        <NamespaceContext.Provider value='test-ns-1'>
+          <EnhancedExperimentList {...generateProps()} />
+        </NamespaceContext.Provider>,
+      );
+      expect(listExperimentsSpy).toHaveBeenCalledTimes(1);
+      expect(listExperimentsSpy).toHaveBeenLastCalledWith(
+        ...LIST_EXPERIMENT_DEFAULTS.slice(0, 4),
+        'NAMESPACE',
+        'test-ns-1',
+      );
+      rerender(
+        <NamespaceContext.Provider value='test-ns-2'>
+          <EnhancedExperimentList {...generateProps()} />
+        </NamespaceContext.Provider>,
+      );
+      expect(listExperimentsSpy).toHaveBeenCalledTimes(2);
+      expect(listExperimentsSpy).toHaveBeenLastCalledWith(
+        ...LIST_EXPERIMENT_DEFAULTS.slice(0, 4),
+        'NAMESPACE',
+        'test-ns-2',
+      );
+    });
   });
 });

--- a/frontend/src/pages/ExperimentList.test.tsx
+++ b/frontend/src/pages/ExperimentList.test.tsx
@@ -40,6 +40,7 @@ const LIST_EXPERIMENT_DEFAULTS = [
   undefined, // resource_reference_key_type
   undefined, // resource_reference_key_id
 ];
+const LIST_EXPERIMENT_DEFAULTS_WITHOUT_RESOURCE_REFERENCE = LIST_EXPERIMENT_DEFAULTS.slice(0, 4);
 
 describe('ExperimentList', () => {
   let tree: ShallowWrapper | ReactWrapper;
@@ -186,7 +187,7 @@ describe('ExperimentList', () => {
   it('calls Apis to list experiments with namespace when available', async () => {
     await mountWithNExperiments(1, 1, { namespace: 'test-ns' });
     expect(listExperimentsSpy).toHaveBeenLastCalledWith(
-      ...LIST_EXPERIMENT_DEFAULTS.slice(0, 4),
+      ...LIST_EXPERIMENT_DEFAULTS_WITHOUT_RESOURCE_REFERENCE,
       'NAMESPACE',
       'test-ns',
     );
@@ -442,7 +443,7 @@ describe('ExperimentList', () => {
         </NamespaceContext.Provider>,
       );
       expect(listExperimentsSpy).toHaveBeenLastCalledWith(
-        ...LIST_EXPERIMENT_DEFAULTS.slice(0, 4),
+        ...LIST_EXPERIMENT_DEFAULTS_WITHOUT_RESOURCE_REFERENCE,
         'NAMESPACE',
         'test-ns',
       );
@@ -456,7 +457,7 @@ describe('ExperimentList', () => {
       );
       expect(listExperimentsSpy).toHaveBeenCalledTimes(1);
       expect(listExperimentsSpy).toHaveBeenLastCalledWith(
-        ...LIST_EXPERIMENT_DEFAULTS.slice(0, 4),
+        ...LIST_EXPERIMENT_DEFAULTS_WITHOUT_RESOURCE_REFERENCE,
         'NAMESPACE',
         'test-ns-1',
       );
@@ -467,7 +468,7 @@ describe('ExperimentList', () => {
       );
       expect(listExperimentsSpy).toHaveBeenCalledTimes(2);
       expect(listExperimentsSpy).toHaveBeenLastCalledWith(
-        ...LIST_EXPERIMENT_DEFAULTS.slice(0, 4),
+        ...LIST_EXPERIMENT_DEFAULTS_WITHOUT_RESOURCE_REFERENCE,
         'NAMESPACE',
         'test-ns-2',
       );

--- a/frontend/src/pages/ExperimentList.tsx
+++ b/frontend/src/pages/ExperimentList.tsx
@@ -272,7 +272,7 @@ export class ExperimentList extends Page<{ namespace?: string }, ExperimentListS
 
 const EnhancedExperimentList: React.FC<PageProps> = props => {
   const namespace = React.useContext(NamespaceContext);
-  return <ExperimentList {...props} namespace={namespace} />;
+  return <ExperimentList key={namespace} {...props} namespace={namespace} />;
 };
 
 export default EnhancedExperimentList;


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/3296
/area frontend
/cc @chensun

Built image for preview:
```
gcr.io/gongyuan-pipeline-test/dev/frontend@sha256:60e2ee94c910f04a86e499a08ef73a9fc3dcbdba8160f5b03f8e2db1eed7a8f9
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3297)
<!-- Reviewable:end -->
