### PR TITLE
SDK - Prioritize lib2to3 when stripping type annotations

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -193,16 +193,16 @@ import pickle
 
 def strip_type_hints(source_code: str) -> str:
     try:
-        return _strip_type_hints_using_strip_hints(source_code)
-    except Exception as ex:
-        print('Error when stripping type annotations: ' + str(ex))
-
-    try:        
         return _strip_type_hints_using_lib2to3(source_code)
     except Exception as ex:
         print('Error when stripping type annotations: ' + str(ex))
 
-    return source_code    
+    try:
+        return _strip_type_hints_using_strip_hints(source_code)
+    except Exception as ex:
+        print('Error when stripping type annotations: ' + str(ex))
+
+    return source_code
 
 
 def _strip_type_hints_using_strip_hints(source_code: str) -> str:

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
@@ -478,7 +478,7 @@ spec:
           - "-u"
           - "-c"
           - |
-              def produce_list_of_dicts()  :
+              def produce_list_of_dicts():
                   return ([{"aaa": "aaa1", "bbb": "bbb1"}, {"aaa": "aaa2", "bbb": "bbb2"}],)
               
               def _serialize_json(obj) -> str:
@@ -542,7 +542,7 @@ spec:
           - "-u"
           - "-c"
           - |
-              def produce_list_of_ints()  :
+              def produce_list_of_ints():
                   return ([1234567890, 987654321],)
               
               def _serialize_json(obj) -> str:
@@ -606,7 +606,7 @@ spec:
           - "-u"
           - "-c"
           - |
-              def produce_list_of_strings()  :
+              def produce_list_of_strings():
                   return (["a", "z"],)
               
               def _serialize_json(obj) -> str:
@@ -670,7 +670,7 @@ spec:
           - "-u"
           - "-c"
           - |
-              def produce_str()  :
+              def produce_str():
                   return "Hello"
               
               def _serialize_str(str_value: str) -> str:


### PR DESCRIPTION
It's a standard python library (although not well supported) and it does not leave training spaces.