### PR TITLE
chore: recommend cherrypick-approved label in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,3 @@
-<!-- Which issue is related to this Pull Request? -->
-<!-- Write "Resolves #<issue-number>" to automatically close the issue when PR merged. -->
-Resolves #
-<!--
-or if the PR is only a part of an issue, write the following instead:
-Part of #<issue-number>
--->
-
 **Description of your changes:**
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,8 +12,8 @@ Part of #<issue-number>
 **Checklist:**
 - [ ] Do you want this PR cherry picked to release branch?
 
-  If yes, please either
-    * ask the approver to add label `cherrypick-approved`, so that release manager
+    If yes, please either
+    * (recommended) ask the approver to add label `cherrypick-approved`, so that release manager
     will handle it in batch
     * or create a cherry pick PR to the release branch after this PR is merged
     (You can refer to [RELEASE.md](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option---git-cherry-pick) for how to do it.)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,18 @@
-**Which issue is resolved by this Pull Request:**
+<!-- Which issue is related to this Pull Request? -->
+<!-- Write "Resolves #<issue-number>" to automatically close the issue when PR merged. -->
 Resolves #
-
-<!-- You can delete this section if no corresponding issue -->
+<!--
+or if the PR is only a part of an issue, write the following instead:
+Part of #<issue-number>
+-->
 
 **Description of your changes:**
 
 
 **Checklist:**
-- Do you want this PR cherry picked to release branch?
+- [ ] Do you want this PR cherry picked to release branch?
 
-    If yes, please either
+  If yes, please either
     * ask the approver to add label `cherrypick-approved`, so that release manager
     will handle it in batch
     * or create a cherry pick PR to the release branch after this PR is merged


### PR DESCRIPTION
**Description of your changes:**
better explanation on resolves issue syntax in PR template

**Checklist:**
- Do you want this PR cherry picked to release branch?

    If yes, please either
    * ask the approver to add label `cherrypick-approved`, so that release manager
    will handle it in batch
    * or create a cherry pick PR to the release branch after this PR is merged
    (You can refer to [RELEASE.md](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option---git-cherry-pick) for how to do it.)
