### PR TITLE
[Sample] Change preloaded TFX samples to use GCR images

### DIFF
--- a/samples/core/iris/iris.py
+++ b/samples/core/iris/iris.py
@@ -198,7 +198,7 @@ if __name__ == '__main__':
   config = kubeflow_dag_runner.KubeflowDagRunnerConfig(
       kubeflow_metadata_config=kubeflow_dag_runner.
       get_default_kubeflow_metadata_config(),
-      tfx_image='tensorflow/tfx:0.21.2',
+      tfx_image='gcr.io/tfx-oss-public/tfx:0.21.2',
   )
   kfp_runner = kubeflow_dag_runner.KubeflowDagRunner(
       output_filename=__file__ + '.yaml', config=config

--- a/samples/core/parameterized_tfx_oss/parameterized_tfx_oss.py
+++ b/samples/core/parameterized_tfx_oss/parameterized_tfx_oss.py
@@ -177,7 +177,7 @@ if __name__ == '__main__':
   config = kubeflow_dag_runner.KubeflowDagRunnerConfig(
       kubeflow_metadata_config=kubeflow_dag_runner.
       get_default_kubeflow_metadata_config(),
-      tfx_image='tensorflow/tfx:0.21.2',
+      tfx_image='gcr.io/tfx-oss-public/tfx:0.21.2',
   )
   kfp_runner = kubeflow_dag_runner.KubeflowDagRunner(
       output_filename=__file__ + '.yaml', config=config

--- a/samples/core/parameterized_tfx_oss/taxi_pipeline_notebook.ipynb
+++ b/samples/core/parameterized_tfx_oss/taxi_pipeline_notebook.ipynb
@@ -276,7 +276,7 @@
    "source": [
     "# Specify a TFX docker image. For the full list of tags please see:\n",
     "# https://hub.docker.com/r/tensorflow/tfx/tags\n",
-    "tfx_image = 'tensorflow/tfx:0.21.2'\n",
+    "tfx_image = 'gcr.io/tfx-oss-public/tfx:0.21.2'\n",
     "config = kubeflow_dag_runner.KubeflowDagRunnerConfig(\n",
     "      kubeflow_metadata_config=kubeflow_dag_runner\n",
     "      .get_default_kubeflow_metadata_config(),\n",


### PR DESCRIPTION
to address the security issues when KFP is deployed to a private cluster without access to docker hub.