### PR TITLE
feat(sdk): Enable AWS ALB authentication in KFP SDK Client

### DIFF
--- a/sdk/python/kfp/_auth.py
+++ b/sdk/python/kfp/_auth.py
@@ -15,6 +15,10 @@
 import logging
 import os
 import subprocess
+import json
+import time
+import getpass
+from webbrowser import open_new_tab
 import google.auth
 import google.auth.app_engine
 import google.auth.compute_engine.credentials
@@ -23,18 +27,9 @@ from google.auth.transport.requests import Request
 import google.oauth2.credentials
 import google.oauth2.service_account
 import requests_toolbelt.adapters.appengine
-from webbrowser import open_new_tab
 import requests
-import json
-import time
-import io
-import getpass
-import platform
-import stat
-import zipfile
 from selenium.webdriver import Chrome
 from selenium.webdriver.chrome.options import Options
-from selenium.common.exceptions import SessionNotCreatedException
 from webdriver_manager.chrome import ChromeDriverManager
 
 IAM_SCOPE = 'https://www.googleapis.com/auth/iam'
@@ -233,7 +228,8 @@ def get_auth_cookie(host, username=None, password=None, from_cache=True):
             return cached_creds
         else:
             logging.info(
-                'Credentials are not found in the cache, trying to login')
+                'Credentials are not found in the cache, trying to login'
+            )
 
     driver = get_chrome_driver()
     driver.get(host)
@@ -242,22 +238,26 @@ def get_auth_cookie(host, username=None, password=None, from_cache=True):
     # Setting the value of email input field
     driver.execute_script(
         'var element = document.getElementById("signInFormUsername");' +
-        f'element.value = "{username}";')
+        f'element.value = "{username}";'
+    )
 
     # Setting the value of password input field
     driver.execute_script(
         'var element = document.getElementById("signInFormPassword");' +
-        f'element.value = "{password}";')
+        f'element.value = "{password}";'
+    )
 
     # Submitting the form or click the sign in button
     driver.execute_script(
-        'document.getElementsByName("signInSubmitButton")[0].click();')
+        'document.getElementsByName("signInSubmitButton")[0].click();'
+    )
 
     cookies_list = driver.get_cookies()
     auth_cookie = f"{cookies_list[0]['name']}={cookies_list[0]['value']}"
     cache.save(auth_cookie)
 
     return auth_cookie
+
 
 def get_chrome_driver():
     """ Download Chrome driver if it doesn't already exists
@@ -278,12 +278,14 @@ def get_chrome_driver():
 
     return Chrome(executable_path=executable_path, options=options)
 
+
 def download_driver():
     """ Helper function for downloading the driver
     """
 
     logging.info('Downloading driver..')
     return ChromeDriverManager(path=DEFAULT_CHROME_DRIVER_PATH).install()
+
 
 class DiskCache:
     """ Helper class for caching data on disk.
@@ -319,8 +321,7 @@ class DiskCache:
         """
 
         try:
-            if expires_in and time.time() - os.path.getmtime(
-                    self.cache_path) > expires_in:
+            if expires_in and time.time() - os.path.getmtime(self.cache_path) > expires_in:
                 return
 
             with open(self.cache_path) as cacheFile:

--- a/sdk/python/kfp/_auth.py
+++ b/sdk/python/kfp/_auth.py
@@ -40,7 +40,7 @@ from webdriver_manager.chrome import ChromeDriverManager
 IAM_SCOPE = 'https://www.googleapis.com/auth/iam'
 OAUTH_TOKEN_URI = 'https://www.googleapis.com/oauth2/v4/token'
 LOCAL_KFP_CREDENTIAL = os.path.expanduser('~/.config/kfp/credentials.json')
-DEFAULT_CHROME_DRIVER_PATH = os.path.join(os.path.expanduser('~'), '.kfp', 'chromedriver')
+DEFAULT_CHROME_DRIVER_PATH = os.path.join(os.path.expanduser('~'), '.config', 'kfp', 'chromedriver')
 
 def get_gcp_access_token():
     """Get and return GCP access token for the current Application Default
@@ -236,9 +236,7 @@ def get_auth_cookie(host, username=None, password=None, from_cache=True):
                 'Credentials are not found in the cache, trying to login')
 
     driver = get_chrome_driver()
-
     driver.get(host)
-
     username, password = validate_creds(username, password)
 
     # Setting the value of email input field
@@ -291,7 +289,7 @@ class DiskCache:
     """ Helper class for caching data on disk.
     """
 
-    _DEFAULT_CACHE_ROOT = os.path.join(os.path.expanduser('~'), '.kfp')
+    _DEFAULT_CACHE_ROOT = os.path.join(os.path.expanduser('~'), '.config', 'kfp')
 
     def __init__(self, name):
         self.name = name

--- a/sdk/python/kfp/_auth.py
+++ b/sdk/python/kfp/_auth.py
@@ -238,13 +238,13 @@ def get_auth_cookie(host, username=None, password=None, from_cache=True):
     # Setting the value of email input field
     driver.execute_script(
         'var element = document.getElementById("signInFormUsername");' +
-        f'element.value = "{username}";'
+        'element.value = "{}";'.format(username)
     )
 
     # Setting the value of password input field
     driver.execute_script(
         'var element = document.getElementById("signInFormPassword");' +
-        f'element.value = "{password}";'
+        'element.value = "{}";'.format(password)
     )
 
     # Submitting the form or click the sign in button
@@ -253,7 +253,7 @@ def get_auth_cookie(host, username=None, password=None, from_cache=True):
     )
 
     cookies_list = driver.get_cookies()
-    auth_cookie = f"{cookies_list[0]['name']}={cookies_list[0]['value']}"
+    auth_cookie = "{}={}".format(cookies_list[0]['name'], cookies_list[0]['value'])
     cache.save(auth_cookie)
 
     return auth_cookie

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -31,7 +31,7 @@ import kfp_server_api
 from kfp.compiler import compiler
 from kfp.compiler._k8s_helper import sanitize_k8s_name
 
-from kfp._auth import get_auth_token, get_gcp_access_token
+from kfp._auth import get_auth_token, get_gcp_access_token, get_auth_cookie
 
 # TTL of the access token associated with the client. This is needed because
 # `gcloud auth print-access-token` generates a token with TTL=1 hour, after
@@ -132,6 +132,21 @@ class Client(object):
     self._pipelines_api = kfp_server_api.api.pipeline_service_api.PipelineServiceApi(api_client)
     self._upload_api = kfp_server_api.api.PipelineUploadServiceApi(api_client)
     self._load_context_setting_or_default()
+
+  @staticmethod
+  def create_cognito_authenticated(host, username=None, password=None):
+    """ Creates a KFP client object that is authenticated against AWS Cognito
+
+    Args:
+      host (str): The host name to use to talk to Kubeflow Pipelines.
+      username (str): Cognito username. If not provided there will be an input prompt
+      password (str): Password for the username provided above. If not provided there will be an input prompt
+
+    Returns:
+      Client : Client authenticated against Cognito
+    """
+    elb_auth_session_cookie = get_auth_cookie(host, username, password)
+    return Client(host=host, cookie=elb_auth_session_cookie)
 
   def _load_config(self, host, client_id, namespace, other_client_id, other_client_secret, existing_token):
     config = kfp_server_api.configuration.Configuration()

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -98,7 +98,7 @@ class Client(object):
   LOCAL_KFP_CONTEXT = os.path.expanduser('~/.config/kfp/context.json')
 
   # TODO: Wrap the configurations for different authentication methods.
-  def __init__(self, host=None, client_id=None, namespace='kubeflow', other_client_id=None, other_client_secret=None, existing_token=None, cookies=None):
+  def __init__(self, host=None, client_id=None, namespace='kubeflow', other_client_id=None, other_client_secret=None, existing_token=None, cookie=None):
     """Create a new instance of kfp client.
 
     Args:
@@ -124,7 +124,7 @@ class Client(object):
     # Save the loaded API client configuration, as a reference if update is
     # needed.
     self._existing_config = config
-    api_client = kfp_server_api.api_client.ApiClient(config, cookie=cookies)
+    api_client = kfp_server_api.api_client.ApiClient(config, cookie)
     _add_generated_apis(self, kfp_server_api, api_client)
     self._job_api = kfp_server_api.api.job_service_api.JobServiceApi(api_client)
     self._run_api = kfp_server_api.api.run_service_api.RunServiceApi(api_client)

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -116,7 +116,7 @@ class Client(object):
       other_client_secret: The client secret used to obtain the auth codes and refresh tokens.
       existing_token: pass in token directly, it's used for cases better get token outside of SDK, e.x. GCP Cloud Functions
           or caller already has a token
-      cookies: CookieJar object containing cookies that will be passed to the pipelines API.
+      cookie: CookieJar object containing cookies that will be passed to the pipelines API.
     """
     host = host or os.environ.get(KF_PIPELINES_ENDPOINT_ENV)
     self._uihost = os.environ.get(KF_PIPELINES_UI_ENDPOINT_ENV, host)
@@ -124,7 +124,7 @@ class Client(object):
     # Save the loaded API client configuration, as a reference if update is
     # needed.
     self._existing_config = config
-    api_client = kfp_server_api.api_client.ApiClient(config, cookie)
+    api_client = kfp_server_api.api_client.ApiClient(config, cookie=cookie)
     _add_generated_apis(self, kfp_server_api, api_client)
     self._job_api = kfp_server_api.api.job_service_api.JobServiceApi(api_client)
     self._run_api = kfp_server_api.api.run_service_api.RunServiceApi(api_client)

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -120,7 +120,7 @@ class Client(object):
     """
     host = host or os.environ.get(KF_PIPELINES_ENDPOINT_ENV)
     self._uihost = os.environ.get(KF_PIPELINES_UI_ENDPOINT_ENV, host)
-    config = self._load_config(host, client_id, namespace, other_client_id, other_client_secret, existing_token)
+    config = self._load_config(host, client_id, namespace, other_client_id, other_client_secret, existing_token, cookie)
     # Save the loaded API client configuration, as a reference if update is
     # needed.
     self._existing_config = config
@@ -148,13 +148,14 @@ class Client(object):
     elb_auth_session_cookie = get_auth_cookie(host, username, password)
     return Client(host=host, cookie=elb_auth_session_cookie)
 
-  def _load_config(self, host, client_id, namespace, other_client_id, other_client_secret, existing_token):
+  def _load_config(self, host, client_id, namespace, other_client_id, other_client_secret, existing_token, cookie):
     config = kfp_server_api.configuration.Configuration()
 
     host = host or ''
     # Preprocess the host endpoint to prevent some common user mistakes.
-    # This should only be done for non-IAP cases (when client_id is None). IAP requires preserving the protocol.
-    if not client_id:
+    # This should only be done for non GCP IAP case (when client_id is None) or non AWS Cognito case (when cookie is None).
+    # GCP IAP and AWS Cognito require preserving the protocol.
+    if not client_id and not cookie:
       host = re.sub(r'^(http|https)://', '', host).rstrip('/')
 
     if host:

--- a/sdk/python/kfp/aws.py
+++ b/sdk/python/kfp/aws.py
@@ -12,6 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import io
+import platform
+import re
+import sys
+import stat
+import requests
+import platform
+import time
+import logging
+import zipfile
+from selenium.webdriver import Chrome
+from selenium.webdriver.chrome.options import Options
+
+
+DRIVER_ROOT_URL = 'https://chromedriver.storage.googleapis.com'
+DEFAULT_CHROME_DRIVER_PATH = os.path.join(os.path.expanduser('~'), '.config', 'kfp', 'chromedriver')
+SUPPORTED_PLATFORMS = {
+    'Windows': 'win32',
+    'Darwin': 'mac64',
+    'Linux': 'linux64'
+}
+
 def use_aws_secret(secret_name='aws-secret', aws_access_key_id_name='AWS_ACCESS_KEY_ID', aws_secret_access_key_name='AWS_SECRET_ACCESS_KEY'):
     """An operator that configures the container to use AWS credentials.
 
@@ -58,3 +81,116 @@ def use_aws_secret(secret_name='aws-secret', aws_access_key_id_name='AWS_ACCESS_
         return task
 
     return _use_aws_secret
+
+class DiskCache:
+    """ Helper class for caching data on disk.
+    """
+
+    _DEFAULT_CACHE_ROOT = os.path.join(os.path.expanduser('~'), '.config', 'kfp')
+
+    def __init__(self, name):
+        self.name = name
+        self.cache_path = os.path.join(self._DEFAULT_CACHE_ROOT, self.name)
+        if not os.path.exists(self._DEFAULT_CACHE_ROOT):
+            os.makedirs(self._DEFAULT_CACHE_ROOT)
+
+    def save(self, content):
+        """ cache content in a known location
+
+        Args:
+            content (str): content to be cached
+        """
+
+        with open(self.cache_path, 'w') as cacheFile:
+            cacheFile.write(content)
+
+    def get(self, expires_in=None):
+        """[summary]
+
+        Args:
+            expires_in (int, optional): Time in seconds since last modifed
+                when the cache is valid. Defaults to None which means for ever.
+
+        Returns:
+            (str): retrived cached content or None if not found
+        """
+
+        try:
+            if expires_in and time.time() - os.path.getmtime(self.cache_path) > expires_in:
+                return
+
+            with open(self.cache_path) as cacheFile:
+                return cacheFile.read()
+        except FileNotFoundError:
+            return
+
+def os_name():
+    pl = sys.platform
+    if pl == "linux" or pl == "linux2":
+        return "linux"
+    elif pl == "darwin":
+        return "mac"
+    elif pl == "win32":
+        return "win"
+
+def get_chrome_version():
+    pattern = r'\d+\.\d+\.\d+'
+
+    cmd_mapping = {
+        "linux": 'google-chrome --version || google-chrome-stable --version',
+        "mac": r'/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version',
+        "win": r'reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version'
+    }
+
+    cmd = cmd_mapping[os_name()]
+    stdout = os.popen(cmd).read()
+    version = re.search(pattern, stdout)
+    if not version:
+        raise ValueError('Could not get version for Chrome with this command: {}'.format(cmd))
+    current_version = version.group(0)
+    return current_version
+
+
+def get_latest_release_version():
+    latest_release_url = "{}/LATEST_RELEASE".format(DRIVER_ROOT_URL)
+    chrome_version = get_chrome_version()
+
+    logging.info("Get LATEST driver version for {}".format(chrome_version))
+    resp = requests.get("{}_{}".format(latest_release_url,chrome_version))
+    return resp.text.rstrip()
+
+def download_driver():
+    """ Helper function for downloading the driver
+    """
+
+    osy = SUPPORTED_PLATFORMS[platform.system()]
+    chrome_release_version = get_latest_release_version()
+    driver_url = '{}/{}/chromedriver_{}.zip'.format(DRIVER_ROOT_URL, chrome_release_version, osy);
+    logging.info('Downloading driver {} ...'.format(driver_url))
+
+    r = requests.get(driver_url)
+    z = zipfile.ZipFile(io.BytesIO(r.content))
+    path = os.path.dirname(DEFAULT_CHROME_DRIVER_PATH)
+
+    if not os.path.exists(path):
+        os.makedirs(path)
+
+    z.extractall(path)
+    os.chmod(DEFAULT_CHROME_DRIVER_PATH, stat.S_IEXEC)
+
+    return os.path.join(DEFAULT_CHROME_DRIVER_PATH, "drivers", "chromedriver",
+                        osy, chrome_release_version, "chromedriver")
+
+def get_chrome_driver():
+    """ Download Chrome driver if it doesn't already exists
+    """
+
+    options = Options()
+    options.add_argument('--headless')
+    options.add_argument('--disable-gpu')
+
+    if not os.path.exists(DEFAULT_CHROME_DRIVER_PATH):
+        logging.info('Selenium driver not found, trying to download one')
+        download_driver()
+
+    return Chrome(executable_path=DEFAULT_CHROME_DRIVER_PATH, options=options)

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -17,6 +17,9 @@ google-cloud-storage>=1.13.0
 google-auth>=1.6.1
 requests_toolbelt>=0.8.0
 
+# kfp.Client AWS auth
+
+
 # CLI
 tabulate
 click

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -18,7 +18,7 @@ google-auth>=1.6.1
 requests_toolbelt>=0.8.0
 
 # kfp.Client AWS auth
-
+selenium>=3.141.0
 
 # CLI
 tabulate

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -37,6 +37,7 @@ REQUIRES = [
     'click',
     'Deprecated',
     'strip-hints',
+    'selenium>=3.141.0',
 ]
 
 TESTS_REQUIRE = [

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -38,7 +38,6 @@ REQUIRES = [
     'Deprecated',
     'strip-hints',
     'selenium>=3.141.0',
-    'webdriver_manager',
 ]
 
 TESTS_REQUIRE = [

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -38,6 +38,7 @@ REQUIRES = [
     'Deprecated',
     'strip-hints',
     'selenium>=3.141.0',
+    'webdriver_manager',
 ]
 
 TESTS_REQUIRE = [


### PR DESCRIPTION
**Description of your changes:**

Currently, kfp client can not be used outside AWS EKS cluster. Application load balancer manages outside traffic and require authentication before traffic coming into mesh. This PR automates ALB authentication and get session cookie to authenticate KFP python client to Kubeflow cluster. 

This unblocks user to submit pipeline/run outside kubeflow cluster and user can integrate with their CI/CD solutions much easier. 

Cognito or OIDC behind ALB both can leverage this solution. 

Usage:

```
# Option 1. Pass username and password

from kfp import Client
HOSTNAME='https://kubeflow.platform.shanjiaxin.com/pipeline'
client = Client.create_cognito_authenticated(HOSTNAME, username='<your_username>', password='<your_passworkd>')
client.list_pipelines()

# Option 2. Interactively type your password without echoing.
client = Client.create_cognito_authenticated(HOSTNAME)


>> from kfp import Client
>>> HOSTNAME='https://kubeflow.platform.shanjiaxin.com/pipeline'
>>> client = Client.create_cognito_authenticated(HOSTNAME)

[WDM] - Current google-chrome version is 83.0.4103
INFO:WDM:Current google-chrome version is 83.0.4103
....
[/Users/shjiaxin/.config/kfp/chromedriver/drivers/chromedriver/mac64/83.0.4103.39]

Username: shjiaxin
Password:
>>> client.list_pipelines()
{'next_page_token': None,
 'pipelines': [{'created_at': datetime.datetime(2020, 7, 8, 7, 0, 13, tzinfo=tzutc()),
                'default_version': {'code_source_url': None,
                                    'created_at': datetime.datetime(2020, 7, 8, 7, 0, 13, tzinfo=tzutc()),
                                    'id': 'cd5251a2-18f6-40e6-ae7d-a7f1b9297928',

```


**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.

- [x] Do you want this pull request (PR) cherry-picked into the current release branch?
    
    If yes, use one of the following options:
  
    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)

Can we pick this PR to 1.0.0 release? 
