### PR TITLE
fix(backend): allow empty userid header prefix. Fixes #4091

### DIFF
--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -216,6 +216,8 @@ func initConfig() {
 	replacer := strings.NewReplacer(".", "_")
 	viper.SetEnvKeyReplacer(replacer)
 	viper.AutomaticEnv()
+	// We need empty string env var for e.g. KUBEFLOW_USERID_PREFIX.
+	viper.AllowEmptyEnv(true)
 
 	// Set configuration file name. The format is auto detected in this case.
 	viper.SetConfigName("config")


### PR DESCRIPTION
**Description of your changes:**
Add a unit test and configure env var to take userid header prefix which can be an empty string.
Ref: https://godoc.org/github.com/spf13/viper#AllowEmptyEnv

Fixes https://github.com/kubeflow/pipelines/issues/4091

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.

- [x] Do you want this pull request (PR) cherry-picked into the current release branch?
    
    If yes, use one of the following options:
  
    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)
