### PR TITLE
Dynamic addition of namespace and app name while creating kubeflow pipeline in gcp

### DIFF
--- a/manifests/kustomize/base/params.env
+++ b/manifests/kustomize/base/params.env
@@ -1,4 +1,4 @@
-appName=pipeline
+appName={appName}
 appVersion=0.5.1
 imageTag=0.5.1
 imagePrefix=gcr.io/ml-pipeline

--- a/manifests/kustomize/cluster-scoped-resources/params.env
+++ b/manifests/kustomize/cluster-scoped-resources/params.env
@@ -1,1 +1,1 @@
-namespace=kubeflow
+namespace={namespace}


### PR DESCRIPTION
@IronPan  To deploy a kubeflow pipeline application in different namespaces on different clusters with different app names,currently it's hardcoded, I have added the two parameters that can be exported from any shell script to automate the pipeline creation.
```
#! /bin/sh
export appName=$1
export namespace=$2
sed -i "s/{namespace}/$namespace/" pipelines/manifests/kustomize/cluster-scoped-resources/params.env
sed -i "s/{appName}/$appName/" pipelines/manifests/kustomize/base/params.env
```