### PR TITLE
Cache [MKP] - Create ServiceAccount, Roles and RoleBindings before running the deployer

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/cache.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/cache.yaml
@@ -4,6 +4,11 @@ metadata:
   name: kubeflow-pipelines-cache-deployer-sa
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
+  annotations:
+    #Need to create the ServiceAccount before the RoleBinding and the deployer
+    "helm.sh/hook": pre-install, pre-upgrade, pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -45,6 +50,11 @@ metadata:
     app: kubeflow-pipelines-cache-deployer-role
     app.kubernetes.io/name: {{ .Release.Name }}
   name: kubeflow-pipelines-cache-deployer-role
+  annotations:
+    #Need to create the Role before the RoleBinding and the deployer
+    "helm.sh/hook": pre-install, pre-upgrade, pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
 rules:
 - apiGroups:
   - ""
@@ -96,6 +106,11 @@ metadata:
   name: kubeflow-pipelines-cache-binding
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
+  annotations:
+    #Need to create the RoleBinding before the deployer
+    "helm.sh/hook": pre-install, pre-upgrade, pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -111,6 +126,11 @@ metadata:
   name: kubeflow-pipelines-cache-deployer-clusterrolebinding
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
+  annotations:
+    #Need to create the ClusterRoleBinding before the deployer
+    "helm.sh/hook": pre-install, pre-upgrade, pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -126,6 +146,10 @@ metadata:
   name: kubeflow-pipelines-cache-deployer-rolebinding
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
+    #Need to create the RoleBinding before the deployer
+    "helm.sh/hook": pre-install, pre-upgrade, pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
The MKP postsubmit tests are flaky. I suspect that the reson for the failure is that at the time the deployer job starts, the deployer service account is not bound to the roles yet, so it has no permissions and fails to create any resources.
This commit uses Heml hooks to solve the issue.
See https://helm.sh/docs/topics/charts_hooks/ https://github.com/helm/helm/issues/4884 https://github.com/helm/charts/blob/edecc9842d1a63758c3bd0fc13a5d019e079f656/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrolebinding.yaml

P.S. In the future we should switch the deployer to `Job`. Helm has explicit support for running pre-install hooks and will automatically wait for the job to complete and then delete the job and the deployer resources (job, service account, roles, rolebindings) https://github.com/helm/charts/blob/edecc9842d1a63758c3bd0fc13a5d019e079f656/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml