### PR TITLE
[UI] Wrap parameter/urls on overflow

### DIFF
--- a/frontend/src/components/DetailsTable.tsx
+++ b/frontend/src/components/DetailsTable.tsx
@@ -40,10 +40,10 @@ export const css = stylesheet({
     flexGrow: 1,
   },
   valueText: {
-    maxWidth: 400,
+    // For current use-cases, value text shouldn't be very long. It will be not readable when it's long.
+    // Therefore, it's easier we just show it completely in the UX.
     overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
+    overflowWrap: 'break-word',
   },
 });
 

--- a/frontend/src/components/DetailsTable.tsx
+++ b/frontend/src/components/DetailsTable.tsx
@@ -43,6 +43,8 @@ export const css = stylesheet({
     // For current use-cases, value text shouldn't be very long. It will be not readable when it's long.
     // Therefore, it's easier we just show it completely in the UX.
     overflow: 'hidden',
+    // Sometimes, urls will be unbreakable for a long string. overflow-wrap: break-word
+    // allows breaking an url at middle of a word so it will not overflow and get hidden.
     overflowWrap: 'break-word',
   },
 });

--- a/frontend/src/components/DetailsTable.tsx
+++ b/frontend/src/components/DetailsTable.tsx
@@ -40,6 +40,8 @@ export const css = stylesheet({
     flexGrow: 1,
   },
   valueText: {
+    // flexGrow expands value text to full width.
+    flexGrow: 1,
     // For current use-cases, value text shouldn't be very long. It will be not readable when it's long.
     // Therefore, it's easier we just show it completely in the UX.
     overflow: 'hidden',

--- a/frontend/src/components/MinioArtifactPreview.tsx
+++ b/frontend/src/components/MinioArtifactPreview.tsx
@@ -11,9 +11,6 @@ import { ValueComponentProps } from './DetailsTable';
 const css = stylesheet({
   root: {
     width: '100%',
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
   },
   preview: {
     maxHeight: 250,


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/2897

Instead of showing a hovering tip, I think it's a better UX if parameters and urls just show up as a whole. From my knowledge, these usages shouldn't include super-long strings that clutter the page too much.

If a parameter is too long, it should be a file instead. URLs have length limit intrinsically.

Demos:
When there are enough space:
![Screen Shot 2020-05-12 at 10 02 12 PM](https://user-images.githubusercontent.com/4957653/81701999-4fee1200-949d-11ea-89ab-b862ba1ef948.png)
When there isn't enough space:
![Screen Shot 2020-05-12 at 10 02 23 PM](https://user-images.githubusercontent.com/4957653/81702015-567c8980-949d-11ea-9a8a-8f7ac26ff03f.png)
