### PR TITLE
[SDK] Fixing bug where client.list_runs filters on empty namespace by default.

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -567,8 +567,10 @@ class Client(object):
     namespace = namespace or self.get_user_namespace()
     if experiment_id is not None:
       response = self._run_api.list_runs(page_token=page_token, page_size=page_size, sort_by=sort_by, resource_reference_key_type=kfp_server_api.models.api_resource_type.ApiResourceType.EXPERIMENT, resource_reference_key_id=experiment_id)
-    else:
+    elif namespace:
       response = self._run_api.list_runs(page_token=page_token, page_size=page_size, sort_by=sort_by, resource_reference_key_type=kfp_server_api.models.api_resource_type.ApiResourceType.NAMESPACE, resource_reference_key_id=namespace)
+    else:
+      response = self._run_api.list_runs(page_token=page_token, page_size=page_size, sort_by=sort_by)
     return response
 
   def get_run(self, run_id):


### PR DESCRIPTION
There's a bug introduced by #3417: `client.list_runs` will filter runs with empty namespace if neither `experiment_id` or `namespace` is specified. This breaks in single-user mode, as runs by default are under "kubeflow" namespace. 
Fix: only filter namespace when it holds a non-empty value.

/cc @Bobgy @IronPan @Ark-kun 