### PR TITLE
[Backend] Allow capital letters and underscore in metric names

### DIFF
--- a/backend/src/apiserver/server/run_metric_util.go
+++ b/backend/src/apiserver/server/run_metric_util.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// This regex expresses the following constraints:
-	// * Allows lowercase/capital letters
+	// * Allows lowercase/uppercase letters
 	// * Allows "_", "-" and numbers in the middle
 	// * Additionally, numbers are also allowed at the end
 	// * At most 64 characters

--- a/backend/src/apiserver/server/run_metric_util.go
+++ b/backend/src/apiserver/server/run_metric_util.go
@@ -24,7 +24,12 @@ import (
 )
 
 const (
-	metricNamePattern = "^[a-zA-Z]([_-a-zA-Z0-9]{0,62}[a-zA-Z0-9])?$"
+	// This regex expresses the following constraints:
+	// * Allows lowercase/capital letters
+	// * Allows "_", "-" and numbers in the middle
+	// * Additionally, numbers are also allowed at the end
+	// * At most 64 characters
+	metricNamePattern = "^[a-zA-Z]([-_a-zA-Z0-9]{0,62}[a-zA-Z0-9])?$"
 )
 
 // ValidateRunMetric validates RunMetric fields from request.

--- a/backend/src/apiserver/server/run_metric_util.go
+++ b/backend/src/apiserver/server/run_metric_util.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	metricNamePattern = "^[a-z]([-a-z0-9]{0,62}[a-z0-9])?$"
+	metricNamePattern = "^[a-zA-Z]([_-a-zA-Z0-9]{0,62}[a-zA-Z0-9])?$"
 )
 
 // ValidateRunMetric validates RunMetric fields from request.

--- a/backend/src/apiserver/server/run_metric_util_test.go
+++ b/backend/src/apiserver/server/run_metric_util_test.go
@@ -76,12 +76,21 @@ func TestValidateRunMetric_InvalidNodeIDs(t *testing.T) {
 }
 
 func TestNewReportRunMetricResult_OK(t *testing.T) {
-	expected := newReportRunMetricResult("metric-1", "node-1")
-	expected.Status = api.ReportRunMetricsResponse_ReportRunMetricResult_OK
+	tests := []struct {
+		metricName string
+	}{
+		{"metric-1"},
+		{"Metric_2"},
+		{"MetricName"},
+	}
 
-	actual := NewReportRunMetricResult(expected.GetMetricName(), expected.GetMetricNodeId(), nil)
+	for _, tc := range tests {
+		expected := newReportRunMetricResult(tc.metricName, "node-1")
+		expected.Status = api.ReportRunMetricsResponse_ReportRunMetricResult_OK
+		actual := NewReportRunMetricResult(expected.GetMetricName(), expected.GetMetricNodeId(), nil)
 
-	assert.Equal(t, expected, actual)
+		assert.Equalf(t, expected, actual, "TestNewReportRunMetricResult_OK metric name '%s' should be OK", tc.metricName)
+	}
 }
 
 func TestNewReportRunMetricResult_UnknownError(t *testing.T) {

--- a/backend/src/apiserver/server/run_metric_util_test.go
+++ b/backend/src/apiserver/server/run_metric_util_test.go
@@ -81,7 +81,7 @@ func TestNewReportRunMetricResult_OK(t *testing.T) {
 	}{
 		{"metric-1"},
 		{"Metric_2"},
-		{"MetricName"},
+		{"Metric3Name"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/3655
Mitigates https://github.com/kubeflow/pipelines/issues/3499
Doc PR in https://github.com/kubeflow/website/pull/1950

FYI, why I did this: https://github.com/kubeflow/pipelines/issues/3499#issuecomment-627132988

Verified it works e2e using test image gcr.io/ml-pipeline-test/d73087f0a2d71aefc891cb269545c3062b9abf0a/api-server@sha256:3b4a1503412e930962e886856abf2fbea6ac31772abcc6aa54072dfef20fe66d
![Screen Shot 2020-05-12 at 4 25 15 PM](https://user-images.githubusercontent.com/4957653/81660374-42209880-946d-11ea-8d89-2a5c509bc41c.png)


/assign @jingzhang36 
/cc @amygdala @numerology 