### PR TITLE
[Deployment] Fix metadata envoy configuration

### DIFF
--- a/manifests/kustomize/base/metadata/metadata-envoy-deployment.yaml
+++ b/manifests/kustomize/base/metadata/metadata-envoy-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/ml-pipeline/envoy:initial
+        image: gcr.io/ml-pipeline/envoy:metadata-grpc
         ports:
         - name: md-envoy
           containerPort: 9090


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/3500

The problem was introduced in https://github.com/kubeflow/pipelines/pull/3108 and already fixed in https://github.com/kubeflow/pipelines/pull/3413, but envoy image rebuilding/release is not part of KFP release.
0.4.0 was still using the initial envoy with config routing to wrong server.

/cc @rmgogogo 
/assign @Ark-kun @dushyanthsc 
/cc @numerology 
Shall we create a 0.4.0 branch and patch 0.4.0 release?