### PR TITLE
[Backend] Make user identity header configurable

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -27,6 +27,8 @@ const (
 	PodNamespace                        string = "POD_NAMESPACE"
 	CacheEnabled                        string = "CacheEnabled"
 	DefaultPipelineRunnerServiceAccount string = "DefaultPipelineRunnerServiceAccount"
+	KubeflowUserIDHeader                string = "KUBEFLOW_USERID_HEADER"
+	KubeflowUserIDPrefix                string = "KUBEFLOW_USERID_PREFIX"
 )
 
 func GetStringConfig(configName string) string {
@@ -87,4 +89,12 @@ func GetBoolFromStringWithDefault(value string, defaultValue bool) bool {
 
 func IsCacheEnabled() string {
 	return GetStringConfigWithDefault(CacheEnabled, "true")
+}
+
+func GetKubeflowUserIDHeader() string {
+	return GetStringConfigWithDefault(KubeflowUserIDHeader, GoogleIAPUserIdentityHeader)
+}
+
+func GetKubeflowUserIDPrefix() string {
+	return GetStringConfigWithDefault(KubeflowUserIDPrefix, GoogleIAPUserIdentityPrefix)
 }

--- a/backend/src/apiserver/common/const.go
+++ b/backend/src/apiserver/common/const.go
@@ -37,7 +37,8 @@ const (
 )
 
 const (
-	GoogleIAPUserIdentityHeader	string = "x-goog-authenticated-user-email"
+	GoogleIAPUserIdentityHeader string = "x-goog-authenticated-user-email"
+	GoogleIAPUserIdentityPrefix string = "accounts.google.com:"
 )
 
 func ToModelResourceType(apiType api.ResourceType) (ResourceType, error) {

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -74,12 +74,10 @@ func main() {
 // A custom http request header matcher to pass on the user identity
 // Reference: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/docs/_docs/customizingyourgateway.md#mapping-from-http-request-headers-to-grpc-client-metadata
 func grpcCustomMatcher(key string) (string, bool) {
-	switch strings.ToLower(key) {
-	case common.GoogleIAPUserIdentityHeader:
+	if strings.EqualFold(key, common.GetKubeflowUserIDHeader()) {
 		return strings.ToLower(key), true
-	default:
-		return strings.ToLower(key), false
 	}
+	return strings.ToLower(key), false
 }
 
 func startRpcServer(resourceManager *resource.ResourceManager) {

--- a/backend/src/apiserver/server/experiment_server_test.go
+++ b/backend/src/apiserver/server/experiment_server_test.go
@@ -71,7 +71,7 @@ func TestCreateExperiment_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
@@ -98,7 +98,7 @@ func TestCreateExperiment_Unauthorized(t *testing.T) {
 func TestCreateExperiment_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
@@ -166,7 +166,7 @@ func TestGetExperiment_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment_KFAM_Unauthorized(t)
@@ -182,7 +182,7 @@ func TestGetExperiment_Unauthorized(t *testing.T) {
 func TestGetExperiment_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
@@ -269,7 +269,7 @@ func TestListExperiment_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment_KFAM_Unauthorized(t)
@@ -291,7 +291,7 @@ func TestListExperiment_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())

--- a/backend/src/apiserver/server/experiment_server_test.go
+++ b/backend/src/apiserver/server/experiment_server_test.go
@@ -71,7 +71,7 @@ func TestCreateExperiment_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
@@ -98,7 +98,7 @@ func TestCreateExperiment_Unauthorized(t *testing.T) {
 func TestCreateExperiment_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
@@ -166,7 +166,7 @@ func TestGetExperiment_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment_KFAM_Unauthorized(t)
@@ -182,7 +182,7 @@ func TestGetExperiment_Unauthorized(t *testing.T) {
 func TestGetExperiment_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
@@ -269,7 +269,7 @@ func TestListExperiment_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment_KFAM_Unauthorized(t)
@@ -291,7 +291,7 @@ func TestListExperiment_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())

--- a/backend/src/apiserver/server/job_server_test.go
+++ b/backend/src/apiserver/server/job_server_test.go
@@ -253,7 +253,7 @@ func TestCreateJob_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment_KFAM_Unauthorized(t)
@@ -268,7 +268,7 @@ func TestGetJob_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment(t)
@@ -290,7 +290,7 @@ func TestGetJob_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment(t)
@@ -308,7 +308,7 @@ func TestListJobs_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, experiment := initWithExperiment_KFAM_Unauthorized(t)
@@ -337,7 +337,7 @@ func TestListJobs_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment(t)
@@ -437,7 +437,7 @@ func TestEnableJob_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment(t)
@@ -459,7 +459,7 @@ func TestEnableJob_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment(t)
@@ -477,7 +477,7 @@ func TestDisableJob_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment(t)
@@ -499,7 +499,7 @@ func TestDisableJob_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment(t)

--- a/backend/src/apiserver/server/job_server_test.go
+++ b/backend/src/apiserver/server/job_server_test.go
@@ -253,7 +253,7 @@ func TestCreateJob_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment_KFAM_Unauthorized(t)
@@ -268,7 +268,7 @@ func TestGetJob_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment(t)
@@ -290,7 +290,7 @@ func TestGetJob_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment(t)
@@ -308,7 +308,7 @@ func TestListJobs_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, experiment := initWithExperiment_KFAM_Unauthorized(t)
@@ -337,7 +337,7 @@ func TestListJobs_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment(t)
@@ -437,7 +437,7 @@ func TestEnableJob_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment(t)
@@ -459,7 +459,7 @@ func TestEnableJob_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment(t)
@@ -477,7 +477,7 @@ func TestDisableJob_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment(t)
@@ -499,7 +499,7 @@ func TestDisableJob_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment(t)

--- a/backend/src/apiserver/server/run_server_test.go
+++ b/backend/src/apiserver/server/run_server_test.go
@@ -123,7 +123,7 @@ func TestCreateRun_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment_KFAM_Unauthorized(t)
@@ -148,7 +148,7 @@ func TestCreateRun_Multiuser(t *testing.T) {
 	defer viper.Set(common.MultiUserMode, "false")
 	defer viper.Set(common.DefaultPipelineRunnerServiceAccount, "pipeline-runner")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, experiment := initWithExperiment(t)
@@ -241,7 +241,7 @@ func TestListRuns_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment_KFAM_Unauthorized(t)
@@ -261,7 +261,7 @@ func TestListRuns_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, experiment := initWithExperiment(t)
@@ -598,7 +598,7 @@ func TestCanAccessRun_Unauthorized(t *testing.T) {
 	defer clients.Close()
 	runServer := RunServer{resourceManager: manager}
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	apiRun := &api.Run{
@@ -635,7 +635,7 @@ func TestCanAccessRun_Authorized(t *testing.T) {
 	defer clients.Close()
 	runServer := RunServer{resourceManager: manager}
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	apiRun := &api.Run{

--- a/backend/src/apiserver/server/run_server_test.go
+++ b/backend/src/apiserver/server/run_server_test.go
@@ -123,7 +123,7 @@ func TestCreateRun_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment_KFAM_Unauthorized(t)
@@ -148,7 +148,7 @@ func TestCreateRun_Multiuser(t *testing.T) {
 	defer viper.Set(common.MultiUserMode, "false")
 	defer viper.Set(common.DefaultPipelineRunnerServiceAccount, "pipeline-runner")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, experiment := initWithExperiment(t)
@@ -241,7 +241,7 @@ func TestListRuns_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, _ := initWithExperiment_KFAM_Unauthorized(t)
@@ -261,7 +261,7 @@ func TestListRuns_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clients, manager, experiment := initWithExperiment(t)
@@ -598,7 +598,7 @@ func TestCanAccessRun_Unauthorized(t *testing.T) {
 	defer clients.Close()
 	runServer := RunServer{resourceManager: manager}
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	apiRun := &api.Run{
@@ -635,7 +635,7 @@ func TestCanAccessRun_Authorized(t *testing.T) {
 	defer clients.Close()
 	runServer := RunServer{resourceManager: manager}
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	apiRun := &api.Run{

--- a/backend/src/apiserver/server/util.go
+++ b/backend/src/apiserver/server/util.go
@@ -282,7 +282,7 @@ func getUserIdentity(ctx context.Context) (string, error) {
 	md, _ := metadata.FromIncomingContext(ctx)
 	// If the request header contains the user identity, requests are authorized
 	// based on the namespace field in the request.
-	if userIdentityHeader, ok := md[common.GoogleIAPUserIdentityHeader]; ok {
+	if userIdentityHeader, ok := md[common.GetKubeflowUserIDHeader()]; ok {
 		if len(userIdentityHeader) != 1 {
 			return "", util.NewBadRequestError(errors.New("Request header error: unexpected number of user identity header. Expect 1 got "+strconv.Itoa(len(userIdentityHeader))),
 				"Request header error: unexpected number of user identity header. Expect 1 got "+strconv.Itoa(len(userIdentityHeader)))

--- a/backend/src/apiserver/server/util_test.go
+++ b/backend/src/apiserver/server/util_test.go
@@ -338,7 +338,7 @@ func TestValidatePipelineSpec_ParameterTooLong(t *testing.T) {
 }
 
 func TestGetUserIdentity(t *testing.T) {
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	userIdentity, err := getUserIdentity(ctx)
 	assert.Nil(t, err)
@@ -352,7 +352,7 @@ func TestCanAccessNamespaceInResourceReferences_Unauthorized(t *testing.T) {
 	clients, manager, _ := initWithExperiment_KFAM_Unauthorized(t)
 	defer clients.Close()
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	references := []*api.ResourceReference{
 		{
@@ -373,7 +373,7 @@ func TestCanAccessNamespaceInResourceReferences_Authorized(t *testing.T) {
 	clients, manager, _ := initWithExperiment(t)
 	defer clients.Close()
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	references := []*api.ResourceReference{
 		{
@@ -393,7 +393,7 @@ func TestCanAccessExperimentInResourceReferences_Unauthorized(t *testing.T) {
 	clients, manager, _ := initWithExperiment_KFAM_Unauthorized(t)
 	defer clients.Close()
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	references := []*api.ResourceReference{
 		{
@@ -414,7 +414,7 @@ func TestCanAccessExperiemntInResourceReferences_Authorized(t *testing.T) {
 	clients, manager, _ := initWithExperiment(t)
 	defer clients.Close()
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	references := []*api.ResourceReference{
 		{

--- a/backend/src/apiserver/server/util_test.go
+++ b/backend/src/apiserver/server/util_test.go
@@ -338,7 +338,7 @@ func TestValidatePipelineSpec_ParameterTooLong(t *testing.T) {
 }
 
 func TestGetUserIdentity(t *testing.T) {
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	userIdentity, err := getUserIdentity(ctx)
 	assert.Nil(t, err)
@@ -352,7 +352,7 @@ func TestCanAccessNamespaceInResourceReferences_Unauthorized(t *testing.T) {
 	clients, manager, _ := initWithExperiment_KFAM_Unauthorized(t)
 	defer clients.Close()
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	references := []*api.ResourceReference{
 		{
@@ -373,7 +373,7 @@ func TestCanAccessNamespaceInResourceReferences_Authorized(t *testing.T) {
 	clients, manager, _ := initWithExperiment(t)
 	defer clients.Close()
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	references := []*api.ResourceReference{
 		{
@@ -393,7 +393,7 @@ func TestCanAccessExperimentInResourceReferences_Unauthorized(t *testing.T) {
 	clients, manager, _ := initWithExperiment_KFAM_Unauthorized(t)
 	defer clients.Close()
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	references := []*api.ResourceReference{
 		{
@@ -414,7 +414,7 @@ func TestCanAccessExperiemntInResourceReferences_Authorized(t *testing.T) {
 	clients, manager, _ := initWithExperiment(t)
 	defer clients.Close()
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	references := []*api.ResourceReference{
 		{

--- a/backend/src/apiserver/server/visualization_server_test.go
+++ b/backend/src/apiserver/server/visualization_server_test.go
@@ -231,7 +231,7 @@ func TestCreateVisualization_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())

--- a/backend/src/apiserver/server/visualization_server_test.go
+++ b/backend/src/apiserver/server/visualization_server_test.go
@@ -231,7 +231,7 @@ func TestCreateVisualization_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: "accounts.google.com:user@google.com"})
+	md := metadata.New(map[string]string{common.GetKubeflowUserIDHeader(): common.GetKubeflowUserIDPrefix() + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())


### PR DESCRIPTION
Part of #3752

Make header configurable by KUBEFLOW_USERID_HEADER and KUBEFLOW_USERID_PREFIX options.

/cc @Bobgy @yanniszark
