### PR TITLE
SDK - Components - Stabilize JSON serialization by sorting keys

### DIFF
--- a/sdk/python/kfp/components/_data_passing.py
+++ b/sdk/python/kfp/components/_data_passing.py
@@ -83,7 +83,7 @@ def _serialize_json(obj) -> str:
             return obj.to_struct()
         else:
             raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
-    return json.dumps(obj, default=default_serializer)
+    return json.dumps(obj, default=default_serializer, sort_keys=True)
 
 
 def _serialize_base64_pickle(obj) -> str:

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
@@ -392,7 +392,7 @@ spec:
                           return obj.to_struct()
                       else:
                           raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
-                  return json.dumps(obj, default=default_serializer)
+                  return json.dumps(obj, default=default_serializer, sort_keys=True)
               
               import argparse
               _parser = argparse.ArgumentParser(prog='Produce list of dicts', description='')
@@ -456,7 +456,7 @@ spec:
                           return obj.to_struct()
                       else:
                           raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
-                  return json.dumps(obj, default=default_serializer)
+                  return json.dumps(obj, default=default_serializer, sort_keys=True)
               
               import argparse
               _parser = argparse.ArgumentParser(prog='Produce list of ints', description='')
@@ -520,7 +520,7 @@ spec:
                           return obj.to_struct()
                       else:
                           raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
-                  return json.dumps(obj, default=default_serializer)
+                  return json.dumps(obj, default=default_serializer, sort_keys=True)
               
               import argparse
               _parser = argparse.ArgumentParser(prog='Produce list of strings', description='')


### PR DESCRIPTION
Otherwise serialization of the default values of the component/pipeline inputs is unstable on Python 3.5.

This will fix https://github.com/kubeflow/pipelines/pull/3832 failure on python3.5.