### PR TITLE
Fix Argo ClusterRole and Binding manifests

### DIFF
--- a/manifests/kustomize/base/argo/cluster-scoped/kustomization.yaml
+++ b/manifests/kustomize/base/argo/cluster-scoped/kustomization.yaml
@@ -2,3 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - workflow-crd.yaml
+- workflow-controller-clusterrole.yaml
+- workflow-controller-clusterrolebinding.yaml

--- a/manifests/kustomize/base/argo/cluster-scoped/workflow-controller-clusterrole.yaml
+++ b/manifests/kustomize/base/argo/cluster-scoped/workflow-controller-clusterrole.yaml
@@ -1,0 +1,43 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: argo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  - workflows/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch

--- a/manifests/kustomize/base/argo/cluster-scoped/workflow-controller-clusterrolebinding.yaml
+++ b/manifests/kustomize/base/argo/cluster-scoped/workflow-controller-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo
+subjects:
+- kind: ServiceAccount
+  name: argo
+  namespace: kubeflow  


### PR DESCRIPTION
When attempting to install KFP standalone, all services are able to stand up correctly. However, when submitting a workflow, the `workflow-controller` pod throws an error in loops while trying to reconcile the workflow resource.

```
E0414 18:08:08.119866       1 reflector.go:134] github.com/argoproj/argo/workflow/controller/controller.go:146: Failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:kubeflow:argo" cannot list resource "pods" in API group "" at the cluster scope
E0414 18:08:08.120763       1 reflector.go:134] github.com/argoproj/argo/workflow/ttlcontroller/ttlcontroller.go:75: Failed to list *unstructured.Unstructured: workflows.argoproj.io is forbidden: User "system:serviceaccount:kubeflow:argo" cannot list resource "workflows" in API group "argoproj.io" at the cluster scope
E0414 18:08:08.121744       1 reflector.go:134] github.com/argoproj/argo/workflow/controller/controller.go:145: Failed to list *unstructured.Unstructured: workflows.argoproj.io is forbidden: User "system:serviceaccount:kubeflow:argo" cannot list resource "workflows" in API group "argoproj.io" at the cluster scope
```

I found that in the kubeflow/manifests repository, Argo is installed using a `ClusterRole` and `ClusterRoleBinding` that would grant access to these resources. Therefore, I have copied the contents of this role and binding into this repository.

## Warning
This current implementation gives a circular reference. Considering these are cluster-scoped resources, they are installed alongside the CRDs (before the deployments). However, this implies the `system:serviceaccount:kubeflow:argo` has not been created yet. In this case, the `ClusterRoleBinding` will fail to bind. 
Either:
1. I put the `ClusterRole` with the cluster-scoped resources and put the `ClusterRoleBinding` with the namespace-scoped resources.
2. I put both in the namespace-scoped resources.