### PR TITLE
[UI] Show execution details in Run Details Page ML Metadata tab of steps

### DIFF
--- a/frontend/src/atoms/ExternalLink.tsx
+++ b/frontend/src/atoms/ExternalLink.tsx
@@ -2,7 +2,7 @@ import React, { DetailedHTMLProps, AnchorHTMLAttributes } from 'react';
 import { stylesheet } from 'typestyle';
 import { color } from '../Css';
 
-export const linkStyles = stylesheet({
+const css = stylesheet({
   link: {
     $nest: {
       '&:hover': {
@@ -19,7 +19,7 @@ export const ExternalLink: React.FC<DetailedHTMLProps<
   HTMLAnchorElement
 >> = props => (
   // eslint-disable-next-line jsx-a11y/anchor-has-content
-  <a {...props} className={linkStyles.link} target='_blank' rel='noopener' />
+  <a {...props} className={css.link} target='_blank' rel='noopener' />
 );
 
 export const AutoLink: React.FC<DetailedHTMLProps<
@@ -28,7 +28,7 @@ export const AutoLink: React.FC<DetailedHTMLProps<
 >> = props =>
   props.href && props.href.startsWith('#') ? (
     // eslint-disable-next-line jsx-a11y/anchor-has-content
-    <a {...props} className={linkStyles.link} />
+    <a {...props} className={css.link} />
   ) : (
     <ExternalLink {...props} />
   );

--- a/frontend/src/atoms/ExternalLink.tsx
+++ b/frontend/src/atoms/ExternalLink.tsx
@@ -2,7 +2,7 @@ import React, { DetailedHTMLProps, AnchorHTMLAttributes } from 'react';
 import { stylesheet } from 'typestyle';
 import { color } from '../Css';
 
-const css = stylesheet({
+export const linkStyles = stylesheet({
   link: {
     $nest: {
       '&:hover': {
@@ -19,7 +19,7 @@ export const ExternalLink: React.FC<DetailedHTMLProps<
   HTMLAnchorElement
 >> = props => (
   // eslint-disable-next-line jsx-a11y/anchor-has-content
-  <a {...props} className={css.link} target='_blank' rel='noopener' />
+  <a {...props} className={linkStyles.link} target='_blank' rel='noopener' />
 );
 
 export const AutoLink: React.FC<DetailedHTMLProps<
@@ -28,7 +28,7 @@ export const AutoLink: React.FC<DetailedHTMLProps<
 >> = props =>
   props.href && props.href.startsWith('#') ? (
     // eslint-disable-next-line jsx-a11y/anchor-has-content
-    <a {...props} className={css.link} />
+    <a {...props} className={linkStyles.link} />
   ) : (
     <ExternalLink {...props} />
   );

--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -119,6 +119,12 @@ export const RoutePageFactory = {
       artifactType,
     ).replace(`:${RouteParams.ID}`, '' + artifactId);
   },
+  executionDetails: (executionType: string, executionId: number) => {
+    return RoutePage.EXECUTION_DETAILS.replace(
+      `:${RouteParams.EXECUTION_TYPE}+`,
+      executionType,
+    ).replace(`:${RouteParams.ID}`, '' + executionId);
+  },
   pipelineDetails: (id: string) => {
     return RoutePage.PIPELINE_DETAILS_NO_VERSION.replace(`:${RouteParams.pipelineId}`, id);
   },

--- a/frontend/src/lib/MlmdUtils.ts
+++ b/frontend/src/lib/MlmdUtils.ts
@@ -1,0 +1,90 @@
+import {
+  Context,
+  Api,
+  Execution,
+  getResourceProperty,
+  ExecutionProperties,
+  ExecutionCustomProperties,
+} from '@kubeflow/frontend';
+import {
+  GetContextByTypeAndNameRequest,
+  GetExecutionsByContextRequest,
+} from '@kubeflow/frontend/src/mlmd/generated/ml_metadata/proto/metadata_store_service_pb';
+
+/**
+ * @throws error when network error
+ */
+export async function getTfxRunContext(argoWorkflowName: string): Promise<Context> {
+  // argoPodName has the general form "pipelineName-workflowId-executionId".
+  // All components of a pipeline within a single run will have the same
+  // "pipelineName-workflowId" prefix.
+  const pipelineName = argoWorkflowName
+    .split('-')
+    .slice(0, -1)
+    .join('_');
+  const runID = argoWorkflowName;
+  // An example run context name is parameterized_tfx_oss.parameterized-tfx-oss-4rq5v.
+  const tfxRunContextName = `${pipelineName}.${runID}`;
+
+  const request = new GetContextByTypeAndNameRequest();
+  request.setTypeName('run');
+  request.setContextName(tfxRunContextName);
+  try {
+    const res = await Api.getInstance().metadataStoreService.getContextByTypeAndName(request);
+    const context = res.getContext();
+    if (context == null) {
+      throw new Error('response.getContext() is empty');
+    }
+    return context;
+  } catch (err) {
+    err.message = `Cannot find run context with name "${tfxRunContextName}": ` + err.message;
+    throw err;
+  }
+}
+
+/**
+ * @throws error when network error
+ */
+export async function getExecutionsFromContext(context: Context): Promise<Execution[]> {
+  const request = new GetExecutionsByContextRequest();
+  request.setContextId(context.getId());
+  try {
+    const res = await Api.getInstance().metadataStoreService.getExecutionsByContext(request);
+    const list = res.getExecutionsList();
+    if (list == null) {
+      throw new Error('response.getExecutionsList() is empty');
+    }
+    return list;
+  } catch (err) {
+    err.message =
+      `Cannot find executions by context ${context.getId()} with name ${context.getName()}: ` +
+      err.message;
+    throw err;
+  }
+}
+
+export enum KfpExecutionProperties {
+  KFP_POD_NAME = 'kfp_pod_name',
+}
+
+export const ExecutionHelpers = {
+  getPipeline(execution: Execution): string | number | undefined {
+    return (
+      getResourceProperty(execution, ExecutionProperties.PIPELINE_NAME) ||
+      getResourceProperty(execution, ExecutionCustomProperties.WORKSPACE, true) ||
+      getResourceProperty(execution, ExecutionCustomProperties.RUN_ID, true) ||
+      undefined
+    );
+  },
+  getName(execution: Execution): string | number | undefined {
+    return (
+      getResourceProperty(execution, ExecutionProperties.NAME) ||
+      getResourceProperty(execution, ExecutionProperties.COMPONENT_ID) ||
+      getResourceProperty(execution, ExecutionCustomProperties.TASK_ID, true) ||
+      undefined
+    );
+  },
+  getState(execution: Execution): string | number | undefined {
+    return getResourceProperty(execution, ExecutionProperties.STATE) || undefined;
+  },
+};

--- a/frontend/src/pages/ExecutionList.tsx
+++ b/frontend/src/pages/ExecutionList.tsx
@@ -18,12 +18,9 @@ import {
   Api,
   Execution,
   ExecutionType,
-  ExecutionProperties,
-  ExecutionCustomProperties,
   GetExecutionsRequest,
   GetExecutionTypesRequest,
   ListRequest,
-  getResourceProperty,
 } from '@kubeflow/frontend';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
@@ -46,6 +43,7 @@ import {
   serviceErrorToString,
 } from '../lib/Utils';
 import { RoutePage, RouteParams } from '../components/Router';
+import { ExecutionHelpers } from 'src/lib/MlmdUtils';
 
 interface ExecutionListState {
   executions: Execution[];
@@ -216,13 +214,9 @@ class ExecutionList extends Page<{}, ExecutionListState> {
           return {
             id: `${type}:${execution.getId()}`, // Join with colon so we can build the link
             otherFields: [
-              getResourceProperty(execution, ExecutionProperties.PIPELINE_NAME) ||
-                getResourceProperty(execution, ExecutionCustomProperties.WORKSPACE, true) ||
-                getResourceProperty(execution, ExecutionCustomProperties.RUN_ID, true),
-              getResourceProperty(execution, ExecutionProperties.NAME) ||
-                getResourceProperty(execution, ExecutionProperties.COMPONENT_ID) ||
-                getResourceProperty(execution, ExecutionCustomProperties.TASK_ID, true),
-              getResourceProperty(execution, ExecutionProperties.STATE),
+              ExecutionHelpers.getPipeline(execution),
+              ExecutionHelpers.getName(execution),
+              ExecutionHelpers.getState(execution),
               execution.getId(),
               type,
             ],

--- a/frontend/src/pages/Page.tsx
+++ b/frontend/src/pages/Page.tsx
@@ -30,6 +30,13 @@ export interface PageProps extends RouteComponentProps {
   updateToolbar: (toolbarProps: Partial<ToolbarProps>) => void;
 }
 
+export type PageErrorHandler = (
+  message: string,
+  error?: Error,
+  mode?: 'error' | 'warning',
+  refresh?: () => Promise<void>,
+) => Promise<void>;
+
 export abstract class Page<P, S> extends React.Component<P & PageProps, S> {
   protected _isMounted = true;
 
@@ -60,11 +67,7 @@ export abstract class Page<P, S> extends React.Component<P & PageProps, S> {
     this.props.updateBanner({});
   }
 
-  public async showPageError(
-    message: string,
-    error?: Error,
-    mode?: 'error' | 'warning',
-  ): Promise<void> {
+  public showPageError: PageErrorHandler = async (message, error, mode, refresh): Promise<void> => {
     const errorMessage = await errorToMessage(error);
     if (!this._isMounted) {
       return;
@@ -73,9 +76,9 @@ export abstract class Page<P, S> extends React.Component<P & PageProps, S> {
       additionalInfo: errorMessage ? errorMessage : undefined,
       message: message + (errorMessage ? ' Click Details for more information.' : ''),
       mode: mode || 'error',
-      refresh: this.refresh.bind(this),
+      refresh: refresh || this.refresh.bind(this),
     });
-  }
+  };
 
   public showErrorDialog(title: string, content: string): void {
     if (!this._isMounted) {

--- a/frontend/src/pages/RunDetails.test.tsx
+++ b/frontend/src/pages/RunDetails.test.tsx
@@ -31,6 +31,17 @@ import TestUtils, { diff } from '../TestUtils';
 import { PageProps } from './Page';
 import { RunDetails, RunDetailsInternalProps } from './RunDetails';
 
+const STEP_TABS = {
+  ARTIFACTS: 0,
+  INPUT_OUTPUT: 1,
+  ML_METADATA: 2,
+  VOLUMES: 3,
+  MANIFEST: 4,
+  LOGS: 5,
+  POD: 6,
+  EVENTS: 7,
+};
+
 const NODE_DETAILS_SELECTOR = '[data-testid="run-details-node-details"]';
 describe('RunDetails', () => {
   let updateBannerSpy: any;
@@ -684,9 +695,9 @@ describe('RunDetails', () => {
     tree
       .find('MD2Tabs')
       .at(1)
-      .simulate('switch', 1);
+      .simulate('switch', STEP_TABS.INPUT_OUTPUT);
     await TestUtils.flushPromises();
-    expect(tree.state('sidepanelSelectedTab')).toEqual(1);
+    expect(tree.state('sidepanelSelectedTab')).toEqual(STEP_TABS.INPUT_OUTPUT);
     expect(tree).toMatchSnapshot();
   });
 
@@ -701,8 +712,8 @@ describe('RunDetails', () => {
     tree
       .find('MD2Tabs')
       .at(1)
-      .simulate('switch', 2);
-    expect(tree.state('sidepanelSelectedTab')).toEqual(2);
+      .simulate('switch', STEP_TABS.VOLUMES);
+    expect(tree.state('sidepanelSelectedTab')).toEqual(STEP_TABS.VOLUMES);
     expect(tree).toMatchSnapshot();
   });
 
@@ -717,8 +728,8 @@ describe('RunDetails', () => {
     tree
       .find('MD2Tabs')
       .at(1)
-      .simulate('switch', 3);
-    expect(tree.state('sidepanelSelectedTab')).toEqual(3);
+      .simulate('switch', STEP_TABS.MANIFEST);
+    expect(tree.state('sidepanelSelectedTab')).toEqual(STEP_TABS.MANIFEST);
     expect(tree).toMatchSnapshot();
   });
 
@@ -749,14 +760,14 @@ describe('RunDetails', () => {
     tree
       .find('MD2Tabs')
       .at(1)
-      .simulate('switch', 4);
+      .simulate('switch', STEP_TABS.LOGS);
     expect(tree.state('selectedNodeDetails')).toHaveProperty('id', 'node1');
-    expect(tree.state('sidepanelSelectedTab')).toEqual(4);
+    expect(tree.state('sidepanelSelectedTab')).toEqual(STEP_TABS.LOGS);
 
     await (tree.instance() as RunDetails).refresh();
     expect(getRunSpy).toHaveBeenCalledTimes(2);
     expect(tree.state('selectedNodeDetails')).toHaveProperty('id', 'node1');
-    expect(tree.state('sidepanelSelectedTab')).toEqual(4);
+    expect(tree.state('sidepanelSelectedTab')).toEqual(STEP_TABS.LOGS);
   });
 
   it('keeps side pane open and on same tab when more nodes are added after refresh', async () => {
@@ -775,14 +786,14 @@ describe('RunDetails', () => {
     tree
       .find('MD2Tabs')
       .at(1)
-      .simulate('switch', 4);
+      .simulate('switch', STEP_TABS.LOGS);
     expect(tree.state('selectedNodeDetails')).toHaveProperty('id', 'node1');
-    expect(tree.state('sidepanelSelectedTab')).toEqual(4);
+    expect(tree.state('sidepanelSelectedTab')).toEqual(STEP_TABS.LOGS);
 
     await (tree.instance() as RunDetails).refresh();
     expect(getRunSpy).toHaveBeenCalledTimes(2);
     expect(tree.state('selectedNodeDetails')).toHaveProperty('id', 'node1');
-    expect(tree.state('sidepanelSelectedTab')).toEqual(4);
+    expect(tree.state('sidepanelSelectedTab')).toEqual(STEP_TABS.LOGS);
   });
 
   it('keeps side pane open and on same tab when run status changes, shows new status', async () => {
@@ -796,9 +807,9 @@ describe('RunDetails', () => {
     tree
       .find('MD2Tabs')
       .at(1)
-      .simulate('switch', 4);
+      .simulate('switch', STEP_TABS.LOGS);
     expect(tree.state('selectedNodeDetails')).toHaveProperty('id', 'node1');
-    expect(tree.state('sidepanelSelectedTab')).toEqual(4);
+    expect(tree.state('sidepanelSelectedTab')).toEqual(STEP_TABS.LOGS);
     expect(updateToolbarSpy).toHaveBeenCalledTimes(3);
 
     const thirdCall = updateToolbarSpy.mock.calls[2][0];
@@ -821,7 +832,7 @@ describe('RunDetails', () => {
     tree
       .find('MD2Tabs')
       .at(1)
-      .simulate('switch', 4);
+      .simulate('switch', STEP_TABS.LOGS);
     expect(tree.state('selectedNodeDetails')).toHaveProperty('phaseMessage', undefined);
 
     testRun.pipeline_runtime!.workflow_manifest = JSON.stringify({
@@ -849,7 +860,7 @@ describe('RunDetails', () => {
     tree
       .find('MD2Tabs')
       .at(1)
-      .simulate('switch', 4);
+      .simulate('switch', STEP_TABS.LOGS);
     expect(tree.state('selectedNodeDetails')).toHaveProperty(
       'phaseMessage',
       'This step is in Succeeded state with this message: some node message',
@@ -938,8 +949,8 @@ describe('RunDetails', () => {
       tree
         .find('MD2Tabs')
         .at(1)
-        .simulate('switch', 4);
-      expect(tree.state('sidepanelSelectedTab')).toEqual(4);
+        .simulate('switch', STEP_TABS.LOGS);
+      expect(tree.state('sidepanelSelectedTab')).toEqual(STEP_TABS.LOGS);
       expect(tree).toMatchSnapshot();
     });
 
@@ -954,7 +965,7 @@ describe('RunDetails', () => {
       tree
         .find('MD2Tabs')
         .at(1)
-        .simulate('switch', 4);
+        .simulate('switch', STEP_TABS.LOGS);
       await getPodLogsSpy;
       expect(getPodLogsSpy).toHaveBeenCalledTimes(1);
       expect(getPodLogsSpy).toHaveBeenLastCalledWith('node1', undefined);
@@ -977,7 +988,7 @@ describe('RunDetails', () => {
       tree
         .find('MD2Tabs')
         .at(1)
-        .simulate('switch', 4);
+        .simulate('switch', STEP_TABS.LOGS);
       await getPodLogsSpy;
       await TestUtils.flushPromises();
       expect(tree.find(NODE_DETAILS_SELECTOR)).toMatchInlineSnapshot(`
@@ -1036,7 +1047,7 @@ describe('RunDetails', () => {
       tree
         .find('MD2Tabs')
         .at(1)
-        .simulate('switch', 4);
+        .simulate('switch', STEP_TABS.LOGS);
       await getPodLogsSpy;
       expect(getPodLogsSpy).toHaveBeenCalledTimes(1);
       expect(getPodLogsSpy).toHaveBeenLastCalledWith('node1', 'username');
@@ -1059,7 +1070,7 @@ describe('RunDetails', () => {
       tree
         .find('MD2Tabs')
         .at(1)
-        .simulate('switch', 4);
+        .simulate('switch', STEP_TABS.LOGS);
       await getPodLogsSpy;
       await TestUtils.flushPromises();
       expect(tree.find(NODE_DETAILS_SELECTOR)).toMatchInlineSnapshot(`
@@ -1108,7 +1119,7 @@ describe('RunDetails', () => {
       tree
         .find('MD2Tabs')
         .at(1)
-        .simulate('switch', 4);
+        .simulate('switch', STEP_TABS.LOGS);
       await getPodLogsSpy;
       await TestUtils.flushPromises();
       expect(tree.find('[data-testid="run-details-node-details"]')).toMatchInlineSnapshot(`
@@ -1148,7 +1159,7 @@ describe('RunDetails', () => {
       tree
         .find('MD2Tabs')
         .at(1)
-        .simulate('switch', 4);
+        .simulate('switch', STEP_TABS.LOGS);
       await getPodLogsSpy;
       await TestUtils.flushPromises();
       expect(getPodLogsSpy).not.toHaveBeenCalled();
@@ -1170,9 +1181,9 @@ describe('RunDetails', () => {
       tree
         .find('MD2Tabs')
         .at(1)
-        .simulate('switch', 4);
+        .simulate('switch', STEP_TABS.LOGS);
       expect(tree.state('selectedNodeDetails')).toHaveProperty('id', 'node1');
-      expect(tree.state('sidepanelSelectedTab')).toEqual(4);
+      expect(tree.state('sidepanelSelectedTab')).toEqual(STEP_TABS.LOGS);
 
       getPodLogsSpy.mockImplementationOnce(() => 'new test logs');
       await (tree.instance() as RunDetails).refresh();
@@ -1191,7 +1202,7 @@ describe('RunDetails', () => {
       tree
         .find('MD2Tabs')
         .at(1)
-        .simulate('switch', 4);
+        .simulate('switch', STEP_TABS.LOGS);
       await getPodLogsSpy;
       await TestUtils.flushPromises();
       expect(tree.state()).toMatchObject({

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -38,7 +38,7 @@ import Graph from '../components/Graph';
 import LogViewer from '../components/LogViewer';
 import MinioArtifactLink from '../components/MinioArtifactLink';
 import PlotCard from '../components/PlotCard';
-import { RoutePage, RouteParams } from '../components/Router';
+import { RoutePage, RouteParams, RoutePageFactory } from '../components/Router';
 import SidePanel from '../components/SidePanel';
 import { ToolbarProps } from '../components/Toolbar';
 import { HTMLViewerConfig } from '../components/viewers/HTMLViewer';
@@ -66,10 +66,19 @@ import WorkflowParser from '../lib/WorkflowParser';
 import { Page, PageProps } from './Page';
 import { statusToIcon } from './Status';
 import { PodEvents, PodInfo } from '../components/PodYaml';
+import { Link } from 'react-router-dom';
+import {
+  getTfxRunContext,
+  getExecutionsFromContext,
+  KfpExecutionProperties,
+  ExecutionHelpers,
+} from 'src/lib/MlmdUtils';
+import { Context, Execution, getResourceProperty } from '@kubeflow/frontend';
 
 enum SidePaneTab {
   ARTIFACTS,
   INPUT_OUTPUT,
+  ML_METADATA,
   VOLUMES,
   MANIFEST,
   LOGS,
@@ -118,6 +127,8 @@ interface RunDetailsState {
   sidepanelBusy: boolean;
   sidepanelSelectedTab: SidePaneTab;
   workflow?: Workflow;
+  mlmdRunContext?: Context;
+  mlmdExecutions?: Execution[];
 }
 
 export const css = stylesheet({
@@ -164,6 +175,8 @@ export class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
     selectedTab: 0,
     sidepanelBusy: false,
     sidepanelSelectedTab: SidePaneTab.ARTIFACTS,
+    mlmdRunContext: undefined,
+    mlmdExecutions: undefined,
   };
 
   private readonly AUTO_REFRESH_INTERVAL = 5000;
@@ -222,6 +235,8 @@ export class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
       selectedNodeDetails,
       sidepanelSelectedTab,
       workflow,
+      mlmdRunContext,
+      mlmdExecutions,
     } = this.state;
     const { projectId, clusterName } = this.props.gkeMetadata;
     const selectedNodeId = selectedNodeDetails ? selectedNodeDetails.id : '';
@@ -240,6 +255,11 @@ export class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
       workflow,
       selectedNodeId,
     );
+    const selectedExecution = mlmdExecutions?.find(
+      execution =>
+        getResourceProperty(execution, KfpExecutionProperties.KFP_POD_NAME) === selectedNodeId,
+    );
+    // const selectedExecution = mlmdExecutions && mlmdExecutions.find(execution => execution.getPropertiesMap())
     const hasMetrics = runMetadata && runMetadata.metrics && runMetadata.metrics.length > 0;
     const visualizationCreatorConfig: VisualizationCreatorConfig = {
       allowCustomVisualizations,
@@ -290,6 +310,7 @@ export class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                 tabs={[
                                   'Artifacts',
                                   'Input/Output',
+                                  'ML Metadata',
                                   'Volumes',
                                   'Manifest',
                                   'Logs',
@@ -343,6 +364,28 @@ export class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                       fields={outputArtifacts}
                                       valueComponent={MinioArtifactLink}
                                     />
+                                  </div>
+                                )}
+
+                                {sidepanelSelectedTab === SidePaneTab.ML_METADATA && (
+                                  <div className={padding(20)}>
+                                    {selectedExecution && (
+                                      <>
+                                        This step corresponds to execution{' '}
+                                        <Link
+                                          className={commonCss.link}
+                                          to={RoutePageFactory.executionDetails(
+                                            selectedExecution.getTypeId() + '',
+                                            selectedExecution.getId(),
+                                          )}
+                                        >
+                                          "{ExecutionHelpers.getName(selectedExecution)}".
+                                        </Link>
+                                      </>
+                                    )}
+                                    {!selectedExecution && (
+                                      <div>Corresponding ML Metadata not found.</div>
+                                    )}
                                   </div>
                                 )}
 
@@ -601,6 +644,20 @@ export class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
         }
       }
 
+      let mlmdRunContext: Context | undefined;
+      let mlmdExecutions: Execution[] | undefined;
+      // Get data about this workflow from MLMD
+      if (workflow.metadata?.name) {
+        try {
+          mlmdRunContext = await getTfxRunContext(workflow.metadata.name);
+          mlmdExecutions = await getExecutionsFromContext(mlmdRunContext);
+        } catch (err) {
+          // Data in MLMD may not exist depending on this pipeline is a TFX pipeline.
+          // So we only log the error in console.
+          logger.warn(err);
+        }
+      }
+
       // Build runtime graph
       const graph =
         workflow && workflow.status && workflow.status.nodes
@@ -664,6 +721,8 @@ export class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
         runFinished,
         runMetadata,
         workflow,
+        mlmdRunContext,
+        mlmdExecutions,
       });
     } catch (err) {
       await this.showPageError(`Error: failed to retrieve run: ${runId}.`, err);

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -74,6 +74,7 @@ import {
   ExecutionHelpers,
 } from 'src/lib/MlmdUtils';
 import { Context, Execution, getResourceProperty } from '@kubeflow/frontend';
+import { ExecutionDetailsContent } from './ExecutionDetails';
 
 enum SidePaneTab {
   ARTIFACTS,
@@ -235,7 +236,6 @@ export class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
       selectedNodeDetails,
       sidepanelSelectedTab,
       workflow,
-      mlmdRunContext,
       mlmdExecutions,
     } = this.state;
     const { projectId, clusterName } = this.props.gkeMetadata;
@@ -371,16 +371,30 @@ export class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                   <div className={padding(20)}>
                                     {selectedExecution && (
                                       <>
-                                        This step corresponds to execution{' '}
-                                        <Link
-                                          className={commonCss.link}
-                                          to={RoutePageFactory.executionDetails(
-                                            selectedExecution.getTypeId() + '',
-                                            selectedExecution.getId(),
-                                          )}
-                                        >
-                                          "{ExecutionHelpers.getName(selectedExecution)}".
-                                        </Link>
+                                        <div>
+                                          This step corresponds to execution{' '}
+                                          <Link
+                                            className={commonCss.link}
+                                            to={RoutePageFactory.executionDetails(
+                                              selectedExecution.getTypeId() + '',
+                                              selectedExecution.getId(),
+                                            )}
+                                          >
+                                            "{ExecutionHelpers.getName(selectedExecution)}".
+                                          </Link>
+                                        </div>
+                                        <ExecutionDetailsContent
+                                          key={selectedExecution.getId()}
+                                          id={selectedExecution.getId()}
+                                          onError={
+                                            ((msg: string, ...args: any[]) => {
+                                              // TODO: show a proper error banner and retry button
+                                              console.warn(msg);
+                                            }) as any
+                                          }
+                                          // No title here
+                                          onTitleUpdate={() => null}
+                                        />
                                       </>
                                     )}
                                     {!selectedExecution && (

--- a/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
@@ -562,11 +562,12 @@ exports[`RunDetails logs tab does not load logs if clicked node status is skippe
             >
               <MD2Tabs
                 onSwitch={[Function]}
-                selectedTab={4}
+                selectedTab={5}
                 tabs={
                   Array [
                     "Artifacts",
                     "Input/Output",
+                    "ML Metadata",
                     "Volumes",
                     "Manifest",
                     "Logs",
@@ -680,11 +681,12 @@ exports[`RunDetails logs tab keeps side pane open and on same tab when logs chan
             >
               <MD2Tabs
                 onSwitch={[Function]}
-                selectedTab={4}
+                selectedTab={5}
                 tabs={
                   Array [
                     "Artifacts",
                     "Input/Output",
+                    "ML Metadata",
                     "Volumes",
                     "Manifest",
                     "Logs",
@@ -798,11 +800,12 @@ exports[`RunDetails logs tab loads and shows logs in side pane 1`] = `
             >
               <MD2Tabs
                 onSwitch={[Function]}
-                selectedTab={4}
+                selectedTab={5}
                 tabs={
                   Array [
                     "Artifacts",
                     "Input/Output",
+                    "ML Metadata",
                     "Volumes",
                     "Manifest",
                     "Logs",
@@ -916,11 +919,12 @@ exports[`RunDetails logs tab switches to logs tab in side pane 1`] = `
             >
               <MD2Tabs
                 onSwitch={[Function]}
-                selectedTab={4}
+                selectedTab={5}
                 tabs={
                   Array [
                     "Artifacts",
                     "Input/Output",
+                    "ML Metadata",
                     "Volumes",
                     "Manifest",
                     "Logs",
@@ -1039,6 +1043,7 @@ exports[`RunDetails opens side panel when graph node is clicked 1`] = `
                   Array [
                     "Artifacts",
                     "Input/Output",
+                    "ML Metadata",
                     "Volumes",
                     "Manifest",
                     "Logs",
@@ -1283,6 +1288,7 @@ exports[`RunDetails shows clicked node message in side panel 1`] = `
                   Array [
                     "Artifacts",
                     "Input/Output",
+                    "ML Metadata",
                     "Volumes",
                     "Manifest",
                     "Logs",
@@ -1734,6 +1740,7 @@ exports[`RunDetails switches to inputs/outputs tab in side pane 1`] = `
                   Array [
                     "Artifacts",
                     "Input/Output",
+                    "ML Metadata",
                     "Volumes",
                     "Manifest",
                     "Logs",
@@ -1872,11 +1879,12 @@ exports[`RunDetails switches to manifest tab in side pane 1`] = `
             >
               <MD2Tabs
                 onSwitch={[Function]}
-                selectedTab={3}
+                selectedTab={4}
                 tabs={
                   Array [
                     "Artifacts",
                     "Input/Output",
+                    "ML Metadata",
                     "Volumes",
                     "Manifest",
                     "Logs",
@@ -2023,11 +2031,12 @@ exports[`RunDetails switches to volumes tab in side pane 1`] = `
             >
               <MD2Tabs
                 onSwitch={[Function]}
-                selectedTab={2}
+                selectedTab={3}
                 tabs={
                   Array [
                     "Artifacts",
                     "Input/Output",
+                    "ML Metadata",
                     "Volumes",
                     "Manifest",
                     "Logs",


### PR DESCRIPTION
Mitigates https://github.com/kubeflow/pipelines/issues/3424 and https://github.com/kubeflow/pipelines/issues/3226

Demo: https://youtu.be/ARsCElYSqq8

Changes:
* Find corresponding ML metadata for pipeline run (context) and steps (execution) from Run Details page
* Refactor execution details page component to be portable
* Show execution details on Run Details' step ML Metadata tab

Current Limitation:
* ML Metadata from mlmd writer doesn't record pod name in execution custom property `kfp_pod_name`, so it isn't recorded at all. Therefore, this only supports tfx. (but we can support kfp dsl later too)

/area frontend