### PR TITLE
Update deployment resource version from /v1beta1 -> /v1

### DIFF
--- a/manifests/kustomize/base/application/application-controller-deployment.yaml
+++ b/manifests/kustomize/base/application/application-controller-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager

--- a/manifests/kustomize/base/argo/workflow-controller-deployment.yaml
+++ b/manifests/kustomize/base/argo/workflow-controller-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/manifests/kustomize/base/metadata/metadata-envoy-deployment.yaml
+++ b/manifests/kustomize/base/metadata/metadata-envoy-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metadata-envoy-deployment

--- a/manifests/kustomize/base/metadata/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/metadata-grpc-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metadata-grpc-deployment

--- a/manifests/kustomize/base/pipeline-application.yaml
+++ b/manifests/kustomize/base/pipeline-application.yaml
@@ -45,5 +45,5 @@ spec:
       kind: ConfigMap
     - group: v1
       kind: Secret
-    - group: apps/v1beta2
+    - group: apps/v1
       kind: Deployment

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/manifests/kustomize/base/pipeline/ml-pipeline-ui-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-ui-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/manifests/kustomize/base/pipeline/ml-pipeline-viewer-crd-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-viewer-crd-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/manifests/kustomize/base/pipeline/ml-pipeline-visualization-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-visualization-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/manifests/kustomize/base/proxy/proxy-deployment.yaml
+++ b/manifests/kustomize/base/proxy/proxy-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/manifests/kustomize/env/dev/minio/minio-deployment.yaml
+++ b/manifests/kustomize/env/dev/minio/minio-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: minio

--- a/manifests/kustomize/env/dev/mysql/mysql-deployment.yaml
+++ b/manifests/kustomize/env/dev/mysql/mysql-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mysql

--- a/manifests/kustomize/env/gcp/gcp-configurations-patch.yaml
+++ b/manifests/kustomize/env/gcp/gcp-configurations-patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ml-pipeline
@@ -15,7 +15,7 @@ spec:
             - name: DBCONFIG_PASSWORD
               value: ''
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cloudsqlproxy

--- a/manifests/kustomize/env/gcp/minio/minio-gcs-gateway-deployment.yaml
+++ b/manifests/kustomize/env/gcp/minio/minio-gcs-gateway-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: minio

--- a/manifests/kustomize/env/gcp/mysql/cloudsql-proxy-deployment.yaml
+++ b/manifests/kustomize/env/gcp/mysql/cloudsql-proxy-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cloudsqlproxy

--- a/manifests/kustomize/namespaced/kustomization.yaml
+++ b/manifests/kustomize/namespaced/kustomization.yaml
@@ -14,7 +14,7 @@ vars:
   - name: NAMESPACE
     objref:
       kind: Deployment
-      apiVersion: apps/v1beta2
+      apiVersion: apps/v1
       name:  workflow-controller
     fieldref:
       fieldpath: metadata.namespace


### PR DESCRIPTION
I tried to deploy Kubeflow Pipelines but had some issues due to that the version on the deployment resource are /v1beta1 which is [deprecated since 1.16](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/). This PR suggest to fix that by updating the version.