### PR TITLE
Validate resourcekey to prevent apiserver being panic for invalid inputs

### DIFF
--- a/backend/src/apiserver/server/pipeline_server.go
+++ b/backend/src/apiserver/server/pipeline_server.go
@@ -166,6 +166,11 @@ func (s *PipelineServer) ListPipelineVersions(ctx context.Context, request *api.
 		return nil, util.Wrap(err, "Failed to create list options")
 	}
 
+	//Ensure resourceKey has been set
+	if request.ResourceKey == nil {
+		return nil, util.NewInvalidInputError("ResourceKey must be set in the input")
+	}
+
 	pipelineVersions, total_size, nextPageToken, err :=
 		s.resourceManager.ListPipelineVersions(request.ResourceKey.Id, opts)
 	if err != nil {

--- a/backend/src/apiserver/server/pipeline_server_test.go
+++ b/backend/src/apiserver/server/pipeline_server_test.go
@@ -244,6 +244,24 @@ func TestCreatePipelineVersion_InvalidURL(t *testing.T) {
 	assert.Equal(t, codes.Internal, err.(*util.UserError).ExternalStatusCode())
 }
 
+func TestListPipelineVersion_NoResourceKey(t *testing.T){
+	httpServer := getMockServer(t)
+	// Close the server when test finishes
+	defer httpServer.Close()
+
+	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	resourceManager := resource.NewResourceManager(clientManager)
+
+	pipelineServer := PipelineServer{resourceManager: resourceManager, httpClient: httpServer.Client()}
+
+
+	_, err := pipelineServer.ListPipelineVersions(context.Background(), &api.ListPipelineVersionsRequest{
+		ResourceKey: nil,
+		PageSize: 20,
+	})
+	assert.Equal(t, "Invalid input error: ResourceKey must be set in the input", err.Error())
+}
+
 func getMockServer(t *testing.T) *httptest.Server {
 	httpServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		// Send response to be tested


### PR DESCRIPTION
Pipeline API server panics when resourcekey is missing in the input. Adding validation to prevent the panic from happenning