### PR TITLE
chore: set up stale bot to focus on important issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,19 @@
+# Configuration for stale probot
+# https://probot.github.io/apps/stale/
+#
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - lifecycle/frozen
+# Label to use when marking an issue as stale
+staleLabel: lifecycle/stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -16,4 +16,6 @@ markComment: >
   recent activity. It will be closed if no further activity occurs. Thank you
   for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: false
+closeComment: >
+  This issue has been automatically closed because it has not had recent
+  activity. Please comment "/reopen" to reopen it.


### PR DESCRIPTION
**Description of your changes:**
Set up stale bot to let us focus on important issues people continually care about. 
The configuration is copied from kubeflow repo: https://github.com/kubeflow/kubeflow/blob/master/.github/stale.yml.

Permissions for the bot has already been enabled for kubeflow organization, so I think we just need to add this config to let it start working.

**Checklist:**
- [ ] Do you want this PR cherry picked to release branch?

    If yes, please either
    * (recommended) ask the approver to add label `cherrypick-approved`, so that release manager
    will handle it in batch
    * or create a cherry pick PR to the release branch after this PR is merged
    (You can refer to [RELEASE.md](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option---git-cherry-pick) for how to do it.)
