### PR TITLE
Metadata Writer - Preserve all Argo artifact information

### DIFF
--- a/backend/metadata_writer/src/metadata_helpers.py
+++ b/backend/metadata_writer/src/metadata_helpers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 import sys
 import ml_metadata
@@ -240,6 +241,8 @@ CONTEXT_RUN_ID_PROPERTY_NAME = "run_id"
 
 KFP_POD_NAME_EXECUTION_PROPERTY_NAME = 'kfp_pod_name'
 
+ARTIFACT_ARGO_ARTIFACT_PROPERTY_NAME = 'argo_artifact'
+
 
 def get_or_create_run_context(
     store,
@@ -374,13 +377,17 @@ def create_new_output_artifact(
     type_name: str,
     output_name: str,
     run_id: str = None,
+    argo_artifact: dict = None,
 ) -> metadata_store_pb2.Artifact:
     properties = {
         ARTIFACT_IO_NAME_PROPERTY_NAME: metadata_store_pb2.Value(string_value=output_name),
     }
+    custom_properties = {}
     if run_id:
         properties[ARTIFACT_PIPELINE_NAME_PROPERTY_NAME] = metadata_store_pb2.Value(string_value=str(run_id))
         properties[ARTIFACT_RUN_ID_PROPERTY_NAME] = metadata_store_pb2.Value(string_value=str(run_id))
+    if argo_artifact:
+        custom_properties[ARTIFACT_ARGO_ARTIFACT_PROPERTY_NAME] = metadata_store_pb2.Value(string_value=json.dumps(argo_artifact, sort_keys=True))
     return create_new_artifact_event_and_attribution(
         store=store,
         execution_id=execution_id,
@@ -402,5 +409,6 @@ def create_new_output_artifact(
             ARTIFACT_PIPELINE_NAME_PROPERTY_NAME: metadata_store_pb2.STRING,
             ARTIFACT_RUN_ID_PROPERTY_NAME: metadata_store_pb2.STRING,
         },
+        custom_properties=custom_properties,
         #milliseconds_since_epoch=int(datetime.now(timezone.utc).timestamp() * 1000), # Happens automatically
     )

--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -83,7 +83,16 @@ def output_name_to_argo(name: str) -> str:
 
 
 def argo_artifact_to_uri(artifact: dict) -> str:
-    return 'argo-artifact://' + json.dumps(artifact, sort_keys=True)
+    if 's3' in artifact:
+        s3_artifact = artifact['s3']
+        return 'minio://{bucket}/{key}'.format(
+            bucket=s3_artifact.get('bucket', ''),
+            key=s3_artifact.get('key', ''),
+        )
+    elif 'raw' in artifact:
+        return None
+    else:
+        return None
 
 
 def is_tfx_pod(pod) -> bool:
@@ -286,6 +295,7 @@ while True:
                             output_name=name,
                             #run_id='Context_' + str(context_id) + '_run',
                             run_id=argo_workflow_name,
+                            argo_artifact=art,
                         )
 
                         artifact_ids.append(dict(

--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -83,16 +83,7 @@ def output_name_to_argo(name: str) -> str:
 
 
 def argo_artifact_to_uri(artifact: dict) -> str:
-    if 's3' in artifact:
-        s3_artifact = artifact['s3']
-        return 'minio://{bucket}/{key}'.format(
-            bucket=s3_artifact.get('bucket', ''),
-            key=s3_artifact.get('key', ''),
-        )
-    elif 'raw' in artifact:
-        return None
-    else:
-        return None
+    return 'argo-artifact://' + json.dumps(artifact, sort_keys=True)
 
 
 def is_tfx_pod(pod) -> bool:


### PR DESCRIPTION
Previously only s3 artifacts were supported and only bucket and key were included (not endpoint, for example).

Related to https://github.com/kubeflow/pipelines/pull/3531
Related to https://github.com/kubeflow/pipelines/pull/3530

@Jeffwan WDYT?

/hold Until UX can parse the new format.