### PR TITLE
fix(backend): reduce confusing ReadArtifact errors for metrics in api server. Fixes #3699

### DIFF
--- a/backend/src/agent/persistence/client/pipeline_client_fake.go
+++ b/backend/src/agent/persistence/client/pipeline_client_fake.go
@@ -25,6 +25,7 @@ type PipelineClientFake struct {
 	scheduledWorkflows        map[string]*util.ScheduledWorkflow
 	err                       error
 	artifacts                 map[string]*api.ReadArtifactResponse
+	readArtifactRequest       *api.ReadArtifactRequest
 	reportedMetricsRequest    *api.ReportRunMetricsRequest
 	reportMetricsResponseStub *api.ReportRunMetricsResponse
 	reportMetricsErrorStub    error
@@ -57,6 +58,7 @@ func (p *PipelineClientFake) ReportScheduledWorkflow(swf *util.ScheduledWorkflow
 }
 
 func (p *PipelineClientFake) ReadArtifact(request *api.ReadArtifactRequest) (*api.ReadArtifactResponse, error) {
+	p.readArtifactRequest = request
 	return p.artifacts[request.String()], nil
 }
 
@@ -79,6 +81,10 @@ func (p *PipelineClientFake) GetScheduledWorkflow(namespace string, name string)
 
 func (p *PipelineClientFake) StubArtifact(request *api.ReadArtifactRequest, response *api.ReadArtifactResponse) {
 	p.artifacts[request.String()] = response
+}
+
+func (p *PipelineClientFake) GetReadArtifactRequest() *api.ReadArtifactRequest {
+	return p.readArtifactRequest
 }
 
 func (p *PipelineClientFake) StubReportRunMetrics(response *api.ReportRunMetricsResponse, err error) {

--- a/backend/src/agent/persistence/worker/metrics_reporter.go
+++ b/backend/src/agent/persistence/worker/metrics_reporter.go
@@ -94,7 +94,7 @@ func (r MetricsReporter) collectNodeMetricsOrNil(
 	if !nodeStatus.Completed() {
 		return nil, nil
 	}
-	metricsJSON, err := r.readNodeMetricsJSONOrEmpty(runID, nodeStatus.ID)
+	metricsJSON, err := r.readNodeMetricsJSONOrEmpty(runID, nodeStatus)
 	if err != nil || metricsJSON == "" {
 		return nil, err
 	}
@@ -126,10 +126,24 @@ func (r MetricsReporter) collectNodeMetricsOrNil(
 	return reportMetricsRequest.GetMetrics(), nil
 }
 
-func (r MetricsReporter) readNodeMetricsJSONOrEmpty(runID string, nodeID string) (string, error) {
+func (r MetricsReporter) readNodeMetricsJSONOrEmpty(runID string, nodeStatus workflowapi.NodeStatus) (string, error) {
+	if nodeStatus.Outputs == nil || nodeStatus.Outputs.Artifacts == nil {
+		return "", nil // No output artifacts, skip the reporting
+	}
+
+	var foundMetricsArtifact bool = false
+	for _, artifact := range nodeStatus.Outputs.Artifacts {
+		if artifact.Name == metricsArtifactName {
+			foundMetricsArtifact = true
+		}
+	}
+	if !foundMetricsArtifact {
+		return "", nil // No metrics artifact, skip the reporting
+	}
+
 	artifactRequest := &api.ReadArtifactRequest{
 		RunId:        runID,
-		NodeId:       nodeID,
+		NodeId:       nodeStatus.ID,
 		ArtifactName: metricsArtifactName,
 	}
 	artifactResponse, err := r.pipelineClient.ReadArtifact(artifactRequest)


### PR DESCRIPTION
**Description of your changes:**
Fixes https://github.com/kubeflow/pipelines/issues/3699

Changes:
* persistence agent only reads metrics artifact when it can find the output artifact in workflow status, so api server will not receive so many ReadArtifact requests that will fail for sure.

Manual Verification:
I deployed the persistence agent image: gcr.io/ml-pipeline-test/112bdfa56ddb54dbc05499d51ba6386362838459/persistenceagent@sha256:bc95106ebc84292652abb41b0088fa55a9b11dd3e6939d70c81b8ba64105568d on my cluster and verified running a few pipelines.

I can no longer see the confusing error messages while metrics are still reported properly.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
- [x] Do you want this pull request (PR) cherry-picked into the current release branch?