### PR TITLE
Fix workflow.uid global variable usage

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -348,11 +348,6 @@ func (r *ResourceManager) CreateRun(apiRun *api.Run) (*model.RunDetail, error) {
 	workflow.SetLabels(util.LabelKeyWorkflowRunId, runId)
 	// Add run name annotation to the workflow so that it can be logged by the Metadata Writer.
 	workflow.SetAnnotations(util.AnnotationKeyRunName, apiRun.Name)
-	// Replace {{workflow.uid}} with runId
-	err = workflow.ReplaceUID(runId)
-	if err != nil {
-		return nil, util.NewInternalServerError(err, "Failed to replace workflow ID")
-	}
 
 	// Marking auto-added artifacts as optional. Otherwise most older workflows will start failing after upgrade to Argo 2.3.
 	// TODO: Fix the components to explicitly declare the artifacts they really output.

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -15,8 +15,6 @@
 package util
 
 import (
-	"strings"
-
 	workflowapi "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	"github.com/golang/glog"
 	swfregister "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow"
@@ -238,17 +236,6 @@ func (w *Workflow) SetAnnotations(key string, value string) {
 		w.Annotations = make(map[string]string)
 	}
 	w.Annotations[key] = value
-}
-
-func (w *Workflow) ReplaceUID(id string) error {
-	newWorkflowString := strings.Replace(w.ToStringForStore(), "{{workflow.uid}}", id, -1)
-	var workflow *workflowapi.Workflow
-	if err := json.Unmarshal([]byte(newWorkflowString), &workflow); err != nil {
-		return NewInternalServerError(err,
-			"Failed to unmarshal workflow spec manifest. Workflow: %s", w.ToStringForStore())
-	}
-	w.Workflow = workflow
-	return nil
 }
 
 func (w *Workflow) SetCannonicalLabels(name string, nextScheduledEpoch int64, index int64) {

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	workflowapi "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
-	"github.com/ghodss/yaml"
 	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -477,62 +476,4 @@ func TestFindS3ArtifactKey_NodeNotFound(t *testing.T) {
 	actualPath := workflow.FindObjectStoreArtifactKeyOrEmpty("node-1", "artifact-1")
 
 	assert.Empty(t, actualPath)
-}
-
-func TestReplaceUID(t *testing.T) {
-	workflowString := `apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: k8s-owner-reference-
-spec:
-  entrypoint: k8s-owner-reference
-  templates:
-  - name: k8s-owner-reference
-    resource:
-      action: create
-      manifest: |
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          generateName: owned-eg-
-          ownerReferences:
-          - apiVersion: argoproj.io/v1alpha1
-            blockOwnerDeletion: true
-            kind: Workflow
-            name: "{{workflow.name}}"
-            uid: "{{workflow.uid}}"
-        data:
-          some: value`
-	var workflow Workflow
-	err := yaml.Unmarshal([]byte(workflowString), &workflow)
-	assert.Nil(t, err)
-	workflow.ReplaceUID("12345")
-	expectedWorkflowString := `apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: k8s-owner-reference-
-spec:
-  entrypoint: k8s-owner-reference
-  templates:
-  - name: k8s-owner-reference
-    resource:
-      action: create
-      manifest: |
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          generateName: owned-eg-
-          ownerReferences:
-          - apiVersion: argoproj.io/v1alpha1
-            blockOwnerDeletion: true
-            kind: Workflow
-            name: "{{workflow.name}}"
-            uid: "12345"
-        data:
-          some: value`
-
-	var expectedWorkflow Workflow
-	err = yaml.Unmarshal([]byte(expectedWorkflowString), &expectedWorkflow)
-	assert.Nil(t, err)
-	assert.Equal(t, expectedWorkflow, workflow)
 }

--- a/backend/src/crd/controller/scheduledworkflow/util/scheduled_workflow.go
+++ b/backend/src/crd/controller/scheduledworkflow/util/scheduled_workflow.go
@@ -194,11 +194,6 @@ func (s *ScheduledWorkflow) NewWorkflow(
 		return nil, err
 	}
 	result.SetLabels(commonutil.LabelKeyWorkflowRunId, uuid.String())
-	// Replace {{workflow.uid}} with runId
-	err = result.ReplaceUID(uuid.String())
-	if err != nil {
-		return nil, err
-	}
 	// The the owner references.
 	result.SetOwnerReferences(s.ScheduledWorkflow)
 

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -1006,8 +1006,10 @@ Please create a new issue at https://github.com/kubeflow/pipelines/issues attach
   if argo_path:
     result = subprocess.run([argo_path, 'lint', '/dev/stdin'], input=yaml_text.encode('utf-8'), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if result.returncode:
-      raise RuntimeError(
-        '''Internal compiler error: Compiler has produced Argo-incompatible workflow.
+      err = result.stderr.decode('utf-8')
+      if dsl.RUN_ID_PLACEHOLDER not in err:
+        raise RuntimeError(
+          '''Internal compiler error: Compiler has produced Argo-incompatible workflow.
 Please create a new issue at https://github.com/kubeflow/pipelines/issues attaching the pipeline code and the pipeline package.
-Error: {}'''.format(result.stderr.decode('utf-8'))
-      )
+Error: {}'''.format(err)
+        )

--- a/sdk/python/kfp/dsl/__init__.py
+++ b/sdk/python/kfp/dsl/__init__.py
@@ -26,4 +26,4 @@ from ._ops_group import OpsGroup, ExitHandler, Condition, ParallelFor
 from ._component import python_component, graph_component, component
 
 EXECUTION_ID_PLACEHOLDER = '{{workflow.uid}}-{{pod.name}}'
-RUN_ID_PLACEHOLDER = '{{workflow.uid}}'
+RUN_ID_PLACEHOLDER = '{{workflow.labels.pipeline/runid}}'


### PR DESCRIPTION
This is the first step into solving kubeflow/pipelines#1779 (please check the discussion there for details).
And also closes kubeflow/pipelines#3681.

Firstly, taking advantage of Argo variables, we make use of the `pipelines/runid` label in `RUN_ID_PLACEHOLDER`. This label is set on the workflow just before submitting it to Argo. [1]

Then, we stop apiserver from replacing Argo's `workflow.uid` variable with the ID of the run.

[1]: I've also added a note on the corresponding commit. Copying here as well:
>The compiled workflow does not contain the label referenced by
`RUN_ID_PLACEHOLDER` [since it's added by the apiserver just before the CR submission]. This makes compiler's workflow validation using argo lint fail.
To work around this issue, we don't raise error if `RUN_ID_PLACEHOLDER` is
in the error message.

/assign @Ark-kun 