### PR TITLE
Cache - Add namespace to webhook config's name

### DIFF
--- a/backend/src/cache/deployer/cache-configmap.yaml.template
+++ b/backend/src/cache/deployer/cache-configmap.yaml.template
@@ -1,7 +1,7 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: cache-webhook
+  name: cache-webhook-${NAMESPACE}
 webhooks:
   - name: cache-server.${NAMESPACE}.svc
     clientConfig:

--- a/backend/src/cache/deployer/deploy-cache-service.sh
+++ b/backend/src/cache/deployer/deploy-cache-service.sh
@@ -23,7 +23,7 @@ set -ex
 echo "Start deploying cache service to existing cluster:"
 
 NAMESPACE=${NAMESPACE_TO_WATCH:-kubeflow}
-MUTATING_WEBHOOK_CONFIGURATION_NAME="cache-webhook"
+MUTATING_WEBHOOK_CONFIGURATION_NAME="cache-webhook-${NAMESPACE}"
 
 # This should fail if there are connectivity problems
 # Gotcha: Listing all objects requires list permission,


### PR DESCRIPTION
Workaround for #3701

I wonder what will be the cluster behavior when there are configs pointing to a non-existing service in non-existing namespace.