### PR TITLE
[UI] Tensorboard support for multi user

### DIFF
--- a/frontend/scripts/start-proxy-and-server.sh
+++ b/frontend/scripts/start-proxy-and-server.sh
@@ -11,6 +11,7 @@ function clean_up() {
   # jobs -l
   kill -15 %1
   kill -15 %2
+  kill -15 %3
 }
 trap clean_up EXIT SIGINT SIGTERM
 
@@ -33,4 +34,7 @@ popd
 echo "Starting to port forward backend apis..."
 kubectl port-forward -n $NAMESPACE svc/metadata-envoy-service 9090:9090 &
 kubectl port-forward -n $NAMESPACE svc/ml-pipeline 3002:8888 &
+kubectl port-forward -n $NAMESPACE svc/minio-service 9000:9000 &
+export MINIO_HOST=localhost
+export MINIO_NAMESPACE=
 ML_PIPELINE_SERVICE_PORT=3002 npm run mock:server 3001

--- a/frontend/server/app.test.ts
+++ b/frontend/server/app.test.ts
@@ -626,23 +626,303 @@ describe('UIServer apis', () => {
     });
   });
 
+  describe('/apps/tensorboard', () => {
+    let request: requests.SuperTest<requests.Test>;
+    let k8sGetCustomObjectSpy: jest.SpyInstance;
+    let k8sDeleteCustomObjectSpy: jest.SpyInstance;
+    let k8sCreateCustomObjectSpy: jest.SpyInstance;
+    function newGetTensorboardResponse({
+      name = 'viewer-example',
+      logDir = 'log-dir-example',
+      tensorflowImage = 'tensorflow:2.0.0',
+      type = 'tensorboard',
+    }: {
+      name?: string;
+      logDir?: string;
+      tensorflowImage?: string;
+      type?: string;
+    }) {
+      return {
+        response: undefined as any, // unused
+        body: {
+          metadata: {
+            name,
+          },
+          spec: {
+            tensorboardSpec: { logDir, tensorflowImage },
+            type,
+          },
+        },
+      };
+    }
+    beforeEach(() => {
+      app = new UIServer(loadConfigs(argv, {}));
+      request = requests(app.start());
+      k8sGetCustomObjectSpy = jest.spyOn(
+        K8S_TEST_EXPORT.k8sV1CustomObjectClient,
+        'getNamespacedCustomObject',
+      );
+      k8sDeleteCustomObjectSpy = jest.spyOn(
+        K8S_TEST_EXPORT.k8sV1CustomObjectClient,
+        'deleteNamespacedCustomObject',
+      );
+      k8sCreateCustomObjectSpy = jest.spyOn(
+        K8S_TEST_EXPORT.k8sV1CustomObjectClient,
+        'createNamespacedCustomObject',
+      );
+    });
+
+    describe('get', () => {
+      it('requires logdir for get tensorboard', done => {
+        request.get('/apps/tensorboard').expect(404, 'logdir argument is required', done);
+      });
+
+      it('requires namespace for get tensorboard', done => {
+        request
+          .get('/apps/tensorboard?logdir=some-log-dir')
+          .expect(404, 'namespace argument is required', done);
+      });
+
+      it('gets tensorboard url and version', done => {
+        k8sGetCustomObjectSpy.mockImplementation(() =>
+          Promise.resolve(
+            newGetTensorboardResponse({
+              name: 'viewer-abcdefg',
+              logDir: 'log-dir-1',
+              tensorflowImage: 'tensorflow:2.0.0',
+            }),
+          ),
+        );
+
+        request
+          .get(`/apps/tensorboard?logdir=${encodeURIComponent('log-dir-1')}&namespace=test-ns`)
+          .expect(
+            200,
+            JSON.stringify({
+              podAddress:
+                'http://viewer-abcdefg-service.test-ns.svc.cluster.local:80/tensorboard/viewer-abcdefg/',
+              tfVersion: '2.0.0',
+            }),
+            err => {
+              expect(k8sGetCustomObjectSpy.mock.calls[0]).toMatchInlineSnapshot(`
+                              Array [
+                                "kubeflow.org",
+                                "v1beta1",
+                                "test-ns",
+                                "viewers",
+                                "viewer-5e1404e679e27b0f0b8ecee8fe515830eaa736c5",
+                              ]
+                          `);
+              done(err);
+            },
+          );
+      });
+    });
+
+    describe('post (create)', () => {
+      it('requires logdir', done => {
+        request.post('/apps/tensorboard').expect(404, 'logdir argument is required', done);
+      });
+
+      it('requires namespace', done => {
+        request
+          .post('/apps/tensorboard?logdir=some-log-dir')
+          .expect(404, 'namespace argument is required', done);
+      });
+
+      it('requires tfversion', done => {
+        request
+          .post('/apps/tensorboard?logdir=some-log-dir&namespace=test-ns')
+          .expect(404, 'tfversion (tensorflow version) argument is required', done);
+      });
+
+      it('creates tensorboard viewer custom object and waits for it', done => {
+        let getRequestCount = 0;
+        k8sGetCustomObjectSpy.mockImplementation(() => {
+          ++getRequestCount;
+          switch (getRequestCount) {
+            case 1:
+              return Promise.reject('Not found');
+            case 2:
+              return Promise.resolve(
+                newGetTensorboardResponse({
+                  name: 'viewer-abcdefg',
+                  logDir: 'log-dir-1',
+                  tensorflowImage: 'tensorflow:2.0.0',
+                }),
+              );
+            default:
+              throw new Error('only expected to be called twice in this test');
+          }
+        });
+        k8sCreateCustomObjectSpy.mockImplementation(() => Promise.resolve());
+
+        request
+          .post(
+            `/apps/tensorboard?logdir=${encodeURIComponent(
+              'log-dir-1',
+            )}&namespace=test-ns&tfversion=2.0.0`,
+          )
+          .expect(
+            200,
+            encodeURIComponent(
+              'http://viewer-abcdefg-service.test-ns.svc.cluster.local:80/tensorboard/viewer-abcdefg/',
+            ),
+            err => {
+              expect(k8sGetCustomObjectSpy.mock.calls[0]).toMatchInlineSnapshot(`
+                Array [
+                  "kubeflow.org",
+                  "v1beta1",
+                  "test-ns",
+                  "viewers",
+                  "viewer-5e1404e679e27b0f0b8ecee8fe515830eaa736c5",
+                ]
+              `);
+              expect(k8sCreateCustomObjectSpy.mock.calls[0]).toMatchInlineSnapshot(`
+                Array [
+                  "kubeflow.org",
+                  "v1beta1",
+                  "test-ns",
+                  "viewers",
+                  Object {
+                    "apiVersion": "kubeflow.org/v1beta1",
+                    "kind": "Viewer",
+                    "metadata": Object {
+                      "name": "viewer-5e1404e679e27b0f0b8ecee8fe515830eaa736c5",
+                      "namespace": "test-ns",
+                    },
+                    "spec": Object {
+                      "podTemplateSpec": Object {
+                        "spec": Object {
+                          "containers": Array [
+                            Object {},
+                          ],
+                        },
+                      },
+                      "tensorboardSpec": Object {
+                        "logDir": "log-dir-1",
+                        "tensorflowImage": "tensorflow/tensorflow:2.0.0",
+                      },
+                      "type": "tensorboard",
+                    },
+                  },
+                ]
+              `);
+              expect(k8sGetCustomObjectSpy.mock.calls[1]).toMatchInlineSnapshot(`
+                Array [
+                  "kubeflow.org",
+                  "v1beta1",
+                  "test-ns",
+                  "viewers",
+                  "viewer-5e1404e679e27b0f0b8ecee8fe515830eaa736c5",
+                ]
+              `);
+              done(err);
+            },
+          );
+      });
+
+      it('returns error when there is an existing tensorboard with different version', done => {
+        const errorSpy = jest.spyOn(console, 'error');
+        errorSpy.mockImplementation();
+        k8sGetCustomObjectSpy.mockImplementation(() =>
+          Promise.resolve(
+            newGetTensorboardResponse({
+              name: 'viewer-abcdefg',
+              logDir: 'log-dir-1',
+              tensorflowImage: 'tensorflow:2.1.0',
+            }),
+          ),
+        );
+        k8sCreateCustomObjectSpy.mockImplementation(() => Promise.resolve());
+
+        request
+          .post(
+            `/apps/tensorboard?logdir=${encodeURIComponent(
+              'log-dir-1',
+            )}&namespace=test-ns&tfversion=2.0.0`,
+          )
+          .expect(
+            500,
+            `Failed to start Tensorboard app: Error: There's already an existing tensorboard instance with a different version 2.1.0`,
+            err => {
+              expect(errorSpy).toHaveBeenCalledTimes(1);
+              done(err);
+            },
+          );
+      });
+
+      it('returns existing pod address if there is an existing tensorboard with the same version', done => {
+        k8sGetCustomObjectSpy.mockImplementation(() =>
+          Promise.resolve(
+            newGetTensorboardResponse({
+              name: 'viewer-abcdefg',
+              logDir: 'log-dir-1',
+              tensorflowImage: 'tensorflow:2.0.0',
+            }),
+          ),
+        );
+        k8sCreateCustomObjectSpy.mockImplementation(() => Promise.resolve());
+
+        request
+          .post(
+            `/apps/tensorboard?logdir=${encodeURIComponent(
+              'log-dir-1',
+            )}&namespace=test-ns&tfversion=2.0.0`,
+          )
+          .expect(
+            200,
+            encodeURIComponent(
+              'http://viewer-abcdefg-service.test-ns.svc.cluster.local:80/tensorboard/viewer-abcdefg/',
+            ),
+            done,
+          );
+      });
+    });
+
+    describe('delete', () => {
+      it('requires logdir', done => {
+        request.delete('/apps/tensorboard').expect(404, 'logdir argument is required', done);
+      });
+
+      it('requires namespace', done => {
+        request
+          .delete('/apps/tensorboard?logdir=some-log-dir')
+          .expect(404, 'namespace argument is required', done);
+      });
+
+      it('deletes tensorboard viewer custom object', done => {
+        k8sGetCustomObjectSpy.mockImplementation(() =>
+          Promise.resolve(
+            newGetTensorboardResponse({
+              name: 'viewer-abcdefg',
+              logDir: 'log-dir-1',
+              tensorflowImage: 'tensorflow:2.0.0',
+            }),
+          ),
+        );
+        k8sDeleteCustomObjectSpy.mockImplementation(() => Promise.resolve());
+
+        request
+          .delete(`/apps/tensorboard?logdir=${encodeURIComponent('log-dir-1')}&namespace=test-ns`)
+          .expect(200, 'Tensorboard deleted.', err => {
+            expect(k8sDeleteCustomObjectSpy.mock.calls[0]).toMatchInlineSnapshot(`
+              Array [
+                "kubeflow.org",
+                "v1beta1",
+                "test-ns",
+                "viewers",
+                "viewer-5e1404e679e27b0f0b8ecee8fe515830eaa736c5",
+                V1DeleteOptions {},
+              ]
+            `);
+            done(err);
+          });
+      });
+    });
+  });
+
   // TODO: Add integration tests for k8s helper related endpoints
-
-  // describe('/apps/tensorboard', () => {
-
-  //   it('get a tensorboard url', done => {
-  //     const tensorboardUrl = 'http://tensorboard.view/abc';
-  //     const mockedGetTensorboardInstance: jest.Mock = getTensorboardInstance as any;
-  //     mockedGetTensorboardInstance.mockResolvedValueOnce(tensorboardUrl);
-  //     const configs = loadConfigs(argv, {});
-  //     app = new UIServer(configs);
-
-  //     const request = requests(app.start());
-  //     request.get('/apps/tensorboard?logdir=hello%2Fworld').expect(200, tensorboardUrl, done);
-  //   });
-
-  // });
-
   // describe('/k8s/pod/logs', () => {});
 
   describe('/apis/v1beta1/', () => {

--- a/frontend/server/app.test.ts
+++ b/frontend/server/app.test.ts
@@ -776,9 +776,7 @@ describe('UIServer apis', () => {
           )
           .expect(
             200,
-            encodeURIComponent(
-              'http://viewer-abcdefg-service.test-ns.svc.cluster.local:80/tensorboard/viewer-abcdefg/',
-            ),
+            'http://viewer-abcdefg-service.test-ns.svc.cluster.local:80/tensorboard/viewer-abcdefg/',
             err => {
               expect(k8sGetCustomObjectSpy.mock.calls[0]).toMatchInlineSnapshot(`
                 Array [
@@ -883,9 +881,7 @@ describe('UIServer apis', () => {
           )
           .expect(
             200,
-            encodeURIComponent(
-              'http://viewer-abcdefg-service.test-ns.svc.cluster.local:80/tensorboard/viewer-abcdefg/',
-            ),
+            'http://viewer-abcdefg-service.test-ns.svc.cluster.local:80/tensorboard/viewer-abcdefg/',
             done,
           );
       });

--- a/frontend/server/app.test.ts
+++ b/frontend/server/app.test.ts
@@ -641,7 +641,7 @@ describe('UIServer apis', () => {
       logDir?: string;
       tensorflowImage?: string;
       type?: string;
-    }) {
+    } = {}) {
       return {
         response: undefined as any, // unused
         body: {
@@ -681,6 +681,17 @@ describe('UIServer apis', () => {
         request
           .get('/apps/tensorboard?logdir=some-log-dir')
           .expect(404, 'namespace argument is required', done);
+      });
+
+      it('does not crash with a weird query', done => {
+        k8sGetCustomObjectSpy.mockImplementation(() =>
+          Promise.resolve(newGetTensorboardResponse()),
+        );
+        // The special case is that, decodeURIComponent('%2') throws an
+        // exception, so this can verify handler doesn't do extra
+        // decodeURIComponent on queries.
+        const weirdLogDir = encodeURIComponent('%2');
+        request.get(`/apps/tensorboard?logdir=${weirdLogDir}&namespace=test-ns`).expect(200, done);
       });
 
       it('gets tensorboard url and version', done => {

--- a/frontend/server/handlers/tensorboard.ts
+++ b/frontend/server/handlers/tensorboard.ts
@@ -20,17 +20,15 @@ import { ViewerTensorboardConfig } from '../configs';
  * handler expects a query string `logdir`.
  */
 export const getTensorboardHandler: Handler = async (req, res) => {
-  if (!req.query.logdir) {
+  const { logdir, namespace } = req.query;
+  if (!logdir) {
     res.status(404).send('logdir argument is required');
     return;
   }
-  if (!req.query.namespace) {
+  if (!namespace) {
     res.status(404).send('namespace argument is required');
     return;
   }
-
-  const logdir = decodeURIComponent(req.query.logdir);
-  const namespace = decodeURIComponent(req.query.namespace);
 
   try {
     res.send(await k8sHelper.getTensorboardInstance(logdir, namespace));
@@ -50,22 +48,19 @@ export const getTensorboardHandler: Handler = async (req, res) => {
  */
 export function getCreateTensorboardHandler(tensorboardConfig: ViewerTensorboardConfig): Handler {
   return async (req, res) => {
-    if (!req.query.logdir) {
+    const { logdir, namespace, tfversion } = req.query;
+    if (!logdir) {
       res.status(404).send('logdir argument is required');
       return;
     }
-    if (!req.query.namespace) {
+    if (!namespace) {
       res.status(404).send('namespace argument is required');
       return;
     }
-    if (!req.query.tfversion) {
+    if (!tfversion) {
       res.status(404).send('tfversion (tensorflow version) argument is required');
       return;
     }
-
-    const logdir = decodeURIComponent(req.query.logdir);
-    const namespace = decodeURIComponent(req.query.namespace);
-    const tfversion = decodeURIComponent(req.query.tfversion);
 
     try {
       await k8sHelper.newTensorboardInstance(
@@ -93,17 +88,15 @@ export function getCreateTensorboardHandler(tensorboardConfig: ViewerTensorboard
  * `logdir` in the request.
  */
 export const deleteTensorboardHandler: Handler = async (req, res) => {
-  if (!req.query.logdir) {
+  const { logdir, namespace } = req.query;
+  if (!logdir) {
     res.status(404).send('logdir argument is required');
     return;
   }
-  if (!req.query.namespace) {
+  if (!namespace) {
     res.status(404).send('namespace argument is required');
     return;
   }
-
-  const logdir = decodeURIComponent(req.query.logdir);
-  const namespace = decodeURIComponent(req.query.namespace);
 
   try {
     await k8sHelper.deleteTensorboardInstance(logdir, namespace);

--- a/frontend/server/handlers/tensorboard.ts
+++ b/frontend/server/handlers/tensorboard.ts
@@ -35,7 +35,8 @@ export const getTensorboardHandler: Handler = async (req, res) => {
   try {
     res.send(await k8sHelper.getTensorboardInstance(logdir, namespace));
   } catch (err) {
-    res.status(500).send('Failed to list Tensorboard pods: ' + JSON.stringify(err));
+    console.error('Failed to list Tensorboard pods: ', err?.body || err);
+    res.status(500).send(`Failed to list Tensorboard pods: ${err}`);
   }
 };
 
@@ -58,7 +59,7 @@ export function getCreateTensorboardHandler(tensorboardConfig: ViewerTensorboard
       return;
     }
     if (!req.query.tfversion) {
-      res.status(404).send('tensorflow version argument is required');
+      res.status(404).send('tfversion (tensorflow version) argument is required');
       return;
     }
 
@@ -81,7 +82,8 @@ export function getCreateTensorboardHandler(tensorboardConfig: ViewerTensorboard
       );
       res.send(tensorboardAddress);
     } catch (err) {
-      res.status(500).send('Failed to start Tensorboard app: ' + JSON.stringify(err));
+      console.error('Failed to start Tensorboard app: ', err?.body || err);
+      res.status(500).send(`Failed to start Tensorboard app: ${err}`);
     }
   };
 }
@@ -97,6 +99,7 @@ export const deleteTensorboardHandler: Handler = async (req, res) => {
   }
   if (!req.query.namespace) {
     res.status(404).send('namespace argument is required');
+    return;
   }
 
   const logdir = decodeURIComponent(req.query.logdir);
@@ -106,6 +109,7 @@ export const deleteTensorboardHandler: Handler = async (req, res) => {
     await k8sHelper.deleteTensorboardInstance(logdir, namespace);
     res.send('Tensorboard deleted.');
   } catch (err) {
-    res.status(500).send('Failed to delete Tensorboard app: ' + JSON.stringify(err));
+    console.error('Failed to delete Tensorboard app: ', err?.body || err);
+    res.status(500).send(`Failed to delete Tensorboard app: ${err}`);
   }
 };

--- a/frontend/server/k8s-helper.ts
+++ b/frontend/server/k8s-helper.ts
@@ -200,7 +200,7 @@ export function waitForTensorboardInstance(
       const tensorboardAddress = tensorboardInstance.podAddress;
       if (tensorboardAddress) {
         clearInterval(handle);
-        resolve(encodeURIComponent(tensorboardAddress));
+        resolve(tensorboardAddress);
       }
     }, 1000);
   });

--- a/frontend/server/k8s-helper.ts
+++ b/frontend/server/k8s-helper.ts
@@ -27,7 +27,7 @@ import { PartialArgoWorkflow } from './workflow-helper';
 // If this is running inside a k8s Pod, its namespace should be written at this
 // path, this is also how we can tell whether we're running in the cluster.
 const namespaceFilePath = '/var/run/secrets/kubernetes.io/serviceaccount/namespace';
-let namespace: string | undefined = undefined;
+let serverNamespace: string | undefined = undefined;
 
 // Constants for creating customer resource Viewer.
 const viewerGroup = 'kubeflow.org';
@@ -48,7 +48,7 @@ export const defaultPodTemplateSpec = {
 
 // The file path contains pod namespace when in Kubernetes cluster.
 if (fs.existsSync(namespaceFilePath)) {
-  namespace = fs.readFileSync(namespaceFilePath, 'utf-8');
+  serverNamespace = fs.readFileSync(namespaceFilePath, 'utf-8');
 }
 const kc = new KubeConfig();
 // This loads kubectl config when not in cluster.
@@ -67,14 +67,17 @@ function getNameOfViewerResource(logdir: string): string {
  */
 export async function newTensorboardInstance(
   logdir: string,
+  namespace: string,
   tfImageName: string,
   tfversion: string,
   podTemplateSpec: object = defaultPodTemplateSpec,
 ): Promise<void> {
   if (!namespace) {
-    throw new Error(`Cannot get namespace from ${namespaceFilePath}.`);
+    throw new Error(
+      `Namespace not specified and cannot get namespace from neither ${namespaceFilePath}.`,
+    );
   }
-  const currentPod = await getTensorboardInstance(logdir);
+  const currentPod = await getTensorboardInstance(logdir, namespace);
   if (currentPod.podAddress) {
     if (tfversion === currentPod.tfVersion) {
       return;
@@ -116,11 +119,8 @@ export async function newTensorboardInstance(
  */
 export async function getTensorboardInstance(
   logdir: string,
+  namespace: string,
 ): Promise<{ podAddress: string; tfVersion: string }> {
-  if (!namespace) {
-    throw new Error(`Cannot get namespace from ${namespaceFilePath}.`);
-  }
-
   return await k8sV1CustomObjectClient
     .getNamespacedCustomObject(
       viewerGroup,
@@ -161,11 +161,8 @@ export async function getTensorboardInstance(
  * and returns the deleted podAddress
  */
 
-export async function deleteTensorboardInstance(logdir: string): Promise<void> {
-  if (!namespace) {
-    throw new Error(`Cannot get namespace from ${namespaceFilePath}.`);
-  }
-  const currentPod = await getTensorboardInstance(logdir);
+export async function deleteTensorboardInstance(logdir: string, namespace: string): Promise<void> {
+  const currentPod = await getTensorboardInstance(logdir, namespace);
   if (!currentPod.podAddress) {
     return;
   }
@@ -187,14 +184,19 @@ export async function deleteTensorboardInstance(logdir: string): Promise<void> {
  * Polls every second for a running Tensorboard instance with the given logdir,
  * and returns the address of one if found, or rejects if a timeout expires.
  */
-export function waitForTensorboardInstance(logdir: string, timeout: number): Promise<string> {
+export function waitForTensorboardInstance(
+  logdir: string,
+  namespace: string,
+  timeout: number,
+): Promise<string> {
   const start = Date.now();
   return new Promise((resolve, reject) => {
-    setInterval(async () => {
+    const handle = setInterval(async () => {
       if (Date.now() - start > timeout) {
+        clearInterval(handle);
         reject('Timed out waiting for tensorboard');
       }
-      const tensorboardInstance = await getTensorboardInstance(logdir);
+      const tensorboardInstance = await getTensorboardInstance(logdir, namespace);
       const tensorboardAddress = tensorboardInstance.podAddress;
       if (tensorboardAddress) {
         resolve(encodeURIComponent(tensorboardAddress));
@@ -204,7 +206,7 @@ export function waitForTensorboardInstance(logdir: string, timeout: number): Pro
 }
 
 export function getPodLogs(podName: string, podNamespace?: string): Promise<string> {
-  podNamespace = podNamespace || namespace;
+  podNamespace = podNamespace || serverNamespace;
   if (!podNamespace) {
     throw new Error(
       `podNamespace is not specified and cannot get namespace from ${namespaceFilePath}.`,
@@ -266,14 +268,14 @@ export async function listPodEvents(
  * @param workflowName name of the argo workflow
  */
 export async function getArgoWorkflow(workflowName: string): Promise<PartialArgoWorkflow> {
-  if (!namespace) {
+  if (!serverNamespace) {
     throw new Error(`Cannot get namespace from ${namespaceFilePath}`);
   }
 
   const res = await k8sV1CustomObjectClient.getNamespacedCustomObject(
     workflowGroup,
     workflowVersion,
-    namespace,
+    serverNamespace,
     workflowPlural,
     workflowName,
   );
@@ -294,11 +296,11 @@ export async function getArgoWorkflow(workflowName: string): Promise<PartialArgo
  * @param key key in the secret
  */
 export async function getK8sSecret(name: string, key: string) {
-  if (!namespace) {
+  if (!serverNamespace) {
     throw new Error(`Cannot get namespace from ${namespaceFilePath}`);
   }
 
-  const k8sSecret = await k8sV1Client.readNamespacedSecret(name, namespace);
+  const k8sSecret = await k8sV1Client.readNamespacedSecret(name, serverNamespace);
   const secretb64 = k8sSecret.body.data[key];
   const buff = new Buffer(secretb64, 'base64');
   return buff.toString('ascii');

--- a/frontend/src/components/viewers/Tensorboard.test.tsx
+++ b/frontend/src/components/viewers/Tensorboard.test.tsx
@@ -15,11 +15,17 @@
  */
 
 import * as React from 'react';
-import TensorboardViewer from './Tensorboard';
+import TensorboardViewer, { TensorboardViewerConfig } from './Tensorboard';
 import TestUtils, { diff } from '../../TestUtils';
 import { Apis } from '../../lib/Apis';
 import { PlotType } from './Viewer';
 import { ReactWrapper, ShallowWrapper, shallow, mount } from 'enzyme';
+
+const DEFAULT_CONFIG: TensorboardViewerConfig = {
+  type: PlotType.TENSORBOARD,
+  url: 'http://test/url',
+  namespace: 'test-ns',
+};
 
 describe('Tensorboard', () => {
   let tree: ReactWrapper | ShallowWrapper;
@@ -80,7 +86,7 @@ describe('Tensorboard', () => {
   it('does not break on empty data', async () => {
     const getAppMock = () => Promise.resolve({ podAddress: '', tfVersion: '' });
     jest.spyOn(Apis, 'getTensorboardApp').mockImplementation(getAppMock);
-    const config = { type: PlotType.TENSORBOARD, url: '' };
+    const config = { ...DEFAULT_CONFIG, url: '' };
     tree = shallow(<TensorboardViewer configs={[config]} />);
     const base = tree.debug();
 
@@ -105,7 +111,7 @@ describe('Tensorboard', () => {
   });
 
   it('shows a link to the tensorboard instance if exists', async () => {
-    const config = { type: PlotType.TENSORBOARD, url: 'http://test/url' };
+    const config = { ...DEFAULT_CONFIG, url: 'http://test/url' };
     const getAppMock = () => Promise.resolve({ podAddress: 'test/address', tfVersion: '1.14.0' });
     jest.spyOn(Apis, 'getTensorboardApp').mockImplementation(getAppMock);
     jest.spyOn(Apis, 'isTensorboardPodReady').mockImplementation(() => Promise.resolve(true));
@@ -119,17 +125,24 @@ describe('Tensorboard', () => {
   });
 
   it('shows start button if no instance exists', async () => {
-    const config = { type: PlotType.TENSORBOARD, url: 'http://test/url' };
+    const config = DEFAULT_CONFIG;
     const getAppMock = () => Promise.resolve({ podAddress: '', tfVersion: '' });
-    const spy = jest.spyOn(Apis, 'getTensorboardApp').mockImplementation(getAppMock);
-    tree = shallow(<TensorboardViewer configs={[config]} />);
+    const getTensorboardSpy = jest.spyOn(Apis, 'getTensorboardApp').mockImplementation(getAppMock);
+    tree = shallow(<TensorboardViewer configs={[DEFAULT_CONFIG]} />);
     const base = tree.debug();
 
     await TestUtils.flushPromises();
-    expect(diff({ base, update: tree.debug() })).toMatchInlineSnapshot(`
+    expect(
+      diff({
+        base,
+        update: tree.debug(),
+        baseAnnotation: 'initial',
+        updateAnnotation: 'no instance exists',
+      }),
+    ).toMatchInlineSnapshot(`
       Snapshot Diff:
-      - Expected
-      + Received
+      - initial
+      + no instance exists
 
       @@ --- --- @@
                   </WithStyles(MenuItem)>
@@ -143,11 +156,11 @@ describe('Tensorboard', () => {
           </div>
         </div>
     `);
-    expect(spy).toHaveBeenCalledWith(config.url);
+    expect(getTensorboardSpy).toHaveBeenCalledWith(config.url, config.namespace);
   });
 
   it('starts tensorboard instance when button is clicked', async () => {
-    const config = { type: PlotType.TENSORBOARD, url: 'http://test/url' };
+    const config = { ...DEFAULT_CONFIG };
     const getAppMock = () => Promise.resolve({ podAddress: '', tfVersion: '' });
     const startAppMock = jest.fn(() => Promise.resolve(''));
     jest.spyOn(Apis, 'getTensorboardApp').mockImplementation(getAppMock);
@@ -155,25 +168,25 @@ describe('Tensorboard', () => {
     tree = shallow(<TensorboardViewer configs={[config]} />);
     await TestUtils.flushPromises();
     tree.find('BusyButton').simulate('click');
-    expect(startAppMock).toHaveBeenCalledWith('http%3A%2F%2Ftest%2Furl', '2.0.0');
+    expect(startAppMock).toHaveBeenCalledWith(config.url, '2.0.0', config.namespace);
   });
 
   it('starts tensorboard instance for two configs', async () => {
-    const config = { type: PlotType.TENSORBOARD, url: 'http://test/url' };
-    const config2 = { type: PlotType.TENSORBOARD, url: 'http://test/url2' };
+    const config = { ...DEFAULT_CONFIG, url: 'http://test/url' };
+    const config2 = { ...DEFAULT_CONFIG, url: 'http://test/url2' };
     const getAppMock = jest.fn(() => Promise.resolve({ podAddress: '', tfVersion: '' }));
     const startAppMock = jest.fn(() => Promise.resolve(''));
     jest.spyOn(Apis, 'getTensorboardApp').mockImplementation(getAppMock);
     jest.spyOn(Apis, 'startTensorboardApp').mockImplementationOnce(startAppMock);
     tree = shallow(<TensorboardViewer configs={[config, config2]} />);
     await TestUtils.flushPromises();
-    expect(getAppMock).toHaveBeenCalledWith(`Series1:${config.url},Series2:${config2.url}`);
+    expect(getAppMock).toHaveBeenCalledWith(
+      `Series1:${config.url},Series2:${config2.url}`,
+      config.namespace,
+    );
     tree.find('BusyButton').simulate('click');
-    const expectedUrl =
-      `Series1${encodeURIComponent(':' + config.url)}` +
-      `${encodeURIComponent(',')}` +
-      `Series2${encodeURIComponent(':' + config2.url)}`;
-    expect(startAppMock).toHaveBeenCalledWith(expectedUrl, '2.0.0');
+    const expectedUrl = `Series1:${config.url},Series2:${config2.url}`;
+    expect(startAppMock).toHaveBeenCalledWith(expectedUrl, '2.0.0', config.namespace);
   });
 
   it('returns friendly display name', () => {
@@ -185,7 +198,7 @@ describe('Tensorboard', () => {
   });
 
   it('select a version, then start a tensorboard of the corresponding version', async () => {
-    const config = { type: PlotType.TENSORBOARD, url: 'http://test/url' };
+    const config = { ...DEFAULT_CONFIG };
 
     const getAppMock = jest.fn(() => Promise.resolve({ podAddress: '', tfVersion: '' }));
     const startAppMock = jest.fn(() => Promise.resolve(''));
@@ -206,7 +219,7 @@ describe('Tensorboard', () => {
       .hostNodes()
       .simulate('click');
     tree.find('BusyButton').simulate('click');
-    expect(startAppSpy).toHaveBeenCalledWith('http%3A%2F%2Ftest%2Furl', '1.15.0');
+    expect(startAppSpy).toHaveBeenCalledWith(config.url, '1.15.0', config.namespace);
   });
 
   it('delete the tensorboard instance, confirm in the dialog,\
@@ -217,7 +230,7 @@ describe('Tensorboard', () => {
     jest.spyOn(Apis, 'getTensorboardApp').mockImplementation(getAppMock);
     const deleteAppMock = jest.fn(() => Promise.resolve(''));
     const deleteAppSpy = jest.spyOn(Apis, 'deleteTensorboardApp').mockImplementation(deleteAppMock);
-    const config = { type: PlotType.TENSORBOARD, url: 'http://test/url' };
+    const config = { ...DEFAULT_CONFIG };
 
     tree = mount(<TensorboardViewer configs={[config]} />);
     await TestUtils.flushPromises();
@@ -230,7 +243,7 @@ describe('Tensorboard', () => {
       .find('Button')
       .simulate('click');
     tree.find('BusyButton').simulate('click');
-    expect(deleteAppSpy).toHaveBeenCalledWith(encodeURIComponent('http://test/url'));
+    expect(deleteAppSpy).toHaveBeenCalledWith(config.url, config.namespace);
     await TestUtils.flushPromises();
     tree.update();
     // the tree has returned to 'start tensorboard' page
@@ -243,7 +256,7 @@ describe('Tensorboard', () => {
       Promise.resolve({ podAddress: 'podaddress', tfVersion: '1.14.0' }),
     );
     jest.spyOn(Apis, 'getTensorboardApp').mockImplementation(getAppMock);
-    const config = { type: PlotType.TENSORBOARD, url: 'http://test/url' };
+    const config = DEFAULT_CONFIG;
     tree = mount(<TensorboardViewer configs={[config]} />);
     await TestUtils.flushPromises();
     tree.update();
@@ -259,7 +272,7 @@ describe('Tensorboard', () => {
       Promise.resolve({ podAddress: 'podaddress', tfVersion: '1.14.0' }),
     );
     jest.spyOn(Apis, 'getTensorboardApp').mockImplementation(getAppMock);
-    const config = { type: PlotType.TENSORBOARD, url: 'http://test/url' };
+    const config = DEFAULT_CONFIG;
     tree = mount(<TensorboardViewer configs={[config]} />);
     await TestUtils.flushPromises();
     tree.update();
@@ -284,7 +297,7 @@ describe('Tensorboard', () => {
     jest.spyOn(Apis, 'getTensorboardApp').mockImplementation(getAppMock);
     jest.spyOn(Apis, 'isTensorboardPodReady').mockImplementation(() => Promise.resolve(false));
     jest.spyOn(Apis, 'deleteTensorboardApp').mockImplementation(jest.fn(() => Promise.resolve('')));
-    const config = { type: PlotType.TENSORBOARD, url: 'http://test/url' };
+    const config = DEFAULT_CONFIG;
     tree = mount(<TensorboardViewer configs={[config]} />);
 
     await TestUtils.flushPromises();

--- a/frontend/src/components/viewers/Tensorboard.test.tsx
+++ b/frontend/src/components/viewers/Tensorboard.test.tsx
@@ -120,7 +120,9 @@ describe('Tensorboard', () => {
     await TestUtils.flushPromises();
     await flushPromisesAndTimers();
     expect(Apis.isTensorboardPodReady).toHaveBeenCalledTimes(1);
-    expect(Apis.isTensorboardPodReady).toHaveBeenCalledWith('apis/v1beta1/_proxy/test/address');
+    expect(Apis.isTensorboardPodReady).toHaveBeenCalledWith(
+      'apis/v1beta1/_proxy/' + encodeURIComponent('test/address'),
+    );
     expect(tree).toMatchSnapshot();
   });
 

--- a/frontend/src/components/viewers/Tensorboard.test.tsx
+++ b/frontend/src/components/viewers/Tensorboard.test.tsx
@@ -120,9 +120,7 @@ describe('Tensorboard', () => {
     await TestUtils.flushPromises();
     await flushPromisesAndTimers();
     expect(Apis.isTensorboardPodReady).toHaveBeenCalledTimes(1);
-    expect(Apis.isTensorboardPodReady).toHaveBeenCalledWith(
-      'apis/v1beta1/_proxy/' + encodeURIComponent('test/address'),
-    );
+    expect(Apis.isTensorboardPodReady).toHaveBeenCalledWith('apis/v1beta1/_proxy/test/address');
     expect(tree).toMatchSnapshot();
   });
 

--- a/frontend/src/components/viewers/Tensorboard.tsx
+++ b/frontend/src/components/viewers/Tensorboard.tsx
@@ -307,7 +307,7 @@ class TensorboardViewer extends Viewer<TensorboardViewerProps, TensorboardViewer
 }
 
 function makeProxyUrl(podAddress: string) {
-  return 'apis/v1beta1/_proxy/' + encodeURIComponent(podAddress).replace(/(^\w+:|^)\/\//, '');
+  return 'apis/v1beta1/_proxy/' + podAddress.replace(/(^\w+:|^)\/\//, '');
 }
 
 export default TensorboardViewer;

--- a/frontend/src/components/viewers/Tensorboard.tsx
+++ b/frontend/src/components/viewers/Tensorboard.tsx
@@ -307,6 +307,13 @@ class TensorboardViewer extends Viewer<TensorboardViewerProps, TensorboardViewer
 }
 
 function makeProxyUrl(podAddress: string) {
+  // Strip the protocol from the URL. This is a workaround for cloud shell
+  // incorrectly decoding the address and replacing the protocol's // with /.
+  // Pod address (after stripping protocol) is of the format
+  // <viewer_service_dns>.kubeflow.svc.cluster.local:6006/tensorboard/<viewer_name>/
+  // We use this pod address without encoding since encoded pod address failed to open the
+  // tensorboard instance on this pod.
+  // TODO: figure out why the encoded pod address failed to open the tensorboard.
   return 'apis/v1beta1/_proxy/' + podAddress.replace(/(^\w+:|^)\/\//, '');
 }
 

--- a/frontend/src/components/viewers/Tensorboard.tsx
+++ b/frontend/src/components/viewers/Tensorboard.tsx
@@ -269,7 +269,7 @@ class TensorboardViewer extends Viewer<TensorboardViewerProps, TensorboardViewer
 
   private async _checkTensorboardApp(): Promise<void> {
     this.setState({ busy: true }, async () => {
-      const { podAddress, tfVersion } = await Apis.getTensorboardApp(this._buildUrl());
+      const { podAddress, tfVersion } = await Apis.getTensorboardApp(this._buildUrl(), 'yuan');
       if (podAddress) {
         this.setState({ busy: false, podAddress, tensorflowVersion: tfVersion });
       } else {
@@ -284,6 +284,7 @@ class TensorboardViewer extends Viewer<TensorboardViewerProps, TensorboardViewer
       await Apis.startTensorboardApp(
         encodeURIComponent(this._buildUrl()),
         encodeURIComponent(this.state.tensorflowVersion),
+        encodeURIComponent('yuan'),
       );
       this.setState({ busy: false, tensorboardReady: false }, () => {
         this._checkTensorboardApp();
@@ -295,7 +296,10 @@ class TensorboardViewer extends Viewer<TensorboardViewerProps, TensorboardViewer
     // delete the already opened Tensorboard, clear the podAddress recorded in frontend,
     // and return to the select & start tensorboard page
     this.setState({ busy: true }, async () => {
-      await Apis.deleteTensorboardApp(encodeURIComponent(this._buildUrl()));
+      await Apis.deleteTensorboardApp(
+        encodeURIComponent(this._buildUrl()),
+        encodeURIComponent('yuan'),
+      );
       this.setState({
         busy: false,
         deleteDialogOpen: false,

--- a/frontend/src/components/viewers/__snapshots__/Tensorboard.test.tsx.snap
+++ b/frontend/src/components/viewers/__snapshots__/Tensorboard.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`Tensorboard shows a link to the tensorboard instance if exists 1`] = `
     </div>
     <a
       className="unstyled"
-      href="apis/v1beta1/_proxy/test%2Faddress"
+      href="apis/v1beta1/_proxy/test/address"
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/frontend/src/components/viewers/__snapshots__/Tensorboard.test.tsx.snap
+++ b/frontend/src/components/viewers/__snapshots__/Tensorboard.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`Tensorboard shows a link to the tensorboard instance if exists 1`] = `
     </div>
     <a
       className="unstyled"
-      href="apis/v1beta1/_proxy/test/address"
+      href="apis/v1beta1/_proxy/test%2Faddress"
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/frontend/src/lib/Apis.test.ts
+++ b/frontend/src/lib/Apis.test.ts
@@ -139,19 +139,22 @@ describe('Apis', () => {
     const spy = fetchSpy(
       JSON.stringify({ podAddress: 'http://some/address', tfVersion: '1.14.0' }),
     );
-    const tensorboardInstance = await Apis.getTensorboardApp('gs://log/dir');
+    const tensorboardInstance = await Apis.getTensorboardApp('gs://log/dir', 'test-ns');
     expect(tensorboardInstance).toEqual({ podAddress: 'http://some/address', tfVersion: '1.14.0' });
     expect(spy).toHaveBeenCalledWith(
-      'apps/tensorboard?logdir=' + encodeURIComponent('gs://log/dir'),
+      `apps/tensorboard?logdir=${encodeURIComponent('gs://log/dir')}&namespace=test-ns`,
       { credentials: 'same-origin' },
     );
   });
 
   it('startTensorboardApp', async () => {
     const spy = fetchSpy('http://some/address');
-    await Apis.startTensorboardApp('gs://log/dir', '1.14.0');
+    await Apis.startTensorboardApp('gs://log/dir', '1.14.0', 'test-ns');
     expect(spy).toHaveBeenCalledWith(
-      'apps/tensorboard?logdir=' + encodeURIComponent('gs://log/dir') + '&tfversion=1.14.0',
+      'apps/tensorboard?logdir=' +
+        encodeURIComponent('gs://log/dir') +
+        '&tfversion=1.14.0' +
+        '&namespace=test-ns',
       {
         credentials: 'same-origin',
         headers: { 'content-type': 'application/json' },
@@ -162,9 +165,9 @@ describe('Apis', () => {
 
   it('deleteTensorboardApp', async () => {
     const spy = fetchSpy('http://some/address');
-    await Apis.deleteTensorboardApp('gs://log/dir');
+    await Apis.deleteTensorboardApp('gs://log/dir', 'test-ns');
     expect(spy).toHaveBeenCalledWith(
-      'apps/tensorboard?logdir=' + encodeURIComponent('gs://log/dir'),
+      'apps/tensorboard?logdir=' + encodeURIComponent('gs://log/dir') + '&namespace=test-ns',
       {
         credentials: 'same-origin',
         method: 'DELETE',

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -212,20 +212,27 @@ export class Apis {
    */
   public static getTensorboardApp(
     logdir: string,
+    namespace: string,
   ): Promise<{ podAddress: string; tfVersion: string }> {
     return this._fetchAndParse<{ podAddress: string; tfVersion: string }>(
-      `apps/tensorboard?logdir=${encodeURIComponent(logdir)}`,
+      `apps/tensorboard?logdir=${encodeURIComponent(logdir)}&namespace=${encodeURIComponent(
+        namespace,
+      )}`,
     );
   }
 
   /**
    * Starts a deployment and service for Tensorboard given the logdir
    */
-  public static startTensorboardApp(logdir: string, tfversion: string): Promise<string> {
+  public static startTensorboardApp(
+    logdir: string,
+    tfversion: string,
+    namespace: string,
+  ): Promise<string> {
     return this._fetch(
       `apps/tensorboard?logdir=${encodeURIComponent(logdir)}&tfversion=${encodeURIComponent(
         tfversion,
-      )}`,
+      )}&namespace=${encodeURIComponent(namespace)}`,
       undefined,
       undefined,
       { headers: { 'content-type': 'application/json' }, method: 'POST' },
@@ -243,9 +250,9 @@ export class Apis {
   /**
    * Delete a deployment and its service of the Tensorboard given the URL
    */
-  public static deleteTensorboardApp(logdir: string): Promise<string> {
+  public static deleteTensorboardApp(logdir: string, namespace: string): Promise<string> {
     return this._fetch(
-      `apps/tensorboard?logdir=${encodeURIComponent(logdir)}`,
+      `apps/tensorboard?logdir=${encodeURIComponent(logdir)}&namespace=${namespace}`,
       undefined,
       undefined,
       { method: 'DELETE' },

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -252,7 +252,9 @@ export class Apis {
    */
   public static deleteTensorboardApp(logdir: string, namespace: string): Promise<string> {
     return this._fetch(
-      `apps/tensorboard?logdir=${encodeURIComponent(logdir)}&namespace=${namespace}`,
+      `apps/tensorboard?logdir=${encodeURIComponent(logdir)}&namespace=${encodeURIComponent(
+        namespace,
+      )}`,
       undefined,
       undefined,
       { method: 'DELETE' },

--- a/frontend/src/lib/OutputArtifactLoader.test.ts
+++ b/frontend/src/lib/OutputArtifactLoader.test.ts
@@ -75,33 +75,35 @@ describe('OutputArtifactLoader', () => {
   describe('buildConfusionMatrixConfig', () => {
     it('requires "source" metadata field', async () => {
       const metadata = { schema: 'schema', format: 'format' };
-      expect(OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
-        'Malformed metadata, property "source" is required.',
-      );
+      await expect(
+        OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any),
+      ).rejects.toThrowError('Malformed metadata, property "source" is required.');
     });
 
-    it('requires "labels" metadata field', () => {
+    it('requires "labels" metadata field', async () => {
       const metadata = { source: 'source', schema: 'schema' };
-      expect(OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
-        'Malformed metadata, property "labels" is required.',
-      );
+      await expect(
+        OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any),
+      ).rejects.toThrowError('Malformed metadata, property "labels" is required.');
     });
 
-    it('requires "schema" metadata field', () => {
+    it('requires "schema" metadata field', async () => {
       const metadata = { source: 'source', labels: 'labels' };
-      expect(OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
-        'Malformed metadata, property "schema" missing.',
-      );
+      await expect(
+        OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any),
+      ).rejects.toThrowError('Malformed metadata, property "schema" missing.');
     });
 
-    it('handles empty schema', () => {
+    it('handles empty schema', async () => {
       const metadata = { source: 'gs://source', labels: ['labels'], schema: 'schema' };
-      expect(OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
+      await expect(
+        OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any),
+      ).rejects.toThrowError(
         '"schema" must be an array of {"name": string, "type": string} objects',
       );
     });
 
-    it('handles schema with bad field format', () => {
+    it('handles schema with bad field format', async () => {
       const metadata = {
         labels: ['field1', 'field2'],
         schema: [
@@ -120,12 +122,12 @@ describe('OutputArtifactLoader', () => {
       field2,field1,0
       field2,field2,0
       `;
-      expect(OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
-        'Each item in the "schema" array must contain a "name" field',
-      );
+      await expect(
+        OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any),
+      ).rejects.toThrowError('Each item in the "schema" array must contain a "name" field');
     });
 
-    it('handles when too many labels are specified for the data', () => {
+    it('handles when too many labels are specified for the data', async () => {
       const metadata = {
         labels: ['labels', 'labels'],
         schema: [
@@ -140,9 +142,9 @@ describe('OutputArtifactLoader', () => {
         source: 'gs://path',
       };
       fileToRead = '';
-      expect(OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any)).rejects.toThrowError(
-        'Data dimensions 0 do not match the number of labels passed 2',
-      );
+      await expect(
+        OutputArtifactLoader.buildConfusionMatrixConfig(metadata as any),
+      ).rejects.toThrowError('Data dimensions 0 do not match the number of labels passed 2');
     });
 
     const basicMetadata = {
@@ -205,32 +207,32 @@ describe('OutputArtifactLoader', () => {
   });
 
   describe('buildPagedTableConfig', () => {
-    it('requires "source" metadata field', () => {
+    it('requires "source" metadata field', async () => {
       const metadata = { header: 'header', format: 'format' };
-      expect(OutputArtifactLoader.buildPagedTableConfig(metadata as any)).rejects.toThrowError(
-        'Malformed metadata, property "source" is required.',
-      );
+      await expect(
+        OutputArtifactLoader.buildPagedTableConfig(metadata as any),
+      ).rejects.toThrowError('Malformed metadata, property "source" is required.');
     });
 
-    it('requires "header" metadata field', () => {
+    it('requires "header" metadata field', async () => {
       const metadata = { source: 'source', format: 'format' };
-      expect(OutputArtifactLoader.buildPagedTableConfig(metadata as any)).rejects.toThrowError(
-        'Malformed metadata, property "header" is required.',
-      );
+      await expect(
+        OutputArtifactLoader.buildPagedTableConfig(metadata as any),
+      ).rejects.toThrowError('Malformed metadata, property "header" is required.');
     });
 
-    it('requires "format" metadata field', () => {
+    it('requires "format" metadata field', async () => {
       const metadata = { source: 'source', header: 'header' };
-      expect(OutputArtifactLoader.buildPagedTableConfig(metadata as any)).rejects.toThrowError(
-        'Malformed metadata, property "format" is required.',
-      );
+      await expect(
+        OutputArtifactLoader.buildPagedTableConfig(metadata as any),
+      ).rejects.toThrowError('Malformed metadata, property "format" is required.');
     });
 
-    it('requires only supports csv format', () => {
-      const metadata = { source: 'source', header: 'header', format: 'json' };
-      expect(OutputArtifactLoader.buildPagedTableConfig(metadata as any)).rejects.toThrowError(
-        'Unsupported table format: json',
-      );
+    it('requires only supports csv format', async () => {
+      const metadata = { source: 'http://source', header: 'header', format: 'json' };
+      await expect(
+        OutputArtifactLoader.buildPagedTableConfig(metadata as any),
+      ).rejects.toThrowError('Unsupported table format: json');
     });
 
     const basicMetadata = {
@@ -284,28 +286,31 @@ describe('OutputArtifactLoader', () => {
   });
 
   describe('buildTensorboardConfig', () => {
-    it('requires "source" metadata field', () => {
+    it('requires "source" metadata field', async () => {
       const metadata = { header: 'header', format: 'format' };
-      expect(OutputArtifactLoader.buildTensorboardConfig(metadata as any)).rejects.toThrowError(
-        'Malformed metadata, property "source" is required.',
-      );
+      await expect(
+        OutputArtifactLoader.buildTensorboardConfig(metadata as any, 'test-ns'),
+      ).rejects.toThrowError('Malformed metadata, property "source" is required.');
     });
 
     it('returns a tensorboard config with basic metadata', async () => {
       const metadata = { source: 'gs://path' };
-      expect(await OutputArtifactLoader.buildTensorboardConfig(metadata as any)).toEqual({
-        type: PlotType.TENSORBOARD,
-        url: 'gs://path',
-      } as TensorboardViewerConfig);
+      expect(await OutputArtifactLoader.buildTensorboardConfig(metadata as any, 'test-ns')).toEqual(
+        {
+          namespace: 'test-ns',
+          type: PlotType.TENSORBOARD,
+          url: 'gs://path',
+        } as TensorboardViewerConfig,
+      );
     });
   });
 
   describe('buildHtmlViewerConfig', () => {
-    it('requires "source" metadata field', () => {
+    it('requires "source" metadata field', async () => {
       const metadata = { header: 'header', format: 'format' };
-      expect(OutputArtifactLoader.buildHtmlViewerConfig(metadata as any)).rejects.toThrowError(
-        'Malformed metadata, property "source" is required.',
-      );
+      await expect(
+        OutputArtifactLoader.buildHtmlViewerConfig(metadata as any),
+      ).rejects.toThrowError('Malformed metadata, property "source" is required.');
     });
 
     it('returns an HTML viewer config with basic metadata', async () => {
@@ -334,11 +339,11 @@ describe('OutputArtifactLoader', () => {
   });
 
   describe('buildMarkdownViewerConfig', () => {
-    it('requires "source" metadata field', () => {
+    it('requires "source" metadata field', async () => {
       const metadata = { header: 'header', format: 'format' };
-      expect(OutputArtifactLoader.buildMarkdownViewerConfig(metadata as any)).rejects.toThrowError(
-        'Malformed metadata, property "source" is required.',
-      );
+      await expect(
+        OutputArtifactLoader.buildMarkdownViewerConfig(metadata as any),
+      ).rejects.toThrowError('Malformed metadata, property "source" is required.');
     });
 
     it('returns a markdown viewer config with basic metadata for inline markdown', async () => {
@@ -373,42 +378,42 @@ describe('OutputArtifactLoader', () => {
   });
 
   describe('buildRocCurveConfig', () => {
-    it('requires "source" metadata field', () => {
+    it('requires "source" metadata field', async () => {
       const metadata = { header: 'header', schema: 'schema' };
-      expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
+      await expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
         'Malformed metadata, property "source" is required.',
       );
     });
 
-    it('requires "schema" metadata field', () => {
+    it('requires "schema" metadata field', async () => {
       const metadata = { source: 'header' };
-      expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
+      await expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
         'Malformed metadata, property "schema" is required.',
       );
     });
 
-    it('throws for a non-array schema', () => {
+    it('throws for a non-array schema', async () => {
       const metadata = { source: 'gs://path', schema: { field1: 'string' } };
-      expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
+      await expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
         'Malformed schema, must be an array of {"name": string, "type": string}',
       );
     });
 
-    it('requires "fpr" field in the schema', () => {
+    it('requires "fpr" field in the schema', async () => {
       const metadata = { source: 'gs://path', schema: [{ name: 'field1', type: 'string' }] };
-      expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
+      await expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
         'Malformed schema, expected to find a column named "fpr"',
       );
     });
 
-    it('requires "tpr" field in the schema', () => {
+    it('requires "tpr" field in the schema', async () => {
       const metadata = { source: 'gs://path', schema: [{ name: 'fpr', type: 'string' }] };
-      expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
+      await expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
         'Malformed schema, expected to find a column named "tpr"',
       );
     });
 
-    it('requires "threshold" field in the schema', () => {
+    it('requires "threshold" field in the schema', async () => {
       const metadata = {
         schema: [
           {
@@ -422,7 +427,7 @@ describe('OutputArtifactLoader', () => {
         ],
         source: 'gs://path',
       };
-      expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
+      await expect(OutputArtifactLoader.buildRocCurveConfig(metadata as any)).rejects.toThrowError(
         'Malformed schema, expected to find a column named "threshold"',
       );
     });

--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -64,7 +64,10 @@ export interface OutputMetadata {
 }
 
 export class OutputArtifactLoader {
-  public static async load(outputPath: StoragePath): Promise<ViewerConfig[]> {
+  public static async load(
+    outputPath: StoragePath,
+    namespace: string | undefined,
+  ): Promise<ViewerConfig[]> {
     let plotMetadataList: PlotMetadata[] = [];
     try {
       const metadataFile = await Apis.readFile(outputPath);
@@ -95,7 +98,7 @@ export class OutputArtifactLoader {
           case PlotType.TABLE:
             return await this.buildPagedTableConfig(metadata);
           case PlotType.TENSORBOARD:
-            return await this.buildTensorboardConfig(metadata);
+            return await this.buildTensorboardConfig(metadata, namespace);
           case PlotType.WEB_APP:
             return await this.buildHtmlViewerConfig(metadata);
           case PlotType.ROC:
@@ -197,14 +200,19 @@ export class OutputArtifactLoader {
 
   public static async buildTensorboardConfig(
     metadata: PlotMetadataContent,
+    namespace: string | undefined,
   ): Promise<TensorboardViewerConfig> {
     if (!metadata.source) {
       throw new Error('Malformed metadata, property "source" is required.');
+    }
+    if (!namespace) {
+      throw new Error('Namespace is required.');
     }
     WorkflowParser.parseStoragePath(metadata.source);
     return {
       type: PlotType.TENSORBOARD,
       url: metadata.source,
+      namespace,
     };
   }
 

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -264,7 +264,10 @@ class Compare extends Page<{}, CompareState> {
     await Promise.all(
       outputPathsList.map(async (pathList, i) => {
         for (const path of pathList) {
-          const configs = await OutputArtifactLoader.load(path);
+          const configs = await OutputArtifactLoader.load(
+            path,
+            workflowObjects[0]?.metadata?.namespace,
+          );
           configs.forEach(config => {
             const currentList: TaggedViewerConfig[] = viewersMap.get(config.type) || [];
             currentList.push({

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -316,6 +316,7 @@ export class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                             ]
                                           : undefined
                                       }
+                                      namespace={this.state.workflow?.metadata?.namespace}
                                       visualizationCreatorConfig={visualizationCreatorConfig}
                                       generatedVisualizations={this.state.generatedVisualizations.filter(
                                         visualization =>
@@ -716,7 +717,7 @@ export class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
 
     const configLists = await Promise.all(
       outputPathsList.map(({ stepName, path }) =>
-        OutputArtifactLoader.load(path).then(configs =>
+        OutputArtifactLoader.load(path, workflow?.metadata?.namespace).then(configs =>
           configs.map(config => ({ config, stepName })),
         ),
       ),
@@ -916,8 +917,16 @@ const ArtifactsTabContent: React.FC<{
   nodeId: string;
   nodeStatus?: NodeStatus;
   generatedVisualizations: GeneratedVisualization[];
+  namespace: string | undefined;
   onError: (error: Error) => void;
-}> = ({ visualizationCreatorConfig, generatedVisualizations, nodeId, nodeStatus, onError }) => {
+}> = ({
+  visualizationCreatorConfig,
+  generatedVisualizations,
+  nodeId,
+  nodeStatus,
+  namespace,
+  onError,
+}) => {
   const [loaded, setLoaded] = React.useState(false);
   // Progress component expects onLoad function identity to stay the same
   const onLoad = React.useCallback(() => setLoaded(true), [setLoaded]);
@@ -959,7 +968,7 @@ const ArtifactsTabContent: React.FC<{
             reportErrorAndReturnEmpty,
           ),
           ...outputPaths.map(path =>
-            OutputArtifactLoader.load(path).catch(reportErrorAndReturnEmpty),
+            OutputArtifactLoader.load(path, namespace).catch(reportErrorAndReturnEmpty),
           ),
         ])
       ).flatMap(configs => configs);
@@ -983,7 +992,7 @@ const ArtifactsTabContent: React.FC<{
     // nodeStatus object instance will keep changing after new requests to get
     // workflow status.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nodeId, nodeCompleted, onError]);
+  }, [nodeId, nodeCompleted, onError, namespace]);
 
   return (
     <div className={commonCss.page}>


### PR DESCRIPTION
/area frontend
/assign @chensun 
/kind feature

Part of https://github.com/kubeflow/pipelines/issues/3294
UI image: gcr.io/gongyuan-pipeline-test/dev/frontend@sha256:de35d56815503c37789150a13d0e724e2b681fbf748c679d5971aa0834fb0369

Feature Changes:
* UI gets namespace from run and sends to node server tensorboard apis
* Node server requires namespace argument for tensorboard apis

Engprod Changes:
* Allow UI node server local development to access minio artifact api in cluster
* Wrote missing tests for tensorboard apis in node server
* Fixed url query decoded twice problem and added a unit test for it:  https://github.com/kubeflow/pipelines/pull/3355/files#diff-bbd9ad97d5d99d826328e300b108a070R690-R694

Verification:
* Tested on https://kfpmu-3-23.endpoints.gongyuan-pipeline-test.cloud.goog/ e2e, with manually fixed mlmd grpc configmap in user namespaces