### PR TITLE
chore: improve writing for cherry pick process

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,10 @@
 
 
 **Checklist:**
-- [ ] Do you want this PR cherry picked to release branch?
-
-    If yes, please either
-    * (recommended) ask the approver to add label `cherrypick-approved`, so that release manager
-    will handle it in batch
-    * or create a cherry pick PR to the release branch after this PR is merged
-    (You can refer to [RELEASE.md](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option---git-cherry-pick) for how to do it.)
+- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?
+    
+    If yes, use one of the following options:
+  
+    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
+    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)
+    


### PR DESCRIPTION
**Description of your changes:**
improve writing for cherry pick process
per suggestion by @joeliedtke in https://github.com/kubeflow/pipelines/pull/4029


**Checklist:**
- [x] Do you want this PR cherry picked to release branch?

    If yes, please either
    * (recommended) ask the approver to add label `cherrypick-approved`, so that release manager
    will handle it in batch
    * or create a cherry pick PR to the release branch after this PR is merged
    (You can refer to [RELEASE.md](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option---git-cherry-pick) for how to do it.)
