### PR TITLE
[Backend][Multi-user] Add authorization check on ListExperiment

### DIFF
--- a/backend/src/apiserver/server/experiment_server.go
+++ b/backend/src/apiserver/server/experiment_server.go
@@ -67,8 +67,13 @@ func (s *ExperimentServer) ListExperiment(ctx context.Context, request *api.List
 		if refKey == nil || refKey.Type != common.Namespace {
 			return nil, util.NewInvalidInputError("Invalid resource references for experiment. ListExperiment requires filtering by namespace.")
 		}
-		if len(refKey.ID) == 0 {
+		namespace := refKey.ID
+		if len(namespace) == 0 {
 			return nil, util.NewInvalidInputError("Invalid resource references for experiment. Namespace is empty.")
+		}
+		err = isAuthorized(s.resourceManager, ctx, namespace)
+		if err != nil {
+			return nil, util.Wrap(err, "Failed to authorize with API resource references")
 		}
 	} else {
 		// In single user mode, apply filter with empty namespace for backward compatibile.


### PR DESCRIPTION
- Fixes the bug where #3243 missed authorization check on `ListExperiment`
- Tested via UT and SDK manual testing.

/cc @IronPan @Bobgy 

Test image: gcr.io/chesu-dev/api-server:pr3341