### PR TITLE
[Backend][Mutli-user] Allow shared read in the special multi-user mode.

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	MultiUserMode                       string = "MULTIUSER"
+	MultiUserModeSharedReadAccess       string = "MULTIUSER_SHARED_READ"
 	PodNamespace                        string = "POD_NAMESPACE"
 	CacheEnabled                        string = "CacheEnabled"
 	DefaultPipelineRunnerServiceAccount string = "DefaultPipelineRunnerServiceAccount"
@@ -73,6 +74,10 @@ func GetDurationConfig(configName string) time.Duration {
 
 func IsMultiUserMode() bool {
 	return GetBoolConfigWithDefault(MultiUserMode, false)
+}
+
+func IsMultiUserSharedReadMode() bool {
+	return GetBoolConfigWithDefault(MultiUserModeSharedReadAccess, false)
 }
 
 func GetPodNamespace() string {

--- a/backend/src/apiserver/server/experiment_server.go
+++ b/backend/src/apiserver/server/experiment_server.go
@@ -65,7 +65,7 @@ func (s *ExperimentServer) ListExperiment(ctx context.Context, request *api.List
 	}
 
 	refKey := filterContext.ReferenceKey
-	if common.IsMultiUserMode() && !common.IsMultiUserSharedReadMode() {
+	if common.IsMultiUserMode() {
 		if refKey == nil || refKey.Type != common.Namespace {
 			return nil, util.NewInvalidInputError("Invalid resource references for experiment. ListExperiment requires filtering by namespace.")
 		}
@@ -77,7 +77,7 @@ func (s *ExperimentServer) ListExperiment(ctx context.Context, request *api.List
 		if err != nil {
 			return nil, util.Wrap(err, "Failed to authorize with API resource references")
 		}
-	} else if !common.IsMultiUserMode() {
+	} else {
 		if refKey != nil && refKey.Type == common.Namespace && len(refKey.ID) > 0 {
 			return nil, util.NewInvalidInputError("In single-user mode, ListExperiment cannot filter by namespace.")
 		}

--- a/backend/src/apiserver/server/job_server.go
+++ b/backend/src/apiserver/server/job_server.go
@@ -75,7 +75,7 @@ func (s *JobServer) ListJobs(ctx context.Context, request *api.ListJobsRequest) 
 		return nil, util.Wrap(err, "Validating filter failed.")
 	}
 
-	if common.IsMultiUserMode() && !common.IsMultiUserSharedReadMode() {
+	if common.IsMultiUserMode() {
 		refKey := filterContext.ReferenceKey
 		if refKey == nil {
 			return nil, util.NewInvalidInputError("ListJobs must filter by resource reference in multi-user mode.")

--- a/backend/src/apiserver/server/job_server.go
+++ b/backend/src/apiserver/server/job_server.go
@@ -49,9 +49,11 @@ func (s *JobServer) CreateJob(ctx context.Context, request *api.CreateJobRequest
 }
 
 func (s *JobServer) GetJob(ctx context.Context, request *api.GetJobRequest) (*api.Job, error) {
-	err := s.canAccessJob(ctx, request.Id)
-	if err != nil {
-		return nil, util.Wrap(err, "Failed to authorize the request.")
+	if !common.IsMultiUserSharedReadMode() {
+		err := s.canAccessJob(ctx, request.Id)
+		if err != nil {
+			return nil, util.Wrap(err, "Failed to authorize the request.")
+		}
 	}
 
 	job, err := s.resourceManager.GetJob(request.Id)
@@ -73,7 +75,7 @@ func (s *JobServer) ListJobs(ctx context.Context, request *api.ListJobsRequest) 
 		return nil, util.Wrap(err, "Validating filter failed.")
 	}
 
-	if common.IsMultiUserMode() {
+	if common.IsMultiUserMode() && !common.IsMultiUserSharedReadMode() {
 		refKey := filterContext.ReferenceKey
 		if refKey == nil {
 			return nil, util.NewInvalidInputError("ListJobs must filter by resource reference in multi-user mode.")

--- a/backend/src/apiserver/server/run_server.go
+++ b/backend/src/apiserver/server/run_server.go
@@ -72,7 +72,7 @@ func (s *RunServer) ListRuns(ctx context.Context, request *api.ListRunsRequest) 
 		return nil, util.Wrap(err, "Validating filter failed.")
 	}
 
-	if common.IsMultiUserMode() && !common.IsMultiUserSharedReadMode() {
+	if common.IsMultiUserMode() {
 		refKey := filterContext.ReferenceKey
 		if refKey == nil {
 			return nil, util.NewInvalidInputError("ListRuns must filter by resource reference in multi-user mode.")

--- a/backend/src/apiserver/server/run_server.go
+++ b/backend/src/apiserver/server/run_server.go
@@ -48,9 +48,11 @@ func (s *RunServer) CreateRun(ctx context.Context, request *api.CreateRunRequest
 }
 
 func (s *RunServer) GetRun(ctx context.Context, request *api.GetRunRequest) (*api.RunDetail, error) {
-	err := s.canAccessRun(ctx, request.RunId)
-	if err != nil {
-		return nil, util.Wrap(err, "Failed to authorize the request.")
+	if !common.IsMultiUserSharedReadMode() {
+		err := s.canAccessRun(ctx, request.RunId)
+		if err != nil {
+			return nil, util.Wrap(err, "Failed to authorize the request.")
+		}
 	}
 	run, err := s.resourceManager.GetRun(request.RunId)
 	if err != nil {
@@ -70,7 +72,7 @@ func (s *RunServer) ListRuns(ctx context.Context, request *api.ListRunsRequest) 
 		return nil, util.Wrap(err, "Validating filter failed.")
 	}
 
-	if common.IsMultiUserMode() {
+	if common.IsMultiUserMode() && !common.IsMultiUserSharedReadMode() {
 		refKey := filterContext.ReferenceKey
 		if refKey == nil {
 			return nil, util.NewInvalidInputError("ListRuns must filter by resource reference in multi-user mode.")


### PR DESCRIPTION
In multi-user mode, allow read access to experiments/runs/jobs under flag MULTIUSER_SHARED_READ.

Manually verified in my dev cluster with image:
gcr.io/chesu-dev/api-server@sha256:91ece58a98ffe0f0796688ae2a593c5e2317e57d5037f93114978ce29aca943a

/assign @Bobgy @IronPan 