### PR TITLE
AWS Sagemaker Components - enhance integration test coverage

### DIFF
--- a/components/aws/sagemaker/tests/integration_tests/README.md
+++ b/components/aws/sagemaker/tests/integration_tests/README.md
@@ -26,7 +26,7 @@ Change the bucket name and run the python script `[s3_sample_data_creator.py](ht
       AWS_SECRET_ACCESS_KEY: YOUR_BASE64_SECRET_ACCESS
     ```
     
-    > Note: To get base64 string, try `echo -n $AWS_ACCESS_KEY_ID | base64`
+    > Note: To get base64 string, run `echo -n $AWS_ACCESS_KEY_ID | base64`
 1. Create conda environment using environment.yml for running tests. Run `conda env create -f environment.yml`
 1. Activate the conda environment `conda activate kfp_test_env`
 1. Run port-forward to minio service in background. Example: `kubectl port-forward svc/minio-service 9000:9000 -n kubeflow &`

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_batch_transform_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_batch_transform_component.py
@@ -1,0 +1,74 @@
+import utils
+import os
+import pytest
+
+from utils import kfp_client_utils
+from utils import minio_utils
+from utils import sagemaker_utils
+from utils import s3_utils
+
+
+@pytest.mark.parametrize(
+    "test_file_dir", ["resources/config/kmeans-mnist-batch-transform"]
+)
+def test_transform_job(
+    kfp_client,
+    experiment_id,
+    s3_client,
+    sagemaker_client,
+    s3_data_bucket,
+    test_file_dir,
+):
+
+    download_dir = utils.mkdir(os.path.join(test_file_dir + "/generated"))
+    test_params = utils.load_params(
+        utils.replace_placeholders(
+            os.path.join(test_file_dir, "config.yaml"),
+            os.path.join(download_dir, "config.yaml"),
+        )
+    )
+
+    # Generate random prefix for model, job name to avoid errors if resources with same name exists
+    test_params["Arguments"]["model_name"] = test_params["Arguments"][
+        "job_name"
+    ] = input_job_name = (
+        utils.generate_random_string(5) + "-" + test_params["Arguments"]["model_name"]
+    )
+
+    # Generate unique location for output since output filename is generated according to the content_type
+    test_params["Arguments"]["output_location"] = os.path.join(
+        test_params["Arguments"]["output_location"], input_job_name
+    )
+
+    run_id, status, workflow_json = kfp_client_utils.compile_run_monitor_pipeline(
+        kfp_client,
+        experiment_id,
+        test_params["PipelineDefinition"],
+        test_params["Arguments"],
+        download_dir,
+        test_params["TestName"],
+        test_params["Timeout"],
+    )
+
+    outputs = {"sagemaker-batch-transformation": ["output_location"]}
+
+    output_files = minio_utils.artifact_download_iterator(
+        workflow_json, outputs, download_dir
+    )
+
+    # Verify Job was successful on SageMaker
+    response = sagemaker_utils.describe_transform_job(sagemaker_client, input_job_name)
+    assert response["TransformJobStatus"] == "Completed"
+    assert response["TransformJobName"] == input_job_name
+
+    # Verify output location from pipeline matches job output and that the transformed file exists
+    output_location = utils.extract_information(
+        output_files["sagemaker-batch-transformation"]["output_location"], "data",
+    )
+    print(f"output location: {output_location}")
+    assert output_location == response["TransformOutput"]["S3OutputPath"]
+    # Get relative path of file in S3 bucket
+    file_key = os.path.join(
+        "/".join(output_location.split("/")[3:]), test_params["ExpectedOutputFile"]
+    )
+    assert s3_utils.check_object_exists(s3_client, s3_data_bucket, file_key)

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_batch_transform_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_batch_transform_component.py
@@ -34,13 +34,14 @@ def test_transform_job(
     ] = input_job_name = (
         utils.generate_random_string(5) + "-" + test_params["Arguments"]["model_name"]
     )
+    print(f"running test with model/job name: {input_job_name}")
 
     # Generate unique location for output since output filename is generated according to the content_type
     test_params["Arguments"]["output_location"] = os.path.join(
         test_params["Arguments"]["output_location"], input_job_name
     )
 
-    run_id, status, workflow_json = kfp_client_utils.compile_run_monitor_pipeline(
+    _, _, workflow_json = kfp_client_utils.compile_run_monitor_pipeline(
         kfp_client,
         experiment_id,
         test_params["PipelineDefinition"],

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_batch_transform_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_batch_transform_component.py
@@ -9,7 +9,13 @@ from utils import s3_utils
 
 
 @pytest.mark.parametrize(
-    "test_file_dir", ["resources/config/kmeans-mnist-batch-transform"]
+    "test_file_dir",
+    [
+        pytest.param(
+            "resources/config/kmeans-mnist-batch-transform",
+            marks=pytest.mark.canary_test,
+        )
+    ],
 )
 def test_transform_job(
     kfp_client,

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_batch_transform_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_batch_transform_component.py
@@ -62,13 +62,17 @@ def test_transform_job(
     assert response["TransformJobName"] == input_job_name
 
     # Verify output location from pipeline matches job output and that the transformed file exists
-    output_location = utils.extract_information(
+    output_location = utils.read_from_file_in_tar(
         output_files["sagemaker-batch-transformation"]["output_location"], "data",
     )
     print(f"output location: {output_location}")
     assert output_location == response["TransformOutput"]["S3OutputPath"]
     # Get relative path of file in S3 bucket
+    # URI is following format s3://<bucket_name>/relative/path/to/file
+    # split below is to extract the part after bucket name
     file_key = os.path.join(
         "/".join(output_location.split("/")[3:]), test_params["ExpectedOutputFile"]
     )
     assert s3_utils.check_object_exists(s3_client, s3_data_bucket, file_key)
+
+    utils.remove_dir(download_dir)

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_deploy_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_deploy_component.py
@@ -40,7 +40,14 @@ def run_predict_mnist(boto3_session, endpoint_name, download_dir):
     return json.loads(response["Body"].read().decode())
 
 
-@pytest.mark.parametrize("test_file_dir", ["resources/config/kmeans-mnist-endpoint"])
+@pytest.mark.parametrize(
+    "test_file_dir",
+    [
+        pytest.param(
+            "resources/config/kmeans-mnist-endpoint", marks=pytest.mark.canary_test
+        )
+    ],
+)
 def test_create_endpoint(
     kfp_client, experiment_id, boto3_session, sagemaker_client, test_file_dir
 ):

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_deploy_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_deploy_component.py
@@ -1,0 +1,102 @@
+import pytest
+import os
+import utils
+import io
+import numpy
+import json
+import pickle
+import gzip
+
+from utils import kfp_client_utils
+from utils import minio_utils
+from utils import sagemaker_utils
+
+
+def run_predict_mnist(boto3_session, endpoint_name, download_dir):
+    """ https://github.com/awslabs/amazon-sagemaker-examples/blob/a8c20eeb72dc7d3e94aaaf28be5bf7d7cd5695cb
+        /sagemaker-python-sdk/1P_kmeans_lowlevel/kmeans_mnist_lowlevel.ipynb """
+    # Download and load dataset
+    region = boto3_session.region_name
+    download_path = os.path.join(download_dir, "mnist.pkl.gz")
+    boto3_session.resource("s3", region_name=region).Bucket(
+        "sagemaker-sample-data-{}".format(region)
+    ).download_file("algorithms/kmeans/mnist/mnist.pkl.gz", download_path)
+    with gzip.open(download_path, "rb") as f:
+        train_set, valid_set, test_set = pickle.load(f, encoding="latin1")
+
+    # Function to create a csv from numpy array
+    def np2csv(arr):
+        csv = io.BytesIO()
+        numpy.savetxt(csv, arr, delimiter=",", fmt="%g")
+        return csv.getvalue().decode().rstrip()
+
+    # Run prediction on an image
+    runtime = boto3_session.client("sagemaker-runtime")
+    payload = np2csv(train_set[0][30:31])
+
+    response = runtime.invoke_endpoint(
+        EndpointName=endpoint_name, ContentType="text/csv", Body=payload,
+    )
+    return json.loads(response["Body"].read().decode())
+
+
+@pytest.mark.parametrize("test_file_dir", ["resources/config/kmeans-mnist-endpoint"])
+def test_create_endpoint(
+    kfp_client, experiment_id, boto3_session, sagemaker_client, test_file_dir
+):
+
+    download_dir = utils.mkdir(os.path.join(test_file_dir + "/generated"))
+    test_params = utils.load_params(
+        utils.replace_placeholders(
+            os.path.join(test_file_dir, "config.yaml"),
+            os.path.join(download_dir, "config.yaml"),
+        )
+    )
+
+    # Generate random prefix for model, endpoint config and endpoint name
+    # to avoid errors if resources with same name exists
+    test_params["Arguments"]["model_name"] = test_params["Arguments"][
+        "endpoint_config_name"
+    ] = test_params["Arguments"]["endpoint_name"] = input_endpoint_name = (
+        utils.generate_random_string(5) + "-" + test_params["Arguments"]["model_name"]
+    )
+
+    run_id, status, workflow_json = kfp_client_utils.compile_run_monitor_pipeline(
+        kfp_client,
+        experiment_id,
+        test_params["PipelineDefinition"],
+        test_params["Arguments"],
+        download_dir,
+        test_params["TestName"],
+        test_params["Timeout"],
+    )
+
+    outputs = {"sagemaker-deploy-model": ["endpoint_name"]}
+
+    output_files = minio_utils.artifact_download_iterator(
+        workflow_json, outputs, download_dir
+    )
+
+    output_endpoint_name = utils.extract_information(
+        output_files["sagemaker-deploy-model"]["endpoint_name"], "endpoint_name.txt"
+    )
+    print(f"endpoint name: {output_endpoint_name}")
+
+    # Verify output from pipeline is endpoint name
+    assert output_endpoint_name == input_endpoint_name
+
+    # Verify endpoint is running
+    assert (
+        sagemaker_utils.describe_endpoint(sagemaker_client, input_endpoint_name)[
+            "EndpointStatus"
+        ]
+        == "InService"
+    )
+
+    # Validate the model for use by running a prediction
+    result = run_predict_mnist(boto3_session, input_endpoint_name, download_dir)
+    assert result is not None
+    print(f"prediction result: {result}")
+
+    # Clean up
+    sagemaker_utils.delete_endpoint(sagemaker_client, input_endpoint_name)

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_hpo_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_hpo_component.py
@@ -1,0 +1,113 @@
+import pytest
+import os
+import json
+import utils
+
+from utils import kfp_client_utils
+from utils import minio_utils
+from utils import sagemaker_utils
+
+
+@pytest.mark.parametrize("test_file_dir", ["resources/config/kmeans-mnist-hpo"])
+def test_hyperparameter_tuning(
+    kfp_client, experiment_id, region, sagemaker_client, test_file_dir
+):
+
+    download_dir = utils.mkdir(os.path.join(test_file_dir + "/generated"))
+    test_params = utils.load_params(
+        utils.replace_placeholders(
+            os.path.join(test_file_dir, "config.yaml"),
+            os.path.join(download_dir, "config.yaml"),
+        )
+    )
+
+    test_params["Arguments"]["channels"] = json.dumps(
+        test_params["Arguments"]["channels"]
+    )
+    test_params["Arguments"]["static_parameters"] = json.dumps(
+        test_params["Arguments"]["static_parameters"]
+    )
+    test_params["Arguments"]["integer_parameters"] = json.dumps(
+        test_params["Arguments"]["integer_parameters"]
+    )
+    test_params["Arguments"]["categorical_parameters"] = json.dumps(
+        test_params["Arguments"]["categorical_parameters"]
+    )
+
+    run_id, status, workflow_json = kfp_client_utils.compile_run_monitor_pipeline(
+        kfp_client,
+        experiment_id,
+        test_params["PipelineDefinition"],
+        test_params["Arguments"],
+        download_dir,
+        test_params["TestName"],
+        test_params["Timeout"],
+    )
+
+    outputs = {
+        "sagemaker-hyperparameter-tuning": [
+            "best_hyperparameters",
+            "best_job_name",
+            "hpo_job_name",
+            "model_artifact_url",
+            "training_image",
+        ]
+    }
+    output_files = minio_utils.artifact_download_iterator(
+        workflow_json, outputs, download_dir
+    )
+
+    # Verify HPO job was successful on SageMaker
+    hpo_job_name = utils.extract_information(
+        output_files["sagemaker-hyperparameter-tuning"]["hpo_job_name"],
+        "hpo_job_name.txt",
+    )
+    print(f"HPO job name: {hpo_job_name}")
+    hpo_response = sagemaker_utils.describe_hpo_job(sagemaker_client, hpo_job_name)
+    assert hpo_response["HyperParameterTuningJobStatus"] == "Completed"
+
+    # Verify training image output is an ECR image
+    training_image = utils.extract_information(
+        output_files["sagemaker-hyperparameter-tuning"]["training_image"],
+        "training_image.txt",
+    )
+    print(f"Training image used: {training_image}")
+    if "ExpectedTrainingImage" in test_params.keys():
+        assert test_params["ExpectedTrainingImage"] == training_image
+    else:
+        assert f"dkr.ecr.{region}.amazonaws.com" in training_image
+
+    # Verify Training job was part of HPO job, returned as best and was successful
+    best_training_job_name = utils.extract_information(
+        output_files["sagemaker-hyperparameter-tuning"]["best_job_name"],
+        "best_job_name.txt",
+    )
+    print(f"best training job name: {best_training_job_name}")
+    train_response = sagemaker_utils.describe_training_job(
+        sagemaker_client, best_training_job_name
+    )
+    assert train_response["TuningJobArn"] == hpo_response["HyperParameterTuningJobArn"]
+    assert (
+        train_response["TrainingJobName"]
+        == hpo_response["BestTrainingJob"]["TrainingJobName"]
+    )
+    assert train_response["TrainingJobStatus"] == "Completed"
+
+    # Verify model artifacts output was generated from this run
+    model_artifact_url = utils.extract_information(
+        output_files["sagemaker-hyperparameter-tuning"]["model_artifact_url"],
+        "model_artifact_url.txt",
+    )
+    print(f"model_artifact_url: {model_artifact_url}")
+    assert model_artifact_url == train_response["ModelArtifacts"]["S3ModelArtifacts"]
+    assert best_training_job_name in model_artifact_url
+
+    # Verify hyper_parameters output is not empty
+    hyper_parameters = json.loads(
+        utils.extract_information(
+            output_files["sagemaker-hyperparameter-tuning"]["best_hyperparameters"],
+            "best_hyperparameters.txt",
+        )
+    )
+    print(f"HPO best hyperparameters: {json.dumps(hyper_parameters, indent = 2)}")
+    assert hyper_parameters is not None

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_hpo_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_hpo_component.py
@@ -58,7 +58,7 @@ def test_hyperparameter_tuning(
     )
 
     # Verify HPO job was successful on SageMaker
-    hpo_job_name = utils.extract_information(
+    hpo_job_name = utils.read_from_file_in_tar(
         output_files["sagemaker-hyperparameter-tuning"]["hpo_job_name"],
         "hpo_job_name.txt",
     )
@@ -67,7 +67,7 @@ def test_hyperparameter_tuning(
     assert hpo_response["HyperParameterTuningJobStatus"] == "Completed"
 
     # Verify training image output is an ECR image
-    training_image = utils.extract_information(
+    training_image = utils.read_from_file_in_tar(
         output_files["sagemaker-hyperparameter-tuning"]["training_image"],
         "training_image.txt",
     )
@@ -78,7 +78,7 @@ def test_hyperparameter_tuning(
         assert f"dkr.ecr.{region}.amazonaws.com" in training_image
 
     # Verify Training job was part of HPO job, returned as best and was successful
-    best_training_job_name = utils.extract_information(
+    best_training_job_name = utils.read_from_file_in_tar(
         output_files["sagemaker-hyperparameter-tuning"]["best_job_name"],
         "best_job_name.txt",
     )
@@ -94,7 +94,7 @@ def test_hyperparameter_tuning(
     assert train_response["TrainingJobStatus"] == "Completed"
 
     # Verify model artifacts output was generated from this run
-    model_artifact_url = utils.extract_information(
+    model_artifact_url = utils.read_from_file_in_tar(
         output_files["sagemaker-hyperparameter-tuning"]["model_artifact_url"],
         "model_artifact_url.txt",
     )
@@ -104,10 +104,12 @@ def test_hyperparameter_tuning(
 
     # Verify hyper_parameters output is not empty
     hyper_parameters = json.loads(
-        utils.extract_information(
+        utils.read_from_file_in_tar(
             output_files["sagemaker-hyperparameter-tuning"]["best_hyperparameters"],
             "best_hyperparameters.txt",
         )
     )
     print(f"HPO best hyperparameters: {json.dumps(hyper_parameters, indent = 2)}")
     assert hyper_parameters is not None
+
+    utils.remove_dir(download_dir)

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_hpo_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_hpo_component.py
@@ -8,7 +8,10 @@ from utils import minio_utils
 from utils import sagemaker_utils
 
 
-@pytest.mark.parametrize("test_file_dir", ["resources/config/kmeans-mnist-hpo"])
+@pytest.mark.parametrize(
+    "test_file_dir",
+    [pytest.param("resources/config/kmeans-mnist-hpo", marks=pytest.mark.canary_test)],
+)
 def test_hyperparameter_tuning(
     kfp_client, experiment_id, region, sagemaker_client, test_file_dir
 ):

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_hpo_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_hpo_component.py
@@ -34,7 +34,7 @@ def test_hyperparameter_tuning(
         test_params["Arguments"]["categorical_parameters"]
     )
 
-    run_id, status, workflow_json = kfp_client_utils.compile_run_monitor_pipeline(
+    _, _, workflow_json = kfp_client_utils.compile_run_monitor_pipeline(
         kfp_client,
         experiment_id,
         test_params["PipelineDefinition"],

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_model_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_model_component.py
@@ -42,8 +42,8 @@ def test_createmodel(kfp_client, experiment_id, sagemaker_client, test_file_dir)
     output_model_name = utils.extract_information(
         output_files["sagemaker-create-model"]["model_name"], "model_name.txt"
     )
-    print(f"model_name: {output_model_name.decode()}")
-    assert output_model_name.decode() == input_model_name
+    print(f"model_name: {output_model_name}")
+    assert output_model_name == input_model_name
     assert (
         sagemaker_utils.describe_model(sagemaker_client, input_model_name) is not None
     )

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_model_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_model_component.py
@@ -22,8 +22,9 @@ def test_createmodel(kfp_client, experiment_id, sagemaker_client, test_file_dir)
     test_params["Arguments"]["model_name"] = input_model_name = (
         utils.generate_random_string(5) + "-" + test_params["Arguments"]["model_name"]
     )
+    print(f"running test with model_name: {input_model_name}")
 
-    run_id, status, workflow_json = kfp_client_utils.compile_run_monitor_pipeline(
+    _, _, workflow_json = kfp_client_utils.compile_run_monitor_pipeline(
         kfp_client,
         experiment_id,
         test_params["PipelineDefinition"],

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_model_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_model_component.py
@@ -7,7 +7,14 @@ from utils import minio_utils
 from utils import sagemaker_utils
 
 
-@pytest.mark.parametrize("test_file_dir", ["resources/config/kmeans-mnist-model"])
+@pytest.mark.parametrize(
+    "test_file_dir",
+    [
+        pytest.param(
+            "resources/config/kmeans-mnist-model", marks=pytest.mark.canary_test
+        )
+    ],
+)
 def test_createmodel(kfp_client, experiment_id, sagemaker_client, test_file_dir):
 
     download_dir = utils.mkdir(os.path.join(test_file_dir + "/generated"))

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_model_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_model_component.py
@@ -39,7 +39,7 @@ def test_createmodel(kfp_client, experiment_id, sagemaker_client, test_file_dir)
         workflow_json, outputs, download_dir
     )
 
-    output_model_name = utils.extract_information(
+    output_model_name = utils.read_from_file_in_tar(
         output_files["sagemaker-create-model"]["model_name"], "model_name.txt"
     )
     print(f"model_name: {output_model_name}")
@@ -47,3 +47,5 @@ def test_createmodel(kfp_client, experiment_id, sagemaker_client, test_file_dir)
     assert (
         sagemaker_utils.describe_model(sagemaker_client, input_model_name) is not None
     )
+
+    utils.remove_dir(download_dir)

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_train_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_train_component.py
@@ -26,7 +26,7 @@ def test_trainingjob(
     test_params["Arguments"]["channels"] = json.dumps(
         test_params["Arguments"]["channels"]
     )
-    run_id, status, workflow_json = kfp_client_utils.compile_run_monitor_pipeline(
+    _, _, workflow_json = kfp_client_utils.compile_run_monitor_pipeline(
         kfp_client,
         experiment_id,
         test_params["PipelineDefinition"],

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_train_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_train_component.py
@@ -36,13 +36,15 @@ def test_trainingjob(
         test_params["Timeout"],
     )
 
-    outputs = {"sagemaker-training-job": ["job_name", "model_artifact_url", "training_image"]}
+    outputs = {
+        "sagemaker-training-job": ["job_name", "model_artifact_url", "training_image"]
+    }
     output_files = minio_utils.artifact_download_iterator(
         workflow_json, outputs, download_dir
     )
 
     # Verify Training job was successful on SageMaker
-    training_job_name = utils.extract_information(
+    training_job_name = utils.read_from_file_in_tar(
         output_files["sagemaker-training-job"]["job_name"], "job_name.txt"
     )
     print(f"training job name: {training_job_name}")
@@ -52,7 +54,7 @@ def test_trainingjob(
     assert train_response["TrainingJobStatus"] == "Completed"
 
     # Verify model artifacts output was generated from this run
-    model_artifact_url = utils.extract_information(
+    model_artifact_url = utils.read_from_file_in_tar(
         output_files["sagemaker-training-job"]["model_artifact_url"],
         "model_artifact_url.txt",
     )
@@ -61,7 +63,7 @@ def test_trainingjob(
     assert training_job_name in model_artifact_url
 
     # Verify training image output is an ECR image
-    training_image = utils.extract_information(
+    training_image = utils.read_from_file_in_tar(
         output_files["sagemaker-training-job"]["training_image"], "training_image.txt",
     )
     print(f"Training image used: {training_image}")
@@ -69,3 +71,5 @@ def test_trainingjob(
         assert test_params["ExpectedTrainingImage"] == training_image
     else:
         assert f"dkr.ecr.{region}.amazonaws.com" in training_image
+
+    utils.remove_dir(download_dir)

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_train_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_train_component.py
@@ -7,7 +7,14 @@ from utils import minio_utils
 from utils import sagemaker_utils
 
 
-@pytest.mark.parametrize("test_file_dir", ["resources/config/simple-mnist-training"])
+@pytest.mark.parametrize(
+    "test_file_dir",
+    [
+        pytest.param(
+            "resources/config/simple-mnist-training", marks=pytest.mark.canary_test
+        )
+    ],
+)
 def test_trainingjob(
     kfp_client, experiment_id, region, sagemaker_client, test_file_dir
 ):

--- a/components/aws/sagemaker/tests/integration_tests/environment.yml
+++ b/components/aws/sagemaker/tests/integration_tests/environment.yml
@@ -3,14 +3,15 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python 3.7.*
-  - pip 20.0.*
-  - awscli 1.18.*
-  - boto3 1.12.*
-  - pytest 5.*
-  - pyyaml 5.3.*
-  - flake8 3.7.*
-  - flake8-black 0.1.*
+  - python=3.7.*
+  - pip=20.0.*
+  - awscli=1.18.*
+  - boto3=1.12.*
+  - pytest=5.*
+  - pytest-xdist=1.31.*
+  - pyyaml=5.3.*
+  - flake8=3.7.*
+  - flake8-black=0.1.*
   - pip:
     - kubernetes==11.0.*
     - kfp==0.5.*

--- a/components/aws/sagemaker/tests/integration_tests/pytest.ini
+++ b/components/aws/sagemaker/tests/integration_tests/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 addopts = -rA
+markers =
+    canary_test: test to be run as part of canaries.

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-batch-transform/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-batch-transform/config.yaml
@@ -1,0 +1,24 @@
+PipelineDefinition: resources/definition/transform_job_pipeline.py
+TestName: kmeans-batch-transform-test
+Timeout: 1200
+ExpectedOutputFile: valid_data.csv.out
+Arguments:
+  region: ((REGION))
+  model_name: kmeans-mnist-model
+  job_name: kmeans-mnist-model
+  image: ((KMEANS_REGISTRY)).dkr.ecr.((REGION)).amazonaws.com/kmeans:1
+  model_artifact_url: s3://((DATA_BUCKET))/mnist_kmeans_example/model/kmeans-mnist-model/model.tar.gz
+  instance_type: ml.m4.xlarge
+  instance_count: 1
+  network_isolation: "True"
+  role: ((ROLE_ARN))
+  data_input: s3://((DATA_BUCKET))/mnist_kmeans_example/input
+  data_type: S3Prefix
+  content_type: text/csv
+  compression_type: None
+  output_location: s3://((DATA_BUCKET))/mnist_kmeans_example/output
+  max_concurrent: 4
+  max_payload: 6
+  batch_strategy: MultiRecord
+  split_type: Line
+  

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-endpoint/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-endpoint/config.yaml
@@ -1,0 +1,16 @@
+PipelineDefinition: resources/definition/create_endpoint_pipeline.py
+TestName: kmeans-create-endpoint-test
+Timeout: 1800
+Arguments:
+  region: ((REGION))
+  model_name: kmeans-mnist-model
+  endpoint_config_name: kmeans-mnist-model
+  endpoint_name: kmeans-mnist-model
+  image: ((KMEANS_REGISTRY)).dkr.ecr.((REGION)).amazonaws.com/kmeans:1
+  model_artifact_url: s3://((DATA_BUCKET))/mnist_kmeans_example/model/kmeans-mnist-model/model.tar.gz
+  variant_name_1: variant-1
+  instance_type_1: ml.m4.xlarge
+  initial_instance_count_1: 1
+  network_isolation: "True"
+  role: ((ROLE_ARN))
+  

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-endpoint/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-endpoint/config.yaml
@@ -1,6 +1,10 @@
 PipelineDefinition: resources/definition/create_endpoint_pipeline.py
 TestName: kmeans-create-endpoint-test
 Timeout: 1800
+ExpectedPrediction:
+  predictions:
+    - distance_to_cluster: 7.448746204376221
+      closest_cluster: 2.0
 Arguments:
   region: ((REGION))
   model_name: kmeans-mnist-model

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-hpo/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-hpo/config.yaml
@@ -1,0 +1,56 @@
+PipelineDefinition: resources/definition/hpo_pipeline.py
+TestName: kmeans-mnist-hpo-training
+Timeout: 3600
+ExpectedTrainingImage: ((KMEANS_REGISTRY)).dkr.ecr.((REGION)).amazonaws.com/kmeans:1
+Arguments:
+  region: ((REGION))
+  algorithm_name: K-Means
+  training_input_mode: File
+  static_parameters:
+    k: "10"
+    feature_dim: "784"
+  integer_parameters:
+    - Name: "mini_batch_size"
+      MinValue: "450"
+      MaxValue: "550"
+    - Name: "extra_center_factor"
+      MinValue: "10"
+      MaxValue: "20"
+  channels:
+    - ChannelName: train
+      DataSource:
+        S3DataSource:
+          S3Uri: s3://((DATA_BUCKET))/mnist_kmeans_example/train_data
+          S3DataType: S3Prefix
+          S3DataDistributionType: FullyReplicated
+      CompressionType: None
+      RecordWrapperType: None
+      InputMode: File
+    - ChannelName: test
+      DataSource:
+        S3DataSource:
+          S3Uri: s3://((DATA_BUCKET))/mnist_kmeans_example/test_data
+          S3DataType: S3Prefix
+          S3DataDistributionType: FullyReplicated
+      CompressionType: None
+      RecordWrapperType: None
+      InputMode: File
+  categorical_parameters:
+    - Name: init_method
+      Values: 
+        - random
+        - kmeans++
+  early_stopping_type: "Off"
+  max_parallel_jobs: 1
+  max_num_jobs: 1
+  metric_name: test:msd
+  metric_type: Minimize
+  hpo_strategy: Bayesian
+  instance_type: ml.p2.16xlarge
+  instance_count: 1
+  volume_size: 50
+  max_run_time: 3600
+  output_location: s3://((DATA_BUCKET))/mnist_kmeans_example/output
+  network_isolation: "True"
+  max_wait_time: 3600
+  role: ((ROLE_ARN))

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-hpo/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-hpo/config.yaml
@@ -46,7 +46,7 @@ Arguments:
   metric_name: test:msd
   metric_type: Minimize
   hpo_strategy: Bayesian
-  instance_type: ml.p2.16xlarge
+  instance_type: ml.m5.xlarge
   instance_count: 1
   volume_size: 50
   max_run_time: 3600

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/simple-mnist-training/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/simple-mnist-training/config.yaml
@@ -19,7 +19,7 @@ Arguments:
       CompressionType: None
       RecordWrapperType: None
       InputMode: File
-  instance_type: ml.p2.xlarge
+  instance_type: ml.m5.xlarge
   instance_count: 1
   volume_size: 50
   max_run_time: 3600

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/simple-mnist-training/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/simple-mnist-training/config.yaml
@@ -1,6 +1,7 @@
 PipelineDefinition: resources/definition/training_pipeline.py
 TestName: simple-mnist-training
 Timeout: 3600
+ExpectedTrainingImage: ((KMEANS_REGISTRY)).dkr.ecr.((REGION)).amazonaws.com/kmeans:1
 Arguments:
   region: ((REGION))
   image: ((KMEANS_REGISTRY)).dkr.ecr.((REGION)).amazonaws.com/kmeans:1

--- a/components/aws/sagemaker/tests/integration_tests/resources/definition/create_endpoint_pipeline.py
+++ b/components/aws/sagemaker/tests/integration_tests/resources/definition/create_endpoint_pipeline.py
@@ -1,0 +1,55 @@
+import kfp
+from kfp import components
+from kfp import dsl
+from kfp.aws import use_aws_secret
+
+sagemaker_model_op = components.load_component_from_file("../../model/component.yaml")
+sagemaker_deploy_op = components.load_component_from_file("../../deploy/component.yaml")
+
+
+@dsl.pipeline(
+    name="Create Hosting Endpoint in SageMaker",
+    description="SageMaker deploy component test",
+)
+def create_endpoint_pipeline(
+    region="",
+    endpoint_url="",
+    image="",
+    model_name="",
+    endpoint_config_name="",
+    endpoint_name="",
+    model_artifact_url="",
+    variant_name_1="",
+    instance_type_1="",
+    initial_instance_count_1="",
+    initial_variant_weight_1="",
+    network_isolation="",
+    role="",
+):
+    create_model = sagemaker_model_op(
+        region=region,
+        endpoint_url=endpoint_url,
+        model_name=model_name,
+        image=image,
+        model_artifact_url=model_artifact_url,
+        network_isolation=network_isolation,
+        role=role,
+    ).apply(use_aws_secret("aws-secret", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"))
+
+    sagemaker_deploy_op(
+        region=region,
+        endpoint_url=endpoint_url,
+        endpoint_config_name=endpoint_config_name,
+        endpoint_name=endpoint_name,
+        model_name_1=create_model.output,
+        variant_name_1=variant_name_1,
+        instance_type_1=instance_type_1,
+        initial_instance_count_1=initial_instance_count_1,
+        initial_variant_weight_1=initial_variant_weight_1,
+    ).apply(use_aws_secret("aws-secret", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"))
+
+
+if __name__ == "__main__":
+    kfp.compiler.Compiler().compile(
+        create_endpoint_pipeline, "SageMaker_hosting_pipeline" + ".yaml"
+    )

--- a/components/aws/sagemaker/tests/integration_tests/resources/definition/hpo_pipeline.py
+++ b/components/aws/sagemaker/tests/integration_tests/resources/definition/hpo_pipeline.py
@@ -1,0 +1,65 @@
+import kfp
+from kfp import components
+from kfp import dsl
+from kfp.aws import use_aws_secret
+
+sagemaker_hpo_op = components.load_component_from_file(
+    "../../hyperparameter_tuning/component.yaml"
+)
+
+
+@dsl.pipeline(
+    name="SageMaker HyperParameter Tuning", description="SageMaker HPO job test"
+)
+def hpo_pipeline(
+    region="",
+    algorithm_name="",
+    training_input_mode="",
+    static_parameters="",
+    integer_parameters="",
+    channels="",
+    categorical_parameters="",
+    early_stopping_type="",
+    max_parallel_jobs="",
+    max_num_jobs="",
+    metric_name="",
+    metric_type="",
+    hpo_strategy="",
+    instance_type="",
+    instance_count="",
+    volume_size="",
+    max_run_time="",
+    output_location="",
+    network_isolation="",
+    max_wait_time="",
+    role="",
+):
+    sagemaker_hpo_op(
+        region=region,
+        algorithm_name=algorithm_name,
+        training_input_mode=training_input_mode,
+        static_parameters=static_parameters,
+        integer_parameters=integer_parameters,
+        channels=channels,
+        categorical_parameters=categorical_parameters,
+        early_stopping_type=early_stopping_type,
+        max_parallel_jobs=max_parallel_jobs,
+        max_num_jobs=max_num_jobs,
+        metric_name=metric_name,
+        metric_type=metric_type,
+        strategy=hpo_strategy,
+        instance_type=instance_type,
+        instance_count=instance_count,
+        volume_size=volume_size,
+        max_run_time=max_run_time,
+        output_location=output_location,
+        network_isolation=network_isolation,
+        max_wait_time=max_wait_time,
+        role=role,
+    ).apply(use_aws_secret("aws-secret", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"))
+
+
+if __name__ == "__main__":
+    kfp.compiler.Compiler().compile(
+        hpo_pipeline, "SageMaker_hyperparameter_tuning_pipeline" + ".yaml"
+    )

--- a/components/aws/sagemaker/tests/integration_tests/resources/definition/transform_job_pipeline.py
+++ b/components/aws/sagemaker/tests/integration_tests/resources/definition/transform_job_pipeline.py
@@ -1,0 +1,66 @@
+import kfp
+from kfp import components
+from kfp import dsl
+from kfp.aws import use_aws_secret
+
+sagemaker_model_op = components.load_component_from_file("../../model/component.yaml")
+sagemaker_batch_transform_op = components.load_component_from_file(
+    "../../batch_transform/component.yaml"
+)
+
+
+@dsl.pipeline(
+    name="Batch Transform Job in SageMaker",
+    description="SageMaker batch transform component test",
+)
+def batch_transform_pipeline(
+    region="",
+    image="",
+    model_name="",
+    job_name="",
+    model_artifact_url="",
+    instance_type="",
+    instance_count="",
+    data_input="",
+    data_type="",
+    content_type="",
+    compression_type="",
+    output_location="",
+    max_concurrent="",
+    max_payload="",
+    batch_strategy="",
+    split_type="",
+    network_isolation="",
+    role="",
+):
+    create_model = sagemaker_model_op(
+        region=region,
+        model_name=model_name,
+        image=image,
+        model_artifact_url=model_artifact_url,
+        network_isolation=network_isolation,
+        role=role,
+    ).apply(use_aws_secret("aws-secret", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"))
+
+    sagemaker_batch_transform_op(
+        region=region,
+        model_name=create_model.output,
+        job_name=job_name,
+        instance_type=instance_type,
+        instance_count=instance_count,
+        max_concurrent=max_concurrent,
+        max_payload=max_payload,
+        batch_strategy=batch_strategy,
+        input_location=data_input,
+        data_type=data_type,
+        content_type=content_type,
+        split_type=split_type,
+        compression_type=compression_type,
+        output_location=output_location,
+    ).apply(use_aws_secret("aws-secret", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"))
+
+
+if __name__ == "__main__":
+    kfp.compiler.Compiler().compile(
+        batch_transform_pipeline, "SageMaker_batch_transform" + ".yaml"
+    )

--- a/components/aws/sagemaker/tests/integration_tests/utils/__init__.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/__init__.py
@@ -45,9 +45,12 @@ def run_command(cmd, *popenargs, **kwargs):
         pytest.fail(f"Command failed. Error code: {e.returncode}, Log: {e.output}")
 
 
-def extract_information(file_path, file_name):
+def extract_information(file_path, file_name, decode=True):
     with tarfile.open(file_path).extractfile(file_name) as f:
-        return f.read()
+        if decode:
+            return f.read().decode()
+        else:
+            return f.read()
 
 
 def replace_placeholders(input_filename, output_filename):

--- a/components/aws/sagemaker/tests/integration_tests/utils/__init__.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/__init__.py
@@ -5,6 +5,7 @@ import tarfile
 import yaml
 import random
 import string
+import shutil
 
 from sagemaker.amazon.amazon_estimator import get_image_uri
 
@@ -45,7 +46,7 @@ def run_command(cmd, *popenargs, **kwargs):
         pytest.fail(f"Command failed. Error code: {e.returncode}, Log: {e.output}")
 
 
-def extract_information(file_path, file_name, decode=True):
+def read_from_file_in_tar(file_path, file_name, decode=True):
     with tarfile.open(file_path).extractfile(file_name) as f:
         if decode:
             return f.read().decode()
@@ -91,3 +92,7 @@ def mkdir(directory_path):
     if not os.path.exists(directory_path):
         os.makedirs(directory_path)
     return directory_path
+
+
+def remove_dir(dir_path):
+    shutil.rmtree(dir_path)

--- a/components/aws/sagemaker/tests/integration_tests/utils/kfp_client_utils.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/kfp_client_utils.py
@@ -58,6 +58,6 @@ def compile_run_monitor_pipeline(
 
     if check and not status:
         argo_utils.print_workflow_logs(workflow_json["metadata"]["name"])
-        pytest.fail(f"Test Failed: {pipeline_name}")
+        pytest.fail(f"Test Failed: {pipeline_name}. Run-id: {run_id}")
 
     return run_id, status, workflow_json

--- a/components/aws/sagemaker/tests/integration_tests/utils/kfp_client_utils.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/kfp_client_utils.py
@@ -13,13 +13,9 @@ def compile_and_run_pipeline(
     output_file_dir,
     pipeline_name,
 ):
-
-    env_value = os.environ.copy()
-    env_value["PYTHONPATH"] = f"{os.getcwd()}:" + os.environ.get("PYTHONPATH", "")
     pipeline_path = os.path.join(output_file_dir, pipeline_name)
     utils.run_command(
-        f"dsl-compile --py {pipeline_definition} --output {pipeline_path}.yaml",
-        env=env_value,
+        f"dsl-compile --py {pipeline_definition} --output {pipeline_path}.yaml"
     )
     run = client.run_pipeline(
         experiment_id, pipeline_name, f"{pipeline_path}.yaml", input_params

--- a/components/aws/sagemaker/tests/integration_tests/utils/minio_utils.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/minio_utils.py
@@ -5,12 +5,15 @@ from minio import Minio
 
 
 def get_artifact_in_minio(workflow_json, step_name, artifact_name, output_dir):
+    """ Minio is the S3 style object storage server for K8s. This method parses a pipeline run's workflow json to
+    fetch the output artifact location in Minio server for given step in the pipeline and downloads it"""
+
     s3_data = {}
     minio_access_key = "minio"
     minio_secret_key = "minio123"
     minio_port = utils.get_minio_service_port()
     for node in workflow_json["status"]["nodes"].values():
-        if step_name in node["name"]:
+        if step_name in node["name"] and node["type"] != "DAG":
             for artifact in node["outputs"]["artifacts"]:
                 if artifact["name"] == artifact_name:
                     s3_data = artifact["s3"]

--- a/components/aws/sagemaker/tests/integration_tests/utils/minio_utils.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/minio_utils.py
@@ -6,7 +6,12 @@ from minio import Minio
 
 def get_artifact_in_minio(workflow_json, step_name, artifact_name, output_dir):
     """ Minio is the S3 style object storage server for K8s. This method parses a pipeline run's workflow json to
-    fetch the output artifact location in Minio server for given step in the pipeline and downloads it"""
+    fetch the output artifact location in Minio server for given step in the pipeline and downloads it
+
+    There are two types of nodes in the workflow_json: DAG and pod. DAG corresonds to the whole pipeline and
+    pod corresponds to a step in the DAG. Check `node["type"] != "DAG"` deals with case where name of component is
+    part of the pipeline name
+    """
 
     s3_data = {}
     minio_access_key = "minio"

--- a/components/aws/sagemaker/tests/integration_tests/utils/s3_utils.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/s3_utils.py
@@ -1,0 +1,4 @@
+def check_object_exists(client, bucket, key):
+    waiter = client.get_waiter("object_exists")
+    waiter.wait(Bucket=bucket, Key=key)
+    return True

--- a/components/aws/sagemaker/tests/integration_tests/utils/sagemaker_utils.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/sagemaker_utils.py
@@ -1,6 +1,33 @@
+import pytest
+from botocore.exceptions import WaiterError
+
+
 def describe_training_job(client, training_job_name):
     return client.describe_training_job(TrainingJobName=training_job_name)
 
 
 def describe_model(client, model_name):
     return client.describe_model(ModelName=model_name)
+
+
+def describe_endpoint(client, endpoint_name):
+    return client.describe_endpoint(EndpointName=endpoint_name)
+
+
+def delete_endpoint(client, endpoint_name):
+    client.delete_endpoint(EndpointName=endpoint_name)
+    waiter = client.get_waiter("endpoint_deleted")
+    try:
+        waiter.wait(EndpointName=endpoint_name)
+    except WaiterError as e:
+        pytest.fail(f"Endpoint - {endpoint_name} deletion failed. Error: {e.__dict__}")
+
+
+def describe_hpo_job(client, job_name):
+    return client.describe_hyper_parameter_tuning_job(
+        HyperParameterTuningJobName=job_name
+    )
+
+
+def describe_transform_job(client, job_name):
+    return client.describe_transform_job(TransformJobName=job_name)

--- a/components/aws/sagemaker/tests/integration_tests/utils/sagemaker_utils.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/sagemaker_utils.py
@@ -1,7 +1,3 @@
-import pytest
-from botocore.exceptions import WaiterError
-
-
 def describe_training_job(client, training_job_name):
     return client.describe_training_job(TrainingJobName=training_job_name)
 
@@ -17,10 +13,7 @@ def describe_endpoint(client, endpoint_name):
 def delete_endpoint(client, endpoint_name):
     client.delete_endpoint(EndpointName=endpoint_name)
     waiter = client.get_waiter("endpoint_deleted")
-    try:
-        waiter.wait(EndpointName=endpoint_name)
-    except WaiterError as e:
-        pytest.fail(f"Endpoint - {endpoint_name} deletion failed. Error: {e.__dict__}")
+    waiter.wait(EndpointName=endpoint_name)
 
 
 def describe_hpo_job(client, job_name):


### PR DESCRIPTION
- Add tests for following components:
  - Create Endpoint
  - Hyperparameter Tuning job and 
  - Batch Transform Job
- Can now run the tests in parallel: Added and tested [pytest-xdist](https://pypi.org/project/pytest-xdist/) plugin which can be used to run the tests in parallel . All the test currently take around 23 mins if run serially and 9 mins if run in parallel on my notebook
- Minor bug fixes and documentation
- Add some utility methods
