### PR TITLE
Fix space typo in the build_api_server.sh build file

### DIFF
--- a/backend/build_api_server.sh
+++ b/backend/build_api_server.sh
@@ -1,4 +1,5 @@
-# !/bin/bash
+#!/bin/bash
+
 #
 # Copyright 2019 Google LLC
 #


### PR DESCRIPTION
Fix space typo in the build file.

Found out trying to use `build_api_server.sh` in ZSH 