### PR TITLE
When patching the {{}} placeholder in parameter, check for possible nil pointer

### DIFF
--- a/backend/src/apiserver/resource/resource_manager_util.go
+++ b/backend/src/apiserver/resource/resource_manager_util.go
@@ -207,6 +207,9 @@ func OverrideParameterWithSystemDefault(workflow util.Workflow, apiRun *api.Run)
 	if servercommon.GetBoolConfigWithDefault(HasDefaultBucketEnvVar, false) {
 		patchedSlice := make([]wfv1.Parameter, 0)
 		for _, currentParam := range workflow.Spec.Arguments.Parameters {
+			if currentParam.Value == nil {
+				continue
+			}
 			desiredValue, err := PatchPipelineDefaultParameter(*currentParam.Value)
 			if err != nil {
 				return fmt.Errorf("failed to patch default value to pipeline. Error: %v", err)

--- a/backend/src/apiserver/resource/resource_manager_util.go
+++ b/backend/src/apiserver/resource/resource_manager_util.go
@@ -207,17 +207,25 @@ func OverrideParameterWithSystemDefault(workflow util.Workflow, apiRun *api.Run)
 	if servercommon.GetBoolConfigWithDefault(HasDefaultBucketEnvVar, false) {
 		patchedSlice := make([]wfv1.Parameter, 0)
 		for _, currentParam := range workflow.Spec.Arguments.Parameters {
-			if currentParam.Value == nil {
-				continue
+			if currentParam.Value != nil {
+				desiredValue, err := PatchPipelineDefaultParameter(*currentParam.Value)
+				if err != nil {
+					return fmt.Errorf("failed to patch default value to pipeline. Error: %v", err)
+				}
+				patchedSlice = append(patchedSlice, wfv1.Parameter{
+					Name:  currentParam.Name,
+					Value: util.StringPointer(desiredValue),
+				})
+			} else if currentParam.Default != nil {
+				desiredValue, err := PatchPipelineDefaultParameter(*currentParam.Default)
+				if err != nil {
+					return fmt.Errorf("failed to patch default value to pipeline. Error: %v", err)
+				}
+				patchedSlice = append(patchedSlice, wfv1.Parameter{
+					Name:  currentParam.Name,
+					Value: util.StringPointer(desiredValue),
+				})
 			}
-			desiredValue, err := PatchPipelineDefaultParameter(*currentParam.Value)
-			if err != nil {
-				return fmt.Errorf("failed to patch default value to pipeline. Error: %v", err)
-			}
-			patchedSlice = append(patchedSlice, wfv1.Parameter{
-				Name:  currentParam.Name,
-				Value: util.StringPointer(desiredValue),
-			})
 		}
 		workflow.Spec.Arguments.Parameters = patchedSlice
 


### PR DESCRIPTION
related : https://github.com/kubeflow/pipelines/issues/3542
related: https://github.com/kubeflow/pipelines/issues/3669

We used to call PatchPipelineDefaultParameter(*currentParam.Value) to replace the {{}} placeholder in currentParam.Value. 
It is reported that currentParam.Value could be nil pointer and the above call crashes api server.
So we check for nil pointer before  currentParam.Value is used. If this is a nil pointer, we switch to currentParam.Default, if currentParam.Default is not nil, we call PatchPipelineDefaultParameter(*currentParam.Default)

/assign @numerology Since I am not familiar with setting parameters, please let me know if we should simply do no-op when currentParam.Value is nil pointer (instead of switching to use currentParam.Default)
/cc @Bobgy 
/cc @rmgogogo 