### PR TITLE
SDK - Simplified the style config

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,9 +1,5 @@
 [style]
 based_on_style = google
-blank_line_before_nested_class_or_def = true
-column_limit = 80
-continuation_indent_width = 4
 dedent_closing_brackets = true
 coalesce_brackets = true
-indent_width = 2
 split_before_first_argument = true


### PR DESCRIPTION
Made the style config simpler and closer to the official [Google style guide](http://google.github.io/styleguide/pyguide.html). Here is the `google` preset:
https://github.com/google/yapf/blob/c4257ed87ce22311fe8f3c5e1fa3ea8e43579f82/yapf/yapflib/style.py#L416

P.S. Just found this old branch and decided to make a PR and cleanup the branch.
