### PR TITLE
[UI] Show step pod yaml and events in RunDetails page

### DIFF
--- a/frontend/server/app.test.ts
+++ b/frontend/server/app.test.ts
@@ -373,9 +373,6 @@ describe('UIServer apis', () => {
 
   describe('/system', () => {
     describe('/cluster-name', () => {
-      beforeEach(() => {
-        mockedK8sHelper.isInCluster = true;
-      });
       it('responds with cluster name data from gke metadata', done => {
         mockedFetch.mockImplementationOnce((url: string, _opts: any) =>
           url === 'http://metadata/computeMetadata/v1/instance/attributes/cluster-name'
@@ -412,9 +409,6 @@ describe('UIServer apis', () => {
       });
     });
     describe('/project-id', () => {
-      beforeEach(() => {
-        mockedK8sHelper.isInCluster = true;
-      });
       it('responds with project id data from gke metadata', done => {
         mockedFetch.mockImplementationOnce((url: string, _opts: any) =>
           url === 'http://metadata/computeMetadata/v1/project/project-id'
@@ -446,10 +440,7 @@ describe('UIServer apis', () => {
     });
   });
 
-  // TODO: refractor k8s helper module so that api that interact with k8s can be
-  // mocked and tested. There is currently no way to mock k8s APIs as
-  // `k8s-helper.isInCluster` is a constant that is generated when the module is
-  // first loaded.
+  // TODO: Add integration tests for k8s helper related endpoints
 
   // describe('/apps/tensorboard', () => {
 

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -26,7 +26,7 @@ import {
   deleteTensorboardHandler,
 } from './handlers/tensorboard';
 import { getPodLogsHandler } from './handlers/pod-logs';
-import { podInfoHandler } from './handlers/pod-info';
+import { podInfoHandler, podEventsHandler } from './handlers/pod-info';
 import { getClusterNameHandler, getProjectIdHandler } from './handlers/gke-metadata';
 import { getAllowCustomVisualizationsHandler } from './handlers/vis';
 import { getIndexHTMLHandler } from './handlers/index-html';
@@ -129,6 +129,7 @@ function createUIServer(options: UIConfigs) {
   registerHandler(app.get, '/k8s/pod/logs', getPodLogsHandler(options.argo, options.artifacts));
   /** Pod info */
   registerHandler(app.get, '/k8s/pod', podInfoHandler);
+  registerHandler(app.get, '/k8s/pod/events', podEventsHandler);
 
   /** Cluster metadata (GKE only) */
   registerHandler(app.get, '/system/cluster-name', getClusterNameHandler(options.gkeMetadata));

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -26,6 +26,7 @@ import {
   deleteTensorboardHandler,
 } from './handlers/tensorboard';
 import { getPodLogsHandler } from './handlers/pod-logs';
+import { podInfoHandler } from './handlers/pod-info';
 import { getClusterNameHandler, getProjectIdHandler } from './handlers/gke-metadata';
 import { getAllowCustomVisualizationsHandler } from './handlers/vis';
 import { getIndexHTMLHandler } from './handlers/index-html';
@@ -126,6 +127,8 @@ function createUIServer(options: UIConfigs) {
 
   /** Pod logs */
   registerHandler(app.get, '/k8s/pod/logs', getPodLogsHandler(options.argo, options.artifacts));
+  /** Pod info */
+  registerHandler(app.get, '/k8s/pod', podInfoHandler);
 
   /** Cluster metadata (GKE only) */
   registerHandler(app.get, '/system/cluster-name', getClusterNameHandler(options.gkeMetadata));

--- a/frontend/server/handlers/gke-metadata.ts
+++ b/frontend/server/handlers/gke-metadata.ts
@@ -28,11 +28,6 @@ export const getClusterNameHandler = (options: GkeMetadataConfigs) => {
 };
 
 const clusterNameHandler: Handler = async (_, res) => {
-  if (!k8sHelper.isInCluster) {
-    res.status(500).send('Not running in Kubernetes cluster.');
-    return;
-  }
-
   const response = await fetch(
     'http://metadata/computeMetadata/v1/instance/attributes/cluster-name',
     { headers: { 'Metadata-Flavor': 'Google' } },
@@ -52,11 +47,6 @@ export const getProjectIdHandler = (options: GkeMetadataConfigs) => {
 };
 
 const projectIdHandler: Handler = async (_, res) => {
-  if (!k8sHelper.isInCluster) {
-    res.status(500).send('Not running in Kubernetes cluster.');
-    return;
-  }
-
   const response = await fetch('http://metadata/computeMetadata/v1/project/project-id', {
     headers: { 'Metadata-Flavor': 'Google' },
   });

--- a/frontend/server/handlers/pod-info.ts
+++ b/frontend/server/handlers/pod-info.ts
@@ -37,6 +37,7 @@ export const podInfoHandler: Handler = async (req, res) => {
     const { message, additionalInfo } = err;
     console.error(message, additionalInfo);
     res.status(500).send(message);
+    return;
   }
   res.status(200).send(JSON.stringify(pod));
 };
@@ -54,13 +55,12 @@ export const podEventsHandler: Handler = async (req, res) => {
   const podName = decodeURIComponent(podname);
   const podNamespace = decodeURIComponent(podnamespace);
 
-  try {
-    const eventList = await k8sHelper.listPodEvents(podName, podNamespace);
-    res.status(200).send(JSON.stringify(eventList));
-  } catch (err) {
-    const message = `Could not list events for pod ${podName} in namespace ${podNamespace}`;
-    console.error(message, err?.body || err);
-    const additionalInfo = err?.body?.message || err?.message || err;
-    res.status(500).send(`${message}: ${additionalInfo}`);
+  const [eventList, err] = await k8sHelper.listPodEvents(podName, podNamespace);
+  if (err) {
+    const { message, additionalInfo } = err;
+    console.error(message, additionalInfo);
+    res.status(500).send(message);
+    return;
   }
+  res.status(200).send(JSON.stringify(eventList));
 };

--- a/frontend/server/handlers/pod-info.ts
+++ b/frontend/server/handlers/pod-info.ts
@@ -36,8 +36,32 @@ export const podInfoHandler: Handler = async (req, res) => {
     res.status(200).send(JSON.stringify(pod));
   } catch (err) {
     const message = `Could not get pod ${podName} in namespace ${podNamespace}`;
-    console.error(message, err);
-    const detailedMessage = err?.body?.message || err?.message || err;
-    res.status(500).send(`${message}: ${detailedMessage}`);
+    console.error(message, err?.body || err);
+    const additionalInfo = err?.body?.message || err?.message || err;
+    res.status(500).send(`${message}: ${additionalInfo}`);
+  }
+};
+
+export const podEventsHandler: Handler = async (req, res) => {
+  const { podname, podnamespace } = req.query;
+  if (!podname) {
+    res.status(404).send('podname argument is required');
+    return;
+  }
+  if (!podnamespace) {
+    res.status(404).send('podnamespace argument is required');
+    return;
+  }
+  const podName = decodeURIComponent(podname);
+  const podNamespace = decodeURIComponent(podnamespace);
+
+  try {
+    const eventList = await k8sHelper.listPodEvents(podName, podNamespace);
+    res.status(200).send(JSON.stringify(eventList));
+  } catch (err) {
+    const message = `Could not list events for pod ${podName} in namespace ${podNamespace}`;
+    console.error(message, err?.body || err);
+    const additionalInfo = err?.body?.message || err?.message || err;
+    res.status(500).send(`${message}: ${additionalInfo}`);
   }
 };

--- a/frontend/server/handlers/pod-info.ts
+++ b/frontend/server/handlers/pod-info.ts
@@ -1,0 +1,43 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Handler } from 'express';
+import * as k8sHelper from '../k8s-helper';
+
+/**
+ * podInfoHandler retrieves pod info and sends back as JSON format.
+ */
+export const podInfoHandler: Handler = async (req, res) => {
+  const { podname, podnamespace } = req.query;
+  if (!podname) {
+    res.status(404).send('podname argument is required');
+    return;
+  }
+  if (!podnamespace) {
+    res.status(404).send('podnamespace argument is required');
+    return;
+  }
+  const podName = decodeURIComponent(podname);
+  const podNamespace = decodeURIComponent(podnamespace);
+
+  try {
+    const pod = await k8sHelper.getPod(podName, podNamespace);
+    res.status(200).send(JSON.stringify(pod));
+  } catch (err) {
+    const message = `Could not get pod ${podName} in namespace ${podNamespace}`;
+    console.error(message, err);
+    const errorMessage = err?.body?.message || err?.message || err;
+    res.status(500).send(`${message}: ${errorMessage}`);
+  }
+};

--- a/frontend/server/handlers/pod-info.ts
+++ b/frontend/server/handlers/pod-info.ts
@@ -37,7 +37,7 @@ export const podInfoHandler: Handler = async (req, res) => {
   } catch (err) {
     const message = `Could not get pod ${podName} in namespace ${podNamespace}`;
     console.error(message, err);
-    const errorMessage = err?.body?.message || err?.message || err;
-    res.status(500).send(`${message}: ${errorMessage}`);
+    const detailedMessage = err?.body?.message || err?.message || err;
+    res.status(500).send(`${message}: ${detailedMessage}`);
   }
 };

--- a/frontend/server/handlers/pod-logs.ts
+++ b/frontend/server/handlers/pod-logs.ts
@@ -61,11 +61,6 @@ export function getPodLogsHandler(
   );
 
   return async (req, res) => {
-    if (!k8sHelper.isInCluster) {
-      res.status(500).send('Cannot talk to Kubernetes master');
-      return;
-    }
-
     if (!req.query.podname) {
       res.status(404).send('podname argument is required');
       return;

--- a/frontend/server/handlers/tensorboard.ts
+++ b/frontend/server/handlers/tensorboard.ts
@@ -20,11 +20,6 @@ import { ViewerTensorboardConfig } from '../configs';
  * handler expects a query string `logdir`.
  */
 export const getTensorboardHandler: Handler = async (req, res) => {
-  if (!k8sHelper.isInCluster) {
-    res.status(500).send('Cannot talk to Kubernetes master');
-    return;
-  }
-
   if (!req.query.logdir) {
     res.status(404).send('logdir argument is required');
     return;
@@ -49,11 +44,6 @@ export const getTensorboardHandler: Handler = async (req, res) => {
  */
 export function getCreateTensorboardHandler(tensorboardConfig: ViewerTensorboardConfig): Handler {
   return async (req, res) => {
-    if (!k8sHelper.isInCluster) {
-      res.status(500).send('Cannot talk to Kubernetes master');
-      return;
-    }
-
     if (!req.query.logdir) {
       res.status(404).send('logdir argument is required');
       return;
@@ -87,11 +77,6 @@ export function getCreateTensorboardHandler(tensorboardConfig: ViewerTensorboard
  * `logdir` in the request.
  */
 export const deleteTensorboardHandler: Handler = async (req, res) => {
-  if (!k8sHelper.isInCluster) {
-    res.status(500).send('Cannot talk to Kubernetes master');
-    return;
-  }
-
   if (!req.query.logdir) {
     res.status(404).send('logdir argument is required');
     return;

--- a/frontend/server/k8s-helper.ts
+++ b/frontend/server/k8s-helper.ts
@@ -165,9 +165,6 @@ export async function deleteTensorboardInstance(logdir: string): Promise<void> {
   if (!namespace) {
     throw new Error(`Cannot get namespace from ${namespaceFilePath}.`);
   }
-  if (!k8sV1CustomObjectClient) {
-    throw new Error('Cannot access kubernetes Custom Object API');
-  }
   const currentPod = await getTensorboardInstance(logdir);
   if (!currentPod.podAddress) {
     return;

--- a/frontend/server/k8s-helper.ts
+++ b/frontend/server/k8s-helper.ts
@@ -72,7 +72,7 @@ export async function newTensorboardInstance(
   podTemplateSpec: object = defaultPodTemplateSpec,
 ): Promise<void> {
   if (!namespace) {
-    throw new Error('Cannot get namespace from /');
+    throw new Error(`Cannot get namespace from ${namespaceFilePath}.`);
   }
   const currentPod = await getTensorboardInstance(logdir);
   if (currentPod.podAddress) {
@@ -118,7 +118,7 @@ export async function getTensorboardInstance(
   logdir: string,
 ): Promise<{ podAddress: string; tfVersion: string }> {
   if (!namespace) {
-    throw new Error('Cannot get namespace from /');
+    throw new Error(`Cannot get namespace from ${namespaceFilePath}.`);
   }
 
   return await k8sV1CustomObjectClient
@@ -270,7 +270,7 @@ export async function listPodEvents(
  */
 export async function getArgoWorkflow(workflowName: string): Promise<PartialArgoWorkflow> {
   if (!namespace) {
-    throw new Error('Cannot get namespace from /');
+    throw new Error(`Cannot get namespace from ${namespaceFilePath}`);
   }
 
   const res = await k8sV1CustomObjectClient.getNamespacedCustomObject(
@@ -298,7 +298,7 @@ export async function getArgoWorkflow(workflowName: string): Promise<PartialArgo
  */
 export async function getK8sSecret(name: string, key: string) {
   if (!namespace) {
-    throw new Error('Cannot get namespace from /');
+    throw new Error(`Cannot get namespace from ${namespaceFilePath}`);
   }
 
   const k8sSecret = await k8sV1Client.readNamespacedSecret(name, namespace);

--- a/frontend/server/proxy-middleware.ts
+++ b/frontend/server/proxy-middleware.ts
@@ -70,7 +70,7 @@ export default (app: express.Application, apisPrefix: string) => {
     proxyPrefix + '*',
     proxy({
       changeOrigin: true,
-      logLevel: 'debug',
+      logLevel: process.env.NODE_ENV === 'test' ? 'warn' : 'debug',
       target: 'http://127.0.0.1',
 
       router: (req: any) => {

--- a/frontend/src/TestUtils.tsx
+++ b/frontend/src/TestUtils.tsx
@@ -149,6 +149,6 @@ export function diff({
   });
 }
 
-function formatHTML(html: string): string {
+export function formatHTML(html: string): string {
   return format(html, { parser: 'html' });
 }

--- a/frontend/src/components/PodYaml.test.tsx
+++ b/frontend/src/components/PodYaml.test.tsx
@@ -1,0 +1,168 @@
+import React, { FC } from 'react';
+import { PodInfo, PodEvents } from './PodYaml';
+import { render, act, fireEvent } from '@testing-library/react';
+import { Apis } from 'src/lib/Apis';
+import TestUtils from 'src/TestUtils';
+
+// Original ./Editor uses a complex external editor inside, we use a simple mock
+// for testing instead.
+jest.mock('./Editor', () => {
+  return ({ value }: { value: string }) => <pre data-testid='Editor'>{value}</pre>;
+});
+
+afterEach(async () => {
+  jest.resetAllMocks();
+  jest.restoreAllMocks();
+});
+
+describe('PodInfo', () => {
+  let podInfoSpy: any;
+  beforeEach(() => {
+    podInfoSpy = jest.spyOn(Apis, 'getPodInfo');
+  });
+
+  it('renders Editor with pod yaml', async () => {
+    podInfoSpy.mockImplementation(() =>
+      Promise.resolve({
+        kind: 'Pod',
+        metadata: {
+          name: 'test-pod',
+        },
+      }),
+    );
+    const { container } = render(<PodInfo name='test-pod' namespace='test-ns' />);
+    // Renders nothing when loading
+    expect(container).toMatchInlineSnapshot(`<div />`);
+
+    await act(TestUtils.flushPromises);
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <pre
+          data-testid="Editor"
+        >
+          kind: Pod
+      metadata:
+        name: test-pod
+
+        </pre>
+      </div>
+    `);
+  });
+
+  it('renders pod yaml putting spec to the last section', async () => {
+    podInfoSpy.mockImplementation(() =>
+      Promise.resolve({
+        kind: 'Pod',
+        spec: {
+          property: 'value',
+        },
+        status: {
+          property: 'value2',
+        },
+      }),
+    );
+    const { container } = render(<PodInfo name='test-pod' namespace='test-ns' />);
+    await act(TestUtils.flushPromises);
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <pre
+          data-testid="Editor"
+        >
+          kind: Pod
+      status:
+        property: value2
+      spec:
+        property: value
+
+        </pre>
+      </div>
+    `);
+  });
+
+  it('shows a warning banner when request fails', async () => {
+    podInfoSpy.mockImplementation(() => Promise.reject('Pod not found'));
+    const { getByText } = render(<PodInfo name='test-pod' namespace='test-ns' />);
+    await act(TestUtils.flushPromises);
+    getByText(
+      'Warning: failed to retrieve pod info. Possible reasons include cluster autoscaling, pod preemption or pod cleaned up by time to live configuration',
+    );
+  });
+
+  it('can be retried when request fails', async () => {
+    // Network was bad initially
+    podInfoSpy.mockImplementation(() => Promise.reject('Network failed'));
+    const { getByText } = render(<PodInfo name='test-pod' namespace='test-ns' />);
+    await act(TestUtils.flushPromises);
+
+    // Now network gets healthy
+    podInfoSpy.mockImplementation(() =>
+      Promise.resolve({
+        kind: 'Pod',
+      }),
+    );
+    const refreshButton = getByText('Refresh');
+    fireEvent.click(refreshButton);
+    await act(TestUtils.flushPromises);
+    getByText('kind: Pod');
+  });
+
+  it('refreshes automatically when pod name or namespace changes', async () => {
+    // Now network gets healthy
+    podInfoSpy.mockImplementation(() =>
+      Promise.resolve({
+        metadata: { name: 'pod-1' },
+      }),
+    );
+    const { getByText, rerender } = render(<PodInfo name='test-pod-1' namespace='test-ns' />);
+    expect(podInfoSpy).toHaveBeenLastCalledWith('test-pod-1', 'test-ns');
+    await act(TestUtils.flushPromises);
+    getByText(/pod-1/);
+
+    podInfoSpy.mockImplementation(() =>
+      Promise.resolve({
+        metadata: { name: 'pod-2' },
+      }),
+    );
+    rerender(<PodInfo name='test-pod-2' namespace='test-ns' />);
+    expect(podInfoSpy).toHaveBeenLastCalledWith('test-pod-2', 'test-ns');
+    await act(TestUtils.flushPromises);
+    getByText(/pod-2/);
+  });
+});
+
+// PodEvents is very similar to PodInfo, so we only test different parts here.
+describe('PodEvents', () => {
+  let podEventsSpy: any;
+  beforeEach(() => {
+    podEventsSpy = jest.spyOn(Apis, 'getPodEvents');
+  });
+
+  it('renders Editor with pod events yaml', async () => {
+    podEventsSpy.mockImplementation(() =>
+      Promise.resolve({
+        kind: 'EventList',
+      }),
+    );
+    const { container } = render(<PodEvents name='test-pod' namespace='test-ns' />);
+    await act(TestUtils.flushPromises);
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <pre
+          data-testid="Editor"
+        >
+          kind: EventList
+
+        </pre>
+      </div>
+    `);
+  });
+
+  it('shows a warning banner when request fails', async () => {
+    podEventsSpy.mockImplementation(() => Promise.reject('Pod not found'));
+    const { getByText } = render(<PodEvents name='test-pod' namespace='test-ns' />);
+    await act(TestUtils.flushPromises);
+    getByText(
+      'Warning: failed to retrieve pod events. Possible reasons include cluster autoscaling, pod preemption or pod cleaned up by time to live configuration',
+    );
+  });
+});

--- a/frontend/src/components/PodYaml.tsx
+++ b/frontend/src/components/PodYaml.tsx
@@ -77,7 +77,7 @@ const PodYaml: React.FC<{
     return () => {
       aborted = true;
     };
-  }, [name, namespace, refreshes]); // When refreshes change, request is fetched again.
+  }, [name, namespace, refreshes, getYaml, errorMessage]); // When refreshes change, request is fetched again.
 
   return (
     <>
@@ -116,3 +116,7 @@ function reorderPodJson(jsonData: JSONObject): JSONObject {
   }
   return orderedData;
 }
+
+export const TEST_ONLY = {
+  PodYaml,
+};

--- a/frontend/src/components/PodYaml.tsx
+++ b/frontend/src/components/PodYaml.tsx
@@ -1,0 +1,118 @@
+import * as JsYaml from 'js-yaml';
+import React from 'react';
+import { Apis, JSONObject } from 'src/lib/Apis';
+import { serviceErrorToString } from 'src/lib/Utils';
+import Banner from './Banner';
+import Editor from './Editor';
+
+async function getPodYaml(name: string, namespace: string): Promise<string> {
+  const response = await Apis.getPodInfo(name, namespace);
+  return JsYaml.safeDump(reorderPodJson(response), { skipInvalid: true });
+}
+export const PodInfo: React.FC<{ name: string; namespace: string }> = ({ name, namespace }) => {
+  return (
+    <PodYaml
+      name={name}
+      namespace={namespace}
+      errorMessage='Warning: failed to retrieve pod info. Possible reasons include cluster autoscaling, pod preemption or pod cleaned up by time to live configuration'
+      getYaml={getPodYaml}
+    />
+  );
+};
+
+async function getPodEventsYaml(name: string, namespace: string): Promise<string> {
+  const response = await Apis.getPodEvents(name, namespace);
+  return JsYaml.safeDump(response, { skipInvalid: true });
+}
+export const PodEvents: React.FC<{
+  name: string;
+  namespace: string;
+}> = ({ name, namespace }) => {
+  return (
+    <PodYaml
+      name={name}
+      namespace={namespace}
+      errorMessage='Warning: failed to retrieve pod events. Possible reasons include cluster autoscaling, pod preemption or pod cleaned up by time to live configuration'
+      getYaml={getPodEventsYaml}
+    />
+  );
+};
+
+const PodYaml: React.FC<{
+  name: string;
+  namespace: string;
+  errorMessage: string;
+  getYaml: (name: string, namespace: string) => Promise<string>;
+}> = ({ name, namespace, getYaml, errorMessage }) => {
+  const [yaml, setYaml] = React.useState<string | undefined>(undefined);
+  const [error, setError] = React.useState<
+    | {
+        message: string;
+        additionalInfo: string;
+      }
+    | undefined
+  >(undefined);
+  const [refreshes, setRefresh] = React.useState(0);
+
+  React.useEffect(() => {
+    let aborted = false;
+    async function load() {
+      setYaml(undefined);
+      setError(undefined);
+      try {
+        const yaml = await getYaml(name, namespace);
+        if (!aborted) {
+          setYaml(yaml);
+        }
+      } catch (err) {
+        if (!aborted) {
+          setError({
+            message: errorMessage,
+            additionalInfo: await serviceErrorToString(err),
+          });
+        }
+      }
+    }
+    load();
+    return () => {
+      aborted = true;
+    };
+  }, [name, namespace, refreshes]); // When refreshes change, request is fetched again.
+
+  return (
+    <>
+      {error && (
+        <Banner
+          message={error.message}
+          mode='warning'
+          additionalInfo={error.additionalInfo}
+          // Increases refresh counter, so it will automatically trigger a refetch.
+          refresh={() => setRefresh(refreshes => refreshes + 1)}
+        />
+      )}
+      {!error && yaml && (
+        <Editor
+          value={yaml || ''}
+          height='100%'
+          width='100%'
+          mode='yaml'
+          theme='github'
+          editorProps={{ $blockScrolling: true }}
+          readOnly={true}
+          highlightActiveLine={true}
+          showGutter={true}
+        />
+      )}
+    </>
+  );
+};
+
+function reorderPodJson(jsonData: JSONObject): JSONObject {
+  const orderedData = { ...jsonData };
+  if (jsonData.spec) {
+    // Deleting spec property and add it again moves spec to the last property in the JSON object.
+    delete orderedData.spec;
+    orderedData.spec = jsonData.spec;
+  }
+  return orderedData;
+}

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -93,6 +93,17 @@ export class Apis {
     return this._fetch(query);
   }
 
+  /**
+   * Get pod info
+   */
+  public static async getPodInfo(podName: string, podNamespace: string): Promise<any> {
+    const query = `k8s/pod?podname=${encodeURIComponent(podName)}&podnamespace=${encodeURIComponent(
+      podNamespace,
+    )}`;
+    const podInfo = await this._fetch(query);
+    return JSON.parse(podInfo);
+  }
+
   public static get basePath(): string {
     const path = window.location.protocol + '//' + window.location.host + window.location.pathname;
     // Trim trailing '/' if exists

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -40,6 +40,12 @@ export interface BuildInfo {
   frontendCommitHash?: string;
 }
 
+// Hack types from https://github.com/microsoft/TypeScript/issues/1897#issuecomment-557057387
+export type JSONPrimitive = string | number | boolean | null;
+export type JSONValue = JSONPrimitive | JSONObject | JSONArray;
+export type JSONObject = { [member: string]: JSONValue };
+export type JSONArray = JSONValue[];
+
 let customVisualizationsAllowed: boolean;
 
 // For cross browser support, fetch should use 'same-origin' as default. This fixes firefox auth issues.
@@ -96,12 +102,23 @@ export class Apis {
   /**
    * Get pod info
    */
-  public static async getPodInfo(podName: string, podNamespace: string): Promise<any> {
+  public static async getPodInfo(podName: string, podNamespace: string): Promise<JSONObject> {
     const query = `k8s/pod?podname=${encodeURIComponent(podName)}&podnamespace=${encodeURIComponent(
       podNamespace,
     )}`;
     const podInfo = await this._fetch(query);
     return JSON.parse(podInfo);
+  }
+
+  /**
+   * Get pod events
+   */
+  public static async getPodEvents(podName: string, podNamespace: string): Promise<JSONObject> {
+    const query = `k8s/pod/events?podname=${encodeURIComponent(
+      podName,
+    )}&podnamespace=${encodeURIComponent(podNamespace)}`;
+    const eventList = await this._fetch(query);
+    return JSON.parse(eventList);
   }
 
   public static get basePath(): string {

--- a/frontend/src/pages/RunDetails.test.tsx
+++ b/frontend/src/pages/RunDetails.test.tsx
@@ -33,24 +33,22 @@ import { RunDetails, RunDetailsInternalProps } from './RunDetails';
 
 const NODE_DETAILS_SELECTOR = '[data-testid="run-details-node-details"]';
 describe('RunDetails', () => {
-  const updateBannerSpy = jest.fn();
-  const updateDialogSpy = jest.fn();
-  const updateSnackbarSpy = jest.fn();
-  const updateToolbarSpy = jest.fn();
-  const historyPushSpy = jest.fn();
-  const getRunSpy = jest.spyOn(Apis.runServiceApi, 'getRun');
-  const getExperimentSpy = jest.spyOn(Apis.experimentServiceApi, 'getExperiment');
-  const isCustomVisualizationsAllowedSpy = jest.spyOn(Apis, 'areCustomVisualizationsAllowed');
-  const getPodLogsSpy = jest.spyOn(Apis, 'getPodLogs');
-  const pathsParser = jest.spyOn(WorkflowParser, 'loadNodeOutputPaths');
-  const pathsWithStepsParser = jest.spyOn(WorkflowParser, 'loadAllOutputPathsWithStepNames');
-  const loaderSpy = jest.spyOn(OutputArtifactLoader, 'load');
-  const retryRunSpy = jest.spyOn(Apis.runServiceApi, 'retryRun');
-  const terminateRunSpy = jest.spyOn(Apis.runServiceApi, 'terminateRun');
-  const artifactTypesSpy = jest.spyOn(Api.getInstance().metadataStoreService, 'getArtifactTypes');
-  // We mock this because it uses toLocaleDateString, which causes mismatches between local and CI
-  // test environments
-  const formatDateStringSpy = jest.spyOn(Utils, 'formatDateString');
+  let updateBannerSpy: any;
+  let updateDialogSpy: any;
+  let updateSnackbarSpy: any;
+  let updateToolbarSpy: any;
+  let historyPushSpy: any;
+  let getRunSpy: any;
+  let getExperimentSpy: any;
+  let isCustomVisualizationsAllowedSpy: any;
+  let getPodLogsSpy: any;
+  let pathsParser: any;
+  let pathsWithStepsParser: any;
+  let loaderSpy: any;
+  let retryRunSpy: any;
+  let terminateRunSpy: any;
+  let artifactTypesSpy: any;
+  let formatDateStringSpy: any;
 
   let testRun: ApiRunDetail = {};
   let tree: ShallowWrapper | ReactWrapper;
@@ -72,11 +70,11 @@ describe('RunDetails', () => {
     });
   }
 
-  beforeAll(() => jest.spyOn(console, 'error').mockImplementation());
-
   beforeEach(() => {
     // The RunDetails page uses timers to periodically refresh
     jest.useFakeTimers();
+    // TODO: mute error only for tests that are expected to have error
+    jest.spyOn(console, 'error').mockImplementation(() => null);
 
     testRun = {
       pipeline_runtime: {
@@ -94,6 +92,25 @@ describe('RunDetails', () => {
         status: 'Succeeded',
       },
     };
+    updateBannerSpy = jest.fn();
+    updateDialogSpy = jest.fn();
+    updateSnackbarSpy = jest.fn();
+    updateToolbarSpy = jest.fn();
+    historyPushSpy = jest.fn();
+    getRunSpy = jest.spyOn(Apis.runServiceApi, 'getRun');
+    getExperimentSpy = jest.spyOn(Apis.experimentServiceApi, 'getExperiment');
+    isCustomVisualizationsAllowedSpy = jest.spyOn(Apis, 'areCustomVisualizationsAllowed');
+    getPodLogsSpy = jest.spyOn(Apis, 'getPodLogs');
+    pathsParser = jest.spyOn(WorkflowParser, 'loadNodeOutputPaths');
+    pathsWithStepsParser = jest.spyOn(WorkflowParser, 'loadAllOutputPathsWithStepNames');
+    loaderSpy = jest.spyOn(OutputArtifactLoader, 'load');
+    retryRunSpy = jest.spyOn(Apis.runServiceApi, 'retryRun');
+    terminateRunSpy = jest.spyOn(Apis.runServiceApi, 'terminateRun');
+    artifactTypesSpy = jest.spyOn(Api.getInstance().metadataStoreService, 'getArtifactTypes');
+    // We mock this because it uses toLocaleDateString, which causes mismatches between local and CI
+    // test environments
+    formatDateStringSpy = jest.spyOn(Utils, 'formatDateString');
+
     getRunSpy.mockImplementation(() => Promise.resolve(testRun));
     getExperimentSpy.mockImplementation(() =>
       Promise.resolve({ id: 'some-experiment-id', name: 'some experiment' }),
@@ -111,7 +128,6 @@ describe('RunDetails', () => {
       response.setArtifactTypesList([]);
       return response;
     });
-    jest.clearAllMocks();
   });
 
   afterEach(async () => {
@@ -119,6 +135,7 @@ describe('RunDetails', () => {
     // depends on mocks/spies
     await tree.unmount();
     jest.resetAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('shows success run status in page title', async () => {

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -1037,7 +1037,7 @@ const PodInfo: React.FC<{ name: string; namespace: string }> = ({ name, namespac
     <PodYamlViewer
       name={name}
       namespace={namespace}
-      errorMessage='Warning: failed to retrieve pod info. Possible reasons include cluster autoscaling or pod preemption'
+      errorMessage='Warning: failed to retrieve pod info. Possible reasons include cluster autoscaling, pod preemption or pod cleaned up by time to live configuration'
       getYaml={getPodYaml}
     />
   );
@@ -1052,7 +1052,7 @@ const PodEvents: React.FC<{ name: string; namespace: string }> = ({ name, namesp
     <PodYamlViewer
       name={name}
       namespace={namespace}
-      errorMessage='Warning: failed to retrieve pod events. Possible reasons include cluster autoscaling or pod preemption'
+      errorMessage='Warning: failed to retrieve pod events. Possible reasons include cluster autoscaling, pod preemption or pod cleaned up by time to live configuration'
       getYaml={getPodEventsYaml}
     />
   );

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -48,7 +48,7 @@ import VisualizationCreator, {
   VisualizationCreatorConfig,
 } from '../components/viewers/VisualizationCreator';
 import { color, commonCss, fonts, fontsize, padding } from '../Css';
-import { Apis, JSONObject } from '../lib/Apis';
+import { Apis } from '../lib/Apis';
 import Buttons, { ButtonKeys } from '../lib/Buttons';
 import CompareUtils from '../lib/CompareUtils';
 import { OutputArtifactLoader } from '../lib/OutputArtifactLoader';

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -225,7 +225,7 @@ export class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
     } = this.state;
     const { projectId, clusterName } = this.props.gkeMetadata;
     const selectedNodeId = selectedNodeDetails ? selectedNodeDetails.id : '';
-    const namespace = workflow?.metadata.namespace;
+    const namespace = workflow?.metadata?.namespace;
     let stackdriverK8sLogsUrl = '';
     if (projectId && clusterName && selectedNodeDetails && selectedNodeDetails.id) {
       stackdriverK8sLogsUrl = `https://console.cloud.google.com/logs/viewer?project=${projectId}&interval=NO_LIMIT&advancedFilter=resource.type%3D"k8s_container"%0Aresource.labels.cluster_name:"${clusterName}"%0Aresource.labels.pod_name:"${selectedNodeDetails.id}"`;
@@ -666,7 +666,7 @@ export class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
       });
     } catch (err) {
       await this.showPageError(`Error: failed to retrieve run: ${runId}.`, err);
-      logger.error('Error loading run:', runId);
+      logger.error('Error loading run:', runId, err);
     }
 
     // Make sure logs and artifacts in the side panel are refreshed when

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -1042,7 +1042,8 @@ const PodInfo: React.FC<{ name: string; namespace: string }> = ({ name, namespac
       } catch (err) {
         if (!aborted) {
           setError({
-            message: 'Failed getting pod info',
+            message:
+              'Warning: failed to retrieve pod info. Possible reasons include cluster autoscaling or pod preemption',
             detailedMessage: await serviceErrorToString(err),
           });
         }
@@ -1059,7 +1060,7 @@ const PodInfo: React.FC<{ name: string; namespace: string }> = ({ name, namespac
         <React.Fragment>
           <Banner
             message={error.message}
-            mode='error'
+            mode='warning'
             additionalInfo={error.detailedMessage}
             refresh={() => setRefresh(refresh => refresh + 1)}
           />

--- a/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
@@ -570,6 +570,8 @@ exports[`RunDetails logs tab does not load logs if clicked node status is skippe
                     "Volumes",
                     "Manifest",
                     "Logs",
+                    "Pod",
+                    "Events",
                   ]
                 }
               />
@@ -686,6 +688,8 @@ exports[`RunDetails logs tab keeps side pane open and on same tab when logs chan
                     "Volumes",
                     "Manifest",
                     "Logs",
+                    "Pod",
+                    "Events",
                   ]
                 }
               />
@@ -802,6 +806,8 @@ exports[`RunDetails logs tab loads and shows logs in side pane 1`] = `
                     "Volumes",
                     "Manifest",
                     "Logs",
+                    "Pod",
+                    "Events",
                   ]
                 }
               />
@@ -918,6 +924,8 @@ exports[`RunDetails logs tab switches to logs tab in side pane 1`] = `
                     "Volumes",
                     "Manifest",
                     "Logs",
+                    "Pod",
+                    "Events",
                   ]
                 }
               />
@@ -1034,6 +1042,8 @@ exports[`RunDetails opens side panel when graph node is clicked 1`] = `
                     "Volumes",
                     "Manifest",
                     "Logs",
+                    "Pod",
+                    "Events",
                   ]
                 }
               />
@@ -1276,6 +1286,8 @@ exports[`RunDetails shows clicked node message in side panel 1`] = `
                     "Volumes",
                     "Manifest",
                     "Logs",
+                    "Pod",
+                    "Events",
                   ]
                 }
               />
@@ -1725,6 +1737,8 @@ exports[`RunDetails switches to inputs/outputs tab in side pane 1`] = `
                     "Volumes",
                     "Manifest",
                     "Logs",
+                    "Pod",
+                    "Events",
                   ]
                 }
               />
@@ -1866,6 +1880,8 @@ exports[`RunDetails switches to manifest tab in side pane 1`] = `
                     "Volumes",
                     "Manifest",
                     "Logs",
+                    "Pod",
+                    "Events",
                   ]
                 }
               />
@@ -2015,6 +2031,8 @@ exports[`RunDetails switches to volumes tab in side pane 1`] = `
                     "Volumes",
                     "Manifest",
                     "Logs",
+                    "Pod",
+                    "Events",
                   ]
                 }
               />

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
@@ -166,6 +166,12 @@ rules:
   - apiGroups:
     - ""
     resources:
+    - events
+    verbs:
+    - list
+  - apiGroups:
+    - ""
+    resources:
     - secrets
     verbs:
     - get

--- a/manifests/kustomize/base/pipeline/ml-pipeline-ui-role.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-ui-role.yaml
@@ -17,6 +17,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get


### PR DESCRIPTION
/area frontend
/kind feature

**Demo for pod yaml**: https://youtu.be/HvsPvUEW4Kk
**Demo for pod events**: https://youtu.be/R-zdTEwoNmw

Resolves https://github.com/kubeflow/pipelines/issues/2094
Resolves https://github.com/kubeflow/pipelines/issues/1711
Resolves https://github.com/kubeflow/pipelines/issues/3112

TODO:
* [x] add related unit tests

Extra changes in this PR:
* I wrote new react component tests using `@testing-library/react`: https://github.com/kubeflow/pipelines/pull/3304/files#diff-0fc4f908858a81da473a9fcae07bcd30.
This the first PR with a very comprehensive test using `@testing-library/react`: https://github.com/kubeflow/pipelines/issues/2732.
* Refactored k8s-helper to no longer export `inCluster` property, so that I could unit test newly added handlers that use k8s-helper: https://github.com/kubeflow/pipelines/pull/3304/files#diff-98ad2c53495f413ec48e3835fc45b86eL55
Resolves https://github.com/kubeflow/pipelines/issues/2215

I personally think `@testing-library/react` is much easier to use comparing to enzyme, because of
* helper methods to get element by text
* helper methods to fire events
* it doesn't test any implementation detail by default (no shallow testing), always asserts the dom
* rerender helper to test a component when its props change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3304)
<!-- Reviewable:end -->
