### PR TITLE
Make it possible to upload a version of the pipeline with CLI

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -688,6 +688,18 @@ class Client(object):
       IPython.display.display(IPython.display.HTML(html))
     return response
 
+  def upload_pipeline_version(self, pipeline_package_path, version_name, pipeline_id):
+    """Uploads a version of the pipeline to the Kubeflow pipeline cluster.
+    Args:
+      pipeline_package_path: Local path to the pipeline package.
+      version_name: Version name of the pipeline.
+      pipeline_id: The string ID of the pipeline.
+    Returns:
+      A response object including details of a pipeline.
+    """
+    response = self._upload_api.upload_pipeline_version(pipeline_package_path, name=version_name, pipelineid=pipeline_id)
+    return response
+
   def get_pipeline(self, pipeline_id):
     """Get pipeline details.
     Args:

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -688,18 +688,6 @@ class Client(object):
       IPython.display.display(IPython.display.HTML(html))
     return response
 
-  def upload_pipeline_version(self, pipeline_package_path, version_name, pipeline_id):
-    """Uploads a version of the pipeline to the Kubeflow pipeline cluster.
-    Args:
-      pipeline_package_path: Local path to the pipeline package.
-      version_name: Version name of the pipeline.
-      pipeline_id: The string ID of the pipeline.
-    Returns:
-      A response object including details of a pipeline.
-    """
-    response = self._upload_api.upload_pipeline_version(pipeline_package_path, name=version_name, pipelineid=pipeline_id)
-    return response
-
   def get_pipeline(self, pipeline_id):
     """Get pipeline details.
     Args:

--- a/sdk/python/kfp/cli/pipeline.py
+++ b/sdk/python/kfp/cli/pipeline.py
@@ -46,12 +46,14 @@ def upload(ctx, pipeline_name, package_file):
 @click.option(
     "-p",
     "--pipeline-id",
-    help="ID of the pipeline"
+    help="ID of the pipeline",
+    required=True
 )
 @click.option(
     "-v",
     "--pipeline-version",
-    help="Name of the pipeline version"
+    help="Name of the pipeline version",
+    required=True
 )
 @click.argument("package-file")
 @click.pass_context

--- a/sdk/python/kfp/cli/pipeline.py
+++ b/sdk/python/kfp/cli/pipeline.py
@@ -43,6 +43,20 @@ def upload(ctx, pipeline_name, package_file):
 
 
 @pipeline.command()
+@click.argument("package-file")
+@click.argument("pipeline-version")
+@click.argument("pipeline-id")
+@click.pass_context
+def upload_version(ctx, package_file, pipeline_version, pipeline_id):
+    """Upload a version of the KFP pipeline"""
+    client = ctx.obj["client"]
+
+    version = client.upload_pipeline_version(package_file, pipeline_version, pipeline_id)
+    logging.info("The {} version of the pipeline {} has been submitted\n".format(pipeline_version, pipeline_id))
+    _display_pipeline_version(version)
+
+
+@pipeline.command()
 @click.option(
     "--max-size",
     default=100,
@@ -110,3 +124,14 @@ def _display_pipeline(pipeline):
     headers = ["Parameter Name", "Default Value"]
     data = [[param.name, param.value] for param in pipeline.parameters]
     print(tabulate(data, headers=headers, tablefmt="grid"))
+
+
+def _display_pipeline_version(version):
+    print(tabulate([], headers=["Pipeline Version Details"]))
+    pipeline_id = version.resource_references[0].key.id
+    table = [
+        ["Pipeline ID", pipeline_id],
+        ["Version Name", version.name],
+        ["Uploaded at", version.created_at.isoformat()],
+    ]
+    print(tabulate(table, tablefmt="plain"))

--- a/sdk/python/kfp/cli/pipeline.py
+++ b/sdk/python/kfp/cli/pipeline.py
@@ -44,7 +44,7 @@ def upload(ctx, pipeline_name, package_file):
 
 @pipeline.command()
 @click.option(
-    "--id",
+    "-p",
     "--pipeline-id",
     help="ID of the pipeline"
 )

--- a/sdk/python/kfp/cli/pipeline.py
+++ b/sdk/python/kfp/cli/pipeline.py
@@ -59,8 +59,11 @@ def upload_version(ctx, package_file, pipeline_version, pipeline_id):
     """Upload a version of the KFP pipeline"""
     client = ctx.obj["client"]
 
-    version = client.pipeline_uploads.upload_pipeline_version(package_file, name=pipeline_version, pipelineid=pipeline_id)
-    logging.info("The {} version of the pipeline {} has been submitted\n".format(pipeline_version, pipeline_id))
+    version = client.pipeline_uploads.upload_pipeline_version(
+        package_file, name=pipeline_version, pipelineid=pipeline_id)
+    logging.info(
+        "The {} version of the pipeline {} has been submitted\n".format(
+            pipeline_version, pipeline_id))
     _display_pipeline_version(version)
 
 

--- a/sdk/python/kfp/cli/pipeline.py
+++ b/sdk/python/kfp/cli/pipeline.py
@@ -43,15 +43,23 @@ def upload(ctx, pipeline_name, package_file):
 
 
 @pipeline.command()
+@click.option(
+    "--id",
+    "--pipeline-id",
+    help="ID of the pipeline"
+)
+@click.option(
+    "-v",
+    "--pipeline-version",
+    help="Name of the pipeline version"
+)
 @click.argument("package-file")
-@click.argument("pipeline-version")
-@click.argument("pipeline-id")
 @click.pass_context
 def upload_version(ctx, package_file, pipeline_version, pipeline_id):
     """Upload a version of the KFP pipeline"""
     client = ctx.obj["client"]
 
-    version = client.upload_pipeline_version(package_file, pipeline_version, pipeline_id)
+    version = client.pipeline_uploads.upload_pipeline_version(package_file, name=pipeline_version, pipelineid=pipeline_id)
     logging.info("The {} version of the pipeline {} has been submitted\n".format(pipeline_version, pipeline_id))
     _display_pipeline_version(version)
 


### PR DESCRIPTION
# What

* Implement the upload_pipeline_version method in kfp.Client
* Add 'kfp pipeline upload_version' to CLI

<details>
<summary>Verification logs with AI Platform Pipeline</summary>

* Upload a version with CLI
```bash
$ kfp --endpoint xxxxxxxx-dot-us-central2.pipelines.googleusercontent.com pipeline upload-version ./hello_world.py.yaml test-cli-3 f06973d6-bc75-4a10-8248-60eff8701129
The test-cli-3 version of the pipeline f06973d6-bc75-4a10-8248-60eff8701129 has been submitted

Pipeline Version Details
--------------------------
Pipeline ID   f06973d6-bc75-4a10-8248-60eff8701129
Version Name  test-cli-3
Uploaded at   2020-05-01T05:00:30+00:00
```
* Check the version on the Web UI
![image](https://user-images.githubusercontent.com/1156179/80783582-175e4800-8b2f-11ea-8073-1cf53fad763a.png)


</details>

# Why

* Make it possible to upload a version of the pipeline with CLI


