### PR TITLE
fix(sdk): added clearer error for case when user uses watch and argo isn't installed

### DIFF
--- a/sdk/python/kfp/cli/run.py
+++ b/sdk/python/kfp/cli/run.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .._client import Client
+
 import sys
 import subprocess
-import pprint
 import time
 import json
 import click
+import shutil
 
 from tabulate import tabulate
 
@@ -81,6 +81,13 @@ def _display_run(client, namespace, run_id, watch):
     _print_runs([run])
     if not watch:
         return
+    argo_path = shutil.which('argo')
+    if not argo_path:
+        raise RuntimeError("argo isn't found in $PATH. It's necessary for watch. "
+                           "Please make sure it's installed and available. "
+                           "Installation instructions be found here - "
+                           "https://github.com/argoproj/argo/releases")
+
     argo_workflow_name = None
     while True:
         time.sleep(1)
@@ -95,7 +102,7 @@ def _display_run(client, namespace, run_id, watch):
             print('Run is finished with status {}.'.format(run_detail.run.status))
             return
     if argo_workflow_name:
-        subprocess.run(['argo', 'watch', argo_workflow_name, '-n', namespace])
+        subprocess.run([argo_path, 'watch', argo_workflow_name, '-n', namespace])
         _print_runs([run])
 
 def _print_runs(runs):


### PR DESCRIPTION
There are no any dependencies to argo in kfp python package.
However, kfp throws error when user tries to use it with `--watch` option.
```
root@caa4a6050d9b:/tmp# kfp --endpoint=$KUBEFLOW_DEV --iap-client-id=$KUBEFLOW_DEV_IAP run submit --watch --pipeline-id 882da26c-0685-4ebd-b844-b3ff79101c07 --experiment-name "run-$PIPELINE_NAME"
Run 57db449d-3beb-458b-b9f2-2cc20452c2e9 is submitted
+--------------------------------------+--------+----------+---------------------------+
| run id                               | name   | status   | created at                |
+======================================+========+==========+===========================+
| 57db449d-3beb-458b-b9f2-2cc20452c2e9 | run-   |          | 2020-09-17T12:07:24+00:00 |
+--------------------------------------+--------+----------+---------------------------+
[Errno 2] No such file or directory: 'argo'
```
This Pr aims to provide clearer error when argo isn't installed.

