### PR TITLE
Add endpoint configuration to context file and environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ _artifacts
 # Generated Python SDK documentation
 docs/_build
 
+
+sdk/python/venv/

--- a/sdk/python/kfp/cli/cli.py
+++ b/sdk/python/kfp/cli/cli.py
@@ -33,7 +33,7 @@ def cli(ctx, endpoint, iap_client_id, namespace, other_client_id, other_client_s
           # Do not create a client for diagnose_me
           return
     ctx.obj['client'] = Client(endpoint, iap_client_id, namespace, other_client_id, other_client_secret)
-    ctx.obj['namespace']= namespace
+    ctx.obj['namespace'] = namespace
 
 def main():
     logging.basicConfig(format='%(message)s', level=logging.INFO)

--- a/sdk/python/kfp/cli/run.py
+++ b/sdk/python/kfp/cli/run.py
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .._client import Client
-import sys
-import subprocess
-import pprint
-import time
 import json
-import click
+import subprocess
+import sys
+import time
 
+import click
 from tabulate import tabulate
+
 
 @click.group()
 def run():


### PR DESCRIPTION
Actually, it's hard to setup kfp CLI configuration for various clusters, and create automated configuration for pipeline deployments (like deploying updates from gitlab or travis).

This pull request increase CLI configurations with the following variabes:

* KFP_NAMESPACE -> namespace to use
* KFP_ENDPOINT -> endoint to use as api host
* KFP_CONTEXT -> Path to kfp context file

and incluse the entry `endpoint` in context file.

The configuration priority is:

Command line parameters -> Environment variables -> context file

I would like help to create tests for this PR if you think this is needed