### PR TITLE
Testing - Upgraded GKE master version to fix tests

### DIFF
--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -71,7 +71,7 @@ else
   NODE_POOL_CONFIG_ARG="--num-nodes=2 --machine-type=n1-standard-8 \
     --enable-autoscaling --max-nodes=8 --min-nodes=2"
   # Use new kubernetes master to improve workload identity stability.
-  KUBERNETES_VERSION_ARG="--cluster-version=1.14.10-gke.17"
+  KUBERNETES_VERSION_ARG="--cluster-version=1.14.10-gke.27"
   if [ "$ENABLE_WORKLOAD_IDENTITY" = true ]; then
     WI_ARG="--identity-namespace=$PROJECT.svc.id.goog"
     SCOPE_ARG=


### PR DESCRIPTION
Fixes this error:
>ERROR: (gcloud.beta.container.clusters.create) ResponseError: code=400, message=Master version "1.14.10-gke.17" is unsupported.