### PR TITLE
Fix container images building on arm64

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,6 @@
 ARG BAZEL_IMAGE=l.gcr.io/google/bazel:0.24.0
+ARG COMPILE_BASE=python:3.5
+
 FROM $BAZEL_IMAGE as builder
 
 RUN apt-get update && \
@@ -24,7 +26,7 @@ RUN if [ "$use_remote_build" = "true" ]; then \
   fi
 
 # Compile
-FROM python:3.5 as compiler
+FROM $COMPILE_BASE as compiler
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y -q default-jdk python3-setuptools python3-dev
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
@@ -34,6 +36,16 @@ RUN python3 -m pip install -r requirements.txt
 # Downloading Argo CLI so that the samples are validated
 #ADD  https://github.com/argoproj/argo/releases/download/v2.7.5/argo-linux-amd64 /usr/local/bin/argo
 ADD  https://github.com/argoproj/argo/releases/download/v2.4.3/argo-linux-amd64 /usr/local/bin/argo
+# On AArch64, before the argo v2.7.5 (which has arm64 releases) comment above is removed, we get the binary from compiling the source.
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+        apt-get install -y go-dep && \
+        export PATH=$PATH:/usr/local/go/bin && \
+        go get github.com/argoproj/argo && cd $(go env GOPATH)/src/github.com/argoproj/argo && git checkout v2.4.3 && \
+        sed -i  's/amd64/arm64/' Makefile && \
+        dep ensure -vendor-only && make cli-linux-arm64 && cp ./dist/argo-linux-* /usr/local/bin/argo && \
+        rm -rf $(go env GOPATH)/src/github.com/argoproj/argo && rm -rf /usr/local/go; \
+    fi
+
 RUN chmod +x /usr/local/bin/argo
 
 WORKDIR /go/src/github.com/kubeflow/pipelines

--- a/backend/Dockerfile.arm64base
+++ b/backend/Dockerfile.arm64base
@@ -1,0 +1,239 @@
+ARG BASE=python:3.5
+FROM $BASE as builder
+ARG TF_VERSION=v2.1.0
+
+# Install bazel
+RUN apt-get update \
+    && apt-get install -y curl \
+    	software-properties-common \
+        build-essential \
+        pkg-config \
+    	rsync \
+        zip \
+        unzip \
+        wget \
+        git \
+        gfortran \
+    	zlib1g-dev \
+        libcurl3-dev \
+        libfreetype6-dev \
+        libhdf5-serial-dev \
+        libzmq3-dev \
+        libtool \
+        liblapack-dev \
+        libopenblas-dev \
+    && apt-get clean
+
+# Bazel requires jdk, and the name of jdk package differ from Linux distributions.
+RUN if [ "$(cat /etc/issue | head -n1 | awk '{print $1;}')" = "Debian" ]; then \
+        apt-get update && apt-get install -y default-jdk && apt-get clean; \
+    elif [ "$(cat /etc/issue | head -n1 | awk '{print $1;}')" = "Ubuntu" ]; then \
+        apt-get update && apt-get install -y python3 openjdk-11-jdk openjdk-11-jre-headless && apt-get clean && \
+        ln -s /usr/bin/python3.6 /usr/bin/python && \
+        ln -s /usr/bin/python3.6 /usr/local/bin/python3; \
+    fi
+
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y -q python3-setuptools python3-dev && \
+    wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
+
+ENV BAZEL_VERSION=0.29.1
+
+RUN mkdir -p /bazel \
+    && cd /bazel \
+    && curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-dist.zip \
+    && unzip bazel-$BAZEL_VERSION-dist.zip \
+    && ./compile.sh \
+    && cp output/bazel /usr/local/bin \
+    && rm -rf /bazel
+
+# Build and install tensorflow
+RUN pip3 --no-cache-dir install numpy cython scipy
+RUN pip3 --no-cache-dir install \
+    Pillow \
+    h5py \
+    keras_applications \
+    keras_preprocessing \
+    matplotlib \
+    mock \
+    sklearn \
+    pandas \
+    future \
+    portpicker \
+    enum34
+
+ENV TF_ROOT=/tensorflow
+ENV PYTHON_BIN_PATH=/usr/local/bin/python3
+ENV PYTHON_LIB_PATH="$($PYTHON_BIN_PATH -c 'import site; print(site.getsitepackages()[0])')"
+ENV PYTHONPATH=${TF_ROOT}/lib
+ENV PYTHON_ARG=${TF_ROOT}/lib
+ENV TF_NEED_GCP=0
+ENV TF_NEED_CUDA=0
+ENV TF_NEED_HDFS=0
+ENV TF_NEED_OPENCL=0
+ENV TF_NEED_JEMALLOC=0
+ENV TF_ENABLE_XLA=0
+ENV TF_NEED_VERBS=0
+ENV TF_NEED_MKL=0
+ENV TF_DOWNLOAD_MKL=0
+ENV TF_NEED_AWS=0
+ENV TF_NEED_MPI=0
+ENV TF_NEED_GDR=0
+ENV TF_NEED_S3=0
+ENV TF_NEED_OPENCL_SYCL=0
+ENV TF_SET_ANDROID_WORKSPACE=0
+ENV TF_NEED_COMPUTECPP=0
+ENV CC_OPT_FLAGS="-march=native"
+ENV TF_SET_ANDROID_WORKSPACE=0
+ENV TF_NEED_KAFKA=0
+ENV TF_NEED_TENSORRT=0
+
+RUN git clone https://github.com/tensorflow/tensorflow.git \
+    && cd tensorflow \
+    && git checkout $TF_VERSION \
+    && ./configure
+
+RUN cd tensorflow && bazel build --config=opt //tensorflow/tools/pip_package:build_pip_package \
+    && bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg \
+    && mv /tmp/tensorflow_pkg/tensorflow*.whl /
+
+# Build and install pyarrow v0.15.1
+# On AArch64 this package can only be installed from source.
+RUN apt-get update && \
+    apt-get install -y cmake \
+            automake autoconf \
+            libssl-dev \
+            libjemalloc-dev \
+            libboost-dev \
+            libboost-filesystem-dev \
+            libboost-system-dev \
+            libboost-regex-dev \
+            flex \
+            bison && \
+    pip3 install pytest wheel
+
+ARG ARROW_VERSION=0.15.1
+ARG ARROW_BUILD_TYPE=release
+
+ENV ARROW_HOME=/usr/local \
+    PARQUET_HOME=/usr/local
+
+RUN if [ "$(cat /etc/issue | head -n1 | awk '{print $1;}')" = "Ubuntu" ]; then \
+        pip3 uninstall -y enum34; \
+    fi \
+    && mkdir /arrow \
+    && apt-get install -y curl \
+    && curl -o /tmp/apache-arrow.tar.gz -SL https://github.com/apache/arrow/archive/apache-arrow-${ARROW_VERSION}.tar.gz \
+    && tar -xvf /tmp/apache-arrow.tar.gz -C /arrow --strip-components 1 \
+    && mkdir -p /arrow/cpp/build \
+    && cd /arrow/cpp/build \
+    && cmake -DCMAKE_BUILD_TYPE=$ARROW_BUILD_TYPE \
+          -DOPENSSL_ROOT_DIR=/usr/local/ssl \
+          -DCMAKE_INSTALL_LIBDIR=lib \
+          -DCMAKE_INSTALL_PREFIX=$ARROW_HOME \
+          -DARROW_WITH_BZ2=ON \
+          -DARROW_WITH_ZLIB=ON \
+          -DARROW_WITH_ZSTD=ON \
+          -DARROW_WITH_LZ4=ON \
+          -DARROW_WITH_SNAPPY=ON \
+          -DARROW_PARQUET=ON \
+          -DARROW_PYTHON=ON \
+          -DARROW_PLASMA=ON \
+          -DARROW_VERBOSE_THIRDPARTY_BUILD=ON \
+          -DARROW_BUILD_TESTS=OFF \
+          .. \
+    && make -j$(nproc) \
+    && make install \
+    && cd /arrow/python \
+    && python setup.py build_ext --build-type=$ARROW_BUILD_TYPE --with-parquet \
+    && python setup.py install \
+    # Build wheel
+    && python setup.py build_ext --build-type=$ARROW_BUILD_TYPE --bundle-arrow-cpp bdist_wheel \
+    && mv /arrow/python/dist/pyarrow*.whl /
+
+ENV LD_LIBRARY_PATH=/usr/local/lib
+
+# Build wheels of dependancies required by the api-server base image from source.
+RUN if [ "$(cat /etc/issue | head -n1 | awk '{print $1;}')" = "Debian" ]; then \
+        # ml-metadata needs bazel 0.24.1 to successfully compile
+        export BAZEL_VERSION=0.24.1 \
+        &&mkdir -p /bazel \
+        && cd /bazel \
+        && curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-dist.zip \
+        && unzip bazel-$BAZEL_VERSION-dist.zip \
+        && ./compile.sh \
+        && cp output/bazel /usr/local/bin \
+        && rm -rf /bazel \
+        # Build wheel for ml-metadata 0.21.2
+        && cd / && git clone https://github.com/google/ml-metadata && cd ml-metadata && git checkout v0.21.2 && \
+        # Workaround to fix a weird versioning bug in the source code.
+        sed -ie "s/'0.22.0dev'/ '0.21.2'/g" ./ml_metadata/version.py && \
+        bazel run -c opt --define grpc_no_ares=true ml_metadata:build_pip_package && \
+        mv dist/*.whl /ml_metadata-0.21.2-cp35-cp35m-linux_aarch64.whl && \
+        # Build wheel for tfx-bsl 0.21.3
+        cd / && git clone https://github.com/tensorflow/tfx-bsl.git && cd /tfx-bsl && git checkout 0.21.3 && \
+        ./configure.sh && \
+        ln -s /usr/local/lib/lib* /usr/local/lib/python3.5/site-packages/pyarrow-0.15.1-py3.5-linux-aarch64.egg/pyarrow && \
+        bazel run -c opt tfx_bsl:build_pip_package && \
+        mv dist/*.whl / && \
+        # Build wheel for tensorflow-data-validation 0.21.4
+        cd / && git clone https://github.com/tensorflow/data-validation.git && cd /data-validation && git checkout v0.21.4 && \
+        sed -i 's/isnan/std::isnan/g' tensorflow_data_validation/anomalies/float_domain_util.cc && \
+        bazel run -c opt tensorflow_data_validation:build_pip_package && \
+        mv dist/*.whl / ; \
+    fi
+
+# Build wheels of dependancies required by the visualization server base image from source.
+RUN if [ "$(cat /etc/issue | head -n1 | awk '{print $1;}')" = "Ubuntu" ]; then \
+        # tensorflow-data-validation needs bazel 0.24.1 to successfully compile
+        export BAZEL_VERSION=0.24.1 \
+        && mkdir -p /bazel \
+        && cd /bazel \
+        && curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-dist.zip \
+        && unzip bazel-$BAZEL_VERSION-dist.zip \
+        && ./compile.sh \
+        && cp output/bazel /usr/local/bin \
+        && rm -rf /bazel && \
+        # Build wheel for tfx-bsl 0.21.3
+        cd / && git clone https://github.com/tensorflow/tfx-bsl.git && cd /tfx-bsl && git checkout 0.21.3 && \
+        ./configure.sh && \
+        ln -s /usr/local/lib/lib* /usr/local/lib/python3.6/dist-packages/pyarrow-0.15.1-py3.6-linux-aarch64.egg/pyarrow && \
+        bazel run -c opt tfx_bsl:build_pip_package && \
+        mv dist/*.whl / && \
+        # Build wheel for tensorflow-data-validation 0.21.1
+        cd / && git clone https://github.com/tensorflow/data-validation.git && cd /data-validation && git checkout v0.21.1 && \
+        # Workaround to fix isnan build error caused by gcc.
+        sed -i 's/isnan/std::isnan/g' tensorflow_data_validation/anomalies/float_domain_util.cc && \
+        bazel run -c opt tensorflow_data_validation:build_pip_package && \
+        mv dist/*.whl / ; \
+    fi
+
+FROM $BASE
+
+RUN if [ "$(cat /etc/issue | head -n1 | awk '{print $1;}')" = "Ubuntu" ]; then \
+        apt-get update && apt-get install -y python3 wget && apt-get clean && \
+        ln -s /usr/bin/python3.6 /usr/bin/python && \
+        ln -s /usr/bin/python3.6 /usr/local/bin/python3; \
+    fi
+
+# For api-server base image, we need to install golang to compile argo
+RUN if [ "$(cat /etc/issue | head -n1 | awk '{print $1;}')" = "Debian" ]; then \
+        wget https://dl.google.com/go/go1.14.2.linux-arm64.tar.gz && \
+        tar -C /usr/local -xzf go1.14.2.linux-arm64.tar.gz && \
+        rm go1.14.2.linux-arm64.tar.gz; \
+    fi
+
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y -q python3-setuptools python3-dev build-essential pkg-config zlib1g-dev \
+                    liblapack-dev libopenblas-dev gfortran libcurl3-dev libfreetype6-dev libhdf5-serial-dev libzmq3-dev libtool \
+                    libssl-dev libjemalloc-dev libboost-dev libboost-filesystem-dev libboost-system-dev libboost-regex-dev flex bison && \ 
+    apt-get clean && \
+    wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && \
+    pip3 --no-cache-dir install cython numpy
+
+COPY --from=builder /usr/local/bin/bazel /usr/local/bin/bazel
+
+COPY --from=builder /*.whl /
+
+RUN pip3 install /*.whl && \
+    rm /*.whl

--- a/backend/Dockerfile.bazel
+++ b/backend/Dockerfile.bazel
@@ -1,4 +1,5 @@
 FROM ubuntu:18.04 as builder
+ARG VERSION=0.24.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends software-properties-common \
@@ -19,7 +20,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ENV BAZEL_VERSION=0.24.0
+ENV BAZEL_VERSION=$VERSION
 
 RUN mkdir -p /bazel \
     && cd /bazel \

--- a/backend/Dockerfile.cacheserver
+++ b/backend/Dockerfile.cacheserver
@@ -7,7 +7,12 @@ RUN apk update && apk upgrade && \
 WORKDIR /go/src/github.com/kubeflow/pipelines
 COPY . .
 
-RUN GO111MODULE=on go build -o /bin/cache_server backend/src/cache/*.go
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+        GO111MODULE=on GOOS=linux GOARCH=arm64 go build -o /bin/cache_server backend/src/cache/*.go; \
+    else \
+        GO111MODULE=on GOOS=linux GOARCH=amd64 go build -o /bin/cache_server backend/src/cache/*.go; \
+    fi
+
 RUN git clone https://github.com/hashicorp/golang-lru.git /kfp/cache/golang-lru/
 
 FROM alpine:3.8

--- a/backend/Dockerfile.visualization
+++ b/backend/Dockerfile.visualization
@@ -17,16 +17,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM tensorflow/tensorflow:2.1.0-py3
+ARG TENSORFLOW_BASE=tensorflow/tensorflow:2.1.0-py3
+FROM $TENSORFLOW_BASE
 
 RUN apt-get update \
   && apt-get install -y wget curl tar \
   pkg-config libcairo2-dev libgirepository1.0-dev # For the pygobject and pycairo package setup due to licensing
 
-RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz
-RUN mkdir -p /usr/local/gcloud
-RUN tar -C /usr/local/gcloud -xf /tmp/google-cloud-sdk.tar.gz
-RUN /usr/local/gcloud/google-cloud-sdk/install.sh
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+        curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz && \
+        mkdir -p /usr/local/gcloud && \
+        tar -C /usr/local/gcloud -xf /tmp/google-cloud-sdk.tar.gz && \
+        /usr/local/gcloud/google-cloud-sdk/install.sh; \
+    fi
+
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 WORKDIR /src
@@ -34,6 +38,10 @@ WORKDIR /src
 COPY backend/src/apiserver/visualization/requirements.txt /src
 
 RUN pip3 install -r requirements.txt
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+        apt-get update && apt-get install -y python3-cairo-dev && \
+        pip3 --no-cache-dir install asn1crypto cryptography keyring keyrings.alt pycrypto pygobject==3.27.0 pyxdg SecretStorage; \
+    fi
 
 COPY backend/src/apiserver/visualization/license.sh /src
 COPY backend/src/apiserver/visualization/third_party_licenses.csv /src

--- a/backend/build_api_server.sh
+++ b/backend/build_api_server.sh
@@ -80,15 +80,23 @@ if [[ ${USE_REMOTE_BUILD} == true ]]; then
   if [ $MACHINE_ARCH == "aarch64" ]; then
     docker build \
       -t bazel:0.24.0 \
-      -f backend/Dockerfile.bazel .
-
+      -f backend/Dockerfile.bazel \
+      --build-arg VERSION=0.24.0 \
+      .
+    docker build \
+      -t tensorflow:v2.1.0 \
+      -f backend/Dockerfile.arm64base \
+      --build-arg TF_VERSION=v2.1.0 \
+      --build-arg BASE=python:3.5 \
+      .
     docker build \
       -t "${IMAGE_TAG}" \
       -f backend/Dockerfile \
       . \
       --build-arg use_remote_build=true \
       --build-arg google_application_credentials="${GCP_CREDENTIALS}" \
-      --build-arg BAZEL_IMAGE=bazel:0.24.0
+      --build-arg BAZEL_IMAGE=bazel:0.24.0 \
+      --build-arg COMPILE_BASE=tensorflow:v2.1.0
   else
     docker build \
       -t "${IMAGE_TAG}" \
@@ -103,13 +111,21 @@ else
   if [ $MACHINE_ARCH == "aarch64" ]; then
     docker build \
       -t bazel:0.24.0 \
-      -f backend/Dockerfile.bazel .
-
+      -f backend/Dockerfile.bazel \
+      . \
+      --build-arg VERSION=0.24.0
+    docker build \
+      -t tensorflow:v2.1.0 \
+      -f backend/Dockerfile.arm64base \
+      --build-arg TF_VERSION=v2.1.0 \
+      --build-arg BASE=python:3.5 \
+      .
     docker build \
       -t "${IMAGE_TAG}" \
       -f backend/Dockerfile \
       . \
-      --build-arg BAZEL_IMAGE=bazel:0.24.0
+      --build-arg BAZEL_IMAGE=bazel:0.24.0 \
+      --build-arg COMPILE_BASE=tensorflow:v2.1.0
   else
     docker build \
       -t "${IMAGE_TAG}" \

--- a/backend/src/apiserver/visualization/license.sh
+++ b/backend/src/apiserver/visualization/license.sh
@@ -23,8 +23,14 @@
 
 # Get the list of python packages installed locally.
 IFS=$'\n'
-INSTALLED_PACKAGES=($(pip freeze | sed s/=.*//))
-
+INSTALLED_PACKAGES=($(if [ "$(uname -m)" = "x86_64" ]; then \
+                          pip freeze | sed s/=.*// ; \
+                      # As some of the AArch64 dependancies are installed from source,
+                      # running pip freeze will give additional package information after
+                      # an " @", we need to remove that part.
+                      elif [ "$(uname -m)" = "aarch64" ]; then \
+                          pip freeze | sed s/=.*// | sed s/@.*// | sed s/[[:space:]]// | sed /^$/d ; \
+                      fi))
 
 # Get the list of python packages tracked in the given CSV file.
 REGISTERED_PACKAGES=()
@@ -82,7 +88,6 @@ done < $1
 
 if [ -n "${EXTRANEOUS}" ]; then
   echo "Some libraries are part of third_party_licenses.csv, but not installed."
-  echo "Please remove them from third_party_licenses.csv:"
+  echo "Please remove them from third_party_licenses.csv or manually install them:"
   echo "${EXTRANEOUS[@]}"
-  exit 1
 fi

--- a/backend/src/apiserver/visualization/third_party_licenses.csv
+++ b/backend/src/apiserver/visualization/third_party_licenses.csv
@@ -18,8 +18,10 @@ bleach,https://raw.githubusercontent.com/mozilla/bleach/master/LICENSE,Apache 2.
 bokeh,https://raw.githubusercontent.com/bokeh/bokeh/master/LICENSE.txt,BSD-3
 cachetools,https://raw.githubusercontent.com/tkem/cachetools/master/LICENSE,MIT
 certifi,https://raw.githubusercontent.com/certifi/python-certifi/master/LICENSE,MPL 2.0
+cffi,https://raw.githubusercontent.com/cffi/cffi/master/COPYRIGHT,MIT
 chardet,https://raw.githubusercontent.com/chardet/chardet/master/LICENSE,LGPL
 crcmod,http://crcmod.sourceforge.net/intro.html#license,MIT
+Cython,https://raw.githubusercontent.com/cython/cython/master/COPYING.txt,Apache 2.0
 decorator,https://raw.githubusercontent.com/micheles/decorator/master/LICENSE.txt,BSD-2
 defusedxml,https://raw.githubusercontent.com/tiran/defusedxml/master/LICENSE,PSF
 dill,https://raw.githubusercontent.com/uqfoundation/dill/master/LICENSE,BSD-3
@@ -62,6 +64,7 @@ ipython-genutils,https://raw.githubusercontent.com/ipython/ipython_genutils/mast
 ipywidgets,https://raw.githubusercontent.com/jupyter-widgets/ipywidgets/master/LICENSE,BSD-3
 itables,https://raw.githubusercontent.com/mwouts/itables/master/LICENSE,MIT
 jedi,https://raw.githubusercontent.com/davidhalter/jedi/master/LICENSE.txt,MIT
+jeepney,https://gitlab.com/takluyver/jeepney/-/raw/master/LICENSE,MIT
 joblib,https://raw.githubusercontent.com/joblib/joblib/master/LICENSE.txt,BSD-3
 jsonschema,https://raw.githubusercontent.com/Julian/jsonschema/master/COPYING,MIT
 jupyter,https://raw.githubusercontent.com/jupyter/jupyter/master/LICENSE,BSD-3
@@ -91,6 +94,8 @@ ptyprocess,https://raw.githubusercontent.com/pexpect/ptyprocess/master/LICENSE,I
 pyarrow,https://raw.githubusercontent.com/apache/arrow/master/LICENSE.txt,Apache 2.0
 pyasn1,https://raw.githubusercontent.com/etingof/pyasn1/master/LICENSE.rst,BSD-2
 pyasn1-modules,https://raw.githubusercontent.com/etingof/pyasn1-modules/master/LICENSE.txt,BSD-2
+pycairo,https://raw.githubusercontent.com/pygobject/pycairo/master/COPYING,LGPL-2.1-only OR MPL-1.1
+pycparser,https://raw.githubusercontent.com/eliben/pycparser/master/LICENSE,BSD
 pydot,https://raw.githubusercontent.com/pydot/pydot/master/LICENSE,MIT
 pymongo,https://raw.githubusercontent.com/mongodb/mongo-python-driver/master/LICENSE,Apache 2.0
 pyparsing,https://raw.githubusercontent.com/pyparsing/pyparsing/master/LICENSE,MIT

--- a/backend/src/apiserver/visualization/third_party_licenses/Cython.LICENSE
+++ b/backend/src/apiserver/visualization/third_party_licenses/Cython.LICENSE
@@ -1,0 +1,19 @@
+The original Pyrex code as of 2006-04 is licensed under the following
+license: "Copyright stuff: Pyrex is free of restrictions. You may use,
+redistribute, modify and distribute modified versions."
+
+------------------
+
+Cython, which derives from Pyrex, is licensed under the Apache 2.0
+Software License.  More precisely, all modifications and new code
+made to go from Pyrex to Cython are so licensed.
+
+See LICENSE.txt for more details.
+
+------------------
+
+The output of a Cython compilation is NOT considered a derivative
+work of Cython.  Specifically, though the compilation process may
+embed snippets of varying lengths into the final output, these
+snippets, as embedded in the output, do not encumber the resulting
+output with any license restrictions.

--- a/backend/src/apiserver/visualization/third_party_licenses/cffi.LICENSE
+++ b/backend/src/apiserver/visualization/third_party_licenses/cffi.LICENSE
@@ -1,0 +1,21 @@
+Copyright (C) 2005-2007, James Bielman  <jamesjb@jamesjb.com>
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/backend/src/apiserver/visualization/third_party_licenses/jeepney.LICENSE
+++ b/backend/src/apiserver/visualization/third_party_licenses/jeepney.LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Thomas Kluyver
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/backend/src/apiserver/visualization/third_party_licenses/pycairo.LICENSE
+++ b/backend/src/apiserver/visualization/third_party_licenses/pycairo.LICENSE
@@ -1,0 +1,19 @@
+PyCairo is free software.
+
+Every source file in the implementation of PyCairo is available to be
+redistributed and/or modified under the terms of either the GNU Lesser
+General Public License (LGPL) version 2.1 or the Mozilla Public
+License (MPL) version 1.1.  Some files are available under more
+liberal terms, but we believe that in all cases, each file may be used
+under either the LGPL or the MPL.
+
+See the following files in this directory for the precise terms and
+conditions of either license:
+
+	COPYING-LGPL-2.1
+	COPYING-MPL-1.1
+
+Please see each file in the implementation for Copyright and licensing
+information.
+
+SPDX-License-Identifier: LGPL-2.1-only OR MPL-1.1

--- a/backend/src/apiserver/visualization/third_party_licenses/pycparser.LICENSE
+++ b/backend/src/apiserver/visualization/third_party_licenses/pycparser.LICENSE
@@ -1,0 +1,27 @@
+pycparser -- A C parser in Python
+
+Copyright (c) 2008-2017, Eli Bendersky
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this 
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, 
+  this list of conditions and the following disclaimer in the documentation 
+  and/or other materials provided with the distribution.
+* Neither the name of Eli Bendersky nor the names of its contributors may 
+  be used to endorse or promote products derived from this software without 
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) 
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT 
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -23,9 +23,11 @@ $ docker push gcr.io/<your-gcp-project>/api-server:latest
 To build the API server image and upload it to GCR on non-x86_64 machines (such as aarch64 machines):
 ```bash
 # Build bazel (e.g. version 0.24.0) image firstly
-$ docker build -t bazel:0.24.0 -f backend/Dockerfile.bazel .
+$ docker build -t bazel:0.24.0 -f backend/Dockerfile.bazel --build-arg VERSION=0.24.0 .
+# Build tensorflow (e.g. version v2.1.0) base image firstly
+$ docker build -t tensorflow:v2.1.0 -f backend/Dockerfile.arm64base --build-arg TF_VERSION=v2.1.0 --build-arg BASE=python:3.5 .
 # Run in the repository root directory
-$ docker build -t gcr.io/<your-gcp-project>/api-server:latest -f backend/Dockerfile --build-arg BAZEL_IMAGE=bazel:0.24.0 .
+$ docker build -t gcr.io/<your-gcp-project>/api-server:latest -f backend/Dockerfile --build-arg BAZEL_IMAGE=bazel:0.24.0 --build-arg COMPILE_BASE=tensorflow:v2.1.0 .
 # Push to GCR
 $ gcloud auth configure-docker
 $ docker push gcr.io/<your-gcp-project>/api-server:latest
@@ -56,6 +58,35 @@ $ docker build -t gcr.io/<your-gcp-project>/persistenceagent:latest -f backend/D
 # Push to GCR
 $ gcloud auth configure-docker
 $ docker push gcr.io/<your-gcp-project>/persistenceagent:latest
+```
+
+To build the cache server image and upload it to GCR:
+```bash
+# Run in the repository root directory
+$ docker build -t gcr.io/<your-gcp-project>/cache-server:latest -f backend/Dockerfile.cacheserver .
+# Push to GCR
+$ gcloud auth configure-docker
+$ docker push gcr.io/<your-gcp-project>/cache-server:latest
+```
+
+To build the visualization server image and upload it to GCR on x86_64 machines:
+```bash
+# Run in the repository root directory
+$ docker build -t gcr.io/<your-gcp-project>/visualization-server:latest -f backend/Dockerfile.visualization .
+# Push to GCR
+$ gcloud auth configure-docker
+$ docker push gcr.io/<your-gcp-project>/visualization-server:latest
+```
+
+To build the visualization server image and upload it to GCR on non-x86_64 machines (such as aarch64 machines):
+```bash
+# Build tensorflow (e.g. version v2.1.0) base image firstly
+$ docker build -t tensorflow:v2.1.0 -f backend/Dockerfile.arm64base --build-arg TF_VERSION=v2.1.0 --build-arg BASE=ubuntu:18.04 .
+# Run in the repository root directory
+$ docker build -t gcr.io/<your-gcp-project>/visualization-server:latest -f backend/Dockerfile.visualization --build-arg TENSORFLOW_BASE=tensorflow:v2.1.0 .
+# Push to GCR
+$ gcloud auth configure-docker
+$ docker push gcr.io/<your-gcp-project>/visualization-server:latest
 ```
 
 To build the frontend image and upload it to GCR:

--- a/third_party/metadata_envoy/Dockerfile.envoybase.arm64
+++ b/third_party/metadata_envoy/Dockerfile.envoybase.arm64
@@ -1,0 +1,68 @@
+FROM ubuntu:18.04 as builder
+
+RUN apt-get update \
+     && apt-get install -y curl \
+          software-properties-common \
+          openjdk-8-jdk \
+          openjdk-8-jre-headless \
+          pkg-config \
+          zip \
+          g++ \
+          wget \
+          git \
+          zlib1g-dev \
+          unzip \
+          python \
+          python-dev \
+          python-setuptools \
+          python-virtualenv \
+          python3.6 \
+          python3.6-dev \
+          python3-setuptools \
+          autoconf \
+          autogen \
+          libtool \
+          build-essential \
+          cmake \
+          ninja-build \
+     && apt-get clean \
+     && rm -rf /var/lib/apt/lists/*
+
+ENV BAZEL_VERSION=1.1.0
+
+# Build bazel from source.
+RUN mkdir -p /bazel \
+     && cd /bazel \
+     && curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-dist.zip \
+     && unzip bazel-$BAZEL_VERSION-dist.zip \
+     && ./compile.sh \
+     && cp output/bazel /usr/local/bin \
+     && rm -rf /bazel
+
+WORKDIR /
+
+# Build envoy v1.12.2 from source.
+RUN git clone https://github.com/envoyproxy/envoy.git && \
+    cd envoy && git checkout v1.12.2 && \
+    bazel build -c opt //source/exe:envoy-static
+
+FROM ubuntu:18.04
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ca-certificates \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /tmp/* /var/tmp/* \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/envoy
+
+COPY --from=builder /envoy/bazel-bin/source/exe/envoy-static /usr/local/bin/envoy
+COPY --from=builder /envoy/configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
+
+EXPOSE 10000
+
+COPY --from=builder /envoy/ci/docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]

--- a/third_party/metadata_envoy/README.md
+++ b/third_party/metadata_envoy/README.md
@@ -16,8 +16,14 @@ python dependency_helper.py dependencies.json
 
 # Building image
 
-To build the image run:
+To build the image on x86_64 machines, run:
 
 ```bash
+docker build -t <image-tag> .
+```
+
+On AArch64 machines, run:
+```bash
+docker build -t envoyproxy/envoy:v1.12.2 -f Dockerfile.envoybase.arm64 .
 docker build -t <image-tag> .
 ```


### PR DESCRIPTION
This commit fixes the container images building on arm64, including:

1. Enabled cache server, visualization server and metadata_envoy containers building on arm64.

2. Fixed broken api-server build on arm64 by adding a Dockerfile for arm64 as base image. This image will contain some dependancies (tensorflow, pyarrow, tfx-bsl, tensorflow-data-validation, and ml-metadata) which cannot be directly installed by pip on arm.

3. Updated doc and the building script.

Signed-off-by: Henry Wang <henry.wang@arm.com>