### PR TITLE
[AWS SageMaker] Add missing import statement

### DIFF
--- a/components/aws/sagemaker/hyperparameter_tuning/src/hyperparameter_tuning.py
+++ b/components/aws/sagemaker/hyperparameter_tuning/src/hyperparameter_tuning.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import argparse
 import logging
 import json


### PR DESCRIPTION
Fix broken HPO component by including missing `sys` import