### PR TITLE
[Testing] Fix build failure because wcwidth LICENSE url changed

### DIFF
--- a/components/third_party_licenses.csv
+++ b/components/third_party_licenses.csv
@@ -167,7 +167,7 @@ simplegeneric,https://opensource.org/licenses/ZPL-2.0,ZPL 2.1
 singledispatch,https://opensource.org/licenses/MIT,MIT
 tensorflow-model-analysis,https://github.com/tensorflow/model-analysis/blob/master/LICENSE,Apache 2.0
 terminado,https://raw.githubusercontent.com/jupyter/terminado/master/LICENSE,BSD
-wcwidth,https://raw.githubusercontent.com/jquast/wcwidth/master/LICENSE.txt,MIT
+wcwidth,https://raw.githubusercontent.com/jquast/wcwidth/master/LICENSE,MIT
 widgetsnbextension,https://raw.githubusercontent.com/jupyter-widgets/ipywidgets/master/widgetsnbextension/LICENSE,BSD
 pandas,https://raw.githubusercontent.com/pandas-dev/pandas/master/LICENSE,3-Clause BSD
 scikit-learn,https://raw.githubusercontent.com/scikit-learn/scikit-learn/master/COPYING,BSD


### PR DESCRIPTION
Error message in cloudbuild
```
--2020-06-04 02:47:51--  https://raw.githubusercontent.com/jquast/wcwidth/master/LICENSE.txt
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 151.101.0.133, 151.101.64.133, 151.101.128.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|151.101.0.133|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2020-06-04 02:47:51 ERROR 404: Not Found.
```