### PR TITLE
refactor(deployment): use minio artifact secret as single source of truth

### DIFF
--- a/manifests/kustomize/base/argo/kustomization.yaml
+++ b/manifests/kustomize/base/argo/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- minio-artifact-secret.yaml
 - workflow-controller-configmap.yaml
 - workflow-controller-deployment.yaml
 - workflow-controller-role.yaml

--- a/manifests/kustomize/base/argo/minio-artifact-secret.yaml
+++ b/manifests/kustomize/base/argo/minio-artifact-secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-data:
-  accesskey: bWluaW8=
-  secretkey: bWluaW8xMjM=
-kind: Secret
-metadata:
-  name: mlpipeline-minio-artifact
-type: Opaque

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -54,12 +54,12 @@ spec:
         - name: OBJECTSTORECONFIG_ACCESSKEY
           valueFrom:
             secretKeyRef:
-              name: minio-artifact-secret
+              name: mlpipeline-minio-artifact
               key: accesskey
         - name: OBJECTSTORECONFIG_SECRETACCESSKEY
           valueFrom:
             secretKeyRef:
-              name: minio-artifact-secret
+              name: mlpipeline-minio-artifact
               key: secretkey
         image: gcr.io/ml-pipeline/api-server:dummy
         imagePullPolicy: IfNotPresent

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -51,6 +51,16 @@ spec:
             configMapKeyRef:
               name: pipeline-install-config
               key: dbPort
+        - name: OBJECTSTORECONFIG_ACCESSKEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-artifact-secret
+              key: accesskey
+        - name: OBJECTSTORECONFIG_SECRETACCESSKEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-artifact-secret
+              key: secretkey
         image: gcr.io/ml-pipeline/api-server:dummy
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-api-server

--- a/manifests/kustomize/base/pipeline/ml-pipeline-ui-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-ui-deployment.yaml
@@ -27,12 +27,12 @@ spec:
           - name: MINIO_ACCESS_KEY
             valueFrom:
               secretKeyRef:
-                name: minio-artifact-secret
+                name: mlpipeline-minio-artifact
                 key: accesskey
           - name: MINIO_SECRET_KEY
             valueFrom:
               secretKeyRef:
-                name: minio-artifact-secret
+                name: mlpipeline-minio-artifact
                 key: secretkey
           - name: ALLOW_CUSTOM_VISUALIZATIONS
             value: "true"

--- a/manifests/kustomize/base/pipeline/ml-pipeline-ui-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-ui-deployment.yaml
@@ -24,6 +24,16 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: MINIO_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: minio-artifact-secret
+                key: accesskey
+          - name: MINIO_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: minio-artifact-secret
+                key: secretkey
           - name: ALLOW_CUSTOM_VISUALIZATIONS
             value: "true"
         readinessProbe:

--- a/manifests/kustomize/env/gcp/minio-gcs-gateway/kustomization.yaml
+++ b/manifests/kustomize/env/gcp/minio-gcs-gateway/kustomization.yaml
@@ -4,3 +4,10 @@ kind: Kustomization
 resources:
 - minio-gcs-gateway-deployment.yaml
 - minio-gcs-gateway-service.yaml
+
+secretGenerator:
+- name: minio-artifact-secret
+  env: minio-artifact-secret.env
+generatorOptions:
+  # minio-artifact-secret needs to be referred by exact name
+  disableNameSuffixHash: true

--- a/manifests/kustomize/env/gcp/minio-gcs-gateway/kustomization.yaml
+++ b/manifests/kustomize/env/gcp/minio-gcs-gateway/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 - minio-gcs-gateway-service.yaml
 
 secretGenerator:
-- name: minio-artifact-secret
+- name: mlpipeline-minio-artifact
   env: minio-artifact-secret.env
 generatorOptions:
   # minio-artifact-secret needs to be referred by exact name

--- a/manifests/kustomize/env/gcp/minio-gcs-gateway/kustomization.yaml
+++ b/manifests/kustomize/env/gcp/minio-gcs-gateway/kustomization.yaml
@@ -9,5 +9,5 @@ secretGenerator:
 - name: mlpipeline-minio-artifact
   env: minio-artifact-secret.env
 generatorOptions:
-  # minio-artifact-secret needs to be referred by exact name
+  # mlpipeline-minio-artifact needs to be referred by exact name
   disableNameSuffixHash: true

--- a/manifests/kustomize/env/gcp/minio-gcs-gateway/minio-artifact-secret.env
+++ b/manifests/kustomize/env/gcp/minio-gcs-gateway/minio-artifact-secret.env
@@ -1,0 +1,2 @@
+accesskey=minio
+secretkey=minio123

--- a/manifests/kustomize/env/gcp/minio-gcs-gateway/minio-gcs-gateway-deployment.yaml
+++ b/manifests/kustomize/env/gcp/minio-gcs-gateway/minio-gcs-gateway-deployment.yaml
@@ -29,8 +29,14 @@ spec:
                   name: pipeline-install-config
                   key: gcsProjectId
             - name: MINIO_ACCESS_KEY
-              value: "minio"
+              valueFrom:
+                secretKeyRef:
+                  name: minio-artifact-secret
+                  key: accesskey
             - name: MINIO_SECRET_KEY
-              value: "minio123"
+              valueFrom:
+                secretKeyRef:
+                  name: minio-artifact-secret
+                  key: secretkey
           ports:
             - containerPort: 9000

--- a/manifests/kustomize/env/gcp/minio-gcs-gateway/minio-gcs-gateway-deployment.yaml
+++ b/manifests/kustomize/env/gcp/minio-gcs-gateway/minio-gcs-gateway-deployment.yaml
@@ -31,12 +31,12 @@ spec:
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: minio-artifact-secret
+                  name: mlpipeline-minio-artifact
                   key: accesskey
             - name: MINIO_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: minio-artifact-secret
+                  name: mlpipeline-minio-artifact
                   key: secretkey
           ports:
             - containerPort: 9000

--- a/manifests/kustomize/env/platform-agnostic/minio/kustomization.yaml
+++ b/manifests/kustomize/env/platform-agnostic/minio/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
 - minio-service.yaml
 
 secretGenerator:
-- name: minio-artifact-secret
+- name: mlpipeline-minio-artifact
   env: minio-artifact-secret.env
 generatorOptions:
-  # minio-artifact-secret needs to be referred by exact name
+  # mlpipeline-minio-artifact needs to be referred by exact name
   disableNameSuffixHash: true

--- a/manifests/kustomize/env/platform-agnostic/minio/kustomization.yaml
+++ b/manifests/kustomize/env/platform-agnostic/minio/kustomization.yaml
@@ -5,3 +5,10 @@ resources:
 - minio-deployment.yaml
 - minio-pvc.yaml
 - minio-service.yaml
+
+secretGenerator:
+- name: minio-artifact-secret
+  env: minio-artifact-secret.env
+generatorOptions:
+  # minio-artifact-secret needs to be referred by exact name
+  disableNameSuffixHash: true

--- a/manifests/kustomize/env/platform-agnostic/minio/minio-artifact-secret.env
+++ b/manifests/kustomize/env/platform-agnostic/minio/minio-artifact-secret.env
@@ -1,0 +1,2 @@
+accesskey=minio
+secretkey=minio123

--- a/manifests/kustomize/env/platform-agnostic/minio/minio-deployment.yaml
+++ b/manifests/kustomize/env/platform-agnostic/minio/minio-deployment.yaml
@@ -23,12 +23,12 @@ spec:
         - name: MINIO_ACCESS_KEY
           valueFrom:
             secretKeyRef:
-              name: minio-artifact-secret
+              name: mlpipeline-minio-artifact
               key: accesskey
         - name: MINIO_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: minio-artifact-secret
+              name: mlpipeline-minio-artifact
               key: secretkey
         image: gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance
         name: minio

--- a/manifests/kustomize/env/platform-agnostic/minio/minio-deployment.yaml
+++ b/manifests/kustomize/env/platform-agnostic/minio/minio-deployment.yaml
@@ -21,9 +21,15 @@ spec:
         - /data
         env:
         - name: MINIO_ACCESS_KEY
-          value: minio
+          valueFrom:
+            secretKeyRef:
+              name: minio-artifact-secret
+              key: accesskey
         - name: MINIO_SECRET_KEY
-          value: minio123
+          valueFrom:
+            secretKeyRef:
+              name: minio-artifact-secret
+              key: secretkey
         image: gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance
         name: minio
         ports:


### PR DESCRIPTION
**Description of your changes:**
Use minio artifact secret as single source of truth, instead of putting default value of
accesskey=minio
accesssecret=minio123
everywhere.

**Verification:**
I searched for minio123, and it's now only occuring twice in kustomize manifests.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.

- [x] Do you want this pull request (PR) cherry-picked into the current release branch?
    
    If yes, use one of the following options:
  
    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)
