### PR TITLE
feat(backend): Increase maximum possible visualization size

### DIFF
--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -151,8 +151,8 @@ func registerHttpHandlerFromEndpoint(handler RegisterHttpHandlerFromEndpoint, se
 
 	// Only change the maxCallRecvMesSize if it is for visualizations
 	if serviceName == "Visualization" {
-		maxCallRecvMsgSize = 50 * 1024 * 1024
-		opts := append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxCallRecvMsgSize)))
+		maxCallRecvMsgSize := 50 * 1024 * 1024
+		opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxCallRecvMsgSize)))
 	}
 	
 	if err := handler(ctx, mux, endpoint, opts); err != nil {

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -149,6 +149,12 @@ func registerHttpHandlerFromEndpoint(handler RegisterHttpHandlerFromEndpoint, se
 	endpoint := "localhost" + *rpcPortFlag
 	opts := []grpc.DialOption{grpc.WithInsecure()}
 
+	// Only change the maxCallRecvMesSize if it is for visualizations
+	if serviceName == "Visualization" {
+		maxCallRecvMsgSize = 50 * 1024 * 1024
+		opts := append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxCallRecvMsgSize)))
+	}
+	
 	if err := handler(ctx, mux, endpoint, opts); err != nil {
 		glog.Fatalf("Failed to register %v handler: %v", serviceName, err)
 	}

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -151,7 +151,7 @@ func registerHttpHandlerFromEndpoint(handler RegisterHttpHandlerFromEndpoint, se
 
 	// Only change the maxCallRecvMesSize if it is for visualizations
 	if serviceName == "Visualization" {
-		maxCallRecvMsgSize := 50 * 1024 * 1024
+		maxCallRecvMsgSize := 50 * 1024 * 1024  // 50MB message size for handling visualizations (default is 4MB)
 		opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxCallRecvMsgSize)))
 	}
 	

--- a/backend/src/apiserver/visualization/README.md
+++ b/backend/src/apiserver/visualization/README.md
@@ -153,21 +153,3 @@ within your cluster.
       - name: KERNEL_TIMEOUT
         value: 100
     ```
-* The HTML content of the generated visualizations cannot be larger than 4MB.
-    * gRPC by default imposes a limit of 4MB as the maximum size that can be
-    sent and received by a server. To allow for visualizations that are larger
-    than 4MB in size to be generated, you must manually set
-    **MaxCallRecvMsgSize** for gRPC. This can be done by editing the provided
-    options given to the gRPC server within [main.go](https://github.com/kubeflow/pipelines/blob/master/backend/src/apiserver/main.go#L128)
-    to 
-    ```golang
-    var maxCallRecvMsgSize = 4 * 1024 * 1024
-	if serviceName == "Visualization" {
-		// Only change the maxCallRecvMesSize if it is for visualizations
-		maxCallRecvMsgSize = 50 * 1024 * 1024
-    }
-	opts := []grpc.DialOption{
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxCallRecvMsgSize)),
-		grpc.WithInsecure(),
-	}
-    ```


### PR DESCRIPTION
**Description of your changes:**

I had some issues with bigger visualizations, I noticed that there is already a [document](https://github.com/kubeflow/pipelines/blob/master/backend/src/apiserver/visualization/README.md) wihich describes how to fix this issue. I made PR with code from the said document and removed section about the issue since it's no longer applicable.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.

- [x] Do you want this pull request (PR) cherry-picked into the current release branch?
    
    If yes, use one of the following options:
  
    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)

Is it possible to add it to 1.0 release? 