### PR TITLE
[Release] Fix cloudbuild: remove compiled manifests

### DIFF
--- a/.release.cloudbuild.yaml
+++ b/.release.cloudbuild.yaml
@@ -554,25 +554,6 @@ steps:
   id:   'copyPythonComponentSDKToLatest'
   waitFor: ['copyPythonComponentSDKLocal']
 
-# Generate and copy the pipeline-lite crd deployment YAML
-- name: 'google/cloud-sdk'
-  args: ['bash', '-c', 'kubectl kustomize /workspace/manifests/kustomize/base/crds > crd.yaml']
-  id:   'generateCrdDeploymentYaml'
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', 'crd.yaml', 'gs://ml-pipeline/pipeline-lite/$TAG_NAME/crd.yaml']
-  id:   'copyCrdDeploymentYaml'
-  waitFor: ['generateCrdDeploymentYaml']
-
-# Generate and copy the pipeline-lite deployment YAML
-- name: 'google/cloud-sdk'
-  args: ['bash', '-c', 'kubectl kustomize /workspace/manifests/kustomize/env/dev > namespaced-install.yaml']
-  id:   'generateDeploymentYaml'
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', 'namespaced-install.yaml', 'gs://ml-pipeline/pipeline-lite/$TAG_NAME/namespaced-install.yaml']
-  id:   'copyDeploymentYaml'
-  waitFor: ['generateDeploymentYaml']
-
-
 images:
 - 'gcr.io/ml-pipeline/scheduledworkflow:$TAG_NAME'
 - 'gcr.io/ml-pipeline/scheduledworkflow:$COMMIT_SHA'


### PR DESCRIPTION
/cc @rmgogogo @IronPan 
We agreed to no longer use the compiled manifests.

So to fix current cloudbuild failure 
https://pantheon.corp.google.com/cloud-build/builds/57066be3-df89-4fc2-827a-bea4187789d6;step=94?project=ml-pipeline-test, I think we can remove them.

error message (caused by recent kustomize manifest folder structure refactoring)
```
Error: absolute path error in '/workspace/manifests/kustomize/base/crds' : evalsymlink failure on '/workspace/manifests/kustomize/base/crds' : lstat /workspace/manifests/kustomize/base/crds: no such file or directory
```