### PR TITLE
[Testing] Fix "1.14.10-gke.27" is unsupported

### DIFF
--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -70,8 +70,7 @@ else
   # easily compare performance. We can reduce usage later.
   NODE_POOL_CONFIG_ARG="--num-nodes=2 --machine-type=n1-standard-8 \
     --enable-autoscaling --max-nodes=8 --min-nodes=2"
-  # Use new kubernetes master to improve workload identity stability.
-  KUBERNETES_VERSION_ARG="--cluster-version=1.14.10-gke.27"
+  KUBERNETES_VERSION_ARG="--cluster-version=1.14"
   if [ "$ENABLE_WORKLOAD_IDENTITY" = true ]; then
     WI_ARG="--identity-namespace=$PROJECT.svc.id.goog"
     SCOPE_ARG=


### PR DESCRIPTION
/cc @chensun @Ark-kun 
/area testing

This fixes the https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kubeflow_pipelines/3776/kubeflow-pipeline-e2e-test/1262573140995739651#1:build-log.txt%3A140
which blocks all presubmit tests