### PR TITLE
test: Install a specific version of TFX instead of HEAD in Python SDK tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,9 @@ matrix:
         - sudo ./bazel_installer.sh
         # Install TFX from head
         - cd $TRAVIS_BUILD_DIR
-        - git clone https://github.com/tensorflow/tfx.git
+        - TFX_VERSION="0.22.0"
+        - curl -SL "https://github.com/tensorflow/tfx/archive/v${TFX_VERSION}.tar.gz" | tar -xzv
+        - mv $TRAVIS_BUILD_DIR/tfx-$TFX_VERSION $TRAVIS_BUILD_DIR/tfx
         - cd $TRAVIS_BUILD_DIR/tfx
         - pip3 install --upgrade pip
         - pip3 install --upgrade 'numpy>=1.16,<1.17'


### PR DESCRIPTION
**Description of your changes:**

After #4211 looks like the tests are still failing, see [this build](https://travis-ci.com/github/kubeflow/pipelines/jobs/361561250) and [this build](https://travis-ci.com/github/kubeflow/pipelines/jobs/361767087). Both of these seem to be related to upstream unstable changes in the `tfx/master` branch so wondering if we should just pin a stable version or we could rely on a `pip install tfx >= 0.22` range as it looks like the tests we're executing are installed within the distributed package and that may be less maintenance longer term.

Essentially the goal is to decouple from the HEAD of `tfx` which seems unsurprisingly a little unstable. Not sure if this negates the goal of the introduction of these tests though, see https://github.com/kubeflow/pipelines/pull/2346.

No need to be cherry-picked unless you want the tests to pass.