### PR TITLE
AWS sagemaker : Make 'endpoint_url' argument default to None instead of empty string 

### DIFF
--- a/components/aws/sagemaker/batch_transform/component.yaml
+++ b/components/aws/sagemaker/batch_transform/component.yaml
@@ -74,7 +74,7 @@ outputs:
   - {name: output_location,    description: 'S3 URI of the transform job results.'}
 implementation:
   container:
-    image: redbackthomson/aws-kubeflow-sagemaker:20191003
+    image: redbackthomson/aws-kubeflow-sagemaker:20200402
     command: ['python']
     args: [
       batch_transform.py,

--- a/components/aws/sagemaker/common/_utils.py
+++ b/components/aws/sagemaker/common/_utils.py
@@ -52,9 +52,16 @@ built_in_algos = {
 # Get current directory to open templates
 __cwd__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
+
+def nullable_string_argument(value):
+    value = value.strip()
+    if not value:
+        return None
+    return value
+
 def add_default_client_arguments(parser):
     parser.add_argument('--region', type=str.strip, required=True, help='The region where the training job launches.')
-    parser.add_argument('--endpoint_url', type=str.strip, required=False, help='The URL to use when communicating with the Sagemaker service.')
+    parser.add_argument('--endpoint_url', type=nullable_string_argument, required=False, help='The URL to use when communicating with the Sagemaker service.')
 
 def get_sagemaker_client(region, endpoint_url=None):
     """Builds a client to the AWS SageMaker API."""

--- a/components/aws/sagemaker/deploy/component.yaml
+++ b/components/aws/sagemaker/deploy/component.yaml
@@ -79,7 +79,7 @@ outputs:
   - {name: endpoint_name,          description: 'Endpoint name'}
 implementation:
   container:
-    image: redbackthomson/aws-kubeflow-sagemaker:20191003
+    image: redbackthomson/aws-kubeflow-sagemaker:20200402
     command: ['python']
     args: [
       deploy.py,

--- a/components/aws/sagemaker/ground_truth/component.yaml
+++ b/components/aws/sagemaker/ground_truth/component.yaml
@@ -88,7 +88,7 @@ outputs:
   - {name: active_learning_model_arn, description: 'The ARN for the most recent Amazon SageMaker model trained as part of automated data labeling.'}
 implementation:
   container:
-    image: redbackthomson/aws-kubeflow-sagemaker:20191003
+    image: redbackthomson/aws-kubeflow-sagemaker:20200402
     command: ['python']
     args: [
       ground_truth.py,

--- a/components/aws/sagemaker/hyperparameter_tuning/component.yaml
+++ b/components/aws/sagemaker/hyperparameter_tuning/component.yaml
@@ -139,7 +139,7 @@ outputs:
     description: 'The registry path of the Docker image that contains the training algorithm'
 implementation:
   container:
-    image: redbackthomson/aws-kubeflow-sagemaker:20191003
+    image: redbackthomson/aws-kubeflow-sagemaker:20200402
     command: ['python']
     args: [
       hyperparameter_tuning.py,

--- a/components/aws/sagemaker/model/component.yaml
+++ b/components/aws/sagemaker/model/component.yaml
@@ -45,7 +45,7 @@ outputs:
   - {name: model_name,          description: 'The model name Sagemaker created'}
 implementation:
   container:
-    image: redbackthomson/aws-kubeflow-sagemaker:20191003
+    image: redbackthomson/aws-kubeflow-sagemaker:20200402
     command: ['python']
     args: [
       create_model.py,

--- a/components/aws/sagemaker/train/component.yaml
+++ b/components/aws/sagemaker/train/component.yaml
@@ -103,7 +103,7 @@ outputs:
   - {name: training_image,        description: 'The registry path of the Docker image that contains the training algorithm'}
 implementation:
   container:
-    image: redbackthomson/aws-kubeflow-sagemaker:20191003
+    image: redbackthomson/aws-kubeflow-sagemaker:20200402
     command: ['python']
     args: [
       train.py,

--- a/components/aws/sagemaker/workteam/component.yaml
+++ b/components/aws/sagemaker/workteam/component.yaml
@@ -27,7 +27,7 @@ outputs:
   - {name: workteam_arn, description: 'The ARN of the workteam.'}
 implementation:
   container:
-    image: redbackthomson/aws-kubeflow-sagemaker:20191003
+    image: redbackthomson/aws-kubeflow-sagemaker:20200402
     command: ['python']
     args: [
       workteam.py,


### PR DESCRIPTION
For all AWS sagemaker components if we don't pass 'endpoint_url' argument it used to default to empty string.

This empty string input throws an error when we call the boto3 client in [_utils.get_sagemaker_client()](https://github.com/kubeflow/pipelines/blob/7b55c2b8101ec2d08b5c4c2f3a0d490d3ff8c0ee/components/aws/sagemaker/common/_utils.py#L61)

Error message:
```
  File "/usr/local/lib/python2.7/dist-packages/botocore/endpoint.py", line 261, in create_endpoint
    raise ValueError("Invalid endpoint: %s" % endpoint_url)
ValueError: Invalid endpoint: 
```

Fixed the issue by making endpoint_url default to None 
Uploaded the new docker container to [redbackthomson/aws-kubeflow-sagemaker](https://hub.docker.com/r/redbackthomson/aws-kubeflow-sagemaker/tags)
Tested the changes by creating a pipeline for train component 

Reference : [Boto3 doc for client() ](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client)
