### PR TITLE
fix(backend): add `MaxCallRecvMsgSize(math.MaxInt32)` to proxy server

### DIFF
--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -154,7 +154,7 @@ func startHttpProxy(resourceManager *resource.ResourceManager) {
 
 func registerHttpHandlerFromEndpoint(handler RegisterHttpHandlerFromEndpoint, serviceName string, ctx context.Context, mux *runtime.ServeMux) {
 	endpoint := "localhost" + *rpcPortFlag
-	opts := []grpc.DialOption{grpc.WithInsecure()}
+	opts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32))}
 
 	if err := handler(ctx, mux, endpoint, opts); err != nil {
 		glog.Fatalf("Failed to register %v handler: %v", serviceName, err)


### PR DESCRIPTION
**Description of your changes:**
The `MaxCallRecvMsgSize` of the backend gRPC server is [2GB](https://github.com/kubeflow/pipelines/blob/master/backend/src/apiserver/main.go#L93)
But the `MaxCallRecvMsgSize` of its proxy server is not specified. So the default value has been set to [4MB](https://github.com/kubeflow/pipelines/blob/master/backend/src/apiserver/main.go#L157)

So I have faced a problem that following codes don't work.

```python3
configuration = kfp_server_api.Configuration(
    host = HOST
)
with kfp_server_api.ApiClient(configuration) as api_client:
    api_instance = kfp_server_api.RunServiceApi(api_client)
    api_response = api_instance.read_artifact(
        run_id=RUN_ID,
        node_id=NODE_ID,
        artifact_name=ARTIFACT_NAME
    )
```

The error message:
```
Traceback (most recent call last):
  File "download.py", line 73, in <module>
    main()
  File "download.py", line 68, in main
    artifact_name=f"merge-{artifact_name}"
  File "/home/zsaladin/Projects/kfplayground/venv/lib/python3.7/site-packages/kfp_server_api/api/run_service_api.py", line 728, in read_artifact
    return self.read_artifact_with_http_info(run_id, node_id, artifact_name, **kwargs)  # noqa: E501
  File "/home/zsaladin/Projects/kfplayground/venv/lib/python3.7/site-packages/kfp_server_api/api/run_service_api.py", line 840, in read_artifact_with_http_info
    collection_formats=collection_formats)
  File "/home/zsaladin/Projects/kfplayground/venv/lib/python3.7/site-packages/kfp_server_api/api_client.py", line 383, in call_api
    _preload_content, _request_timeout, _host)
  File "/home/zsaladin/Projects/kfplayground/venv/lib/python3.7/site-packages/kfp_server_api/api_client.py", line 202, in __call_api
    raise e
  File "/home/zsaladin/Projects/kfplayground/venv/lib/python3.7/site-packages/kfp_server_api/api_client.py", line 199, in __call_api
    _request_timeout=_request_timeout)
  File "/home/zsaladin/Projects/kfplayground/venv/lib/python3.7/site-packages/kfp_server_api/api_client.py", line 407, in request
    headers=headers)
  File "/home/zsaladin/Projects/kfplayground/venv/lib/python3.7/site-packages/kfp_server_api/rest.py", line 248, in GET
    query_params=query_params)
  File "/home/zsaladin/Projects/kfplayground/venv/lib/python3.7/site-packages/kfp_server_api/rest.py", line 238, in request
    raise ApiException(http_resp=r)
kfp_server_api.exceptions.ApiException: (429)
Reason: Too Many Requests
HTTP response headers: HTTPHeaderDict({'X-Powered-By': 'Express', 'content-type': 'application/json', 'grpc-metadata-content-type': 'application/grpc', 'date': 'Sun, 23 Aug 2020 07:27:07 GMT', 'content-length': '156', 'connection': 'close'})
HTTP response body: {"error":"grpc: received message larger than max (25333822 vs. 4194304)","message":"grpc: received message larger than max (25333822 vs. 4194304)","code":8}
```

I believe the proxy server should have the same `MaxCallRecvMsgSize` as gRPC server's.

**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.

- [X] Do you want this pull request (PR) cherry-picked into the current release branch?
    
    If yes, use one of the following options:
  
    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)
