### PR TITLE
Support execution throttling for executing the pipelines (#3346)

### DIFF
--- a/samples/core/pipeline_parallelism/pipeline_parallelism_limits.py
+++ b/samples/core/pipeline_parallelism/pipeline_parallelism_limits.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import kfp
+from kfp import dsl
+
+
+def print_op(msg):
+  """Print a message."""
+  return dsl.ContainerOp(
+      name='Print',
+      image='alpine:3.6',
+      command=['echo', msg],
+  )
+
+
+@dsl.pipeline(
+    name='Pipeline service account',
+    description='The pipeline shows how to set the max number of parallel pods in a pipeline.'
+)
+def pipeline_service_account():
+  op1 = print_op('hey, what are you up to?')
+  op2 = print_op('train my model.')
+  dsl.get_pipeline_conf().set_parallelism(1)
+
+if __name__ == '__main__':
+  kfp.compiler.Compiler().compile(transform_pipeline, __file__ + '.yaml')

--- a/samples/core/pipeline_parallelism/pipeline_parallelism_limits.py
+++ b/samples/core/pipeline_parallelism/pipeline_parallelism_limits.py
@@ -31,10 +31,10 @@ def print_op(msg):
     name='Pipeline service account',
     description='The pipeline shows how to set the max number of parallel pods in a pipeline.'
 )
-def pipeline_service_account():
+def pipeline_parallelism():
   op1 = print_op('hey, what are you up to?')
   op2 = print_op('train my model.')
   dsl.get_pipeline_conf().set_parallelism(1)
 
 if __name__ == '__main__':
-  kfp.compiler.Compiler().compile(transform_pipeline, __file__ + '.yaml')
+  kfp.compiler.Compiler().compile(pipeline_parallelism, __file__ + '.yaml')

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -670,9 +670,13 @@ class Compiler(object):
         'entrypoint': pipeline_template_name,
         'templates': templates,
         'arguments': {'parameters': input_params},
-        'serviceAccountName': 'pipeline-runner'
+        'serviceAccountName': 'pipeline-runner',
       }
     }
+    # set parallelism limits at pipeline level
+    if pipeline_conf.parallelism:
+      workflow['spec']['parallelism'] = pipeline_conf.parallelism
+
     # set ttl after workflow finishes
     if pipeline_conf.ttl_seconds_after_finished >= 0:
       workflow['spec']['ttlSecondsAfterFinished'] = pipeline_conf.ttl_seconds_after_finished

--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -62,6 +62,7 @@ class PipelineConf():
     self.ttl_seconds_after_finished = -1
     self.op_transformers = []
     self.image_pull_policy = None
+    self.parallelism = None
 
   def set_image_pull_secrets(self, image_pull_secrets):
     """Configures the pipeline level imagepullsecret
@@ -83,6 +84,15 @@ class PipelineConf():
     self.timeout = seconds
     return self
 
+  def set_parallelism(self, max_num_pods: int):
+    """Configures the max number of total parallel pods that can execute at the same time in a workflow.
+
+    Args:
+        max_num_pods (int): max number of total parallel pods.
+    """
+    self.parallelism = max_num_pods
+    return self
+
   def set_ttl_seconds_after_finished(self, seconds: int):
     """Configures the ttl after the pipeline has finished.
 
@@ -96,7 +106,7 @@ class PipelineConf():
     """Configures the default image pull policy
 
     Args:
-      policy: the pull policy, has to be one of: Always, Never, IfNotPresent. 
+      policy: the pull policy, has to be one of: Always, Never, IfNotPresent.
       For more info: https://github.com/kubernetes-client/python/blob/10a7f95435c0b94a6d949ba98375f8cc85a70e5a/kubernetes/docs/V1Container.md
     """
     self.image_pull_policy = policy


### PR DESCRIPTION
/cc @DmitryBe
Support `set_parallelism` for pipeline conf.  This is mostly to support `dsl.ParallelFor`.

See #3346

PS: Should we also support this inside the api-server? 

> NOTE  
> kfp sdk does not seems to support `steps`, hence step parallelism limits are not supported in this PR