### PR TITLE
 Infer artifact store endpoint in metadata writer

### DIFF
--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -16,6 +16,7 @@ import json
 import hashlib
 import os
 import sys
+import re
 import kubernetes
 import yaml
 from time import sleep
@@ -83,11 +84,21 @@ def output_name_to_argo(name: str) -> str:
     import re
     return re.sub('-+', '-', re.sub('[^-0-9a-z]+', '-', name.lower())).strip('-')
 
+def is_s3_endpoint(endpoint: str) -> bool:
+    return re.search('^.*s3.*amazonaws.com.*$', endpoint)
+
+def get_object_store_provider(endpoint: str) -> bool:
+    if is_s3_endpoint(endpoint):
+        return 's3'
+    else:
+        return 'minio'
 
 def argo_artifact_to_uri(artifact: dict) -> str:
+    # s3 here means s3 compatible object storage. not AWS S3.
     if 's3' in artifact:
         s3_artifact = artifact['s3']
-        return 'minio://{bucket}/{key}'.format(
+        return '{provider}://{bucket}/{key}'.format(
+            provider=get_object_store_provider(s3_artifact['endpoint']),
             bucket=s3_artifact.get('bucket', ''),
             key=s3_artifact.get('key', ''),
         )


### PR DESCRIPTION
Related issue: https://github.com/kubeflow/pipelines/issues/3405

Seems this is just text error, I can still write artifact and metadata into s3. But we can not easily download `mlpipeline-ui-metadata.tgz` easily because of the incorrect protocol. 

`argo_artifact_to_uri` does one thing, it get outputs value from `workflows.argoproj.io/outputs` and return an uri.

One example is 
```
{
  "artifacts": [
    {
      "name": "mlpipeline-ui-metadata",
      "path": "/mlpipeline-ui-metadata.json",
      "s3": {
        "endpoint": "s3.amazonaws.com",
        "bucket": "jiaxin-kubeflow-pipeline-data",
        "insecure": false,
        "accessKeySecret": {
          "name": "aws-secret",
          "key": "AWS_ACCESS_KEY_ID"
        },
        "secretKeySecret": {
          "name": "aws-secret",
          "key": "AWS_SECRET_ACCESS_KEY"
        },
        "key": "artifacts/iris-classification-pipeline-9shz4/iris-classification-pipeline-9shz4-385916632/mlpipeline-ui-metadata.tgz"
      },
      "optional": true
    }
  ]
}
```

We use same strategy to give a right provider based on different endpoints. 

/cc @eterna2 @Ark-kun @gautamkmr

Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>