### PR TITLE
[UI] Also cloning recurring run schedule, fixes #3761

### DIFF
--- a/frontend/global-setup.js
+++ b/frontend/global-setup.js
@@ -1,0 +1,6 @@
+export default () => {
+  // This let unit tests run in UTC timezone consistently, despite developers'
+  // dev machine's timezone.
+  // Reference: https://stackoverflow.com/a/56482581
+  process.env.TZ = 'UTC';
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -110,6 +110,7 @@
       "!src/index.tsx",
       "!src/CSSReset.tsx"
     ],
+    "globalSetup": "./global-setup.js",
     "snapshotSerializers": [
       "./src/__serializers__/mock-function",
       "snapshot-diff/serializer.js",

--- a/frontend/src/components/Trigger.test.tsx
+++ b/frontend/src/components/Trigger.test.tsx
@@ -36,14 +36,21 @@ describe('Trigger', () => {
 
   function mockDate(isoDate: any): void {
     (global as any).Date = class extends RealDate {
-      constructor() {
+      constructor(...args: any[]) {
         super();
-        return new RealDate(isoDate);
+        if (args.length === 0) {
+          // Use mocked date when calling new Date()
+          return new RealDate(isoDate);
+        } else {
+          // Otherwise, use real Date constructor
+          return new (RealDate as any)(...args);
+        }
       }
     };
   }
-  const testDate = new Date(2018, 11, 21, 7, 53);
-  mockDate(testDate);
+  const now = new Date(2018, 11, 21, 7, 53);
+  mockDate(now);
+  const oneWeekLater = new Date(2018, 11, 28, 7, 53);
 
   it('renders periodic schedule controls for initial render', () => {
     const tree = shallow(<Trigger />);
@@ -113,7 +120,7 @@ describe('Trigger', () => {
       expect(spy).toHaveBeenLastCalledWith({
         ...PARAMS_DEFAULT,
         trigger: {
-          periodic_schedule: { ...PERIODIC_DEFAULT, start_time: testDate },
+          periodic_schedule: { ...PERIODIC_DEFAULT, start_time: now },
         },
       });
     });
@@ -128,7 +135,7 @@ describe('Trigger', () => {
         target: { type: 'checkbox', checked: true },
       });
       (tree.instance() as Trigger).handleChange('startDate')({ target: { value: '2018-11-23' } });
-      (tree.instance() as Trigger).handleChange('endTime')({ target: { value: '08:35' } });
+      (tree.instance() as Trigger).handleChange('startTime')({ target: { value: '08:35' } });
       expect(spy).toHaveBeenLastCalledWith({
         ...PARAMS_DEFAULT,
         trigger: {
@@ -193,7 +200,7 @@ describe('Trigger', () => {
       expect(spy).toHaveBeenLastCalledWith({
         ...PARAMS_DEFAULT,
         trigger: {
-          periodic_schedule: { ...PERIODIC_DEFAULT, end_time: testDate, start_time: testDate },
+          periodic_schedule: { ...PERIODIC_DEFAULT, end_time: oneWeekLater, start_time: now },
         },
       });
     });
@@ -292,6 +299,38 @@ describe('Trigger', () => {
         },
       });
     });
+
+    it('inits with cloned initial props', () => {
+      const spy = jest.fn();
+      const startTime = new Date('2020-01-01T23:53:00.000Z');
+      shallow(
+        <Trigger
+          onChange={spy}
+          initialProps={{
+            maxConcurrentRuns: '3',
+            catchup: false,
+            trigger: {
+              periodic_schedule: {
+                interval_second: '' + 60 * 60 * 3, // 3 hours
+                start_time: startTime.toISOString() as any,
+              },
+            },
+          }}
+        />,
+      );
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenLastCalledWith({
+        catchup: false,
+        maxConcurrentRuns: '3',
+        trigger: {
+          periodic_schedule: {
+            end_time: undefined,
+            interval_second: '10800',
+            start_time: startTime,
+          },
+        },
+      });
+    });
   });
 
   describe('cron', () => {
@@ -318,7 +357,7 @@ describe('Trigger', () => {
       expect(spy).toHaveBeenLastCalledWith({
         ...PARAMS_DEFAULT,
         trigger: {
-          cron_schedule: { ...CRON_DEFAULT, start_time: testDate },
+          cron_schedule: { ...CRON_DEFAULT, start_time: new Date('2018-03-22T23:53:00.000Z') },
         },
       });
     });
@@ -336,7 +375,7 @@ describe('Trigger', () => {
       expect(spy).toHaveBeenLastCalledWith({
         ...PARAMS_DEFAULT,
         trigger: {
-          cron_schedule: { ...CRON_DEFAULT, end_time: testDate, cron: '0 0 0 * * ?' },
+          cron_schedule: { ...CRON_DEFAULT, end_time: oneWeekLater, cron: '0 0 0 * * ?' },
         },
       });
     });
@@ -381,6 +420,40 @@ describe('Trigger', () => {
         ...PARAMS_DEFAULT,
         trigger: {
           cron_schedule: { ...CRON_DEFAULT, cron: 'oops this will break!' },
+        },
+      });
+    });
+
+    it('inits with cloned initial props', () => {
+      const spy = jest.fn();
+      const startTime = new Date('2020-01-01T00:00:00.000Z');
+      const endTime = new Date('2020-01-02T01:02:00.000Z');
+      shallow(
+        <Trigger
+          onChange={spy}
+          initialProps={{
+            maxConcurrentRuns: '4',
+            catchup: true,
+            trigger: {
+              cron_schedule: {
+                cron: '0 0 0 ? * 1,5,6',
+                start_time: startTime.toISOString() as any,
+                end_time: endTime.toISOString() as any,
+              },
+            },
+          }}
+        />,
+      );
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenLastCalledWith({
+        catchup: true,
+        maxConcurrentRuns: '4',
+        trigger: {
+          cron_schedule: {
+            cron: '0 0 0 ? * 1,5,6',
+            start_time: startTime,
+            end_time: endTime,
+          },
         },
       });
     });

--- a/frontend/src/components/Trigger.test.tsx
+++ b/frontend/src/components/Trigger.test.tsx
@@ -30,6 +30,10 @@ const PERIODIC_DEFAULT = {
 };
 const CRON_DEFAULT = { cron: '0 * * * * ?', end_time: undefined, start_time: undefined };
 
+beforeAll(() => {
+  process.env.TZ = 'UTC';
+});
+
 describe('Trigger', () => {
   // tslint:disable-next-line:variable-name
   const RealDate = Date;
@@ -357,7 +361,7 @@ describe('Trigger', () => {
       expect(spy).toHaveBeenLastCalledWith({
         ...PARAMS_DEFAULT,
         trigger: {
-          cron_schedule: { ...CRON_DEFAULT, start_time: new Date('2018-03-22T23:53:00.000Z') },
+          cron_schedule: { ...CRON_DEFAULT, start_time: new Date('2018-03-23T07:53:00.000Z') },
         },
       });
     });

--- a/frontend/src/components/Trigger.tsx
+++ b/frontend/src/components/Trigger.tsx
@@ -89,32 +89,16 @@ export default class Trigger extends React.Component<TriggerProps, TriggerState>
       logger.warn('Failed to parse original trigger: ', trigger);
       logger.warn(err);
     }
-    let startDateTime = new Date();
-    let endDateTime = new Date(
-      startDateTime.getFullYear(),
-      startDateTime.getMonth(),
-      startDateTime.getDate() + 7,
-      startDateTime.getHours(),
-      startDateTime.getMinutes(),
-    );
-    if (parsedTrigger.startDateTime) {
-      // Although startDateTime has Date type, but real data is string
-      // type time string. So we had to convert it to Date.
-      // TODO: fix the api client generator.
-      const clonedStartTime = new Date(parsedTrigger.startDateTime);
-      // Invalid dates will get NaN by .getTime()
-      if (Number.isFinite(clonedStartTime.getTime())) {
-        startDateTime = clonedStartTime;
-      }
-    }
-    if (parsedTrigger.endDateTime) {
-      // endDateTime is string in real data as explained above.
-      const clonedEndTime = new Date(parsedTrigger.endDateTime);
-      // Invalid dates will get NaN by .getTime()
-      if (Number.isFinite(clonedEndTime.getTime())) {
-        endDateTime = clonedEndTime;
-      }
-    }
+    const startDateTime = parsedTrigger.startDateTime ?? new Date();
+    const endDateTime =
+      parsedTrigger.endDateTime ??
+      new Date(
+        startDateTime.getFullYear(),
+        startDateTime.getMonth(),
+        startDateTime.getDate() + 7,
+        startDateTime.getHours(),
+        startDateTime.getMinutes(),
+      );
     const [startDate, startTime] = dateToPickerFormat(startDateTime);
     const [endDate, endTime] = dateToPickerFormat(endDateTime);
 

--- a/frontend/src/components/__snapshots__/Trigger.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Trigger.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`Trigger enables a single day on click 1`] = `
           }
         }
         type="date"
-        value="2018-12-21"
+        value="2018-12-28"
         variant="outlined"
         width={160}
       />
@@ -459,7 +459,7 @@ exports[`Trigger renders all week days enabled 1`] = `
           }
         }
         type="date"
-        value="2018-12-21"
+        value="2018-12-28"
         variant="outlined"
         width={160}
       />
@@ -800,7 +800,7 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
           }
         }
         type="date"
-        value="2018-12-21"
+        value="2018-12-28"
         variant="outlined"
         width={160}
       />
@@ -1039,7 +1039,7 @@ exports[`Trigger renders periodic schedule controls if the trigger type is CRON 
           }
         }
         type="date"
-        value="2018-12-21"
+        value="2018-12-28"
         variant="outlined"
         width={160}
       />
@@ -1301,7 +1301,7 @@ exports[`Trigger renders week days if the trigger type is CRON and interval is w
           }
         }
         type="date"
-        value="2018-12-21"
+        value="2018-12-28"
         variant="outlined"
         width={160}
       />

--- a/frontend/src/lib/TriggerUtils.test.ts
+++ b/frontend/src/lib/TriggerUtils.test.ts
@@ -23,6 +23,7 @@ import {
   TriggerType,
   dateToPickerFormat,
   triggerDisplayString,
+  parseTrigger,
 } from './TriggerUtils';
 import { ApiTrigger } from '../apis/job';
 
@@ -233,6 +234,47 @@ describe('TriggerUtils', () => {
           '',
         ),
       ).toThrowError('Invalid TriggerType: ' + 'not a trigger type');
+    });
+  });
+
+  describe('parseTrigger', () => {
+    it('throws on invalid trigger', () => {
+      expect(() => parseTrigger({})).toThrow('Invalid trigger: {}');
+    });
+
+    it('parses periodic schedule', () => {
+      const startTime = new Date(1234);
+      const parsedTrigger = parseTrigger({
+        periodic_schedule: {
+          // there's type mismatch between real data and typing here, test by real data
+          start_time: startTime.toISOString() as any,
+          interval_second: '120',
+        },
+      });
+      expect(parsedTrigger).toEqual({
+        type: TriggerType.INTERVALED,
+        startDateTime: startTime.toISOString(),
+        endDateTime: undefined,
+        intervalCategory: PeriodicInterval.MINUTE,
+        intervalValue: 2,
+      });
+    });
+
+    it('parses cron schedule', () => {
+      const endTime = new Date(12345);
+      const parsedTrigger = parseTrigger({
+        cron_schedule: {
+          // there's type mismatch between real data and typing here, test by real data
+          end_time: endTime.toISOString() as any,
+          cron: '0 0 0 ? * 0,6',
+        },
+      });
+      expect(parsedTrigger).toEqual({
+        type: TriggerType.CRON,
+        cron: '0 0 0 ? * 0,6',
+        startDateTime: undefined,
+        endDateTime: endTime.toISOString(),
+      });
     });
   });
 

--- a/frontend/src/lib/TriggerUtils.test.ts
+++ b/frontend/src/lib/TriggerUtils.test.ts
@@ -246,14 +246,13 @@ describe('TriggerUtils', () => {
       const startTime = new Date(1234);
       const parsedTrigger = parseTrigger({
         periodic_schedule: {
-          // there's type mismatch between real data and typing here, test by real data
-          start_time: startTime.toISOString() as any,
+          start_time: startTime,
           interval_second: '120',
         },
       });
       expect(parsedTrigger).toEqual({
         type: TriggerType.INTERVALED,
-        startDateTime: startTime.toISOString(),
+        startDateTime: startTime,
         endDateTime: undefined,
         intervalCategory: PeriodicInterval.MINUTE,
         intervalValue: 2,
@@ -264,8 +263,7 @@ describe('TriggerUtils', () => {
       const endTime = new Date(12345);
       const parsedTrigger = parseTrigger({
         cron_schedule: {
-          // there's type mismatch between real data and typing here, test by real data
-          end_time: endTime.toISOString() as any,
+          end_time: endTime,
           cron: '0 0 0 ? * 0,6',
         },
       });
@@ -273,7 +271,7 @@ describe('TriggerUtils', () => {
         type: TriggerType.CRON,
         cron: '0 0 0 ? * 0,6',
         startDateTime: undefined,
-        endDateTime: endTime.toISOString(),
+        endDateTime: endTime,
       });
     });
   });

--- a/frontend/src/lib/TriggerUtils.ts
+++ b/frontend/src/lib/TriggerUtils.ts
@@ -222,16 +222,25 @@ export function parseTrigger(trigger: ApiTrigger): ParsedTrigger {
       type: TriggerType.INTERVALED,
       intervalCategory,
       intervalValue,
-      startDateTime: periodicSchedule.start_time,
-      endDateTime: periodicSchedule.end_time,
+      // Generated client has a bug the fields will be string here instead, so
+      // we use new Date() to convert them to Date.
+      startDateTime: periodicSchedule.start_time
+        ? new Date(periodicSchedule.start_time as any)
+        : undefined,
+      endDateTime: periodicSchedule.end_time
+        ? new Date(periodicSchedule.end_time as any)
+        : undefined,
     };
   }
   if (trigger.cron_schedule) {
+    const { cron, start_time: startTime, end_time: endTime } = trigger.cron_schedule;
     return {
       type: TriggerType.CRON,
-      cron: trigger.cron_schedule.cron || '',
-      startDateTime: trigger.cron_schedule.start_time,
-      endDateTime: trigger.cron_schedule.end_time,
+      cron: cron || '',
+      // Generated client has a bug the fields will be string here instead, so
+      // we use new Date() to convert them to Date.
+      startDateTime: startTime ? new Date(startTime as any) : undefined,
+      endDateTime: endTime ? new Date(endTime as any) : undefined,
     };
   }
   throw new Error(`Invalid trigger: ${JSON.stringify(trigger)}`);

--- a/frontend/src/lib/TriggerUtils.ts
+++ b/frontend/src/lib/TriggerUtils.ts
@@ -28,6 +28,20 @@ export enum PeriodicInterval {
   WEEK = 'Week',
   MONTH = 'Month',
 }
+const INTERVAL_SECONDS = {
+  [PeriodicInterval.MINUTE]: 60,
+  [PeriodicInterval.HOUR]: 60 * 60,
+  [PeriodicInterval.DAY]: 60 * 60 * 24,
+  [PeriodicInterval.WEEK]: 60 * 60 * 24 * 7,
+  [PeriodicInterval.MONTH]: 60 * 60 * 24 * 30,
+};
+const PERIODIC_INTERVAL_DESCENDING = [
+  PeriodicInterval.MONTH,
+  PeriodicInterval.WEEK,
+  PeriodicInterval.DAY,
+  PeriodicInterval.HOUR,
+  PeriodicInterval.MINUTE,
+];
 
 export const triggers = new Map<TriggerType, { displayName: string }>([
   [TriggerType.INTERVALED, { displayName: 'Periodic' }],
@@ -35,27 +49,25 @@ export const triggers = new Map<TriggerType, { displayName: string }>([
 ]);
 
 export function getPeriodInSeconds(interval: PeriodicInterval, count: number): number {
-  let intervalSeconds = 0;
-  switch (interval) {
-    case PeriodicInterval.MINUTE:
-      intervalSeconds = 60;
-      break;
-    case PeriodicInterval.HOUR:
-      intervalSeconds = 60 * 60;
-      break;
-    case PeriodicInterval.DAY:
-      intervalSeconds = 60 * 60 * 24;
-      break;
-    case PeriodicInterval.WEEK:
-      intervalSeconds = 60 * 60 * 24 * 7;
-      break;
-    case PeriodicInterval.MONTH:
-      intervalSeconds = 60 * 60 * 24 * 30;
-      break;
-    default:
-      throw new Error('Invalid interval category: ' + interval);
+  const intervalSeconds = INTERVAL_SECONDS[interval];
+  if (!intervalSeconds) {
+    throw new Error('Invalid interval category: ' + interval);
   }
   return intervalSeconds * count;
+}
+export function parsePeriodFromSeconds(
+  seconds: number,
+): { interval: PeriodicInterval; count: number } {
+  for (const interval of PERIODIC_INTERVAL_DESCENDING) {
+    const intervalSeconds = INTERVAL_SECONDS[interval];
+    if (seconds % intervalSeconds === 0) {
+      return {
+        interval,
+        count: seconds / intervalSeconds,
+      };
+    }
+  }
+  throw new Error('Invalid seconds: ' + seconds);
 }
 
 export function buildCron(
@@ -172,6 +184,57 @@ export function buildTrigger(
   }
 
   return trigger;
+}
+
+export type ParsedTrigger =
+  | {
+      type: TriggerType.INTERVALED;
+      intervalCategory: PeriodicInterval;
+      intervalValue: number;
+      startDateTime?: Date;
+      endDateTime?: Date;
+      cron?: undefined;
+    }
+  | {
+      type: TriggerType.CRON;
+      intervalCategory?: undefined;
+      intervalValue?: undefined;
+      startDateTime?: Date;
+      endDateTime?: Date;
+      cron: string;
+    };
+
+export function parseTrigger(trigger: ApiTrigger): ParsedTrigger {
+  if (trigger.periodic_schedule) {
+    const periodicSchedule = trigger.periodic_schedule;
+    const intervalSeconds = parseInt(periodicSchedule.interval_second || '', 10);
+    if (Number.isNaN(intervalSeconds)) {
+      throw new Error(
+        `Interval seconds is NaN: ${periodicSchedule.interval_second} for ${JSON.stringify(
+          trigger,
+        )}`,
+      );
+    }
+    const { interval: intervalCategory, count: intervalValue } = parsePeriodFromSeconds(
+      intervalSeconds,
+    );
+    return {
+      type: TriggerType.INTERVALED,
+      intervalCategory,
+      intervalValue,
+      startDateTime: periodicSchedule.start_time,
+      endDateTime: periodicSchedule.end_time,
+    };
+  }
+  if (trigger.cron_schedule) {
+    return {
+      type: TriggerType.CRON,
+      cron: trigger.cron_schedule.cron || '',
+      startDateTime: trigger.cron_schedule.start_time,
+      endDateTime: trigger.cron_schedule.end_time,
+    };
+  }
+  throw new Error(`Invalid trigger: ${JSON.stringify(trigger)}`);
 }
 
 export function dateToPickerFormat(d: Date): [string, string] {

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -559,6 +559,11 @@ export class NewRun extends Page<{ namespace?: string }, NewRunState> {
               <div>Choose a method by which new runs will be triggered</div>
 
               <Trigger
+                initialProps={{
+                  trigger: this.state.trigger,
+                  maxConcurrentRuns: this.state.maxConcurrentRuns,
+                  catchup: this.state.catchup,
+                }}
                 onChange={({ trigger, maxConcurrentRuns, catchup }) =>
                   this.setStateSafe(
                     {
@@ -658,10 +663,15 @@ export class NewRun extends Page<{ namespace?: string }, NewRunState> {
     } else if (originalRecurringRunId) {
       // If we are cloning a recurring run, fetch the original
       try {
-        const originalRun = await Apis.jobServiceApi.getJob(originalRecurringRunId);
-        await this._prepareFormFromClone(originalRun);
+        const originalJob = await Apis.jobServiceApi.getJob(originalRecurringRunId);
+        await this._prepareFormFromClone(originalJob);
+        this.setStateSafe({
+          trigger: originalJob.trigger,
+          maxConcurrentRuns: originalJob.max_concurrency,
+          catchup: !originalJob.no_catchup,
+        });
         if (!experimentId) {
-          experimentId = RunUtils.getFirstExperimentReferenceId(originalRun);
+          experimentId = RunUtils.getFirstExperimentReferenceId(originalJob);
         }
       } catch (err) {
         await this.showPageError(

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -1482,6 +1482,13 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
       Choose a method by which new runs will be triggered
     </div>
     <Trigger
+      initialProps={
+        Object {
+          "catchup": true,
+          "maxConcurrentRuns": undefined,
+          "trigger": undefined,
+        }
+      }
       onChange={[Function]}
     />
     <NewRunParameters
@@ -3575,6 +3582,13 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
       Choose a method by which new runs will be triggered
     </div>
     <Trigger
+      initialProps={
+        Object {
+          "catchup": true,
+          "maxConcurrentRuns": undefined,
+          "trigger": undefined,
+        }
+      }
       onChange={[Function]}
     />
     <NewRunParameters


### PR DESCRIPTION
Fixes #3761

/area frontend
/kind feature

Cloning schedule of recurring run wasn't implemented in UI, this PR implemented it.

## Verification
I tried cloning two recurring runs in UI. They are the same as cloned one except for creation date.
![Screen Shot 2020-05-25 at 12 22 03 PM](https://user-images.githubusercontent.com/4957653/82788832-c9253600-9e9b-11ea-8cb8-60f83a2194ec.png)
![Screen Shot 2020-05-25 at 12 22 16 PM](https://user-images.githubusercontent.com/4957653/82788835-ca566300-9e9b-11ea-806f-8e7e9a83fc05.png)
![Screen Shot 2020-05-25 at 12 22 25 PM](https://user-images.githubusercontent.com/4957653/82788837-caeef980-9e9b-11ea-85c6-2a2731952741.png)
![Screen Shot 2020-05-25 at 12 22 35 PM](https://user-images.githubusercontent.com/4957653/82788838-cb879000-9e9b-11ea-8f47-8d469815ca0e.png)


## Potential future improvement
when user uses cron schedule, current implementation only clones the cron expression, but cannot parse it to meaning like "once a day", it might confuse users on the option, but the cron expression is in fact the same as cloned one.