### PR TITLE
SDK - CLI - Fixed incompatibility with Python 3.5

### DIFF
--- a/sdk/python/kfp/cli/pipeline.py
+++ b/sdk/python/kfp/cli/pipeline.py
@@ -82,7 +82,7 @@ def delete(ctx, pipeline_id):
     client = ctx.obj["client"]
 
     client.delete_pipeline(pipeline_id)
-    print(f"{pipeline_id} is deleted")
+    print("{} is deleted".format(pipeline_id))
 
 
 def _print_pipelines(pipelines):


### PR DESCRIPTION
Fixing issue introduced in https://github.com/kubeflow/pipelines/pull/2879