### PR TITLE
Update the GCP components

### DIFF
--- a/components/gcp/bigquery/query/bigquery_query_to_gcs_op.yaml
+++ b/components/gcp/bigquery/query/bigquery_query_to_gcs_op.yaml
@@ -1,0 +1,83 @@
+# Export to bucket in gcs
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Bigquery - Query
+description: |
+  A Kubeflow Pipeline component to submit a query to Google Cloud Bigquery 
+  service and dump outputs to a Google Cloud Storage blob.
+metadata:
+  labels:
+    add-pod-env: 'true'
+inputs:
+  - name: query
+    description: 'The query used by Bigquery service to fetch the results.'
+    type: String
+  - name: project_id
+    description: 'The project to execute the query job.'
+    type: GCPProjectID
+  - name: dataset_id
+    description: 'The ID of the persistent dataset to keep the results of the query.'
+    default: ''
+    type: String
+  - name: table_id
+    description: >-
+      The ID of the table to keep the results of the query. If absent, the operation
+      will generate a random id for the table.
+    default: '' 
+    type: String
+  - name: output_gcs_path
+    description: 'The path to the Cloud Storage bucket to store the query output.'
+    default: ''
+    type: GCSPath
+  - name: dataset_location
+    description: 'The location to create the dataset. Defaults to `US`.'
+    default: 'US'
+    type: String
+  - name: job_config
+    description: >-
+      The full config spec for the query job.See 
+      [QueryJobConfig](https://googleapis.github.io/google-cloud-python/latest/bigquery/generated/google.cloud.bigquery.job.QueryJobConfig.html#google.cloud.bigquery.job.QueryJobConfig) 
+      for details.
+    default: ''
+    type: Dict
+  - name: output_kfp_path
+    description: 'The path to where the file should be stored.'
+    default: ''
+    type: String
+outputs:
+  - name: output_gcs_path
+    description: 'The path to the Cloud Storage bucket containing the query output in CSV format.'
+    type: GCSPath
+  - name: MLPipeline UI metadata
+    type: UI metadata
+implementation:
+  container:
+    image: gcr.io/ds-production-259110/ml-pipeline-gcp
+    args: [
+      --ui_metadata_path, {outputPath: MLPipeline UI metadata},
+      kfp_component.google.bigquery, query,
+      --query, {inputValue: query},
+      --project_id, {inputValue: project_id},
+      --dataset_id, {inputValue: dataset_id},
+      --table_id, {inputValue: table_id},
+      --dataset_location, {inputValue: dataset_location},
+      --output_gcs_path, {inputValue: output_gcs_path},
+      --job_config, {inputValue: job_config},
+    ]
+    env:
+      KFP_POD_NAME: "{{pod.name}}"
+    fileOutputs:
+      output_gcs_path: /tmp/kfp/output/bigquery/query-output-path.txt

--- a/components/gcp/bigquery/query/biqquery_query_op.yaml
+++ b/components/gcp/bigquery/query/biqquery_query_op.yaml
@@ -1,0 +1,61 @@
+# Export to file for next processing step in pipeline
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Bigquery - Query
+description: |
+  A Kubeflow Pipeline component to submit a query to Google Cloud Bigquery 
+  service. 
+metadata:
+  labels:
+    add-pod-env: 'true'
+inputs:
+  - name: query
+    description: 'The query used by Bigquery service to fetch the results.'
+    type: String
+  - name: project_id
+    description: 'The project to execute the query job.'
+    type: GCPProjectID
+  - name: output_kfp_path
+    description: 'The path to where the file should be stored.'
+    default: ''
+    type: String
+  - name: dataset_location
+    description: 'The location to create the dataset. Defaults to `US`.'
+    default: 'US'
+    type: String
+  - name: job_config
+    description: >-
+      The full config spec for the query job.See 
+      [QueryJobConfig](https://googleapis.github.io/google-cloud-python/latest/bigquery/generated/google.cloud.bigquery.job.QueryJobConfig.html#google.cloud.bigquery.job.QueryJobConfig) 
+      for details.
+    default: ''
+    type: Dict
+outputs:
+  - name: MLPipeline UI metadata
+    type: UI metadata
+implementation:
+  container:
+    image: gcr.io/ds-production-259110/ml-pipeline-gcp
+    args: [
+      --ui_metadata_path, {outputPath: MLPipeline UI metadata},
+      kfp_component.google.bigquery, query_only,
+      --query, {inputValue: query},
+      --project_id, {inputValue: project_id},
+      --dataset_location, {inputValue: dataset_location},
+      --job_config, {inputValue: job_config},
+    ]
+    env:
+      KFP_POD_NAME: "{{pod.name}}"

--- a/components/gcp/bigquery/query/biqquery_query_to_table.yaml
+++ b/components/gcp/bigquery/query/biqquery_query_to_table.yaml
@@ -1,0 +1,69 @@
+# export to new table. 
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Bigquery - Query
+description: |
+  A Kubeflow Pipeline component to submit a query to Google Cloud Bigquery 
+  service and dump outputs to new table.
+metadata:
+  labels:
+    add-pod-env: 'true'
+inputs:
+  - name: query
+    description: 'The query used by Bigquery service to fetch the results.'
+    type: String
+  - name: project_id
+    description: 'The project to execute the query job.'
+    type: GCPProjectID
+  - name: dataset_id
+    description: 'The ID of the persistent dataset to keep the results of the query.'
+    default: ''
+    type: String
+  - name: table_id
+    description: >-
+      The ID of the table to keep the results of the query. If absent, the operation
+      will generate a random id for the table.
+    default: '' 
+    type: String
+  - name: dataset_location
+    description: 'The location to create the dataset. Defaults to `US`.'
+    default: 'US'
+    type: String
+  - name: job_config
+    description: >-
+      The full config spec for the query job.See 
+      [QueryJobConfig](https://googleapis.github.io/google-cloud-python/latest/bigquery/generated/google.cloud.bigquery.job.QueryJobConfig.html#google.cloud.bigquery.job.QueryJobConfig) 
+      for details.
+    default: ''
+    type: Dict
+outputs:
+  - name: MLPipeline UI metadata
+    type: UI metadata
+implementation:
+  container:
+    image: gcr.io/ds-production-259110/ml-pipeline-gcp
+    args: [
+      --ui_metadata_path, {outputPath: MLPipeline UI metadata},
+      kfp_component.google.bigquery, query,
+      --query, {inputValue: query},
+      --project_id, {inputValue: project_id},
+      --dataset_id, {inputValue: dataset_id},
+      --table_id, {inputValue: table_id},
+      --dataset_location, {inputValue: dataset_location},
+      --job_config, {inputValue: job_config},
+    ]
+    env:
+      KFP_POD_NAME: "{{pod.name}}"

--- a/components/gcp/container/component_sdk/python/kfp_component/google/bigquery/__init__.py
+++ b/components/gcp/container/component_sdk/python/kfp_component/google/bigquery/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ._query import query
+from ._query import query, query_only

--- a/frontend/server/aws-helper.test.ts
+++ b/frontend/server/aws-helper.test.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import fetch from 'node-fetch';
-import { awsInstanceProfileCredentials } from './aws-helper';
+import { awsInstanceProfileCredentials, isS3Endpoint } from './aws-helper';
 
 // mock node-fetch module
 jest.mock('node-fetch');
@@ -102,5 +102,27 @@ describe('awsInstanceProfileCredentials', () => {
       expect(awsInstanceProfileCredentials.getCredentials).not.toThrow();
       expect(await awsInstanceProfileCredentials.getCredentials()).toBeUndefined();
     });
+  });
+});
+
+describe('isS3Endpoint', () => {
+  it('checks a valid s3 endpoint', () => {
+    expect(isS3Endpoint('s3.amazonaws.com')).toBe(true);
+  });
+
+  it('checks a valid s3 regional endpoint', () => {
+    expect(isS3Endpoint('s3.dualstack.us-east-1.amazonaws.com')).toBe(true);
+  });
+
+  it('checks a valid s3 cn endpoint', () => {
+    expect(isS3Endpoint('s3.cn-north-1.amazonaws.com.cn')).toBe(true);
+  });
+
+  it('checks an invalid s3 endpoint', () => {
+    expect(isS3Endpoint('amazonaws.com')).toBe(false);
+  });
+
+  it('checks non-s3 endpoint', () => {
+    expect(isS3Endpoint('minio.kubeflow')).toBe(false);
   });
 });

--- a/frontend/server/aws-helper.ts
+++ b/frontend/server/aws-helper.ts
@@ -47,6 +47,15 @@ async function getIAMInstanceProfile(): Promise<string | undefined> {
 }
 
 /**
+ * Check if the provided string is an S3 endpoint (can be any region).
+ *
+ * @param endpoint minio endpoint to check.
+ */
+export function isS3Endpoint(endpoint: string = ''): boolean {
+  return !!endpoint.match(/s3.{0,}\.amazonaws\.com\.?.{0,}/i);
+}
+
+/**
  * Class to handle the session credentials for AWS ec2 instance profile.
  */
 class AWSInstanceProfileCredentials {

--- a/frontend/src/lib/AwsHelper.test.ts
+++ b/frontend/src/lib/AwsHelper.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018-2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isS3Endpoint } from './AwsHelper';
+
+describe('isS3Endpoint', () => {
+  it('checks a valid s3 endpoint', () => {
+    expect(isS3Endpoint('s3.amazonaws.com')).toBe(true);
+  });
+
+  it('checks a valid s3 regional endpoint', () => {
+    expect(isS3Endpoint('s3.dualstack.us-east-1.amazonaws.com')).toBe(true);
+  });
+
+  it('checks a valid s3 cn endpoint', () => {
+    expect(isS3Endpoint('s3.cn-north-1.amazonaws.com.cn')).toBe(true);
+  });
+
+  it('checks an invalid s3 endpoint', () => {
+    expect(isS3Endpoint('amazonaws.com')).toBe(false);
+  });
+
+  it('checks non-s3 endpoint', () => {
+    expect(isS3Endpoint('minio.kubeflow')).toBe(false);
+  });
+});

--- a/frontend/src/lib/AwsHelper.ts
+++ b/frontend/src/lib/AwsHelper.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Check if the provided string is an S3 endpoint (can be any region).
+ *
+ * @param endpoint minio endpoint to check.
+ */
+export function isS3Endpoint(endpoint: string = ''): boolean {
+  return !!endpoint.match(/s3.{0,}\.amazonaws\.com\.?.{0,}/i);
+}

--- a/frontend/src/lib/WorkflowParser.test.ts
+++ b/frontend/src/lib/WorkflowParser.test.ts
@@ -887,7 +887,7 @@ describe('WorkflowParser', () => {
       ]);
     });
 
-    it('returns the right bucket and key for a correct metadata artifact', () => {
+    it('returns the right bucket, key and source eq `minio` for a correct metadata artifact', () => {
       expect(
         WorkflowParser.loadNodeOutputPaths({
           outputs: {
@@ -907,6 +907,31 @@ describe('WorkflowParser', () => {
           bucket: 'test bucket',
           key: 'test key',
           source: 'minio',
+        },
+      ]);
+    });
+
+    it('returns the right bucket, key and source eq `s3` for a correct metadata artifact', () => {
+      expect(
+        WorkflowParser.loadNodeOutputPaths({
+          outputs: {
+            artifacts: [
+              {
+                name: 'mlpipeline-ui-metadata',
+                s3: {
+                  endpoint: 's3.amazonaws.com',
+                  bucket: 'test bucket',
+                  key: 'test key',
+                },
+              },
+            ],
+          },
+        } as any),
+      ).toEqual([
+        {
+          bucket: 'test bucket',
+          key: 'test key',
+          source: 's3',
         },
       ]);
     });

--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -29,6 +29,7 @@ import { Constants } from './Constants';
 import { KeyValue } from './StaticGraphParser';
 import { hasFinished, NodePhase, statusToBgColor, parseNodePhase } from './StatusUtils';
 import { parseTaskDisplayName } from './ParserUtils';
+import { isS3Endpoint } from './AwsHelper';
 
 export enum StorageService {
   GCS = 'gcs',
@@ -292,11 +293,10 @@ export default class WorkflowParser {
           outputPaths.push({
             bucket: a.s3!.bucket,
             key: a.s3!.key,
-            source: StorageService.MINIO,
+            source: isS3Endpoint(a.s3!.endpoint) ? StorageService.S3 : StorageService.MINIO,
           }),
         );
     }
-
     return outputPaths;
   }
 


### PR DESCRIPTION
Update the kubeflow GCP components for BigQuery to separate different use cases. The updates are related to this issue https://github.com/kubeflow/pipelines/issues/2640

The goal of this PR is to split it up to three different components: 
- bigquery_query_to_gcs_op - write data to a gcp bucket(and a table)
- biqquery_query_op - execute the query
- biqquery_query_to_table - write the results to a table in BigQuery

