### PR TITLE
feat(sdk): add the "optional" option to the pipeline YAML file

### DIFF
--- a/sdk/python/kfp/components/_structures.py
+++ b/sdk/python/kfp/components/_structures.py
@@ -90,6 +90,8 @@ class OutputSpec(ModelBase):
         type: Optional[TypeSpecType] = None,
         description: Optional[str] = None,
         annotations: Optional[Dict[str, Any]] = None,
+        default: Optional[str] = None,
+        optional: Optional[bool] = False,
     ):
         super().__init__(locals())
 

--- a/sdk/python/kfp/components/modelbase.py
+++ b/sdk/python/kfp/components/modelbase.py
@@ -196,7 +196,7 @@ def convert_object_to_struct(obj, serialized_names: Mapping[str, str] = {}):
             result[attr_name] = {k: (v.to_dict() if hasattr(v, 'to_dict') else v) for k, v in value.items()}
         else:
             param = signature.parameters.get(python_name, None)
-            if param is None or param.default == inspect.Parameter.empty or value != param.default:
+            if param is None or param.default == inspect.Parameter.empty or value != param.default or attr_name == 'optional' or attr_name == 'default':
                 result[attr_name] = value
 
     return result


### PR DESCRIPTION
**Description of your changes:**
In the original project code, the output of a component does not have `optional` options, but the Argo engine does.
In this case:
```
kfp.dsl.Condition(....)
    task1 = op1()
task2 = op2(input=task1.outputs['out'])
```
If condition is not satisfied, op2 will not be able to get op1's output, then there will be an error when running the pipeline, but this problem can be solved by adding the `optional` option.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.

- [x] Do you want this pull request (PR) cherry-picked into the current release branch?
    
    If yes, use one of the following options:
  
    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)
