### PR TITLE
[Cache] Change cache-deployer deployment to strategy recreate

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/cache.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/cache.yaml
@@ -148,6 +148,8 @@ spec:
     matchLabels:
       app: cache-deployer
       app.kubernetes.io/name: {{ .Release.Name }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/manifests/kustomize/base/cache-deployer/cache-deployer-deployment.yaml
+++ b/manifests/kustomize/base/cache-deployer/cache-deployer-deployment.yaml
@@ -9,6 +9,8 @@ spec:
   selector:
     matchLabels:
       app: cache-deployer
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Problem: when cache-deployer deployment has any updates, Kubernetes will create a new instance first and stop the old one afterwards
Solution:
Adding strategy: type: Recreate makes sure Kubernetes first stops the old instance before starting the new one, so that there is only one instance running when cache-deployer deployment is updated and they won't conflict with each other.
/cc @rmgogogo @IronPan 

(we are using the same pattern for mysql deployment).

Reference:
* https://kubernetes.io/docs/tasks/run-application/run-single-instance-stateful-application/#updating