### PR TITLE
fix(sample): Fix syntax error in openvino sample component

### DIFF
--- a/contrib/samples/openvino/deployer/component.yaml
+++ b/contrib/samples/openvino/deployer/component.yaml
@@ -46,10 +46,10 @@ implementation:
     command: [./evaluate.py]
     args: [
       --images_list, {inputValue: Evaluation images list},
-      --image_path_prefix {inputValue: Image path prefix}
+      --image_path_prefix, {inputValue: Image path prefix},
       --grpc_endpoint, {outputValue: Server endpoint},
       --input_name, {inputValue: Model input name},
       --output_name, {inputValue: Model output name},
       --size, {inputValue: Model input size},
-      --replicas, {inputValue: Replicas}
+      --replicas, {inputValue: Replicas},
     ]


### PR DESCRIPTION
**Description of your changes:**
I was running some analysis on all sample components in KFP repo, and discovered that this one has some syntax error preventing correct parsing.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.

- [x] Do you want this pull request (PR) cherry-picked into the current release branch?
    
    If yes, use one of the following options:
  
    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)

/cc @numerology @Ark-kun 