### PR TITLE
fix(sdk): Fix opsgroups dependency resolution

### DIFF
--- a/samples/core/execution_order/group_exution_order.py
+++ b/samples/core/execution_order/group_exution_order.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import kfp
+from kfp import dsl
+
+
+@dsl.graph_component
+def echo1_graph_component(text1):
+  """A two step graph component with an explicitly defined execution order."""
+  step1_task = dsl.ContainerOp(
+      name='echo1-task1',
+      image='library/bash:4.4.23',
+      command=['sh', '-c'],
+      arguments=['echo "$0"', text1])
+  step2_task = dsl.ContainerOp(
+      name='echo1-task2',
+      image='library/bash:4.4.23',
+      command=['sh', '-c'],
+      arguments=['echo "$0"', text1])
+  step2_task.after(step1_task)
+
+
+@dsl.graph_component
+def echo2_graph_component(text2):
+  """A two step graph component with an explicitly defined execution order."""
+  step1_task = dsl.ContainerOp(
+      name='echo2-task1',
+      image='library/bash:4.4.23',
+      command=['sh', '-c'],
+      arguments=['echo "$0"', text2])
+  step2_task = dsl.ContainerOp(
+      name='echo2-task2',
+      image='library/bash:4.4.23',
+      command=['sh', '-c'],
+      arguments=['echo "$0"', text2])
+  step2_task.after(step1_task)
+
+
+@dsl.pipeline(
+    name='Execution order pipeline',
+    description='A pipeline to demonstrate execution order management.'
+)
+def execution_order_pipeline(text1='message 1', text2='message 2'):
+  """A two step pipeline with an explicitly defined execution order."""
+  step1_graph_component = echo1_graph_component(text1)
+  step2_graph_component = echo2_graph_component(text2)
+  step2_graph_component.after(step1_graph_component)
+
+if __name__ == '__main__':
+  kfp.compiler.Compiler().compile(execution_order_pipeline, __file__ + '.yaml')

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -367,8 +367,8 @@ class Compiler(object):
       for op_name in upstream_op_names:
         if op_name in pipeline.ops:
           upstream_op = pipeline.ops[op_name]
-        elif op_name in opsgroups_groups:
-          upstream_op = opsgroups_groups[op_name]
+        elif op_name in opsgroups:
+          upstream_op = opsgroups[op_name]
         else:
           raise ValueError('compiler cannot find the ' + op_name)
         upstream_groups, downstream_groups = \


### PR DESCRIPTION
**Description of your changes:**
There is a bug in the `Compiler` class when it resolves dependencies for `Op`s and `OpsGroup`s. The nature of this bug is the following: when a dependency is an `OpsGroup`, compiler fails with an uncaught exception because it tries to access the wrong variable. This diff fixes this bug by changing the variable to access.

The example from this diff surfaces the bug and proves the fix: without the fix execution fails with the following exception:
```
Traceback (most recent call last):
  File "./group_exution_order.py", line 62, in <module>
    kfp.compiler.Compiler().compile(execution_order_pipeline, __file__ + '.yaml')
  File "/usr/local/lib/python3.8/site-packages/kfp/compiler/compiler.py", line 902, in compile
    self._create_and_write_workflow(
  File "/usr/local/lib/python3.8/site-packages/kfp/compiler/compiler.py", line 955, in _create_and_write_workflow
    workflow = self._create_workflow(
  File "/usr/local/lib/python3.8/site-packages/kfp/compiler/compiler.py", line 833, in _create_workflow
    workflow = self._create_pipeline_workflow(
  File "/usr/local/lib/python3.8/site-packages/kfp/compiler/compiler.py", line 642, in _create_pipeline_workflow
    templates = self._create_dag_templates(pipeline, op_transformers)
  File "/usr/local/lib/python3.8/site-packages/kfp/compiler/compiler.py", line 603, in _create_dag_templates
    dependencies = self._get_dependencies(
  File "/usr/local/lib/python3.8/site-packages/kfp/compiler/compiler.py", line 381, in _get_dependencies
    _get_dependency_opsgroup(root_group, dependencies)
  File "/usr/local/lib/python3.8/site-packages/kfp/compiler/compiler.py", line 379, in _get_dependency_opsgroup
    _get_dependency_opsgroup(subgroup, dependencies)
  File "/usr/local/lib/python3.8/site-packages/kfp/compiler/compiler.py", line 375, in _get_dependency_opsgroup
    self._get_uncommon_ancestors(op_groups, opsgroups_groups, upstream_op, group)
  File "/usr/local/lib/python3.8/site-packages/kfp/compiler/compiler.py", line 145, in _get_uncommon_ancestors
    if op1.name in op_groups:
AttributeError: 'list' object has no attribute 'name'
```
With the fix execution succeeds and produces a correct yaml file.

If the example does not comply with the high standards I will be happy to remove it from PR - I mainly added it to surface the bug and its fix.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention.
- [x] Do you want this pull request (PR) cherry-picked into the current release branch? *- Yes, please! Can I please have `cherrypick-approved` label added to the pull request when it gets accepted? Thanks!*
    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.