### PR TITLE
feat(sdk): SDK - Components - Added annotations to InputSpec and OutputSpec

### DIFF
--- a/sdk/python/kfp/components/_structures.py
+++ b/sdk/python/kfp/components/_structures.py
@@ -80,6 +80,7 @@ class InputSpec(ModelBase):
         description: Optional[str] = None,
         default: Optional[PrimitiveTypes] = None,
         optional: Optional[bool] = False,
+        annotations: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(locals())
 
@@ -90,6 +91,7 @@ class OutputSpec(ModelBase):
         name: str,
         type: Optional[TypeSpecType] = None,
         description: Optional[str] = None,
+        annotations: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(locals())
 


### PR DESCRIPTION
This allows the component authors to add custom annotation to particular component inputs or outputs.
For example, they can use the annotations to specify the data schema for structured data.
It's might also be a place to set other per-input information.