### PR TITLE
Testing - Pin numpy version to fix TFX installation instability in Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ matrix:
         - git clone https://github.com/tensorflow/tfx.git
         - cd $TRAVIS_BUILD_DIR/tfx
         - pip3 install --upgrade pip
+        - pip3 install --upgrade 'numpy>=1.16,<1.17'
         - set -x
         - set -e
         - python3 setup.py bdist_wheel


### PR DESCRIPTION
TFX package is has inconsistent dependencies which causes the installation to be flaky and install different numpy version every time leading to failures.