### PR TITLE
[UI] fix - create run missing-param warning not reacting to param value changes

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -56,6 +56,7 @@ This requires you already have a real KFP cluster, you can proxy requests to it.
 Before you start, configure your `kubectl` to talk to your KFP cluster.
 
 Then it depends on what you want to develop:
+
 | What to develop?        | Script to run                                                  | Extra notes                                                        |
 | ----------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------ |
 | Client UI               | `NAMESPACE=kubeflow npm run start:proxy`            |                                                                    |

--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -463,7 +463,7 @@ describe('NewRun', () => {
     await TestUtils.flushPromises();
 
     const pipeline = newMockPipelineWithParameters();
-    tree.setState({ pipeline, pipelineName: pipeline.name });
+    tree.setState({ parameters: pipeline.parameters });
 
     // Ensure that at least one of the provided parameters has a missing value.
     expect((pipeline.parameters || []).some(parameter => !parameter.value)).toBe(true);
@@ -478,7 +478,7 @@ describe('NewRun', () => {
     (pipeline.parameters || []).forEach(parameter => {
       parameter.value = 'I am not set';
     });
-    tree.setState({ pipeline, pipelineName: pipeline.name });
+    tree.setState({ parameters: pipeline.parameters });
 
     // Ensure all provided parameters have valid values.
     expect((pipeline.parameters || []).every(parameter => !!parameter.value)).toBe(true);

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -1136,12 +1136,8 @@ export class NewRun extends Page<{ namespace?: string }, NewRunState> {
   }
 
   private _areParametersMissing(): boolean {
-    const { pipeline } = this.state;
-    if (pipeline && Array.isArray(pipeline.parameters) && pipeline.parameters.length > 0) {
-      const missingParameters = pipeline.parameters.filter(parameter => !parameter.value);
-      return missingParameters.length !== 0;
-    }
-    return false;
+    const { parameters } = this.state;
+    return parameters.some(parameter => !parameter.value);
   }
 }
 


### PR DESCRIPTION
small ui bug fix as a first merge request.
The yellow warning `Some parameters are missing values` set when creating a run was fixed to initial values, and did not get removed or re-added if a value was added or taken away for one of the params.

Also fixes table formatting in frontend README.md.