### PR TITLE
Update Watson ML example to take output param path

### DIFF
--- a/components/ibm-components/watson/deploy/component.yaml
+++ b/components/ibm-components/watson/deploy/component.yaml
@@ -28,7 +28,7 @@ implementation:
     image: docker.io/aipipeline/wml-deploy:latest
     command: ['python']
     args: [
-      /app/wml-deploy.py,
+      -u, /app/wml-deploy.py,
       --model-uid, {inputValue: model_uid},
       --model-name, {inputValue: model_name},
       --scoring-payload, {inputValue: scoring_payload},

--- a/components/ibm-components/watson/deploy/component.yaml
+++ b/components/ibm-components/watson/deploy/component.yaml
@@ -32,8 +32,7 @@ implementation:
       --model-uid, {inputValue: model_uid},
       --model-name, {inputValue: model_name},
       --scoring-payload, {inputValue: scoring_payload},
-      --deployment-name, {inputValue: deployment_name}
+      --deployment-name, {inputValue: deployment_name},
+      --output-scoring-endpoint-path, {outputPath: scoring_endpoint},
+      --output-model-uid-path, {outputPath: model_uid}
     ]
-    fileOutputs:
-      scoring_endpoint: /tmp/scoring_endpoint
-      model_uid: /tmp/model_uid

--- a/components/ibm-components/watson/deploy/src/wml-deploy.py
+++ b/components/ibm-components/watson/deploy/src/wml-deploy.py
@@ -21,6 +21,7 @@ def getSecret(secret):
 def deploy(args):
     from watson_machine_learning_client import WatsonMachineLearningAPIClient
     from minio import Minio
+    from pathlib import Path
     import os
     import re
 
@@ -85,12 +86,10 @@ def deploy(args):
         result = 'Scoring payload is not provided'
 
     print(result)
-    with open("/tmp/scoring_endpoint", "w") as f:
-        print(scoring_endpoint, file=f)
-    f.close()
-    with open("/tmp/model_uid", "w") as f:
-        print(model_uid, file=f)
-    f.close()
+    Path(args.output_scoring_endpoint_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.output_scoring_endpoint_path).write_text(scoring_endpoint)
+    Path(args.output_model_uid_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.output_model_uid_path).write_text(model_uid)
 
 
 if __name__ == "__main__":
@@ -100,5 +99,7 @@ if __name__ == "__main__":
     parser.add_argument('--model-uid', type=str, required=True)
     parser.add_argument('--deployment-name', type=str)
     parser.add_argument('--scoring-payload', type=str)
+    parser.add_argument('--output-scoring-endpoint-path', type=str, default='/tmp/scoring_endpoint')
+    parser.add_argument('--output-model-uid-path', type=str, default='/tmp/model_uid')
     args = parser.parse_args()
     deploy(args)

--- a/components/ibm-components/watson/store/component.yaml
+++ b/components/ibm-components/watson/store/component.yaml
@@ -28,7 +28,7 @@ implementation:
     image: docker.io/aipipeline/wml-store:latest
     command: ['python3']
     args: [
-      /app/wml-store.py,
+      -u, /app/wml-store.py,
       --run-uid, {inputValue: run_uid},
       --model-name, {inputValue: model_name},
       --framework, {inputValue: framework},

--- a/components/ibm-components/watson/store/component.yaml
+++ b/components/ibm-components/watson/store/component.yaml
@@ -34,6 +34,5 @@ implementation:
       --framework, {inputValue: framework},
       --framework-version, {inputValue: framework_version},
       --runtime-version, {inputValue: runtime_version},
+      --output-model-uid-path, {outputPath: model_uid}
     ]
-    fileOutputs:
-      model_uid: /tmp/model_uid

--- a/components/ibm-components/watson/store/src/wml-store.py
+++ b/components/ibm-components/watson/store/src/wml-store.py
@@ -18,8 +18,9 @@ def getSecret(secret):
     f.close()
     return res
 
-def store(wml_model_name, run_uid, framework, framework_version, runtime_version):
+def store(wml_model_name, run_uid, framework, framework_version, runtime_version, output_model_uid_path):
     from watson_machine_learning_client import WatsonMachineLearningAPIClient
+    from pathlib import Path
 
     # retrieve credentials
     wml_url = getSecret("/app/secrets/wml_url")
@@ -42,7 +43,7 @@ def store(wml_model_name, run_uid, framework, framework_version, runtime_version
     # store the model
     meta_props_tf = {
      client.repository.ModelMetaNames.NAME: wml_model_name,
-     client.repository.ModelMetaNames.RUNTIME_UID : runtime_uid,
+     client.repository.ModelMetaNames.RUNTIME_UID: runtime_uid,
      client.repository.ModelMetaNames.TYPE: runtime_type
     }
 
@@ -51,9 +52,8 @@ def store(wml_model_name, run_uid, framework, framework_version, runtime_version
     model_uid = client.repository.get_model_uid(model_details)
     print("model_uid: ", model_uid)
 
-    with open("/tmp/model_uid", "w") as f:
-        f.write(model_uid)
-    f.close()
+    Path(output_model_uid_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(output_model_uid_path).write_text(model_uid)
 
     import time
     time.sleep(120)
@@ -66,5 +66,11 @@ if __name__ == "__main__":
     parser.add_argument('--framework', type=str, required=True)
     parser.add_argument('--framework-version', type=str, required=True)
     parser.add_argument('--runtime-version', type=str, required=True)
+    parser.add_argument('--output-model-uid-path', type=str, default='/tmp/model_uid')
     args = parser.parse_args()
-    store(args.model_name, args.run_uid, args.framework, args.framework_version, args.runtime_version)
+    store(args.model_name,
+          args.run_uid,
+          args.framework,
+          args.framework_version,
+          args.runtime_version,
+          args.output_model_uid_path)

--- a/components/ibm-components/watson/train/component.yaml
+++ b/components/ibm-components/watson/train/component.yaml
@@ -36,7 +36,7 @@ implementation:
     image: docker.io/aipipeline/wml-train:latest
     command: ['python3']
     args: [
-      /app/wml-train.py,
+      -u, /app/wml-train.py,
       --config, {inputValue: config},
       --train-code, {inputValue: train_code},
       --execution-command, {inputValue: execution_command},

--- a/components/ibm-components/watson/train/component.yaml
+++ b/components/ibm-components/watson/train/component.yaml
@@ -48,8 +48,7 @@ implementation:
       --run-name, {inputValue: run_name},
       --author-name, {inputValue: author_name},
       --compute-name, {inputValue: compute_name},
-      --compute-nodes,{inputValue: compute_nodes}
+      --compute-nodes,{inputValue: compute_nodes},
+      --output-run-uid-path, {outputPath: run_uid},
+      --output-training-uid-path, {outputPath: training_uid}
     ]
-    fileOutputs:
-      run_uid: /tmp/run_uid
-      training_uid: /tmp/training_uid

--- a/components/ibm-components/watson/train/src/wml-train.py
+++ b/components/ibm-components/watson/train/src/wml-train.py
@@ -22,6 +22,7 @@ def train(args):
     from watson_machine_learning_client import WatsonMachineLearningAPIClient
     from minio import Minio
     from urllib.parse import urlsplit
+    from pathlib import Path
     import os,time
 
     wml_train_code = args.train_code
@@ -82,7 +83,19 @@ def train(args):
         client.runtimes.LibraryMetaNames.FILEPATH: model_code,
         client.runtimes.LibraryMetaNames.PLATFORM: {"name": wml_framework_name, "versions": [wml_framework_version]}
     }
-    custom_library_details = client.runtimes.store_library(lib_meta)
+    # check exisiting library
+    custom_library_details = ''
+    library_details = client.runtimes.list_libraries()
+    for library_detail in library_details:
+        if library_detail['entity']['name'] == wml_run_definition:
+            # Update library if exist
+            custom_library_details = library_detail
+            uid = client.runtimes.get_library_uid(custom_library_details)
+            client.runtimes.update_library(uid, changes=lib_meta)
+            break
+    if not custom_library_details:
+        custom_library_details = client.runtimes.store_library(lib_meta)
+
     custom_library_uid = client.runtimes.get_library_uid(custom_library_details)
 
     # create a pipeline with the model definitions included
@@ -175,18 +188,16 @@ def train(args):
         status = client.training.get_status(run_uid)
     print(status)
 
-    with open("/tmp/run_uid", "w") as f:
-        f.write(run_uid)
-    f.close()
+    Path(args.output_run_uid_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.output_run_uid_path).write_text(run_uid)
 
     # Get training details
     training_details = client.training.get_details(run_uid)
     print("training_details", training_details)
  
-    with open("/tmp/training_uid", "w") as f:
-        training_uid = training_uid = training_details['entity']['results_reference']['location']['training']
-        f.write(training_uid)
-    f.close()
+    training_uid = training_details['entity']['results_reference']['location']['training']
+    Path(args.output_training_uid_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.output_training_uid_path).write_text(training_uid)
 
 if __name__ == "__main__":
     import argparse
@@ -203,6 +214,8 @@ if __name__ == "__main__":
     parser.add_argument('--config', type=str, default="secret_name")
     parser.add_argument('--compute-name', type=str)
     parser.add_argument('--compute-nodes', type=str)
+    parser.add_argument('--output-run-uid-path', type=str, default="/tmp/run_uid")
+    parser.add_argument('--output-training-uid-path', type=str, default="/tmp/training_uid")
     args = parser.parse_args()
     # Check secret name is not empty
     if (not args.config):

--- a/components/ibm-components/watson/train/src/wml-train.py
+++ b/components/ibm-components/watson/train/src/wml-train.py
@@ -84,18 +84,14 @@ def train(args):
         client.runtimes.LibraryMetaNames.PLATFORM: {"name": wml_framework_name, "versions": [wml_framework_version]}
     }
     # check exisiting library
-    custom_library_details = ''
-    library_details = client.runtimes.list_libraries()
-    for library_detail in library_details:
+    library_details = client.runtimes.get_library_details()
+    for library_detail in library_details['resources']:
         if library_detail['entity']['name'] == wml_run_definition:
-            # Update library if exist
-            custom_library_details = library_detail
-            uid = client.runtimes.get_library_uid(custom_library_details)
-            client.runtimes.update_library(uid, changes=lib_meta)
+            # Delete library if exist because we cannot update model_code
+            uid = client.runtimes.get_library_uid(library_detail)
+            client.repository.delete(uid)
             break
-    if not custom_library_details:
-        custom_library_details = client.runtimes.store_library(lib_meta)
-
+    custom_library_details = client.runtimes.store_library(lib_meta)
     custom_library_uid = client.runtimes.get_library_uid(custom_library_details)
 
     # create a pipeline with the model definitions included

--- a/samples/contrib/ibm-samples/watson/watson_train_serve_pipeline.py
+++ b/samples/contrib/ibm-samples/watson/watson_train_serve_pipeline.py
@@ -78,7 +78,7 @@ def kfp_wml_pipeline(
                    run_name=run_name,
                    compute_name=compute_name,
                    compute_nodes=compute_nodes
-                   ).apply(use_ai_pipeline_params(secret_name, 'Always'))
+                   ).apply(use_ai_pipeline_params(secret_name, image_pull_policy='Always'))
 
     # op3 - this operation stores the model trained above
     wml_store = store_op(
@@ -87,14 +87,14 @@ def kfp_wml_pipeline(
                    framework=framework,
                    framework_version=framework_version,
                    runtime_version=runtime_version
-                   ).apply(use_ai_pipeline_params(secret_name, 'Always'))
+                   ).apply(use_ai_pipeline_params(secret_name, image_pull_policy='Always'))
 
     # op4 - this operation deploys the model to a web service and run scoring with the payload in the cloud object store
     wml_deploy = deploy_op(
                   wml_store.output,
                   model_name,
                   scoring_payload
-                  ).apply(use_ai_pipeline_params(secret_name, 'Always'))
+                  ).apply(use_ai_pipeline_params(secret_name, image_pull_policy='Always'))
 
 if __name__ == '__main__':
     # compile the pipeline

--- a/samples/contrib/ibm-samples/watson/watson_train_serve_pipeline.py
+++ b/samples/contrib/ibm-samples/watson/watson_train_serve_pipeline.py
@@ -16,13 +16,25 @@ import os
 import kfp
 from kfp import components
 from kfp import dsl
-import ai_pipeline_params as params
 
 secret_name = 'kfp-creds'
 configuration_op = components.load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/commons/config/component.yaml')
 train_op = components.load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/watson/train/component.yaml')
 store_op = components.load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/watson/store/component.yaml')
 deploy_op = components.load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/watson/deploy/component.yaml')
+
+# Helper function for secret mount and image pull policy
+def use_ai_pipeline_params(secret_name, secret_volume_mount_path='/app/secrets', image_pull_policy='IfNotPresent'):
+    def _use_ai_pipeline_params(task):
+        from kubernetes import client as k8s_client
+        task = task.add_volume(k8s_client.V1Volume(name=secret_name,  # secret_name as volume name
+                                                   secret=k8s_client.V1SecretVolumeSource(secret_name=secret_name)))
+        task.container.add_volume_mount(k8s_client.V1VolumeMount(mount_path=secret_volume_mount_path, 
+                                                                 name=secret_name))
+        task.container.set_image_pull_policy(image_pull_policy)
+        return task
+    return _use_ai_pipeline_params
+
 
 # create pipelines
 
@@ -66,7 +78,7 @@ def kfp_wml_pipeline(
                    run_name=run_name,
                    compute_name=compute_name,
                    compute_nodes=compute_nodes
-                   ).apply(params.use_ai_pipeline_params(secret_name)).set_image_pull_policy('Always')
+                   ).apply(use_ai_pipeline_params(secret_name, 'Always'))
 
     # op3 - this operation stores the model trained above
     wml_store = store_op(
@@ -75,14 +87,14 @@ def kfp_wml_pipeline(
                    framework=framework,
                    framework_version=framework_version,
                    runtime_version=runtime_version
-                  ).apply(params.use_ai_pipeline_params(secret_name)).set_image_pull_policy('Always')
+                   ).apply(use_ai_pipeline_params(secret_name, 'Always'))
 
     # op4 - this operation deploys the model to a web service and run scoring with the payload in the cloud object store
     wml_deploy = deploy_op(
                   wml_store.output,
                   model_name,
                   scoring_payload
-                 ).apply(params.use_ai_pipeline_params(secret_name)).set_image_pull_policy('Always')
+                  ).apply(use_ai_pipeline_params(secret_name, 'Always'))
 
 if __name__ == '__main__':
     # compile the pipeline


### PR DESCRIPTION
We want to add Tekton support for this pipeline. Since Tekton only allows parameter to be passed under certain path, updating the Watson ML example to take output param path. Also improving some usability on the existing example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3316)
<!-- Reviewable:end -->
