### PR TITLE
Docs - Show inherited members in the kfp.dsl docs

### DIFF
--- a/docs/source/kfp.dsl.rst
+++ b/docs/source/kfp.dsl.rst
@@ -6,6 +6,7 @@ kfp.dsl package
     :undoc-members:
     :show-inheritance:
     :imported-members:
+    :inherited-members:
     :exclude-members: Pipeline, OpsGroup, match_serialized_pipelineparam
 
     .. py:data::  RUN_ID_PLACEHOLDER


### PR DESCRIPTION
Previously many ContainerOp members inherited from baseOp were not shown.