### PR TITLE
Update Dataflow component _client.py to use projects.locations.templates API endpoint

### DIFF
--- a/components/gcp/container/component_sdk/python/kfp_component/google/dataflow/_client.py
+++ b/components/gcp/container/component_sdk/python/kfp_component/google/dataflow/_client.py
@@ -21,7 +21,7 @@ class DataflowClient:
 
     def launch_template(self, project_id, gcs_path, location, 
         validate_only, launch_parameters):
-        return self._df.projects().templates().launch(
+        return self._df.projects().templates().locations().launch(
             projectId = project_id,
             gcsPath = gcs_path,
             location = location,

--- a/components/gcp/container/component_sdk/python/kfp_component/google/dataflow/_client.py
+++ b/components/gcp/container/component_sdk/python/kfp_component/google/dataflow/_client.py
@@ -21,7 +21,7 @@ class DataflowClient:
 
     def launch_template(self, project_id, gcs_path, location, 
         validate_only, launch_parameters):
-        return self._df.projects().templates().locations().launch(
+        return self._df.projects().locations().templates().launch(
             projectId = project_id,
             gcsPath = gcs_path,
             location = location,


### PR DESCRIPTION
Fix for https://github.com/kubeflow/pipelines/issues/3801. Updated client to use the in order to support more regions the component should switch to the projects.locations.templates API endpoint instead of the projects.templates endpoint it uses currently.

This is based upon the suggestion from @DennisVis

The project.locations.templates API is described [here](https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.locations.templates/launch). 