### PR TITLE
test: postsubmit - fix cloudbuild job filtering. Part of #4046

### DIFF
--- a/.cloudbuild.yaml
+++ b/.cloudbuild.yaml
@@ -294,3 +294,5 @@ timeout: '3600s'
 options:
  diskSizeGb: 300
  machineType: 'N1_HIGHCPU_8'
+tags:
+- build-each-commit

--- a/.release.cloudbuild.yaml
+++ b/.release.cloudbuild.yaml
@@ -649,3 +649,5 @@ images:
 - 'gcr.io/ml-pipeline/google/pipelines-test/deployer:$TAG_NAME'
 - 'gcr.io/ml-pipeline/google/pipelines-test:$TAG_NAME'
 timeout: '1200s'
+tags:
+- release-on-tag

--- a/test/postsubmit-tests-with-pipeline-deployment.sh
+++ b/test/postsubmit-tests-with-pipeline-deployment.sh
@@ -86,10 +86,11 @@ source "${DIR}/test-prep.sh"
 CLOUDBUILD_TIMEOUT_SECONDS=3600
 PULL_CLOUDBUILD_STATUS_MAX_ATTEMPT=$(expr ${CLOUDBUILD_TIMEOUT_SECONDS} / 20 )
 CLOUDBUILD_STARTED=TIMEOUT
+CLOUDBUILD_FILTER="substitutions.COMMIT_SHA:${PULL_BASE_SHA} AND tags:build-each-commit"
 
 for i in $(seq 1 ${PULL_CLOUDBUILD_STATUS_MAX_ATTEMPT})
 do
-  output=`gcloud builds list --project="$CLOUDBUILD_PROJECT" --filter="sourceProvenance.resolvedRepoSource.commitSha:${PULL_BASE_SHA}"`
+  output=`gcloud builds list --project="$CLOUDBUILD_PROJECT" --filter="$CLOUDBUILD_FILTER"`
   if [[ ${output} != "" ]]; then
     CLOUDBUILD_STARTED=True
     break
@@ -106,7 +107,7 @@ fi
 CLOUDBUILD_FINISHED=TIMEOUT
 for i in $(seq 1 ${PULL_CLOUDBUILD_STATUS_MAX_ATTEMPT})
 do
-  output=`gcloud builds list --project="$CLOUDBUILD_PROJECT" --filter="sourceProvenance.resolvedRepoSource.commitSha:${PULL_BASE_SHA}"`
+  output=`gcloud builds list --project="$CLOUDBUILD_PROJECT" --filter="$CLOUDBUILD_FILTER"`
   if [[ ${output} == *"SUCCESS"* ]]; then
     CLOUDBUILD_FINISHED=SUCCESS
     break


### PR DESCRIPTION
**Description of your changes:**
Part of #4046 

Related cloudbuild documentation: https://cloud.google.com/cloud-build/docs/view-build-results#gcloud.

Note that `sourceProvenance.resolvedRepoSource.commitSha` isn't available in Github App Trigger triggered cloudbuild tasks, that's strange, but we can first work around that by querying `substitutions.COMMIT_SHA`.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.

- [x] Do you want this pull request (PR) cherry-picked into the current release branch?
    
    If yes, use one of the following options:
  
    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)
