### PR TITLE
fix(sdk): Ensure we pass through correct namespace when using the kfp cli

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -146,6 +146,7 @@ class Client(object):
       config.ssl_ca_cert = ssl_ca_cert
 
     host = host or ''
+    namespace = 'kubeflow'  # TODO AIP-1676 Introduce api-namespace and experiment-namespace contents into KFP CLI/SDK :/
     # Preprocess the host endpoint to prevent some common user mistakes.
     if not client_id:
       # always preserving the protocol (http://localhost requires it)

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -146,7 +146,6 @@ class Client(object):
       config.ssl_ca_cert = ssl_ca_cert
 
     host = host or ''
-    namespace = 'kubeflow'  # TODO AIP-1676 Introduce api-namespace and experiment-namespace contents into KFP CLI/SDK :/
     # Preprocess the host endpoint to prevent some common user mistakes.
     if not client_id:
       # always preserving the protocol (http://localhost requires it)

--- a/sdk/python/kfp/cli/cli.py
+++ b/sdk/python/kfp/cli/cli.py
@@ -25,16 +25,24 @@ from .experiment import experiment
 @click.option('--endpoint', help='Endpoint of the KFP API service to connect.')
 @click.option('--iap-client-id', help='Client ID for IAP protected endpoint.')
 @click.option('-n', '--namespace', default='kubeflow', help='Kubernetes namespace to run the pipeline within.')
-@click.option('-an', '--api-namespace', default=None, help='Kubernetes namespace to connect to the KFP API.')
+@click.option('-an', '--api-namespace', help='Kubernetes namespace to connect to the KFP API.')
 @click.option('--other-client-id', help='Client ID for IAP protected endpoint to obtain the refresh token.')
 @click.option('--other-client-secret', help='Client ID for IAP protected endpoint to obtain the refresh token.')
+@click.option('--userid', help='Client ID for IAP protected endpoint to obtain the refresh token.')
 @click.pass_context
-def cli(ctx, endpoint, iap_client_id, namespace, api_namespace, other_client_id, other_client_secret):
+def cli(ctx, endpoint, iap_client_id, namespace, api_namespace, other_client_id, other_client_secret, userid):
     """kfp is the command line interface to KFP service."""
     if ctx.invoked_subcommand == 'diagnose_me':
           # Do not create a client for diagnose_me
           return
-    ctx.obj['client'] = Client(endpoint, iap_client_id, api_namespace or namespace, other_client_id, other_client_secret)
+    ctx.obj['client'] = Client(
+        host=endpoint,
+        client_id=iap_client_id,
+        namespace=api_namespace or namespace,
+        other_client_id=other_client_id,
+        other_client_secret=other_client_secret,
+        userid=userid
+    )
     ctx.obj['namespace']= namespace
 
 def main():

--- a/sdk/python/kfp/cli/cli.py
+++ b/sdk/python/kfp/cli/cli.py
@@ -24,16 +24,17 @@ from .experiment import experiment
 @click.group()
 @click.option('--endpoint', help='Endpoint of the KFP API service to connect.')
 @click.option('--iap-client-id', help='Client ID for IAP protected endpoint.')
-@click.option('-n', '--namespace', default='kubeflow', help='Kubernetes namespace to connect to the KFP API.')
+@click.option('-n', '--namespace', default='kubeflow', help='Kubernetes namespace to run the pipeline within.')
+@click.option('-an', '--api-namespace', default=None, help='Kubernetes namespace to connect to the KFP API.')
 @click.option('--other-client-id', help='Client ID for IAP protected endpoint to obtain the refresh token.')
 @click.option('--other-client-secret', help='Client ID for IAP protected endpoint to obtain the refresh token.')
 @click.pass_context
-def cli(ctx, endpoint, iap_client_id, namespace, other_client_id, other_client_secret):
+def cli(ctx, endpoint, iap_client_id, namespace, api_namespace, other_client_id, other_client_secret):
     """kfp is the command line interface to KFP service."""
     if ctx.invoked_subcommand == 'diagnose_me':
           # Do not create a client for diagnose_me
           return
-    ctx.obj['client'] = Client(endpoint, iap_client_id, namespace, other_client_id, other_client_secret)
+    ctx.obj['client'] = Client(endpoint, iap_client_id, api_namespace or namespace, other_client_id, other_client_secret)
     ctx.obj['namespace']= namespace
 
 def main():

--- a/sdk/python/kfp/cli/experiment.py
+++ b/sdk/python/kfp/cli/experiment.py
@@ -19,8 +19,9 @@ def experiment():
 def create(ctx, description, name):
     """Create an experiment"""
     client = ctx.obj["client"]
+    namespace = ctx.obj["namespace"]
 
-    response = client.create_experiment(name, description=description)
+    response = client.create_experiment(name, description=description, namespace=namespace)
     logging.info("Experiment {} has been submitted\n".format(name))
     _display_experiment(response)
 
@@ -35,10 +36,12 @@ def create(ctx, description, name):
 def list(ctx, max_size):
     """List experiments"""
     client = ctx.obj['client']
+    namespace = ctx.obj["namespace"]
 
     response = client.experiments.list_experiment(
         page_size=max_size,
-        sort_by="created_at desc"
+        sort_by="created_at desc",
+        namespace=namespace
     )
     if response.experiments:
         _display_experiments(response.experiments)
@@ -52,27 +55,29 @@ def list(ctx, max_size):
 def get(ctx, experiment_id):
     """Get detailed information about an experiment"""
     client = ctx.obj["client"]
+    namespace = ctx.obj["namespace"]
 
-    response = client.get_experiment(experiment_id)
+    response = client.get_experiment(experiment_id, namespace)
     _display_experiment(response)
 
 
-@experiment.command()
-@click.argument("experiment-id")
-@click.pass_context
-def delete(ctx, experiment_id):
-    """Delete an experiment"""
+# TODO Add in client method for deleting experiments.
+# @experiment.command()
+# @click.argument("experiment-id")
+# @click.pass_context
+# def delete(ctx, experiment_id):
+#     """Delete an experiment"""
 
-    confirmation = "Caution. The RunDetails page could have an issue" \
-                   " when it renders a run that has no experiment." \
-                   " Do you want to continue?"
-    if not click.confirm(confirmation):
-        return
+#     confirmation = "Caution. The RunDetails page could have an issue" \
+#                    " when it renders a run that has no experiment." \
+#                    " Do you want to continue?"
+#     if not click.confirm(confirmation):
+#         return
 
-    client = ctx.obj["client"]
+#     client = ctx.obj["client"]
 
-    client.experiments.delete_experiment(id=experiment_id)
-    print("{} is deleted.".format(experiment_id))
+#     client.experiments.delete_experiment(id=experiment_id)
+#     print("{} is deleted.".format(experiment_id))
 
 
 def _display_experiments(experiments):

--- a/sdk/python/kfp/cli/run.py
+++ b/sdk/python/kfp/cli/run.py
@@ -34,7 +34,7 @@ def run():
 def list(ctx, experiment_id, max_size):
     """list recent KFP runs"""
     client = ctx.obj['client']
-    response = client.list_runs(experiment_id=experiment_id, page_size=max_size, sort_by='created_at desc')
+    response = client.list_runs(experiment_id=experiment_id, page_size=max_size, sort_by='created_at desc', namespace=ctx.obj['namespace'])
     if response and response.runs:
         _print_runs(response.runs)
     else:
@@ -61,7 +61,7 @@ def submit(ctx, experiment_name, run_name, package_file, pipeline_id, watch, ver
         sys.exit(1)
 
     arg_dict = dict(arg.split('=') for arg in args)
-    experiment = client.create_experiment(experiment_name)
+    experiment = client.create_experiment(experiment_name, namespace=ctx.obj['namespace'])
     run = client.run_pipeline(experiment.id, run_name, package_file, arg_dict, pipeline_id, version_id=version)
     print('Run {} is submitted'.format(run.id))
     _display_run(client, namespace, run.id, watch)


### PR DESCRIPTION
**FYI This PR is still in draft, no need to review yet!**

**Description of your changes:**

We run the KFP API Server in the `kubeflow` namespace but want to run pipelines in a separate namespace, currently the `kfp` CLI only has configuration for one namespace so need to extend it to have conceptually two.

**Checklist:**

Would be good to cherry pick this please.
