### PR TITLE
fix(backend): skip reporting native Argo workflows which do not have Run ID label. Fixes #3584

### DIFF
--- a/backend/src/agent/persistence/worker/persistence_worker_test.go
+++ b/backend/src/agent/persistence/worker/persistence_worker_test.go
@@ -45,6 +45,7 @@ func TestPersistenceWorker_Success(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "MY_NAMESPACE",
 			Name:      "MY_NAME",
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: "MY_UUID"},
 		},
 	})
 	workflowClient := client.NewWorkflowClientFake()
@@ -137,6 +138,7 @@ func TestPersistenceWorker_ReportWorkflowRetryableError(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "MY_NAMESPACE",
 			Name:      "MY_NAME",
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: "MY_UUID"},
 		},
 	})
 	workflowClient := client.NewWorkflowClientFake()

--- a/backend/src/agent/persistence/worker/workflow_saver.go
+++ b/backend/src/agent/persistence/worker/workflow_saver.go
@@ -56,6 +56,10 @@ func (s *WorkflowSaver) Save(key string, namespace string, name string, nowEpoch
 			"Workflow (%s): transient failure: %v", key, err)
 
 	}
+	if _, ok := wf.ObjectMeta.Labels[util.LabelKeyWorkflowRunId]; !ok {
+		log.Infof("Skip syncing Workflow (%v): workflow does not have a Run ID label.", name)
+		return nil
+	}
 	if wf.PersistedFinalState() && time.Now().Unix()-wf.FinishedAt() < s.ttlSecondsAfterWorkflowFinish {
 		// Skip persisting the workflow if the workflow is finished
 		// and the workflow hasn't being passing the TTL

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -686,7 +686,7 @@ func (r *ResourceManager) DeleteJob(jobID string) error {
 func (r *ResourceManager) ReportWorkflowResource(workflow *util.Workflow) error {
 	if _, ok := workflow.ObjectMeta.Labels[util.LabelKeyWorkflowRunId]; !ok {
 		// Skip reporting if the workflow doesn't have the run id label
-		return util.NewInvalidInputError("Workflow missing the Run ID label")
+		return util.NewInvalidInputError("Workflow[%s] missing the Run ID label", workflow.Name)
 	}
 	runId := workflow.ObjectMeta.Labels[util.LabelKeyWorkflowRunId]
 	jobId := workflow.ScheduledWorkflowUUIDAsStringOrEmpty()

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -1435,6 +1435,19 @@ func TestReportWorkflowResource_ScheduledWorkflowIDNotEmpty_NoExperiment_Success
 	assert.Equal(t, expectedRunDetail, runDetail)
 }
 
+func TestReportWorkflowResource_WorkflowMissingRunID(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.Name,
+		},
+	})
+	err := manager.ReportWorkflowResource(workflow)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Workflow[workflow-name] missing the Run ID label")
+}
+
 func TestReportWorkflowResource_WorkflowCompleted(t *testing.T) {
 	store, manager, run := initWithOneTimeRun(t)
 	namespace := "kubeflow"


### PR DESCRIPTION
Fixes #3584.

For clusters with existing native Argo Workflows, ml-pipeline logs were dirtied
with unneccessary stack traces due to "missing Run ID label" situation.

With this PR there will be no request to `apiserver` and we will have single line of info log in `persistenceagent` side with the Workflow name causing the situation.

It'll look like this:
```
time="2020-09-01T15:39:26Z" level=info msg="Skip syncing Workflow (workflow-20200901-05-10-7030-end2end): workflow does not have a Run ID label."
```

rather than:
```
I0831 22:52:48.218775       1 interceptor.go:29] /api.ReportService/ReportWorkflow handler starting
I0831 22:52:48.219095       1 error.go:218] Invalid input error: Workflow missing the Run ID label
github.com/kubeflow/pipelines/backend/src/common/util.NewInvalidInputError
        backend/src/common/util/error.go:165
github.com/kubeflow/pipelines/backend/src/apiserver/resource.(*ResourceManager).ReportWorkflowResource
        backend/src/apiserver/resource/resource_manager.go:689
github.com/kubeflow/pipelines/backend/src/apiserver/server.(*ReportServer).ReportWorkflow
        backend/src/apiserver/server/report_server.go:39
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler.func1
        bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:174
main.apiServerInterceptor
        backend/src/apiserver/interceptor.go:30
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler
        bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:176
google.golang.org/grpc.(*Server).processUnaryRPC
        external/org_golang_google_grpc/server.go:966
google.golang.org/grpc.(*Server).handleStream
        external/org_golang_google_grpc/server.go:1245
google.golang.org/grpc.(*Server).serveStreams.func1.1
        external/org_golang_google_grpc/server.go:685
runtime.goexit
        GOROOT/src/runtime/asm_amd64.s:1333
Report workflow failed.
github.com/kubeflow/pipelines/backend/src/common/util.(*UserError).wrap
        backend/src/common/util/error.go:211
github.com/kubeflow/pipelines/backend/src/common/util.Wrap
        backend/src/common/util/error.go:244
github.com/kubeflow/pipelines/backend/src/apiserver/server.(*ReportServer).ReportWorkflow
        backend/src/apiserver/server/report_server.go:41
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler.func1
        bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:174
main.apiServerInterceptor
        backend/src/apiserver/interceptor.go:30
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler
        bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:176
google.golang.org/grpc.(*Server).processUnaryRPC
        external/org_golang_google_grpc/server.go:966
google.golang.org/grpc.(*Server).handleStream
        external/org_golang_google_grpc/server.go:1245
google.golang.org/grpc.(*Server).serveStreams.func1.1
        external/org_golang_google_grpc/server.go:685
runtime.goexit  
        GOROOT/src/runtime/asm_amd64.s:1333
/api.ReportService/ReportWorkflow call failed
github.com/kubeflow/pipelines/backend/src/common/util.(*UserError).wrapf
        backend/src/common/util/error.go:206    
github.com/kubeflow/pipelines/backend/src/common/util.Wrapf
        backend/src/common/util/error.go:231
main.apiServerInterceptor
        backend/src/apiserver/interceptor.go:32
github.com/kubeflow/pipelines/backend/api/go_client._ReportService_ReportWorkflow_Handler
        bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/report.pb.go:176
google.golang.org/grpc.(*Server).processUnaryRPC
        external/org_golang_google_grpc/server.go:966
google.golang.org/grpc.(*Server).handleStream
        external/org_golang_google_grpc/server.go:1245
google.golang.org/grpc.(*Server).serveStreams.func1.1
        external/org_golang_google_grpc/server.go:685
runtime.goexit
        GOROOT/src/runtime/asm_amd64.s:1333

```

And I kindly ask the PR approver to add the `cherrypick-approved` label to this PR, thanks in advance.
