### PR TITLE
[UI] Show tooltip on long version names

### DIFF
--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -148,10 +148,15 @@ export class NewRun extends Page<{ namespace?: string }, NewRunState> {
   ];
 
   private pipelineVersionSelectorColumns = [
-    { label: 'Version name', flex: 1, sortKey: PipelineVersionSortKeys.NAME },
+    {
+      customRenderer: NameWithTooltip,
+      flex: 2,
+      label: 'Version name',
+      sortKey: PipelineVersionSortKeys.NAME,
+    },
     // TODO(jingzhang36): version doesn't have description field; remove it and
     // fix the rendering.
-    { label: 'Description', flex: 2, customRenderer: descriptionCustomRenderer },
+    { label: 'Description', flex: 1, customRenderer: descriptionCustomRenderer },
     { label: 'Uploaded on', flex: 1, sortKey: PipelineVersionSortKeys.CREATED_AT },
   ];
 

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -246,18 +246,19 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
           ':' + RouteParams.pipelineId,
           props.value.pipelineId || '',
         );
-    const link = (
-      <Link className={commonCss.link} onClick={e => e.stopPropagation()} to={url}>
-        {props.value.usePlaceholder ? '[View pipeline]' : props.value.displayName}
-      </Link>
-    );
     if (props.value.usePlaceholder) {
-      return link;
+      return (
+        <Link className={commonCss.link} onClick={e => e.stopPropagation()} to={url}>
+          [View pipeline]
+        </Link>
+      );
     } else {
       // Display name could be too long, so we show the full content in tooltip on hover.
       return (
         <Tooltip title={props.value.displayName || ''} enterDelay={300} placement='top-start'>
-          {link}
+          <Link className={commonCss.link} onClick={e => e.stopPropagation()} to={url}>
+            {props.value.displayName}
+          </Link>
         </Tooltip>
       );
     }

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -246,11 +246,21 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
           ':' + RouteParams.pipelineId,
           props.value.pipelineId || '',
         );
-    return (
+    const link = (
       <Link className={commonCss.link} onClick={e => e.stopPropagation()} to={url}>
         {props.value.usePlaceholder ? '[View pipeline]' : props.value.displayName}
       </Link>
     );
+    if (props.value.usePlaceholder) {
+      return link;
+    } else {
+      // Display name could be too long, so we show the full content in tooltip on hover.
+      return (
+        <Tooltip title={props.value.displayName || ''} enterDelay={300} placement='top-start'>
+          {link}
+        </Tooltip>
+      );
+    }
   };
 
   public _recurringRunCustomRenderer: React.FC<CustomRendererProps<RecurringRunInfo>> = (

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -148,13 +148,14 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
           columns={
             Array [
               Object {
-                "flex": 1,
+                "customRenderer": [Function],
+                "flex": 2,
                 "label": "Version name",
                 "sortKey": "name",
               },
               Object {
                 "customRenderer": [Function],
-                "flex": 2,
+                "flex": 1,
                 "label": "Description",
               },
               Object {
@@ -668,13 +669,14 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
           columns={
             Array [
               Object {
-                "flex": 1,
+                "customRenderer": [Function],
+                "flex": 2,
                 "label": "Version name",
                 "sortKey": "name",
               },
               Object {
                 "customRenderer": [Function],
-                "flex": 2,
+                "flex": 1,
                 "label": "Description",
               },
               Object {
@@ -1188,13 +1190,14 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
           columns={
             Array [
               Object {
-                "flex": 1,
+                "customRenderer": [Function],
+                "flex": 2,
                 "label": "Version name",
                 "sortKey": "name",
               },
               Object {
                 "customRenderer": [Function],
-                "flex": 2,
+                "flex": 1,
                 "label": "Description",
               },
               Object {
@@ -1719,13 +1722,14 @@ exports[`NewRun changes title and form to default state if the new run is a one-
           columns={
             Array [
               Object {
-                "flex": 1,
+                "customRenderer": [Function],
+                "flex": 2,
                 "label": "Version name",
                 "sortKey": "name",
               },
               Object {
                 "customRenderer": [Function],
-                "flex": 2,
+                "flex": 1,
                 "label": "Description",
               },
               Object {
@@ -2239,13 +2243,14 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
           columns={
             Array [
               Object {
-                "flex": 1,
+                "customRenderer": [Function],
+                "flex": 2,
                 "label": "Version name",
                 "sortKey": "name",
               },
               Object {
                 "customRenderer": [Function],
-                "flex": 2,
+                "flex": 1,
                 "label": "Description",
               },
               Object {
@@ -2757,13 +2762,14 @@ exports[`NewRun renders the new run page 1`] = `
           columns={
             Array [
               Object {
-                "flex": 1,
+                "customRenderer": [Function],
+                "flex": 2,
                 "label": "Version name",
                 "sortKey": "name",
               },
               Object {
                 "customRenderer": [Function],
-                "flex": 2,
+                "flex": 1,
                 "label": "Description",
               },
               Object {
@@ -3277,13 +3283,14 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
           columns={
             Array [
               Object {
-                "flex": 1,
+                "customRenderer": [Function],
+                "flex": 2,
                 "label": "Version name",
                 "sortKey": "name",
               },
               Object {
                 "customRenderer": [Function],
-                "flex": 2,
+                "flex": 1,
                 "label": "Description",
               },
               Object {
@@ -3808,13 +3815,14 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
           columns={
             Array [
               Object {
-                "flex": 1,
+                "customRenderer": [Function],
+                "flex": 2,
                 "label": "Version name",
                 "sortKey": "name",
               },
               Object {
                 "customRenderer": [Function],
-                "flex": 2,
+                "flex": 1,
                 "label": "Description",
               },
               Object {
@@ -4328,13 +4336,14 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
           columns={
             Array [
               Object {
-                "flex": 1,
+                "customRenderer": [Function],
+                "flex": 2,
                 "label": "Version name",
                 "sortKey": "name",
               },
               Object {
                 "customRenderer": [Function],
-                "flex": 2,
+                "flex": 1,
                 "label": "Description",
               },
               Object {
@@ -4859,13 +4868,14 @@ exports[`NewRun starting a new run updates the pipeline params as user selects d
           columns={
             Array [
               Object {
-                "flex": 1,
+                "customRenderer": [Function],
+                "flex": 2,
                 "label": "Version name",
                 "sortKey": "name",
               },
               Object {
                 "customRenderer": [Function],
-                "flex": 2,
+                "flex": 1,
                 "label": "Description",
               },
               Object {
@@ -5379,13 +5389,14 @@ exports[`NewRun updates the run's state with the associated experiment if one is
           columns={
             Array [
               Object {
-                "flex": 1,
+                "customRenderer": [Function],
+                "flex": 2,
                 "label": "Version name",
                 "sortKey": "name",
               },
               Object {
                 "customRenderer": [Function],
-                "flex": 2,
+                "flex": 1,
                 "label": "Description",
               },
               Object {

--- a/frontend/src/pages/__snapshots__/RunList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunList.test.tsx.snap
@@ -7570,14 +7570,20 @@ exports[`RunList renders percentage metric 1`] = `
 `;
 
 exports[`RunList renders pipeline name as link to its details page 1`] = `
-<Link
-  className="link"
-  onClick={[Function]}
-  replace={false}
-  to="/pipelines/details/pipeline-id?"
+<WithStyles(Tooltip)
+  enterDelay={300}
+  placement="top-start"
+  title="test pipeline"
 >
-  test pipeline
-</Link>
+  <Link
+    className="link"
+    onClick={[Function]}
+    replace={false}
+    to="/pipelines/details/pipeline-id?"
+  >
+    test pipeline
+  </Link>
+</WithStyles(Tooltip)>
 `;
 
 exports[`RunList renders pipeline name as link to its details page 2`] = `
@@ -7592,14 +7598,20 @@ exports[`RunList renders pipeline name as link to its details page 2`] = `
 `;
 
 exports[`RunList renders pipeline version name as link to its details page 1`] = `
-<Link
-  className="link"
-  onClick={[Function]}
-  replace={false}
-  to="/pipelines/details/pipeline-id/version/version-id?"
+<WithStyles(Tooltip)
+  enterDelay={300}
+  placement="top-start"
+  title="test pipeline version"
 >
-  test pipeline version
-</Link>
+  <Link
+    className="link"
+    onClick={[Function]}
+    replace={false}
+    to="/pipelines/details/pipeline-id/version/version-id?"
+  >
+    test pipeline version
+  </Link>
+</WithStyles(Tooltip)>
 `;
 
 exports[`RunList renders raw metric 1`] = `


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/2897
/assign @jingzhang36 
/area frontend
/kind bug

Changes:
* Add tooltip on version selector
* Add tooltip on run list page's version name column