### PR TITLE
Fixing volume size default value from 1 to 30

### DIFF
--- a/components/aws/sagemaker/hyperparameter_tuning/README.md
+++ b/components/aws/sagemaker/hyperparameter_tuning/README.md
@@ -30,7 +30,7 @@ output_location | The Amazon S3 path where you want Amazon SageMaker to store th
 output_encryption_key | The AWS KMS key that Amazon SageMaker uses to encrypt the model artifacts | Yes | Yes | String | | |
 instance_type | The ML compute instance type | Yes | No | String | ml.m4.xlarge, ml.m4.2xlarge, ml.m4.4xlarge, ml.m4.10xlarge, ml.m4.16xlarge, ml.m5.large, ml.m5.xlarge, ml.m5.2xlarge, ml.m5.4xlarge, ml.m5.12xlarge, ml.m5.24xlarge, ml.c4.xlarge, ml.c4.2xlarge, ml.c4.4xlarge, ml.c4.8xlarge, ml.p2.xlarge, ml.p2.8xlarge, ml.p2.16xlarge, ml.p3.2xlarge, ml.p3.8xlarge, ml.p3.16xlarge, ml.c5.xlarge, ml.c5.2xlarge, ml.c5.4xlarge, ml.c5.9xlarge, ml.c5.18xlarge | ml.m4.xlarge |
 instance_count | The number of ML compute instances to use in each training job | Yes | Yes | Int | ≥ 1 | 1 |
-volume_size | The size of the ML storage volume that you want to provision in GB | Yes | Yes | Int | ≥ 1 | 1 |
+volume_size | The size of the ML storage volume that you want to provision in GB | Yes | Yes | Int | ≥ 1 | 30 |
 max_num_jobs | The maximum number of training jobs that a hyperparameter tuning job can launch | No | No | Int | [1, 500] | |
 max_parallel_jobs | The maximum number of concurrent training jobs that a hyperparameter tuning job can launch | No | No | Int | [1, 10] | |
 max_run_time | The maximum run time in seconds per training job | Yes | Yes | Int | ≤ 432000 (5 days) | 86400 (1 day) |

--- a/components/aws/sagemaker/hyperparameter_tuning/component.yaml
+++ b/components/aws/sagemaker/hyperparameter_tuning/component.yaml
@@ -58,7 +58,7 @@ inputs:
     default: '1'
   - name: volume_size
     description: 'The size of the ML storage volume that you want to provision.'
-    default: '1'
+    default: '30'
   - name: max_num_jobs
     description: 'The maximum number of training jobs that a hyperparameter tuning job can launch.'
   - name: max_parallel_jobs

--- a/components/aws/sagemaker/train/README.md
+++ b/components/aws/sagemaker/train/README.md
@@ -23,7 +23,7 @@ hyperparameters  | Hyperparameters for the selected algorithm | No | Dict | [Dep
 channels | A list of dicts specifying the input channels (at least one); refer to [documentation](https://github.com/awsdocs/amazon-sagemaker-developer-guide/blob/master/doc_source/API_Channel.md) for parameters | No | No | List of Dicts | | |
 instance_type | The ML compute instance type | Yes | No | String | ml.m4.xlarge, ml.m4.2xlarge, ml.m4.4xlarge, ml.m4.10xlarge, ml.m4.16xlarge, ml.m5.large, ml.m5.xlarge, ml.m5.2xlarge, ml.m5.4xlarge, ml.m5.12xlarge, ml.m5.24xlarge, ml.c4.xlarge, ml.c4.2xlarge, ml.c4.4xlarge, ml.c4.8xlarge, ml.p2.xlarge, ml.p2.8xlarge, ml.p2.16xlarge, ml.p3.2xlarge, ml.p3.8xlarge, ml.p3.16xlarge, ml.c5.xlarge, ml.c5.2xlarge, ml.c5.4xlarge, ml.c5.9xlarge, ml.c5.18xlarge | ml.m4.xlarge |
 instance_count | The number of ML compute instances to use in each training job | Yes | Int | ≥ 1 | 1 |
-volume_size | The size of the ML storage volume that you want to provision in GB | Yes | Int | ≥ 1 | 1 |
+volume_size | The size of the ML storage volume that you want to provision in GB | Yes | Int | ≥ 1 | 30 |
 resource_encryption_key | The AWS KMS key that Amazon SageMaker uses to encrypt data on the storage volume attached to the ML compute instance(s) | Yes | String | | |
 max_run_time | The maximum run time in seconds per training job | Yes | Int | ≤ 432000 (5 days) | 86400 (1 day) |
 model_artifact_path | | No | String | | |

--- a/components/aws/sagemaker/train/component.yaml
+++ b/components/aws/sagemaker/train/component.yaml
@@ -34,7 +34,7 @@ inputs:
     default: '1'
   - name: volume_size
     description: 'The size of the ML storage volume that you want to provision.'
-    default: '1'
+    default: '30'
   - name: resource_encryption_key
     description: 'The AWS KMS key that Amazon SageMaker uses to encrypt data on the storage volume attached to the ML compute instance(s).'
     default: ''


### PR DESCRIPTION
Generally speaking 1 GB volume size is way too small. In general we recommend 25-30GB. I took this number from [default](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/estimator.py#L1119) mentioned in sagemaker python sdk 