### PR TITLE
doc(sdk): Fixed documentation by updating the kfp-server-api dependency

### DIFF
--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -20,7 +20,7 @@ googleapis-common-protos==1.51.0  # via google-api-core
 idna==2.9                 # via requests
 importlib-metadata==1.5.0  # via jsonschema
 jsonschema==3.2.0         # via -r requirements.in
-kfp-server-api==0.3.0     # via -r requirements.in
+kfp-server-api==1.0.0     # via -r requirements.in
 kubernetes==11.0.0        # via -r requirements.in
 oauthlib==3.1.0           # via requests-oauthlib
 protobuf==3.11.3          # via google-api-core, googleapis-common-protos


### PR DESCRIPTION
I've fixed the OpenAPI documentation generation and @Bobgy has generated the improved `kfp-server-api` package. However the documentation hasn't changed on the docs website since the `requirements.txt` was still pinning the old version.

P.S. The kfp-server-api dependency wasn't updated in https://github.com/kubeflow/pipelines/pull/3918/ and https://github.com/kubeflow/pipelines/pull/3566 We might want to add rules to require updating `requirements.in` and `requirements.txt` when changing the dependencies.