### PR TITLE
[UI] Cleanup, remove types from urls in artifact/execution details page

### DIFF
--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -97,10 +97,10 @@ export const RoutePage = {
   ARCHIVED_RUNS: '/archive/runs',
   ARCHIVED_EXPERIMENTS: '/archive/experiments',
   ARTIFACTS: '/artifacts',
-  ARTIFACT_DETAILS: `/artifact_types/:${RouteParams.ARTIFACT_TYPE}+/artifacts/:${RouteParams.ID}`,
+  ARTIFACT_DETAILS: `/artifacts/:${RouteParams.ID}`,
   COMPARE: `/compare`,
   EXECUTIONS: '/executions',
-  EXECUTION_DETAILS: `/execution_types/:${RouteParams.EXECUTION_TYPE}+/executions/:${RouteParams.ID}`,
+  EXECUTION_DETAILS: `/executions/:${RouteParams.ID}`,
   EXPERIMENTS: '/experiments',
   EXPERIMENT_DETAILS: `/experiments/details/:${RouteParams.experimentId}`,
   NEW_EXPERIMENT: '/experiments/new',
@@ -116,17 +116,11 @@ export const RoutePage = {
 };
 
 export const RoutePageFactory = {
-  artifactDetails: (artifactType: string, artifactId: number) => {
-    return RoutePage.ARTIFACT_DETAILS.replace(
-      `:${RouteParams.ARTIFACT_TYPE}+`,
-      artifactType,
-    ).replace(`:${RouteParams.ID}`, '' + artifactId);
+  artifactDetails: (artifactId: number) => {
+    return RoutePage.ARTIFACT_DETAILS.replace(`:${RouteParams.ID}`, '' + artifactId);
   },
-  executionDetails: (executionType: string, executionId: number) => {
-    return RoutePage.EXECUTION_DETAILS.replace(
-      `:${RouteParams.EXECUTION_TYPE}+`,
-      executionType,
-    ).replace(`:${RouteParams.ID}`, '' + executionId);
+  executionDetails: (executionId: number) => {
+    return RoutePage.EXECUTION_DETAILS.replace(`:${RouteParams.ID}`, '' + executionId);
   },
   pipelineDetails: (id: string) => {
     return RoutePage.PIPELINE_DETAILS_NO_VERSION.replace(`:${RouteParams.pipelineId}`, id);

--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -79,8 +79,6 @@ export enum RouteParams {
   pipelineId = 'pid',
   pipelineVersionId = 'vid',
   runId = 'rid',
-  ARTIFACT_TYPE = 'artifactType',
-  EXECUTION_TYPE = 'executionType',
   // TODO: create one of these for artifact and execution?
   ID = 'id',
 }

--- a/frontend/src/components/__snapshots__/Router.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Router.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Router initial render 1`] = `
     <Route
       exact={false}
       key="4"
-      path="/artifact_types/:artifactType+/artifacts/:id"
+      path="/artifacts/:id"
       render={[Function]}
     />
     <Route
@@ -47,7 +47,7 @@ exports[`Router initial render 1`] = `
     <Route
       exact={true}
       key="6"
-      path="/execution_types/:executionType+/executions/:id"
+      path="/executions/:id"
       render={[Function]}
     />
     <Route

--- a/frontend/src/lib/MlmdUtils.ts
+++ b/frontend/src/lib/MlmdUtils.ts
@@ -83,9 +83,7 @@ const EXECUTION_PROPERTY_REPOS = [ExecutionProperties, ExecutionCustomProperties
 export const ExecutionHelpers = {
   getWorkspace(execution: Execution): string | number | undefined {
     return (
-      getResourcePropertyViaFallBack(execution, EXECUTION_PROPERTY_REPOS, [
-        ExecutionProperties.RUN_ID,
-      ]) ||
+      getResourcePropertyViaFallBack(execution, EXECUTION_PROPERTY_REPOS, ['RUN_ID']) ||
       getResourceProperty(execution, ExecutionCustomProperties.WORKSPACE, true) ||
       getResourceProperty(execution, ExecutionProperties.PIPELINE_NAME) ||
       undefined

--- a/frontend/src/pages/ArtifactList.tsx
+++ b/frontend/src/pages/ArtifactList.tsx
@@ -156,12 +156,11 @@ class ArtifactList extends Page<{}, ArtifactListState> {
   private nameCustomRenderer: React.FC<CustomRendererProps<string>> = (
     props: CustomRendererProps<string>,
   ) => {
-    const [artifactType, artifactId] = props.id.split(':');
     return (
       <Link
         onClick={e => e.stopPropagation()}
         className={commonCss.link}
-        to={RoutePageFactory.artifactDetails(artifactType, Number(artifactId))}
+        to={RoutePageFactory.artifactDetails(Number(props.id))}
       >
         {props.value}
       </Link>
@@ -221,7 +220,7 @@ class ArtifactList extends Page<{}, ArtifactListState> {
             const artifactType = this.artifactTypesMap!.get(typeId);
             const type = artifactType ? artifactType.getName() : artifact.getTypeId();
             return {
-              id: `${type}:${artifact.getId()}`, // Join with colon so we can build the link
+              id: `${artifact.getId()}`,
               otherFields: [
                 getResourcePropertyViaFallBack(
                   artifact,

--- a/frontend/src/pages/ExecutionDetails.tsx
+++ b/frontend/src/pages/ExecutionDetails.tsx
@@ -102,15 +102,7 @@ export class ExecutionDetailsContent extends Component<
   public state: ExecutionDetailsState = {};
 
   private get fullTypeName(): string {
-    // This can be called during constructor, so this.state may not be initialized.
-    if (this.state) {
-      const { executionType } = this.state;
-      const name = executionType?.getName();
-      if (name) {
-        return name;
-      }
-    }
-    return '';
+    return this.state.executionType?.getName() || '';
   }
 
   public async componentDidMount(): Promise<void> {
@@ -159,7 +151,7 @@ export class ExecutionDetailsContent extends Component<
     return {
       actions: {},
       breadcrumbs: [{ displayName: 'Executions', href: RoutePage.EXECUTIONS }],
-      pageTitle: `${this.fullTypeName} ${this.props.id} details`,
+      pageTitle: `Execution #${this.props.id} details`,
     };
   }
 
@@ -201,7 +193,7 @@ export class ExecutionDetailsContent extends Component<
 
       if (!executionResponse.getExecutionsList().length) {
         this.props.onError(
-          `No ${this.fullTypeName} identified by id: ${this.props.id}`,
+          `No execution identified by id: ${this.props.id}`,
           undefined,
           'error',
           this.refresh,
@@ -398,8 +390,8 @@ const ArtifactRow: React.FC<{ id: number; name: string; type?: string; uri: stri
 }) => (
   <tr>
     <td className={css.tableCell}>
-      {type && id ? (
-        <Link className={commonCss.link} to={RoutePageFactory.artifactDetails(type, id)}>
+      {id ? (
+        <Link className={commonCss.link} to={RoutePageFactory.artifactDetails(id)}>
           {id}
         </Link>
       ) : (
@@ -407,8 +399,8 @@ const ArtifactRow: React.FC<{ id: number; name: string; type?: string; uri: stri
       )}
     </td>
     <td className={css.tableCell}>
-      {type && id ? (
-        <Link className={commonCss.link} to={RoutePageFactory.artifactDetails(type, id)}>
+      {id ? (
+        <Link className={commonCss.link} to={RoutePageFactory.artifactDetails(id)}>
           {name}
         </Link>
       ) : (

--- a/frontend/src/pages/ExecutionList.tsx
+++ b/frontend/src/pages/ExecutionList.tsx
@@ -42,7 +42,7 @@ import {
   CollapsedAndExpandedRows,
   serviceErrorToString,
 } from '../lib/Utils';
-import { RoutePage, RouteParams } from '../components/Router';
+import { RoutePageFactory } from '../components/Router';
 import { ExecutionHelpers } from 'src/lib/MlmdUtils';
 
 interface ExecutionListState {
@@ -182,13 +182,12 @@ class ExecutionList extends Page<{}, ExecutionListState> {
   private nameCustomRenderer: React.FC<CustomRendererProps<string>> = (
     props: CustomRendererProps<string>,
   ) => {
-    const [executionType, executionId] = props.id.split(':');
-    const link = RoutePage.EXECUTION_DETAILS.replace(
-      `:${RouteParams.EXECUTION_TYPE}+`,
-      executionType,
-    ).replace(`:${RouteParams.ID}`, executionId);
     return (
-      <Link onClick={e => e.stopPropagation()} className={commonCss.link} to={link}>
+      <Link
+        onClick={e => e.stopPropagation()}
+        className={commonCss.link}
+        to={RoutePageFactory.executionDetails(Number(props.id))}
+      >
         {props.value}
       </Link>
     );
@@ -212,7 +211,7 @@ class ExecutionList extends Page<{}, ExecutionListState> {
           const executionType = this.executionTypesMap!.get(execution.getTypeId());
           const type = executionType ? executionType.getName() : execution.getTypeId();
           return {
-            id: `${type}:${execution.getId()}`, // Join with colon so we can build the link
+            id: `${execution.getId()}`,
             otherFields: [
               ExecutionHelpers.getWorkspace(execution),
               ExecutionHelpers.getName(execution),

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -380,7 +380,6 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                           <Link
                                             className={commonCss.link}
                                             to={RoutePageFactory.executionDetails(
-                                              selectedExecution.getTypeId() + '',
                                               selectedExecution.getId(),
                                             )}
                                           >


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/2669

We shouldn't include type names in urls from the first place, because artifact/executions only use the id as unique identifier.

/area frontend
/cc @Ark-kun