### PR TITLE
[Testing] Reduce image build flakiness by share and retry cloudbuild jobs

### DIFF
--- a/test/build-images.sh
+++ b/test/build-images.sh
@@ -50,9 +50,9 @@ else
   # The object name is inited as ${TEST_RESULTS_GCS_DIR} below, so it always has ${COMMIT_SHA} in it.
   ongoing_build_ids=($(gcloud builds list --filter='source.storageSource.object~'${COMMIT_SHA}' AND (status=QUEUED OR status=WORKING)' --format='value(id)'))
   if [ "${#ongoing_build_ids[@]}" -gt "0" ]; then
-    echo "There is an existing cloud build job, wait for it: id=${ongoing_build_ids[1]}"
+    echo "There is an existing cloud build job, wait for it: id=${ongoing_build_ids[0]}"
     IMAGES_BUILDING=true
-    BUILD_IDS=(${ongoing_build_ids[1]})
+    BUILD_IDS=(${ongoing_build_ids[0]})
   else
     echo "submitting cloud build to build docker images for commit ${COMMIT_SHA}..."
     IMAGES_BUILDING=true
@@ -61,10 +61,10 @@ else
       --async \
       --format='value(id)' \
       --substitutions=_GCR_BASE=${GCR_IMAGE_BASE_DIR} \
-      --gcs-source-staging-dir ${TEST_RESULTS_GCS_DIR}/cloudbuild \
     )
     BUILD_ID_BATCH=$(gcloud builds submit ${CLOUD_BUILD_COMMON_ARGS[@]} \
-      --config ${DIR}/cloudbuild/batch_build.yaml)
+      --config ${DIR}/cloudbuild/batch_build.yaml) \
+      --gcs-source-staging-dir ${TEST_RESULTS_GCS_DIR}/cloudbuild
 
     BUILD_IDS=("${BUILD_ID_BATCH}")
     echo "Submitted the following cloud build jobs: ${BUILD_IDS[@]}"

--- a/test/build-images.sh
+++ b/test/build-images.sh
@@ -63,8 +63,8 @@ else
       --substitutions=_GCR_BASE=${GCR_IMAGE_BASE_DIR} \
     )
     BUILD_ID_BATCH=$(gcloud builds submit ${CLOUD_BUILD_COMMON_ARGS[@]} \
-      --config ${DIR}/cloudbuild/batch_build.yaml) \
-      --gcs-source-staging-dir ${TEST_RESULTS_GCS_DIR}/cloudbuild
+      --config ${DIR}/cloudbuild/batch_build.yaml \
+      --gcs-source-staging-dir ${TEST_RESULTS_GCS_DIR}/cloudbuild)
 
     BUILD_IDS=("${BUILD_ID_BATCH}")
     echo "Submitted the following cloud build jobs: ${BUILD_IDS[@]}"

--- a/test/build-images.sh
+++ b/test/build-images.sh
@@ -48,7 +48,7 @@ else
   sleep $((RANDOM%30))
 
   # The object name is inited as ${TEST_RESULTS_GCS_DIR} below, so it always has ${COMMIT_SHA} in it.
-  ongoing_build_ids=$(gcloud builds list --filter='source.storageSource.object~'${COMMIT_SHA}' AND (status=QUEUED OR status=WORKING)' --format='value(id)')
+  ongoing_build_ids=($(gcloud builds list --filter='source.storageSource.object~'${COMMIT_SHA}' AND (status=QUEUED OR status=WORKING)' --format='value(id)'))
   if [ "${#ongoing_build_ids[@]}" -gt "0" ]; then
     echo "There is an existing cloud build job, wait for it: id=${ongoing_build_ids[1]}"
     IMAGES_BUILDING=true

--- a/test/build-images.sh
+++ b/test/build-images.sh
@@ -44,12 +44,12 @@ BUILD_IDS=()
 function build_image {
   local build_target=$1
   # sleep randomly to reduce chance of submitting two cloudbuild jobs at the same time
-  sleep $((RANDOM%10))
+  sleep $((RANDOM%30))
 
   # The object name is inited as ${TEST_RESULTS_GCS_DIR} below, so it always has ${COMMIT_SHA} in it.
   local ongoing_build_ids=($(gcloud builds list \
-    --filter='source.storageSource.object~'${COMMIT_SHA}.*/${build_target}' \
-    AND (status=QUEUED OR status=WORKING)' --format='value(id)'))
+    --filter='source.storageSource.object~'${COMMIT_SHA}.*/${build_target}' AND (status=QUEUED OR status=WORKING)' \
+    --format='value(id)'))
   if [ "${#ongoing_build_ids[@]}" -gt "0" ]; then
     echo "There is an existing cloud build job, wait for it: id=${ongoing_build_ids[0]}"
     BUILD_IDS+=("${ongoing_build_ids[0]}")

--- a/test/build-images.sh
+++ b/test/build-images.sh
@@ -18,10 +18,9 @@ set -ex
 
 IMAGES_BUILDING=false
 
-function has_images_been_built {
+function has_batch_images_been_built {
   local images=$(gcloud container images list --repository=${GCR_IMAGE_BASE_DIR})
   local result=1
-  echo "$images" | grep api-server && \
   echo "$images" | grep frontend && \
   echo "$images" | grep scheduledworkflow && \
   echo "$images" | grep persistenceagent && \
@@ -34,39 +33,62 @@ function has_images_been_built {
   return $result
 }
 
-# Image caching can be turned off by setting $DISABLE_IMAGE_CACHING env flag.
-# Note that GCR_IMAGE_BASE_DIR contains commit hash, so whenever there's a code
-# change, we won't use caches for sure.
-if
-  test -z "$DISABLE_IMAGE_CACHING" && has_images_been_built
-then
-  echo "docker images for api-server, frontend, scheduledworkflow, \
-    persistenceagent, viewer-crd-controller, inverse-proxy-agent, metadata-writer, cache-server, \
-    cache-deployer and visualization-server are already built in ${GCR_IMAGE_BASE_DIR}."
-else
+function has_api_server_image_been_built {
+  local images=$(gcloud container images list --repository=${GCR_IMAGE_BASE_DIR})
+  local result=1
+  echo "$images" | grep api-server && result=0
+  return $result
+}
+
+BUILD_IDS=()
+function build_image {
+  local build_target = $1
   # sleep randomly to reduce chance of submitting two cloudbuild jobs at the same time
-  sleep $((RANDOM%30))
+  sleep $((RANDOM%10))
 
   # The object name is inited as ${TEST_RESULTS_GCS_DIR} below, so it always has ${COMMIT_SHA} in it.
-  ongoing_build_ids=($(gcloud builds list --filter='source.storageSource.object~'${COMMIT_SHA}' AND (status=QUEUED OR status=WORKING)' --format='value(id)'))
+  local ongoing_build_ids=($(gcloud builds list \
+    --filter='source.storageSource.object~'${COMMIT_SHA}.*/${build_target}' \
+    AND (status=QUEUED OR status=WORKING)' --format='value(id)'))
   if [ "${#ongoing_build_ids[@]}" -gt "0" ]; then
     echo "There is an existing cloud build job, wait for it: id=${ongoing_build_ids[0]}"
-    IMAGES_BUILDING=true
-    BUILD_IDS=(${ongoing_build_ids[0]})
+    BUILD_IDS+="${ongoing_build_ids[0]}"
   else
-    echo "submitting cloud build to build docker images for commit ${COMMIT_SHA}..."
-    IMAGES_BUILDING=true
-    CLOUD_BUILD_COMMON_ARGS=( \
+    echo "submitting cloud build to build docker images for commit ${COMMIT_SHA} and target ${build_target}..."
+    local common_args=( \
       $remote_code_archive_uri \
       --async \
       --format='value(id)' \
       --substitutions=_GCR_BASE=${GCR_IMAGE_BASE_DIR} \
     )
-    BUILD_ID_BATCH=$(gcloud builds submit ${CLOUD_BUILD_COMMON_ARGS[@]} \
-      --config ${DIR}/cloudbuild/batch_build.yaml \
-      --gcs-source-staging-dir ${TEST_RESULTS_GCS_DIR}/cloudbuild)
+    local build_id=$(gcloud builds submit ${common_args[@]} \
+      --config ${DIR}/cloudbuild/${build_target}.yaml \
+      --gcs-source-staging-dir "${TEST_RESULTS_GCS_DIR}/cloudbuild/${build_target}")
 
-    BUILD_IDS=("${BUILD_ID_BATCH}")
-    echo "Submitted the following cloud build jobs: ${BUILD_IDS[@]}"
+    BUILD_IDS+="${build_id}"
+    echo "Submitted the following cloud build job: ${build_id}"
   fi
+}
+
+# Image caching can be turned off by setting $DISABLE_IMAGE_CACHING env flag.
+# Note that GCR_IMAGE_BASE_DIR contains commit hash, so whenever there's a code
+# change, we won't use caches for sure.
+if
+  test -z "$DISABLE_IMAGE_CACHING" && has_batch_images_been_built
+then
+  echo "docker images for frontend, scheduledworkflow, \
+    persistenceagent, viewer-crd-controller, inverse-proxy-agent, metadata-writer, cache-server, \
+    cache-deployer and visualization-server are already built in ${GCR_IMAGE_BASE_DIR}."
+else
+  IMAGES_BUILDING=true
+  build_image "batch_build"
+fi
+
+if
+  test -z "$DISABLE_IMAGE_CACHING" && has_api_server_image_been_built
+then
+  echo "docker image for api-server is already built in ${GCR_IMAGE_BASE_DIR}."
+else
+  IMAGES_BUILDING=true
+  build_image "api_server"
 fi

--- a/test/build-images.sh
+++ b/test/build-images.sh
@@ -52,7 +52,7 @@ function build_image {
     AND (status=QUEUED OR status=WORKING)' --format='value(id)'))
   if [ "${#ongoing_build_ids[@]}" -gt "0" ]; then
     echo "There is an existing cloud build job, wait for it: id=${ongoing_build_ids[0]}"
-    BUILD_IDS+="${ongoing_build_ids[0]}"
+    BUILD_IDS+=("${ongoing_build_ids[0]}")
   else
     echo "submitting cloud build to build docker images for commit ${COMMIT_SHA} and target ${build_target}..."
     local common_args=( \
@@ -65,7 +65,7 @@ function build_image {
       --config ${DIR}/cloudbuild/${build_target}.yaml \
       --gcs-source-staging-dir "${TEST_RESULTS_GCS_DIR}/cloudbuild/${build_target}")
 
-    BUILD_IDS+="${build_id}"
+    BUILD_IDS+=("${build_id}")
     echo "Submitted the following cloud build job: ${build_id}"
   fi
 }

--- a/test/build-images.sh
+++ b/test/build-images.sh
@@ -42,7 +42,7 @@ function has_api_server_image_been_built {
 
 BUILD_IDS=()
 function build_image {
-  local build_target = $1
+  local build_target=$1
   # sleep randomly to reduce chance of submitting two cloudbuild jobs at the same time
   sleep $((RANDOM%10))
 

--- a/test/build-images.sh
+++ b/test/build-images.sh
@@ -18,40 +18,55 @@ set -ex
 
 IMAGES_BUILDING=false
 
+function has_images_been_built {
+  local images=$(gcloud container images list --repository=${GCR_IMAGE_BASE_DIR})
+  local result=1
+  echo "$images" | grep api-server && \
+  echo "$images" | grep frontend && \
+  echo "$images" | grep scheduledworkflow && \
+  echo "$images" | grep persistenceagent && \
+  echo "$images" | grep viewer-crd-controller && \
+  echo "$images" | grep inverse-proxy-agent && \
+  echo "$images" | grep metadata-writer && \
+  echo "$images" | grep cache-server && \
+  echo "$images" | grep cache-deployer && \
+  echo "$images" | grep visualization-server && result=0
+  return $result
+}
+
 # Image caching can be turned off by setting $DISABLE_IMAGE_CACHING env flag.
 # Note that GCR_IMAGE_BASE_DIR contains commit hash, so whenever there's a code
 # change, we won't use caches for sure.
-BUILT_IMAGES=$(gcloud container images list --repository=${GCR_IMAGE_BASE_DIR})
 if
-  test -z "$DISABLE_IMAGE_CACHING" && \
-  echo "$BUILT_IMAGES" | grep api-server && \
-  echo "$BUILT_IMAGES" | grep frontend && \
-  echo "$BUILT_IMAGES" | grep scheduledworkflow && \
-  echo "$BUILT_IMAGES" | grep persistenceagent && \
-  echo "$BUILT_IMAGES" | grep viewer-crd-controller && \
-  echo "$BUILT_IMAGES" | grep inverse-proxy-agent && \
-  echo "$BUILT_IMAGES" | grep metadata-writer && \
-  echo "$BUILT_IMAGES" | grep cache-server && \
-  echo "$BUILT_IMAGES" | grep cache-deployer && \
-  echo "$BUILT_IMAGES" | grep visualization-server;
+  test -z "$DISABLE_IMAGE_CACHING" && has_images_been_built
 then
   echo "docker images for api-server, frontend, scheduledworkflow, \
     persistenceagent, viewer-crd-controller, inverse-proxy-agent, metadata-writer, cache-server, \
     cache-deployer and visualization-server are already built in ${GCR_IMAGE_BASE_DIR}."
 else
-  echo "submitting cloud build to build docker images for commit ${COMMIT_SHA}..."
-  IMAGES_BUILDING=true
-  CLOUD_BUILD_COMMON_ARGS=(. --async --format='value(id)' --substitutions=_GCR_BASE=${GCR_IMAGE_BASE_DIR})
-  # Split into two tasks because api_server builds slowly, use a separate task
-  # to make it faster.
-  BUILD_ID_API_SERVER=$(gcloud builds submit ${CLOUD_BUILD_COMMON_ARGS[@]} \
-    --config ${DIR}/cloudbuild/api_server.yaml)
-  BUILD_ID_BATCH=$(gcloud builds submit ${CLOUD_BUILD_COMMON_ARGS[@]} \
-    --config ${DIR}/cloudbuild/batch_build.yaml)
+  # sleep randomly to reduce chance of submitting two cloudbuild jobs at the same time
+  sleep $((RANDOM%30))
 
-  BUILD_IDS=(
-    "${BUILD_ID_API_SERVER}"
-    "${BUILD_ID_BATCH}"
-  )
-  echo "Submitted the following cloud build jobs: ${BUILD_IDS[@]}"
+  # The object name is inited as ${TEST_RESULTS_GCS_DIR} below, so it always has ${COMMIT_SHA} in it.
+  ongoing_build_ids=$(gcloud builds list --filter='source.storageSource.object~'${COMMIT_SHA}' AND (status=QUEUED OR status=WORKING)' --format='value(id)')
+  if [ "${#ongoing_build_ids[@]}" -gt "0" ]; then
+    echo "There is an existing cloud build job, wait for it: id=${ongoing_build_ids[1]}"
+    IMAGES_BUILDING=true
+    BUILD_IDS=(${ongoing_build_ids[1]})
+  else
+    echo "submitting cloud build to build docker images for commit ${COMMIT_SHA}..."
+    IMAGES_BUILDING=true
+    CLOUD_BUILD_COMMON_ARGS=( \
+      $remote_code_archive_uri \
+      --async \
+      --format='value(id)' \
+      --substitutions=_GCR_BASE=${GCR_IMAGE_BASE_DIR} \
+      --gcs-source-staging-dir ${TEST_RESULTS_GCS_DIR}/cloudbuild \
+    )
+    BUILD_ID_BATCH=$(gcloud builds submit ${CLOUD_BUILD_COMMON_ARGS[@]} \
+      --config ${DIR}/cloudbuild/batch_build.yaml)
+
+    BUILD_IDS=("${BUILD_ID_BATCH}")
+    echo "Submitted the following cloud build jobs: ${BUILD_IDS[@]}"
+  fi
 fi

--- a/test/build-images.sh
+++ b/test/build-images.sh
@@ -51,7 +51,7 @@ function build_image {
     --filter='source.storageSource.object~'${COMMIT_SHA}.*/${build_target}' AND (status=QUEUED OR status=WORKING)' \
     --format='value(id)'))
   if [ "${#ongoing_build_ids[@]}" -gt "0" ]; then
-    echo "There is an existing cloud build job, wait for it: id=${ongoing_build_ids[0]}"
+    echo "There is an existing cloud build job for ${build_target}, wait for it: id=${ongoing_build_ids[0]}"
     BUILD_IDS+=("${ongoing_build_ids[0]}")
   else
     echo "submitting cloud build to build docker images for commit ${COMMIT_SHA} and target ${build_target}..."
@@ -66,7 +66,7 @@ function build_image {
       --gcs-source-staging-dir "${TEST_RESULTS_GCS_DIR}/cloudbuild/${build_target}")
 
     BUILD_IDS+=("${build_id}")
-    echo "Submitted the following cloud build job: ${build_id}"
+    echo "Submitted ${build_target} cloud build job: ${build_id}"
   fi
 }
 

--- a/test/build-images.sh
+++ b/test/build-images.sh
@@ -73,6 +73,8 @@ function build_image {
 # Image caching can be turned off by setting $DISABLE_IMAGE_CACHING env flag.
 # Note that GCR_IMAGE_BASE_DIR contains commit hash, so whenever there's a code
 # change, we won't use caches for sure.
+#
+# Split into two tasks because api_server builds slowly, use a separate task to speed up.
 if
   test -z "$DISABLE_IMAGE_CACHING" && has_batch_images_been_built
 then

--- a/test/check-build-image-status.sh
+++ b/test/check-build-image-status.sh
@@ -66,6 +66,8 @@ if [ "$IMAGES_BUILDING" == true ]; then
   else
     # retry again when failure
     source "${DIR}/build-images.sh"
-    wait_for_builds "${BUILD_IDS[@]}"
+    if [ "$IMAGES_BUILDING" == true ]; then
+      wait_for_builds "${BUILD_IDS[@]}"
+    fi
   fi
 fi

--- a/test/check-build-image-status.sh
+++ b/test/check-build-image-status.sh
@@ -56,7 +56,7 @@ function wait_for_builds {
     echo "Cloud build in progress, waiting for 20 seconds..."
     sleep 20
   done
-  # time out
+  echo "Waiting for cloud build ids ${pending_ids[@]} timed out."
   return 2
 }
 

--- a/test/cloudbuild/batch_build.yaml
+++ b/test/cloudbuild/batch_build.yaml
@@ -1,4 +1,8 @@
 steps:
+  - id: "api-server"
+    name: "gcr.io/cloud-builders/docker"
+    args:
+      [ 'build', '-t', '$_GCR_BASE/api-server', '-f', 'backend/Dockerfile', '.' ]
   - id: "persistenceagent"
     name: "gcr.io/cloud-builders/docker"
     args:
@@ -44,6 +48,7 @@ steps:
 options:
   machineType: N1_HIGHCPU_8 # use a fast machine to build because there a lot of work
 images:
+  - '$_GCR_BASE/api-server'
   - "$_GCR_BASE/persistenceagent"
   - "$_GCR_BASE/scheduledworkflow"
   - "$_GCR_BASE/frontend"

--- a/test/cloudbuild/batch_build.yaml
+++ b/test/cloudbuild/batch_build.yaml
@@ -1,8 +1,4 @@
 steps:
-  - id: "api-server"
-    name: "gcr.io/cloud-builders/docker"
-    args:
-      [ 'build', '-t', '$_GCR_BASE/api-server', '-f', 'backend/Dockerfile', '.' ]
   - id: "persistenceagent"
     name: "gcr.io/cloud-builders/docker"
     args:
@@ -48,7 +44,6 @@ steps:
 options:
   machineType: N1_HIGHCPU_8 # use a fast machine to build because there a lot of work
 images:
-  - '$_GCR_BASE/api-server'
   - "$_GCR_BASE/persistenceagent"
   - "$_GCR_BASE/scheduledworkflow"
   - "$_GCR_BASE/frontend"

--- a/test/deploy-pipeline-lite.sh
+++ b/test/deploy-pipeline-lite.sh
@@ -111,8 +111,11 @@ if [ "$ENABLE_WORKLOAD_IDENTITY" = true ]; then
   # not add retry there. Also unless for testing scenario like this, it won't
   # meet the concurrent change issue.
   sleep $((RANDOM%30))
-  yes | PROJECT_ID=$PROJECT CLUSTER_NAME=$TEST_CLUSTER NAMESPACE=$NAMESPACE \
-    ${DIR}/../manifests/kustomize/gcp-workload-identity-setup.sh
+  function setup_workload_identity {
+    yes | PROJECT_ID=$PROJECT CLUSTER_NAME=$TEST_CLUSTER NAMESPACE=$NAMESPACE \
+      ${DIR}/../manifests/kustomize/gcp-workload-identity-setup.sh
+  }
+  retry setup_workload_identity
 
   source "${DIR}/scripts/retry.sh"
   retry gcloud projects add-iam-policy-binding $PROJECT \

--- a/test/deploy-pipeline-lite.sh
+++ b/test/deploy-pipeline-lite.sh
@@ -103,14 +103,14 @@ if [ "$ENABLE_WORKLOAD_IDENTITY" = true ]; then
   export SYSTEM_GSA="test-kfp-system"
   export USER_GSA="test-kfp-user"
 
-  # Workaround for flakiness from gcp-workload-identity-setup.sh:
-  # When two tests add iam policy bindings at the same time, one will fail because
-  # there could be two concurrent changes.
-  # Wait here randomly to reduce chance both scripts are run at the same time
-  # between tests. Unless for testing scenario like this, it won't
-  # meet the concurrent change issue.
-  sleep $((RANDOM%30))
   function setup_workload_identity {
+    # Workaround for flakiness from gcp-workload-identity-setup.sh:
+    # When two tests add iam policy bindings at the same time, one will fail because
+    # there could be two concurrent changes.
+    # Wait here randomly to reduce chance both scripts are run at the same time
+    # between tests. Unless for testing scenario like this, it won't
+    # meet the concurrent change issue.
+    sleep $((RANDOM%30))
     yes | PROJECT_ID=$PROJECT CLUSTER_NAME=$TEST_CLUSTER NAMESPACE=$NAMESPACE \
       ${DIR}/../manifests/kustomize/gcp-workload-identity-setup.sh
   }

--- a/test/deploy-pipeline-lite.sh
+++ b/test/deploy-pipeline-lite.sh
@@ -107,8 +107,7 @@ if [ "$ENABLE_WORKLOAD_IDENTITY" = true ]; then
   # When two tests add iam policy bindings at the same time, one will fail because
   # there could be two concurrent changes.
   # Wait here randomly to reduce chance both scripts are run at the same time
-  # between tests. gcp-workload-identity-setup.sh is user facing, we'd better
-  # not add retry there. Also unless for testing scenario like this, it won't
+  # between tests. Unless for testing scenario like this, it won't
   # meet the concurrent change issue.
   sleep $((RANDOM%30))
   function setup_workload_identity {


### PR DESCRIPTION
Part of https://github.com/kubeflow/pipelines/issues/3256

Changes:
* All 3 presubmit tests will share one cloudbuild job for image building
* Add retry at most twice if the first build fails
* (not mentioned in title, but it's a simple change) Added retry to workload identity setup

Flakiness rate should be greatly reduced.

Previously, we had 3 presubmit tests and 1 cloudbuild job for each presubmit test.
If any one of them fails, developer need to retry at least one test.
With this PR, all 3 presubmit tests share one cloudbuild job and they can retry it 2 times (total 3 attempts).

e.g. current data for image building is averagely 10% jobs fail randomly.

Previous flakiness rate was 1-(1-10%)^3 = 27.1%.
With this PR, it will be 10%^3 = 0.1%.