### PR TITLE
Fix #3906 - mount_pvc transform should ignore non-ContainerOps

### DIFF
--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -102,9 +102,9 @@ class PipelineConf():
     """
     self.ttl_seconds_after_finished = seconds
     return self
-  
-  def set_default_pod_node_selector(self, label_name: str, value: str): 
-    """Add a constraint for nodeSelector for a pipeline. Each constraint is a key-value pair label. For the 
+
+  def set_default_pod_node_selector(self, label_name: str, value: str):
+    """Add a constraint for nodeSelector for a pipeline. Each constraint is a key-value pair label. For the
       container to be eligible to run on a node, the node must have each of the constraints appeared
       as labels.
 
@@ -114,7 +114,7 @@ class PipelineConf():
     """
     self.default_pod_node_selector[label_name] = value
     return self
-  
+
 
   def set_image_pull_policy(self, policy: str):
     """Configures the default image pull policy
@@ -128,9 +128,10 @@ class PipelineConf():
 
   def add_op_transformer(self, transformer):
     """Configures the op_transformers which will be applied to all ops in the pipeline.
+    The ops can be ResourceOp, VolumenOp, or ContainerOp.
 
     Args:
-      transformer: a function that takes a ContainOp as input and returns a ContainerOp
+      transformer: a function that takes a kfp Op as input and returns a kfp Op
     """
     self.op_transformers.append(transformer)
 

--- a/sdk/python/kfp/onprem.py
+++ b/sdk/python/kfp/onprem.py
@@ -1,7 +1,7 @@
 
 def mount_pvc(pvc_name='pipeline-claim', volume_name='pipeline', volume_mount_path='/mnt/pipeline'):
     """
-        Modifier function to apply to a Container Op to simplify volume, volume mount addition and 
+        Modifier function to apply to a Container Op to simplify volume, volume mount addition and
         enable better reuse of volumes, volume claims across container ops.
         Usage:
             train = train_op(...)
@@ -9,6 +9,10 @@ def mount_pvc(pvc_name='pipeline-claim', volume_name='pipeline', volume_mount_pa
     """
     def _mount_pvc(task):
         from kubernetes import client as k8s_client
+        # there can be other ops in a pipeline (e.g. ResourceOp, VolumeOp)
+        # refer to #3906
+        if not hasattr(task, "add_volume") or not hasattr(task, "add_volume_mount"):
+            return task
         local_pvc = k8s_client.V1PersistentVolumeClaimVolumeSource(claim_name=pvc_name)
         return (
             task


### PR DESCRIPTION
Refer to #3906 

This PR fix the transform `mount_pvc` to only mount the PVC to ContainerOps only.

**Rationale-for-fix**
- instead of modifying `apply_op_transformer`  to only pass in ContainerOp, we should retain flexibility to modify any ops inside a pipeline. 

The implication is that dev will need to note that `apply_op_transformer` can pass in ResourceOp, VolumeOp, and ContainerOp. They will need to check the op and apply the transform appropriately.

I have also update the doc string for `apply_op_transformer` to reflect the change. 