### PR TITLE
Katib Launcher Experiment Name Conflict

### DIFF
--- a/components/kubeflow/katib-launcher/src/launch_experiment.py
+++ b/components/kubeflow/katib-launcher/src/launch_experiment.py
@@ -100,7 +100,7 @@ def main(argv=None):
   config.load_incluster_config()
   api_client = k8s_client.ApiClient()
   experiment = Experiment(version=args.version, client=api_client)
-  exp_name = str(args.name)+'-'+str(uuid.uuid4().hex)
+  exp_name = (args.name+'-'+uuid.uuid4().hex)[0:63]
   
   inst = {
     "apiVersion": "%s/%s" % (ExperimentGroup, args.version),

--- a/components/kubeflow/katib-launcher/src/launch_experiment.py
+++ b/components/kubeflow/katib-launcher/src/launch_experiment.py
@@ -100,11 +100,13 @@ def main(argv=None):
   config.load_incluster_config()
   api_client = k8s_client.ApiClient()
   experiment = Experiment(version=args.version, client=api_client)
+  exp_name = str(args.name)+'-'+str(uuid.uuid4().hex)
+  
   inst = {
     "apiVersion": "%s/%s" % (ExperimentGroup, args.version),
     "kind": "Experiment",
     "metadata": {
-      "name": str(args.name)+'-'+str(uuid.uuid4().hex),
+      "name": exp_name,
       "namespace": args.namespace,
     },
     "spec": {
@@ -122,7 +124,7 @@ def main(argv=None):
 
   expected_conditions = ["Succeeded", "Failed"]
   current_inst = experiment.wait_for_condition(
-      args.namespace, args.name, expected_conditions,
+      args.namespace, exp_name, expected_conditions,
       timeout=datetime.timedelta(minutes=args.experimentTimeoutMinutes))
   expected, conditon = experiment.is_expected_conditions(current_inst, ["Succeeded"])
   if expected:
@@ -132,7 +134,7 @@ def main(argv=None):
     with open(args.outputFile, 'w') as f:
       f.write(json.dumps(paramAssignments))
   if args.deleteAfterDone:
-    experiment.delete(args.name, args.namespace)
+    experiment.delete(exp_name, args.namespace)
 
 if __name__== "__main__":
   main()

--- a/components/kubeflow/katib-launcher/src/launch_experiment.py
+++ b/components/kubeflow/katib-launcher/src/launch_experiment.py
@@ -19,6 +19,7 @@ import json
 import os
 import logging
 import yaml
+import uuid
 import launch_crd
 
 from kubernetes import client as k8s_client
@@ -103,7 +104,7 @@ def main(argv=None):
     "apiVersion": "%s/%s" % (ExperimentGroup, args.version),
     "kind": "Experiment",
     "metadata": {
-      "name": args.name,
+      "name": str(args.name)+'-'+str(uuid.uuid4().hex),
       "namespace": args.namespace,
     },
     "spec": {

--- a/components/kubeflow/katib-launcher/src/launch_experiment.py
+++ b/components/kubeflow/katib-launcher/src/launch_experiment.py
@@ -102,7 +102,8 @@ def main(argv=None):
   experiment = Experiment(version=args.version, client=api_client)
   exp_name = (args.name+'-'+uuid.uuid4().hex)[0:63]
   
-  inst = {
+
+  iinst = {
     "apiVersion": "%s/%s" % (ExperimentGroup, args.version),
     "kind": "Experiment",
     "metadata": {

--- a/components/kubeflow/katib-launcher/src/launch_experiment.py
+++ b/components/kubeflow/katib-launcher/src/launch_experiment.py
@@ -102,8 +102,7 @@ def main(argv=None):
   experiment = Experiment(version=args.version, client=api_client)
   exp_name = (args.name+'-'+uuid.uuid4().hex)[0:63]
   
-
-  iinst = {
+  inst = {
     "apiVersion": "%s/%s" % (ExperimentGroup, args.version),
     "kind": "Experiment",
     "metadata": {


### PR DESCRIPTION
Katib Experiment name should be unique else we get "Experiment Already Exists" error. This creates a problem when running a katib gridsearch experiment for the same ML model.
So, one simple solution is to append a UUID at the end of experiment name to avoid the conflict. 
I have updated the code in my branch to do just that. 

It takes experiment name provided by user in pipeline code and append a 32-character hexadecimal string at the end of it.
