### PR TITLE
fix typo on sort order: 'des' --> 'desc'

### DIFF
--- a/backend/api/experiment.proto
+++ b/backend/api/experiment.proto
@@ -127,7 +127,7 @@ message ListExperimentsRequest {
   // nextPageToken field you can use to fetch the next page.
   int32 page_size = 2;
 
-  // Can be format of "field_name", "field_name asc" or "field_name des"
+  // Can be format of "field_name", "field_name asc" or "field_name desc"
   // Ascending by default.
   string sort_by = 3;
 

--- a/backend/api/job.proto
+++ b/backend/api/job.proto
@@ -128,7 +128,7 @@ message ListJobsRequest {
   // to fetch the next page.
   int32 page_size = 2;
 
-  // Can be format of "field_name", "field_name asc" or "field_name des".
+  // Can be format of "field_name", "field_name asc" or "field_name desc".
   // Ascending by default.
   string sort_by = 3;
 

--- a/backend/api/pipeline.proto
+++ b/backend/api/pipeline.proto
@@ -170,7 +170,7 @@ message ListPipelinesRequest {
   // nextPageToken field.
   int32 page_size = 2;
 
-  // Can be format of "field_name", "field_name asc" or "field_name des"
+  // Can be format of "field_name", "field_name asc" or "field_name desc"
   // Ascending by default.
   string sort_by = 3;
 
@@ -236,7 +236,7 @@ message ListPipelineVersionsRequest {
   // ListPipelineVersions call or can be omitted when fetching the first page.
   string page_token = 3;
 
-  // Can be format of "field_name", "field_name asc" or "field_name des"
+  // Can be format of "field_name", "field_name asc" or "field_name desc"
   // Ascending by default.
   string sort_by = 4;
   // A base-64 encoded, JSON-serialized Filter protocol buffer (see

--- a/backend/api/run.proto
+++ b/backend/api/run.proto
@@ -158,8 +158,8 @@ message ListRunsRequest {
   // to fetch the next page.
   int32 page_size = 2;
 
-  // Can be format of "field_name", "field_name asc" or "field_name des"
-  // (Example, "name asc" or "id des"). Ascending by default.
+  // Can be format of "field_name", "field_name asc" or "field_name desc"
+  // (Example, "name asc" or "id desc"). Ascending by default.
   string sort_by = 3;
 
   // What resource reference to filter on.

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -291,7 +291,7 @@ class Client(object):
     Args:
       page_token: token for starting of the page.
       page_size: size of the page.
-      sort_by: can be '[field_name]', '[field_name] des'. For example, 'name des'.
+      sort_by: can be '[field_name]', '[field_name] des'. For example, 'name desc'.
       namespace: kubernetes namespace where the experiment was created.
         For single user deployment, leave it as None;
         For multi user, input a namespace where the user is authorized.
@@ -370,7 +370,7 @@ class Client(object):
     Args:
       page_token: token for starting of the page.
       page_size: size of the page.
-      sort_by: one of 'field_name', 'field_name des'. For example, 'name des'.
+      sort_by: one of 'field_name', 'field_name desc'. For example, 'name desc'.
     Returns:
       A response object including a list of pipelines and next page token.
     """
@@ -582,7 +582,7 @@ class Client(object):
     Args:
       page_token: token for starting of the page.
       page_size: size of the page.
-      sort_by: one of 'field_name', 'field_name des'. For example, 'name des'.
+      sort_by: one of 'field_name', 'field_name desc'. For example, 'name desc'.
       experiment_id: experiment id to filter upon
       namespace: kubernetes namespace to filter upon.
         For single user deployment, leave it as None;
@@ -604,7 +604,7 @@ class Client(object):
     Args:
       page_token: token for starting of the page.
       page_size: size of the page.
-      sort_by: one of 'field_name', 'field_name des'. For example, 'name des'.
+      sort_by: one of 'field_name', 'field_name desc'. For example, 'name desc'.
       experiment_id: experiment id to filter upon
     Returns:
       A response object including a list of recurring_runs and next page token.


### PR DESCRIPTION
Fix typo in various proto file comments and `_client.py`.
There were a number of other auto-generated files with the typo as well.  I'm assuming don't need to fix any of those, but LMK if I missed something.
The ones I skipped included the files in `backend/api/swagger`, `frontend/src/apis/..*.ts`, and `backend/api/go_http_client`.

Addresses https://github.com/kubeflow/website/issues/1941 .