### PR TITLE
Docs - Mention the Bazel version requirements in the README.md

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,11 @@
 This directory contains code for the components that comprise the Kubeflow
 Pipelines backend.
 
+
+## Bazel
+
+There are some [know issues](https://github.com/kubeflow/pipelines/issues/3942) with the latest version of Bazel and the kubeflow pipelines repo, therefore use version 0.24.1 or older. 
+
 ## Building & Testing
 
 All components can be built using [Bazel](https://bazel.build/). To build

--- a/backend/README.md
+++ b/backend/README.md
@@ -4,7 +4,7 @@ Pipelines backend.
 
 ## Bazel
 
-There are some [know issues](https://github.com/kubeflow/pipelines/issues/3942) with the latest version of Bazel and the kubeflow pipelines repo, therefore use version 0.24.1 or older. 
+The supported Bazel version is 0.24.0. 
 
 ## Building & Testing
 
@@ -55,4 +55,3 @@ WORKSPACE go_repository rules using the following command: `bazel run
 dependencies. To update dependencies, edit [requirements.in](requirements.in)
 and run `./update_requirements.sh <requirements.in >requirements.txt` to update and pin the transitive
 dependencies.
-


### PR DESCRIPTION
Update the readme with the Bazel version since it don't work with the latest versions. See this issue for more info: https://github.com/kubeflow/pipelines/issues/3942