### PR TITLE
[Viewer] Service needs port name for istio

### DIFF
--- a/backend/src/crd/controller/viewer/reconciler/reconciler.go
+++ b/backend/src/crd/controller/viewer/reconciler/reconciler.go
@@ -260,6 +260,7 @@ func serviceFrom(v *viewerV1beta1.Viewer, deploymentName string) *corev1.Service
 			},
 			Ports: []corev1.ServicePort{
 				corev1.ServicePort{
+					Name:       "http",
 					Protocol:   corev1.ProtocolTCP,
 					Port:       80,
 					TargetPort: intstr.IntOrString{IntVal: viewerTargetPort}},

--- a/backend/src/crd/controller/viewer/reconciler/reconciler_test.go
+++ b/backend/src/crd/controller/viewer/reconciler/reconciler_test.go
@@ -359,6 +359,7 @@ func TestReconcile_EachViewerCreatesAService(t *testing.T) {
 			}},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{corev1.ServicePort{
+				Name:       "http",
 				Protocol:   corev1.ProtocolTCP,
 				Port:       int32(80),
 				TargetPort: intstr.IntOrString{IntVal: viewerTargetPort},


### PR DESCRIPTION
/assign @IronPan @chensun 
/area backend

Resolves the problem described in https://github.com/kubeflow/pipelines/issues/3294#issuecomment-619562103

> After some troubleshooting, I found that it seems istio didn't automatically find out the traffic is in http, so authorization rules based on http properties didn't take effect. https://istio.io/docs/ops/configuration/traffic-management/protocol-selection/