### PR TITLE
[Test] Fix concurrent IAM policy changes flakiness

### DIFF
--- a/test/deploy-pipeline-lite.sh
+++ b/test/deploy-pipeline-lite.sh
@@ -102,6 +102,7 @@ if [ "$ENABLE_WORKLOAD_IDENTITY" = true ]; then
   # Use static GSAs for testing, so we don't need to GC them.
   export SYSTEM_GSA="test-kfp-system"
   export USER_GSA="test-kfp-user"
+  source "${DIR}/scripts/retry.sh"
 
   function setup_workload_identity {
     # Workaround for flakiness from gcp-workload-identity-setup.sh:
@@ -116,7 +117,6 @@ if [ "$ENABLE_WORKLOAD_IDENTITY" = true ]; then
   }
   retry setup_workload_identity
 
-  source "${DIR}/scripts/retry.sh"
   retry gcloud projects add-iam-policy-binding $PROJECT \
     --member="serviceAccount:$SYSTEM_GSA@$PROJECT.iam.gserviceaccount.com" \
     --role="roles/editor"

--- a/test/install-argo.sh
+++ b/test/install-argo.sh
@@ -54,11 +54,11 @@ if [ "$ENABLE_WORKLOAD_IDENTITY" = true ]; then
   source "$DIR/../manifests/kustomize/wi-utils.sh"
   create_gsa_if_not_present $ARGO_GSA
 
-  gcloud projects add-iam-policy-binding $PROJECT \
+  source "${DIR}/scripts/retry.sh"
+  retry gcloud projects add-iam-policy-binding $PROJECT \
     --member="serviceAccount:$ARGO_GSA@$PROJECT.iam.gserviceaccount.com" \
     --role="roles/editor" \
     > /dev/null # hide verbose output
-  source "$DIR/scripts/retry.sh"
   retry bind_gsa_and_ksa $ARGO_GSA $ARGO_KSA $PROJECT $NAMESPACE
 
   verify_workload_identity_binding $ARGO_KSA $NAMESPACE


### PR DESCRIPTION
Part of https://github.com/kubeflow/pipelines/issues/3256
Example error log: https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kubeflow_pipelines/3502/kubeflow-pipeline-e2e-test/1249953399206580227#1:build-log.txt%3A219

/assign @numerology 
I'm going to quickly merge this by myself because it's a small obvious fix.