### PR TITLE
[Testing] pipeline-install-config should be in kubeflow namespace

### DIFF
--- a/test/manifests/dev/kustomization.yaml
+++ b/test/manifests/dev/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+# namespace is required to change generated configmap to correct namespace
+namespace: kubeflow
 bases:
 - ../../../manifests/kustomize/env/dev
 


### PR DESCRIPTION
I inspected test cluster and found the `pipeline-install-config` was generated in `default` namespace.
/cc @rmgogogo 

This PR fixes it.