### PR TITLE
chore: make Pull Request template conciser

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,8 +16,7 @@
 -->
 - [ ] Do you want this pull request (PR) cherry-picked into the current release branch?
 
-    If yes, use one of the options in [Contributor Instructions](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
+    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
 <!--
-    * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
-    *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)
+    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 
 **Checklist:**
 - [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
-
+<!--
    PR titles examples:
     * `fix(frontend): fixes empty page. Fixes #1234`
        Use `fix` to indicate that this PR fixes a bug.
@@ -13,10 +13,11 @@
        Use `chore` to indicate that this PR makes some changes that users don't need to know.
     * `test: fix CI failure. Part of #1234`
         Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-
+-->
 - [ ] Do you want this pull request (PR) cherry-picked into the current release branch?
-    
-    If yes, use one of the following options:
-  
+
+    If yes, use one of the options in [Contributor Instructions](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
+<!--
     * **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update.
     *  After this PR is merged, create a cherry-pick PR to add these changes to the release branch. (For more information about creating a cherry-pick PR, see the [Kubeflow Pipelines release guide](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#option--git-cherry-pick).)
+-->


### PR DESCRIPTION
The current PR template is kind of too long and starts to be distracting.

**CHANGES**:
* Included link to detailed instructions
* Commented inline explanations so that they don't show up in pull request body