### PR TITLE
Fix #3980 - mockapi tsconfig should reference root dir correctly

### DIFF
--- a/frontend/mock-backend/tsconfig.json
+++ b/frontend/mock-backend/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
+    "baseUrl": "..",
     "outDir": "build/dist",
     "module": "esnext",
     "target": "es5",


### PR DESCRIPTION
Refer to  #3980

This PR fix the tsconfig for the mockapi server to correctly reference the correct folder. 

I also note that there is inconsistency in the relative module import. Should we be using `../..` or `src/**/*`?

There is a mix, where majority follows the `../..` convention. 