### PR TITLE
[SDK] Skip host name preprocess for the IAP case

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -118,7 +118,9 @@ class Client(object):
 
     host = host or ''
     # Preprocess the host endpoint to prevent some common user mistakes.
-    host = re.sub(r'^(http|https)://', '', host).rstrip('/')
+    # This should only be done for non-IAP cases (when client_id is None). IAP requires preserving the protocol.
+    if not client_id:
+      host = re.sub(r'^(http|https)://', '', host).rstrip('/')
 
     if host:
       config.host = host


### PR DESCRIPTION
Turned out that IAP will break without the "https" protocol. So we have to limit the processing to only non-IAP case.

Part of #3280

/cc @numerology @rmgogogo 
/assign @numerology 