### PR TITLE
[PROPOSAL ]Add a new kustomize section to avoid to install gcp proxy

### DIFF
--- a/manifests/kustomize/env/local/kustomization.yaml
+++ b/manifests/kustomize/env/local/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+## Kustomize for the environment without gpc inverse-proxy
+## For example, local developing with KIND or Minikube
+
+bases:
+  - ../platform-agnostic
+
+# Identifier for application manager to apply ownerReference.
+# The ownerReference ensures the resources get garbage collected
+# when application is deleted.
+commonLabels:
+  application-crd-id: kubeflow-pipelines
+
+# !!! If you want to customize the namespace,
+# please refer sample/cluster-scoped-resources to update the namespace for cluster-scoped-resources
+namespace: kubeflow


### PR DESCRIPTION
There are environments where there isn't gcp, especially for local developing. 

We use Kind and with this patch works without problems locally:
![kind](https://user-images.githubusercontent.com/386987/84393317-baf54a80-abfb-11ea-98e6-c327775341f1.png)

Please let me know if it makes sense for you. 
If yes we will add documentation "how to run pipelines in Kind"  



It will be:
```
kubectl apply -k manifests/kustomize/cluster-scoped-resources
kubectl apply -k manifests/kustomize/env/local/
kubectl port-forward -n kubeflow svc/ml-pipeline-ui 8080:80
```