### PR TITLE
Backend - Upgraded MLMD client to fix Metadata Writer

### DIFF
--- a/backend/metadata_writer/requirements.in
+++ b/backend/metadata_writer/requirements.in
@@ -1,2 +1,2 @@
 kubernetes>=8.0.0,<11.0.0
-ml-metadata==0.15.2
+ml-metadata==0.21.2

--- a/backend/metadata_writer/requirements.txt
+++ b/backend/metadata_writer/requirements.txt
@@ -20,7 +20,7 @@ keras-applications==1.0.8  # via tensorflow
 keras-preprocessing==1.1.0  # via tensorflow
 kubernetes==10.1.0        # via -r requirements.in (line 1)
 markdown==3.2.1           # via tensorboard
-ml-metadata==0.15.2       # via -r requirements.in (line 2)
+ml-metadata==0.21.2       # via -r requirements.in (line 2)
 numpy==1.18.2             # via h5py, keras-applications, keras-preprocessing, opt-einsum, scipy, tensorboard, tensorflow
 oauthlib==3.1.0           # via requests-oauthlib
 opt-einsum==3.2.0         # via tensorflow


### PR DESCRIPTION
There was a backwards-incompatible MLMD server-side change that caused the get_artifacts_by_uri API to start silently returning empty lists of artifacts.
Fixes https://github.com/kubeflow/pipelines/issues/3656