### PR TITLE
[SDK] Pipeline can now set user-defined service account

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -668,7 +668,7 @@ class Compiler(object):
         'entrypoint': pipeline_template_name,
         'templates': templates,
         'arguments': {'parameters': input_params},
-        'serviceAccountName': 'pipeline-runner'
+        'serviceAccountName': pipeline_conf.service_account_name or 'pipeline-runner'
       }
     }
     # set ttl after workflow finishes

--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -20,7 +20,7 @@ from ._component_bridge import _create_container_op_from_component_and_arguments
 from ..components import _components
 from ..components._naming import _make_name_unique_by_adding_index
 import sys
-
+import typing
 
 # This handler is called whenever the @pipeline decorator is applied.
 # It can be used by command-line DSL compiler to inject code that runs for every pipeline definition.
@@ -61,12 +61,28 @@ class PipelineConf():
     self.timeout = 0
     self.ttl_seconds_after_finished = -1
     self.op_transformers = []
+    self.service_account_name = "pipeline-runner"
 
-  def set_image_pull_secrets(self, image_pull_secrets):
+  def set_service_account_name(self, service_account_name: str):
+    """Configures the k8s service account to use for the pipeline. If not provided,
+    'pipeline-runner' will be used as the default service account.
+
+    Please ensure the service account has the required permissions required for
+    running the workflow.
+
+    See https://github.com/argoproj/argo/blob/master/docs/workflow-rbac.md
+
+    Args:
+        service_account_name (str): Name of the service account to use.
+    """
+    self.service_account_name = service_account_name
+    return self
+
+  def set_image_pull_secrets(self, image_pull_secrets: typing.List[str]):
     """Configures the pipeline level imagepullsecret
 
     Args:
-      image_pull_secrets: a list of Kubernetes V1LocalObjectReference
+      image_pull_secrets (List[str]): a list of Kubernetes V1LocalObjectReference
       For detailed description, check Kubernetes V1LocalObjectReference definition
       https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1LocalObjectReference.md
     """
@@ -77,7 +93,7 @@ class PipelineConf():
     """Configures the pipeline level timeout
 
     Args:
-      seconds: number of seconds for timeout
+      seconds (int): number of seconds for timeout
     """
     self.timeout = seconds
     return self
@@ -86,7 +102,7 @@ class PipelineConf():
     """Configures the ttl after the pipeline has finished.
 
     Args:
-      seconds: number of seconds for the workflow to be garbage collected after it is finished.
+      seconds (int): number of seconds for the workflow to be garbage collected after it is finished.
     """
     self.ttl_seconds_after_finished = seconds
     return self

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -692,7 +692,7 @@ implementation:
     @dsl.pipeline()
     def some_pipeline():
       some_op()
-      dsl.get_pipeline_conf().test_set_service_account_name('custom_pipeline_runner')
+      dsl.get_pipeline_conf().set_service_account_name('custom_pipeline_runner')
 
     workflow_dict = kfp.compiler.Compiler()._compile(some_pipeline)
     self.assertEqual(workflow_dict['spec']['serviceAccountName'], 'custom_pipeline_runner')

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -152,7 +152,7 @@ class TestCompiler(unittest.TestCase):
       self.maxDiff = None
       self.assertEqual(golden_output, compiler._op_to_template._op_to_template(op))
       self.assertEqual(res_output, compiler._op_to_template._op_to_template(res))
-    
+
     kfp.compiler.Compiler()._compile(my_pipeline)
 
   def _get_yaml_from_zip(self, zip_file):
@@ -327,7 +327,7 @@ class TestCompiler(unittest.TestCase):
 
       with open(os.path.join(test_data_dir, target_yaml), 'r') as f:
         compiled = yaml.safe_load(f)
-      
+
       for workflow in golden, compiled:
         annotations = workflow['metadata']['annotations']
         del annotations['pipelines.kubeflow.org/pipeline_spec']
@@ -679,6 +679,25 @@ implementation:
       if container:
         self.assertEqual(template['retryStrategy']['limit'], 5)
 
+
+  def test_set_service_account_name(self):
+    """Test a pipeline using a custom service account."""
+    def some_op():
+        return dsl.ContainerOp(
+            name='sleep',
+            image='busybox',
+            command=['sleep 1'],
+        )
+
+    @dsl.pipeline()
+    def some_pipeline():
+      some_op()
+      dsl.get_pipeline_conf().test_set_service_account_name('custom_pipeline_runner')
+
+    workflow_dict = kfp.compiler.Compiler()._compile(some_pipeline)
+    self.assertEqual(workflow_dict['spec']['serviceAccountName'], 'custom_pipeline_runner')
+
+
   def test_container_op_output_error_when_no_or_multiple_outputs(self):
 
     def no_outputs_pipeline():
@@ -747,11 +766,11 @@ implementation:
               name="foo-bar-cm",
               namespace="default"
           )
-        )        
+        )
         # delete the config map in k8s
         dsl.ResourceOp(
-          name="delete-config-map", 
-          action="delete", 
+          name="delete-config-map",
+          action="delete",
           k8s_resource=config_map
         )
 


### PR DESCRIPTION
With reference to: 
- https://github.com/kubeflow/pipelines/issues/1691#issuecomment-569025651
- https://kubeflow.slack.com/archives/CE10KS9M4/p1585084024016300
- https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html

AWS EKS just introduced IAM role for service account recently. This feature essentially replaces `kube2iam` - i.e. user can assume AWS IAM roles by using pre-created k8s service accounts (binded to AWS IAM roles with annotations).

Hence,  AWS users using k8s service accounts to manage IAM needs to be able to set the service account to use for each specific pipeline.

This PR have the following changes:
- Added `PipelineConf.set_service_account_name` with a default value of "pipeline-runner".
- Added unit test to compiler for this additional setting
- Added an example on using this setting into `samples/pipelines_service_account`