### PR TITLE
Fix the missing description in the CreatePipelineAPI

### DIFF
--- a/backend/src/apiserver/server/pipeline_server.go
+++ b/backend/src/apiserver/server/pipeline_server.go
@@ -54,7 +54,7 @@ func (s *PipelineServer) CreatePipeline(ctx context.Context, request *api.Create
 		return nil, util.Wrap(err, "Invalid pipeline name.")
 	}
 
-	pipeline, err := s.resourceManager.CreatePipeline(pipelineName, "", pipelineFile)
+	pipeline, err := s.resourceManager.CreatePipeline(pipelineName, request.Pipeline.Description, pipelineFile)
 	if err != nil {
 		return nil, util.Wrap(err, "Create pipeline failed.")
 	}

--- a/backend/src/apiserver/server/pipeline_server_test.go
+++ b/backend/src/apiserver/server/pipeline_server_test.go
@@ -29,6 +29,7 @@ func TestCreatePipeline_YAML(t *testing.T) {
 		Pipeline: &api.Pipeline{
 			Url:  &api.Url{PipelineUrl: httpServer.URL + "/arguments-parameters.yaml"},
 			Name: "argument-parameters",
+			Description: "pipeline description",
 		}})
 
 	assert.Nil(t, err)
@@ -41,6 +42,7 @@ func TestCreatePipeline_YAML(t *testing.T) {
 	err = json.Unmarshal([]byte(newPipeline.Parameters), &params)
 	assert.Nil(t, err)
 	assert.Equal(t, []api.Parameter{{Name: "param1", Value: "hello"}, {Name: "param2"}}, params)
+	assert.Equal(t, "pipeline description", newPipeline.Description)
 }
 
 func TestCreatePipeline_Tarball(t *testing.T) {
@@ -56,6 +58,7 @@ func TestCreatePipeline_Tarball(t *testing.T) {
 		Pipeline: &api.Pipeline{
 			Url:  &api.Url{PipelineUrl: httpServer.URL + "/arguments_tarball/arguments.tar.gz"},
 			Name: "argument-parameters",
+			Description: "pipeline description",
 		}})
 
 	assert.Nil(t, err)
@@ -68,6 +71,7 @@ func TestCreatePipeline_Tarball(t *testing.T) {
 	err = json.Unmarshal([]byte(newPipeline.Parameters), &params)
 	assert.Nil(t, err)
 	assert.Equal(t, []api.Parameter{{Name: "param1", Value: "hello"}, {Name: "param2"}}, params)
+	assert.Equal(t, "pipeline description", newPipeline.Description)
 }
 
 func TestCreatePipeline_InvalidYAML(t *testing.T) {


### PR DESCRIPTION
Invoke CreatePipeline always get an empty description. This is because the passing input parameter is not used and empty string is always passed in