### PR TITLE
[Backend] Always disable istio sidecar injection

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -285,9 +285,7 @@ func (r *ResourceManager) CreateRun(apiRun *api.Run) (*model.RunDetail, error) {
 	}
 
 	// Disable istio sidecar injection
-	if multiuserMode == true {
-		workflow.SetAnnotationsToAllTemplates(util.AnnotationKeyIstioSidecarInject, util.AnnotationValueIstioSidecarInjectDisabled)
-	}
+	workflow.SetAnnotationsToAllTemplates(util.AnnotationKeyIstioSidecarInject, util.AnnotationValueIstioSidecarInjectDisabled)
 	// Append provided parameter
 	workflow.OverrideParameters(parameters)
 


### PR DESCRIPTION
/assign @IronPan @chensun 
/area backend

To unblock https://github.com/kubeflow/kubeflow/issues/3866#issuecomment-600409563, KFP should always disable istio sidecar injection after kubeflow namespace enables auto injection, so that single user mode KFP can keep working in kubeflow deployment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3305)
<!-- Reviewable:end -->
