### PR TITLE
fix(components): Simplified the build of the kubeflow - dnntrainer component. Fixes #4416

### DIFF
--- a/components/kubeflow/dnntrainer/Dockerfile
+++ b/components/kubeflow/dnntrainer/Dockerfile
@@ -15,16 +15,9 @@
 ARG TF_TAG
 FROM tensorflow/tensorflow:$TF_TAG
 
-RUN apt-get update -y
-
-RUN apt-get install --no-install-recommends -y -q ca-certificates python-dev python-setuptools \
-                                                  wget unzip git
-
-RUN apt-get install --no-install-recommends -y -q build-essential && \
-    pip install pyyaml==3.12 six==1.11.0 \
+RUN pip install pyyaml==3.12 six==1.11.0 \
         tensorflow-transform==0.23.0 \
-        tensorflow-model-analysis==0.23.0 && \
-    apt-get --purge autoremove -y build-essential
+        tensorflow-model-analysis==0.23.0
 
 ADD build /ml
 


### PR DESCRIPTION
Currently the build starts with python3-based tensorflow image, but then installs python2 and  all the packages.
This PR stops installing and using python2.
This change speeds-up the build significantly