### PR TITLE
fix(backend): persistence agent - workflow not found error should be a permanent error

### DIFF
--- a/backend/src/agent/persistence/client/pipeline_client.go
+++ b/backend/src/agent/persistence/client/pipeline_client.go
@@ -85,8 +85,10 @@ func (p *PipelineClient) ReportWorkflow(workflow *util.Workflow) error {
 
 	if err != nil {
 		statusCode, _ := status.FromError(err)
-		if statusCode.Code() == codes.InvalidArgument {
-			// Do not retry if there is something wrong with the workflow
+		if statusCode.Code() == codes.InvalidArgument || statusCode.Code() == codes.NotFound {
+			// Do not retry if either:
+			// * there is something wrong with the workflow
+			// * the workflow has been deleted by someone else
 			return util.NewCustomError(err, util.CUSTOM_CODE_PERMANENT,
 				"Error while reporting workflow resource (code: %v, message: %v): %v, %+v",
 				statusCode.Code(),

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -719,6 +719,9 @@ func (r *ResourceManager) ReportWorkflowResource(workflow *util.Workflow) error 
 		// If workflow's final state has being persisted, the workflow should be garbage collected.
 		err := r.getWorkflowClient(workflow.Namespace).Delete(workflow.Name, &v1.DeleteOptions{})
 		if err != nil {
+			// A fix for kubeflow/pipelines#4484, persistence agent might have an outdated item in its workqueue, so it will
+			// report workflows that no longer exist. It's important to return a permanent error, so that persistence
+			// agent won't retry again.
 			if util.IsNotFound(err) {
 				return util.NewCustomError(err, util.CUSTOM_CODE_PERMANENT, "Failed to delete the completed workflow for run %s", runId)
 			} else {
@@ -794,7 +797,15 @@ func (r *ResourceManager) ReportWorkflowResource(workflow *util.Workflow) error 
 	if workflow.IsInFinalState() {
 		err := AddWorkflowLabel(r.getWorkflowClient(workflow.Namespace), workflow.Name, util.LabelKeyWorkflowPersistedFinalState, "true")
 		if err != nil {
-			return util.Wrap(err, "Failed to add PersistedFinalState label to workflow")
+			message := fmt.Sprintf("Failed to add PersistedFinalState label to workflow %s", workflow.GetName())
+			// A fix for kubeflow/pipelines#4484, persistence agent might have an outdated item in its workqueue, so it will
+			// report workflows that no longer exist. It's important to return a permanent error, so that persistence
+			// agent won't retry again.
+			if util.IsNotFound(err) {
+				return util.NewCustomError(err, util.CUSTOM_CODE_PERMANENT, message)
+			} else {
+				return util.Wrapf(err, message)
+			}
 		}
 	}
 

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -719,7 +719,11 @@ func (r *ResourceManager) ReportWorkflowResource(workflow *util.Workflow) error 
 		// If workflow's final state has being persisted, the workflow should be garbage collected.
 		err := r.getWorkflowClient(workflow.Namespace).Delete(workflow.Name, &v1.DeleteOptions{})
 		if err != nil {
-			return util.NewInternalServerError(err, "Failed to delete the completed workflow for run %s", runId)
+			if util.IsNotFound(err) {
+				return util.NewCustomError(err, util.CUSTOM_CODE_PERMANENT, "Failed to delete the completed workflow for run %s", runId)
+			} else {
+				return util.NewInternalServerError(err, "Failed to delete the completed workflow for run %s", runId)
+			}
 		}
 		// TODO(jingzhang36): find a proper way to pass collectMetricsFlag here.
 		workflowGCCounter.Inc()

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -720,10 +720,10 @@ func (r *ResourceManager) ReportWorkflowResource(workflow *util.Workflow) error 
 		err := r.getWorkflowClient(workflow.Namespace).Delete(workflow.Name, &v1.DeleteOptions{})
 		if err != nil {
 			// A fix for kubeflow/pipelines#4484, persistence agent might have an outdated item in its workqueue, so it will
-			// report workflows that no longer exist. It's important to return a permanent error, so that persistence
+			// report workflows that no longer exist. It's important to return a not found error, so that persistence
 			// agent won't retry again.
 			if util.IsNotFound(err) {
-				return util.NewCustomError(err, util.CUSTOM_CODE_PERMANENT, "Failed to delete the completed workflow for run %s", runId)
+				return util.NewNotFoundError(err, "Failed to delete the completed workflow for run %s", runId)
 			} else {
 				return util.NewInternalServerError(err, "Failed to delete the completed workflow for run %s", runId)
 			}
@@ -799,10 +799,10 @@ func (r *ResourceManager) ReportWorkflowResource(workflow *util.Workflow) error 
 		if err != nil {
 			message := fmt.Sprintf("Failed to add PersistedFinalState label to workflow %s", workflow.GetName())
 			// A fix for kubeflow/pipelines#4484, persistence agent might have an outdated item in its workqueue, so it will
-			// report workflows that no longer exist. It's important to return a permanent error, so that persistence
+			// report workflows that no longer exist. It's important to return a not found error, so that persistence
 			// agent won't retry again.
 			if util.IsNotFound(err) {
-				return util.NewCustomError(err, util.CUSTOM_CODE_PERMANENT, message)
+				return util.NewNotFoundError(err, message)
 			} else {
 				return util.Wrapf(err, message)
 			}

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -1550,7 +1550,7 @@ func TestReportWorkflowResource_WorkflowCompleted_FinalStatePersisted_WorkflowNo
 	})
 	err := manager.ReportWorkflowResource(workflow)
 	require.NotNil(t, err)
-	assert.Truef(t, util.HasCustomCode(err, util.CUSTOM_CODE_NOT_FOUND), "Expected not found error, but got ", err.Error())
+	assert.Truef(t, util.HasCustomCode(err, util.CUSTOM_CODE_PERMANENT), "Expected permanent error, but got %s", err.Error())
 }
 
 func TestReportWorkflowResource_WorkflowCompleted_FinalStatePersisted_DeleteFailed(t *testing.T) {

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -670,7 +671,7 @@ func TestCreateRun_NullWorkflowSpec(t *testing.T) {
 	apiRun := &api.Run{
 		Name: "run1",
 		PipelineSpec: &api.PipelineSpec{
-			WorkflowManifest: "null",  // this situation occurs for real when the manifest file disappears from object store in some way due to retention policy or manual deletion.
+			WorkflowManifest: "null", // this situation occurs for real when the manifest file disappears from object store in some way due to retention policy or manual deletion.
 			Parameters: []*api.Parameter{
 				{Name: "param1", Value: "world"},
 			},
@@ -1489,7 +1490,7 @@ func TestReportWorkflowResource_WorkflowMissingRunID(t *testing.T) {
 	defer store.Close()
 	workflow := util.NewWorkflow(&v1alpha1.Workflow{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      run.Name,
+			Name: run.Name,
 		},
 	})
 	err := manager.ReportWorkflowResource(workflow)
@@ -1534,6 +1535,22 @@ func TestReportWorkflowResource_WorkflowCompleted_FinalStatePersisted(t *testing
 	})
 	err := manager.ReportWorkflowResource(workflow)
 	assert.Nil(t, err)
+}
+
+func TestReportWorkflowResource_WorkflowCompleted_FinalStatePersisted_WorkflowNotFound(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "non-existent-workflow",
+			Namespace: "kubeflow",
+			UID:       types.UID(run.UUID),
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID, util.LabelKeyWorkflowPersistedFinalState: "true"},
+		},
+	})
+	err := manager.ReportWorkflowResource(workflow)
+	require.NotNil(t, err)
+	assert.Truef(t, util.HasCustomCode(err, util.CUSTOM_CODE_NOT_FOUND), "Expected not found error, but got ", err.Error())
 }
 
 func TestReportWorkflowResource_WorkflowCompleted_FinalStatePersisted_DeleteFailed(t *testing.T) {

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -1534,7 +1534,7 @@ func TestReportWorkflowResource_WorkflowCompleted_WorkflowNotFound(t *testing.T)
 	})
 	err := manager.ReportWorkflowResource(workflow)
 	require.NotNil(t, err)
-	assert.Truef(t, util.HasCustomCode(err, util.CUSTOM_CODE_PERMANENT), "Expected permanent error, but got %s", err.Error())
+	assert.Equalf(t, codes.NotFound, err.(*util.UserError).ExternalStatusCode(), "Expected not found error, but got %s", err.Error())
 	assert.Contains(t, err.Error(), "Failed to add PersistedFinalState label")
 }
 
@@ -1569,7 +1569,7 @@ func TestReportWorkflowResource_WorkflowCompleted_FinalStatePersisted_WorkflowNo
 	})
 	err := manager.ReportWorkflowResource(workflow)
 	require.NotNil(t, err)
-	assert.Truef(t, util.HasCustomCode(err, util.CUSTOM_CODE_PERMANENT), "Expected permanent error, but got %s", err.Error())
+	assert.Equalf(t, codes.NotFound, err.(*util.UserError).ExternalStatusCode(), "Expected not found error, but got %s", err.Error())
 	assert.Contains(t, err.Error(), "Failed to delete the completed workflow")
 }
 

--- a/backend/src/common/util/error.go
+++ b/backend/src/common/util/error.go
@@ -144,6 +144,15 @@ func NewInternalServerError(err error, internalMessageFormat string,
 		codes.Internal)
 }
 
+func NewNotFoundError(err error, externalMessageFormat string,
+	a ...interface{}) *UserError {
+	externalMessage := fmt.Sprintf(externalMessageFormat, a...)
+	return newUserError(
+		errors.Wrapf(err, fmt.Sprintf("NotFoundError: %v", externalMessage)),
+		externalMessage,
+		codes.NotFound)
+}
+
 func NewResourceNotFoundError(resourceType string, resourceName string) *UserError {
 	externalMessage := fmt.Sprintf("%s %s not found.", resourceType, resourceName)
 	return newUserError(


### PR DESCRIPTION
**Description of your changes:**
Fixes https://github.com/kubeflow/pipelines/issues/4484

> KFP API server should mark delete workflow not found errors as permanent, so persistence agent won't need to keep retrying them and can just drop outdated items from the queue.

The error happens only when persistence worker cannot update its work queue. The only reported case was caused by too many workflows in the cluster. The error messages are super long and recurring, so they make it impossible to find if there are other errors that caused persistence agent fail to GC workflows.

/area backend