### PR TITLE
Fix lstrip with regex bug in the KFP client

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -118,7 +118,7 @@ class Client(object):
 
     host = host or ''
     # Preprocess the host endpoint to prevent some common user mistakes.
-    host = host.lstrip(r'(https|http)://').rstrip('/')
+    host = re.sub(r'^(http|https)://', '', host).rstrip('/')
 
     if host:
       config.host = host
@@ -522,7 +522,7 @@ class Client(object):
         trigger=trigger,
         enabled=True,
         )
-    #[TODO] Add link to the scheduled job. 
+    #[TODO] Add link to the scheduled job.
     response = self._job_api.create_job(body=schedule_body)
 
 


### PR DESCRIPTION
**Context**
A recent change in the `Client` code config loader added a preprocessing step to strip the protocol (`http://` or `https://`) from the host endpoint, in order to prevent some common user mistakes. It is currently implemented with `lstrip(regex_pattern)`.

**Bug**
`lstrip` does not support regexes but a set of characters to remove as leading characters. 

Meaning that characters included in the pattern would be wrongly removed, for example:
```python
host = "https://test.kubeflow-cluster.my.org.net"
host.lstrip(r'(https|http)://')
# returns "est.kubeflow-cluster.my.org.net" 
# instead of "test.kubeflow-cluster.my.org.net"
```

**Fix**
Use `re.sub` instead of `lstrip` to achieve the desired behavior.