### PR TITLE
feat(deployment): KFP standalone should keep user data when application deleted

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/application.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/application.yaml
@@ -41,8 +41,6 @@ spec:
   - group: v1
     kind: Service
   - group: v1
-    kind: PersistentVolumeClaim
-  - group: v1
     kind: ConfigMap
   - group: v1
     kind: Secret

--- a/manifests/kustomize/base/pipeline-application.yaml
+++ b/manifests/kustomize/base/pipeline-application.yaml
@@ -40,8 +40,6 @@ spec:
     - group: v1
       kind: Service
     - group: v1
-      kind: PersistentVolumeClaim
-    - group: v1
       kind: ConfigMap
     - group: v1
       kind: Secret


### PR DESCRIPTION
**Description of your changes:**
KFP standalone should keep user data when application deleted.

There's currently a behavior difference when deleting KFP application from https://cloud.console.google.com/ai-platform/pipelines/clusters.

If AI Platform Pipelines is deleted, it keeps data in the cluster.

If KFP standalone is deleted, it deletes data too (non recoverable because underlying GCE persistent disk is auto deleted too). This behavior is very dangerous to me, especially when we document to users they should delete AI Platform Pipelines instance to upgrade.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
- [x] Do you want this pull request (PR) cherry-picked into the current release branch?