### PR TITLE
feat(sdk): SDK - Deprecation warning when using ContainerOp

### DIFF
--- a/sdk/python/kfp/dsl/__init__.py
+++ b/sdk/python/kfp/dsl/__init__.py
@@ -15,7 +15,7 @@
 
 from ._pipeline_param import PipelineParam, match_serialized_pipelineparam
 from ._pipeline import Pipeline, pipeline, get_pipeline_conf, PipelineConf
-from ._container_op import ContainerOp, InputArgumentPath, UserContainer, Sidecar, DISABLE_REUSABLE_COMPONENT_WARNING
+from ._container_op import ContainerOp, InputArgumentPath, UserContainer, Sidecar
 from ._resource_op import ResourceOp
 from ._volume_op import (
     VolumeOp, VOLUME_MODE_RWO, VOLUME_MODE_RWM, VOLUME_MODE_ROM

--- a/sdk/python/kfp/dsl/__init__.py
+++ b/sdk/python/kfp/dsl/__init__.py
@@ -15,7 +15,7 @@
 
 from ._pipeline_param import PipelineParam, match_serialized_pipelineparam
 from ._pipeline import Pipeline, pipeline, get_pipeline_conf, PipelineConf
-from ._container_op import ContainerOp, InputArgumentPath, UserContainer, Sidecar
+from ._container_op import ContainerOp, InputArgumentPath, UserContainer, Sidecar, DISABLE_REUSABLE_COMPONENT_WARNING
 from ._resource_op import ResourceOp
 from ._volume_op import (
     VolumeOp, VOLUME_MODE_RWO, VOLUME_MODE_RWM, VOLUME_MODE_ROM

--- a/sdk/python/kfp/dsl/_component_bridge.py
+++ b/sdk/python/kfp/dsl/_component_bridge.py
@@ -42,6 +42,8 @@ def _create_container_op_from_component_and_arguments(
 
     container_spec = component_spec.implementation.container
 
+    old_warn_value = dsl.DISABLE_REUSABLE_COMPONENT_WARNING
+    DISABLE_REUSABLE_COMPONENT_WARNING = True
     task = dsl.ContainerOp(
         name=component_spec.name or _default_component_name,
         image=container_spec.image,
@@ -57,6 +59,7 @@ def _create_container_op_from_component_and_arguments(
             for input_name, path in resolved_cmd.input_paths.items()
         ],
     )
+    dsl.DISABLE_REUSABLE_COMPONENT_WARNING = old_warn_value
 
     component_meta = copy.copy(component_spec)
     task._set_metadata(component_meta)

--- a/sdk/python/kfp/dsl/_component_bridge.py
+++ b/sdk/python/kfp/dsl/_component_bridge.py
@@ -42,8 +42,8 @@ def _create_container_op_from_component_and_arguments(
 
     container_spec = component_spec.implementation.container
 
-    old_warn_value = dsl.DISABLE_REUSABLE_COMPONENT_WARNING
-    DISABLE_REUSABLE_COMPONENT_WARNING = True
+    old_warn_value = dsl.ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING
+    dsl.ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING = True
     task = dsl.ContainerOp(
         name=component_spec.name or _default_component_name,
         image=container_spec.image,
@@ -59,7 +59,7 @@ def _create_container_op_from_component_and_arguments(
             for input_name, path in resolved_cmd.input_paths.items()
         ],
     )
-    dsl.DISABLE_REUSABLE_COMPONENT_WARNING = old_warn_value
+    dsl.ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING = old_warn_value
 
     component_meta = copy.copy(component_spec)
     task._set_metadata(component_meta)

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -920,9 +920,6 @@ class InputArgumentPath:
         self.path = path
 
 
-DISABLE_REUSABLE_COMPONENT_WARNING = False
-
-
 class ContainerOp(BaseOp):
     """
     Represents an op implemented by a container image.
@@ -962,6 +959,8 @@ class ContainerOp(BaseOp):
     # the input parameters during compilation.
     # Excludes `file_outputs` and `outputs` as they are handled separately
     # in the compilation process to generate the DAGs and task io parameters.
+
+    _DISABLE_REUSABLE_COMPONENT_WARNING = False
 
     def __init__(
       self,
@@ -1014,7 +1013,7 @@ class ContainerOp(BaseOp):
 
         super().__init__(name=name, init_containers=init_containers, sidecars=sidecars, is_exit_handler=is_exit_handler)
 
-        if not DISABLE_REUSABLE_COMPONENT_WARNING and '--component_launcher_class_path' not in (arguments or []):
+        if not ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING and '--component_launcher_class_path' not in (arguments or []):
             # The warning is suppressed for pipelines created using the TFX SDK.
             warnings.warn(
                 "Please create reusable components instead of constructing ContainerOp instances directly."

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -920,6 +920,9 @@ class InputArgumentPath:
         self.path = path
 
 
+DISABLE_REUSABLE_COMPONENT_WARNING = False
+
+
 class ContainerOp(BaseOp):
     """
     Represents an op implemented by a container image.
@@ -1010,6 +1013,18 @@ class ContainerOp(BaseOp):
         """
 
         super().__init__(name=name, init_containers=init_containers, sidecars=sidecars, is_exit_handler=is_exit_handler)
+
+        if not DISABLE_REUSABLE_COMPONENT_WARNING:
+            warnings.warn(
+                "Please create reusable components instead of constructing ContainerOp instances directly."
+                " Reusable components are shareable, portable and have compatibility and support guarantees."
+                " Please see the documentation: https://www.kubeflow.org/docs/pipelines/sdk/component-development/#writing-your-component-definition-file"
+                " The components can be created manually (or, in case of python, using kfp.components.create_component_from_func or func_to_container_op)"
+                " and then loaded using kfp.components.load_component_from_file, load_component_from_uri or load_component_from_text: "
+                "https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.components.html#kfp.components.load_component_from_file",
+                category=DeprecationWarning,
+            )
+
         self.attrs_with_pipelineparams = BaseOp.attrs_with_pipelineparams + ['_container', 'artifact_arguments'] #Copying the BaseOp class variable!
 
         input_artifact_paths = {}

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -1014,7 +1014,8 @@ class ContainerOp(BaseOp):
 
         super().__init__(name=name, init_containers=init_containers, sidecars=sidecars, is_exit_handler=is_exit_handler)
 
-        if not DISABLE_REUSABLE_COMPONENT_WARNING:
+        if not DISABLE_REUSABLE_COMPONENT_WARNING and '--component_launcher_class_path' not in (arguments or []):
+            # The warning is suppressed for pipelines created using the TFX SDK.
             warnings.warn(
                 "Please create reusable components instead of constructing ContainerOp instances directly."
                 " Reusable components are shareable, portable and have compatibility and support guarantees."


### PR DESCRIPTION
We have long advised our users to create reusable components.
Creating reusable components is as easy as creating ContainerOp instances, but the components are shareable, portable and are easier to support going forward.
