### PR TITLE
Add hostNetwork for marketplace proxy-agent manifest

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/proxy.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/proxy.yaml
@@ -54,6 +54,7 @@ spec:
         app: proxy-agent
         app.kubernetes.io/name: {{ .Release.Name }}
     spec:
+      hostNetwork: true
       containers:
         - image: {{ .Values.images.proxyagent }}
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
/assign @rmgogogo 

This enables using marketplace with workload identity similar to https://github.com/kubeflow/pipelines/pull/2614.

Cloud AI Platform pipelines doc actually provided a link to instructions setting up workload identity: https://cloud.google.com/ai-platform/pipelines/docs/configure-gke-cluster#grant-access, so we should better support this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3330)
<!-- Reviewable:end -->
