### PR TITLE
[AWS SageMaker] Update GroundTruth integration test timeout

### DIFF
--- a/components/aws/sagemaker/tests/integration_tests/resources/config/image-classification-groundtruth/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/image-classification-groundtruth/config.yaml
@@ -1,6 +1,6 @@
 PipelineDefinition: resources/definition/groundtruth_pipeline.py
 TestName: image-classification-groundtruth
-Timeout: 10
+Timeout: 1200
 StatusToCheck: 'running'
 Arguments:
   region: ((REGION))


### PR DESCRIPTION
Update the timeout for the GroundTruth integration test from 10 seconds to 1200 seconds.