### PR TITLE
SDK - Components - Use relative imports for tests

### DIFF
--- a/sdk/python/kfp/components_tests/test_components.py
+++ b/sdk/python/kfp/components_tests/test_components.py
@@ -20,10 +20,10 @@ from contextlib import contextmanager
 from pathlib import Path
 
 
-import kfp.components as comp
-from kfp.components._components import _resolve_command_line_and_paths
-from kfp.components._yaml_utils import load_yaml
-from kfp.components.structures import ComponentSpec
+from .. import components as comp
+from ..components._components import _resolve_command_line_and_paths
+from ..components._yaml_utils import load_yaml
+from ..components.structures import ComponentSpec
 
 
 class LoadComponentTestCase(unittest.TestCase):

--- a/sdk/python/kfp/components_tests/test_data/retail_product_stockout_prediction_pipeline.py
+++ b/sdk/python/kfp/components_tests/test_data/retail_product_stockout_prediction_pipeline.py
@@ -1,4 +1,4 @@
-from kfp.components import load_component_from_url
+from ...components import load_component_from_url
 
 automl_create_dataset_for_tables_op        = load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/b3179d86b239a08bf4884b50dbf3a9151da96d66/components/gcp/automl/create_dataset_for_tables/component.yaml')
 automl_import_data_from_bigquery_source_op = load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/b3179d86b239a08bf4884b50dbf3a9151da96d66/components/gcp/automl/import_data_from_bigquery/component.yaml')

--- a/sdk/python/kfp/components_tests/test_graph_components.py
+++ b/sdk/python/kfp/components_tests/test_graph_components.py
@@ -18,10 +18,10 @@ import unittest
 from pathlib import Path
 
 
-import kfp.components as comp
-from kfp.components.structures import ComponentReference, ComponentSpec, ContainerSpec, GraphInputReference, GraphSpec, InputSpec, InputValuePlaceholder, GraphImplementation, OutputPathPlaceholder, OutputSpec, TaskOutputArgument, TaskSpec
+from .. import components as comp
+from ..components.structures import ComponentReference, ComponentSpec, ContainerSpec, GraphInputReference, GraphSpec, InputSpec, InputValuePlaceholder, GraphImplementation, OutputPathPlaceholder, OutputSpec, TaskOutputArgument, TaskSpec
 
-from kfp.components._yaml_utils import load_yaml
+from ..components._yaml_utils import load_yaml
 
 class GraphComponentTestCase(unittest.TestCase):
     def test_handle_constructing_graph_component(self):

--- a/sdk/python/kfp/components_tests/test_python_op.py
+++ b/sdk/python/kfp/components_tests/test_python_op.py
@@ -19,10 +19,10 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Callable, NamedTuple, Sequence
 
-import kfp.components as comp
-from kfp.components import InputPath, InputTextFile, InputBinaryFile, OutputPath, OutputTextFile, OutputBinaryFile
-from kfp.components.structures import InputSpec, OutputSpec
-from kfp.components._components import _resolve_command_line_and_paths
+from .. import components as comp
+from ..components import InputPath, InputTextFile, InputBinaryFile, OutputPath, OutputTextFile, OutputBinaryFile
+from ..components.structures import InputSpec, OutputSpec
+from ..components._components import _resolve_command_line_and_paths
 
 def add_two_numbers(a: float, b: float) -> float:
     '''Returns sum of two arguments'''

--- a/sdk/python/kfp/components_tests/test_python_pipeline_to_graph_component.py
+++ b/sdk/python/kfp/components_tests/test_python_pipeline_to_graph_component.py
@@ -18,8 +18,8 @@ import unittest
 from collections import OrderedDict
 from pathlib import Path
 
-import kfp.components as comp
-from kfp.components._python_to_graph_component import create_graph_component_spec_from_pipeline_func
+from .. import components as comp
+from ..components._python_to_graph_component import create_graph_component_spec_from_pipeline_func
 
 
 class PythonPipelineToGraphComponentTestCase(unittest.TestCase):

--- a/sdk/python/kfp/components_tests/test_structure_model_base.py
+++ b/sdk/python/kfp/components_tests/test_structure_model_base.py
@@ -18,7 +18,7 @@ import unittest
 from pathlib import Path
 
 from typing import List, Dict, Union, Optional
-from kfp.components.modelbase import ModelBase
+from ..components.modelbase import ModelBase
 
 class TestModel1(ModelBase):
     _serialized_names = {


### PR DESCRIPTION
This makes tests easier to run in local dev scenarios.

Fixes https://github.com/kubeflow/pipelines/issues/3786