### PR TITLE
Update deployment resource version from /v1beta1 -> /v1 in gcp_marketplace

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/application.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/application.yaml
@@ -46,6 +46,6 @@ spec:
       kind: ConfigMap
     - group: v1
       kind: Secret
-    - group: apps/v1beta2
+    - group: apps/v1
       kind: Deployment
 

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/argo.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/argo.yaml
@@ -126,7 +126,7 @@ metadata:
     app.kubernetes.io/name: {{ .Release.Name }}
 type: Opaque
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/metadata.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/metadata.yaml
@@ -14,7 +14,7 @@ spec:
     component: metadata-grpc-server
     app.kubernetes.io/name: {{ .Release.Name }}
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -98,7 +98,7 @@ spec:
       protocol: TCP
       name: md-envoy
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metadata-envoy

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/minio.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/minio.yaml
@@ -14,7 +14,7 @@ spec:
     app.kubernetes.io/name: {{ .Release.Name }}
 ---
 {{ if .Values.managedstorage.enabled }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: minio
@@ -73,7 +73,7 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: minio

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
@@ -16,7 +16,7 @@ spec:
     app.kubernetes.io/name: {{ .Release.Name }}
 ---
 {{ if .Values.managedstorage.enabled }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cloudsqlproxy
@@ -93,7 +93,7 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mysql

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
@@ -485,7 +485,7 @@ spec:
     app: ml-pipeline
     app.kubernetes.io/name: {{ .Release.Name }}
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -512,7 +512,7 @@ spec:
           name: ml-pipeline-persistenceagent
       serviceAccountName: ml-pipeline-persistenceagent
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -539,7 +539,7 @@ spec:
           name: ml-pipeline-scheduledworkflow
       serviceAccountName: ml-pipeline-scheduledworkflow
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -572,7 +572,7 @@ spec:
             - containerPort: 3000
       serviceAccountName: ml-pipeline-ui
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -601,7 +601,7 @@ spec:
           name: ml-pipeline-viewer-crd
       serviceAccountName: ml-pipeline-viewer-crd-service-account
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -627,7 +627,7 @@ spec:
             - containerPort: 8888
       serviceAccountName: ml-pipeline-visualizationserver
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/proxy.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/proxy.yaml
@@ -36,7 +36,7 @@ subjects:
     name: proxy-agent-runner
     namespace: {{ .Release.Namespace }}
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
I tried to deploy Kubeflow Pipelines but had some issues due to that the version on the deployment resource are /v1beta1 which is deprecated since 1.16. This PR suggest to fix that by updating the version.

Related to https://github.com/kubeflow/pipelines/pull/3421

