### PR TITLE
[UI - multiuser] Fix pod log namespace source

### DIFF
--- a/frontend/src/lib/RunUtils.ts
+++ b/frontend/src/lib/RunUtils.ts
@@ -28,6 +28,7 @@ import {
 } from '../apis/run';
 import { logger } from './Utils';
 import WorkflowParser from './WorkflowParser';
+import { ApiExperiment } from 'src/apis/experiment';
 
 export interface MetricMetadata {
   count: number;
@@ -117,7 +118,7 @@ function getAllExperimentReferences(run?: ApiRun | ApiJob): ApiResourceReference
   );
 }
 
-function getNamespaceReferenceName(run?: ApiRun | ApiJob): string | undefined {
+function getNamespaceReferenceName(run?: ApiExperiment): string | undefined {
   // There should be only one namespace reference.
   const namespaceRef =
     run &&

--- a/frontend/src/pages/RunDetails.test.tsx
+++ b/frontend/src/pages/RunDetails.test.tsx
@@ -1021,14 +1021,9 @@ describe('RunDetails', () => {
 
     it("loads logs in run's namespace", async () => {
       testRun.pipeline_runtime!.workflow_manifest = JSON.stringify({
+        metadata: { namespace: 'username' },
         status: { nodes: { node1: { id: 'node1' } } },
       });
-      testRun.run!.resource_references = [
-        {
-          key: { type: ApiResourceType.NAMESPACE, id: 'username' },
-          relationship: ApiRelationship.OWNER,
-        },
-      ];
       tree = shallow(<RunDetails {...generateProps()} />);
       await getRunSpy;
       await TestUtils.flushPromises();

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -784,7 +784,7 @@ export class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
     try {
       const logs = await Apis.getPodLogs(
         selectedNodeDetails.id,
-        RunUtils.getNamespaceReferenceName(this.state.runMetadata),
+        this.state.workflow?.metadata?.namespace || '',
       );
       selectedNodeDetails.logs = logs;
       this.setStateSafe({

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -784,7 +784,7 @@ export class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
     try {
       const logs = await Apis.getPodLogs(
         selectedNodeDetails.id,
-        this.state.workflow?.metadata?.namespace || '',
+        this.state.workflow?.metadata?.namespace,
       );
       selectedNodeDetails.logs = logs;
       this.setStateSafe({


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/3290

After change in https://github.com/kubeflow/pipelines/pull/3403,
we can no longer get namespace from resource reference, instead read it from workflow metadata

Problem
now UI cannot read pod logs because it cannot get namespace when in multi user mode

/area frontend
