### PR TITLE
MetadataStore: Update to release metadata-envoy in each release

### DIFF
--- a/.release.cloudbuild.yaml
+++ b/.release.cloudbuild.yaml
@@ -381,6 +381,14 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['pull', 'gcr.io/$PROJECT_ID/metadata-envoy:$COMMIT_SHA']
   id:   'pullMetadataEnvoy'
+- id:   'tagMetadataEnvoyVersionNumber'
+  name: 'gcr.io/cloud-builders/docker'
+  args: ['tag', 'gcr.io/$PROJECT_ID/metadata-envoy:$COMMIT_SHA', 'gcr.io/ml-pipeline/metadata-envoy:$TAG_NAME']
+  waitFor: ['pullMetadataEnvoy']
+- id:   'tagMetadataEnvoyCommitSHA'
+  name: 'gcr.io/cloud-builders/docker'
+  args: ['tag', 'gcr.io/$PROJECT_ID/metadata-envoy:$COMMIT_SHA', 'gcr.io/ml-pipeline/metadata-envoy:$COMMIT_SHA']
+  waitFor: ['pullMetadataEnvoy']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['tag', 'gcr.io/$PROJECT_ID/metadata-envoy:$COMMIT_SHA', 'gcr.io/ml-pipeline/google/pipelines/metadataenvoy:$TAG_NAME']
   id:   'tagMetadataEnvoyForMarketplace'
@@ -598,6 +606,8 @@ images:
 - 'gcr.io/ml-pipeline/inverse-proxy-agent:$COMMIT_SHA'
 - 'gcr.io/ml-pipeline/visualization-server:$TAG_NAME'
 - 'gcr.io/ml-pipeline/visualization-server:$COMMIT_SHA'
+- 'gcr.io/ml-pipeline/metadata-envoy:$TAG_NAME'
+- 'gcr.io/ml-pipeline/metadata-envoy:$COMMIT_SHA'
 - 'gcr.io/ml-pipeline/metadata-writer:$TAG_NAME'
 - 'gcr.io/ml-pipeline/metadata-writer:$COMMIT_SHA'
 - 'gcr.io/ml-pipeline/cache-server:$TAG_NAME'

--- a/manifests/kustomize/base/kustomization.yaml
+++ b/manifests/kustomize/base/kustomization.yaml
@@ -29,6 +29,8 @@ images:
   newTag: 0.5.1
 - name: gcr.io/ml-pipeline/cache-deployer
   newTag: 0.5.1
+- name: gcr.io/ml-pipeline/metadata-envoy
+  newTag: 0.5.1
 # Used by Kustomize
 configMapGenerator:
 - name: pipeline-install-config

--- a/manifests/kustomize/base/metadata/metadata-envoy-deployment.yaml
+++ b/manifests/kustomize/base/metadata/metadata-envoy-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/ml-pipeline/envoy:metadata-grpc
+        image: gcr.io/ml-pipeline/metadata-envoy:dummy
         ports:
         - name: md-envoy
           containerPort: 9090

--- a/test/cloudbuild/batch_build.yaml
+++ b/test/cloudbuild/batch_build.yaml
@@ -41,6 +41,10 @@ steps:
     name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', '$_GCR_BASE/cache-deployer', '-f', 'backend/src/cache/deployer/Dockerfile', '.']
     waitFor: ["-"]
+  - id: 'buildMetadataEnvoy'
+    name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', '$_GCR_BASE/metadata-envoy', '-f', 'third_party/metadata_envoy/Dockerfile', '.']
+    waitFor: ["-"]
 options:
   machineType: N1_HIGHCPU_8 # use a fast machine to build because there a lot of work
 images:
@@ -53,4 +57,5 @@ images:
   - "$_GCR_BASE/metadata-writer"
   - "$_GCR_BASE/cache-server"
   - "$_GCR_BASE/cache-deployer"
+  - "$_GCR_BASE/metadata-envoy"
 timeout: 1800s # 30min

--- a/test/deploy-pipeline-lite.sh
+++ b/test/deploy-pipeline-lite.sh
@@ -61,6 +61,7 @@ if [ -z "$KFP_DEPLOY_RELEASE" ]; then
   kustomize edit set image gcr.io/ml-pipeline/metadata-writer=${GCR_IMAGE_BASE_DIR}/metadata-writer:${GCR_IMAGE_TAG}
   kustomize edit set image gcr.io/ml-pipeline/cache-server=${GCR_IMAGE_BASE_DIR}/cache-server:${GCR_IMAGE_TAG}
   kustomize edit set image gcr.io/ml-pipeline/cache-deployer=${GCR_IMAGE_BASE_DIR}/cache-deployer:${GCR_IMAGE_TAG}
+  kustomize edit set image gcr.io/ml-pipeline/metadata-envoy=${GCR_IMAGE_BASE_DIR}/metadata-envoy:${GCR_IMAGE_TAG}
   cat kustomization.yaml
 
   kubectl apply -k .


### PR DESCRIPTION
Metadata envoy image was built in every build but only release for marketplace. This change releases metadata-envoy image for OSS also in each release.
