### PR TITLE
feat(sdk): add aws region field in use_aws_secret in kfp sdk

### DIFF
--- a/sdk/python/kfp/aws.py
+++ b/sdk/python/kfp/aws.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def use_aws_secret(secret_name='aws-secret', aws_access_key_id_name='AWS_ACCESS_KEY_ID', aws_secret_access_key_name='AWS_SECRET_ACCESS_KEY'):
+def use_aws_secret(secret_name='aws-secret', aws_access_key_id_name='AWS_ACCESS_KEY_ID', aws_secret_access_key_name='AWS_SECRET_ACCESS_KEY', aws_region=None):
     """An operator that configures the container to use AWS credentials.
 
     AWS doesn't create secret along with kubeflow deployment and it requires users
@@ -32,31 +32,38 @@ def use_aws_secret(secret_name='aws-secret', aws_access_key_id_name='AWS_ACCESS_
 
     def _use_aws_secret(task):
         from kubernetes import client as k8s_client
-        (
-            task.container
-                .add_env_variable(
-                    k8s_client.V1EnvVar(
-                        name='AWS_ACCESS_KEY_ID',
-                        value_from=k8s_client.V1EnvVarSource(
-                            secret_key_ref=k8s_client.V1SecretKeySelector(
-                                name=secret_name,
-                                key=aws_access_key_id_name
-                            )
+        task.container \
+            .add_env_variable(
+                k8s_client.V1EnvVar(
+                    name='AWS_ACCESS_KEY_ID',
+                    value_from=k8s_client.V1EnvVarSource(
+                        secret_key_ref=k8s_client.V1SecretKeySelector(
+                            name=secret_name,
+                            key=aws_access_key_id_name
                         )
                     )
                 )
-                .add_env_variable(
-                    k8s_client.V1EnvVar(
-                        name='AWS_SECRET_ACCESS_KEY',
-                        value_from=k8s_client.V1EnvVarSource(
-                            secret_key_ref=k8s_client.V1SecretKeySelector(
-                                name=secret_name,
-                                key=aws_secret_access_key_name
-                            )
+            ) \
+            .add_env_variable(
+                k8s_client.V1EnvVar(
+                    name='AWS_SECRET_ACCESS_KEY',
+                    value_from=k8s_client.V1EnvVarSource(
+                        secret_key_ref=k8s_client.V1SecretKeySelector(
+                            name=secret_name,
+                            key=aws_secret_access_key_name
                         )
                     )
                 )
-        )
+            )
+
+        if aws_region:
+            task.container \
+                .add_env_variable(
+                    k8s_client.V1EnvVar(
+                        name='AWS_REGION',
+                        value=aws_region
+                    )
+                )
         return task
 
     return _use_aws_secret

--- a/sdk/python/tests/dsl/aws_extensions_tests.py
+++ b/sdk/python/tests/dsl/aws_extensions_tests.py
@@ -21,10 +21,11 @@ import inspect
 class TestAwsExtension(unittest.TestCase):
   def test_default_aws_secret_name(self):
     spec = inspect.getfullargspec(use_aws_secret)
-    assert len(spec.defaults) == 3
+    assert len(spec.defaults) == 4
     assert spec.defaults[0] == 'aws-secret'
     assert spec.defaults[1] == 'AWS_ACCESS_KEY_ID'
     assert spec.defaults[2] == 'AWS_SECRET_ACCESS_KEY'
+    assert spec.defaults[3] == None
 
   def test_use_aws_secret(self):
       op1 = ContainerOp(name='op1', image='image')
@@ -37,3 +38,20 @@ class TestAwsExtension(unittest.TestCase):
           assert op1.container.env[index].value_from.secret_key_ref.name == 'myaws-secret'
           assert op1.container.env[index].value_from.secret_key_ref.key == expected_key
           index += 1
+
+  def test_use_aws_secret_with_region(self):
+      op1 = ContainerOp(name='op1', image='image')
+      aws_region = 'us-west-2'
+      op1 = op1.apply(use_aws_secret('myaws-secret', 'key_id', 'access_key', aws_region))
+      assert len(op1.container.env) == 3
+
+      index = 0
+      for expected_name, expected_key in [('AWS_ACCESS_KEY_ID', 'key_id'), ('AWS_SECRET_ACCESS_KEY', 'access_key')]:
+          assert op1.container.env[index].name == expected_name
+          assert op1.container.env[index].value_from.secret_key_ref.name == 'myaws-secret'
+          assert op1.container.env[index].value_from.secret_key_ref.key == expected_key
+          index += 1
+
+      for expected_name, expected_key in [('AWS_REGION', aws_region)]:
+          assert op1.container.env[index].name == expected_name
+          assert op1.container.env[index].value == expected_key


### PR DESCRIPTION
**Description of your changes:**
`use_aws_secret` didn't consider `AWS_REGION`, depends on the AWS SDK version and services to requests, some of the applications needs `AWS_REGION` to finish request. One example is Tensorflow. 

This PR adds an extra optional field `aws_region` in  `use_aws_secret` util for user who need it. 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.

- [x] Do you want this pull request (PR) cherry-picked into the current release branch?
    
    If yes, use one of the following options:
  
    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)
