### PR TITLE
feat(deployment): Add env/platform-agnostic-pns standalone deployment option

### DIFF
--- a/manifests/kustomize/base/argo/workflow-controller-configmap.yaml
+++ b/manifests/kustomize/base/argo/workflow-controller-configmap.yaml
@@ -7,6 +7,7 @@ data:
     {
     namespace: $(kfp-namespace),
     executorImage: gcr.io/ml-pipeline/argoexec:v2.7.5-license-compliance,
+    containerRuntimeExecutor: $(kfp-container-runtime-executor),
     artifactRepository:
     {
         s3: {

--- a/manifests/kustomize/base/kustomization.yaml
+++ b/manifests/kustomize/base/kustomization.yaml
@@ -46,5 +46,12 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.bucketName
+- name: kfp-container-runtime-executor
+  objref:
+    kind: ConfigMap
+    name: pipeline-install-config
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.containerRuntimeExecutor
 configurations:
 - params.yaml

--- a/manifests/kustomize/base/params.env
+++ b/manifests/kustomize/base/params.env
@@ -6,3 +6,10 @@ mlmdDb=metadb
 cacheDb=cachedb
 pipelineDb=mlpipeline
 bucketName=mlpipeline
+
+
+## containerRuntimeExecutor: A workflow executor is a process
+## that allows Argo to perform certain actions like monitoring pod logs,
+## artifacts, container lifecycles, etc..
+## Doc: https://github.com/argoproj/argo/blob/master/docs/workflow-executors.md
+containerRuntimeExecutor=docker

--- a/manifests/kustomize/env/platform-agnostic-pns/kustomization.yaml
+++ b/manifests/kustomize/env/platform-agnostic-pns/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../platform-agnostic
+
+# Identifier for application manager to apply ownerReference.
+# The ownerReference ensures the resources get garbage collected
+# when application is deleted.
+commonLabels:
+  application-crd-id: kubeflow-pipelines
+
+# !!! If you want to customize the namespace,
+# please refer sample/cluster-scoped-resources to update the namespace for cluster-scoped-resources
+namespace: kubeflow
+
+# Used by Kustomize
+configMapGenerator:
+  - name: pipeline-install-config
+    env: params.env
+    behavior: merge

--- a/manifests/kustomize/env/platform-agnostic-pns/params.env
+++ b/manifests/kustomize/env/platform-agnostic-pns/params.env
@@ -1,0 +1,1 @@
+containerRuntimeExecutor=pns


### PR DESCRIPTION
**Description of your changes:**
Add `containerRuntimeExecutor` explicit type on `workflow-controller-configmap.yaml` configuration.  
`docker` is the default.
platform-agnostic-pns type configuration needed by Kind, K3s and Minikube.
Part of https://github.com/kubeflow/pipelines/issues/4256
Related to: https://github.com/kubeflow/website/pull/2056

**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

   PR titles examples:
    * `feat(deployment): configurable containerRuntimeExecutor` fixes (part of) https://github.com/kubeflow/pipelines/issues/4256
   
example new PNS feature:
```
kubectl kustomize  manifests/kustomize/env/platform-agnostic-pns | grep containerRuntimeExecutor -A 5
  containerRuntimeExecutor: pns
  dbHost: mysql
  dbPort: "3306"
  mlmdDb: metadb
  pipelineDb: mlpipeline
kind: ConfigMap
--
    containerRuntimeExecutor: pns,
    artifactRepository:
    {
        s3: {
            bucket: mlpipeline,
            keyPrefix: artifacts,
```
example with docker feature:
```
 kubectl kustomize  manifests/kustomize/env/platform-agnostic | grep containerRuntimeExecutor -A 5
  containerRuntimeExecutor: docker
  dbHost: mysql
  dbPort: "3306"
  mlmdDb: metadb
  pipelineDb: mlpipeline
kind: ConfigMap
--
    containerRuntimeExecutor: docker,
    artifactRepository:
    {
        s3: {
            bucket: mlpipeline,
            keyPrefix: artifacts,
```



