### PR TITLE
Integration tests for AWS SageMaker Components

### DIFF
--- a/components/aws/sagemaker/tests/integration_tests/.flake8
+++ b/components/aws/sagemaker/tests/integration_tests/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 120
+extend-ignore =
+    # See https://github.com/PyCQA/pycodestyle/issues/373
+    E203,

--- a/components/aws/sagemaker/tests/integration_tests/README.md
+++ b/components/aws/sagemaker/tests/integration_tests/README.md
@@ -7,59 +7,8 @@
 1. IAM User credentials with SageMakerFullAccess permissions
 
 ## Creating S3 buckets with datasets
-Create an S3 bucket and use the following python script to copy `train_data`, `test_data`, and `valid_data.csv` to your buckets.  
-[create the bucket in AWS region where you want to run your tests](https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html)
 
-Create a new file named `s3_sample_data_creator.py` with following content :
-```python
-import pickle, gzip, numpy, urllib.request, json
-from urllib.parse import urlparse
-
-# Load the dataset
-urllib.request.urlretrieve("http://deeplearning.net/data/mnist/mnist.pkl.gz", "mnist.pkl.gz")
-with gzip.open('mnist.pkl.gz', 'rb') as f:
-    train_set, valid_set, test_set = pickle.load(f, encoding='latin1')
-
-
-# Upload dataset to S3
-from sagemaker.amazon.common import write_numpy_to_dense_tensor
-import io
-import boto3
-
-###################################################################
-# This is the only thing that you need to change to run this code 
-# Give the name of your S3 bucket 
-bucket = 'bucket-name' 
-###################################################################
-
-train_data_key = 'mnist_kmeans_example/train_data'
-test_data_key = 'mnist_kmeans_example/test_data'
-train_data_location = 's3://{}/{}'.format(bucket, train_data_key)
-test_data_location = 's3://{}/{}'.format(bucket, test_data_key)
-print('training data will be uploaded to: {}'.format(train_data_location))
-print('training data will be uploaded to: {}'.format(test_data_location))
-
-# Convert the training data into the format required by the SageMaker KMeans algorithm
-buf = io.BytesIO()
-write_numpy_to_dense_tensor(buf, train_set[0], train_set[1])
-buf.seek(0)
-
-boto3.resource('s3').Bucket(bucket).Object(train_data_key).upload_fileobj(buf)
-
-# Convert the test data into the format required by the SageMaker KMeans algorithm
-write_numpy_to_dense_tensor(buf, test_set[0], test_set[1])
-buf.seek(0)
-
-boto3.resource('s3').Bucket(bucket).Object(test_data_key).upload_fileobj(buf)
-
-# Convert the valid data into the format required by the SageMaker KMeans algorithm
-numpy.savetxt('valid-data.csv', valid_set[0], delimiter=',', fmt='%g')
-s3_client = boto3.client('s3')
-input_key = "{}/valid_data.csv".format("mnist_kmeans_example/input")
-s3_client.upload_file('valid-data.csv', bucket, input_key)
-```
-
-Change the bucket name and run the python script `[s3_sample_data_creator.py]()` to create S3 buckets with mnist dataset
+Change the bucket name and run the python script `[s3_sample_data_creator.py](https://github.com/kubeflow/pipelines/tree/master/samples/contrib/aws-samples/mnist-kmeans-sagemaker#the-sample-dataset)` to create S3 buckets with mnist dataset in the region where you want to run the tests
 
 ## Step to run integration tests
 1. Configure AWS credentials with access to EKS cluster

--- a/components/aws/sagemaker/tests/integration_tests/README.md
+++ b/components/aws/sagemaker/tests/integration_tests/README.md
@@ -1,0 +1,93 @@
+## Requirements
+1. [Conda](https://docs.conda.io/en/latest/miniconda.html)
+1. [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+1. Argo CLI: [Mac](https://github.com/argoproj/homebrew-tap), [Linux](https://eksworkshop.com/advanced/410_batch/install/)
+1. K8s cluster with Kubeflow pipelines > 0.4.0 installed
+1. [IAM Role](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-roles.html) with a SageMakerFullAccess and S3FullAccess
+1. IAM User credentials with SageMakerFullAccess permissions
+
+## Creating S3 buckets with datasets
+Create an S3 bucket and use the following python script to copy `train_data`, `test_data`, and `valid_data.csv` to your buckets.  
+[create the bucket in AWS region where you want to run your tests](https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html)
+
+Create a new file named `s3_sample_data_creator.py` with following content :
+```python
+import pickle, gzip, numpy, urllib.request, json
+from urllib.parse import urlparse
+
+# Load the dataset
+urllib.request.urlretrieve("http://deeplearning.net/data/mnist/mnist.pkl.gz", "mnist.pkl.gz")
+with gzip.open('mnist.pkl.gz', 'rb') as f:
+    train_set, valid_set, test_set = pickle.load(f, encoding='latin1')
+
+
+# Upload dataset to S3
+from sagemaker.amazon.common import write_numpy_to_dense_tensor
+import io
+import boto3
+
+###################################################################
+# This is the only thing that you need to change to run this code 
+# Give the name of your S3 bucket 
+bucket = 'bucket-name' 
+###################################################################
+
+train_data_key = 'mnist_kmeans_example/train_data'
+test_data_key = 'mnist_kmeans_example/test_data'
+train_data_location = 's3://{}/{}'.format(bucket, train_data_key)
+test_data_location = 's3://{}/{}'.format(bucket, test_data_key)
+print('training data will be uploaded to: {}'.format(train_data_location))
+print('training data will be uploaded to: {}'.format(test_data_location))
+
+# Convert the training data into the format required by the SageMaker KMeans algorithm
+buf = io.BytesIO()
+write_numpy_to_dense_tensor(buf, train_set[0], train_set[1])
+buf.seek(0)
+
+boto3.resource('s3').Bucket(bucket).Object(train_data_key).upload_fileobj(buf)
+
+# Convert the test data into the format required by the SageMaker KMeans algorithm
+write_numpy_to_dense_tensor(buf, test_set[0], test_set[1])
+buf.seek(0)
+
+boto3.resource('s3').Bucket(bucket).Object(test_data_key).upload_fileobj(buf)
+
+# Convert the valid data into the format required by the SageMaker KMeans algorithm
+numpy.savetxt('valid-data.csv', valid_set[0], delimiter=',', fmt='%g')
+s3_client = boto3.client('s3')
+input_key = "{}/valid_data.csv".format("mnist_kmeans_example/input")
+s3_client.upload_file('valid-data.csv', bucket, input_key)
+```
+
+Change the bucket name and run the python script `[s3_sample_data_creator.py]()` to create S3 buckets with mnist dataset
+
+## Step to run integration tests
+1. Configure AWS credentials with access to EKS cluster
+1. Fetch kubeconfig to `~/.kube/config` or set `KUBECONFIG` environment variable to point to kubeconfig of the cluster
+1. Create a [secret](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/) named `aws-secret` in kubeflow namespace with credentials of IAM User for SageMakerFullAccess
+    ```yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: aws-secret
+      namespace: kubeflow
+    type: Opaque
+    data:
+      AWS_ACCESS_KEY_ID: YOUR_BASE64_ACCESS_KEY
+      AWS_SECRET_ACCESS_KEY: YOUR_BASE64_SECRET_ACCESS
+    ```
+    
+    > Note: To get base64 string, try `echo -n $AWS_ACCESS_KEY_ID | base64`
+1. Create conda environment using environment.yml for running tests. Run `conda env create -f environment.yml`
+1. Activate the conda environment `conda activate kfp_test_env`
+1. Run port-forward to minio service in background. Example: `kubectl port-forward svc/minio-service 9000:9000 -n kubeflow &`
+1. Provide the following arguments to pytest:
+    1. `region`: AWS region where test will run. Default - us-west-2
+    1. `role-arn`: SageMaker execution IAM role ARN
+    1. `s3-data-bucket`: Regional S3 bucket in which test data is hosted
+    1. `minio-service-port`: Localhost port to which minio service is mapped to. Default - 9000
+    1. `kfp-namespace`: Cluster namespace where kubeflow pipelines is installed. Default - Kubeflow
+1.  cd into this directory and run 
+    ```
+    pytest --region <> --role-arn <> --s3-data-bucket <> --minio-service-port <> --kfp-namespace <>
+    ```

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_model_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_model_component.py
@@ -1,0 +1,49 @@
+import pytest
+import os
+import utils
+
+from utils import kfp_client_utils
+from utils import minio_utils
+from utils import sagemaker_utils
+
+
+@pytest.mark.parametrize("test_file_dir", ["resources/config/kmeans-mnist-model"])
+def test_createmodel(kfp_client, experiment_id, sagemaker_client, test_file_dir):
+
+    download_dir = utils.mkdir(os.path.join(test_file_dir + "/generated"))
+    test_params = utils.load_params(
+        utils.replace_placeholders(
+            os.path.join(test_file_dir, "config.yaml"),
+            os.path.join(download_dir, "config.yaml"),
+        )
+    )
+
+    # Generate random prefix for model name to avoid errors if model with same name exists
+    test_params["Arguments"]["model_name"] = input_model_name = (
+        utils.generate_random_string(5) + "-" + test_params["Arguments"]["model_name"]
+    )
+
+    run_id, status, workflow_json = kfp_client_utils.compile_run_monitor_pipeline(
+        kfp_client,
+        experiment_id,
+        test_params["PipelineDefinition"],
+        test_params["Arguments"],
+        download_dir,
+        test_params["TestName"],
+        test_params["Timeout"],
+    )
+
+    outputs = {"sagemaker-create-model": ["model_name"]}
+
+    output_files = minio_utils.artifact_download_iterator(
+        workflow_json, outputs, download_dir
+    )
+
+    output_model_name = utils.extract_information(
+        output_files["sagemaker-create-model"]["model_name"], "model_name.txt"
+    )
+    print(f"model_name: {output_model_name.decode()}")
+    assert output_model_name.decode() == input_model_name
+    assert (
+        sagemaker_utils.describe_model(sagemaker_client, input_model_name) is not None
+    )

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_train_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_train_component.py
@@ -1,0 +1,71 @@
+import pytest
+import os
+import json
+import utils
+from utils import kfp_client_utils
+from utils import argo_utils
+from utils import minio_utils
+from utils import sagemaker_utils
+
+
+@pytest.mark.parametrize("test_file_dir", ["resources/config/simple-mnist-training",])
+def test_simple_mnist_training(
+    kfp_client, experiment_id, s3_client, sagemaker_client, region, test_file_dir
+):
+
+    test_params = utils.load_params(
+        utils.replace_placeholders(os.path.join(test_file_dir, "config.yaml"))
+    )
+
+    pipeline_name = test_params["TestName"]
+    test_params["Arguments"]["hyperparameters"] = json.dumps(
+        test_params["Arguments"]["hyperparameters"]
+    )
+    test_params["Arguments"]["channels"] = json.dumps(
+        test_params["Arguments"]["channels"]
+    )
+    run_id, status = kfp_client_utils.compile_run_monitor_pipeline(
+        kfp_client,
+        experiment_id,
+        test_params["PipelineDefinition"],
+        test_params["Arguments"],
+        test_file_dir,
+        pipeline_name,
+        test_params["Timeout"],
+    )
+
+    workflow_json = kfp_client_utils.get_workflow_json(kfp_client, run_id)
+
+    if not status:
+        argo_utils.print_workflow_logs(workflow_json["metadata"]["name"])
+        pytest.fail(f"Test Failed: {pipeline_name}")
+    else:
+        outputs = {"sagemaker-training-job": ["job_name", "model_artifact_url"]}
+        output_files = minio_utils.artifact_download_iterator(
+            workflow_json, outputs, test_file_dir
+        )
+
+        # Verify Training job was successful on SageMaker
+        training_job_name = utils.extract_information(
+            output_files["sagemaker-training-job"]["job_name"], "job_name.txt"
+        )
+        print("training job name: ", training_job_name)
+        train_response = sagemaker_utils.describe_training_job(
+            sagemaker_client, training_job_name.decode()
+        )
+        assert train_response["TrainingJobStatus"] == "Completed"
+
+        # Verify model artifacts output was generated from this run
+        model_artifact_url = utils.extract_information(
+            output_files["sagemaker-training-job"]["model_artifact_url"],
+            "model_artifact_url.txt",
+        )
+        print("model_artifact_url: ", model_artifact_url)
+        assert (
+            model_artifact_url.decode()
+            == train_response["ModelArtifacts"]["S3ModelArtifacts"]
+        )
+        assert (
+            train_response["ModelArtifacts"]["S3ModelArtifacts"]
+            in model_artifact_url.decode().con
+        )

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_train_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_train_component.py
@@ -8,9 +8,9 @@ from utils import minio_utils
 from utils import sagemaker_utils
 
 
-@pytest.mark.parametrize("test_file_dir", ["resources/config/simple-mnist-training",])
-def test_simple_mnist_training(
-    kfp_client, experiment_id, s3_client, sagemaker_client, region, test_file_dir
+@pytest.mark.parametrize("test_file_dir", ["resources/config/simple-mnist-training"])
+def test_trainingjob(
+    kfp_client, experiment_id, sagemaker_client, region, test_file_dir
 ):
 
     test_params = utils.load_params(
@@ -67,5 +67,5 @@ def test_simple_mnist_training(
         )
         assert (
             train_response["ModelArtifacts"]["S3ModelArtifacts"]
-            in model_artifact_url.decode().con
+            in model_artifact_url.decode()
         )

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_train_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_train_component.py
@@ -3,69 +3,63 @@ import os
 import json
 import utils
 from utils import kfp_client_utils
-from utils import argo_utils
 from utils import minio_utils
 from utils import sagemaker_utils
 
 
 @pytest.mark.parametrize("test_file_dir", ["resources/config/simple-mnist-training"])
-def test_trainingjob(
-    kfp_client, experiment_id, sagemaker_client, region, test_file_dir
-):
+def test_trainingjob(kfp_client, experiment_id, sagemaker_client, test_file_dir):
 
+    download_dir = utils.mkdir(os.path.join(test_file_dir + "/generated"))
     test_params = utils.load_params(
-        utils.replace_placeholders(os.path.join(test_file_dir, "config.yaml"))
+        utils.replace_placeholders(
+            os.path.join(test_file_dir, "config.yaml"),
+            os.path.join(download_dir, "config.yaml"),
+        )
     )
 
-    pipeline_name = test_params["TestName"]
     test_params["Arguments"]["hyperparameters"] = json.dumps(
         test_params["Arguments"]["hyperparameters"]
     )
     test_params["Arguments"]["channels"] = json.dumps(
         test_params["Arguments"]["channels"]
     )
-    run_id, status = kfp_client_utils.compile_run_monitor_pipeline(
+    run_id, status, workflow_json = kfp_client_utils.compile_run_monitor_pipeline(
         kfp_client,
         experiment_id,
         test_params["PipelineDefinition"],
         test_params["Arguments"],
-        test_file_dir,
-        pipeline_name,
+        download_dir,
+        test_params["TestName"],
         test_params["Timeout"],
     )
 
-    workflow_json = kfp_client_utils.get_workflow_json(kfp_client, run_id)
+    outputs = {"sagemaker-training-job": ["job_name", "model_artifact_url"]}
+    output_files = minio_utils.artifact_download_iterator(
+        workflow_json, outputs, download_dir
+    )
 
-    if not status:
-        argo_utils.print_workflow_logs(workflow_json["metadata"]["name"])
-        pytest.fail(f"Test Failed: {pipeline_name}")
-    else:
-        outputs = {"sagemaker-training-job": ["job_name", "model_artifact_url"]}
-        output_files = minio_utils.artifact_download_iterator(
-            workflow_json, outputs, test_file_dir
-        )
+    # Verify Training job was successful on SageMaker
+    training_job_name = utils.extract_information(
+        output_files["sagemaker-training-job"]["job_name"], "job_name.txt"
+    )
+    print(f"training job name: {training_job_name}")
+    train_response = sagemaker_utils.describe_training_job(
+        sagemaker_client, training_job_name.decode()
+    )
+    assert train_response["TrainingJobStatus"] == "Completed"
 
-        # Verify Training job was successful on SageMaker
-        training_job_name = utils.extract_information(
-            output_files["sagemaker-training-job"]["job_name"], "job_name.txt"
-        )
-        print("training job name: ", training_job_name)
-        train_response = sagemaker_utils.describe_training_job(
-            sagemaker_client, training_job_name.decode()
-        )
-        assert train_response["TrainingJobStatus"] == "Completed"
-
-        # Verify model artifacts output was generated from this run
-        model_artifact_url = utils.extract_information(
-            output_files["sagemaker-training-job"]["model_artifact_url"],
-            "model_artifact_url.txt",
-        )
-        print("model_artifact_url: ", model_artifact_url)
-        assert (
-            model_artifact_url.decode()
-            == train_response["ModelArtifacts"]["S3ModelArtifacts"]
-        )
-        assert (
-            train_response["ModelArtifacts"]["S3ModelArtifacts"]
-            in model_artifact_url.decode()
-        )
+    # Verify model artifacts output was generated from this run
+    model_artifact_url = utils.extract_information(
+        output_files["sagemaker-training-job"]["model_artifact_url"],
+        "model_artifact_url.txt",
+    )
+    print(f"model_artifact_url: {model_artifact_url}")
+    assert (
+        model_artifact_url.decode()
+        == train_response["ModelArtifacts"]["S3ModelArtifacts"]
+    )
+    assert (
+        train_response["ModelArtifacts"]["S3ModelArtifacts"]
+        in model_artifact_url.decode()
+    )

--- a/components/aws/sagemaker/tests/integration_tests/conftest.py
+++ b/components/aws/sagemaker/tests/integration_tests/conftest.py
@@ -1,0 +1,97 @@
+import pytest
+import boto3
+import kfp
+import os
+import utils
+
+from datetime import datetime
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--region",
+        default="us-west-2",
+        required=False,
+        help="AWS region where test will run",
+    )
+    parser.addoption(
+        "--role-arn", required=True, help="SageMaker execution IAM role ARN",
+    )
+    parser.addoption(
+        "--s3-data-bucket",
+        required=True,
+        help="Regional S3 bucket name in which test data is hosted",
+    )
+    parser.addoption(
+        "--minio-service-port",
+        default="9000",
+        required=False,
+        help="Localhost port to which minio service is mapped to",
+    )
+    parser.addoption(
+        "--kfp-namespace",
+        default="kubeflow",
+        required=False,
+        help="Cluster namespace where kubeflow pipelines is installed",
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def region(request):
+    os.environ["AWS_REGION"] = request.config.getoption("--region")
+    return request.config.getoption("--region")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def role_arn(request):
+    os.environ["ROLE_ARN"] = request.config.getoption("--role-arn")
+    return request.config.getoption("--role-arn")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def s3_data_bucket(request):
+    os.environ["S3_DATA_BUCKET"] = request.config.getoption("--s3-data-bucket")
+    return request.config.getoption("--s3-data-bucket")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def minio_service_port(request):
+    os.environ["MINIO_SERVICE_PORT"] = request.config.getoption("--minio-service-port")
+    return request.config.getoption("--minio-service-port")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def kfp_namespace(request):
+    os.environ["NAMESPACE"] = request.config.getoption("--kfp-namespace")
+    return request.config.getoption("--kfp-namespace")
+
+
+@pytest.fixture(scope="session")
+def boto3_session(region):
+    return boto3.Session(region_name=region)
+
+
+@pytest.fixture(scope="session")
+def sagemaker_client(boto3_session):
+    return boto3_session.client(service_name="sagemaker")
+
+
+@pytest.fixture(scope="session")
+def s3_client(boto3_session):
+    return boto3_session.client(service_name="s3")
+
+
+@pytest.fixture(scope="session")
+def kfp_client():
+    kfp_installed_namespace = utils.get_kfp_namespace()
+    return kfp.Client(namespace=kfp_installed_namespace)
+
+
+@pytest.fixture(scope="session")
+def experiment_id(kfp_client):
+    exp_name = datetime.now().strftime("%Y-%m-%d")
+    try:
+        experiment = kfp_client.get_experiment(experiment_name=exp_name)
+    except ValueError:
+        experiment = kfp_client.create_experiment(name=exp_name)
+    return experiment.id

--- a/components/aws/sagemaker/tests/integration_tests/environment.yml
+++ b/components/aws/sagemaker/tests/integration_tests/environment.yml
@@ -12,8 +12,9 @@ dependencies:
   - flake8 3.7.*
   - flake8-black 0.1.*
   - pip:
-    - kubernetes 11.0.*
-    - kfp 0.5.*
-    - minio 5.0.*
+    - kubernetes==11.0.*
+    - kfp==0.5.*
+    - minio==5.0.10
+    - sagemaker==1.56.*
       
       

--- a/components/aws/sagemaker/tests/integration_tests/environment.yml
+++ b/components/aws/sagemaker/tests/integration_tests/environment.yml
@@ -1,0 +1,19 @@
+name: kfp_test_env
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python 3.7.*
+  - pip 20.0.*
+  - awscli 1.18.*
+  - boto3 1.12.*
+  - pytest 5.*
+  - pyyaml 5.3.*
+  - flake8 3.7.*
+  - flake8-black 0.1.*
+  - pip:
+    - kubernetes 11.0.*
+    - kfp 0.5.*
+    - minio 5.0.*
+      
+      

--- a/components/aws/sagemaker/tests/integration_tests/pytest.ini
+++ b/components/aws/sagemaker/tests/integration_tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -rA

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-model/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-model/config.yaml
@@ -1,0 +1,11 @@
+PipelineDefinition: resources/definition/create_model_pipeline.py
+TestName: kmeans-create-model-test
+Timeout: 300
+Arguments:
+  region: ((REGION))
+  model_name: kmeans-mnist-model
+  image: ((KMEANS_REGISTRY)).dkr.ecr.((REGION)).amazonaws.com/kmeans:1
+  model_artifact_url: s3://((DATA_BUCKET))/mnist_kmeans_example/model/kmeans-mnist-model/model.tar.gz
+  network_isolation: "True"
+  role: ((ROLE_ARN))
+  

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/simple-mnist-training/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/simple-mnist-training/config.yaml
@@ -1,0 +1,31 @@
+PipelineDefinition: resources/definition/training_pipeline.py
+TestName: simple-mnist-training
+Timeout: 3600
+Arguments:
+  region: ((REGION))
+  image: ((KMEANS_REGISTRY)).dkr.ecr.((REGION)).amazonaws.com/kmeans:1
+  training_input_mode: File
+  hyperparameters:
+    k: "10"
+    feature_dim: "784"
+  channels:
+    - ChannelName: train
+      DataSource:
+        S3DataSource:
+          S3Uri: s3://((DATA_BUCKET))/mnist_kmeans_example/data
+          S3DataType: S3Prefix
+          S3DataDistributionType: FullyReplicated
+      CompressionType: None
+      RecordWrapperType: None
+      InputMode: File
+  instance_type: ml.p2.xlarge
+  instance_count: 1
+  volume_size: 50
+  max_run_time: 3600
+  model_artifact_path: s3://((DATA_BUCKET))/mnist_kmeans_example/output
+  network_isolation: "True"
+  traffic_encryption: "False"
+  spot_instance: "False"
+  max_wait_time: 3600
+  checkpoint_config: "{}"
+  role: ((ROLE_ARN))

--- a/components/aws/sagemaker/tests/integration_tests/resources/definition/create_model_pipeline.py
+++ b/components/aws/sagemaker/tests/integration_tests/resources/definition/create_model_pipeline.py
@@ -1,0 +1,35 @@
+import kfp
+from kfp import components
+from kfp import dsl
+from kfp.aws import use_aws_secret
+
+sagemaker_model_op = components.load_component_from_file("../../model/component.yaml")
+
+
+@dsl.pipeline(
+    name="Create Model in SageMaker", description="SageMaker model component test"
+)
+def create_model_pipeline(
+    region="",
+    endpoint_url="",
+    image="",
+    model_name="",
+    model_artifact_url="",
+    network_isolation="",
+    role="",
+):
+    sagemaker_model_op(
+        region=region,
+        endpoint_url=endpoint_url,
+        model_name=model_name,
+        image=image,
+        model_artifact_url=model_artifact_url,
+        network_isolation=network_isolation,
+        role=role,
+    ).apply(use_aws_secret("aws-secret", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"))
+
+
+if __name__ == "__main__":
+    kfp.compiler.Compiler().compile(
+        create_model_pipeline, "SageMaker_create_model_pipeline" + ".yaml"
+    )

--- a/components/aws/sagemaker/tests/integration_tests/resources/definition/training_pipeline.py
+++ b/components/aws/sagemaker/tests/integration_tests/resources/definition/training_pipeline.py
@@ -1,0 +1,55 @@
+import kfp
+from kfp import components
+from kfp import dsl
+from kfp.aws import use_aws_secret
+
+sagemaker_train_op = components.load_component_from_file("../../train/component.yaml")
+
+
+@dsl.pipeline(name="SageMaker Training", description="SageMaker training job test")
+def training_pipeline(
+    region="",
+    endpoint_url="",
+    image="",
+    training_input_mode="",
+    hyperparameters="",
+    channels="",
+    instance_type="",
+    instance_count="",
+    volume_size="",
+    max_run_time="",
+    model_artifact_path="",
+    output_encryption_key="",
+    network_isolation="",
+    traffic_encryption="",
+    spot_instance="",
+    max_wait_time="",
+    checkpoint_config="{}",
+    role="",
+):
+    sagemaker_train_op(
+        region=region,
+        endpoint_url=endpoint_url,
+        image=image,
+        training_input_mode=training_input_mode,
+        hyperparameters=hyperparameters,
+        channels=channels,
+        instance_type=instance_type,
+        instance_count=instance_count,
+        volume_size=volume_size,
+        max_run_time=max_run_time,
+        model_artifact_path=model_artifact_path,
+        output_encryption_key=output_encryption_key,
+        network_isolation=network_isolation,
+        traffic_encryption=traffic_encryption,
+        spot_instance=spot_instance,
+        max_wait_time=max_wait_time,
+        checkpoint_config=checkpoint_config,
+        role=role,
+    ).apply(use_aws_secret("aws-secret", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"))
+
+
+if __name__ == "__main__":
+    kfp.compiler.Compiler().compile(
+        training_pipeline, "SageMaker_training_pipeline" + ".yaml"
+    )

--- a/components/aws/sagemaker/tests/integration_tests/utils/__init__.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/__init__.py
@@ -4,57 +4,7 @@ import pytest
 import tarfile
 import yaml
 
-# https://github.com/aws/sagemaker-python-sdk/blob/fbebd805e6efc212211b87eafbff3dc84c1062b9/src/sagemaker/amazon/amazon_estimator.py
-KMEANS_REGISTRY = {
-    "us-east-1": "382416733822",
-    "us-east-2": "404615174143",
-    "us-west-2": "174872318107",
-    "eu-west-1": "438346466558",
-    "eu-central-1": "664544806723",
-    "ap-northeast-1": "351501993468",
-    "ap-northeast-2": "835164637446",
-    "ap-southeast-2": "712309505854",
-    "us-gov-west-1": "226302683700",
-    "ap-southeast-1": "475088953585",
-    "ap-south-1": "991648021394",
-    "ca-central-1": "469771592824",
-    "eu-west-2": "644912444149",
-    "us-west-1": "632365934929",
-    "us-iso-east-1": "490574956308",
-    "ap-east-1": "286214385809",
-    "eu-north-1": "669576153137",
-    "eu-west-3": "749696950732",
-    "sa-east-1": "855470959533",
-    "me-south-1": "249704162688",
-    "cn-north-1": "390948362332",
-    "cn-northwest-1": "387376663083",
-}
-
-
-XGBOOST_REGISTRY = {
-    "us-east-1": "811284229777",
-    "us-east-2": "825641698319",
-    "us-west-2": "433757028032",
-    "eu-west-1": "685385470294",
-    "eu-central-1": "813361260812",
-    "ap-northeast-1": "501404015308",
-    "ap-northeast-2": "306986355934",
-    "ap-southeast-2": "544295431143",
-    "us-gov-west-1": "226302683700",
-    "ap-southeast-1": "475088953585",
-    "ap-south-1": "991648021394",
-    "ca-central-1": "469771592824",
-    "eu-west-2": "644912444149",
-    "us-west-1": "632365934929",
-    "us-iso-east-1": "490574956308",
-    "ap-east-1": "286214385809",
-    "eu-north-1": "669576153137",
-    "eu-west-3": "749696950732",
-    "sa-east-1": "855470959533",
-    "me-south-1": "249704162688",
-    "cn-north-1": "390948362332",
-    "cn-northwest-1": "387376663083",
-}
+from sagemaker.amazon.amazon_estimator import get_image_uri
 
 
 def get_region():
@@ -75,6 +25,10 @@ def get_minio_service_port():
 
 def get_kfp_namespace():
     return os.environ.get("NAMESPACE")
+
+
+def get_algorithm_image_registry(region, algorithm):
+    return get_image_uri(region, algorithm).split(".")[0]
 
 
 def run_command(cmd, *popenargs, **kwargs):
@@ -100,7 +54,7 @@ def replace_placeholders(file_name):
         "((REGION))": region,
         "((ROLE_ARN))": get_role_arn(),
         "((DATA_BUCKET))": get_s3_data_bucket(),
-        "((KMEANS_REGISTRY))": KMEANS_REGISTRY[region],
+        "((KMEANS_REGISTRY))": get_algorithm_image_registry(region, "kmeans"),
     }
 
     filedata = ""

--- a/components/aws/sagemaker/tests/integration_tests/utils/__init__.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/__init__.py
@@ -1,0 +1,119 @@
+import os
+import subprocess
+import pytest
+import tarfile
+import yaml
+
+# https://github.com/aws/sagemaker-python-sdk/blob/fbebd805e6efc212211b87eafbff3dc84c1062b9/src/sagemaker/amazon/amazon_estimator.py
+KMEANS_REGISTRY = {
+    "us-east-1": "382416733822",
+    "us-east-2": "404615174143",
+    "us-west-2": "174872318107",
+    "eu-west-1": "438346466558",
+    "eu-central-1": "664544806723",
+    "ap-northeast-1": "351501993468",
+    "ap-northeast-2": "835164637446",
+    "ap-southeast-2": "712309505854",
+    "us-gov-west-1": "226302683700",
+    "ap-southeast-1": "475088953585",
+    "ap-south-1": "991648021394",
+    "ca-central-1": "469771592824",
+    "eu-west-2": "644912444149",
+    "us-west-1": "632365934929",
+    "us-iso-east-1": "490574956308",
+    "ap-east-1": "286214385809",
+    "eu-north-1": "669576153137",
+    "eu-west-3": "749696950732",
+    "sa-east-1": "855470959533",
+    "me-south-1": "249704162688",
+    "cn-north-1": "390948362332",
+    "cn-northwest-1": "387376663083",
+}
+
+
+XGBOOST_REGISTRY = {
+    "us-east-1": "811284229777",
+    "us-east-2": "825641698319",
+    "us-west-2": "433757028032",
+    "eu-west-1": "685385470294",
+    "eu-central-1": "813361260812",
+    "ap-northeast-1": "501404015308",
+    "ap-northeast-2": "306986355934",
+    "ap-southeast-2": "544295431143",
+    "us-gov-west-1": "226302683700",
+    "ap-southeast-1": "475088953585",
+    "ap-south-1": "991648021394",
+    "ca-central-1": "469771592824",
+    "eu-west-2": "644912444149",
+    "us-west-1": "632365934929",
+    "us-iso-east-1": "490574956308",
+    "ap-east-1": "286214385809",
+    "eu-north-1": "669576153137",
+    "eu-west-3": "749696950732",
+    "sa-east-1": "855470959533",
+    "me-south-1": "249704162688",
+    "cn-north-1": "390948362332",
+    "cn-northwest-1": "387376663083",
+}
+
+
+def get_region():
+    return os.environ.get("AWS_REGION")
+
+
+def get_role_arn():
+    return os.environ.get("ROLE_ARN")
+
+
+def get_s3_data_bucket():
+    return os.environ.get("S3_DATA_BUCKET")
+
+
+def get_minio_service_port():
+    return os.environ.get("MINIO_SERVICE_PORT")
+
+
+def get_kfp_namespace():
+    return os.environ.get("NAMESPACE")
+
+
+def run_command(cmd, *popenargs, **kwargs):
+    if isinstance(cmd, str):
+        cmd = cmd.split(" ")
+    try:
+        print("executing command: {}".format(" ".join(cmd)))
+        return subprocess.check_output(
+            cmd, stderr=subprocess.STDOUT, *popenargs, **kwargs
+        )
+    except subprocess.CalledProcessError as e:
+        pytest.fail(f"Command failed. Error code: {e.returncode}, Log: {e.output}")
+
+
+def extract_information(file_path, file_name):
+    with tarfile.open(file_path).extractfile(file_name) as f:
+        return f.read()
+
+
+def replace_placeholders(file_name):
+    region = get_region()
+    variables_to_replace = {
+        "((REGION))": region,
+        "((ROLE_ARN))": get_role_arn(),
+        "((DATA_BUCKET))": get_s3_data_bucket(),
+        "((KMEANS_REGISTRY))": KMEANS_REGISTRY[region],
+    }
+
+    filedata = ""
+    with open(file_name, "r") as f:
+        filedata = f.read()
+        for replace_key, replace_value in variables_to_replace.items():
+            filedata = filedata.replace(replace_key, replace_value)
+    output_filename = file_name + ".generated"
+    with open(output_filename, "w") as f:
+        f.write(filedata)
+    return output_filename
+
+
+def load_params(file_name):
+    with open(file_name, "r") as f:
+        return yaml.safe_load(f)

--- a/components/aws/sagemaker/tests/integration_tests/utils/__init__.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/__init__.py
@@ -3,6 +3,8 @@ import subprocess
 import pytest
 import tarfile
 import yaml
+import random
+import string
 
 from sagemaker.amazon.amazon_estimator import get_image_uri
 
@@ -37,7 +39,7 @@ def run_command(cmd, *popenargs, **kwargs):
     try:
         print("executing command: {}".format(" ".join(cmd)))
         return subprocess.check_output(
-            cmd, stderr=subprocess.STDOUT, *popenargs, **kwargs
+            cmd, *popenargs, stderr=subprocess.STDOUT, **kwargs
         )
     except subprocess.CalledProcessError as e:
         pytest.fail(f"Command failed. Error code: {e.returncode}, Log: {e.output}")
@@ -48,7 +50,7 @@ def extract_information(file_path, file_name):
         return f.read()
 
 
-def replace_placeholders(file_name):
+def replace_placeholders(input_filename, output_filename):
     region = get_region()
     variables_to_replace = {
         "((REGION))": region,
@@ -58,11 +60,11 @@ def replace_placeholders(file_name):
     }
 
     filedata = ""
-    with open(file_name, "r") as f:
+    with open(input_filename, "r") as f:
         filedata = f.read()
         for replace_key, replace_value in variables_to_replace.items():
             filedata = filedata.replace(replace_key, replace_value)
-    output_filename = file_name + ".generated"
+
     with open(output_filename, "w") as f:
         f.write(filedata)
     return output_filename
@@ -71,3 +73,18 @@ def replace_placeholders(file_name):
 def load_params(file_name):
     with open(file_name, "r") as f:
         return yaml.safe_load(f)
+
+
+def generate_random_string(length):
+    """Generate a random string with twice the length of input parameter"""
+    assert isinstance(length, int)
+    return "".join(
+        [random.choice(string.ascii_lowercase) for n in range(length)]
+        + [random.choice(string.digits) for n in range(length)]
+    )
+
+
+def mkdir(directory_path):
+    if not os.path.exists(directory_path):
+        os.makedirs(directory_path)
+    return directory_path

--- a/components/aws/sagemaker/tests/integration_tests/utils/argo_utils.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/argo_utils.py
@@ -1,0 +1,8 @@
+import utils
+
+
+def print_workflow_logs(workflow_name):
+    output = utils.run_command(
+        f"argo logs {workflow_name} -n {utils.get_kfp_namespace()}"
+    )
+    print(f"workflow logs:\n", output.decode())

--- a/components/aws/sagemaker/tests/integration_tests/utils/kfp_client_utils.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/kfp_client_utils.py
@@ -1,0 +1,62 @@
+import os
+import json
+import utils
+
+
+def compile_and_run_pipeline(
+    client,
+    experiment_id,
+    pipeline_definition,
+    input_params,
+    output_file_dir,
+    pipeline_name,
+):
+
+    env_value = os.environ.copy()
+    env_value["PYTHONPATH"] = f"{os.getcwd()}:" + os.environ.get("PYTHONPATH", "")
+    pipeline_path = os.path.join(output_file_dir, pipeline_name)
+    utils.run_command(
+        f"dsl-compile --py {pipeline_definition} --output {pipeline_path}.yaml",
+        env=env_value,
+    )
+    run = client.run_pipeline(
+        experiment_id, pipeline_name, f"{pipeline_path}.yaml", input_params
+    )
+    return run.id
+
+
+def wait_for_job_completion(client, run_id, timeout):
+    response = client.wait_for_run_completion(run_id, timeout)
+    status = response.run.status.lower() == "succeeded"
+    return status
+
+
+def compile_run_monitor_pipeline(
+    client,
+    experiment_id,
+    pipeline_definition,
+    input_params,
+    output_file_dir,
+    pipeline_name,
+    timeout,
+):
+    run_id = compile_and_run_pipeline(
+        client,
+        experiment_id,
+        pipeline_definition,
+        input_params,
+        output_file_dir,
+        pipeline_name,
+    )
+    status = wait_for_job_completion(client, run_id, timeout)
+    return run_id, status
+
+
+def get_workflow_json(client, run_id):
+    # https://github.com/kubeflow/pipelines/blob/master/sdk/python/kfp/_client.py#L663
+    return client._get_workflow_json(run_id)
+
+
+def get_workflow_name(client, run_id):
+    response = client.get_run(run_id)
+    return json.loads(response.pipeline_runtime.workflow_manifest)["metadata"]["name"]

--- a/components/aws/sagemaker/tests/integration_tests/utils/minio_utils.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/minio_utils.py
@@ -1,0 +1,39 @@
+import utils
+import os
+
+from minio import Minio
+
+
+def get_artifact_in_minio(workflow_json, step_name, artifact_name, output_dir):
+    s3_data = {}
+    minio_access_key = "minio"
+    minio_secret_key = "minio123"
+    minio_port = utils.get_minio_service_port()
+    for node in workflow_json["status"]["nodes"].values():
+        if step_name in node["name"]:
+            for artifact in node["outputs"]["artifacts"]:
+                if artifact["name"] == artifact_name:
+                    s3_data = artifact["s3"]
+    minio_client = Minio(
+        "localhost:{}".format(minio_port),
+        access_key=minio_access_key,
+        secret_key=minio_secret_key,
+        secure=False,
+    )
+    output_file = os.path.join(output_dir, artifact_name + ".tgz")
+    minio_client.fget_object(s3_data["bucket"], s3_data["key"], output_file)
+    # https://docs.min.io/docs/python-client-api-reference.html#fget_object
+
+    return output_file
+
+
+def artifact_download_iterator(workflow_json, outputs_dict, output_dir):
+    output_files = {}
+    for step_name, artifacts in outputs_dict.items():
+        output_files[step_name] = {}
+        for artifact in artifacts:
+            output_files[step_name][artifact] = get_artifact_in_minio(
+                workflow_json, step_name, step_name + "-" + artifact, output_dir
+            )
+
+    return output_files

--- a/components/aws/sagemaker/tests/integration_tests/utils/sagemaker_utils.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/sagemaker_utils.py
@@ -1,0 +1,3 @@
+def describe_training_job(client, training_job_name):
+    response = client.describe_training_job(TrainingJobName=training_job_name)
+    return response

--- a/components/aws/sagemaker/tests/integration_tests/utils/sagemaker_utils.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/sagemaker_utils.py
@@ -1,3 +1,6 @@
 def describe_training_job(client, training_job_name):
-    response = client.describe_training_job(TrainingJobName=training_job_name)
-    return response
+    return client.describe_training_job(TrainingJobName=training_job_name)
+
+
+def describe_model(client, model_name):
+    return client.describe_model(ModelName=model_name)


### PR DESCRIPTION
As a developer, I want to have an easy to use testing framework for AWS SageMaker components so that we can maintain code quality and prevent regressions.

Hence I have created Pytest based integration tests for SageMaker components. Workflow of a test run:
1. User follows the README and completes the requirements.
1. User runs pytest command which triggers a pipeline run using KFP SDK for the user defined pipeline definition under resources directory
1. Test writer knows an approximate job completion time and output jobs/artifacts which would be created once the run is complete. Hence the test is configured to wait for run completion, download the output artifacts and verify the job/artifacts were created in AWS

This PR is a proof of concept for #3631. Looking for feedback

Notes: Some variables are exported as environment variables for convenience because they are being shared across, test functions and utils

**rev2**: 
  - address comments from rev1

**rev3**: 
 - bug fix in conda env yaml and resuse sagemaker method to get image_uri

**rev4**: 
  - add createModel test, 
 - logging options for pytest, 
- some utility methods and 
- refractor to reduce code duplication
- put all generated artifacts during test in a separate directory