### PR TITLE
Add an operator to configure toleration of the GKE GPU node taints

### DIFF
--- a/sdk/python/kfp/gcp.py
+++ b/sdk/python/kfp/gcp.py
@@ -122,7 +122,7 @@ def use_preemptible_nodepool(toleration: V1Toleration = V1Toleration(effect='NoS
 
   return _set_preemptible
 
-def use_gpu_nodepool(toleration: V1Toleration = V1Toleration(
+def add_gpu_toleration(toleration: V1Toleration = V1Toleration(
     effect='NoSchedule', key='nvidia.com/gpu', operator='Equal', value='true')):
     """An operator that configures the GKE GPU nodes in a container op.
 

--- a/sdk/python/kfp/gcp.py
+++ b/sdk/python/kfp/gcp.py
@@ -121,3 +121,15 @@ def use_preemptible_nodepool(toleration: V1Toleration = V1Toleration(effect='NoS
     return task
 
   return _set_preemptible
+
+def use_gpu_nodepool(toleration: V1Toleration = V1Toleration(effect='NoSchedule', key='nvidia.com/gpu', operator='Equal', value='true')):
+    """An operator that configures the GKE GPU nodes in a container op.
+
+    Args:
+      toleration {V1Toleration} -- toleration to pods, default is the nvidia.com/gpu label.
+    """
+
+    def _set_toleration(task):
+        task.add_toleration(toleration)
+
+    return _set_toleration

--- a/sdk/python/kfp/gcp.py
+++ b/sdk/python/kfp/gcp.py
@@ -122,7 +122,8 @@ def use_preemptible_nodepool(toleration: V1Toleration = V1Toleration(effect='NoS
 
   return _set_preemptible
 
-def use_gpu_nodepool(toleration: V1Toleration = V1Toleration(effect='NoSchedule', key='nvidia.com/gpu', operator='Equal', value='true')):
+def use_gpu_nodepool(toleration: V1Toleration = V1Toleration(
+    effect='NoSchedule', key='nvidia.com/gpu', operator='Equal', value='true')):
     """An operator that configures the GKE GPU nodes in a container op.
 
     Args:


### PR DESCRIPTION
# What

* Add an operator to configure toleration of the taints the GKE automatically assigns to the GPU nodes.

# Why

* https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#gpu_pool says

![image](https://user-images.githubusercontent.com/1156179/80781039-d0b82000-8b25-11ea-8984-8147b542f273.png)
