### PR TITLE
chore(backend): fixes typo empty space

### DIFF
--- a/backend/build_api_server.sh
+++ b/backend/build_api_server.sh
@@ -1,4 +1,4 @@
-# !/bin/bash
+#!/bin/bash
 #
 # Copyright 2019 Google LLC
 #


### PR DESCRIPTION
Fix empty space on the script, it could raise an error when using
different shell as zsh.

**Description of your changes:**
Just a typo on the shell script.

**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

