### PR TITLE
Allow PipelineParams in dict keys too.

### DIFF
--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -59,7 +59,7 @@ def _process_obj(obj: Any, map_to_tmpl_var: dict):
     # dict
     if isinstance(obj, dict):
         return {
-            key: _process_obj(value, map_to_tmpl_var)
+            _process_obj(key, map_to_tmpl_var): _process_obj(value, map_to_tmpl_var)
             for key, value in obj.items()
         }
 

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -777,7 +777,6 @@ class Compiler(object):
     if params_list and pipeline_meta.inputs:
       raise ValueError('Either specify pipeline params in the pipeline function, or in "params_list", but not both.')
 
-
     args_list = []
     for arg_name in argspec.args:
       arg_type = None

--- a/sdk/python/kfp/dsl/_pipeline_param.py
+++ b/sdk/python/kfp/dsl/_pipeline_param.py
@@ -112,8 +112,9 @@ def extract_pipelineparams_from_any(payload) -> List['PipelineParam']:
   # dict
   if isinstance(payload, dict):
     pipeline_params = []
-    for item in payload.values():
-      pipeline_params += extract_pipelineparams_from_any(item)
+    for key, value in payload.items():
+      pipeline_params += extract_pipelineparams_from_any(key)
+      pipeline_params += extract_pipelineparams_from_any(value)
     return list(set(pipeline_params))
 
   # k8s OpenAPI object

--- a/sdk/python/tests/dsl/pipeline_param_tests.py
+++ b/sdk/python/tests/dsl/pipeline_param_tests.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kubernetes.client.models import V1Container, V1EnvVar
+from kubernetes.client.models import V1ConfigMap, V1Container, V1EnvVar
 from kfp.dsl import PipelineParam
 from kfp.dsl._pipeline_param import _extract_pipelineparams, extract_pipelineparams_from_any
 import unittest
 
 
 class TestPipelineParam(unittest.TestCase):
-  
+
   def test_invalid(self):
     """Invalid pipeline param name and op_name."""
     with self.assertRaises(ValueError):
@@ -59,13 +59,23 @@ class TestPipelineParam(unittest.TestCase):
     stuff_chars = ' between '
     payload = str(p1) + stuff_chars + str(p2) + stuff_chars + str(p3)
 
-    container = V1Container(name=p1, 
-                            image=p2, 
+    container = V1Container(name=p1,
+                            image=p2,
                             env=[V1EnvVar(name="foo", value=payload)])
 
-    params = extract_pipelineparams_from_any(container)   
+    params = extract_pipelineparams_from_any(container)
     self.assertListEqual(sorted([p1, p2, p3]), sorted(params))
-    
+
+  def test_extract_pipelineparams_from_dict(self):
+    """Test extract_pipeleineparams."""
+    p1 = PipelineParam(name='param1', op_name='op1')
+    p2 = PipelineParam(name='param2')
+
+    configmap = V1ConfigMap(data={str(p1): str(p2)})
+
+    params = extract_pipelineparams_from_any(configmap)
+    self.assertListEqual(sorted([p1, p2]), sorted(params))
+
   def test_extract_pipelineparam_with_types(self):
     """Test _extract_pipelineparams. """
     p1 = PipelineParam(name='param1', op_name='op1', param_type={'customized_type_a': {'property_a': 'value_a'}})


### PR DESCRIPTION
Currently PipelineParam doesn't get replaced if it's part of a dict key. 

This is needed for example when the key of a configmap is derived from a pipeline input.