### PR TITLE
test: Fix KFP SDK TFX tests by specifying transitive dependency to resolve google-auth mismatch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,8 @@ matrix:
         - cd $TRAVIS_BUILD_DIR/tfx
         - pip3 install --upgrade pip
         - pip3 install --upgrade 'numpy>=1.16,<1.17'
+        # Specify transitive dependency to get around: https://github.com/pypa/pip/issues/8583
+        - pip3 install --upgrade 'google-auth>=1.18.0'
         - set -x
         - set -e
         - python3 setup.py bdist_wheel


### PR DESCRIPTION
**Description of your changes:**

Deep dove onto why the TFX pipeline tests were failing for the KFP SDK, see [this build](https://travis-ci.com/github/kubeflow/pipelines/jobs/360913188). Looks like it was because of an intermittent bug with `pip`, see [here](https://github.com/pypa/pip/issues/8583).

**tl;dr** on the upstream `pip` bug, if an existing version of a package is installed (in KFP SDK case, `google-auth==1.11.3`) then when a package (in our case `google-python-api-client==1.9.3`) is installed and it contains overlapping transitive dependency ranges on `google-auth` (from `kubernetes==11.0.0` we have `google-auth>=1.0.1`, see [here](https://github.com/kubernetes-client/python/blob/v11.0.0/requirements.txt), and from `google-api-core==1.21.0` we have `google-auth>=1.18.0,<2.0dev`, see [here](https://github.com/googleapis/python-api-core/blob/v1.21.0/setup.py#L34)) then `pip` will just resolve randomly to one of these it seems. Sometimes it'll use `google-api-core` (see [this build](https://travis-ci.com/github/kubeflow/pipelines/builds/175090262) and the tests *should* pass, other times it'll resolve to `kubernetes` (see [this build](https://travis-ci.com/github/kubeflow/pipelines/jobs/360913188)) and will fail.

This problem is exacerbated by the fact we run the build on multiple versions of python, thus why it seems to randomly fail on different python versions. I don't believe that is related or a contributing factor.

This change mitigates the issue and fixes the test until the upstream `pip` bug is resolved (I think), I can't actually run the tests as I'm not a Kubeflow contributor yet! So hopefully it will 😅 

No need to `cherry-pick` this change over the release branch unless you want the tests to pass :) 
