### PR TITLE
[UI] Fix confusion matrix wrong axes

### DIFF
--- a/frontend/src/components/viewers/ConfusionMatrix.tsx
+++ b/frontend/src/components/viewers/ConfusionMatrix.tsx
@@ -55,35 +55,7 @@ class ConfusionMatrix extends Viewer<ConfusionMatrixProps, ConfusionMatrixState>
       ) - 1
     : 0;
   private _shrinkThreshold = 600;
-  private _uiData = (() => {
-    // Raw data:
-    // [
-    //   [1, 2],
-    //   [3, 4],
-    // ]
-    // converts to UI data:
-    // y-axis
-    // ^
-    // |
-    // 1  [2, 4],
-    // |
-    // 0  [1, 3],
-    // |
-    // *---0--1---> x-axis
-    if (!this._config || !this._config.labels || !this._config.data) {
-      return [];
-    }
-    const labelCount = this._config.labels.length;
-    const uiData: number[][] = new Array(labelCount)
-      .fill(undefined)
-      .map(() => new Array(labelCount));
-    for (let i = 0; i < labelCount; ++i) {
-      for (let j = 0; j < labelCount; ++j) {
-        uiData[labelCount - 1 - j][i] = this._config.data[i]?.[j];
-      }
-    }
-    return uiData;
-  })();
+  private _uiData: number[][] = [];
 
   private _css = stylesheet({
     activeLabel: {
@@ -183,8 +155,36 @@ class ConfusionMatrix extends Viewer<ConfusionMatrixProps, ConfusionMatrixState>
     this.state = {
       activeCell: [-1, -1],
     };
+    // Raw data:
+    // [
+    //   [1, 2],
+    //   [3, 4],
+    // ]
+    // converts to UI data:
+    // y-axis
+    // ^
+    // |
+    // 1  [2, 4],
+    // |
+    // 0  [1, 3],
+    // |
+    // *---0--1---> x-axis
+    if (!this._config || !this._config.labels || !this._config.data) {
+      this._uiData = [];
+    } else {
+      const labelCount = this._config.labels.length;
+      const uiData: number[][] = new Array(labelCount)
+        .fill(undefined)
+        .map(() => new Array(labelCount));
+      for (let i = 0; i < labelCount; ++i) {
+        for (let j = 0; j < labelCount; ++j) {
+          uiData[labelCount - 1 - j][i] = this._config.data[i]?.[j];
+        }
+      }
+      this._uiData = uiData;
+    }
 
-    for (const i of this._config.data) {
+    for (const i of this._uiData) {
       const row = [];
       for (const j of i) {
         row.push(+j / this._max);

--- a/frontend/src/components/viewers/ConfusionMatrix.tsx
+++ b/frontend/src/components/viewers/ConfusionMatrix.tsx
@@ -55,6 +55,35 @@ class ConfusionMatrix extends Viewer<ConfusionMatrixProps, ConfusionMatrixState>
       ) - 1
     : 0;
   private _shrinkThreshold = 600;
+  private _uiData = (() => {
+    // Raw data:
+    // [
+    //   [1, 2],
+    //   [3, 4],
+    // ]
+    // converts to UI data:
+    // y-axis
+    // ^
+    // |
+    // 1  [2, 4],
+    // |
+    // 0  [1, 3],
+    // |
+    // *---0--1---> x-axis
+    if (!this._config || !this._config.labels || !this._config.data) {
+      return [];
+    }
+    const labelCount = this._config.labels.length;
+    const uiData: number[][] = new Array(labelCount)
+      .fill(undefined)
+      .map(() => new Array(labelCount));
+    for (let i = 0; i < labelCount; ++i) {
+      for (let j = 0; j < labelCount; ++j) {
+        uiData[labelCount - 1 - j][i] = this._config.data[i]?.[j];
+      }
+    }
+    return uiData;
+  })();
 
   private _css = stylesheet({
     activeLabel: {
@@ -186,7 +215,7 @@ class ConfusionMatrix extends Viewer<ConfusionMatrixProps, ConfusionMatrixState>
                 <td className={this._css.yAxisLabel}>{yAxisLabel}</td>
               </tr>
             )}
-            {this._config.data.map((row, r) => (
+            {this._uiData.map((row, r) => (
               <tr key={r}>
                 {!small && (
                   <td>
@@ -196,7 +225,11 @@ class ConfusionMatrix extends Viewer<ConfusionMatrixProps, ConfusionMatrixState>
                         r === activeRow ? this._css.activeLabel : '',
                       )}
                     >
-                      {this._config.labels[r]}
+                      {
+                        this._config.labels[
+                          this._config.labels.length - 1 - r
+                        ] /* uiData's ith's row corresponds to the reverse ordered label */
+                      }
                     </div>
                   </td>
                 )}
@@ -209,6 +242,15 @@ class ConfusionMatrix extends Viewer<ConfusionMatrixProps, ConfusionMatrixState>
                       color: this._opacities[r][c] < 0.6 ? color.foreground : color.background,
                     }}
                     onMouseOver={() => this.setState({ activeCell: [r, c] })}
+                    onMouseLeave={() =>
+                      this.setState(state => ({
+                        // Remove active cell if it's still the one active
+                        activeCell:
+                          state.activeCell[0] === r && state.activeCell[1] === c
+                            ? [-1, -1]
+                            : state.activeCell,
+                      }))
+                    }
                   >
                     <div
                       className={this._css.overlay}

--- a/frontend/src/components/viewers/__snapshots__/ConfusionMatrix.test.tsx.snap
+++ b/frontend/src/components/viewers/__snapshots__/ConfusionMatrix.test.tsx.snap
@@ -20,12 +20,13 @@ exports[`ConfusionMatrix does not break on asymetric data 1`] = `
           <div
             className="ylabel"
           >
-            label1
+            label2
           </div>
         </td>
         <td
           className="cell"
           key="0"
+          onMouseLeave={[Function]}
           onMouseOver={[Function]}
           style={
             Object {
@@ -42,11 +43,12 @@ exports[`ConfusionMatrix does not break on asymetric data 1`] = `
               }
             }
           />
-          3
+          4
         </td>
         <td
           className="cell"
           key="1"
+          onMouseLeave={[Function]}
           onMouseOver={[Function]}
           style={
             Object {
@@ -63,28 +65,7 @@ exports[`ConfusionMatrix does not break on asymetric data 1`] = `
               }
             }
           />
-          4
-        </td>
-        <td
-          className="cell"
-          key="2"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.625)",
-              "color": "#fff",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          5
+          7
         </td>
       </tr>
       <tr
@@ -94,12 +75,13 @@ exports[`ConfusionMatrix does not break on asymetric data 1`] = `
           <div
             className="ylabel"
           >
-            label2
+            label1
           </div>
         </td>
         <td
           className="cell"
           key="0"
+          onMouseLeave={[Function]}
           onMouseOver={[Function]}
           style={
             Object {
@@ -116,11 +98,12 @@ exports[`ConfusionMatrix does not break on asymetric data 1`] = `
               }
             }
           />
-          6
+          3
         </td>
         <td
           className="cell"
           key="1"
+          onMouseLeave={[Function]}
           onMouseOver={[Function]}
           style={
             Object {
@@ -137,28 +120,7 @@ exports[`ConfusionMatrix does not break on asymetric data 1`] = `
               }
             }
           />
-          7
-        </td>
-        <td
-          className="cell"
-          key="2"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 1)",
-              "color": "#fff",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          8
+          6
         </td>
       </tr>
       <tr>
@@ -314,16 +276,72 @@ exports[`ConfusionMatrix renders a basic confusion matrix 1`] = `
           <div
             className="ylabel"
           >
+            label2
+          </div>
+        </td>
+        <td
+          className="cell"
+          key="0"
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          style={
+            Object {
+              "backgroundColor": "rgba(41, 121, 255, 0)",
+              "color": "#000",
+            }
+          }
+        >
+          <div
+            className="overlay"
+            style={
+              Object {
+                "opacity": 0,
+              }
+            }
+          />
+          1
+        </td>
+        <td
+          className="cell"
+          key="1"
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          style={
+            Object {
+              "backgroundColor": "rgba(41, 121, 255, 0.125)",
+              "color": "#000",
+            }
+          }
+        >
+          <div
+            className="overlay"
+            style={
+              Object {
+                "opacity": 0,
+              }
+            }
+          />
+          4
+        </td>
+      </tr>
+      <tr
+        key="1"
+      >
+        <td>
+          <div
+            className="ylabel"
+          >
             label1
           </div>
         </td>
         <td
           className="cell"
           key="0"
+          onMouseLeave={[Function]}
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0)",
+              "backgroundColor": "rgba(41, 121, 255, 0.375)",
               "color": "#000",
             }
           }
@@ -341,80 +359,7 @@ exports[`ConfusionMatrix renders a basic confusion matrix 1`] = `
         <td
           className="cell"
           key="1"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.125)",
-              "color": "#000",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          1
-        </td>
-        <td
-          className="cell"
-          key="2"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.25)",
-              "color": "#000",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          2
-        </td>
-      </tr>
-      <tr
-        key="1"
-      >
-        <td>
-          <div
-            className="ylabel"
-          >
-            label2
-          </div>
-        </td>
-        <td
-          className="cell"
-          key="0"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.375)",
-              "color": "#000",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          3
-        </td>
-        <td
-          className="cell"
-          key="1"
+          onMouseLeave={[Function]}
           onMouseOver={[Function]}
           style={
             Object {
@@ -431,100 +376,7 @@ exports[`ConfusionMatrix renders a basic confusion matrix 1`] = `
               }
             }
           />
-          4
-        </td>
-        <td
-          className="cell"
-          key="2"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.625)",
-              "color": "#fff",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          5
-        </td>
-      </tr>
-      <tr
-        key="2"
-      >
-        <td>
-          <div
-            className="ylabel"
-          />
-        </td>
-        <td
-          className="cell"
-          key="0"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.75)",
-              "color": "#fff",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          6
-        </td>
-        <td
-          className="cell"
-          key="1"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.875)",
-              "color": "#fff",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          7
-        </td>
-        <td
-          className="cell"
-          key="2"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 1)",
-              "color": "#fff",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          8
+          3
         </td>
       </tr>
       <tr>
@@ -670,10 +522,59 @@ exports[`ConfusionMatrix renders a small confusion matrix snapshot, with no labe
         <td
           className="cell"
           key="0"
+          onMouseLeave={[Function]}
           onMouseOver={[Function]}
           style={
             Object {
               "backgroundColor": "rgba(41, 121, 255, 0)",
+              "color": "#000",
+            }
+          }
+        >
+          <div
+            className="overlay"
+            style={
+              Object {
+                "opacity": 0,
+              }
+            }
+          />
+          1
+        </td>
+        <td
+          className="cell"
+          key="1"
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          style={
+            Object {
+              "backgroundColor": "rgba(41, 121, 255, 0.125)",
+              "color": "#000",
+            }
+          }
+        >
+          <div
+            className="overlay"
+            style={
+              Object {
+                "opacity": 0,
+              }
+            }
+          />
+          4
+        </td>
+      </tr>
+      <tr
+        key="1"
+      >
+        <td
+          className="cell"
+          key="0"
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          style={
+            Object {
+              "backgroundColor": "rgba(41, 121, 255, 0.375)",
               "color": "#000",
             }
           }
@@ -691,73 +592,7 @@ exports[`ConfusionMatrix renders a small confusion matrix snapshot, with no labe
         <td
           className="cell"
           key="1"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.125)",
-              "color": "#000",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          1
-        </td>
-        <td
-          className="cell"
-          key="2"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.25)",
-              "color": "#000",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          2
-        </td>
-      </tr>
-      <tr
-        key="1"
-      >
-        <td
-          className="cell"
-          key="0"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.375)",
-              "color": "#000",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          3
-        </td>
-        <td
-          className="cell"
-          key="1"
+          onMouseLeave={[Function]}
           onMouseOver={[Function]}
           style={
             Object {
@@ -774,95 +609,7 @@ exports[`ConfusionMatrix renders a small confusion matrix snapshot, with no labe
               }
             }
           />
-          4
-        </td>
-        <td
-          className="cell"
-          key="2"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.625)",
-              "color": "#fff",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          5
-        </td>
-      </tr>
-      <tr
-        key="2"
-      >
-        <td
-          className="cell"
-          key="0"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.75)",
-              "color": "#fff",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          6
-        </td>
-        <td
-          className="cell"
-          key="1"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.875)",
-              "color": "#fff",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          7
-        </td>
-        <td
-          className="cell"
-          key="2"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 1)",
-              "color": "#fff",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          8
+          3
         </td>
       </tr>
     </tbody>
@@ -890,16 +637,72 @@ exports[`ConfusionMatrix renders only one of the given list of configs 1`] = `
           <div
             className="ylabel"
           >
+            label2
+          </div>
+        </td>
+        <td
+          className="cell"
+          key="0"
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          style={
+            Object {
+              "backgroundColor": "rgba(41, 121, 255, 0)",
+              "color": "#000",
+            }
+          }
+        >
+          <div
+            className="overlay"
+            style={
+              Object {
+                "opacity": 0,
+              }
+            }
+          />
+          1
+        </td>
+        <td
+          className="cell"
+          key="1"
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          style={
+            Object {
+              "backgroundColor": "rgba(41, 121, 255, 0.125)",
+              "color": "#000",
+            }
+          }
+        >
+          <div
+            className="overlay"
+            style={
+              Object {
+                "opacity": 0,
+              }
+            }
+          />
+          4
+        </td>
+      </tr>
+      <tr
+        key="1"
+      >
+        <td>
+          <div
+            className="ylabel"
+          >
             label1
           </div>
         </td>
         <td
           className="cell"
           key="0"
+          onMouseLeave={[Function]}
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0)",
+              "backgroundColor": "rgba(41, 121, 255, 0.375)",
               "color": "#000",
             }
           }
@@ -917,80 +720,7 @@ exports[`ConfusionMatrix renders only one of the given list of configs 1`] = `
         <td
           className="cell"
           key="1"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.125)",
-              "color": "#000",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          1
-        </td>
-        <td
-          className="cell"
-          key="2"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.25)",
-              "color": "#000",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          2
-        </td>
-      </tr>
-      <tr
-        key="1"
-      >
-        <td>
-          <div
-            className="ylabel"
-          >
-            label2
-          </div>
-        </td>
-        <td
-          className="cell"
-          key="0"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.375)",
-              "color": "#000",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          3
-        </td>
-        <td
-          className="cell"
-          key="1"
+          onMouseLeave={[Function]}
           onMouseOver={[Function]}
           style={
             Object {
@@ -1007,100 +737,7 @@ exports[`ConfusionMatrix renders only one of the given list of configs 1`] = `
               }
             }
           />
-          4
-        </td>
-        <td
-          className="cell"
-          key="2"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.625)",
-              "color": "#fff",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          5
-        </td>
-      </tr>
-      <tr
-        key="2"
-      >
-        <td>
-          <div
-            className="ylabel"
-          />
-        </td>
-        <td
-          className="cell"
-          key="0"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.75)",
-              "color": "#fff",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          6
-        </td>
-        <td
-          className="cell"
-          key="1"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.875)",
-              "color": "#fff",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          7
-        </td>
-        <td
-          className="cell"
-          key="2"
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "backgroundColor": "rgba(41, 121, 255, 1)",
-              "color": "#fff",
-            }
-          }
-        >
-          <div
-            className="overlay"
-            style={
-              Object {
-                "opacity": 0,
-              }
-            }
-          />
-          8
+          3
         </td>
       </tr>
       <tr>

--- a/frontend/src/components/viewers/__snapshots__/ConfusionMatrix.test.tsx.snap
+++ b/frontend/src/components/viewers/__snapshots__/ConfusionMatrix.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`ConfusionMatrix does not break on asymetric data 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.375)",
+              "backgroundColor": "rgba(41, 121, 255, 0.5)",
               "color": "#000",
             }
           }
@@ -52,8 +52,8 @@ exports[`ConfusionMatrix does not break on asymetric data 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.5)",
-              "color": "#000",
+              "backgroundColor": "rgba(41, 121, 255, 0.875)",
+              "color": "#fff",
             }
           }
         >
@@ -85,8 +85,8 @@ exports[`ConfusionMatrix does not break on asymetric data 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.75)",
-              "color": "#fff",
+              "backgroundColor": "rgba(41, 121, 255, 0.375)",
+              "color": "#000",
             }
           }
         >
@@ -107,7 +107,7 @@ exports[`ConfusionMatrix does not break on asymetric data 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.875)",
+              "backgroundColor": "rgba(41, 121, 255, 0.75)",
               "color": "#fff",
             }
           }
@@ -286,7 +286,7 @@ exports[`ConfusionMatrix renders a basic confusion matrix 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0)",
+              "backgroundColor": "rgba(41, 121, 255, 0.125)",
               "color": "#000",
             }
           }
@@ -308,7 +308,7 @@ exports[`ConfusionMatrix renders a basic confusion matrix 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.125)",
+              "backgroundColor": "rgba(41, 121, 255, 0.5)",
               "color": "#000",
             }
           }
@@ -341,7 +341,7 @@ exports[`ConfusionMatrix renders a basic confusion matrix 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.375)",
+              "backgroundColor": "rgba(41, 121, 255, 0)",
               "color": "#000",
             }
           }
@@ -363,7 +363,7 @@ exports[`ConfusionMatrix renders a basic confusion matrix 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.5)",
+              "backgroundColor": "rgba(41, 121, 255, 0.375)",
               "color": "#000",
             }
           }
@@ -526,7 +526,7 @@ exports[`ConfusionMatrix renders a small confusion matrix snapshot, with no labe
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0)",
+              "backgroundColor": "rgba(41, 121, 255, 0.125)",
               "color": "#000",
             }
           }
@@ -548,7 +548,7 @@ exports[`ConfusionMatrix renders a small confusion matrix snapshot, with no labe
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.125)",
+              "backgroundColor": "rgba(41, 121, 255, 0.5)",
               "color": "#000",
             }
           }
@@ -574,7 +574,7 @@ exports[`ConfusionMatrix renders a small confusion matrix snapshot, with no labe
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.375)",
+              "backgroundColor": "rgba(41, 121, 255, 0)",
               "color": "#000",
             }
           }
@@ -596,7 +596,7 @@ exports[`ConfusionMatrix renders a small confusion matrix snapshot, with no labe
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.5)",
+              "backgroundColor": "rgba(41, 121, 255, 0.375)",
               "color": "#000",
             }
           }
@@ -647,7 +647,7 @@ exports[`ConfusionMatrix renders only one of the given list of configs 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0)",
+              "backgroundColor": "rgba(41, 121, 255, 0.125)",
               "color": "#000",
             }
           }
@@ -669,7 +669,7 @@ exports[`ConfusionMatrix renders only one of the given list of configs 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.125)",
+              "backgroundColor": "rgba(41, 121, 255, 0.5)",
               "color": "#000",
             }
           }
@@ -702,7 +702,7 @@ exports[`ConfusionMatrix renders only one of the given list of configs 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.375)",
+              "backgroundColor": "rgba(41, 121, 255, 0)",
               "color": "#000",
             }
           }
@@ -724,7 +724,7 @@ exports[`ConfusionMatrix renders only one of the given list of configs 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "backgroundColor": "rgba(41, 121, 255, 0.5)",
+              "backgroundColor": "rgba(41, 121, 255, 0.375)",
               "color": "#000",
             }
           }

--- a/frontend/src/lib/OutputArtifactLoader.test.ts
+++ b/frontend/src/lib/OutputArtifactLoader.test.ts
@@ -208,24 +208,27 @@ describe('OutputArtifactLoader', () => {
       fileToRead = '';
 
       const source = `
-      field1,field1,1
-      field1,field2,2
-      field2,field1,3
-      field2,field2,4
+      label1,label1,1
+      label1,label2,2
+      label2,label1,3
+      label2,label2,4
       `;
       const expectedResult: ConfusionMatrixConfig = {
         axes: ['field1', 'field2'],
         data: [
-          [1, 2],
-          [3, 4],
+          // Note, the data matrix's layout does not match how we show it in UI.
+          // field1 is x-axis, field2 is y-axis
+          [1 /* field1=label1, field2=label1 */, 2 /* field1=label1, field2=label2 */],
+          [3 /* field1=label2, field2=label1 */, 4 /* field1=label2, field2=label2 */],
         ],
-        labels: ['field1', 'field2'],
+        labels: ['label1', 'label2'],
         type: PlotType.CONFUSION_MATRIX,
       };
 
       const result = await OutputArtifactLoader.buildConfusionMatrixConfig(
         {
           ...basicMetadata,
+          labels: ['label1', 'label2'],
           storage: 'inline',
           source,
         } as any,

--- a/frontend/src/lib/OutputArtifactLoader.ts
+++ b/frontend/src/lib/OutputArtifactLoader.ts
@@ -143,9 +143,10 @@ export class OutputArtifactLoader {
     }
 
     const data = Array.from(Array(labels.length), () => new Array(labels.length));
-    csvRows.forEach(([target, predicted, count]) => {
-      const i = labelIndex[target.trim()];
-      const j = labelIndex[predicted.trim()];
+    csvRows.forEach(([labelX, labelY, count]) => {
+      const i = labelIndex[labelX.trim()];
+      const j = labelIndex[labelY.trim()];
+      // Note: data[i][j] means data(i, j) i on x-axis, j on y-axis
       data[i][j] = Number.parseInt(count, 10);
     });
 


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/3733

/area frontend
/kind bug

Note that the number for (target=NONE, predicted=ACTION) changed, with the bug it was 855, but after the fix it is 195.

195 is correct corresponding to schema and data:
```
// schema
{
"outputs": [
  {
    "labels": ["NONE", "ACTION"],
    "source": "gs://gongyuan-test/fb13d79c-28b2-443e-96e2-30f9a7919dbb/data/confusion_matrix.csv",
    "schema": [
      {"type": "CATEGORY", "name": "target"},
      {"type": "CATEGORY", "name": "predicted"},
      {"type": "NUMBER", "name": "count"}
    ],
    "type": "confusion_matrix", "format": "csv"
  }
]}
// data
NONE,NONE,3800
NONE,ACTION,195
ACTION,NONE,855
ACTION,ACTION,1659
```

bug:
![Screen Shot 2020-05-22 at 1 56 09 PM](https://user-images.githubusercontent.com/4957653/82637946-70099800-9c38-11ea-8d81-461726f04fbd.png)
after fix:
![Screen Shot 2020-05-22 at 2 32 12 PM](https://user-images.githubusercontent.com/4957653/82638243-105fbc80-9c39-11ea-84f9-0024e257464f.png)

Implementation:
The fix changed confusion matrix to be in a more conventional representation, with NONE labels from both x and y axis starting at bottom left.