### PR TITLE
[Frontend server] Update UI node server to use TLS for AWS S3 endpoint

### DIFF
--- a/frontend/server/app.test.ts
+++ b/frontend/server/app.test.ts
@@ -249,6 +249,7 @@ describe('UIServer apis', () => {
             accessKey: 'aws123',
             endPoint: 's3.amazonaws.com',
             secretKey: 'awsSecret123',
+            useSSL: true,
           });
           done(err);
         });
@@ -281,6 +282,7 @@ describe('UIServer apis', () => {
             accessKey: 'aws123',
             endPoint: 's3.amazonaws.com',
             secretKey: 'awsSecret123',
+            useSSL: true,
           });
           done(err);
         });

--- a/frontend/server/configs.ts
+++ b/frontend/server/configs.ts
@@ -104,6 +104,7 @@ export function loadConfigs(
         accessKey: AWS_ACCESS_KEY_ID || '',
         endPoint: 's3.amazonaws.com',
         secretKey: AWS_SECRET_ACCESS_KEY || '',
+        useSSL: true, // shld always use TLS for AWS s3 endpoint
       },
       http: {
         auth: {
@@ -171,6 +172,7 @@ export interface AWSConfigs {
   endPoint: string;
   accessKey: string;
   secretKey: string;
+  useSSL: boolean;
 }
 export interface HttpConfigs {
   baseUrl: string;


### PR DESCRIPTION
/cc @discordianfish 

This PR fixes the issue of the minio client defaulting to non-TLS when accessing S3 artifacts. S3 inherently supports TLS and is the recommended approach. It will not break any existing deployments and will support cluster policies that restrict unsecure calls to S3 (i.e. http instead of https).

Non-S3 minio artifact will still be controlled by the `MINIO_SSL` flag, and not affect by this PR as the minio client configs are independent from AWS minio configs.
