### PR TITLE
feat(sdk): SDK - Components - Added annotations to TaskSpec

### DIFF
--- a/sdk/python/kfp/components/_structures.py
+++ b/sdk/python/kfp/components/_structures.py
@@ -588,6 +588,7 @@ class TaskSpec(ModelBase):
         arguments: Optional[Mapping[str, ArgumentType]] = None,
         is_enabled: Optional[PredicateType] = None,
         execution_options: Optional[ExecutionOptionsSpec] = None,
+        annotations: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(locals())
         #TODO: If component_ref is resolved to component spec, then check that the arguments correspond to the inputs


### PR DESCRIPTION
This allows the pipeline authors to add custom annotations to particular tasks.

Annotations
You can use annotations to attach arbitrary metadata to the task objects. Clients such as tools and libraries can retrieve this metadata.
For example, they can use the annotations to differentiate between the main model training task and  the auxiliary CV training tasks.
It's might also be a place to set other per-task information like the task display name for the UX.
We've had several users requesting the ability to tag tasks and the annotations provide a way to do so.

This feature is expected to mostly be used by external tools, so there are no needed changes in the backend or frontend.