### PR TITLE
fix(cache): adds certificate approver permission to kubeflow-pipelines-cache-deployer-role. Fixes #4138 (#4246)

### DIFF
--- a/manifests/kustomize/base/cache-deployer/cluster-scoped/cache-deployer-clusterrole.yaml
+++ b/manifests/kustomize/base/cache-deployer/cluster-scoped/cache-deployer-clusterrole.yaml
@@ -25,3 +25,11 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - signers
+  resourceNames:
+  - kubernetes.io/*
+  verbs:
+  - approve  


### PR DESCRIPTION
Release - Back-port #4246 to master

The https://github.com/kubeflow/pipelines/pull/4246 PR has been merged to the release-1.0 branch instead of master. This commit fixes that