### PR TITLE
SDK - Compiler - Added support for volume-based data passing

### DIFF
--- a/sdk/python/kfp/compiler/_data_passing_using_volume.py
+++ b/sdk/python/kfp/compiler/_data_passing_using_volume.py
@@ -1,0 +1,200 @@
+#/bin/env python3
+
+import copy
+import json
+import os
+import re
+import warnings
+from typing import List, Optional, Set
+
+
+def rewrite_data_passing_to_use_volumes(
+        workflow: dict,
+        volume: dict,
+        path_prefix: str = 'artifact_data/',
+) -> dict:
+    '''Converts Argo workflow that passes data using artifacts to workflow that passes data using a single multi-write volume.
+
+    Implementation: Changes file passing system from passing Argo artifacts to passing parameters holding volumeMount subPaths.
+
+    Limitations:
+    * All artifact file names must be the same (e.g. "data"). E.g. "/tmp/outputs/my_out_1/data".
+      Otherwise consumer component that can receive data from different producers won't be able to specify input file path since files from different upstreams will have different names.
+    * Passing constant arguments to artifact inputs is not supported for now. Only references can be passed.
+
+    Args:
+        workflow: Workflow (dict) that needs to be converted.
+        volume: Kubernetes spec (dict) of a volume that should be used for data passing. The volume should support multi-write (READ_WRITE_MANY) if the workflow has any parallel steps. Example: {'persistentVolumeClaim': {'claimName': 'my-pvc'}}
+
+    Returns:
+        Converted workflow (dict).
+    '''
+
+    # Limitation: All artifact file names must be the same (e.g. "data"). E.g. "/tmp/outputs/my_out_1/data".
+    # Otherwise consumer component that can receive data from different producers won't be able to specify input file path since files from different upstreams will have different names.
+    # Maybe this limitation can be lifted, but it is not trivial. Maybe with DSL compile it's easier since the graph it creates is usually a tree. But recursion creates a real graph.
+    # Limitation: Passing constant values to artifact inputs is not supported for now.
+
+    # Idea: Passing volumeMount subPaths instead of artifcats
+
+    workflow = copy.deepcopy(workflow)
+    templates = workflow['spec']['templates']
+
+    container_templates = [template for template in templates if 'container' in template]
+    dag_templates = [template for template in templates if 'dag' in template]
+    steps_templates = [template for template in templates if 'steps' in template]
+
+    execution_data_dir = path_prefix + '{{workflow.uid}}_{{pod.name}}/'
+
+    data_volume_name = 'data-storage'
+    volume['name'] = data_volume_name
+
+    subpath_parameter_name_suffix = '-subpath'
+
+    def convert_artifact_reference_to_parameter_reference(reference: str) -> str:
+        parameter_reference = re.sub(
+            r'{{([^}]+)\.artifacts\.([^}]+)}}',
+            r'{{\1.parameters.\2' + subpath_parameter_name_suffix + '}}', # re.escape(subpath_parameter_name_suffix) escapes too much.
+            reference,
+        )
+        return parameter_reference
+
+    # Adding the data storage volume to the workflow
+    workflow['spec'].setdefault('volumes', []).append(volume)
+
+    all_artifact_file_names = set() # All artifacts should have same file name (usually, "data"). This variable holds all different artifact names for verification.
+
+    # Rewriting container templates
+    for template in templates:
+        if 'container' not in template and 'script' not in template:
+            continue
+        container_spec = template['container'] or template['steps']
+        # Inputs
+        input_artifacts = template.get('inputs', {}).get('artifacts', [])
+        if input_artifacts:
+            input_parameters = template.setdefault('inputs', {}).setdefault('parameters', [])
+            volume_mounts = container_spec.setdefault('volumeMounts', [])
+            for input_artifact in input_artifacts:
+                subpath_parameter_name = input_artifact['name'] + subpath_parameter_name_suffix # TODO: Maybe handle clashing names.
+                artifact_file_name = os.path.basename(input_artifact['path'])
+                all_artifact_file_names.add(artifact_file_name)
+                artifact_dir = os.path.dirname(input_artifact['path'])
+                volume_mounts.append({
+                    'mountPath': artifact_dir,
+                    'name': data_volume_name,
+                    'subPath': '{{inputs.parameters.' + subpath_parameter_name + '}}',
+                    'readOnly': True,
+                })
+                input_parameters.append({
+                    'name': subpath_parameter_name,
+                })
+        template.get('inputs', {}).pop('artifacts', None)
+
+        # Outputs
+        output_artifacts = template.get('outputs', {}).get('artifacts', [])
+        if output_artifacts:
+            output_parameters = template.setdefault('outputs', {}).setdefault('parameters', [])
+            del template.get('outputs', {})['artifacts']
+            volume_mounts = container_spec.setdefault('volumeMounts', [])
+            for output_artifact in output_artifacts:
+                output_name = output_artifact['name']
+                subpath_parameter_name = output_name + subpath_parameter_name_suffix # TODO: Maybe handle clashing names.
+                artifact_file_name = os.path.basename(output_artifact['path'])
+                all_artifact_file_names.add(artifact_file_name)
+                artifact_dir = os.path.dirname(output_artifact['path'])
+                output_subpath = execution_data_dir + output_name
+                volume_mounts.append({
+                    'mountPath': artifact_dir,
+                    'name': data_volume_name,
+                    'subPath': output_subpath, # TODO: Switch to subPathExpr when it's out of beta: https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath-with-expanded-environment-variables
+                })
+                output_parameters.append({
+                    'name': subpath_parameter_name,
+                    'value': output_subpath, # Requires Argo 2.3.0+
+                })
+            template.get('outputs', {}).pop('artifacts', None)
+
+    # Rewrite DAG templates
+    for template in templates:
+        if 'dag' not in template and 'steps' not in template:
+            continue
+
+        # Inputs
+        input_artifacts = template.get('inputs', {}).get('artifacts', [])
+        if input_artifacts:
+            input_parameters = template.setdefault('inputs', {}).setdefault('parameters', [])
+            volume_mounts = container_spec.setdefault('volumeMounts', [])
+            for input_artifact in input_artifacts:
+                subpath_parameter_name = input_artifact['name'] + subpath_parameter_name_suffix # TODO: Maybe handle clashing names.
+                input_parameters.append({
+                    'name': subpath_parameter_name,
+                })
+        template.get('inputs', {}).pop('artifacts', None)
+
+        # Outputs
+        output_artifacts = template.get('outputs', {}).get('artifacts', [])
+        if output_artifacts:
+            output_parameters = template.setdefault('outputs', {}).setdefault('parameters', [])
+            volume_mounts = container_spec.setdefault('volumeMounts', [])
+            for output_artifact in output_artifacts:
+                output_name = output_artifact['name']
+                subpath_parameter_name = output_name + subpath_parameter_name_suffix # TODO: Maybe handle clashing names.
+                output_parameters.append({
+                    'name': subpath_parameter_name,
+                    'valueFrom': {
+                        'parameter': convert_artifact_reference_to_parameter_reference(output_artifact['from'])
+                    },
+                })
+        template.get('outputs', {}).pop('artifacts', None)
+        
+        # Arguments
+        for task in template.get('dag', {}).get('tasks', []) + [steps for group in template.get('steps', []) for steps in group]:
+            argument_artifacts = task.get('arguments', {}).get('artifacts', [])
+            if argument_artifacts:
+                argument_parameters = task.setdefault('arguments', {}).setdefault('parameters', [])
+                for argument_artifact in argument_artifacts:
+                    if 'from' not in argument_artifact:
+                        raise NotImplementedError('Volume-based data passing rewriter does not support constant artifact arguments at this moment. Only references can be passed.')
+                    subpath_parameter_name = argument_artifact['name'] + subpath_parameter_name_suffix # TODO: Maybe handle clashing names.
+                    argument_parameters.append({
+                        'name': subpath_parameter_name,
+                        'valueFrom': {
+                            'parameter': convert_artifact_reference_to_parameter_reference(argument_artifact['from'])
+                        },
+                    })
+            task.get('arguments', {}).pop('artifacts', None)
+
+        # There should not be any artifact references in any other part of DAG template (only parameter references)
+
+    # Check that all artifacts have the same file names
+    if len(all_artifact_file_names) > 1:
+        warnings.warn('Detected different artifact file names: [{}]. The workflow can fail at runtime. Please use the same file name (e.g. "data") for all artifacts.'.format(', '.join(all_artifact_file_names)))
+
+    # Fail if workflow has argument artifacts
+    workflow_argument_artifacts = workflow['spec'].get('arguments', {}).get('artifacts', [])
+    if workflow_argument_artifacts:
+        raise NotImplementedError('Volume-based data passing rewriter does not support constant artifact arguments at this moment. Only references can be passed.')
+
+    return workflow
+
+
+if __name__ == '__main__':
+    '''Converts Argo workflow that passes data using artifacts to workflow that passes data using a single multi-write volume.'''
+    
+    import argparse
+    import io
+    import yaml
+
+    parser = argparse.ArgumentParser(
+        prog='data_passing_using_volume',
+        epilog='''Example: data_passing_using_volume.py --input argo/examples/artifact-passing.yaml --output argo/examples/artifact-passing-volumes.yaml --volume "persistentVolumeClaim: {claimName: my-pvc}"'''
+    )
+    parser.add_argument("--input", type=argparse.FileType('r'), required=True, help='Path to workflow that needs to be converted.')
+    parser.add_argument("--output", type=argparse.FileType('w'), required=True, help='Path where to write converted workflow.')
+    parser.add_argument("--volume", type=str, required=True, help='''Kubernetes spec (YAML) of a volume that should be used for data passing. The volume should support multi-write (READ_WRITE_MANY) if the workflow has any parallel steps. Example: "persistentVolumeClaim: {claimName: my-pvc}".''')
+    args = parser.parse_args()
+
+    input_workflow = yaml.safe_load(args.input)
+    volume = yaml.safe_load(io.StringIO(args.volume))
+    output_workflow = rewrite_data_passing_to_use_volumes(input_workflow, volume)
+    yaml.dump(output_workflow, args.output)

--- a/sdk/python/kfp/compiler/_data_passing_using_volume.py
+++ b/sdk/python/kfp/compiler/_data_passing_using_volume.py
@@ -158,9 +158,7 @@ def rewrite_data_passing_to_use_volumes(
                     subpath_parameter_name = argument_artifact['name'] + subpath_parameter_name_suffix # TODO: Maybe handle clashing names.
                     argument_parameters.append({
                         'name': subpath_parameter_name,
-                        'valueFrom': {
-                            'parameter': convert_artifact_reference_to_parameter_reference(argument_artifact['from'])
-                        },
+                        'value': convert_artifact_reference_to_parameter_reference(argument_artifact['from']),
                     })
             task.get('arguments', {}).pop('artifacts', None)
 

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -850,6 +850,9 @@ class Compiler(object):
     from ._data_passing_rewriter import fix_big_data_passing
     workflow = fix_big_data_passing(workflow)
 
+    if pipeline_conf and pipeline_conf.data_passing_method != None:
+      workflow = pipeline_conf.data_passing_method(workflow)
+
     metadata = workflow.setdefault('metadata', {})
     annotations = metadata.setdefault('annotations', {})
 

--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -64,6 +64,7 @@ class PipelineConf():
     self.default_pod_node_selector = {}
     self.image_pull_policy = None
     self.parallelism = None
+    self._data_passing_method = None
 
   def set_image_pull_secrets(self, image_pull_secrets):
     """Configures the pipeline level imagepullsecret
@@ -134,6 +135,27 @@ class PipelineConf():
     """
     self.op_transformers.append(transformer)
 
+  @property
+  def data_passing_method(self):
+    return self._data_passing_method
+
+  @data_passing_method.setter
+  def data_passing_method(self, value):
+    '''Sets the object representing the method used for intermediate data passing.
+    Example::
+
+      from kfp.dsl import PipelineConf, data_passing_methods
+      from kubernetes.client.models import V1Volume, V1PersistentVolumeClaim
+      pipeline_conf = PipelineConf()
+      pipeline_conf.data_passing_method = data_passing_methods.KubernetesVolume(
+          volume=V1Volume(
+              name='data',
+              persistent_volume_claim=V1PersistentVolumeClaim('data-volume'),
+          ),
+          path_prefix='artifact_data/',
+      )
+    '''
+    self._data_passing_method = value
 
 def get_pipeline_conf():
   """Configure the pipeline level setting to the current pipeline

--- a/sdk/python/kfp/dsl/data_passing_methods.py
+++ b/sdk/python/kfp/dsl/data_passing_methods.py
@@ -1,0 +1,22 @@
+import kubernetes
+from kubernetes.client.models import V1Volume
+
+class KubernetesVolume:
+    '''KubernetesVolume data passing method involves passing data by mounting a single multi-write Kubernetes volume to containers instead of using Argo's artifact passing method (which stores the data in an S3 blob store).'''
+
+    def __init__(self, volume: V1Volume, path_prefix: str = 'artifact_data/'):
+        if not isinstance(volume, (dict, V1Volume)):
+            raise TypeError('volume must be either V1Volume or dict')
+        self._volume = volume
+        self._path_prefix = path_prefix
+
+    def transform_workflow(self, workflow: dict) -> dict:
+        from ..compiler._data_passing_using_volume import rewrite_data_passing_to_use_volumes
+        if isinstance(self._volume, dict):
+            volume_dict = self._volume
+        else:
+            volume_dict = kubernetes.kubernetes.client.ApiClient().sanitize_for_serialization(self._volume)
+        return rewrite_data_passing_to_use_volumes(workflow, volume_dict, self._path_prefix)
+
+    def __call__(self, workflow: dict) -> dict:
+        return self.transform_workflow(workflow)

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -954,3 +954,6 @@ implementation:
     workflow_dict = kfp.compiler.Compiler()._compile(some_pipeline)
     template = workflow_dict['spec']['templates'][0]
     self.assertEqual(template['metadata']['annotations']['pipelines.kubeflow.org/max_cache_staleness'], "P30D")
+
+  def test_artifact_passing_using_volume(self):
+    self._test_py_compile_yaml('artifact_passing_using_volume')

--- a/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.py
+++ b/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import kfp
+from kfp.components import load_component_from_file
+
+test_data_dir = Path(__file__).parent / 'test_data'
+producer_op = load_component_from_file(str(test_data_dir / 'produce_2.component.yaml'))
+processor_op = load_component_from_file(str(test_data_dir / 'process_2_2.component.yaml'))
+consumer_op = load_component_from_file(str(test_data_dir / 'consume_2.component.yaml'))
+
+
+@kfp.dsl.pipeline()
+def artifact_passing_pipeline():
+    producer_task = producer_op()
+    processor_task = processor_op(producer_task.outputs['output_1'], producer_task.outputs['output_2'])
+    consumer_task = consumer_op(processor_task.outputs['output_1'], processor_task.outputs['output_2'])
+
+    # This line is only needed for compiling using dsl-compile to work
+    kfp.dsl.get_pipeline_conf().data_passing_method = volume_based_data_passing_method
+
+
+from kubernetes.client.models import V1Volume, V1PersistentVolumeClaim
+from kfp.dsl import data_passing_methods
+
+
+volume_based_data_passing_method = data_passing_methods.KubernetesVolume(
+    volume=V1Volume(
+        name='data',
+        persistent_volume_claim=V1PersistentVolumeClaim('data-volume'),
+    ),
+    path_prefix='artifact_data/',
+)
+
+
+if __name__ == '__main__':
+    pipeline_conf = kfp.dsl.PipelineConf()
+    pipeline_conf.data_passing_method = volume_based_data_passing_method
+    kfp.compiler.Compiler().compile(artifact_passing_pipeline, __file__ + '.yaml', pipeline_conf=pipeline_conf)

--- a/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.py
+++ b/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.py
@@ -19,17 +19,15 @@ def artifact_passing_pipeline():
     kfp.dsl.get_pipeline_conf().data_passing_method = volume_based_data_passing_method
 
 
-from kubernetes.client.models import V1Volume, V1PersistentVolumeClaim, V1PersistentVolumeClaimVolumeSource
+from kubernetes.client.models import V1Volume, V1PersistentVolumeClaimVolumeSource
 from kfp.dsl import data_passing_methods
 
 
 volume_based_data_passing_method = data_passing_methods.KubernetesVolume(
     volume=V1Volume(
         name='data',
-        persistent_volume_claim=V1PersistentVolumeClaim(
-            spec=V1PersistentVolumeClaimVolumeSource(
-                claim_name='data-volume',
-            ),
+        persistent_volume_claim=V1PersistentVolumeClaimVolumeSource(
+            claim_name='data-volume',
         ),
     ),
     path_prefix='artifact_data/',

--- a/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.py
+++ b/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.py
@@ -19,7 +19,7 @@ def artifact_passing_pipeline():
     kfp.dsl.get_pipeline_conf().data_passing_method = volume_based_data_passing_method
 
 
-from kubernetes.client.models import V1Volume, V1PersistentVolumeClaim, V1PersistentVolumeClaimSpec
+from kubernetes.client.models import V1Volume, V1PersistentVolumeClaim, V1PersistentVolumeClaimVolumeSource
 from kfp.dsl import data_passing_methods
 
 
@@ -27,8 +27,8 @@ volume_based_data_passing_method = data_passing_methods.KubernetesVolume(
     volume=V1Volume(
         name='data',
         persistent_volume_claim=V1PersistentVolumeClaim(
-            spec=V1PersistentVolumeClaimSpec(
-                volume_name='data-volume',
+            spec=V1PersistentVolumeClaimVolumeSource(
+                claim_name='data-volume',
             ),
         ),
     ),

--- a/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.py
+++ b/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.py
@@ -19,14 +19,18 @@ def artifact_passing_pipeline():
     kfp.dsl.get_pipeline_conf().data_passing_method = volume_based_data_passing_method
 
 
-from kubernetes.client.models import V1Volume, V1PersistentVolumeClaim
+from kubernetes.client.models import V1Volume, V1PersistentVolumeClaim, V1PersistentVolumeClaimSpec
 from kfp.dsl import data_passing_methods
 
 
 volume_based_data_passing_method = data_passing_methods.KubernetesVolume(
     volume=V1Volume(
         name='data',
-        persistent_volume_claim=V1PersistentVolumeClaim('data-volume'),
+        persistent_volume_claim=V1PersistentVolumeClaim(
+            spec=V1PersistentVolumeClaimSpec(
+                volume_name='data-volume',
+            ),
+        ),
     ),
     path_prefix='artifact_data/',
 )

--- a/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.yaml
@@ -1,0 +1,143 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"name": "artifact_passing_pipeline"}'
+  generateName: artifact-passing-pipeline-
+spec:
+  arguments:
+    parameters: []
+  entrypoint: artifact-passing-pipeline
+  serviceAccountName: pipeline-runner
+  templates:
+  - name: artifact-passing-pipeline
+    dag:
+      tasks:
+      - name: consumer
+        template: consumer
+        arguments:
+          parameters:
+          - name: processor-output_1
+            value: '{{tasks.processor.outputs.parameters.processor-output_1}}'
+          - name: processor-output_2-subpath
+            valueFrom:
+              parameter: '{{tasks.processor.outputs.parameters.processor-output_2-subpath}}'
+        dependencies:
+        - processor
+      - name: processor
+        template: processor
+        arguments:
+          parameters:
+          - name: producer-output_1
+            value: '{{tasks.producer.outputs.parameters.producer-output_1}}'
+          - name: producer-output_2-subpath
+            valueFrom:
+              parameter: '{{tasks.producer.outputs.parameters.producer-output_2-subpath}}'
+        dependencies:
+        - producer
+      - name: producer
+        template: producer
+  - name: consumer
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/component_spec: '{"inputs": [{"name": "Input parameter"}, {"name": "Input artifact"}], "name": "Consumer"}'
+    inputs:
+      parameters:
+      - name: processor-output_1
+      - name: processor-output_2-subpath
+    container:
+      image: alpine
+      command:
+      - sh
+      - -c
+      - |
+        echo "Input parameter = $0"
+        echo "Input artifact = " && cat "$1"
+      args:
+      - '{{inputs.parameters.processor-output_1}}'
+      - /tmp/inputs/Input_artifact/data
+      volumeMounts:
+      - name: data-storage
+        mountPath: /tmp/inputs/Input_artifact
+        readOnly: true
+        subPath: '{{inputs.parameters.processor-output_2-subpath}}'
+  - name: processor
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/component_spec: '{"inputs": [{"name": "Input parameter"}, {"name": "Input artifact"}], "name": "Processor", "outputs": [{"name": "Output 1"}, {"name": "Output 2"}]}'
+    inputs:
+      parameters:
+      - name: producer-output_1
+      - name: producer-output_2-subpath
+    outputs:
+      parameters:
+      - name: processor-output_1
+        valueFrom:
+          path: /tmp/outputs/Output_1/data
+      - name: processor-output_1-subpath
+        value: artifact_data/{{workflow.uid}}_{{pod.name}}/processor-output_1
+      - name: processor-output_2-subpath
+        value: artifact_data/{{workflow.uid}}_{{pod.name}}/processor-output_2
+    container:
+      image: alpine
+      command:
+      - sh
+      - -c
+      - |
+        mkdir -p "$(dirname "$2")"
+        mkdir -p "$(dirname "$3")"
+        echo "$0" > "$2"
+        cp "$1" "$3"
+      args:
+      - '{{inputs.parameters.producer-output_1}}'
+      - /tmp/inputs/Input_artifact/data
+      - /tmp/outputs/Output_1/data
+      - /tmp/outputs/Output_2/data
+      volumeMounts:
+      - mountPath: /tmp/inputs/Input_artifact
+        name: data-storage
+        readOnly: true
+        subPath: '{{inputs.parameters.producer-output_2-subpath}}'
+      - mountPath: /tmp/outputs/Output_1
+        name: data-storage
+        subPath: artifact_data/{{workflow.uid}}_{{pod.name}}/processor-output_1
+      - mountPath: /tmp/outputs/Output_2
+        name: data-storage
+        subPath: artifact_data/{{workflow.uid}}_{{pod.name}}/processor-output_2
+  - name: producer
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/component_spec: '{"name": "Producer", "outputs": [{"name": "Output 1"}, {"name": "Output 2"}]}'
+    outputs:
+      parameters:
+      - name: producer-output_1
+        valueFrom:
+          path: /tmp/outputs/Output_1/data
+      - name: producer-output_1-subpath
+        value: artifact_data/{{workflow.uid}}_{{pod.name}}/producer-output_1
+      - name: producer-output_2-subpath
+        value: artifact_data/{{workflow.uid}}_{{pod.name}}/producer-output_2
+    container:
+      image: alpine
+      command:
+      - sh
+      - -c
+      - |
+        mkdir -p "$(dirname "$0")"
+        mkdir -p "$(dirname "$1")"
+        echo "Data 1" > $0
+        echo "Data 2" > $1
+      args:
+      - /tmp/outputs/Output_1/data
+      - /tmp/outputs/Output_2/data
+      volumeMounts:
+      - mountPath: /tmp/outputs/Output_1
+        name: data-storage
+        subPath: artifact_data/{{workflow.uid}}_{{pod.name}}/producer-output_1
+      - mountPath: /tmp/outputs/Output_2
+        name: data-storage
+        subPath: artifact_data/{{workflow.uid}}_{{pod.name}}/producer-output_2
+  volumes:
+  - name: data-storage
+    persistentVolumeClaim:
+      apiVersion: data-volume

--- a/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.yaml
@@ -138,5 +138,4 @@ spec:
   volumes:
   - name: data-storage
     persistentVolumeClaim:
-      spec:
-        volumeName: data-volume
+      claimName: data-volume

--- a/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.yaml
@@ -140,4 +140,5 @@ spec:
   volumes:
   - name: data-storage
     persistentVolumeClaim:
-      apiVersion: data-volume
+      spec:
+        volumeName: data-volume

--- a/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.yaml
@@ -20,8 +20,7 @@ spec:
           - name: processor-output_1
             value: '{{tasks.processor.outputs.parameters.processor-output_1}}'
           - name: processor-output_2-subpath
-            valueFrom:
-              parameter: '{{tasks.processor.outputs.parameters.processor-output_2-subpath}}'
+            value: '{{tasks.processor.outputs.parameters.processor-output_2-subpath}}'
         dependencies:
         - processor
       - name: processor
@@ -31,8 +30,7 @@ spec:
           - name: producer-output_1
             value: '{{tasks.producer.outputs.parameters.producer-output_1}}'
           - name: producer-output_2-subpath
-            valueFrom:
-              parameter: '{{tasks.producer.outputs.parameters.producer-output_2-subpath}}'
+            value: '{{tasks.producer.outputs.parameters.producer-output_2-subpath}}'
         dependencies:
         - producer
       - name: producer

--- a/sdk/python/tests/compiler/testdata/test_data/consume_2.component.yaml
+++ b/sdk/python/tests/compiler/testdata/test_data/consume_2.component.yaml
@@ -1,0 +1,16 @@
+name: Consumer
+inputs:
+- {name: Input parameter}
+- {name: Input artifact}
+implementation:
+  container:
+    image: alpine
+    command:
+    - sh
+    - -c
+    - |
+      echo "Input parameter = $0"
+      echo "Input artifact = " && cat "$1"
+    args:
+    - {inputValue: Input parameter}
+    - {inputPath: Input artifact}

--- a/sdk/python/tests/compiler/testdata/test_data/process_2_2.component.yaml
+++ b/sdk/python/tests/compiler/testdata/test_data/process_2_2.component.yaml
@@ -1,0 +1,23 @@
+name: Processor
+inputs:
+- {name: Input parameter}
+- {name: Input artifact}
+outputs:
+- {name: Output 1}
+- {name: Output 2}
+implementation:
+  container:
+    image: alpine
+    command:
+    - sh
+    - -c
+    - |
+      mkdir -p "$(dirname "$2")"
+      mkdir -p "$(dirname "$3")"
+      echo "$0" > "$2"
+      cp "$1" "$3"
+    args:
+    - {inputValue: Input parameter}
+    - {inputPath: Input artifact}
+    - {outputPath: Output 1}
+    - {outputPath: Output 2}

--- a/sdk/python/tests/compiler/testdata/test_data/produce_2.component.yaml
+++ b/sdk/python/tests/compiler/testdata/test_data/produce_2.component.yaml
@@ -1,0 +1,18 @@
+name: Producer
+outputs:
+- {name: Output 1}
+- {name: Output 2}
+implementation:
+  container:
+    image: alpine
+    command:
+    - sh
+    - -c
+    - |
+      mkdir -p "$(dirname "$0")"
+      mkdir -p "$(dirname "$1")"
+      echo "Data 1" > $0
+      echo "Data 2" > $1
+    args:
+    - {outputPath: Output 1}
+    - {outputPath: Output 2}


### PR DESCRIPTION
Currently artifact passing is performed by Argo sidecar containers what download input data and upload output data to artifact repository (usually, S3-compatible blob storage like Minio).
The performance of this method is not optimal and it requires that pod disks have enough capacity to hold all artifact data.

This commit adds support for volume-based data passing.
This method involves using a single milti-write Kubernetes data volume to pass all intermediate data.
Parts of the volume are mounted to the input/output artifact directories, so when the user program reads and writes files, the files actually reside in the data volume.
This method improves the performance and reduces storage resource requirements.

The data volume must exist and support "READ_WRITE_MANY". (Or it can be an auto-provisioning PVC)

Limitations:
* All artifact file names must be the same (e.g. "data"). All auto-generated paths are already consistent. Avoid using any hard-coded paths.
* Passing constant values (text) as arguments for artifact inputs is not supported. (Rare case)
* The feature is experimental.