### PR TITLE
SDK/CLI: Allow to use version properly with kfp run submit

### DIFF
--- a/sdk/python/kfp/cli/run.py
+++ b/sdk/python/kfp/cli/run.py
@@ -56,8 +56,8 @@ def submit(ctx, experiment_name, run_name, package_file, pipeline_id, watch, ver
     if not run_name:
         run_name = experiment_name
 
-    if not package_file and not pipeline_id:
-        print('You must provide one of [package_file, pipeline_id].')
+    if not package_file and not pipeline_id and not version:
+        print('You must provide one of [package_file, pipeline_id, version].')
         sys.exit(1)
 
     arg_dict = dict(arg.split('=') for arg in args)


### PR DESCRIPTION
When using command `kfp run submit`, we have to provide package_file or pipeline_id option.
But when using an existing pipeline with a specific version like 
`kfp run submit -p <pipeline_id> -e <experiment> -r <name> -w -v <version_id>
`
the version is being ignored because of the pipeline ID. So there is no way to run a specific pipeline version.
As said in _client.py **_create_job_config** function : 

>       version_id: The string ID of a pipeline version. 
>         If both pipeline_id and version_id are specified, pipeline_id will take precendence
>         This will change in a future version, so it is recommended to use version_id by itself.

which is inconsistent with **run_pipeline** function by the way which says 

> version_id will take precendence

So we should allow only version ID to be provided when using submit command to run a specific version of a pipeline.

This change fix this and allows to run : 
`kfp run submit -e <experiment> -r <name> -w -v <version_id>
`
which is not possible right now and gives following message : 

> You must provide one of [package_file, pipeline_id].

What do you think ?