### PR TITLE
[Release] Fix $(cat VERSION) not in bash script

### DIFF
--- a/.cloudbuild.yaml
+++ b/.cloudbuild.yaml
@@ -48,23 +48,28 @@ steps:
   waitFor: ['preparePythonComponentSDK']
 
 # Build the pipeline system images
-- name: 'debian'
-  entrypoint: '/bin/bash'
-  args: ['-c', 'sed -i -e "s/ARG DATE/ENV DATE \"$(date -u)\"/" /workspace/frontend/Dockerfile']
-  id:   'prepareFrontend'
-  waitFor: ["-"]
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/frontend:$COMMIT_SHA',
-         '--build-arg', 'COMMIT_HASH=$COMMIT_SHA',
-         '--build-arg', 'TAG_NAME=$(cat /workspace/VERSION)',
-         '-f', '/workspace/frontend/Dockerfile', '/workspace']
+  entrypoint: /bin/bash
+  args:
+    - -ceux
+    - |
+      sed -i -e "s/ARG DATE/ENV DATE \"$(date -u)\"/" /workspace/frontend/Dockerfile
+      docker build -t gcr.io/$PROJECT_ID/frontend:$COMMIT_SHA \
+        --build-arg COMMIT_HASH=$COMMIT_SHA \
+        --build-arg TAG_NAME=$(cat /workspace/VERSION) \
+        -f /workspace/frontend/Dockerfile \
+        /workspace
   id:   'buildFrontend'
-  waitFor: ['prepareFrontend']
+  waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/api-server:$COMMIT_SHA',
-         '--build-arg', 'COMMIT_SHA=$COMMIT_SHA',
-         '--build-arg', 'TAG_NAME=$(cat /workspace/VERSION)',
-         '-f', '/workspace/backend/Dockerfile', '/workspace']
+  entrypoint: /bin/bash
+  args:
+    - -ceux
+    - |
+      docker build -t gcr.io/$PROJECT_ID/api-server:$COMMIT_SHA \
+        --build-arg COMMIT_SHA=$COMMIT_SHA \
+        --build-arg TAG_NAME=$(cat /workspace/VERSION) \
+        -f /workspace/backend/Dockerfile /workspace
   id:   'buildApiServer'
   waitFor: ['copyPythonSDK']
 

--- a/.cloudbuild.yaml
+++ b/.cloudbuild.yaml
@@ -56,7 +56,7 @@ steps:
       sed -i -e "s/ARG DATE/ENV DATE \"$(date -u)\"/" /workspace/frontend/Dockerfile
       docker build -t gcr.io/$PROJECT_ID/frontend:$COMMIT_SHA \
         --build-arg COMMIT_HASH=$COMMIT_SHA \
-        --build-arg TAG_NAME=$(cat /workspace/VERSION) \
+        --build-arg TAG_NAME="$(cat /workspace/VERSION)" \
         -f /workspace/frontend/Dockerfile \
         /workspace
   id:   'buildFrontend'
@@ -68,7 +68,7 @@ steps:
     - |
       docker build -t gcr.io/$PROJECT_ID/api-server:$COMMIT_SHA \
         --build-arg COMMIT_SHA=$COMMIT_SHA \
-        --build-arg TAG_NAME=$(cat /workspace/VERSION) \
+        --build-arg TAG_NAME="$(cat /workspace/VERSION)" \
         -f /workspace/backend/Dockerfile /workspace
   id:   'buildApiServer'
   waitFor: ['copyPythonSDK']


### PR DESCRIPTION
I made a mistake in https://github.com/kubeflow/pipelines/pull/3921.
`$(cat /workspace/VERSION)` cannot be used in arguments, it has to be part of a bash script.