### PR TITLE
Fix(component): Update default TensorFlow version for Watson ML example

### DIFF
--- a/components/ibm-components/watson/store/component.yaml
+++ b/components/ibm-components/watson/store/component.yaml
@@ -19,7 +19,7 @@ inputs:
   - {name: run_uid,        description: 'Required. UID for the Watson Machine Learning training-runs'}
   - {name: model_name,     description: 'Required. Model Name to store on Watson Machine Learning'}
   - {name: framework,         description: 'ML/DL Model Framework', default: 'tensorflow'}
-  - {name: framework_version, description: 'Model Framework version', default: '1.14'}
+  - {name: framework_version, description: 'Model Framework version', default: '1.15'}
   - {name: runtime_version,   description: 'Model Code runtime version', default: '3.6'}
 outputs:
   - {name: model_uid,      description: 'UID for the stored model on Watson Machine Learning'}

--- a/components/ibm-components/watson/train/component.yaml
+++ b/components/ibm-components/watson/train/component.yaml
@@ -20,7 +20,7 @@ inputs:
   - {name: execution_command, description: 'Required. Execution command to start the model training.'}
   - {name: config,            description: 'Credential configfile is properly created.', default: 'secret_name'}
   - {name: framework,         description: 'ML/DL Model Framework', default: 'tensorflow'}
-  - {name: framework_version, description: 'Model Framework version', default: '1.14'}
+  - {name: framework_version, description: 'Model Framework version', default: '1.15'}
   - {name: runtime,           description: 'Model Code runtime language', default: 'python'}
   - {name: runtime_version,   description: 'Model Code runtime version', default: '3.6'}
   - {name: run_definition,    description: 'Name for the Watson Machine Learning training definition', default: 'python-tensorflow-definition'}

--- a/components/ibm-components/watson/train/src/wml-train.py
+++ b/components/ibm-components/watson/train/src/wml-train.py
@@ -28,7 +28,7 @@ def train(args):
     wml_train_code = args.train_code
     wml_execution_command = args.execution_command.strip('\'')
     wml_framework_name = args.framework if args.framework else 'tensorflow'
-    wml_framework_version = args.framework_version if args.framework_version else '1.14'
+    wml_framework_version = args.framework_version if args.framework_version else '1.15'
     wml_runtime_name = args.runtime if args.runtime else 'python'
     wml_runtime_version = args.runtime_version if args.runtime_version else '3.6'
     wml_run_definition = args.run_definition if args.run_definition else 'python-tensorflow-definition'

--- a/samples/contrib/ibm-samples/watson/watson_train_serve_pipeline.py
+++ b/samples/contrib/ibm-samples/watson/watson_train_serve_pipeline.py
@@ -48,7 +48,7 @@ def kfp_wml_pipeline(
     train_code='tf-model.zip',
     execution_command='\'python3 convolutional_network.py --trainImagesFile ${DATA_DIR}/train-images-idx3-ubyte.gz --trainLabelsFile ${DATA_DIR}/train-labels-idx1-ubyte.gz --testImagesFile ${DATA_DIR}/t10k-images-idx3-ubyte.gz --testLabelsFile ${DATA_DIR}/t10k-labels-idx1-ubyte.gz --learningRate 0.001 --trainingIters 20000\'',
     framework='tensorflow',
-    framework_version='1.14',
+    framework_version='1.15',
     runtime = 'python',
     runtime_version='3.6',
     run_definition = 'wml-tensorflow-definition',


### PR DESCRIPTION
**Description of your changes:**
Due to the security concern with TensorFlow 1.14, Watson ML has deprecated the support for it. Thus, changing the default TF version in the Watson ML example to 1.15. 
Reference: https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/pm_service_supported_frameworks.html

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.

- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?
    
    If yes, use one of the following options:
  
    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)
