### PR TITLE
Fix maximum timeout in `wait_for_run_completion`

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -422,7 +422,7 @@ class Client(object):
         self.run_id = run_info.id
 
       def wait_for_run_completion(self, timeout=None):
-        timeout = timeout or datetime.max - datetime.min
+        timeout = timeout or (datetime.max - datetime.min).seconds
         return self._client.wait_for_run_completion(self.run_id, timeout)
 
       def __repr__(self):

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -422,7 +422,7 @@ class Client(object):
         self.run_id = run_info.id
 
       def wait_for_run_completion(self, timeout=None):
-        timeout = timeout or datetime.datetime.max - datetime.datetime.min
+        timeout = timeout or datetime.max - datetime.min
         return self._client.wait_for_run_completion(self.run_id, timeout)
 
       def __repr__(self):


### PR DESCRIPTION
When no timeout is provided, the function fails.

Datetime is imported with `from datetime import datetime`, so `datetime.datetime.min` refers to `datetime.datetime.datetime.min`, which is not defined.

To fix this, call `datetime.min` instead.