### PR TITLE
AWS sagemaker: fixed a bug in ground_truth and updated all components to use images from new docker hub repo

### DIFF
--- a/components/aws/sagemaker/batch_transform/component.yaml
+++ b/components/aws/sagemaker/batch_transform/component.yaml
@@ -74,7 +74,7 @@ outputs:
   - {name: output_location,    description: 'S3 URI of the transform job results.'}
 implementation:
   container:
-    image: redbackthomson/aws-kubeflow-sagemaker:20200402
+    image: amazon/aws-sagemaker-kfp-components:20200407
     command: ['python']
     args: [
       batch_transform.py,

--- a/components/aws/sagemaker/batch_transform/component.yaml
+++ b/components/aws/sagemaker/batch_transform/component.yaml
@@ -74,7 +74,7 @@ outputs:
   - {name: output_location,    description: 'S3 URI of the transform job results.'}
 implementation:
   container:
-    image: amazon/aws-sagemaker-kfp-components:20200407
+    image: amazon/aws-sagemaker-kfp-components:0.2
     command: ['python']
     args: [
       batch_transform.py,

--- a/components/aws/sagemaker/common/_utils.py
+++ b/components/aws/sagemaker/common/_utils.py
@@ -808,7 +808,7 @@ def get_labeling_job_outputs(client, labeling_job_name, auto_labeling):
     if auto_labeling:
         active_learning_model_arn = info['LabelingJobOutput']['FinalActiveLearningModelArn']
     else:
-        active_learning_model_arn = ''
+        active_learning_model_arn = ' '
     return output_manifest, active_learning_model_arn
 
 def enable_spot_instance_support(training_job_config, args):

--- a/components/aws/sagemaker/common/_utils.py
+++ b/components/aws/sagemaker/common/_utils.py
@@ -59,14 +59,17 @@ def nullable_string_argument(value):
         return None
     return value
 
+
 def add_default_client_arguments(parser):
     parser.add_argument('--region', type=str.strip, required=True, help='The region where the training job launches.')
     parser.add_argument('--endpoint_url', type=nullable_string_argument, required=False, help='The URL to use when communicating with the Sagemaker service.')
+
 
 def get_sagemaker_client(region, endpoint_url=None):
     """Builds a client to the AWS SageMaker API."""
     client = boto3.client('sagemaker', region_name=region, endpoint_url=endpoint_url)
     return client
+
 
 def create_training_job_request(args):
     ### Documentation: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.create_training_job

--- a/components/aws/sagemaker/deploy/component.yaml
+++ b/components/aws/sagemaker/deploy/component.yaml
@@ -79,7 +79,7 @@ outputs:
   - {name: endpoint_name,          description: 'Endpoint name'}
 implementation:
   container:
-    image: redbackthomson/aws-kubeflow-sagemaker:20200402
+    image: amazon/aws-sagemaker-kfp-components:20200407
     command: ['python']
     args: [
       deploy.py,

--- a/components/aws/sagemaker/deploy/component.yaml
+++ b/components/aws/sagemaker/deploy/component.yaml
@@ -79,7 +79,7 @@ outputs:
   - {name: endpoint_name,          description: 'Endpoint name'}
 implementation:
   container:
-    image: amazon/aws-sagemaker-kfp-components:20200407
+    image: amazon/aws-sagemaker-kfp-components:0.2
     command: ['python']
     args: [
       deploy.py,

--- a/components/aws/sagemaker/ground_truth/component.yaml
+++ b/components/aws/sagemaker/ground_truth/component.yaml
@@ -88,7 +88,7 @@ outputs:
   - {name: active_learning_model_arn, description: 'The ARN for the most recent Amazon SageMaker model trained as part of automated data labeling.'}
 implementation:
   container:
-    image: redbackthomson/aws-kubeflow-sagemaker:20200402
+    image: amazon/aws-sagemaker-kfp-components:20200407
     command: ['python']
     args: [
       ground_truth.py,

--- a/components/aws/sagemaker/ground_truth/component.yaml
+++ b/components/aws/sagemaker/ground_truth/component.yaml
@@ -88,7 +88,7 @@ outputs:
   - {name: active_learning_model_arn, description: 'The ARN for the most recent Amazon SageMaker model trained as part of automated data labeling.'}
 implementation:
   container:
-    image: amazon/aws-sagemaker-kfp-components:20200407
+    image: amazon/aws-sagemaker-kfp-components:0.2
     command: ['python']
     args: [
       ground_truth.py,

--- a/components/aws/sagemaker/hyperparameter_tuning/component.yaml
+++ b/components/aws/sagemaker/hyperparameter_tuning/component.yaml
@@ -139,7 +139,7 @@ outputs:
     description: 'The registry path of the Docker image that contains the training algorithm'
 implementation:
   container:
-    image: redbackthomson/aws-kubeflow-sagemaker:20200402
+    image: amazon/aws-sagemaker-kfp-components:20200407
     command: ['python']
     args: [
       hyperparameter_tuning.py,

--- a/components/aws/sagemaker/hyperparameter_tuning/component.yaml
+++ b/components/aws/sagemaker/hyperparameter_tuning/component.yaml
@@ -139,7 +139,7 @@ outputs:
     description: 'The registry path of the Docker image that contains the training algorithm'
 implementation:
   container:
-    image: amazon/aws-sagemaker-kfp-components:20200407
+    image: amazon/aws-sagemaker-kfp-components:0.2
     command: ['python']
     args: [
       hyperparameter_tuning.py,

--- a/components/aws/sagemaker/model/component.yaml
+++ b/components/aws/sagemaker/model/component.yaml
@@ -45,7 +45,7 @@ outputs:
   - {name: model_name,          description: 'The model name Sagemaker created'}
 implementation:
   container:
-    image: redbackthomson/aws-kubeflow-sagemaker:20200402
+    image: amazon/aws-sagemaker-kfp-components:20200407
     command: ['python']
     args: [
       create_model.py,

--- a/components/aws/sagemaker/model/component.yaml
+++ b/components/aws/sagemaker/model/component.yaml
@@ -45,7 +45,7 @@ outputs:
   - {name: model_name,          description: 'The model name Sagemaker created'}
 implementation:
   container:
-    image: amazon/aws-sagemaker-kfp-components:20200407
+    image: amazon/aws-sagemaker-kfp-components:0.2
     command: ['python']
     args: [
       create_model.py,

--- a/components/aws/sagemaker/train/component.yaml
+++ b/components/aws/sagemaker/train/component.yaml
@@ -103,7 +103,7 @@ outputs:
   - {name: training_image,        description: 'The registry path of the Docker image that contains the training algorithm'}
 implementation:
   container:
-    image: redbackthomson/aws-kubeflow-sagemaker:20200402
+    image: amazon/aws-sagemaker-kfp-components:20200407
     command: ['python']
     args: [
       train.py,

--- a/components/aws/sagemaker/train/component.yaml
+++ b/components/aws/sagemaker/train/component.yaml
@@ -103,7 +103,7 @@ outputs:
   - {name: training_image,        description: 'The registry path of the Docker image that contains the training algorithm'}
 implementation:
   container:
-    image: amazon/aws-sagemaker-kfp-components:20200407
+    image: amazon/aws-sagemaker-kfp-components:0.2
     command: ['python']
     args: [
       train.py,

--- a/components/aws/sagemaker/workteam/component.yaml
+++ b/components/aws/sagemaker/workteam/component.yaml
@@ -27,7 +27,7 @@ outputs:
   - {name: workteam_arn, description: 'The ARN of the workteam.'}
 implementation:
   container:
-    image: redbackthomson/aws-kubeflow-sagemaker:20200402
+    image: amazon/aws-sagemaker-kfp-components:20200407
     command: ['python']
     args: [
       workteam.py,

--- a/components/aws/sagemaker/workteam/component.yaml
+++ b/components/aws/sagemaker/workteam/component.yaml
@@ -27,7 +27,7 @@ outputs:
   - {name: workteam_arn, description: 'The ARN of the workteam.'}
 implementation:
   container:
-    image: amazon/aws-sagemaker-kfp-components:20200407
+    image: amazon/aws-sagemaker-kfp-components:0.2
     command: ['python']
     args: [
       workteam.py,

--- a/samples/contrib/aws-samples/ground_truth_pipeline_demo/README.md
+++ b/samples/contrib/aws-samples/ground_truth_pipeline_demo/README.md
@@ -18,18 +18,21 @@ Create a s3 bucket and run [this python script](https://github.com/kubeflow/pipe
 
 ## Amazon Cognito user groups
 
-To use the workteam component, you must have an Amazon Cognito user group(s) set up with the workers you want for the workteam.
+From Cognito note down Pool ID, User Group Name and client ID  
+You need this information to fill arguments user_pool, user_groups and client_ID
 
-For this demo, please create a user group with only yourself in it.
+[Official doc for Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-getting-started.html)
 
-If this is your first time creating a private workteam in the region you are using, follow the steps below to set up a new user pool, user group, and app client ID on Amazon Cognito.
-If you already have private workteams in the region you are using, skip step 1 and do steps 2 and 3 in the user pool that is already being used.
+For this demo you can create a new user pool (if you don't have one already).   
 
-Steps:
-1. Create a user pool in Amazon Cognito. Configure the user pool as needed, and make sure to create an app client. The Pool ID will be found under General settings.
-2. After creating the user pool, go to the Users and Groups section and create a group. Create users for the team, and add those users to the group.
-3. Under App integration > Domain name, create an Amazon Cognito domain for the user pool.
+AWS console -> Amazon SageMaker -> Ground Truth, Labeling workforces -> Private -> Create Private Team -> Give it "KFP-ground-truth-demo-pool" name and use your email address -> Create Private team -> Click on the radio button and from summary note down the "Amazon Cognito user pool", "App client" and "Labeling portal sign-in URL" -> click on the team name that you created and note down "Amazon Cognito user group"
 
+Use the info that you noted down to fill arguments for the pipeline  
+user_pool = Amazon Cognito user pool  
+user_groups = Amazon Cognito user group  
+client_ID = App client  
+
+> Note : Once you start a run on the pipeline you will receive the ground_truth labeling jobs at "Labeling portal sign-in URL" link 
 
 ## SageMaker permission
 
@@ -56,6 +59,7 @@ data:
 
 Follow the guide to [building a pipeline](https://www.kubeflow.org/docs/guides/pipelines/build-pipeline/) to install the Kubeflow Pipelines SDK, then run the following command to compile the sample Python into a workflow specification. The specification takes the form of a YAML file compressed into a `.tar.gz` file.
 
+
 ```bash
 dsl-compile --py mini-image-classification-pipeline.py --output mini-image-classification-pipeline.tar.gz
 ```
@@ -66,11 +70,14 @@ Open the Kubeflow pipelines UI. Create a new pipeline, and then upload the compi
 
 The pipeline requires several arguments - replace `role_arn`, Amazon Cognito information, and the S3 input paths with your settings, and run the pipeline.
 
+> Note : team_name, ground_truth_train_job_name and ground_truth_validation_job_name need to be unique or else pipeline will error out if the names already exist
+
 If you are a new worker, you will receive an email with a link to the labeling portal and login information after the create workteam component completes.
 During the execution of the two Ground Truth components (one for training data, one for validation data), the labeling jobs will appear in the portal and you will need to complete these jobs.  
 
 After the pipeline finished, you may delete the user pool/ user group and the S3 bucket.
 
+  
 
 ## Components source
 


### PR DESCRIPTION
AWS ground_truth component expects active_learning_model_arn.txt to be always non-empty 
[component.yaml #L129](https://github.com/kubeflow/pipelines/blob/cfcd824ed1c7bb6924cee30b14e49d281f1d4a73/components/aws/sagemaker/ground_truth/component.yaml#L129)

But when we don't pass the optional argument "enable_auto_labeling", empty string is stored in [active_learning_model_arn.txt](https://github.com/kubeflow/pipelines/blob/cfcd824ed1c7bb6924cee30b14e49d281f1d4a73/components/aws/sagemaker/ground_truth/src/ground_truth.py#L71)

- [string variable which gets stored in active_learning_model_arn.txt](https://github.com/kubeflow/pipelines/blob/cfcd824ed1c7bb6924cee30b14e49d281f1d4a73/components/aws/sagemaker/ground_truth/src/ground_truth.py#L64) 
- [util function which returns that value](https://github.com/kubeflow/pipelines/blob/cfcd824ed1c7bb6924cee30b14e49d281f1d4a73/components/aws/sagemaker/common/_utils.py#L804)

Solved the issue by storing space instead of empty string 

Error message: 
```
This step is in Error state with this message: failed to save outputs: 
path /tmp/active_learning_model_arn.txt does not exist (or /tmp/active_learning_model_arn.txt is empty)
```
----------

uploaded this change to new docker hub repo 
and
updated readme for ground_truth_pipeline_demo pipeline