### PR TITLE
fix(backend): fixes useless error message when visualization-server is not accessible. Fixes #4157

### DIFF
--- a/backend/src/apiserver/server/visualization_server_test.go
+++ b/backend/src/apiserver/server/visualization_server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -155,7 +156,30 @@ func TestGenerateVisualization_ServiceNotAvailableError(t *testing.T) {
 	}
 	body, err := server.generateVisualizationFromRequest(request)
 	assert.Nil(t, body)
-	assert.Equal(t, "InternalServerError: Service not available: service not available", err.Error())
+	assert.Contains(t, err.Error(), "500 Internal Server Error")
+}
+
+func TestGenerateVisualization_ServiceHostNotExistError(t *testing.T) {
+	clients, manager, _ := initWithExperiment(t)
+	defer clients.Close()
+	nonExistingServerURL := "http://127.0.0.2:53484"
+	server := &VisualizationServer{
+		resourceManager: manager,
+		serviceURL:      nonExistingServerURL,
+	}
+	visualization := &go_client.Visualization{
+		Type:      go_client.Visualization_ROC_CURVE,
+		Source:    "gs://ml-pipeline/roc/data.csv",
+		Arguments: "{}",
+	}
+	request := &go_client.CreateVisualizationRequest{
+		Visualization: visualization,
+	}
+	body, err := server.generateVisualizationFromRequest(request)
+	assert.Nil(t, body)
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "Unable to verify visualization service aliveness")
+	assert.Contains(t, err.Error(), fmt.Sprintf("dial tcp %s", nonExistingServerURL[7:]))
 }
 
 func TestGenerateVisualization_ServerError(t *testing.T) {


### PR DESCRIPTION
**Description of your changes:**
Fixes #4157 

### What we have before:

When visualization server is not accessible, the error message only mentions: `Service not available`, this doesn't provide enough context and information for users/developers to debug.

### What we have now:
When visualization server is not accessible, the error message is: `visualization server is not responsible`, which provides more information and context. 

### Test we made every time before pushing:
`bazel test //backend/src/apiserver/server:go_default_test --test_filter=TestListRuns_Pagination --test_output=all`

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.

- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?
    
    If yes, use one of the following options:
  
    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)
