### PR TITLE
[UI] Get execution details from metadata writer

### DIFF
--- a/frontend/src/lib/MlmdUtils.ts
+++ b/frontend/src/lib/MlmdUtils.ts
@@ -1,10 +1,10 @@
 import {
-  Context,
   Api,
+  Context,
   Execution,
-  getResourceProperty,
-  ExecutionProperties,
   ExecutionCustomProperties,
+  ExecutionProperties,
+  getResourceProperty,
 } from '@kubeflow/frontend';
 import {
   GetContextByTypeAndNameRequest,
@@ -96,5 +96,12 @@ export const ExecutionHelpers = {
   },
   getState(execution: Execution): string | number | undefined {
     return getResourceProperty(execution, ExecutionProperties.STATE) || undefined;
+  },
+  getKfpPod(execution: Execution): string | number | undefined {
+    return (
+      getResourceProperty(execution, KfpExecutionProperties.KFP_POD_NAME) ||
+      getResourceProperty(execution, KfpExecutionProperties.KFP_POD_NAME, true) ||
+      undefined
+    );
   },
 };

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Context, Execution, getResourceProperty } from '@kubeflow/frontend';
+import { Context, Execution } from '@kubeflow/frontend';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import InfoIcon from '@material-ui/icons/InfoOutlined';
 import { flatten } from 'lodash';
@@ -25,8 +25,8 @@ import { useNamespaceChangeEvent } from 'src/lib/KubeflowClient';
 import {
   ExecutionHelpers,
   getExecutionsFromContext,
+  getKfpRunContext,
   getTfxRunContext,
-  KfpExecutionProperties,
 } from 'src/lib/MlmdUtils';
 import { classes, stylesheet } from 'typestyle';
 import {
@@ -257,8 +257,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
       selectedNodeId,
     );
     const selectedExecution = mlmdExecutions?.find(
-      execution =>
-        getResourceProperty(execution, KfpExecutionProperties.KFP_POD_NAME) === selectedNodeId,
+      execution => ExecutionHelpers.getKfpPod(execution) === selectedNodeId,
     );
     // const selectedExecution = mlmdExecutions && mlmdExecutions.find(execution => execution.getPropertiesMap())
     const hasMetrics = runMetadata && runMetadata.metrics && runMetadata.metrics.length > 0;
@@ -664,7 +663,12 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
       // Get data about this workflow from MLMD
       if (workflow.metadata?.name) {
         try {
-          mlmdRunContext = await getTfxRunContext(workflow.metadata.name);
+          try {
+            mlmdRunContext = await getTfxRunContext(workflow.metadata.name);
+          } catch (err) {
+            logger.warn(`Cannot find tfx run context (this is expected for non tfx runs)`, err);
+            mlmdRunContext = await getKfpRunContext(workflow.metadata.name);
+          }
           mlmdExecutions = await getExecutionsFromContext(mlmdRunContext);
         } catch (err) {
           // Data in MLMD may not exist depending on this pipeline is a TFX pipeline.


### PR DESCRIPTION
Mitigates https://github.com/kubeflow/pipelines/issues/3226

This makes https://github.com/kubeflow/pipelines/pull/3457 available for metadata written by metadata writer (implemented in https://github.com/kubeflow/pipelines/issues/3462).

/assign @Ark-kun 
~This is a rough implementation, I didn't successfully verify it e2e, because I was blocked by https://github.com/kubeflow/pipelines/issues/3552~

EDIT: verified e2e
/area frontend