### PR TITLE
chore(components): AWS SageMaker - Fix leaking Workteam(GroundTruth) resources

### DIFF
--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_groundtruth_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_groundtruth_component.py
@@ -110,12 +110,19 @@ def test_groundtruth_labeling_job(
         )
         assert response["LabelingJobStatus"] in ["Stopping", "Stopped"]
     finally:
-        # Cleanup the SageMaker Resources
-        if ground_truth_train_job_name:
+        # Check if terminate failed, and stop the labeling job
+        labeling_jobs = sagemaker_utils.list_labeling_jobs_for_workteam(
+            sagemaker_client, workteam_arn
+        )
+        if len(labeling_jobs["LabelingJobSummaryList"]) > 0:
             sagemaker_utils.stop_labeling_job(
                 sagemaker_client, ground_truth_train_job_name
             )
-        if workteam_name:
+
+        # Cleanup the workteam
+        workteams = sagemaker_utils.list_workteams(sagemaker_client)["Workteams"]
+        workteam_names = list(map((lambda x: x["WorkteamName"]), workteams))
+        if workteam_name in workteam_names:
             sagemaker_utils.delete_workteam(sagemaker_client, workteam_name)
 
     # Delete generated files


### PR DESCRIPTION
**Description of your changes:**
Cleanup of workteams which are created in the `test_groundtruth_component` was failing since the addition of the terminate test. This test caused the first part of the `finally` block to fail and it never got to workteam cleanup. 

As a part of this fix, this cleanup command is only conditionally executed. 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
