### PR TITLE
[UI] Make visualization tab easier to understand

### DIFF
--- a/frontend/src/components/Banner.test.tsx
+++ b/frontend/src/components/Banner.test.tsx
@@ -52,6 +52,34 @@ describe('Banner', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('shows troubleshooting link instructed by prop', () => {
+    const tree = shallow(<Banner message='Some message' showTroubleshootingGuideLink={true} />);
+    expect(tree).toMatchInlineSnapshot(`
+      <div
+        className="flex banner mode"
+      >
+        <div
+          className="message"
+        >
+          <pure(ErrorIcon)
+            className="icon"
+          />
+          Some message
+        </div>
+        <div
+          className="flex"
+        >
+          <a
+            className="troubleShootingLink"
+            href="https://www.kubeflow.org/docs/pipelines/troubleshooting"
+          >
+            Troubleshooting guide
+          </a>
+        </div>
+      </div>
+    `);
+  });
+
   it('opens details dialog when button is clicked', () => {
     const tree = shallow(<Banner message='hello' additionalInfo='world' />);
     tree

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -69,6 +69,7 @@ export interface BannerProps {
   additionalInfo?: string;
   message?: string;
   mode?: Mode;
+  showTroubleshootingGuideLink?: boolean;
   refresh?: () => void;
 }
 
@@ -120,12 +121,14 @@ class Banner extends React.Component<BannerProps, BannerState> {
           {this.props.message}
         </div>
         <div className={commonCss.flex}>
-          <a
-            className={css.troubleShootingLink}
-            href='https://www.kubeflow.org/docs/pipelines/troubleshooting'
-          >
-            Troubleshooting guide
-          </a>
+          {this.props.showTroubleshootingGuideLink && (
+            <a
+              className={css.troubleShootingLink}
+              href='https://www.kubeflow.org/docs/pipelines/troubleshooting'
+            >
+              Troubleshooting guide
+            </a>
+          )}
           {this.props.additionalInfo && (
             <Button
               className={classes(css.button, css.detailsButton)}

--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -266,6 +266,7 @@ class RoutedPage extends React.Component<{ route?: RouteConfig }, RouteComponent
             mode={this.state.bannerProps.mode}
             additionalInfo={this.state.bannerProps.additionalInfo}
             refresh={this.state.bannerProps.refresh}
+            showTroubleshootingGuideLink={true}
           />
         )}
         <Switch>

--- a/frontend/src/components/__snapshots__/Banner.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Banner.test.tsx.snap
@@ -14,14 +14,7 @@ exports[`Banner defaults to error mode 1`] = `
   </div>
   <div
     className="flex"
-  >
-    <a
-      className="troubleShootingLink"
-      href="https://www.kubeflow.org/docs/pipelines/troubleshooting"
-    >
-      Troubleshooting guide
-    </a>
-  </div>
+  />
 </div>
 `;
 
@@ -40,12 +33,6 @@ exports[`Banner shows "Details" button and has dialog when there is additional i
   <div
     className="flex"
   >
-    <a
-      className="troubleShootingLink"
-      href="https://www.kubeflow.org/docs/pipelines/troubleshooting"
-    >
-      Troubleshooting guide
-    </a>
     <WithStyles(Button)
       className="button detailsButton"
       onClick={[Function]}
@@ -92,12 +79,6 @@ exports[`Banner shows "Refresh" button when passed a refresh function 1`] = `
   <div
     className="flex"
   >
-    <a
-      className="troubleShootingLink"
-      href="https://www.kubeflow.org/docs/pipelines/troubleshooting"
-    >
-      Troubleshooting guide
-    </a>
     <WithStyles(Button)
       className="button refreshButton"
       onClick={[Function]}
@@ -122,14 +103,7 @@ exports[`Banner uses error mode when instructed 1`] = `
   </div>
   <div
     className="flex"
-  >
-    <a
-      className="troubleShootingLink"
-      href="https://www.kubeflow.org/docs/pipelines/troubleshooting"
-    >
-      Troubleshooting guide
-    </a>
-  </div>
+  />
 </div>
 `;
 
@@ -147,13 +121,6 @@ exports[`Banner uses warning mode when instructed 1`] = `
   </div>
   <div
     className="flex"
-  >
-    <a
-      className="troubleShootingLink"
-      href="https://www.kubeflow.org/docs/pipelines/troubleshooting"
-    >
-      Troubleshooting guide
-    </a>
-  </div>
+  />
 </div>
 `;

--- a/frontend/src/components/viewers/VisualizationCreator.test.tsx
+++ b/frontend/src/components/viewers/VisualizationCreator.test.tsx
@@ -16,9 +16,11 @@
 
 import * as React from 'react';
 import { shallow, mount } from 'enzyme';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { PlotType } from './Viewer';
 import VisualizationCreator, { VisualizationCreatorConfig } from './VisualizationCreator';
 import { ApiVisualizationType } from '../../apis/visualization';
+import { diffHTML } from 'src/TestUtils';
 
 describe('VisualizationCreator', () => {
   it('does not render component when no config is provided', () => {
@@ -330,5 +332,51 @@ describe('VisualizationCreator', () => {
 
   it('returns friendly display name', () => {
     expect(VisualizationCreator.prototype.getDisplayName()).toBe('Visualization Creator');
+  });
+
+  it('can be configured as collapsed initially and clicks to open', () => {
+    const baseConfig: VisualizationCreatorConfig = {
+      isBusy: false,
+      onGenerate: jest.fn(),
+      type: PlotType.VISUALIZATION_CREATOR,
+      collapsedInitially: false,
+    };
+    const { container: baseContainer } = render(<VisualizationCreator configs={[baseConfig]} />);
+    const { container } = render(
+      <VisualizationCreator
+        configs={[
+          {
+            ...baseConfig,
+            collapsedInitially: true,
+          },
+        ]}
+      />,
+    );
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <button
+          class="MuiButtonBase-root-114 MuiButton-root-88 MuiButton-text-90 MuiButton-flat-93"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label-89"
+          >
+            create visualizations manually
+          </span>
+          <span
+            class="MuiTouchRipple-root-117"
+          />
+        </button>
+      </div>
+    `);
+    const button = screen.getByText('create visualizations manually');
+    fireEvent.click(button);
+    // expanding a visualization creator is equivalent to rendering a non-collapsed visualization creator
+    expect(diffHTML({ base: baseContainer.innerHTML, update: container.innerHTML }))
+      .toMatchInlineSnapshot(`
+      Snapshot Diff:
+      Compared values have no visual difference.
+    `);
   });
 });

--- a/frontend/src/components/viewers/VisualizationCreator.tsx
+++ b/frontend/src/components/viewers/VisualizationCreator.tsx
@@ -37,6 +37,8 @@ export interface VisualizationCreatorConfig extends ViewerConfig {
   isBusy?: boolean;
   // Function called to generate a visualization.
   onGenerate?: (visualizationArguments: string, source: string, type: ApiVisualizationType) => void;
+  // Facilitate testing by not collapsing by default.
+  collapsedInitially?: boolean;
 }
 
 interface VisualizationCreatorProps {
@@ -54,16 +56,13 @@ interface VisualizationCreatorState {
 }
 
 class VisualizationCreator extends Viewer<VisualizationCreatorProps, VisualizationCreatorState> {
-  constructor(props: VisualizationCreatorProps) {
-    super(props);
-    this.state = {
-      // This feature is only for rare occasions, collapse by default.
-      expanded: false,
-      arguments: '',
-      code: '',
-      source: '',
-    };
-  }
+  state: VisualizationCreatorState = {
+    // This feature is only for rare occasions, collapse by default.
+    expanded: !this.props.configs[0]?.collapsedInitially,
+    arguments: '',
+    code: '',
+    source: '',
+  };
 
   public getDisplayName(): string {
     return 'Visualization Creator';

--- a/frontend/src/components/viewers/VisualizationCreator.tsx
+++ b/frontend/src/components/viewers/VisualizationCreator.tsx
@@ -29,6 +29,7 @@ import 'brace/ext/language_tools';
 import 'brace/mode/json';
 import 'brace/mode/python';
 import 'brace/theme/github';
+import Button from '@material-ui/core/Button';
 
 export interface VisualizationCreatorConfig extends ViewerConfig {
   allowCustomVisualizations?: boolean;
@@ -44,6 +45,7 @@ interface VisualizationCreatorProps {
 }
 
 interface VisualizationCreatorState {
+  expanded: boolean;
   // arguments is expected to be a JSON object in string form.
   arguments: string;
   code: string;
@@ -55,6 +57,8 @@ class VisualizationCreator extends Viewer<VisualizationCreatorProps, Visualizati
   constructor(props: VisualizationCreatorProps) {
     super(props);
     this.state = {
+      // This feature is only for rare occasions, collapse by default.
+      expanded: false,
       arguments: '',
       code: '',
       source: '',
@@ -86,6 +90,14 @@ class VisualizationCreator extends Viewer<VisualizationCreatorProps, Visualizati
       !isBusy && !!onGenerate && (hasSourceAndSelectedType || isCustomTypeAndHasCode);
 
     const argumentsPlaceholder = this.getArgumentPlaceholderForType(selectedType);
+
+    if (!this.state.expanded) {
+      return (
+        <Button variant='text' onClick={this.handleExpansion}>
+          create visualizations manually
+        </Button>
+      );
+    }
 
     return (
       <div
@@ -258,6 +270,12 @@ class VisualizationCreator extends Viewer<VisualizationCreatorProps, Visualizati
         .replace(new RegExp('\t', 'g'), '&nbsp&nbsp&nbsp&nbsp')
     );
   }
+
+  private handleExpansion = () => {
+    this.setState({
+      expanded: true,
+    });
+  };
 }
 
 export default VisualizationCreator;

--- a/frontend/src/components/viewers/VisualizationCreator.tsx
+++ b/frontend/src/components/viewers/VisualizationCreator.tsx
@@ -57,7 +57,6 @@ interface VisualizationCreatorState {
 
 class VisualizationCreator extends Viewer<VisualizationCreatorProps, VisualizationCreatorState> {
   public state: VisualizationCreatorState = {
-    // This feature is only for rare occasions, collapse by default.
     expanded: !this.props.configs[0]?.collapsedInitially,
     arguments: '',
     code: '',

--- a/frontend/src/components/viewers/VisualizationCreator.tsx
+++ b/frontend/src/components/viewers/VisualizationCreator.tsx
@@ -56,7 +56,7 @@ interface VisualizationCreatorState {
 }
 
 class VisualizationCreator extends Viewer<VisualizationCreatorProps, VisualizationCreatorState> {
-  state: VisualizationCreatorState = {
+  public state: VisualizationCreatorState = {
     // This feature is only for rare occasions, collapse by default.
     expanded: !this.props.configs[0]?.collapsedInitially,
     arguments: '',

--- a/frontend/src/pages/ArchivedExperiments.tsx
+++ b/frontend/src/pages/ArchivedExperiments.tsx
@@ -33,10 +33,6 @@ interface ArchivedExperimentsState {}
 export class ArchivedExperiments extends Page<ArchivedExperimentsProp, ArchivedExperimentsState> {
   private _experimentlistRef = React.createRef<ExperimentList>();
 
-  constructor(props: any) {
-    super(props);
-  }
-
   public getInitialToolbarState(): ToolbarProps {
     const buttons = new Buttons(this.props, this.refresh.bind(this));
     return {

--- a/frontend/src/pages/RunDetails.test.tsx
+++ b/frontend/src/pages/RunDetails.test.tsx
@@ -38,8 +38,8 @@ import { NamespaceContext } from 'src/lib/KubeflowClient';
 const RunDetails = TEST_ONLY.RunDetails;
 
 const STEP_TABS = {
-  ARTIFACTS: 0,
-  INPUT_OUTPUT: 1,
+  INPUT_OUTPUT: 0,
+  VISUALIZATIONS: 1,
   ML_METADATA: 2,
   VOLUMES: 3,
   LOGS: 4,
@@ -637,7 +637,12 @@ describe('RunDetails', () => {
       'phaseMessage',
       'This step is in ' + testRun.run!.status + ' state with this message: some test message',
     );
-    expect(tree).toMatchSnapshot();
+    expect(tree.find('Banner')).toMatchInlineSnapshot(`
+      <Banner
+        message="This step is in Succeeded state with this message: some test message"
+        mode="warning"
+      />
+    `);
   });
 
   it('shows clicked node output in side pane', async () => {

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -76,10 +76,11 @@ import WorkflowParser from '../lib/WorkflowParser';
 import { ExecutionDetailsContent } from './ExecutionDetails';
 import { Page, PageProps } from './Page';
 import { statusToIcon } from './Status';
+import { ExternalLink } from 'src/atoms/ExternalLink';
 
 enum SidePaneTab {
-  ARTIFACTS,
   INPUT_OUTPUT,
+  VISUALIZATIONS,
   ML_METADATA,
   VOLUMES,
   LOGS,
@@ -176,7 +177,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
     selectedNodeDetails: null,
     selectedTab: 0,
     sidepanelBusy: false,
-    sidepanelSelectedTab: SidePaneTab.ARTIFACTS,
+    sidepanelSelectedTab: SidePaneTab.INPUT_OUTPUT,
     mlmdRunContext: undefined,
     mlmdExecutions: undefined,
   };
@@ -308,8 +309,8 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                             <div className={commonCss.page}>
                               <MD2Tabs
                                 tabs={[
-                                  'Artifacts',
                                   'Input/Output',
+                                  'Visualizations',
                                   'ML Metadata',
                                   'Volumes',
                                   'Logs',
@@ -329,10 +330,10 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                 data-testid='run-details-node-details'
                                 className={commonCss.page}
                               >
-                                {sidepanelSelectedTab === SidePaneTab.ARTIFACTS &&
+                                {sidepanelSelectedTab === SidePaneTab.VISUALIZATIONS &&
                                   this.state.selectedNodeDetails &&
                                   this.state.workflow && (
-                                    <ArtifactsTabContent
+                                    <VisualizationsTabContent
                                       execution={selectedExecution}
                                       nodeId={selectedNodeId}
                                       nodeStatus={
@@ -997,10 +998,10 @@ const COMPLETED_NODE_PHASES: ArgoNodePhase[] = ['Succeeded', 'Failed', 'Error'];
 
 // TODO: add unit tests for this.
 /**
- * Artifacts tab content component, it handles loading progress state of
- * artifacts and visualize progress as a circular progress icon.
+ * Visualizations tab content component, it handles loading progress state of
+ * visualize progress as a circular progress icon.
  */
-const ArtifactsTabContent: React.FC<{
+const VisualizationsTabContent: React.FC<{
   visualizationCreatorConfig: VisualizationCreatorConfig;
   execution?: Execution;
   nodeId: string;
@@ -1027,7 +1028,7 @@ const ArtifactsTabContent: React.FC<{
 
   React.useEffect(() => {
     let aborted = false;
-    async function loadArtifacts() {
+    async function loadVisualizations() {
       if (aborted) {
         return;
       }
@@ -1076,7 +1077,7 @@ const ArtifactsTabContent: React.FC<{
       setProgress(100); // Loaded will be set by Progress onComplete
       return;
     }
-    loadArtifacts();
+    loadVisualizations();
 
     const abort = () => {
       aborted = true;
@@ -1115,6 +1116,15 @@ const ArtifactsTabContent: React.FC<{
               maxDimension={500}
             />
             <Hr />
+          </div>
+          <div className={padding(20)}>
+            <p>
+              Add visualizations to your own components following instructions in{' '}
+              <ExternalLink href='https://www.kubeflow.org/docs/pipelines/sdk/output-viewer/'>
+                Visualize Results in the Pipelines UI
+              </ExternalLink>
+              .
+            </p>
           </div>
         </>
       )}

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -269,6 +269,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
         this._onGenerate(visualizationArguments, source, type, namespace || '');
       },
       type: PlotType.VISUALIZATION_CREATOR,
+      collapsedInitially: true,
     };
 
     return (

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -1097,6 +1097,9 @@ const VisualizationsTabContent: React.FC<{
         <Progress value={progress} onComplete={onLoad} />
       ) : (
         <>
+          {viewerConfigs.length + generatedVisualizations.length === 0 && (
+            <Banner message='There are no visualizations in this step.' mode='warning' />
+          )}
           {[
             ...viewerConfigs,
             ...generatedVisualizations.map(visualization => visualization.config),

--- a/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
@@ -565,8 +565,8 @@ exports[`RunDetails logs tab does not load logs if clicked node status is skippe
                 selectedTab={4}
                 tabs={
                   Array [
-                    "Artifacts",
                     "Input/Output",
+                    "Visualizations",
                     "ML Metadata",
                     "Volumes",
                     "Logs",
@@ -683,8 +683,8 @@ exports[`RunDetails logs tab keeps side pane open and on same tab when logs chan
                 selectedTab={4}
                 tabs={
                   Array [
-                    "Artifacts",
                     "Input/Output",
+                    "Visualizations",
                     "ML Metadata",
                     "Volumes",
                     "Logs",
@@ -801,8 +801,8 @@ exports[`RunDetails logs tab loads and shows logs in side pane 1`] = `
                 selectedTab={4}
                 tabs={
                   Array [
-                    "Artifacts",
                     "Input/Output",
+                    "Visualizations",
                     "ML Metadata",
                     "Volumes",
                     "Logs",
@@ -919,8 +919,8 @@ exports[`RunDetails logs tab switches to logs tab in side pane 1`] = `
                 selectedTab={4}
                 tabs={
                   Array [
-                    "Artifacts",
                     "Input/Output",
+                    "Visualizations",
                     "ML Metadata",
                     "Volumes",
                     "Logs",
@@ -1037,8 +1037,8 @@ exports[`RunDetails opens side panel when graph node is clicked 1`] = `
                 selectedTab={0}
                 tabs={
                   Array [
-                    "Artifacts",
                     "Input/Output",
+                    "Visualizations",
                     "ML Metadata",
                     "Volumes",
                     "Logs",
@@ -1051,24 +1051,28 @@ exports[`RunDetails opens side panel when graph node is clicked 1`] = `
                 className="page"
                 data-testid="run-details-node-details"
               >
-                <ArtifactsTabContent
-                  generatedVisualizations={Array []}
-                  nodeId="node1"
-                  nodeStatus={
-                    Object {
-                      "id": "node1",
-                    }
-                  }
-                  onError={[Function]}
-                  visualizationCreatorConfig={
-                    Object {
-                      "allowCustomVisualizations": false,
-                      "isBusy": false,
-                      "onGenerate": [Function],
-                      "type": "visualization-creator",
-                    }
-                  }
-                />
+                <div
+                  className=""
+                >
+                  <DetailsTable
+                    fields={Array []}
+                    title="Input parameters"
+                  />
+                  <DetailsTable
+                    fields={Array []}
+                    title="Input artifacts"
+                    valueComponent={[Function]}
+                  />
+                  <DetailsTable
+                    fields={Array []}
+                    title="Output parameters"
+                  />
+                  <DetailsTable
+                    fields={Array []}
+                    title="Output artifacts"
+                    valueComponent={[Function]}
+                  />
+                </div>
               </div>
             </div>
           </SidePanel>
@@ -1191,133 +1195,6 @@ exports[`RunDetails shows a one-node graph 1`] = `
             onClose={[Function]}
             title=""
           />
-          <div
-            className="footer"
-          >
-            <div
-              className="flex"
-            >
-              <pure(InfoOutlinedIcon)
-                className="infoIcon"
-              />
-              <span
-                className="infoSpan"
-              >
-                Runtime execution graph. Only steps that are currently running or have already completed are shown.
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`RunDetails shows clicked node message in side panel 1`] = `
-<div
-  className="page"
->
-  <div
-    className="page"
-  >
-    <MD2Tabs
-      onSwitch={[Function]}
-      selectedTab={0}
-      tabs={
-        Array [
-          "Graph",
-          "Run output",
-          "Config",
-        ]
-      }
-    />
-    <div
-      className="page"
-    >
-      <div
-        className="page graphPane"
-      >
-        <div
-          className="page"
-        >
-          <EnhancedGraph
-            graph={
-              Graph {
-                "_defaultEdgeLabelFn": [Function],
-                "_defaultNodeLabelFn": [Function],
-                "_edgeLabels": Object {},
-                "_edgeObjs": Object {},
-                "_in": Object {},
-                "_isCompound": false,
-                "_isDirected": true,
-                "_isMultigraph": false,
-                "_label": Object {},
-                "_nodes": Object {},
-                "_out": Object {},
-                "_preds": Object {},
-                "_sucs": Object {},
-              }
-            }
-            onClick={[Function]}
-            onError={[Function]}
-            selectedNodeId="node1"
-          />
-          <SidePanel
-            isBusy={false}
-            isOpen={true}
-            onClose={[Function]}
-            title="node1"
-          >
-            <Banner
-              message="This step is in Succeeded state with this message: some test message"
-              mode="warning"
-            />
-            <div
-              className="page"
-            >
-              <MD2Tabs
-                onSwitch={[Function]}
-                selectedTab={0}
-                tabs={
-                  Array [
-                    "Artifacts",
-                    "Input/Output",
-                    "ML Metadata",
-                    "Volumes",
-                    "Logs",
-                    "Pod",
-                    "Events",
-                  ]
-                }
-              />
-              <div
-                className="page"
-                data-testid="run-details-node-details"
-              >
-                <ArtifactsTabContent
-                  generatedVisualizations={Array []}
-                  nodeId="node1"
-                  nodeStatus={
-                    Object {
-                      "id": "node1",
-                      "message": "some test message",
-                      "phase": "Succeeded",
-                    }
-                  }
-                  onError={[Function]}
-                  visualizationCreatorConfig={
-                    Object {
-                      "allowCustomVisualizations": false,
-                      "isBusy": false,
-                      "onGenerate": [Function],
-                      "type": "visualization-creator",
-                    }
-                  }
-                />
-              </div>
-            </div>
-          </SidePanel>
           <div
             className="footer"
           >
@@ -1729,11 +1606,11 @@ exports[`RunDetails switches to inputs/outputs tab in side pane 1`] = `
             >
               <MD2Tabs
                 onSwitch={[Function]}
-                selectedTab={1}
+                selectedTab={0}
                 tabs={
                   Array [
-                    "Artifacts",
                     "Input/Output",
+                    "Visualizations",
                     "ML Metadata",
                     "Volumes",
                     "Logs",
@@ -1875,8 +1752,8 @@ exports[`RunDetails switches to manifest tab in side pane 1`] = `
                 selectedTab={7}
                 tabs={
                   Array [
-                    "Artifacts",
                     "Input/Output",
+                    "Visualizations",
                     "ML Metadata",
                     "Volumes",
                     "Logs",
@@ -2026,8 +1903,8 @@ exports[`RunDetails switches to volumes tab in side pane 1`] = `
                 selectedTab={3}
                 tabs={
                   Array [
-                    "Artifacts",
                     "Input/Output",
+                    "Visualizations",
                     "ML Metadata",
                     "Volumes",
                     "Logs",


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/3328

demo: https://youtu.be/Xo3OxBwV55U

Changes:
* Rename artifacts tab to visualizations tab
* Move inputs/outputs tab as the default tab (instead of visualizations)
* Show visualization doc link in the tab
* Show a warning banner when there are no visualizations
* Hide the visualization creator with an extra click because it's an advanced feature and shouldn't usually be used.

/kind feature
/area frontend
/area ux