### PR TITLE
Add probes to metadata grpc service

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -112,7 +112,7 @@ To understand more what prettier is: [What is Prettier](https://prettier.io/docs
   },
   ```
   Also, vscode builtin trailing whitespace [conflicts with jest inline snapshot](https://github.com/Microsoft/vscode/issues/52711), so recommend disabling it.
-- For others, refer to https://prettier.io/docs/en/editors.html
+- For others, refer to https://prettier.io/docs/en/editors.html.
 
 ### Format Code Manually
 

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/metadata.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/metadata.yaml
@@ -7,7 +7,7 @@ metadata:
   name: metadata-grpc-service
 spec:
   ports:
-    - name: grpc-md-backendapi
+    - name: grpc-api
       port: 8080
       protocol: TCP
   selector:
@@ -81,16 +81,16 @@ spec:
                 ]
         ports:
         - containerPort: 8080
-          name: grpc-md-backendapi
+          name: grpc-api
         livenessProbe:
           tcpSocket:
-            port: grpc-md-backendapi
+            port: grpc-api
           initialDelaySeconds: 3
           periodSeconds: 5
           timeoutSeconds: 2
         readinessProbe:
           tcpSocket:
-            port: grpc-md-backendapi
+            port: grpc-api
           initialDelaySeconds: 3
           periodSeconds: 5
           timeoutSeconds: 2

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/metadata.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/metadata.yaml
@@ -7,7 +7,7 @@ metadata:
   name: metadata-grpc-service
 spec:
   ports:
-    - name: md-backendapi
+    - name: grpc-md-backendapi
       port: 8080
       protocol: TCP
   selector:
@@ -81,7 +81,19 @@ spec:
                 ]
         ports:
         - containerPort: 8080
-          name: md-backendapi
+          name: grpc-md-backendapi
+        livenessProbe:
+          tcpSocket:
+            port: grpc-md-backendapi
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
+        readinessProbe:
+          tcpSocket:
+            port: grpc-md-backendapi
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
 ---
 kind: Service
 apiVersion: v1

--- a/manifests/kustomize/base/metadata/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/metadata-grpc-deployment.yaml
@@ -52,5 +52,17 @@ spec:
                "--mysql_config_password=$(DBCONFIG_PASSWORD)"
                ]
         ports:
-        - name: md-backendapi
+        - name: grpc-md-backendapi
           containerPort: 8080
+        livenessProbe:
+          tcpSocket:
+            port: grpc-md-backendapi
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
+        readinessProbe:
+          tcpSocket:
+            port: grpc-md-backendapi
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2

--- a/manifests/kustomize/base/metadata/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/metadata-grpc-deployment.yaml
@@ -52,17 +52,17 @@ spec:
                "--mysql_config_password=$(DBCONFIG_PASSWORD)"
                ]
         ports:
-        - name: grpc-md-backendapi
+        - name: grpc-api
           containerPort: 8080
         livenessProbe:
           tcpSocket:
-            port: grpc-md-backendapi
+            port: grpc-api
           initialDelaySeconds: 3
           periodSeconds: 5
           timeoutSeconds: 2
         readinessProbe:
           tcpSocket:
-            port: grpc-md-backendapi
+            port: grpc-api
           initialDelaySeconds: 3
           periodSeconds: 5
           timeoutSeconds: 2

--- a/manifests/kustomize/base/metadata/metadata-grpc-service.yaml
+++ b/manifests/kustomize/base/metadata/metadata-grpc-service.yaml
@@ -11,4 +11,4 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
-    name: grpc-md-backendapi
+    name: grpc-api

--- a/manifests/kustomize/base/metadata/metadata-grpc-service.yaml
+++ b/manifests/kustomize/base/metadata/metadata-grpc-service.yaml
@@ -11,4 +11,4 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
-    name: md-backendapi
+    name: grpc-md-backendapi


### PR DESCRIPTION
Part of https://github.com/kubeflow/pipelines/issues/3756

Add tcp probe to metadata grpc service.
(Use tcp probe, because it's the only support for grpc service.)
https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/

Using an extra CLI tool to probe grpc endpoint seems unnecessary at this moment. We can evaluate that later.

/assign @rmgogogo 
/cc @IronPan 