### PR TITLE
[Testing] Disable cache-deployer temporarily because it blocks upgrade tests

### DIFF
--- a/test/manifests/dev/kustomization.yaml
+++ b/test/manifests/dev/kustomization.yaml
@@ -7,5 +7,6 @@ namespace: kubeflow
 images: []
 resources:
 - ../../../manifests/kustomize/env/dev
-- ../../../manifests/kustomize/base/cache
-- ../../../manifests/kustomize/base/cache-deployer
+# Disables cache and cache-deployer temporarily because they block upgrade tests
+# - ../../../manifests/kustomize/base/cache
+# - ../../../manifests/kustomize/base/cache-deployer


### PR DESCRIPTION
/cc @rui5i 

Failure error message: https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kubeflow_pipelines/3193/kubeflow-pipeline-upgrade-test/1241989672616333312#1:build-log.txt%3A938

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pipelines/3333)
<!-- Reviewable:end -->
