### PR TITLE
[UI] Improve TFX artifact visualization speed

### DIFF
--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -239,12 +239,12 @@ export class OutputArtifactLoader {
    * @returns config array, also returns empty array when expected erros happen
    */
   public static async buildTFXArtifactViewerConfig({
-    argoPodName,
     namespace,
+    execution,
     reportProgress = () => null,
   }: {
     namespace: string;
-    argoPodName: string;
+    execution: Execution;
     reportProgress: (progress: number) => void;
   }): Promise<HTMLViewerConfig[]> {
     // Error handling assumptions:
@@ -260,33 +260,15 @@ export class OutputArtifactLoader {
     // Since artifact types don't change per run, this can be optimized further so
     // that we don't fetch them on every page load.
     reportProgress(10);
-    const artifactTypes = await getArtifactTypes();
-    if (artifactTypes.length === 0) {
+    const [artifactTypes, artifacts] = await Promise.all([
+      getArtifactTypes(),
+      getOutputArtifactsInExecution(execution),
+    ]);
+    if (artifactTypes.length === 0 || artifacts.length === 0) {
       // There are no artifact types data.
       return [];
     }
-    reportProgress(20);
-
-    const context = await getMlmdContext(argoPodName);
-    if (!context) {
-      // Failed finding corresponding MLMD context.
-      return [];
-    }
-    reportProgress(40);
-
-    const execution = await getExecutionInContextWithPodName(argoPodName, context);
-    if (!execution) {
-      // Failed finding corresponding MLMD execution.
-      return [];
-    }
-    reportProgress(60);
-
-    const artifacts = await getOutputArtifactsInExecution(execution);
-    if (artifacts.length === 0) {
-      // There are no artifacts in this execution.
-      return [];
-    }
-    reportProgress(80);
+    reportProgress(70);
 
     // TODO: Visualize non-TFDV artifacts, such as ModelEvaluation using TFMA
     let viewers: Array<Promise<HTMLViewerConfig>> = [];

--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -265,7 +265,7 @@ export class OutputArtifactLoader {
       getOutputArtifactsInExecution(execution),
     ]);
     if (artifactTypes.length === 0 || artifacts.length === 0) {
-      // There are no artifact types data.
+      // There are no artifact types data or no artifacts.
       return [];
     }
     reportProgress(70);

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -1081,7 +1081,7 @@ const ArtifactsTabContent: React.FC<{
     // nodeStatus object instance will keep changing after new requests to get
     // workflow status.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [execution, nodeCompleted, onError, namespace]);
+  }, [execution?.getId(), nodeCompleted, onError, namespace]);
 
   return (
     <div className={commonCss.page}>

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -329,7 +329,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                   this.state.selectedNodeDetails &&
                                   this.state.workflow && (
                                     <ArtifactsTabContent
-                                      nodeId={this.state.selectedNodeDetails.id}
+                                      execution={selectedExecution}
                                       nodeStatus={
                                         this.state.workflow && this.state.workflow.status
                                           ? this.state.workflow.status.nodes[
@@ -997,7 +997,7 @@ const COMPLETED_NODE_PHASES: ArgoNodePhase[] = ['Succeeded', 'Failed', 'Error'];
  */
 const ArtifactsTabContent: React.FC<{
   visualizationCreatorConfig: VisualizationCreatorConfig;
-  nodeId: string;
+  execution?: Execution;
   nodeStatus?: NodeStatus;
   generatedVisualizations: GeneratedVisualization[];
   namespace: string | undefined;
@@ -1005,7 +1005,7 @@ const ArtifactsTabContent: React.FC<{
 }> = ({
   visualizationCreatorConfig,
   generatedVisualizations,
-  nodeId,
+  execution,
   nodeStatus,
   namespace,
   onError,
@@ -1047,11 +1047,15 @@ const ArtifactsTabContent: React.FC<{
       // Load the viewer configurations from the output paths
       const builtConfigs = (
         await Promise.all([
-          OutputArtifactLoader.buildTFXArtifactViewerConfig({
-            argoPodName: nodeId,
-            reportProgress,
-            namespace: namespace || '',
-          }).catch(reportErrorAndReturnEmpty),
+          ...(!execution
+            ? []
+            : [
+                OutputArtifactLoader.buildTFXArtifactViewerConfig({
+                  reportProgress,
+                  execution,
+                  namespace: namespace || '',
+                }).catch(reportErrorAndReturnEmpty),
+              ]),
           ...outputPaths.map(path =>
             OutputArtifactLoader.load(path, namespace).catch(reportErrorAndReturnEmpty),
           ),
@@ -1077,7 +1081,7 @@ const ArtifactsTabContent: React.FC<{
     // nodeStatus object instance will keep changing after new requests to get
     // workflow status.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nodeId, nodeCompleted, onError, namespace]);
+  }, [execution, nodeCompleted, onError, namespace]);
 
   return (
     <div className={commonCss.page}>

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -240,7 +240,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
       mlmdExecutions,
     } = this.state;
     const { projectId, clusterName } = this.props.gkeMetadata;
-    const selectedNodeId = selectedNodeDetails ? selectedNodeDetails.id : '';
+    const selectedNodeId = selectedNodeDetails?.id || '';
     const namespace = workflow?.metadata?.namespace;
     let stackdriverK8sLogsUrl = '';
     if (projectId && clusterName && selectedNodeDetails && selectedNodeDetails.id) {
@@ -330,6 +330,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                   this.state.workflow && (
                                     <ArtifactsTabContent
                                       execution={selectedExecution}
+                                      nodeId={selectedNodeId}
                                       nodeStatus={
                                         this.state.workflow && this.state.workflow.status
                                           ? this.state.workflow.status.nodes[
@@ -998,6 +999,7 @@ const COMPLETED_NODE_PHASES: ArgoNodePhase[] = ['Succeeded', 'Failed', 'Error'];
 const ArtifactsTabContent: React.FC<{
   visualizationCreatorConfig: VisualizationCreatorConfig;
   execution?: Execution;
+  nodeId: string;
   nodeStatus?: NodeStatus;
   generatedVisualizations: GeneratedVisualization[];
   namespace: string | undefined;
@@ -1006,6 +1008,7 @@ const ArtifactsTabContent: React.FC<{
   visualizationCreatorConfig,
   generatedVisualizations,
   execution,
+  nodeId,
   nodeStatus,
   namespace,
   onError,
@@ -1081,7 +1084,7 @@ const ArtifactsTabContent: React.FC<{
     // nodeStatus object instance will keep changing after new requests to get
     // workflow status.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [execution?.getId(), nodeCompleted, onError, namespace]);
+  }, [nodeId, execution?.getId(), nodeCompleted, onError, namespace]);
 
   return (
     <div className={commonCss.page}>


### PR DESCRIPTION
Part of https://github.com/kubeflow/pipelines/issues/3114

Previous request waterfall:
![Screen Shot 2020-05-08 at 1 53 38 PM](https://user-images.githubusercontent.com/4957653/81375096-53973700-9133-11ea-9f16-625a7433151f.png)

With the improvement:
![Screen Shot 2020-05-08 at 1 52 36 PM](https://user-images.githubusercontent.com/4957653/81375042-2f3b5a80-9133-11ea-88bf-b31bf221bf0f.png)

Improvements:
* executions are already fetched in RunDetails page
* some requests can be done in paralell.

This reduces 5 level request waterfall to 2 levels, a drastic improvement specially when network roundtrip delay is long.

/area frontend
/assign @jingzhang36 