### PR TITLE
SDK - Moved the @python_component decorator test to dsl tests

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -400,8 +400,9 @@ def _extract_component_interface(func) -> ComponentSpec:
         output_spec._passing_style = None
         outputs.append(output_spec)
 
-    #Component name and description are derived from the function's name and docstribng, but can be overridden by @python_component function decorator
-    #The decorator can set the _component_human_name and _component_description attributes. getattr is needed to prevent error when these attributes do not exist.
+    # Component name and description are derived from the function's name and docstring.
+    # The name can be overridden by setting setting func.__name__ attribute (of the legacy func._component_human_name attribute).
+    # The description can be overridden by setting the func.__doc__ attribute (or the legacy func._component_description attribute).
     component_name = getattr(func, '_component_human_name', None) or _python_function_name_to_component_name(func.__name__)
     description = getattr(func, '_component_description', None) or func.__doc__
     if description:

--- a/sdk/python/kfp/dsl/_component.py
+++ b/sdk/python/kfp/dsl/_component.py
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from deprecated.sphinx import deprecated
 from ._pipeline_param import PipelineParam
 from .types import check_types, InconsistentTypeException
 from ._ops_group import Graph
 import kfp
 
+
+@deprecated(
+  version='0.2.6',
+  reason='This decorator does not seem to be used, so we deprecate it. If you need this decorator, please create an issue at https://github.com/kubeflow/pipelines/issues',
+)
 def python_component(name, description=None, base_image=None, target_component_file: str = None):
   """Decorator for Python component functions.
   This decorator adds the metadata to the function object itself.

--- a/sdk/python/tests/components/test_python_op.py
+++ b/sdk/python/tests/components/test_python_op.py
@@ -412,36 +412,34 @@ class PythonOpTestCase(unittest.TestCase):
 
         self.helper_test_2_in_1_out_component_using_local_call(func, op)
 
-    def test_python_component_decorator(self):
-        from kfp.dsl import python_component
-        import kfp.components._python_op as _python_op
+    def test_legacy_python_component_name_description_overrides(self):
+        # Deprecated feature
 
         expected_name = 'Sum component name'
         expected_description = 'Sum component description'
         expected_image = 'org/image'
 
-        @python_component(
-            name=expected_name,
-            description=expected_description,
-            base_image=expected_image
-        )
         def add_two_numbers_decorated(
             a: float,
             b: float,
         ) -> float:
             '''Returns sum of two arguments'''
             return a + b
+        
+        # Deprecated features
+        add_two_numbers_decorated._component_human_name = expected_name
+        add_two_numbers_decorated._component_description = expected_description
+        add_two_numbers_decorated._component_base_image = expected_image
 
-        component_spec = _python_op._func_to_component_spec(add_two_numbers_decorated)
+        func = add_two_numbers_decorated
+        op = comp.func_to_container_op(func)
+
+        component_spec = op.component_spec
 
         self.assertEqual(component_spec.name, expected_name)
         self.assertEqual(component_spec.description.strip(), expected_description.strip())
         self.assertEqual(component_spec.implementation.container.image, expected_image)
 
-        func = add_two_numbers_decorated
-        op = comp.func_to_container_op(func)
-
-        self.helper_test_component_against_func_using_local_call(func, op, arguments={'a': 3, 'b': 5.0})
 
     def test_saving_default_values(self):
         from typing import NamedTuple

--- a/sdk/python/tests/dsl/component_tests.py
+++ b/sdk/python/tests/dsl/component_tests.py
@@ -43,6 +43,34 @@ class TestPythonComponent(unittest.TestCase):
 
     self.assertEqual(containerOp._metadata, golden_meta)
 
+  def test_python_component_decorator(self):
+    # Deprecated
+    from kfp.dsl import python_component
+    from kfp.components import create_component_from_func
+
+    expected_name = 'Sum component name'
+    expected_description = 'Sum component description'
+    expected_image = 'org/image'
+
+    @python_component(
+        name=expected_name,
+        description=expected_description,
+        base_image=expected_image
+    )
+    def add_two_numbers_decorated(
+        a: float,
+        b: float,
+    ) -> float:
+        '''Returns sum of two arguments'''
+        return a + b
+
+    op = create_component_from_func(add_two_numbers_decorated)
+
+    component_spec = op.component_spec
+    self.assertEqual(component_spec.name, expected_name)
+    self.assertEqual(component_spec.description.strip(), expected_description.strip())
+    self.assertEqual(component_spec.implementation.container.image, expected_image)
+
   def test_type_check_with_same_representation(self):
     """Test type check at the decorator."""
     kfp.TYPE_CHECK = True


### PR DESCRIPTION
Removing stray dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3324)
<!-- Reviewable:end -->
