### PR TITLE
[AWS SageMaker] Add more unit tests

### DIFF
--- a/components/aws/sagemaker/batch_transform/src/batch_transform.py
+++ b/components/aws/sagemaker/batch_transform/src/batch_transform.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import argparse
 import logging
 from pathlib2 import Path
@@ -54,7 +55,7 @@ def create_parser():
 
 def main(argv=None):
   parser = create_parser()
-  args = parser.parse_args()
+  args = parser.parse_args(argv)
 
   logging.getLogger().setLevel(logging.INFO)
   client = _utils.get_sagemaker_client(args.region, args.endpoint_url)
@@ -64,10 +65,11 @@ def main(argv=None):
   _utils.wait_for_transform_job(client, batch_job_name)
 
   Path(args.output_location_file).parent.mkdir(parents=True, exist_ok=True)
-  Path(args.output_location_file).write_text(unicode(args.output_location))
+  with open(args.output_location_file, 'w') as f:
+    f.write(unicode(args.output_location))
 
   logging.info('Batch Transformation creation completed.')
 
 
 if __name__== "__main__":
-  main()
+  main(sys.argv[1:])

--- a/components/aws/sagemaker/common/_utils.py
+++ b/components/aws/sagemaker/common/_utils.py
@@ -254,21 +254,17 @@ def create_model_request(args):
         else:
             request['PrimaryContainer'].pop('ContainerHostname')
 
-        if (args['image'] or args['model_artifact_url']) and args['model_package']:
-            logging.error("Please specify an image AND model artifact url, OR a model package name.")
-            raise Exception("Could not make create model request.")
-        elif args['model_package']:
+        if args['model_package']:
             request['PrimaryContainer']['ModelPackageName'] = args['model_package']
             request['PrimaryContainer'].pop('Image')
             request['PrimaryContainer'].pop('ModelDataUrl')
+        elif args['image'] and args['model_artifact_url']:
+            request['PrimaryContainer']['Image'] = args['image']
+            request['PrimaryContainer']['ModelDataUrl'] = args['model_artifact_url']
+            request['PrimaryContainer'].pop('ModelPackageName')
         else:
-            if args['image'] and args['model_artifact_url']:
-                request['PrimaryContainer']['Image'] = args['image']
-                request['PrimaryContainer']['ModelDataUrl'] = args['model_artifact_url']
-                request['PrimaryContainer'].pop('ModelPackageName')
-            else:
-                logging.error("Please specify an image AND model artifact url.")
-                raise Exception("Could not make create model request.")
+            logging.error("Please specify an image AND model artifact url, OR a model package name.")
+            raise Exception("Could not make create model request.")
 
     request['ExecutionRoleArn'] = args['role']
     request['EnableNetworkIsolation'] = args['network_isolation']
@@ -296,6 +292,10 @@ def create_endpoint_config_request(args):
     with open(os.path.join(__cwd__, 'endpoint_config.template.yaml'), 'r') as f:
         request = yaml.safe_load(f)
 
+    if not args['model_name_1']:
+        logging.error("Must specify at least one model (model name) to host.")
+        raise Exception("Could not create endpoint config.")
+
     endpoint_config_name = args['endpoint_config_name'] if args['endpoint_config_name'] else 'EndpointConfig' + args['model_name_1'][args['model_name_1'].index('-'):]
     request['EndpointConfigName'] = endpoint_config_name
 
@@ -303,10 +303,6 @@ def create_endpoint_config_request(args):
         request['KmsKeyId'] = args['resource_encryption_key']
     else:
         request.pop('KmsKeyId')
-
-    if not args['model_name_1']:
-        logging.error("Must specify at least one model (model name) to host.")
-        raise Exception("Could not create endpoint config.")
 
     for i in range(len(request['ProductionVariants']), 0, -1):
         if args['model_name_' + str(i)]:
@@ -377,14 +373,14 @@ def wait_for_endpoint_creation(client, endpoint_name):
   finally:
     resp = client.describe_endpoint(EndpointName=endpoint_name)
     status = resp['EndpointStatus']
-    logging.info("Endpoint Arn: " + resp['EndpointArn'])
-    logging.info("Create endpoint ended with status: " + status)
 
     if status != 'InService':
-      message = client.describe_endpoint(EndpointName=endpoint_name)['FailureReason']
+      message = resp['FailureReason']
       logging.info('Create endpoint failed with the following error: {}'.format(message))
       raise Exception('Endpoint creation did not succeed')
 
+    logging.info("Endpoint Arn: " + resp['EndpointArn'])
+    logging.info("Create endpoint ended with status: " + status)
 
 def create_transform_job_request(args):
     ### Documentation: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.create_transform_job

--- a/components/aws/sagemaker/common/_utils.py
+++ b/components/aws/sagemaker/common/_utils.py
@@ -462,7 +462,7 @@ def create_transform_job(client, args):
       raise Exception(e.response['Error']['Message'])
 
 
-def wait_for_transform_job(client, batch_job_name):
+def wait_for_transform_job(client, batch_job_name, poll_interval=30):
   ### Wait until the job finishes
   while(True):
     response = client.describe_transform_job(TransformJobName=batch_job_name)
@@ -475,7 +475,7 @@ def wait_for_transform_job(client, batch_job_name):
       logging.info('Transform failed with the following error: {}'.format(message))
       raise Exception('Transform job failed')
     logging.info("Transform job is still in status: " + status)
-    time.sleep(30)
+    time.sleep(poll_interval)
 
 
 def create_hyperparameter_tuning_job_request(args):
@@ -809,7 +809,7 @@ def create_labeling_job(client, args):
         raise Exception(e.response['Error']['Message'])
 
 
-def wait_for_labeling_job(client, labeling_job_name):
+def wait_for_labeling_job(client, labeling_job_name, poll_interval=30):
     ### Wait until the job finishes
     status = 'InProgress'
     while(status == 'InProgress'):
@@ -820,7 +820,7 @@ def wait_for_labeling_job(client, labeling_job_name):
             logging.info('Labeling failed with the following error: {}'.format(message))
             raise Exception('Labeling job failed')
         logging.info("Labeling job is still in status: " + status)
-        time.sleep(30)
+        time.sleep(poll_interval)
 
     if status == 'Completed':
         logging.info("Labeling job ended with status: " + status)

--- a/components/aws/sagemaker/deploy/src/deploy.py
+++ b/components/aws/sagemaker/deploy/src/deploy.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import argparse
 import logging
 
@@ -47,7 +48,7 @@ def create_parser():
 
 def main(argv=None):
   parser = create_parser()
-  args = parser.parse_args()
+  args = parser.parse_args(argv)
 
   logging.getLogger().setLevel(logging.INFO)
   client = _utils.get_sagemaker_client(args.region, args.endpoint_url)
@@ -63,4 +64,4 @@ def main(argv=None):
 
 
 if __name__== "__main__":
-  main()
+  main(sys.argv[1:])

--- a/components/aws/sagemaker/ground_truth/src/ground_truth.py
+++ b/components/aws/sagemaker/ground_truth/src/ground_truth.py
@@ -53,7 +53,7 @@ def create_parser():
 
 def main(argv=None):
   parser = create_parser()
-  args = parser.parse_args()
+  args = parser.parse_args(argv)
 
   logging.getLogger().setLevel(logging.INFO)
   client = _utils.get_sagemaker_client(args.region, args.endpoint_url)

--- a/components/aws/sagemaker/ground_truth/src/ground_truth.py
+++ b/components/aws/sagemaker/ground_truth/src/ground_truth.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import argparse
 import logging
 
@@ -72,4 +73,4 @@ def main(argv=None):
 
 
 if __name__== "__main__":
-  main()
+  main(sys.argv[1:])

--- a/components/aws/sagemaker/model/src/create_model.py
+++ b/components/aws/sagemaker/model/src/create_model.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import argparse
 import logging
 
@@ -36,7 +37,7 @@ def create_parser():
 
 def main(argv=None):
   parser = create_parser()
-  args = parser.parse_args()
+  args = parser.parse_args(argv)
 
   logging.getLogger().setLevel(logging.INFO)
   client = _utils.get_sagemaker_client(args.region, args.endpoint_url)
@@ -50,4 +51,4 @@ def main(argv=None):
 
 
 if __name__== "__main__":
-  main()
+  main(sys.argv[1:])

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_batch_transform.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_batch_transform.py
@@ -92,6 +92,7 @@ class BatchTransformTestCase(unittest.TestCase):
                           '--split_type', 'RecordIO',
                           '--assemble_with', 'Line',
                           '--join_source', 'Input',
+                          '--tags', '{"fake_key": "fake_value"}'
                 ])
     response = _utils.create_transform_job(mock_client, vars(mock_args))
 
@@ -103,7 +104,7 @@ class BatchTransformTestCase(unittest.TestCase):
       MaxConcurrentTransforms=5,
       MaxPayloadInMB=100,
       ModelName='model-test',
-      Tags=[],
+      Tags=[{'Key': 'fake_key', 'Value': 'fake_value'}],
       TransformInput={
           'DataSource': {'S3DataSource': {'S3DataType': 'S3Prefix',
                          'S3Uri': 's3://fake-bucket/data'}},

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_deploy.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_deploy.py
@@ -53,11 +53,13 @@ class DeployTestCase(unittest.TestCase):
     mock_args = self.parser.parse_args(required_args + ['--endpoint_name', 'test-endpoint-name', '--endpoint_config_name', 'test-endpoint-config-name'])
     response = _utils.deploy_model(mock_client, vars(mock_args))
 
-    # todo : Reformat this
     mock_client.create_endpoint_config.assert_called_once_with(
-      EndpointConfigName='test-endpoint-config-name', ProductionVariants=[
+      EndpointConfigName='test-endpoint-config-name',
+      ProductionVariants=[
         {'VariantName': 'variant-name-1', 'ModelName': 'model-test', 'InitialInstanceCount': 1,
-         'InstanceType': 'ml.m4.xlarge', 'InitialVariantWeight': 1.0}], Tags=[]
+         'InstanceType': 'ml.m4.xlarge', 'InitialVariantWeight': 1.0}
+      ],
+      Tags=[]
     )
 
     self.assertEqual(response, 'test-endpoint-name')

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_deploy.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_deploy.py
@@ -73,6 +73,22 @@ class DeployTestCase(unittest.TestCase):
     with self.assertRaises(Exception):
       _utils.deploy_model(mock_client, vars(mock_args))
 
+  def test_model_name_exception(self):
+    mock_client = MagicMock()
+    mock_args = vars(self.parser.parse_args(required_args))
+    mock_args['model_name_1'] = None
+
+    with self.assertRaises(Exception):
+      _utils.create_endpoint_config_request(mock_args)
+
+  def test_create_endpoint_exception(self):
+    mock_client = MagicMock()
+    mock_exception = ClientError({"Error": {"Message": "SageMaker broke"}}, "deploy_model")
+    mock_client.create_endpoint.side_effect = mock_exception
+
+    with self.assertRaises(Exception):
+      _utils.create_endpoint(mock_client, 'us-east-1', 'fake-endpoint', 'fake-endpoint-config', {})
+
   def test_wait_for_endpoint_creation(self):
     mock_client = MagicMock()
     mock_client.describe_endpoint.side_effect = [
@@ -103,38 +119,57 @@ class DeployTestCase(unittest.TestCase):
     # if we don't pass --endpoint_name argument then endpoint name is constructed using --model_name_1
     self.assertEqual(_utils.deploy_model(mock_client, vars(self.parser.parse_args(required_args))), 'Endpoint-test')
 
-
-  def test_reasonable_required_args(self):
+  def test_pass_most_args(self):
     arguments =  [
       '--region', 'us-west-2',
+      '--endpoint_url', 'fake-url',
       '--model_name_1', 'model-test-1',
+      '--accelerator_type_1', 'ml.eia1.medium',
       '--model_name_2', 'model-test-2',
+      '--accelerator_type_2', 'ml.eia1.medium',
       '--model_name_3', 'model-test-3',
-      '--resource_encryption_key', 'fake-key'
+      '--accelerator_type_3', 'ml.eia1.medium',
+      '--resource_encryption_key', 'fake-key',
+      '--endpoint_config_tags', '{"fake_config_key": "fake_config_value"}',
+      '--endpoint_tags', '{"fake_key": "fake_value"}'
     ]
-    self.maxDiff=None
+
     response = _utils.create_endpoint_config_request(vars(self.parser.parse_args(arguments)))
     self.assertEqual(response, {'EndpointConfigName': 'EndpointConfig-test-1',
                                 'KmsKeyId': 'fake-key',
                                 'ProductionVariants': [
                                    {'InitialInstanceCount': 1,
+                                    'AcceleratorType': 'ml.eia1.medium',
                                     'InitialVariantWeight': 1.0,
                                     'InstanceType': 'ml.m4.xlarge',
                                     'ModelName': 'model-test-1',
                                     'VariantName': 'variant-name-1'
                                     },
                                    {'InitialInstanceCount': 1,
+                                    'AcceleratorType': 'ml.eia1.medium',
                                     'InitialVariantWeight': 1.0,
                                     'InstanceType': 'ml.m4.xlarge',
                                     'ModelName': 'model-test-2',
                                     'VariantName': 'variant-name-2'
                                     },
                                    {'InitialInstanceCount': 1,
+                                    'AcceleratorType': 'ml.eia1.medium',
                                     'InitialVariantWeight': 1.0,
                                     'InstanceType': 'ml.m4.xlarge',
                                     'ModelName': 'model-test-3',
                                     'VariantName': 'variant-name-3'
                                     }
                                   ],
-                                'Tags': []
+                                'Tags': [{'Key': 'fake_config_key', 'Value': 'fake_config_value'}]
                                })
+
+  def test_tag_in_create_endpoint(self):
+    mock_client = MagicMock()
+    _utils.create_endpoint(mock_client, 'us-east-1', 'fake-endpoint', 'fake-endpoint-config', {"fake_key": "fake_value"})
+
+    mock_client.create_endpoint.assert_called_once_with(
+        EndpointConfigName='fake-endpoint-config',
+        EndpointName='fake-endpoint',
+        Tags=[{'Key': 'fake_key', 'Value': 'fake_value'}]
+    )
+

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_deploy.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_deploy.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 
-from unittest.mock import patch, Mock, MagicMock
+from unittest.mock import patch, call, Mock, MagicMock, mock_open
 from botocore.exceptions import ClientError
 from datetime import datetime
 
@@ -21,12 +21,52 @@ class DeployTestCase(unittest.TestCase):
     parser = deploy.create_parser()
     cls.parser = parser
 
-  def test_sample(self):
-    args = self.parser.parse_args(required_args)
-    response = _utils.create_endpoint_config_request(vars(args))
-    self.assertEqual(response['EndpointConfigName'], 'EndpointConfig-test')
+  def test_create_parser(self):
+    self.assertIsNotNone(self.parser)
 
-  def test_empty_string(self):
-    args = self.parser.parse_args(required_args)
-    response = _utils.create_endpoint_config_request(vars(args))
-    test_utils.check_empty_string_values(response)
+  def test_main(self):
+    # Mock out all of utils except parser
+    deploy._utils = MagicMock()
+    deploy._utils.add_default_client_arguments = _utils.add_default_client_arguments
+
+    # Set some static returns
+    deploy._utils.deploy_model.return_value = 'test-endpoint-name'
+
+    with patch('builtins.open', mock_open()) as file_open:
+      deploy.main(required_args)
+
+    # Check if correct requests were created and triggered
+    deploy._utils.deploy_model.assert_called()
+    deploy._utils.wait_for_endpoint_creation.assert_called()
+
+    # Check the file outputs
+    file_open.assert_has_calls([
+      call('/tmp/endpoint_name.txt', 'w')
+    ])
+
+    file_open().write.assert_has_calls([
+      call('test-endpoint-name')
+    ])
+
+  def test_deploy_model(self):
+    mock_client = MagicMock()
+    mock_args = self.parser.parse_args(required_args + ['--endpoint_name', 'test-endpoint-name', '--endpoint_config_name', 'test-endpoint-config-name'])
+    response = _utils.deploy_model(mock_client, vars(mock_args))
+
+    # todo : Reformat this
+    mock_client.create_endpoint_config.assert_called_once_with(
+      EndpointConfigName='test-endpoint-config-name', ProductionVariants=[
+        {'VariantName': 'variant-name-1', 'ModelName': 'model-test', 'InitialInstanceCount': 1,
+         'InstanceType': 'ml.m4.xlarge', 'InitialVariantWeight': 1.0}], Tags=[]
+    )
+
+    self.assertEqual(response, 'test-endpoint-name')
+
+  def test_sagemaker_exception_in_deploy_model(self):
+    mock_client = MagicMock()
+    mock_exception = ClientError({"Error": {"Message": "SageMaker broke"}}, "deploy_model")
+    mock_client.create_endpoint_config.side_effect = mock_exception
+    mock_args = self.parser.parse_args(required_args)
+
+    with self.assertRaises(Exception):
+      _utils.deploy_model(mock_client, vars(mock_args))

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_ground_truth.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_ground_truth.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 
-from unittest.mock import patch, Mock, MagicMock
+from unittest.mock import patch, call, Mock, MagicMock, mock_open
 from botocore.exceptions import ClientError
 from datetime import datetime
 
@@ -31,12 +31,61 @@ class GroundTruthTestCase(unittest.TestCase):
     parser = ground_truth.create_parser()
     cls.parser = parser
 
-  def test_sample(self):
-    args = self.parser.parse_args(required_args)
-    response = _utils.create_labeling_job_request(vars(args))
-    self.assertEqual(response['LabelingJobName'], 'test_job')
+  def test_create_parser(self):
+    self.assertIsNotNone(self.parser)
 
-  def test_empty_string(self):
-    args = self.parser.parse_args(required_args)
-    response = _utils.create_labeling_job_request(vars(args))
-    test_utils.check_empty_string_values(response)
+  def test_main(self):
+    # Mock out all of utils except parser
+    ground_truth._utils = MagicMock()
+    ground_truth._utils.add_default_client_arguments = _utils.add_default_client_arguments
+
+    # Set some static returns
+    ground_truth._utils.get_labeling_job_outputs.return_value = ('s3://fake-bucket/output', 'arn:aws:sagemaker:us-east-1:999999999999:labeling-job')
+
+    with patch('builtins.open', mock_open()) as file_open:
+      ground_truth.main(required_args)
+
+    # Check if correct requests were created and triggered
+    ground_truth._utils.create_labeling_job.assert_called()
+    ground_truth._utils.wait_for_labeling_job.assert_called()
+    ground_truth._utils.get_labeling_job_outputs.assert_called()
+
+    # Check the file outputs
+    file_open.assert_has_calls([
+      call('/tmp/output_manifest_location.txt', 'w'),
+      call('/tmp/active_learning_model_arn.txt', 'w')
+    ], any_order=True)
+
+    file_open().write.assert_has_calls([
+      call('s3://fake-bucket/output'),
+      call('arn:aws:sagemaker:us-east-1:999999999999:labeling-job')
+    ], any_order=False)
+
+  def test_ground_truth(self):
+    mock_client = MagicMock()
+    mock_args = self.parser.parse_args(required_args)
+    response = _utils.create_labeling_job(mock_client, vars(mock_args))
+
+    mock_client.create_labeling_job.assert_called_once_with(
+      HumanTaskConfig={'WorkteamArn': None, 'UiConfig': {'UiTemplateS3Uri': 's3://fake-bucket/ui_template'},
+                       'PreHumanTaskLambdaArn': '', 'TaskTitle': 'fake-image-labelling-work',
+                       'TaskDescription': 'fake job', 'NumberOfHumanWorkersPerDataObject': 1,
+                       'TaskTimeLimitInSeconds': 180,
+                       'AnnotationConsolidationConfig': {'AnnotationConsolidationLambdaArn': ''}},
+      InputConfig={'DataSource': {'S3DataSource': {'ManifestS3Uri': 's3://fake-bucket/manifest'}}},
+      LabelAttributeName='test_job', LabelCategoryConfigS3Uri='', LabelingJobName='test_job',
+      OutputConfig={'S3OutputPath': 's3://fake-bucket/output', 'KmsKeyId': ''},
+      RoleArn='arn:aws:iam::123456789012:user/Development/product_1234/*', Tags=[]
+    )
+
+    self.assertEqual(response, 'test_job')
+
+  def test_sagemaker_exception_in_ground_truth(self):
+    mock_client = MagicMock()
+    mock_exception = ClientError({"Error": {"Message": "SageMaker broke"}}, "ground_truth")
+    mock_client.create_labeling_job.side_effect = mock_exception
+    mock_args = self.parser.parse_args(required_args)
+
+    with self.assertRaises(Exception):
+      _utils.get_labeling_job_outputs(mock_client, vars(mock_args))
+

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_ground_truth.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_ground_truth.py
@@ -122,3 +122,60 @@ class GroundTruthTestCase(unittest.TestCase):
     output_manifest, active_learning_model_arn = _utils.get_labeling_job_outputs(mock_client, 'labeling-job', True)
     self.assertEqual(output_manifest, 's3://path/')
     self.assertEqual(active_learning_model_arn, 'fake-arn')
+
+  def test_pass_most_args(self):
+    required_args = [
+      '--region', 'us-west-2',
+      '--role', 'arn:aws:iam::123456789012:user/Development/product_1234/*',
+      '--job_name', 'test_job',
+      '--manifest_location', 's3://fake-bucket/manifest',
+      '--output_location', 's3://fake-bucket/output',
+      '--task_type', 'image classification',
+      '--worker_type', 'fake_worker',
+      '--ui_template', 's3://fake-bucket/ui_template',
+      '--title', 'fake-image-labelling-work',
+      '--description', 'fake job',
+      '--num_workers_per_object', '1',
+      '--time_limit', '180',
+    ]
+    arguments = required_args + ['--label_attribute_name', 'fake-attribute',
+                                 '--max_human_labeled_objects', '10',
+                                 '--max_percent_objects', '50',
+                                 '--enable_auto_labeling', 'True',
+                                 '--initial_model_arn', 'fake-model-arn',
+                                 '--task_availibility', '30',
+                                 '--max_concurrent_tasks', '10',
+                                 '--task_keywords', 'fake-keyword',
+                                 '--worker_type', 'public',
+                                 '--no_adult_content', 'True',
+                                 '--no_ppi', 'True',
+                                 '--tags', '{"fake_key": "fake_value"}'
+                                 ]
+    response = _utils.create_labeling_job_request(vars(self.parser.parse_args(arguments)))
+    print(response)
+    self.assertEqual(response, {'LabelingJobName': 'test_job',
+                                'LabelAttributeName': 'fake-attribute',
+                                'InputConfig': {'DataSource': {'S3DataSource': {'ManifestS3Uri': 's3://fake-bucket/manifest'}},
+                                                'DataAttributes': {'ContentClassifiers': ['FreeOfAdultContent', 'FreeOfPersonallyIdentifiableInformation']}},
+                                'OutputConfig': {'S3OutputPath': 's3://fake-bucket/output', 'KmsKeyId': ''},
+                                'RoleArn': 'arn:aws:iam::123456789012:user/Development/product_1234/*',
+                                'LabelCategoryConfigS3Uri': '',
+                                'StoppingConditions': {'MaxHumanLabeledObjectCount': 10, 'MaxPercentageOfInputDatasetLabeled': 50},
+                                'LabelingJobAlgorithmsConfig': {'LabelingJobAlgorithmSpecificationArn': 'arn:aws:sagemaker:us-west-2:027400017018:labeling-job-algorithm-specification/image-classification',
+                                                                'InitialActiveLearningModelArn': 'fake-model-arn',
+                                                                'LabelingJobResourceConfig': {'VolumeKmsKeyId': ''}},
+                                'HumanTaskConfig': {'WorkteamArn': 'arn:aws:sagemaker:us-west-2:394669845002:workteam/public-crowd/default',
+                                                    'UiConfig': {'UiTemplateS3Uri': 's3://fake-bucket/ui_template'},
+                                                    'PreHumanTaskLambdaArn': 'arn:aws:lambda:us-west-2:081040173940:function:PRE-ImageMultiClass',
+                                                    'TaskKeywords': ['fake-keyword'],
+                                                    'TaskTitle': 'fake-image-labelling-work',
+                                                    'TaskDescription': 'fake job',
+                                                    'NumberOfHumanWorkersPerDataObject': 1,
+                                                    'TaskTimeLimitInSeconds': 180,
+                                                    'TaskAvailabilityLifetimeInSeconds': 30,
+                                                    'MaxConcurrentTaskCount': 10,
+                                                    'AnnotationConsolidationConfig': {'AnnotationConsolidationLambdaArn': 'arn:aws:lambda:us-west-2:081040173940:function:ACS-ImageMultiClass'},
+                                                    'PublicWorkforceTaskPrice': {'AmountInUsd': {'Dollars': 0, 'Cents': 0, 'TenthFractionsOfACent': 0}}},
+                                'Tags': [{'Key': 'fake_key', 'Value': 'fake_value'}]}
+                     )
+

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_hpo.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_hpo.py
@@ -127,7 +127,7 @@ class HyperparameterTestCase(unittest.TestCase):
                                                     'RecordWrapperType': 'None', 
                                                     'InputMode': 'File'}], 
                                'OutputDataConfig': {'KmsKeyId': '', 'S3OutputPath': 'test-output-location'}, 
-                               'ResourceConfig': {'InstanceType': 'ml.m4.xlarge', 'InstanceCount': 1, 'VolumeSizeInGB': 1, 'VolumeKmsKeyId': ''}, 
+                               'ResourceConfig': {'InstanceType': 'ml.m4.xlarge', 'InstanceCount': 1, 'VolumeSizeInGB': 30, 'VolumeKmsKeyId': ''},
                                'StoppingCondition': {'MaxRuntimeInSeconds': 86400}, 
                                'EnableNetworkIsolation': True, 
                                'EnableInterContainerTrafficEncryption': False, 
@@ -327,12 +327,6 @@ class HyperparameterTestCase(unittest.TestCase):
     response = _utils.create_hyperparameter_tuning_job_request(vars(args))
     self.assertIn({'Key': 'key1', 'Value': 'val1'}, response['Tags'])
     self.assertIn({'Key': 'key2', 'Value': 'val2'}, response['Tags'])
-
-  def test_invalid_instance_type(self):
-    invalid_instance_args = required_args + ['--instance_type', 'invalid-instance']
-
-    with self.assertRaises(SystemExit):
-      self.parser.parse_args(invalid_instance_args)
 
   def test_valid_hyperparameters(self):
     hyperparameters_str = '{"hp1": "val1", "hp2": "val2", "hp3": "val3"}'

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_model.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_model.py
@@ -72,3 +72,48 @@ class ModelTestCase(unittest.TestCase):
 
     with self.assertRaises(Exception):
       _utils.create_model(mock_client, vars(mock_args))
+
+  def test_secondary_containers(self):
+    arguments = required_args + ['--secondary_containers', '["fake-container"]']
+    response = _utils.create_model_request(vars(self.parser.parse_args(arguments)))
+
+    self.assertEqual(response['Containers'], ['fake-container'])
+
+  def test_pass_most_arguments(self):
+    arguments = required_args + ['--container_host_name', 'fake-host',
+                                 '--tags', '{"fake_key": "fake_value"}',
+                                 '--vpc_security_group_ids', 'fake-ids',
+                                 '--vpc_subnets', 'fake-subnets']
+    response = _utils.create_model_request(vars(self.parser.parse_args(arguments)))
+    print(response)
+    self.assertEqual(response, {'ModelName': 'model_test',
+                                'PrimaryContainer': {'ContainerHostname': 'fake-host',
+                                                     'Image': 'test-image',
+                                                     'ModelDataUrl': 's3://fake-bucket/model_artifact',
+                                                     'Environment': {}
+                                                    },
+                                'ExecutionRoleArn': 'arn:aws:iam::123456789012:user/Development/product_1234/*',
+                                'Tags': [{'Key': 'fake_key', 'Value': 'fake_value'}],
+                                'VpcConfig': {'SecurityGroupIds': ['fake-ids'], 'Subnets': ['fake-subnets']},
+                                'EnableNetworkIsolation': True
+                               })
+
+  def test_image_model_package(self):
+    arguments = [ '--region', 'us-west-2',
+                  '--model_name', 'model_test',
+                  '--role', 'arn:aws:iam::123456789012:user/Development/product_1234/*'
+    ]
+
+    # does not error out
+    _utils.create_model_request(vars(self.parser.parse_args(arguments + ['--image', 'test-image',
+                                                                         '--model_artifact_url', 's3://fake-bucket/model_artifact'
+                                                                         ])))
+    # does not error out
+    _utils.create_model_request(vars(self.parser.parse_args(arguments + ['--model_package', 'fake-package'])))
+
+    with self.assertRaises(Exception):
+      _utils.create_model_request(vars(self.parser.parse_args(arguments)))
+    with self.assertRaises(Exception):
+      _utils.create_model_request(vars(self.parser.parse_args(arguments+ ['--image', 'test-image'])))
+    with self.assertRaises(Exception):
+      _utils.create_model_request(vars(self.parser.parse_args(arguments+ ['--model_artifact_url', 's3://fake-bucket/model_artifact'])))

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_model.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_model.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 
-from unittest.mock import patch, Mock, MagicMock
+from unittest.mock import patch, call, Mock, MagicMock, mock_open
 from botocore.exceptions import ClientError
 from datetime import datetime
 
@@ -24,12 +24,51 @@ class ModelTestCase(unittest.TestCase):
     parser = create_model.create_parser()
     cls.parser = parser
 
-  def test_sample(self):
-    args = self.parser.parse_args(required_args)
-    response = _utils.create_model_request(vars(args))
-    self.assertEqual(response['ModelName'], 'model_test')
+  def test_create_parser(self):
+    self.assertIsNotNone(self.parser)
 
-  def test_empty_string(self):
-    args = self.parser.parse_args(required_args)
-    response = _utils.create_model_request(vars(args))
-    test_utils.check_empty_string_values(response)
+  def test_main(self):
+    # Mock out all of utils except parser
+    create_model._utils = MagicMock()
+    create_model._utils.add_default_client_arguments = _utils.add_default_client_arguments
+
+    # Set some static returns
+    create_model._utils.create_model.return_value = 'model_test'
+
+    with patch('builtins.open', mock_open()) as file_open:
+      create_model.main(required_args)
+
+    # Check if correct requests were created and triggered
+    create_model._utils.create_model.assert_called()
+
+    # Check the file outputs
+    file_open.assert_has_calls([
+      call('/tmp/model_name.txt', 'w')
+    ])
+
+    file_open().write.assert_has_calls([
+      call('model_test')
+    ])
+
+  def test_create_model(self):
+    mock_client = MagicMock()
+    mock_args = self.parser.parse_args(required_args)
+    response = _utils.create_model(mock_client, vars(mock_args))
+
+    mock_client.create_model.assert_called_once_with(
+      EnableNetworkIsolation=True,
+      ExecutionRoleArn='arn:aws:iam::123456789012:user/Development/product_1234/*',
+      ModelName='model_test',
+      PrimaryContainer={'Image': 'test-image', 'ModelDataUrl': 's3://fake-bucket/model_artifact', 'Environment': {}},
+      Tags=[]
+    )
+
+
+  def test_sagemaker_exception_in_create_model(self):
+    mock_client = MagicMock()
+    mock_exception = ClientError({"Error": {"Message": "SageMaker broke"}}, "deploy_model")
+    mock_client.create_model.side_effect = mock_exception
+    mock_args = self.parser.parse_args(required_args)
+
+    with self.assertRaises(Exception):
+      _utils.create_model(mock_client, vars(mock_args))

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_model.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_model.py
@@ -66,7 +66,7 @@ class ModelTestCase(unittest.TestCase):
 
   def test_sagemaker_exception_in_create_model(self):
     mock_client = MagicMock()
-    mock_exception = ClientError({"Error": {"Message": "SageMaker broke"}}, "deploy_model")
+    mock_exception = ClientError({"Error": {"Message": "SageMaker broke"}}, "create_model")
     mock_client.create_model.side_effect = mock_exception
     mock_args = self.parser.parse_args(required_args)
 

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_train.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_train.py
@@ -65,15 +65,26 @@ class TrainTestCase(unittest.TestCase):
     mock_args = self.parser.parse_args(required_args + ['--job_name', 'test-job'])
     response = _utils.create_training_job(mock_client, vars(mock_args))
 
-    mock_client.create_training_job.assert_called_once_with(AlgorithmSpecification={'TrainingImage': 'test-image',
-      'TrainingInputMode': 'File'}, EnableInterContainerTrafficEncryption=False, EnableManagedSpotTraining=False,
-      EnableNetworkIsolation=True, HyperParameters={}, InputDataConfig=[{'ChannelName': 'train', 'DataSource':
-      {'S3DataSource': {'S3Uri': 's3://fake-bucket/data', 'S3DataType': 'S3Prefix', 'S3DataDistributionType':
-      'FullyReplicated'}}, 'ContentType': '', 'CompressionType': 'None', 'RecordWrapperType': 'None', 'InputMode':
-      'File'}], OutputDataConfig={'KmsKeyId': '', 'S3OutputPath': 'test-path'}, ResourceConfig={'InstanceType':
-      'ml.m4.xlarge', 'InstanceCount': 1, 'VolumeSizeInGB': 50, 'VolumeKmsKeyId': ''},
-      RoleArn='arn:aws:iam::123456789012:user/Development/product_1234/*', StoppingCondition={'MaxRuntimeInSeconds':
-      3600}, Tags=[], TrainingJobName='test-job')
+    mock_client.create_training_job.assert_called_once_with(
+      AlgorithmSpecification={'TrainingImage': 'test-image', 'TrainingInputMode': 'File'},
+      EnableInterContainerTrafficEncryption=False,
+      EnableManagedSpotTraining=False,
+      EnableNetworkIsolation=True,
+      HyperParameters={},
+      InputDataConfig=[{'ChannelName': 'train',
+                        'DataSource': {'S3DataSource': {'S3Uri': 's3://fake-bucket/data', 'S3DataType': 'S3Prefix', 'S3DataDistributionType': 'FullyReplicated'}},
+                        'ContentType': '',
+                        'CompressionType': 'None',
+                        'RecordWrapperType': 'None',
+                        'InputMode': 'File'
+                      }],
+      OutputDataConfig={'KmsKeyId': '', 'S3OutputPath': 'test-path'},
+      ResourceConfig={'InstanceType': 'ml.m4.xlarge', 'InstanceCount': 1, 'VolumeSizeInGB': 50, 'VolumeKmsKeyId': ''},
+      RoleArn='arn:aws:iam::123456789012:user/Development/product_1234/*',
+      StoppingCondition={'MaxRuntimeInSeconds': 3600},
+      Tags=[],
+      TrainingJobName='test-job'
+    )
     self.assertEqual(response, 'test-job')
 
   def test_sagemaker_exception_in_create_training_job(self):
@@ -254,7 +265,7 @@ class TrainTestCase(unittest.TestCase):
 
     good_args = self.parser.parse_args(required_args + ['--hyperparameters', hyperparameters_str])
     response = _utils.create_training_job_request(vars(good_args))
-    
+
     self.assertIn('hp1', response['HyperParameters'])
     self.assertIn('hp2', response['HyperParameters'])
     self.assertIn('hp3', response['HyperParameters'])
@@ -267,7 +278,7 @@ class TrainTestCase(unittest.TestCase):
 
     good_args = self.parser.parse_args(required_args + ['--hyperparameters', hyperparameters_str])
     response = _utils.create_training_job_request(vars(good_args))
-    
+
     self.assertEqual(response['HyperParameters'], {})
 
   def test_object_hyperparameters(self):
@@ -280,7 +291,7 @@ class TrainTestCase(unittest.TestCase):
   def test_vpc_configuration(self):
     required_vpc_args = self.parser.parse_args(required_args + ['--vpc_security_group_ids', 'sg1,sg2', '--vpc_subnets', 'subnet1,subnet2'])
     response = _utils.create_training_job_request(vars(required_vpc_args))
-    
+
     self.assertIn('VpcConfig', response)
     self.assertIn('sg1', response['VpcConfig']['SecurityGroupIds'])
     self.assertIn('sg2', response['VpcConfig']['SecurityGroupIds'])
@@ -305,7 +316,7 @@ class TrainTestCase(unittest.TestCase):
   def test_spot_lesser_wait_time(self):
     args = self.parser.parse_args(required_args + ['--spot_instance', 'True', '--max_wait_time', '3599', '--checkpoint_config', '{"S3Uri": "s3://fake-uri/", "LocalPath": "local-path"}'])
     with self.assertRaises(Exception):
-      _utils.create_training_job_request(vars(args))    
+      _utils.create_training_job_request(vars(args))
 
   def test_spot_good_args(self):
     good_args = self.parser.parse_args(required_args + ['--spot_instance', 'True', '--max_wait_time', '3600', '--checkpoint_config', '{"S3Uri": "s3://fake-uri/"}'])

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_train.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_train.py
@@ -254,11 +254,6 @@ class TrainTestCase(unittest.TestCase):
     with self.assertRaises(Exception):
       _utils.create_training_job_request(vars(parsed_args))
 
-  def test_invalid_instance_type(self):
-    invalid_instance_args = required_args + ['--instance_type', 'invalid-instance']
-
-    with self.assertRaises(SystemExit):
-      self.parser.parse_args(invalid_instance_args)
 
   def test_valid_hyperparameters(self):
     hyperparameters_str = '{"hp1": "val1", "hp2": "val2", "hp3": "val3"}'

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_workteam.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_workteam.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 
-from unittest.mock import patch, Mock, MagicMock
+from unittest.mock import patch, call, Mock, MagicMock, mock_open
 from botocore.exceptions import ClientError
 from datetime import datetime
 
@@ -22,12 +22,49 @@ class WorkTeamTestCase(unittest.TestCase):
     parser = workteam.create_parser()
     cls.parser = parser
 
-  def test_sample(self):
-    args = self.parser.parse_args(required_args)
-    response = _utils.create_workteam_request(vars(args))
-    self.assertEqual(response['WorkteamName'], 'test-team')
+  def test_create_parser(self):
+    self.assertIsNotNone(self.parser)
 
-  def test_empty_string(self):
-    args = self.parser.parse_args(required_args)
-    response = _utils.create_workteam_request(vars(args))
-    test_utils.check_empty_string_values(response)
+  def test_main(self):
+    # Mock out all of utils except parser
+    workteam._utils = MagicMock()
+    workteam._utils.add_default_client_arguments = _utils.add_default_client_arguments
+
+    # Set some static returns
+    workteam._utils.create_workteam.return_value = 'arn:aws:sagemaker:us-east-1:999999999999:work-team'
+
+    with patch('builtins.open', mock_open()) as file_open:
+      workteam.main(required_args)
+
+    # Check if correct requests were created and triggered
+    workteam._utils.create_workteam.assert_called()
+
+    # Check the file outputs
+    file_open.assert_has_calls([
+      call('/tmp/workteam_arn.txt', 'w')
+    ])
+
+    file_open().write.assert_has_calls([
+      call('arn:aws:sagemaker:us-east-1:999999999999:work-team')
+    ])
+
+  def test_deploy_model(self):
+    mock_client = MagicMock()
+    mock_args = self.parser.parse_args(required_args)
+    response = _utils.create_workteam(mock_client, vars(mock_args))
+
+    mock_client.create_workteam.assert_called_once_with(
+      Description='fake team',
+      MemberDefinitions=[{'CognitoMemberDefinition': {'UserPool': '', 'UserGroup': '', 'ClientId': ''}}], Tags=[],
+      WorkteamName='test-team'
+    )
+
+  def test_sagemaker_exception_in_deploy_model(self):
+    mock_client = MagicMock()
+    mock_exception = ClientError({"Error": {"Message": "SageMaker broke"}}, "deploy_model")
+    mock_client.create_workteam.side_effect = mock_exception
+    mock_args = self.parser.parse_args(required_args)
+
+    with self.assertRaises(Exception):
+      _utils.create_workteam(mock_client, vars(mock_args))
+

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_workteam.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_workteam.py
@@ -68,3 +68,8 @@ class WorkTeamTestCase(unittest.TestCase):
     with self.assertRaises(Exception):
       _utils.create_workteam(mock_client, vars(mock_args))
 
+  def test_get_workteam_output_from_job(self):
+    mock_client = MagicMock()
+    mock_client.create_workteam.return_value = {"WorkteamArn": "fake-arn"}
+
+    self.assertEqual(_utils.create_workteam(mock_client, vars(self.parser.parse_args(required_args))), 'fake-arn')

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_workteam.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_workteam.py
@@ -48,7 +48,7 @@ class WorkTeamTestCase(unittest.TestCase):
       call('arn:aws:sagemaker:us-east-1:999999999999:work-team')
     ])
 
-  def test_deploy_model(self):
+  def test_workteam(self):
     mock_client = MagicMock()
     mock_args = self.parser.parse_args(required_args)
     response = _utils.create_workteam(mock_client, vars(mock_args))
@@ -59,7 +59,7 @@ class WorkTeamTestCase(unittest.TestCase):
       WorkteamName='test-team'
     )
 
-  def test_sagemaker_exception_in_deploy_model(self):
+  def test_sagemaker_exception_in_workteam(self):
     mock_client = MagicMock()
     mock_exception = ClientError({"Error": {"Message": "SageMaker broke"}}, "deploy_model")
     mock_client.create_workteam.side_effect = mock_exception

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_workteam.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_workteam.py
@@ -73,3 +73,14 @@ class WorkTeamTestCase(unittest.TestCase):
     mock_client.create_workteam.return_value = {"WorkteamArn": "fake-arn"}
 
     self.assertEqual(_utils.create_workteam(mock_client, vars(self.parser.parse_args(required_args))), 'fake-arn')
+
+  def test_pass_most_arguments(self):
+    arguments = required_args + ['--sns_topic', 'fake-topic', '--tags', '{"fake_key": "fake_value"}']
+    response = _utils.create_workteam_request(vars(self.parser.parse_args(arguments)))
+
+    self.assertEqual(response, {'WorkteamName': 'test-team',
+                                'MemberDefinitions': [{'CognitoMemberDefinition': {'UserPool': '', 'UserGroup': '', 'ClientId': ''}}],
+                                'Description': 'fake team',
+                                'NotificationConfiguration' : {'NotificationTopicArn': 'fake-topic'},
+                                'Tags': [{'Key': 'fake_key', 'Value': 'fake_value'}]
+                                })

--- a/components/aws/sagemaker/tests/unit_tests/tests/test_workteam.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/test_workteam.py
@@ -61,7 +61,7 @@ class WorkTeamTestCase(unittest.TestCase):
 
   def test_sagemaker_exception_in_workteam(self):
     mock_client = MagicMock()
-    mock_exception = ClientError({"Error": {"Message": "SageMaker broke"}}, "deploy_model")
+    mock_exception = ClientError({"Error": {"Message": "SageMaker broke"}}, "workteam")
     mock_client.create_workteam.side_effect = mock_exception
     mock_args = self.parser.parse_args(required_args)
 

--- a/components/aws/sagemaker/workteam/src/workteam.py
+++ b/components/aws/sagemaker/workteam/src/workteam.py
@@ -31,7 +31,7 @@ def create_parser():
 
 def main(argv=None):
   parser = create_parser()
-  args = parser.parse_args()
+  args = parser.parse_args(argv)
 
   logging.getLogger().setLevel(logging.INFO)
   client = _utils.get_sagemaker_client(args.region, args.endpoint_url)
@@ -45,4 +45,4 @@ def main(argv=None):
 
 
 if __name__== "__main__":
-  main()
+  main(sys.argv[1:])

--- a/components/aws/sagemaker/workteam/src/workteam.py
+++ b/components/aws/sagemaker/workteam/src/workteam.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import argparse
 import logging
 


### PR DESCRIPTION
Added more tests for following components :
Deploy            (98% coverage)
Ground_truth  (98% coverage)
Workteam (96% coverage)
Model (97% coverage)
Batch Transform (98% coverage)

https://github.com/kubeflow/pipelines/issues/3782

```
====================================================================================== 94 passed, 3 warnings in 1.67s ======================================================================================
Name                                                      Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------------
/app/batch_transform/src/batch_transform.py                  51      1    98%   75
/app/common/_utils.py                                       567     31    95%   62, 73-83, 88-92, 693, 710, 714, 724, 727, 738-742, 804-805, 816-817, 821-824, 834, 870, 873-874
/app/deploy/src/deploy.py                                    45      1    98%   67
/app/ground_truth/src/ground_truth.py                        54      1    98%   76
/app/hyperparameter_tuning/src/hyperparameter_tuning.py      67      1    99%   93
/app/model/src/create_model.py                               32      1    97%   54
/app/train/src/train.py                                      52      1    98%   80
/app/workteam/src/workteam.py                                27      1    96%   49
---------------------------------------------------------------------------------------
TOTAL                                                       895     38    96%
```

These tests check : (for 1 inout)
1. Argument parsing is proper 
2. main() function is proper
3. emulate boto3 client and verify the output 

These things can be done more extensively to verify every combination of input 