### PR TITLE
Generate clickable artifact url for s3 URI

### DIFF
--- a/frontend/src/components/ArtifactLink.tsx
+++ b/frontend/src/components/ArtifactLink.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
-import { generateGcsConsoleUri, generateS3ArtifactUrl, generateMinioArtifactUrl } from '../lib/Utils';
+import {
+  generateGcsConsoleUri,
+  generateS3ArtifactUrl,
+  generateMinioArtifactUrl,
+} from '../lib/Utils';
 
 /**
  * A component that renders an artifact URL as clickable link if URL is correct
@@ -12,7 +16,8 @@ export const ArtifactLink: React.FC<{ artifactUri?: string }> = ({ artifactUri }
       if (gcsConsoleUrl) {
         clickableUrl = gcsConsoleUrl;
       }
-    } if (artifactUri.startsWith('s3:')) {
+    }
+    if (artifactUri.startsWith('s3:')) {
       clickableUrl = generateS3ArtifactUrl(artifactUri);
     } else if (artifactUri.startsWith('http:') || artifactUri.startsWith('https:')) {
       clickableUrl = artifactUri;

--- a/frontend/src/components/ArtifactLink.tsx
+++ b/frontend/src/components/ArtifactLink.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { generateGcsConsoleUri, generateMinioArtifactUrl } from '../lib/Utils';
+import { generateGcsConsoleUri, generateS3ArtifactUrl, generateMinioArtifactUrl } from '../lib/Utils';
 
 /**
  * A component that renders an artifact URL as clickable link if URL is correct
@@ -12,6 +12,8 @@ export const ArtifactLink: React.FC<{ artifactUri?: string }> = ({ artifactUri }
       if (gcsConsoleUrl) {
         clickableUrl = gcsConsoleUrl;
       }
+    } if (artifactUri.startsWith('s3:')) {
+      clickableUrl = generateS3ArtifactUrl(artifactUri);
     } else if (artifactUri.startsWith('http:') || artifactUri.startsWith('https:')) {
       clickableUrl = artifactUri;
     } else if (artifactUri.startsWith('minio:')) {

--- a/frontend/src/lib/Utils.test.ts
+++ b/frontend/src/lib/Utils.test.ts
@@ -253,4 +253,12 @@ describe('Utils', () => {
       expect(generateMinioArtifactUrl('ZZZ://my-bucket/a/b/c')).toBe(undefined);
     });
   });
+
+  describe('generateS3ArtifactUrl', () => {
+    it('handles s3:// URIs', () => {
+      expect(generateMinioArtifactUrl('s3://my-bucket/a/b/c')).toBe(
+          'artifacts/get?source=s3&bucket=my-bucket&key=a/b/c',
+      );
+    });
+  });
 });

--- a/frontend/src/lib/Utils.test.ts
+++ b/frontend/src/lib/Utils.test.ts
@@ -257,7 +257,7 @@ describe('Utils', () => {
   describe('generateS3ArtifactUrl', () => {
     it('handles s3:// URIs', () => {
       expect(generateMinioArtifactUrl('s3://my-bucket/a/b/c')).toBe(
-          'artifacts/get?source=s3&bucket=my-bucket&key=a/b/c',
+        'artifacts/get?source=s3&bucket=my-bucket&key=a/b/c',
       );
     });
   });

--- a/frontend/src/lib/Utils.test.ts
+++ b/frontend/src/lib/Utils.test.ts
@@ -258,7 +258,7 @@ describe('Utils', () => {
   describe('generateS3ArtifactUrl', () => {
     it('handles s3:// URIs', () => {
       expect(generateS3ArtifactUrl('s3://my-bucket/a/b/c')).toBe(
-        'artifacts/get?source=s3&bucket=my-bucket&key=a/b/c',
+        'artifacts/get?source=s3&bucket=my-bucket&key=a%2Fb%2Fc',
       );
     });
   });

--- a/frontend/src/lib/Utils.test.ts
+++ b/frontend/src/lib/Utils.test.ts
@@ -19,6 +19,7 @@ import {
   enabledDisplayString,
   formatDateString,
   generateMinioArtifactUrl,
+  generateS3ArtifactUrl,
   getRunDuration,
   getRunDurationFromWorkflow,
   logger,
@@ -256,7 +257,7 @@ describe('Utils', () => {
 
   describe('generateS3ArtifactUrl', () => {
     it('handles s3:// URIs', () => {
-      expect(generateMinioArtifactUrl('s3://my-bucket/a/b/c')).toBe(
+      expect(generateS3ArtifactUrl('s3://my-bucket/a/b/c')).toBe(
         'artifacts/get?source=s3&bucket=my-bucket&key=a/b/c',
       );
     });

--- a/frontend/src/lib/Utils.tsx
+++ b/frontend/src/lib/Utils.tsx
@@ -328,6 +328,26 @@ export function generateMinioArtifactUrl(minioUri: string, peek?: number): strin
   return generateArtifactUrl('minio', matches[1], matches[2], peek);
 }
 
+const S3_URI_PREFIX = 's3://';
+/**
+ * Generates an HTTPS API URL from s3:// uri
+ *
+ * @param s3Uri S3 uri that starts with s3://, like s3://ml-pipeline/path/file
+ * @returns A URL that leads to the artifact data. Returns undefined when s3Uri is not valid.
+ */
+export function generateS3ArtifactUrl(s3Uri: string): string | undefined {
+  if (!s3Uri.startsWith(S3_URI_PREFIX)) {
+    return undefined;
+  }
+
+  // eslint-disable-next-line no-useless-escape
+  const matches = s3Uri.match(/^s3:\/\/([^\/]+)\/(.+)$/);
+  if (matches == null) {
+    return undefined;
+  }
+  return generateArtifactUrl('s3', matches[1], matches[2]);
+}
+
 export function buildQuery(queriesMap: { [key: string]: string | number | undefined }): string {
   const queryContent = Object.entries(queriesMap)
     .filter((entry): entry is [string, string | number] => entry[1] != null)


### PR DESCRIPTION
This is a follow up PR of #3530, resolves some issues of #3405 

![link](https://user-images.githubusercontent.com/4739316/79520867-a38b4e00-800c-11ea-81d4-b34ad1ebf9f7.png)

We need to have this PR to generate clickable artifact url for s3 URI. 

It's working now. Click link will automatically download file. (we may consider to redirect user to AWS S3 console later, this is good enough now.)

![image](https://user-images.githubusercontent.com/4739316/79523048-26fb6e00-8012-11ea-999a-0af5b51bcdcf.png)

Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>

/cc @eterna2 @Ark-kun @Bobgy @gautamkmr