### PR TITLE
[AWS SageMaker] allow no input for LabelCategoryConfigS3Uri

### DIFF
--- a/components/aws/sagemaker/common/_utils.py
+++ b/components/aws/sagemaker/common/_utils.py
@@ -698,7 +698,12 @@ def create_labeling_job_request(args):
     request['OutputConfig']['S3OutputPath'] = args['output_location']
     request['OutputConfig']['KmsKeyId'] = args['output_encryption_key']
     request['RoleArn'] = args['role']
-    request['LabelCategoryConfigS3Uri'] = args['label_category_config']
+    
+    ### Update or pop label category config s3 uri
+    if not args['label_category_config']:
+        request.pop('LabelCategoryConfigS3Uri')
+    else:
+        request['LabelCategoryConfigS3Uri'] = args['label_category_config']
 
     ### Update or pop stopping conditions
     if not args['max_human_labeled_objects'] and not args['max_percent_objects']:


### PR DESCRIPTION
pop `LabelCategoryConfigS3Uri` from create labeling job request dictionary if not given, as an empty string doesn't match the regex defined in https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateLabelingJob.html (the argument is optional)
