### PR TITLE
SDK - Tests - Fixed two test failures in hermetic systems

### DIFF
--- a/sdk/python/kfp/components_tests/test_components.py
+++ b/sdk/python/kfp/components_tests/test_components.py
@@ -44,17 +44,11 @@ class LoadComponentTestCase(unittest.TestCase):
         self.assertEqual(resolved_cmd.args[1], str(arg2))
 
     def test_load_component_from_yaml_file(self):
-        _this_file = Path(__file__).resolve()
-        _this_dir = _this_file.parent
-        _test_data_dir = _this_dir.joinpath('test_data')
-        component_path = _test_data_dir.joinpath('python_add.component.yaml')
+        component_path = Path(__file__).parent / 'test_data' / 'python_add.component.yaml'
         self._test_load_component_from_file(str(component_path))
 
     def test_load_component_from_zipped_yaml_file(self):
-        _this_file = Path(__file__).resolve()
-        _this_dir = _this_file.parent
-        _test_data_dir = _this_dir.joinpath('test_data')
-        component_path = _test_data_dir.joinpath('python_add.component.zip')
+        component_path = Path(__file__).parent / 'test_data' / 'python_add.component.zip'
         self._test_load_component_from_file(str(component_path))
 
     def test_load_component_from_url(self):


### PR DESCRIPTION
Removed path resolving in two tests.
The `.resolve()` should be harmless, but I've seen these tests fail to work in some unusual strict hermetic systems. The test code file path was resolving to a tree which was different from the parent of the file, so the test could not find the test data.
