### PR TITLE
fix(cache): Fix cache deployer not regenerating secrets when secret not present

### DIFF
--- a/backend/src/cache/deployer/deploy-cache-service.sh
+++ b/backend/src/cache/deployer/deploy-cache-service.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # This script is for deploying cache service to an existing cluster.
-# Prerequisite: config kubectl to talk to your cluster. See ref below: 
+# Prerequisite: config kubectl to talk to your cluster. See ref below:
 # https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl
 
 set -ex
@@ -40,7 +40,7 @@ fi
 
 webhook_secret_exists=false
 if grep "${WEBHOOK_SECRET_NAME}" -w <cache_secret.txt; then
-    webhook_config_exists=true
+    webhook_secret_exists=true
 fi
 
 if [ "$webhook_config_exists" == "true" ] && [ "$webhook_config_exists" == "true" ]; then
@@ -76,8 +76,8 @@ cat ./cache-configmap-ca-bundle.yaml
 kubectl apply -f ./cache-configmap-ca-bundle.yaml --namespace "${NAMESPACE}"
 
 # TODO: Check whether we really need to check for the existence of the webhook
-# Usually the Kubernetes objects appear immediately. 
-while true; do 
+# Usually the Kubernetes objects appear immediately.
+while true; do
     # Should fail if there are connectivity problems
     kubectl get mutatingwebhookconfigurations "${MUTATING_WEBHOOK_CONFIGURATION_NAME}" --namespace "${NAMESPACE}" --ignore-not-found >webhooks.txt
 
@@ -87,5 +87,5 @@ while true; do
     else
         echo "Webhook is not visible yet. Waiting a bit."
         sleep 10s
-    fi    
+    fi
 done


### PR DESCRIPTION
**Description of your changes:**
I deleted kubeflow namespace, then reinstalled KFP 1.0.0-rc.4.
I found my cache-server cannot mount the tls secret.

After reading cache deployer code, the root cause seems to be a typo as fixed in the PR.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.

- [x] Do you want this pull request (PR) cherry-picked into the current release branch?
    
    If yes, use one of the following options:
  
    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)
