### PR TITLE
[Backend] Filter run on status

### DIFF
--- a/backend/src/apiserver/model/BUILD.bazel
+++ b/backend/src/apiserver/model/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
     srcs = [
         "pipeline_version_test.go",
         "resource_reference_test.go",
+        "run_test.go",
     ],
     embed = [":go_default_library"],
     importpath = "github.com/kubeflow/pipelines/backend/src/apiserver/model",

--- a/backend/src/apiserver/model/run.go
+++ b/backend/src/apiserver/model/run.go
@@ -77,6 +77,7 @@ var runAPIToModelFieldMap = map[string]string{
 	"description":   "Description",
 	"scheduled_at":  "ScheduledAtInSec",
 	"storage_state": "StorageState",
+	"status":        "Conditions",
 }
 
 // APIToModelFieldMap returns a map from API names to field names for model Run.

--- a/backend/src/apiserver/model/run_test.go
+++ b/backend/src/apiserver/model/run_test.go
@@ -29,22 +29,24 @@ func TestAddStatusFilterToSelect(t *testing.T) {
 	listableOptions, err := list.NewOptions(listable, 10, "name", protoFilter)
 	assert.Nil(t, err)
 	sqlBuilder := sq.Select("*").From("run_details")
-	sql, _, err := listableOptions.AddFilterToSelect(sqlBuilder).ToSql()
+	sql, args, err := listableOptions.AddFilterToSelect(sqlBuilder).ToSql()
 	assert.Nil(t, err)
 	assert.Contains(t, sql, "WHERE Conditions = ?") // filtering on status, aka Conditions in db
+	fmt.Println(args)
 
 	notEqualProtoFilter := &api.Filter{}
 	notEqualProtoFilter.Predicates = []*api.Predicate{
 		{
 			Key:   "status",
 			Op:    api.Predicate_NOT_EQUALS,
-			Value: &api.Predicate_StringValue{StringValue: "Succeeded"},
+			Value: &api.Predicate_StringValue{StringValue: "somevalue"},
 		},
 	}
 	listableOptions, err = list.NewOptions(listable, 10, "name", protoFilter)
 	assert.Nil(t, err)
 	sqlBuilder = sq.Select("*").From("run_details")
-	sql, _, err = listableOptions.AddFilterToSelect(sqlBuilder).ToSql()
+	sql, args, err = listableOptions.AddFilterToSelect(sqlBuilder).ToSql()
 	assert.Nil(t, err)
 	fmt.Println(sql)
+	fmt.Println(args)
 }

--- a/backend/src/apiserver/model/run_test.go
+++ b/backend/src/apiserver/model/run_test.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"fmt"
 	"testing"
 
 	sq "github.com/Masterminds/squirrel"
@@ -32,7 +31,7 @@ func TestAddStatusFilterToSelect(t *testing.T) {
 	sql, args, err := listableOptions.AddFilterToSelect(sqlBuilder).ToSql()
 	assert.Nil(t, err)
 	assert.Contains(t, sql, "WHERE Conditions = ?") // filtering on status, aka Conditions in db
-	fmt.Println(args)
+	assert.Contains(t, args, "Succeeded")
 
 	notEqualProtoFilter := &api.Filter{}
 	notEqualProtoFilter.Predicates = []*api.Predicate{
@@ -42,11 +41,11 @@ func TestAddStatusFilterToSelect(t *testing.T) {
 			Value: &api.Predicate_StringValue{StringValue: "somevalue"},
 		},
 	}
-	listableOptions, err = list.NewOptions(listable, 10, "name", protoFilter)
+	listableOptions, err = list.NewOptions(listable, 10, "name", notEqualProtoFilter)
 	assert.Nil(t, err)
 	sqlBuilder = sq.Select("*").From("run_details")
 	sql, args, err = listableOptions.AddFilterToSelect(sqlBuilder).ToSql()
 	assert.Nil(t, err)
-	fmt.Println(sql)
-	fmt.Println(args)
+	assert.Contains(t, sql, "WHERE Conditions <> ?") // filtering on status, aka Conditions in db
+	assert.Contains(t, args, "somevalue")
 }

--- a/backend/src/apiserver/model/run_test.go
+++ b/backend/src/apiserver/model/run_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"testing"
 
 	sq "github.com/Masterminds/squirrel"
@@ -31,4 +32,19 @@ func TestAddStatusFilterToSelect(t *testing.T) {
 	sql, _, err := listableOptions.AddFilterToSelect(sqlBuilder).ToSql()
 	assert.Nil(t, err)
 	assert.Contains(t, sql, "WHERE Conditions = ?") // filtering on status, aka Conditions in db
+
+	notEqualProtoFilter := &api.Filter{}
+	notEqualProtoFilter.Predicates = []*api.Predicate{
+		{
+			Key:   "status",
+			Op:    api.Predicate_NOT_EQUALS,
+			Value: &api.Predicate_StringValue{StringValue: "Succeeded"},
+		},
+	}
+	listableOptions, err = list.NewOptions(listable, 10, "name", protoFilter)
+	assert.Nil(t, err)
+	sqlBuilder = sq.Select("*").From("run_details")
+	sql, _, err = listableOptions.AddFilterToSelect(sqlBuilder).ToSql()
+	assert.Nil(t, err)
+	fmt.Println(sql)
 }

--- a/backend/src/apiserver/model/run_test.go
+++ b/backend/src/apiserver/model/run_test.go
@@ -1,0 +1,37 @@
+package model
+
+import (
+	"fmt"
+	"testing"
+
+	sq "github.com/Masterminds/squirrel"
+	api "github.com/kubeflow/pipelines/backend/api/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/list"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test model name usage in sorting clause
+func TestAddStatusFilterToSelect(t *testing.T) {
+	listable := &Run{
+		UUID:           "run_id_1",
+		CreatedAtInSec: 1,
+		Name:           "run_name_1",
+		Conditions:     "Succeeded",
+	}
+	protoFilter := &api.Filter{}
+	protoFilter.Predicates = []*api.Predicate{
+		{
+			Key:   "status",
+			Op:    api.Predicate_EQUALS,
+			Value: &api.Predicate_StringValue{StringValue: "Succeeded"},
+		},
+	}
+	listableOptions, err := list.NewOptions(listable, 10, "name", protoFilter)
+	assert.Nil(t, err)
+	sqlBuilder := sq.Select("*").From("run_details")
+	sql, _, err := listableOptions.AddFilterToSelect(sqlBuilder).ToSql()
+	assert.Nil(t, err)
+	fmt.Println(sql)
+	// assert.Contains(t, sql, "pipeline_versions.Name") // sorting field
+	// assert.Contains(t, sql, "pipeline_versions.UUID") // primary key field
+}

--- a/backend/src/apiserver/model/run_test.go
+++ b/backend/src/apiserver/model/run_test.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"fmt"
 	"testing"
 
 	sq "github.com/Masterminds/squirrel"
@@ -31,7 +30,5 @@ func TestAddStatusFilterToSelect(t *testing.T) {
 	sqlBuilder := sq.Select("*").From("run_details")
 	sql, _, err := listableOptions.AddFilterToSelect(sqlBuilder).ToSql()
 	assert.Nil(t, err)
-	fmt.Println(sql)
-	// assert.Contains(t, sql, "pipeline_versions.Name") // sorting field
-	// assert.Contains(t, sql, "pipeline_versions.UUID") // primary key field
+	assert.Contains(t, sql, "WHERE Conditions = ?") // filtering on status, aka Conditions in db
 }


### PR DESCRIPTION
By supporting filter on the status of run (i.e., conditions field in our db), uses can list runs of particular status via our SDK. E.g.

import kfp
import json
client=kfp.Client(<host address>)
filter = json.dumps({'predicates': [{'key': 'status', 'op': 1, 'string_value': 'Succeeded'}]})
client.runs.list_runs(filter=filter)

Will give you all the runs with status being 'succeeded'.

Manual test with our sdk and local api server image using the above code snippet.

related: https://github.com/kubeflow/pipelines/issues/3591