### PR TITLE
Add s3fs package to support visualization of s3 data

### DIFF
--- a/backend/src/apiserver/visualization/requirements.txt
+++ b/backend/src/apiserver/visualization/requirements.txt
@@ -9,6 +9,7 @@ nbconvert==5.5.0
 nbformat==4.4.0
 pandas==0.24.2
 pyarrow==0.15.1
+s3fs==0.4.2
 scikit_learn==0.21.2
 tensorflow-metadata==0.21.1
 tensorflow-model-analysis==0.21.5


### PR DESCRIPTION
Right now pipeline artifacts stored on s3 cannot be visualized because of the following error:
`ImportError: The s3fs library is required to handle s3 files`

The error takes place because pandas library is used to render at least Table Visualization and if we use s3 source it misses the optional package - s3fs (https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#optional-dependencies)