### PR TITLE
edited docstring of ContainerOp to address Issue #2593

### DIFF
--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -1002,7 +1002,7 @@ class ContainerOp(BaseOp):
               the value of a PipelineParam is saved to its corresponding local file. It's
               one way for outside world to receive outputs of the container.
           output_artifact_paths: Maps output artifact labels to local artifact file paths.
-              It has the following default artifact paths during compile time.
+              To get metrics to show up in the UI, add the following dict to `output_artifact_paths`
               {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json',
                'mlpipeline-metrics': '/mlpipeline-metrics.json'}
           artifact_location: Deprecated. Configures the default artifact location for artifacts


### PR DESCRIPTION
The documentation of the constructor for `ContainerOp` is out of date. Now, the artifact paths are no longer automatically included (inferred from [#2046](https://github.com/kubeflow/pipelines/pull/2046/files#diff-a65b15d94e67f77a796e4940651e5c62R7)). 

This is a small fix to address that. 