### PR TITLE
Travis - Disabled coveralls for python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
         - coverage run --source=kfp --append sdk/python/tests/dsl/main.py
         - coverage run --source=kfp --append sdk/python/tests/compiler/main.py
         - coverage run --source=kfp --append -m unittest discover --verbose --start-dir sdk/python/tests --top-level-directory=sdk/python
-        - coveralls
+        #- coveralls
 
         # Test against TFX
         # Compile and setup protobuf


### PR DESCRIPTION
There have been many persistent coveralls errors that are blocking our PRs. Disabling coveralls for now.