### PR TITLE
SDK - Components - Restored the yaml formatting style

### DIFF
--- a/sdk/python/kfp/components/_yaml_utils.py
+++ b/sdk/python/kfp/components/_yaml_utils.py
@@ -50,8 +50,8 @@ def dump_yaml(data):
                 #print('Switching style for multiline text:' + data)
                 style = '|'
             return self.represent_scalar(u'tag:yaml.org,2002:str', data, style)
-    
-        OrderedDumper.add_representer(str, represent_str_or_text)   
-        
+
+        OrderedDumper.add_representer(str, represent_str_or_text)
+
         return yaml.dump(data, stream, OrderedDumper, **kwds)
-    return ordered_dump(data)
+    return ordered_dump(data, default_flow_style=None)


### PR DESCRIPTION
Fixing compatibility with PyYaml 5.3