### PR TITLE
[UI] No longer pass namespace to createRun api

### DIFF
--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -1256,39 +1256,6 @@ describe('NewRun', () => {
       });
     });
 
-    it('starts a run in provided namespace', async () => {
-      const props = generateProps();
-      props.location.search =
-        `?${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}` +
-        `&${QUERY_PARAMS.pipelineVersionId}=${MOCK_PIPELINE_VERSION.id}`;
-
-      tree = mount(<TestNewRun {...props} namespace='test-ns' />);
-      fillRequiredFields(tree.find(TestNewRun).instance() as TestNewRun);
-      await TestUtils.flushPromises();
-
-      tree
-        .find('#startNewRunBtn')
-        .hostNodes()
-        .simulate('click');
-      // The start APIs are called in a callback triggered by clicking 'Start', so we wait again
-      await TestUtils.flushPromises();
-
-      expect(startRunSpy).toHaveBeenCalledTimes(1);
-      expect(startRunSpy).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          resource_references: expect.arrayContaining([
-            {
-              key: {
-                id: 'test-ns',
-                type: ApiResourceType.NAMESPACE,
-              },
-              relationship: ApiRelationship.OWNER,
-            },
-          ]),
-        }),
-      );
-    });
-
     it('updates the parameters in state on handleParamChange', async () => {
       const props = generateProps();
       const pipeline = newMockPipeline();

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -1012,20 +1012,6 @@ export class NewRun extends Page<{ namespace?: string }, NewRunState> {
       });
     }
 
-    // namespace resource ref is only supported in create run for now
-    if (!this.state.isRecurringRun) {
-      const currentNamespace = this.props.namespace;
-      if (currentNamespace) {
-        references.push({
-          key: {
-            id: currentNamespace,
-            type: ApiResourceType.NAMESPACE,
-          },
-          relationship: ApiRelationship.OWNER,
-        });
-      }
-    }
-
     let newRun: ApiRun | ApiJob = {
       description: this.state.description,
       name: this.state.runName,


### PR DESCRIPTION
/assign @chensun 
/cc @IronPan 
/area frontend

Part of https://github.com/kubeflow/pipelines/issues/3290

The namespace resource reference is no longer needed, experiment will have namespace info already in PR: https://github.com/kubeflow/pipelines/issues/3273