### PR TITLE
[Backend] Fix user identity extraction logic in getUserIdentity()

### DIFF
--- a/backend/src/apiserver/server/util_test.go
+++ b/backend/src/apiserver/server/util_test.go
@@ -345,6 +345,34 @@ func TestGetUserIdentity(t *testing.T) {
 	assert.Equal(t, "user@google.com", userIdentity)
 }
 
+func TestGetUserIdentityError(t *testing.T) {
+	md := metadata.New(map[string]string{"no-identity-header": "user"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	_, err := getUserIdentity(ctx)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Request header error: there is no user identity header.")
+}
+
+func TestGetUserIdentityFromHeaderGoogle(t *testing.T) {
+	userIdentity, err := getUserIdentityFromHeader(common.GoogleIAPUserIdentityPrefix+"user@google.com", common.GoogleIAPUserIdentityPrefix)
+	assert.Nil(t, err)
+	assert.Equal(t, "user@google.com", userIdentity)
+}
+
+func TestGetUserIdentityFromHeaderNonGoogle(t *testing.T) {
+	prefix := ""
+	userIdentity, err := getUserIdentityFromHeader(prefix+"user", prefix)
+	assert.Nil(t, err)
+	assert.Equal(t, "user", userIdentity)
+}
+
+func TestGetUserIdentityFromHeaderError(t *testing.T) {
+	prefix := "expected-prefix"
+	_, err := getUserIdentityFromHeader("user", prefix)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Request header error: user identity value is incorrectly formatted")
+}
+
 func TestCanAccessNamespaceInResourceReferences_Unauthorized(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")


### PR DESCRIPTION
Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>

---

Fixes #3752

The backend incorrectly parses the contents of the `KUBEFLOW_USERID_HEADER`.
Moreover, it totally ignores `KUBEFLOW_USERID_PREFIX`.

Currently, the backend gets the header, splits it on `:` and gets the 2nd element of the result.

The author of this part of code must have been carried away by google headers which look like this:
```
x-goog-authenticated-user-email: accounts.google.com:user
```

However, this is leads to errors for different values of the environment variables. For example:
```
KUBEFLOW_USERID_HEADER = "kubeflow-userid"
KUBEFLOW_USERID_PREFIX = "prefix"
```
In this case, the header should look like this:
```
kubeflow-userid: prefixuser
```
but the apiserver will raise errors.

This PR fixes this issue.