### PR TITLE
fix(backend): Add a permission to create events to argo-role

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/argo.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/argo.yaml
@@ -103,6 +103,7 @@ rules:
       - ""
     resources:
       - persistentvolumeclaims
+      - events
     verbs:
       - create
       - delete

--- a/manifests/kustomize/base/argo/workflow-controller-role.yaml
+++ b/manifests/kustomize/base/argo/workflow-controller-role.yaml
@@ -28,6 +28,7 @@ rules:
   - ""
   resources:
   - persistentvolumeclaims
+  - events
   verbs:
   - create
   - delete


### PR DESCRIPTION
Add a permission to create events to argo-role.

The workflow-controller logs a message "Unable to create audit event: events is forbidden: User \"system:serviceaccount:kubeflow:argo\" cannot create resource \"events\" in API group \"\" in the namespace \"kubeflow\"" reason=WorkflowSucceeded" indicating that it fails to emit K8s events (https://github.com/argoproj/argo/issues/2274) 

This is a fix.
