### PR TITLE
test(backend): fix TestJobApis test is flaky. Fixes #4419

### DIFF
--- a/backend/test/integration/job_api_test.go
+++ b/backend/test/integration/job_api_test.go
@@ -137,6 +137,9 @@ func (s *JobApiTestSuite) TestJobApis() {
 	assert.Nil(t, err)
 
 	/* ---------- Create a new argument parameter job by uploading workflow manifest ---------- */
+	// Make sure the job is created at least 1 second later than the first one,
+	// because sort by created_at has precision of 1 second.
+	time.Sleep(1 * time.Second)
 	argParamsBytes, err := ioutil.ReadFile("../resources/arguments-parameters.yaml")
 	assert.Nil(t, err)
 	argParamsBytes, err = yaml.ToJSON(argParamsBytes)

--- a/backend/test/integration/upgrade_test.go
+++ b/backend/test/integration/upgrade_test.go
@@ -108,15 +108,16 @@ func (s *UpgradeTests) SetupSuite() {
 
 func (s *UpgradeTests) TearDownSuite() {
 	if *runIntegrationTests {
-		t := s.T()
-
-		// Clean up after the suite to unblock other tests. (Not needed for upgrade
-		// tests because it needs changes in prepare tests to persist and verified
-		// later.)
-		test.DeleteAllExperiments(s.experimentClient, t)
-		test.DeleteAllPipelines(s.pipelineClient, t)
-		test.DeleteAllRuns(s.runClient, t)
-		test.DeleteAllJobs(s.jobClient, t)
+		if !*isDevMode {
+			t := s.T()
+			// Clean up after the suite to unblock other tests. (Not needed for upgrade
+			// tests because it needs changes in prepare tests to persist and verified
+			// later.)
+			test.DeleteAllExperiments(s.experimentClient, t)
+			test.DeleteAllPipelines(s.pipelineClient, t)
+			test.DeleteAllRuns(s.runClient, t)
+			test.DeleteAllJobs(s.jobClient, t)
+		}
 	}
 }
 


### PR DESCRIPTION
**Description of your changes:**
We list by created_at time, but its precision is 1 second.

Fixes #4419