### PR TITLE
[Servers] Add liveness and readiness probes

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -78,7 +78,9 @@ COPY backend/src/apiserver/config/ /config
 COPY --from=compiler /samples/ /samples/
 
 # Adding CA certificate so API server can download pipeline through URL
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates \
+    # wget is used for liveness/readiness probe command
+    wget
 
 # Pin sample doc links to the commit that built the backend image
 RUN sed -E "s#/(blob|tree)/master/#/\1/${COMMIT_SHA}/#g" -i /config/sample_config.json && \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -38,7 +38,3 @@ EXPOSE 3000
 RUN npm run build
 ENV API_SERVER_ADDRESS http://localhost:3001
 CMD node dist/server.js ../client/ 3000
-
-# HACK: curl is required for running liveness/readiness probe inside the container
-# refer to https://github.com/kubeflow/pipelines/issues/3756
-RUN apk add --no-cache curl

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -38,3 +38,8 @@ EXPOSE 3000
 RUN npm run build
 ENV API_SERVER_ADDRESS http://localhost:3001
 CMD node dist/server.js ../client/ 3000
+
+# HACK: curl is required for running liveness/readiness probe inside the container
+# refer to https://github.com/kubeflow/pipelines/issues/3756
+# We can get rid of this when we no longer need to support using KFP with istio 1.1.
+RUN apk add --no-cache curl

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -41,5 +41,4 @@ CMD node dist/server.js ../client/ 3000
 
 # HACK: curl is required for running liveness/readiness probe inside the container
 # refer to https://github.com/kubeflow/pipelines/issues/3756
-# We can get rid of this when we no longer need to support using KFP with istio 1.1.
 RUN apk add --no-cache curl

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
@@ -573,8 +573,11 @@ spec:
           readinessProbe:
             exec:
               command:
-                - curl
-                - -f
+                - wget
+                - -q # quiet
+                - -S # show server response
+                - -O
+                - "-" # Redirect output to stdout
                 - http://localhost:3000/apis/v1beta1/healthz
             initialDelaySeconds: 3
             periodSeconds: 5
@@ -582,8 +585,11 @@ spec:
           livenessProbe:
             exec:
               command:
-                - curl
-                - -f
+                - wget
+                - -q # quiet
+                - -S # show server response
+                - -O
+                - "-" # Redirect output to stdout
                 - http://localhost:3000/apis/v1beta1/healthz
             initialDelaySeconds: 3
             periodSeconds: 5

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
@@ -570,6 +570,24 @@ spec:
           name: ml-pipeline-ui
           ports:
             - containerPort: 3000
+          readinessProbe:
+            exec:
+              command:
+                - curl
+                - -f
+                - http://localhost:3000/apis/v1beta1/healthz
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          livenessProbe:
+            exec:
+              command:
+                - curl
+                - -f
+                - http://localhost:3000/apis/v1beta1/healthz
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
       serviceAccountName: ml-pipeline-ui
 ---
 apiVersion: apps/v1beta2

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
@@ -718,8 +718,34 @@ spec:
           imagePullPolicy: IfNotPresent
           name: ml-pipeline-api-server
           ports:
-            - containerPort: 8888
-            - containerPort: 8887
+            - name: http
+              containerPort: 8888
+            - name: grpc
+              containerPort: 8887
+          readinessProbe:
+            exec:
+              command:
+                - wget
+                - -q # quiet
+                - -S # show server response
+                - -O
+                - "-" # Redirect output to stdout
+                - http://localhost:8888/apis/v1beta1/healthz
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          livenessProbe:
+            exec:
+              command:
+                - wget
+                - -q # quiet
+                - -S # show server response
+                - -O
+                - "-" # Redirect output to stdout
+                - http://localhost:8888/apis/v1beta1/healthz
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
       serviceAccountName: ml-pipeline
 ---
 apiVersion: v1

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
@@ -648,7 +648,32 @@ spec:
           imagePullPolicy: IfNotPresent
           name: ml-pipeline-visualizationserver
           ports:
-            - containerPort: 8888
+            - name: http
+              containerPort: 8888
+          readinessProbe:
+            exec:
+              command:
+                - wget
+                - -q # quiet
+                - -S # show server response
+                - -O
+                - "-" # Redirect output to stdout
+                - http://localhost:8888/
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          livenessProbe:
+            exec:
+              command:
+                - wget
+                - -q # quiet
+                - -S # show server response
+                - -O
+                - "-" # Redirect output to stdout
+                - http://localhost:8888/
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
       serviceAccountName: ml-pipeline-visualizationserver
 ---
 apiVersion: apps/v1beta2

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -48,12 +48,36 @@ spec:
             configMapKeyRef:
               name: mysql-configmap
               key: port
-
-
         image: $(IMAGE_PREFIX)/api-server:$(IMAGE_TAG)
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-api-server
         ports:
-        - containerPort: 8888
-        - containerPort: 8887
+        - name: http
+          containerPort: 8888
+        - name: grpc
+          containerPort: 8887
+        readinessProbe:
+          exec:
+            command:
+              - wget
+              - -q # quiet
+              - -S # show server response
+              - -O
+              - "-" # Redirect output to stdout
+              - http://localhost:8888/apis/v1beta1/healthz
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
+        livenessProbe:
+          exec:
+            command:
+              - wget
+              - -q # quiet
+              - -S # show server response
+              - -O
+              - "-" # Redirect output to stdout
+              - http://localhost:8888/apis/v1beta1/healthz
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
       serviceAccountName: ml-pipeline

--- a/manifests/kustomize/base/pipeline/ml-pipeline-ui-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-ui-deployment.yaml
@@ -29,8 +29,11 @@ spec:
         readinessProbe:
           exec:
             command:
-              - curl
-              - -f
+              - wget
+              - -q # quiet
+              - -S # show server response
+              - -O
+              - "-" # Redirect output to stdout
               - http://localhost:3000/apis/v1beta1/healthz
           initialDelaySeconds: 3
           periodSeconds: 5
@@ -38,8 +41,11 @@ spec:
         livenessProbe:
           exec:
             command:
-              - curl
-              - -f
+              - wget
+              - -q # quiet
+              - -S # show server response
+              - -O
+              - "-" # Redirect output to stdout
               - http://localhost:3000/apis/v1beta1/healthz
           initialDelaySeconds: 3
           periodSeconds: 5

--- a/manifests/kustomize/base/pipeline/ml-pipeline-ui-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-ui-deployment.yaml
@@ -26,4 +26,22 @@ spec:
                 fieldPath: metadata.namespace
           - name: ALLOW_CUSTOM_VISUALIZATIONS
             value: "true"
+        readinessProbe:
+          exec:
+            command:
+              - curl
+              - -f
+              - http://localhost:3000/apis/v1beta1/healthz
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
+        livenessProbe:
+          exec:
+            command:
+              - curl
+              - -f
+              - http://localhost:3000/apis/v1beta1/healthz
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
       serviceAccountName: ml-pipeline-ui

--- a/manifests/kustomize/base/pipeline/ml-pipeline-visualization-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-visualization-deployment.yaml
@@ -18,5 +18,30 @@ spec:
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-visualizationserver
         ports:
-        - containerPort: 8888
+        - name: http
+          containerPort: 8888
+        readinessProbe:
+          exec:
+            command:
+              - wget
+              - -q # quiet
+              - -S # show server response
+              - -O
+              - "-" # Redirect output to stdout
+              - http://localhost:8888/
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
+        livenessProbe:
+          exec:
+            command:
+              - wget
+              - -q # quiet
+              - -S # show server response
+              - -O
+              - "-" # Redirect output to stdout
+              - http://localhost:8888/
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
       serviceAccountName: ml-pipeline-visualizationserver


### PR DESCRIPTION
/assign @IronPan @rmgogogo 
Part of https://github.com/kubeflow/pipelines/issues/3756

Added probes for UI, api, visualization servers. Operators will be added in a separate PR.
I verified this workaround works properly when istio mutual TLS is enabled.