### PR TITLE
SDK - Components - Calculate component hash digest

### DIFF
--- a/sdk/python/tests/components/test_components.py
+++ b/sdk/python/tests/components/test_components.py
@@ -97,7 +97,7 @@ implementation:
         task_factory1 = comp.load_component_from_text(component_text)
         task1 = task_factory1()
 
-        self.assertEqual(len(task1.component_ref.digest), 64)  # The length of SHA256 hash digest is 32256 bits = 32 bytes = 64 hex digits
+        self.assertEqual(task1.component_ref.digest, '1ede211233e869581d098673962c2c1e8c1e4cebb7cf5d7332c2f73cb4900823')
 
     def test_accessing_component_spec_from_task_factory(self):
         component_text = '''\

--- a/sdk/python/tests/components/test_components.py
+++ b/sdk/python/tests/components/test_components.py
@@ -87,6 +87,18 @@ implementation:
 
         self.assertEqual(task_factory1.component_spec.implementation.container.image, component_dict['implementation']['container']['image'])
 
+    def test_digest_of_loaded_component(self):
+        component_text = textwrap.dedent('''\
+            implementation:
+              container:
+                image: busybox
+            '''
+        )
+        task_factory1 = comp.load_component_from_text(component_text)
+        task1 = task_factory1()
+
+        self.assertEqual(len(task1.component_ref.digest), 64)  # The length of SHA256 hash digest is 32256 bits = 32 bytes = 64 hex digits
+
     def test_accessing_component_spec_from_task_factory(self):
         component_text = '''\
 implementation:

--- a/sdk/python/tests/components/test_data/retail_product_stockout_prediction_pipeline.component.yaml
+++ b/sdk/python/tests/components/test_data/retail_product_stockout_prediction_pipeline.component.yaml
@@ -38,6 +38,7 @@ implementation:
     tasks:
       Automl create dataset for tables:
         componentRef:
+          digest: 98381958ba8b0d2b83a23a78f482f08b48e665409820b3a6254bccdbcf206df3
           url: https://raw.githubusercontent.com/kubeflow/pipelines/b3179d86b239a08bf4884b50dbf3a9151da96d66/components/gcp/automl/create_dataset_for_tables/component.yaml
         arguments:
           gcp_project_id:
@@ -51,6 +52,7 @@ implementation:
               inputName: dataset_display_name
       Automl import data from bigquery:
         componentRef:
+          digest: a965621525a9081a8c7d4c12806bf4359a03b9842a7d3e891ab5b48422dbe527
           url: https://raw.githubusercontent.com/kubeflow/pipelines/b3179d86b239a08bf4884b50dbf3a9151da96d66/components/gcp/automl/import_data_from_bigquery/component.yaml
         arguments:
           dataset_path:
@@ -63,6 +65,7 @@ implementation:
               inputName: dataset_bq_input_uri
       Automl split dataset table column names:
         componentRef:
+          digest: a77ef9ecb87e543290a02b3fa933bcd5e67947a12f6d011fdd37bf38c1b26ade
           url: https://raw.githubusercontent.com/kubeflow/pipelines/b3179d86b239a08bf4884b50dbf3a9151da96d66/components/gcp/automl/split_dataset_table_column_names/component.yaml
         arguments:
           dataset_path:
@@ -76,6 +79,7 @@ implementation:
           table_index: '0'
       Automl create model for tables:
         componentRef:
+          digest: e52ee882685380988ee2f4de6beacdcd0d2ab21d37bef45c4e16a20a224d374e
           url: https://raw.githubusercontent.com/kubeflow/pipelines/b3179d86b239a08bf4884b50dbf3a9151da96d66/components/gcp/automl/create_model_for_tables/component.yaml
         arguments:
           gcp_project_id:
@@ -108,6 +112,7 @@ implementation:
               inputName: train_budget_milli_node_hours
       Automl prediction service batch predict:
         componentRef:
+          digest: 908ea1855f5aa3d35f60145f0f15007ea437b35b0a1be2fd1d0db5a76221cad1
           url: https://raw.githubusercontent.com/kubeflow/pipelines/b3179d86b239a08bf4884b50dbf3a9151da96d66/components/gcp/automl/prediction_service_batch_predict/component.yaml
         arguments:
           model_path:


### PR DESCRIPTION
The digest is calculated when loading the component from URL, file or text.
Slightly refactored component loading - streams are no longer used, only bytes.
TODO: Calculate the digest if missing
TODO: Report possible digest conflicts