### PR TITLE
fix(components): AWS SageMaker - Fix MinIO PID early exit

### DIFF
--- a/components/aws/sagemaker/tests/integration_tests/scripts/run_integration_tests
+++ b/components/aws/sagemaker/tests/integration_tests/scripts/run_integration_tests
@@ -126,8 +126,6 @@ function install_kfp() {
 
   kubectl wait --for=condition=ready -n "${KFP_NAMESPACE}" pod -l app=minio --timeout=5m
   kubectl port-forward -n kubeflow svc/minio-service $MINIO_LOCAL_PORT:9000 &
-  echo "Forcing error"
-  exit 1
   MINIO_PID=$!
 
   echo "[Installing KFP] Minio port-forwarded to ${MINIO_LOCAL_PORT}"
@@ -161,6 +159,7 @@ function delete_generated_role() {
 function cleanup_kfp() {
   # Clean up Minio
   if [[ ! -z "${MINIO_PID:-}" ]]; then
+    # If this fails, deleting the nodegroup later will clean it up anyway
     kill -9 $MINIO_PID || true
   fi
 }

--- a/components/aws/sagemaker/tests/integration_tests/scripts/run_integration_tests
+++ b/components/aws/sagemaker/tests/integration_tests/scripts/run_integration_tests
@@ -126,6 +126,8 @@ function install_kfp() {
 
   kubectl wait --for=condition=ready -n "${KFP_NAMESPACE}" pod -l app=minio --timeout=5m
   kubectl port-forward -n kubeflow svc/minio-service $MINIO_LOCAL_PORT:9000 &
+  echo "Forcing error"
+  exit 1
   MINIO_PID=$!
 
   echo "[Installing KFP] Minio port-forwarded to ${MINIO_LOCAL_PORT}"
@@ -158,7 +160,7 @@ function delete_generated_role() {
 
 function cleanup_kfp() {
   # Clean up Minio
-  if [ ! -z "${MINIO_PID}" ]; then
+  if [[ ! -z "${MINIO_PID:-}" ]]; then
     kill -9 $MINIO_PID || true
   fi
 }


### PR DESCRIPTION
**Description of your changes:**
Fixes a bug where if the MinIO PID was not defined the script would exit early with `unbound variable: ${MINIO_PID}`. Instead, now, we default the variable to an empty string in the case it isn't defined.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.

- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?
    
    If yes, use one of the following options:
  
    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)
