### PR TITLE
[Test] Switch Travis dependency to TF2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ matrix:
         - git clone https://github.com/tensorflow/tfx.git
         - cd $TRAVIS_BUILD_DIR/tfx
         - pip3 install --upgrade pip
-        - python3 -m pip install "tensorflow>=1.14,<2"
         - set -x
         - set -e
         - python3 setup.py bdist_wheel


### PR DESCRIPTION
It's likely because TFX switched their head to depending on TF2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3299)
<!-- Reviewable:end -->
