### PR TITLE
Fix source for mlpipeline-ui-metadata in WorkflowParser

### DIFF
--- a/frontend/src/lib/WorkflowParser.test.ts
+++ b/frontend/src/lib/WorkflowParser.test.ts
@@ -887,7 +887,7 @@ describe('WorkflowParser', () => {
       ]);
     });
 
-    it('returns the right bucket and key for a correct metadata artifact', () => {
+    it('returns the right bucket, key and source eq `minio` for a correct metadata artifact', () => {
       expect(
         WorkflowParser.loadNodeOutputPaths({
           outputs: {
@@ -910,6 +910,32 @@ describe('WorkflowParser', () => {
         },
       ]);
     });
+
+    it('returns the right bucket, key and source eq `s3` for a correct metadata artifact', () => {
+      expect(
+        WorkflowParser.loadNodeOutputPaths({
+          outputs: {
+            artifacts: [
+              {
+                name: 'mlpipeline-ui-metadata',
+                s3: {
+                  endpoint: 's3.amazonaws.com',
+                  bucket: 'test bucket',
+                  key: 'test key',
+                },
+              },
+            ],
+          },
+        } as any),
+      ).toEqual([
+        {
+          bucket: 'test bucket',
+          key: 'test key',
+          source: 's3',
+        },
+      ]);
+    });
+
   });
 
   describe('loadAllOutputPaths', () => {

--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -292,7 +292,7 @@ export default class WorkflowParser {
           outputPaths.push({
             bucket: a.s3!.bucket,
             key: a.s3!.key,
-            source: StorageService.MINIO,
+            source: a.s3!.endpoint === 's3.amazonaws.com' ? StorageService.S3 : StorageService.MINIO,
           }),
         );
     }


### PR DESCRIPTION
```
{
    bucket: a.s3!.bucket,
    key: a.s3!.key,
    source: StorageService.MINIO,
    source: a.s3!.endpoint === 's3.amazonaws.com' ? StorageService.S3 : StorageService.MINIO
}
```