### PR TITLE
Marketplace - Only use CloudSQL when connection is provided

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/cache.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/cache.yaml
@@ -205,7 +205,7 @@ spec:
       - name: server
         image: {{ .Values.images.cacheserver }}
         env:
-          {{ if .Values.managedstorage.enabled }}
+          {{ if .Values.managedstorage.cloudsqlInstanceConnectionName }}
           - name: DBCONFIG_USER
             valueFrom:
               secretKeyRef:

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/metadata.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/metadata.yaml
@@ -39,7 +39,7 @@ spec:
         imagePullPolicy: 'Always'
         env:
         # TODO: merge all into mysql-credential
-        {{ if .Values.managedstorage.enabled }}
+        {{ if .Values.managedstorage.cloudsqlInstanceConnectionName }}
         - name: DBCONFIG_USER
           valueFrom:
             secretKeyRef:

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
@@ -8,14 +8,14 @@ spec:
   ports:
     - port: 3306
   selector:
-    {{ if .Values.managedstorage.enabled }}
+    {{ if .Values.managedstorage.cloudsqlInstanceConnectionName }}
     app: cloudsqlproxy
     {{ else }}
     app: mysql
     {{ end }}
     app.kubernetes.io/name: {{ .Release.Name }}
 ---
-{{ if .Values.managedstorage.enabled }}
+{{ if .Values.managedstorage.cloudsqlInstanceConnectionName }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
@@ -726,7 +726,7 @@ spec:
               value: 'pipeline-runner'
             - name: OBJECTSTORECONFIG_SECURE
               value: "false"
-            {{ if .Values.managedstorage.enabled }}
+            {{ if .Values.managedstorage.cloudsqlInstanceConnectionName }}
             - name: OBJECTSTORECONFIG_BUCKETNAME
               value: '{{ tpl .Values.managedstorage.gcsBucketName . }}'
             - name: DBCONFIG_DBNAME

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
@@ -726,9 +726,11 @@ spec:
               value: 'pipeline-runner'
             - name: OBJECTSTORECONFIG_SECURE
               value: "false"
-            {{ if .Values.managedstorage.cloudsqlInstanceConnectionName }}
+            {{ if .Values.managedstorage.enabled }}
             - name: OBJECTSTORECONFIG_BUCKETNAME
               value: '{{ tpl .Values.managedstorage.gcsBucketName . }}'
+            {{ end }}
+            {{ if .Values.managedstorage.cloudsqlInstanceConnectionName }}
             - name: DBCONFIG_DBNAME
               {{ if .Values.managedstorage.databaseNamePrefix }}
               value: '{{ .Values.managedstorage.databaseNamePrefix }}_pipeline'


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/3798

This PR only fixes the CloudSQL issue. The GCS bucket issue is fixed in other PRs.

The new logic is: Since CloudSQL cannot function without `cloudsqlInstanceConnectionName`, the presence of this value now controls whether CloudSQL replaces the in-cluster MySQL.