### PR TITLE
Add new instructions to ensure compatibility for managed ai platform …

### DIFF
--- a/samples/tutorials/mnist/00_Kubeflow_Cluster_Setup.ipynb
+++ b/samples/tutorials/mnist/00_Kubeflow_Cluster_Setup.ipynb
@@ -27,7 +27,13 @@
    "metadata": {},
    "source": [
     "# Deploying a Kubeflow Cluster on Google Cloud Platform (GCP)\n",
-    "This notebook provides instructions for setting up a Kubeflow cluster on GCP using the command-line interface (CLI). For additional help, see the guide to [deploying Kubeflow using the CLI](https://www.kubeflow.org/docs/gke/deploy/deploy-cli/)."
+    "This notebook provides instructions for setting up a Kubeflow cluster on GCP using the command-line interface (CLI). For additional help, see the guide to [deploying Kubeflow using the CLI](https://www.kubeflow.org/docs/gke/deploy/deploy-cli/).\n",
+    "\n",
+    "There are two possible alternatives:\n",
+    "- The first alternative is to deploy Kubeflow cluster using the [Kubeflow deployment web app](https://deploy.kubeflow.cloud/), and the instruction can be found [here](https://www.kubeflow.org/docs/gke/deploy/deploy-ui/).\n",
+    "- Another alternative is to use recently launched [AI Platform Pipeline](https://cloud.google.com/ai-platform/pipelines/docs/introduction). But, it is important to note that the AI Platform Pipeline is a standalone [Kubeflow Pipeline](https://www.kubeflow.org/docs/pipelines/overview/pipelines-overview/) deployment, where a lot of the components in full Kubeflow deployment won't be pre-installed. The instruction can be found [here](https://cloud.google.com/ai-platform/pipelines/docs/setting-up).\n",
+    "\n",
+    "The CLI deployment gives you more control over the deployment process and configuration than you get if you use the deployment UI."
    ]
   },
   {
@@ -66,9 +72,7 @@
     "3. Create dedicated service account for deployment\n",
     "4. Deploy Kubefow\n",
     "5. Install Kubeflow Pipelines SDK\n",
-    "6. Sanity check\n",
-    "\n",
-    "`NOTE` : It is also possible to deploy the kubeflow cluster though [UI](https://www.kubeflow.org/docs/gke/deploy/deploy-ui/)"
+    "6. Sanity check"
    ]
   },
   {

--- a/samples/tutorials/mnist/01_Lightweight_Python_Components.ipynb
+++ b/samples/tutorials/mnist/01_Lightweight_Python_Components.ipynb
@@ -104,10 +104,30 @@
    "outputs": [],
    "source": [
     "# Optional Parameters, but required for running outside Kubeflow cluster\n",
+    "\n",
+    "# The host for 'managed AI Platform Pipeline' ends with 'pipelines.googleusercontent.com'\n",
+    "# The host for pipeline endpoint of 'full Kubeflow deployment' ends with '/pipeline'\n",
+    "# Examples are:\n",
+    "# https://7c021d0340d296aa-dot-us-central2.pipelines.googleusercontent.com\n",
+    "# https://kubeflow.endpoints.kubeflow-pipeline.cloud.goog/pipeline\n",
     "HOST = '<ADD HOST NAME TO TALK TO KUBEFLOW PIPELINE HERE>'\n",
+    "\n",
+    "# For 'full Kubeflow deployment' on GCP, the endpoint is usually protected through IAP, therefore the following \n",
+    "# will be needed to access the endpoint.\n",
     "CLIENT_ID = '<ADD OAuth CLIENT ID USED BY IAP HERE>'\n",
     "OTHER_CLIENT_ID = '<ADD OAuth CLIENT ID USED TO OBTAIN AUTH CODES HERE>'\n",
     "OTHER_CLIENT_SECRET = '<ADD OAuth CLIENT SECRET USED TO OBTAIN AUTH CODES HERE>'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is to ensure the proper access token is present to reach the end point for managed 'AI Platform Pipeline'\n",
+    "# If you are not working with managed 'AI Platform Pipeline', this step is not necessary\n",
+    "! gcloud auth print-access-token"
    ]
   },
   {
@@ -127,6 +147,11 @@
     "if in_cluster:\n",
     "    client = kfp.Client()\n",
     "else:\n",
+    "    if HOST.endswith('googleusercontent.com'):\n",
+    "        CLIENT_ID = None\n",
+    "        OTHER_CLIENT_ID = None\n",
+    "        OTHER_CLIENT_SECRET = None\n",
+    "\n",
     "    client = kfp.Client(host=HOST, \n",
     "                        client_id=CLIENT_ID,\n",
     "                        other_client_id=OTHER_CLIENT_ID, \n",

--- a/samples/tutorials/mnist/01_Lightweight_Python_Components.ipynb
+++ b/samples/tutorials/mnist/01_Lightweight_Python_Components.ipynb
@@ -105,7 +105,7 @@
    "source": [
     "# Optional Parameters, but required for running outside Kubeflow cluster\n",
     "\n",
-    "# The host for 'managed AI Platform Pipeline' ends with 'pipelines.googleusercontent.com'\n",
+    "# The host for 'AI Platform Pipelines' ends with 'pipelines.googleusercontent.com'\n",
     "# The host for pipeline endpoint of 'full Kubeflow deployment' ends with '/pipeline'\n",
     "# Examples are:\n",
     "# https://7c021d0340d296aa-dot-us-central2.pipelines.googleusercontent.com\n",
@@ -125,8 +125,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This is to ensure the proper access token is present to reach the end point for managed 'AI Platform Pipeline'\n",
-    "# If you are not working with managed 'AI Platform Pipeline', this step is not necessary\n",
+    "# This is to ensure the proper access token is present to reach the end point for 'AI Platform Pipelines'\n",
+    "# If you are not working with 'AI Platform Pipelines', this step is not necessary\n",
     "! gcloud auth print-access-token"
    ]
   },

--- a/samples/tutorials/mnist/02_Local_Development_with_Docker_Image_Components.ipynb
+++ b/samples/tutorials/mnist/02_Local_Development_with_Docker_Image_Components.ipynb
@@ -112,7 +112,7 @@
    "source": [
     "# Optional Parameters, but required for running outside Kubeflow cluster\n",
     "\n",
-    "# The host for 'managed AI Platform Pipeline' ends with 'pipelines.googleusercontent.com'\n",
+    "# The host for 'AI Platform Pipelines' ends with 'pipelines.googleusercontent.com'\n",
     "# The host for pipeline endpoint of 'full Kubeflow deployment' ends with '/pipeline'\n",
     "# Examples are:\n",
     "# https://7c021d0340d296aa-dot-us-central2.pipelines.googleusercontent.com\n",
@@ -132,8 +132,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This is to ensure the proper access token is present to reach the end point for managed 'AI Platform Pipeline'\n",
-    "# If you are not working with managed 'AI Platform Pipeline', this step is not necessary\n",
+    "# This is to ensure the proper access token is present to reach the end point for 'AI Platform Pipelines'\n",
+    "# If you are not working with 'AI Platform Pipelines', this step is not necessary\n",
     "! gcloud auth print-access-token"
    ]
   },
@@ -294,8 +294,8 @@
    "metadata": {},
    "source": [
     "Now that we have created our Dockerfile for creating our Docker image. Then we need to build the image and push to a registry to host the image. There are three possible options:\n",
-    "- Use the `kfp.containers.build_image_from_working_dir` to build the image and push to the Container Registry (GCR). This requires [kaniko](https://cloud.google.com/blog/products/gcp/introducing-kaniko-build-container-images-in-kubernetes-and-google-container-builder-even-without-root-access), which will be auto-installed with 'full Kubeflow deployment' but not 'managed AI Platform Pipeline'.\n",
-    "- Use [Cloud Build](https://cloud.google.com/cloud-build), which would require the setup of GCP project and enablement of corresponding API. If you are working with GCP 'managed AI Platform Pipeline' with GCP project running, it is recommended to use Cloud Build.\n",
+    "- Use the `kfp.containers.build_image_from_working_dir` to build the image and push to the Container Registry (GCR). This requires [kaniko](https://cloud.google.com/blog/products/gcp/introducing-kaniko-build-container-images-in-kubernetes-and-google-container-builder-even-without-root-access), which will be auto-installed with 'full Kubeflow deployment' but not 'AI Platform Pipelines'.\n",
+    "- Use [Cloud Build](https://cloud.google.com/cloud-build), which would require the setup of GCP project and enablement of corresponding API. If you are working with GCP 'AI Platform Pipelines' with GCP project running, it is recommended to use Cloud Build.\n",
     "- Use [Docker](https://www.docker.com/get-started) installed locally and push to e.g. GCR."
    ]
   },
@@ -345,11 +345,11 @@
    "outputs": [],
    "source": [
     "# In the following, for the purpose of demonstration\n",
-    "# Cloud Build is choosen for 'managed AI Platform Pipeline'\n",
+    "# Cloud Build is choosen for 'AI Platform Pipelines'\n",
     "# kaniko is choosen for 'full Kubeflow deployment'\n",
     "\n",
     "if HOST.endswith('googleusercontent.com'):\n",
-    "    # kaniko is not pre-installed with 'managed AI Platform Pipeline'\n",
+    "    # kaniko is not pre-installed with 'AI Platform Pipelines'\n",
     "    import subprocess\n",
     "    # ! gcloud builds submit --tag ${IMAGE_NAME} ${APP_FOLDER}\n",
     "    cmd = ['gcloud', 'builds', 'submit', '--tag', GCR_IMAGE, APP_FOLDER]\n",

--- a/samples/tutorials/mnist/02_Local_Development_with_Docker_Image_Components.ipynb
+++ b/samples/tutorials/mnist/02_Local_Development_with_Docker_Image_Components.ipynb
@@ -111,10 +111,30 @@
    "outputs": [],
    "source": [
     "# Optional Parameters, but required for running outside Kubeflow cluster\n",
+    "\n",
+    "# The host for 'managed AI Platform Pipeline' ends with 'pipelines.googleusercontent.com'\n",
+    "# The host for pipeline endpoint of 'full Kubeflow deployment' ends with '/pipeline'\n",
+    "# Examples are:\n",
+    "# https://7c021d0340d296aa-dot-us-central2.pipelines.googleusercontent.com\n",
+    "# https://kubeflow.endpoints.kubeflow-pipeline.cloud.goog/pipeline\n",
     "HOST = '<ADD HOST NAME TO TALK TO KUBEFLOW PIPELINE HERE>'\n",
+    "\n",
+    "# For 'full Kubeflow deployment' on GCP, the endpoint is usually protected through IAP, therefore the following \n",
+    "# will be needed to access the endpoint.\n",
     "CLIENT_ID = '<ADD OAuth CLIENT ID USED BY IAP HERE>'\n",
     "OTHER_CLIENT_ID = '<ADD OAuth CLIENT ID USED TO OBTAIN AUTH CODES HERE>'\n",
     "OTHER_CLIENT_SECRET = '<ADD OAuth CLIENT SECRET USED TO OBTAIN AUTH CODES HERE>'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is to ensure the proper access token is present to reach the end point for managed 'AI Platform Pipeline'\n",
+    "# If you are not working with managed 'AI Platform Pipeline', this step is not necessary\n",
+    "! gcloud auth print-access-token"
    ]
   },
   {
@@ -134,6 +154,11 @@
     "if in_cluster:\n",
     "    client = kfp.Client()\n",
     "else:\n",
+    "    if HOST.endswith('googleusercontent.com'):\n",
+    "        CLIENT_ID = None\n",
+    "        OTHER_CLIENT_ID = None\n",
+    "        OTHER_CLIENT_SECRET = None\n",
+    "\n",
     "    client = kfp.Client(host=HOST, \n",
     "                        client_id=CLIENT_ID,\n",
     "                        other_client_id=OTHER_CLIENT_ID, \n",
@@ -268,9 +293,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have created our Dockerfile for creating our Docker image. Then we need to push the image to a registry to host the image. \n",
-    "- We are going to use the `kfp.containers.build_image_from_working_dir` to build the image and push to the Container Registry (GCR), which uses [kaniko](https://cloud.google.com/blog/products/gcp/introducing-kaniko-build-container-images-in-kubernetes-and-google-container-builder-even-without-root-access).\n",
-    "- It is possible to build the image locally using Docker and then to push it to GCR."
+    "Now that we have created our Dockerfile for creating our Docker image. Then we need to build the image and push to a registry to host the image. There are three possible options:\n",
+    "- Use the `kfp.containers.build_image_from_working_dir` to build the image and push to the Container Registry (GCR). This requires [kaniko](https://cloud.google.com/blog/products/gcp/introducing-kaniko-build-container-images-in-kubernetes-and-google-container-builder-even-without-root-access), which will be auto-installed with 'full Kubeflow deployment' but not 'managed AI Platform Pipeline'.\n",
+    "- Use [Cloud Build](https://cloud.google.com/cloud-build), which would require the setup of GCP project and enablement of corresponding API. If you are working with GCP 'managed AI Platform Pipeline' with GCP project running, it is recommended to use Cloud Build.\n",
+    "- Use [Docker](https://www.docker.com/get-started) installed locally and push to e.g. GCR."
    ]
   },
   {
@@ -278,7 +304,7 @@
    "metadata": {},
    "source": [
     "**Note**:\n",
-    "If you run this notebook **within Kubeflow cluster**, **with Kubeflow version >= 0.7**, you need to ensure that valid credentials are created within your notebook's namespace.\n",
+    "If you run this notebook **within Kubeflow cluster**, **with Kubeflow version >= 0.7** and exploring **kaniko option**, you need to ensure that valid credentials are created within your notebook's namespace.\n",
     "- With Kubeflow version >= 0.7, the credential is supposed to be copied automatically while creating notebook through `Configurations`, which doesn't work properly at the time of creating this notebook. \n",
     "- You can also add credentials to the new namespace by either [copying credentials from an existing Kubeflow namespace, or by creating a new service account](https://www.kubeflow.org/docs/gke/authentication/#kubeflow-v0-6-and-before-gcp-service-account-key-as-secret).\n",
     "- The following cell demonstrates how to copy the default secret to your own namespace.\n",
@@ -309,16 +335,43 @@
     "    TAG=TAG\n",
     ")\n",
     "\n",
-    "builder = kfp.containers._container_builder.ContainerBuilder(\n",
-    "    gcs_staging=GCS_BUCKET + \"/kfp_container_build_staging\")\n",
+    "APP_FOLDER='./tmp/components/mnist_training/'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# In the following, for the purpose of demonstration\n",
+    "# Cloud Build is choosen for 'managed AI Platform Pipeline'\n",
+    "# kaniko is choosen for 'full Kubeflow deployment'\n",
     "\n",
-    "image_name = kfp.containers.build_image_from_working_dir(\n",
-    "    image_name=GCR_IMAGE,\n",
-    "    working_dir='./tmp/components/mnist_training/',\n",
-    "    builder=builder\n",
-    ")\n",
+    "if HOST.endswith('googleusercontent.com'):\n",
+    "    # kaniko is not pre-installed with 'managed AI Platform Pipeline'\n",
+    "    import subprocess\n",
+    "    # ! gcloud builds submit --tag ${IMAGE_NAME} ${APP_FOLDER}\n",
+    "    cmd = ['gcloud', 'builds', 'submit', '--tag', GCR_IMAGE, APP_FOLDER]\n",
+    "    build_log = (subprocess.run(cmd, stdout=subprocess.PIPE).stdout[:-1].decode('utf-8'))\n",
+    "    print(build_log)\n",
+    "    \n",
+    "else:\n",
+    "    if kfp.__version__ <= '0.1.36':\n",
+    "        # kfp with version 0.1.36+ introduce broken change that will make the following code not working\n",
+    "        import subprocess\n",
+    "        \n",
+    "        builder = kfp.containers._container_builder.ContainerBuilder(\n",
+    "            gcs_staging=GCS_BUCKET + \"/kfp_container_build_staging\"\n",
+    "        )\n",
     "\n",
-    "image_name"
+    "        kfp.containers.build_image_from_working_dir(\n",
+    "            image_name=GCR_IMAGE,\n",
+    "            working_dir=APP_FOLDER,\n",
+    "            builder=builder\n",
+    "        )\n",
+    "    else:\n",
+    "        raise(\"Please build the docker image use either [Docker] or [Cloud Build]\")"
    ]
   },
   {
@@ -349,6 +402,15 @@
     "cd tmp/components/mnist_training\n",
     "bash build_image.sh\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_name = GCR_IMAGE"
    ]
   },
   {

--- a/samples/tutorials/mnist/03_Reusable_Components.ipynb
+++ b/samples/tutorials/mnist/03_Reusable_Components.ipynb
@@ -112,10 +112,30 @@
    "outputs": [],
    "source": [
     "# Optional Parameters, but required for running outside Kubeflow cluster\n",
+    "\n",
+    "# The host for 'managed AI Platform Pipeline' ends with 'pipelines.googleusercontent.com'\n",
+    "# The host for pipeline endpoint of 'full Kubeflow deployment' ends with '/pipeline'\n",
+    "# Examples are:\n",
+    "# https://7c021d0340d296aa-dot-us-central2.pipelines.googleusercontent.com\n",
+    "# https://kubeflow.endpoints.kubeflow-pipeline.cloud.goog/pipeline\n",
     "HOST = '<ADD HOST NAME TO TALK TO KUBEFLOW PIPELINE HERE>'\n",
+    "\n",
+    "# For 'full Kubeflow deployment' on GCP, the endpoint is usually protected through IAP, therefore the following \n",
+    "# will be needed to access the endpoint.\n",
     "CLIENT_ID = '<ADD OAuth CLIENT ID USED BY IAP HERE>'\n",
     "OTHER_CLIENT_ID = '<ADD OAuth CLIENT ID USED TO OBTAIN AUTH CODES HERE>'\n",
     "OTHER_CLIENT_SECRET = '<ADD OAuth CLIENT SECRET USED TO OBTAIN AUTH CODES HERE>'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is to ensure the proper access token is present to reach the end point for managed 'AI Platform Pipeline'\n",
+    "# If you are not working with managed 'AI Platform Pipeline', this step is not necessary\n",
+    "! gcloud auth print-access-token"
    ]
   },
   {
@@ -135,6 +155,11 @@
     "if in_cluster:\n",
     "    client = kfp.Client()\n",
     "else:\n",
+    "    if HOST.endswith('googleusercontent.com'):\n",
+    "        CLIENT_ID = None\n",
+    "        OTHER_CLIENT_ID = None\n",
+    "        OTHER_CLIENT_SECRET = None\n",
+    "\n",
     "    client = kfp.Client(host=HOST, \n",
     "                        client_id=CLIENT_ID,\n",
     "                        other_client_id=OTHER_CLIENT_ID, \n",
@@ -275,9 +300,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have created our Dockerfile for creating our Docker image. Then we need to push the image to a registry to host the image. \n",
-    "- We are going to use the `kfp.containers.build_image_from_working_dir` to build the image and push to the Container Registry (GCR), which uses [kaniko](https://cloud.google.com/blog/products/gcp/introducing-kaniko-build-container-images-in-kubernetes-and-google-container-builder-even-without-root-access).\n",
-    "- It is possible to build the image locally using Docker and then to push it to GCR."
+    "Now that we have created our Dockerfile for creating our Docker image. Then we need to build the image and push to a registry to host the image. There are three possible options:\n",
+    "- Use the `kfp.containers.build_image_from_working_dir` to build the image and push to the Container Registry (GCR). This requires [kaniko](https://cloud.google.com/blog/products/gcp/introducing-kaniko-build-container-images-in-kubernetes-and-google-container-builder-even-without-root-access), which will be auto-installed with 'full Kubeflow deployment' but not 'managed AI Platform Pipeline'.\n",
+    "- Use [Cloud Build](https://cloud.google.com/cloud-build), which would require the setup of GCP project and enablement of corresponding API. If you are working with GCP 'managed AI Platform Pipeline' with GCP project running, it is recommended to use Cloud Build.\n",
+    "- Use [Docker](https://www.docker.com/get-started) installed locally and push to e.g. GCR."
    ]
   },
   {
@@ -285,7 +311,7 @@
    "metadata": {},
    "source": [
     "**Note**:\n",
-    "If you run this notebook **within Kubeflow cluster**, **with Kubeflow version >= 0.7**, you need to ensure that valid credentials are created within your notebook's namespace.\n",
+    "If you run this notebook **within Kubeflow cluster**, **with Kubeflow version >= 0.7** and exploring **kaniko option**, you need to ensure that valid credentials are created within your notebook's namespace.\n",
     "- With Kubeflow version >= 0.7, the credential is supposed to be copied automatically while creating notebook through `Configurations`, which doesn't work properly at the time of creating this notebook. \n",
     "- You can also add credentials to the new namespace by either [copying credentials from an existing Kubeflow namespace, or by creating a new service account](https://www.kubeflow.org/docs/gke/authentication/#kubeflow-v0-6-and-before-gcp-service-account-key-as-secret).\n",
     "- The following cell demonstrates how to copy the default secret to your own namespace.\n",
@@ -316,16 +342,43 @@
     "    TAG=TAG\n",
     ")\n",
     "\n",
-    "builder = kfp.containers._container_builder.ContainerBuilder(\n",
-    "    gcs_staging=GCS_BUCKET + \"/kfp_container_build_staging\")\n",
+    "APP_FOLDER='./tmp/reuse_components/mnist_training/'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# In the following, for the purpose of demonstration\n",
+    "# Cloud Build is choosen for 'managed AI Platform Pipeline'\n",
+    "# kaniko is choosen for 'full Kubeflow deployment'\n",
     "\n",
-    "image_name = kfp.containers.build_image_from_working_dir(\n",
-    "    image_name=GCR_IMAGE,\n",
-    "    working_dir='./tmp/reuse_components/mnist_training/',\n",
-    "    builder=builder\n",
-    ")\n",
+    "if HOST.endswith('googleusercontent.com'):\n",
+    "    # kaniko is not pre-installed with 'managed AI Platform Pipeline'\n",
+    "    import subprocess\n",
+    "    # ! gcloud builds submit --tag ${IMAGE_NAME} ${APP_FOLDER}\n",
+    "    cmd = ['gcloud', 'builds', 'submit', '--tag', GCR_IMAGE, APP_FOLDER]\n",
+    "    build_log = (subprocess.run(cmd, stdout=subprocess.PIPE).stdout[:-1].decode('utf-8'))\n",
+    "    print(build_log)\n",
+    "    \n",
+    "else:\n",
+    "    if kfp.__version__ <= '0.1.36':\n",
+    "        # kfp with version 0.1.36+ introduce broken change that will make the following code not working\n",
+    "        import subprocess\n",
+    "        \n",
+    "        builder = kfp.containers._container_builder.ContainerBuilder(\n",
+    "            gcs_staging=GCS_BUCKET + \"/kfp_container_build_staging\"\n",
+    "        )\n",
     "\n",
-    "image_name"
+    "        kfp.containers.build_image_from_working_dir(\n",
+    "            image_name=GCR_IMAGE,\n",
+    "            working_dir=APP_FOLDER,\n",
+    "            builder=builder\n",
+    "        )\n",
+    "    else:\n",
+    "        raise(\"Please build the docker image use either [Docker] or [Cloud Build]\")"
    ]
   },
   {
@@ -355,12 +408,16 @@
     "\n",
     "cd tmp/reuse_components/mnist_training\n",
     "bash build_image.sh\n",
-    "```\n",
-    "\n",
-    "**Remember to set the image_name after the image is built**\n",
-    "```python\n",
-    "image_name = <the image uri>\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_name = GCR_IMAGE"
    ]
   },
   {

--- a/samples/tutorials/mnist/03_Reusable_Components.ipynb
+++ b/samples/tutorials/mnist/03_Reusable_Components.ipynb
@@ -113,7 +113,7 @@
    "source": [
     "# Optional Parameters, but required for running outside Kubeflow cluster\n",
     "\n",
-    "# The host for 'managed AI Platform Pipeline' ends with 'pipelines.googleusercontent.com'\n",
+    "# The host for 'AI Platform Pipelines' ends with 'pipelines.googleusercontent.com'\n",
     "# The host for pipeline endpoint of 'full Kubeflow deployment' ends with '/pipeline'\n",
     "# Examples are:\n",
     "# https://7c021d0340d296aa-dot-us-central2.pipelines.googleusercontent.com\n",
@@ -133,8 +133,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This is to ensure the proper access token is present to reach the end point for managed 'AI Platform Pipeline'\n",
-    "# If you are not working with managed 'AI Platform Pipeline', this step is not necessary\n",
+    "# This is to ensure the proper access token is present to reach the end point for 'AI Platform Pipelines'\n",
+    "# If you are not working with 'AI Platform Pipelines', this step is not necessary\n",
     "! gcloud auth print-access-token"
    ]
   },
@@ -301,8 +301,8 @@
    "metadata": {},
    "source": [
     "Now that we have created our Dockerfile for creating our Docker image. Then we need to build the image and push to a registry to host the image. There are three possible options:\n",
-    "- Use the `kfp.containers.build_image_from_working_dir` to build the image and push to the Container Registry (GCR). This requires [kaniko](https://cloud.google.com/blog/products/gcp/introducing-kaniko-build-container-images-in-kubernetes-and-google-container-builder-even-without-root-access), which will be auto-installed with 'full Kubeflow deployment' but not 'managed AI Platform Pipeline'.\n",
-    "- Use [Cloud Build](https://cloud.google.com/cloud-build), which would require the setup of GCP project and enablement of corresponding API. If you are working with GCP 'managed AI Platform Pipeline' with GCP project running, it is recommended to use Cloud Build.\n",
+    "- Use the `kfp.containers.build_image_from_working_dir` to build the image and push to the Container Registry (GCR). This requires [kaniko](https://cloud.google.com/blog/products/gcp/introducing-kaniko-build-container-images-in-kubernetes-and-google-container-builder-even-without-root-access), which will be auto-installed with 'full Kubeflow deployment' but not 'AI Platform Pipelines'.\n",
+    "- Use [Cloud Build](https://cloud.google.com/cloud-build), which would require the setup of GCP project and enablement of corresponding API. If you are working with GCP 'AI Platform Pipelines' with GCP project running, it is recommended to use Cloud Build.\n",
     "- Use [Docker](https://www.docker.com/get-started) installed locally and push to e.g. GCR."
    ]
   },
@@ -352,11 +352,11 @@
    "outputs": [],
    "source": [
     "# In the following, for the purpose of demonstration\n",
-    "# Cloud Build is choosen for 'managed AI Platform Pipeline'\n",
+    "# Cloud Build is choosen for 'AI Platform Pipelines'\n",
     "# kaniko is choosen for 'full Kubeflow deployment'\n",
     "\n",
     "if HOST.endswith('googleusercontent.com'):\n",
-    "    # kaniko is not pre-installed with 'managed AI Platform Pipeline'\n",
+    "    # kaniko is not pre-installed with 'AI Platform Pipelines'\n",
     "    import subprocess\n",
     "    # ! gcloud builds submit --tag ${IMAGE_NAME} ${APP_FOLDER}\n",
     "    cmd = ['gcloud', 'builds', 'submit', '--tag', GCR_IMAGE, APP_FOLDER]\n",

--- a/samples/tutorials/mnist/04_Reusable_and_Pre-build_Components_as_Pipeline.ipynb
+++ b/samples/tutorials/mnist/04_Reusable_and_Pre-build_Components_as_Pipeline.ipynb
@@ -117,10 +117,30 @@
    "outputs": [],
    "source": [
     "# Optional Parameters, but required for running outside Kubeflow cluster\n",
+    "\n",
+    "# The host for 'managed AI Platform Pipeline' ends with 'pipelines.googleusercontent.com'\n",
+    "# The host for pipeline endpoint of 'full Kubeflow deployment' ends with '/pipeline'\n",
+    "# Examples are:\n",
+    "# https://7c021d0340d296aa-dot-us-central2.pipelines.googleusercontent.com\n",
+    "# https://kubeflow.endpoints.kubeflow-pipeline.cloud.goog/pipeline\n",
     "HOST = '<ADD HOST NAME TO TALK TO KUBEFLOW PIPELINE HERE>'\n",
+    "\n",
+    "# For 'full Kubeflow deployment' on GCP, the endpoint is usually protected through IAP, therefore the following \n",
+    "# will be needed to access the endpoint.\n",
     "CLIENT_ID = '<ADD OAuth CLIENT ID USED BY IAP HERE>'\n",
     "OTHER_CLIENT_ID = '<ADD OAuth CLIENT ID USED TO OBTAIN AUTH CODES HERE>'\n",
     "OTHER_CLIENT_SECRET = '<ADD OAuth CLIENT SECRET USED TO OBTAIN AUTH CODES HERE>'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is to ensure the proper access token is present to reach the end point for managed 'AI Platform Pipeline'\n",
+    "# If you are not working with managed 'AI Platform Pipeline', this step is not necessary\n",
+    "! gcloud auth print-access-token"
    ]
   },
   {
@@ -140,6 +160,11 @@
     "if in_cluster:\n",
     "    client = kfp.Client()\n",
     "else:\n",
+    "    if HOST.endswith('googleusercontent.com'):\n",
+    "        CLIENT_ID = None\n",
+    "        OTHER_CLIENT_ID = None\n",
+    "        OTHER_CLIENT_SECRET = None\n",
+    "\n",
     "    client = kfp.Client(host=HOST, \n",
     "                        client_id=CLIENT_ID,\n",
     "                        other_client_id=OTHER_CLIENT_ID, \n",
@@ -285,9 +310,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have created our Dockerfile for creating our Docker image. Then we need to push the image to a registry to host the image. \n",
-    "- We are going to use the `kfp.containers.build_image_from_working_dir` to build the image and push to the Container Registry (GCR), which uses [kaniko](https://cloud.google.com/blog/products/gcp/introducing-kaniko-build-container-images-in-kubernetes-and-google-container-builder-even-without-root-access).\n",
-    "- It is possible to build the image locally using Docker and then to push it to GCR."
+    "Now that we have created our Dockerfile for creating our Docker image. Then we need to build the image and push to a registry to host the image. There are three possible options:\n",
+    "- Use the `kfp.containers.build_image_from_working_dir` to build the image and push to the Container Registry (GCR). This requires [kaniko](https://cloud.google.com/blog/products/gcp/introducing-kaniko-build-container-images-in-kubernetes-and-google-container-builder-even-without-root-access), which will be auto-installed with 'full Kubeflow deployment' but not 'managed AI Platform Pipeline'.\n",
+    "- Use [Cloud Build](https://cloud.google.com/cloud-build), which would require the setup of GCP project and enablement of corresponding API. If you are working with GCP 'managed AI Platform Pipeline' with GCP project running, it is recommended to use Cloud Build.\n",
+    "- Use [Docker](https://www.docker.com/get-started) installed locally and push to e.g. GCR."
    ]
   },
   {
@@ -295,7 +321,7 @@
    "metadata": {},
    "source": [
     "**Note**:\n",
-    "If you run this notebook **within Kubeflow cluster**, **with Kubeflow version >= 0.7**, you need to ensure that valid credentials are created within your notebook's namespace.\n",
+    "If you run this notebook **within Kubeflow cluster**, **with Kubeflow version >= 0.7** and exploring **kaniko option**, you need to ensure that valid credentials are created within your notebook's namespace.\n",
     "- With Kubeflow version >= 0.7, the credential is supposed to be copied automatically while creating notebook through `Configurations`, which doesn't work properly at the time of creating this notebook. \n",
     "- You can also add credentials to the new namespace by either [copying credentials from an existing Kubeflow namespace, or by creating a new service account](https://www.kubeflow.org/docs/gke/authentication/#kubeflow-v0-6-and-before-gcp-service-account-key-as-secret).\n",
     "- The following cell demonstrates how to copy the default secret to your own namespace.\n",
@@ -326,16 +352,43 @@
     "    TAG=TAG\n",
     ")\n",
     "\n",
-    "builder = kfp.containers._container_builder.ContainerBuilder(\n",
-    "    gcs_staging=GCS_BUCKET + \"/kfp_container_build_staging\")\n",
+    "APP_FOLDER='./tmp/reuse_components_pipeline/mnist_training/'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# In the following, for the purpose of demonstration\n",
+    "# Cloud Build is choosen for 'managed AI Platform Pipeline'\n",
+    "# kaniko is choosen for 'full Kubeflow deployment'\n",
     "\n",
-    "image_name = kfp.containers.build_image_from_working_dir(\n",
-    "    image_name=GCR_IMAGE,\n",
-    "    working_dir='./tmp/reuse_components_pipeline/mnist_training/',\n",
-    "    builder=builder\n",
-    ")\n",
+    "if HOST.endswith('googleusercontent.com'):\n",
+    "    # kaniko is not pre-installed with 'managed AI Platform Pipeline'\n",
+    "    import subprocess\n",
+    "    # ! gcloud builds submit --tag ${IMAGE_NAME} ${APP_FOLDER}\n",
+    "    cmd = ['gcloud', 'builds', 'submit', '--tag', GCR_IMAGE, APP_FOLDER]\n",
+    "    build_log = (subprocess.run(cmd, stdout=subprocess.PIPE).stdout[:-1].decode('utf-8'))\n",
+    "    print(build_log)\n",
+    "    \n",
+    "else:\n",
+    "    if kfp.__version__ <= '0.1.36':\n",
+    "        # kfp with version 0.1.36+ introduce broken change that will make the following code not working\n",
+    "        import subprocess\n",
+    "        \n",
+    "        builder = kfp.containers._container_builder.ContainerBuilder(\n",
+    "            gcs_staging=GCS_BUCKET + \"/kfp_container_build_staging\"\n",
+    "        )\n",
     "\n",
-    "image_name"
+    "        kfp.containers.build_image_from_working_dir(\n",
+    "            image_name=GCR_IMAGE,\n",
+    "            working_dir=APP_FOLDER,\n",
+    "            builder=builder\n",
+    "        )\n",
+    "    else:\n",
+    "        raise(\"Please build the docker image use either [Docker] or [Cloud Build]\")"
    ]
   },
   {
@@ -365,12 +418,16 @@
     "\n",
     "cd tmp/components/mnist_training\n",
     "bash build_image.sh\n",
-    "```\n",
-    "\n",
-    "**Remember to set the image_name after the image is built**\n",
-    "```python\n",
-    "image_name = <the image uri>\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_name = GCR_IMAGE"
    ]
   },
   {

--- a/samples/tutorials/mnist/04_Reusable_and_Pre-build_Components_as_Pipeline.ipynb
+++ b/samples/tutorials/mnist/04_Reusable_and_Pre-build_Components_as_Pipeline.ipynb
@@ -118,7 +118,7 @@
    "source": [
     "# Optional Parameters, but required for running outside Kubeflow cluster\n",
     "\n",
-    "# The host for 'managed AI Platform Pipeline' ends with 'pipelines.googleusercontent.com'\n",
+    "# The host for 'AI Platform Pipelines' ends with 'pipelines.googleusercontent.com'\n",
     "# The host for pipeline endpoint of 'full Kubeflow deployment' ends with '/pipeline'\n",
     "# Examples are:\n",
     "# https://7c021d0340d296aa-dot-us-central2.pipelines.googleusercontent.com\n",
@@ -138,8 +138,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This is to ensure the proper access token is present to reach the end point for managed 'AI Platform Pipeline'\n",
-    "# If you are not working with managed 'AI Platform Pipeline', this step is not necessary\n",
+    "# This is to ensure the proper access token is present to reach the end point for 'AI Platform Pipelines'\n",
+    "# If you are not working with 'AI Platform Pipelines', this step is not necessary\n",
     "! gcloud auth print-access-token"
    ]
   },
@@ -311,8 +311,8 @@
    "metadata": {},
    "source": [
     "Now that we have created our Dockerfile for creating our Docker image. Then we need to build the image and push to a registry to host the image. There are three possible options:\n",
-    "- Use the `kfp.containers.build_image_from_working_dir` to build the image and push to the Container Registry (GCR). This requires [kaniko](https://cloud.google.com/blog/products/gcp/introducing-kaniko-build-container-images-in-kubernetes-and-google-container-builder-even-without-root-access), which will be auto-installed with 'full Kubeflow deployment' but not 'managed AI Platform Pipeline'.\n",
-    "- Use [Cloud Build](https://cloud.google.com/cloud-build), which would require the setup of GCP project and enablement of corresponding API. If you are working with GCP 'managed AI Platform Pipeline' with GCP project running, it is recommended to use Cloud Build.\n",
+    "- Use the `kfp.containers.build_image_from_working_dir` to build the image and push to the Container Registry (GCR). This requires [kaniko](https://cloud.google.com/blog/products/gcp/introducing-kaniko-build-container-images-in-kubernetes-and-google-container-builder-even-without-root-access), which will be auto-installed with 'full Kubeflow deployment' but not 'AI Platform Pipelines'.\n",
+    "- Use [Cloud Build](https://cloud.google.com/cloud-build), which would require the setup of GCP project and enablement of corresponding API. If you are working with GCP 'AI Platform Pipelines' with GCP project running, it is recommended to use Cloud Build.\n",
     "- Use [Docker](https://www.docker.com/get-started) installed locally and push to e.g. GCR."
    ]
   },
@@ -362,11 +362,11 @@
    "outputs": [],
    "source": [
     "# In the following, for the purpose of demonstration\n",
-    "# Cloud Build is choosen for 'managed AI Platform Pipeline'\n",
+    "# Cloud Build is choosen for 'AI Platform Pipelines'\n",
     "# kaniko is choosen for 'full Kubeflow deployment'\n",
     "\n",
     "if HOST.endswith('googleusercontent.com'):\n",
-    "    # kaniko is not pre-installed with 'managed AI Platform Pipeline'\n",
+    "    # kaniko is not pre-installed with 'AI Platform Pipelines'\n",
     "    import subprocess\n",
     "    # ! gcloud builds submit --tag ${IMAGE_NAME} ${APP_FOLDER}\n",
     "    cmd = ['gcloud', 'builds', 'submit', '--tag', GCR_IMAGE, APP_FOLDER]\n",


### PR DESCRIPTION
This PR is to ensure the tutorial is easily compatible to the newly launched "managed pipeline" on GCP. Specifically, the following has been added:

- Alter user about the host for 'managed AI Platform Pipeline' ends with 'pipelines.googleusercontent.com' and the host for pipeline endpoint of 'full Kubeflow deployment' ends with '/pipeline'. More over, for 'full Kubeflow deployment' on GCP, the endpoint is usually protected through IAP.
- Since kaniko is not pre-installed with 'managed pipeline', add instruction for the option of Cloud Build.