### PR TITLE
feat(sdk): Preserve parameter arguments and input names

### DIFF
--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -279,6 +279,9 @@ def _op_to_template(op: BaseOp):
     if hasattr(op, '_component_ref'):
         template.setdefault('metadata', {}).setdefault('annotations', {})['pipelines.kubeflow.org/component_ref'] = json.dumps(op._component_ref.to_dict(), sort_keys=True)
 
+    if hasattr(op, '_parameter_arguments') and op._parameter_arguments:
+        template.setdefault('metadata', {}).setdefault('annotations', {})['pipelines.kubeflow.org/arguments.parameters'] = json.dumps(op._parameter_arguments, sort_keys=True)
+
     if isinstance(op, dsl.ContainerOp) and op.execution_options:
         if op.execution_options.caching_strategy.max_cache_staleness:
             template.setdefault('metadata', {}).setdefault('annotations', {})['pipelines.kubeflow.org/max_cache_staleness'] = str(op.execution_options.caching_strategy.max_cache_staleness)

--- a/sdk/python/kfp/dsl/_component_bridge.py
+++ b/sdk/python/kfp/dsl/_component_bridge.py
@@ -69,6 +69,8 @@ def _create_container_op_from_component_and_arguments(
     component_ref_without_spec.spec = None
     task._component_ref = component_ref_without_spec
 
+    task._parameter_arguments = resolved_cmd.inputs_consumed_by_value
+
     # Previously, ContainerOp had strict requirements for the output names, so we had to
     # convert all the names before passing them to the ContainerOp constructor.
     # Outputs with non-pythonic names could not be accessed using their original names.

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -1033,7 +1033,7 @@ class ContainerOp(BaseOp):
                 category=DeprecationWarning,
             )
 
-        self.attrs_with_pipelineparams = BaseOp.attrs_with_pipelineparams + ['_container', 'artifact_arguments'] #Copying the BaseOp class variable!
+        self.attrs_with_pipelineparams = BaseOp.attrs_with_pipelineparams + ['_container', 'artifact_arguments', '_parameter_arguments'] #Copying the BaseOp class variable!
 
         input_artifact_paths = {}
         artifact_arguments = {}
@@ -1113,6 +1113,7 @@ class ContainerOp(BaseOp):
             warnings.warn('The output_artifact_paths parameter is deprecated since SDK v0.1.32. Use the file_outputs parameter instead. file_outputs now supports outputting big data.', DeprecationWarning)
 
         self._metadata = None
+        self._parameter_arguments = None
 
         self.execution_options = ExecutionOptionsSpec(
             caching_strategy=CachingStrategySpec(),

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -976,7 +976,6 @@ implementation:
         self.fail('Unexpected input name: ' + argument['name'])
 
   def test_input_name_sanitization(self):
-    # Verifying that the recursive call arguments are passed correctly when specified out of order
     component_2_in_1_out_op = kfp.components.load_component_from_text('''
 inputs:
 - name: Input 1
@@ -1003,3 +1002,30 @@ implementation:
         self.assertNotIn(' ', argument['name'], 'The input name "{}" of template "{}" was not sanitized.'.format(argument['name'], template['name']))
       for argument in template['inputs']['artifacts']:
         self.assertNotIn(' ', argument['name'], 'The input name "{}" of template "{}" was not sanitized.'.format(argument['name'], template['name']))
+
+  def test_preserving_parameter_arguments_map(self):
+    component_2_in_1_out_op = kfp.components.load_component_from_text('''
+inputs:
+- name: Input 1
+- name: Input 2
+outputs:
+- name: Output 1
+implementation:
+  container:
+    image: busybox
+    command:
+    - echo
+    - inputValue: Input 1
+    - inputPath: Input 2
+    - outputPath: Output 1
+    ''')
+    def some_pipeline():
+      task1 = component_2_in_1_out_op('value 1', 'value 2')
+      component_2_in_1_out_op(task1.output, task1.output)
+
+    workflow_dict = kfp.compiler.Compiler()._compile(some_pipeline)
+    container_templates = [template for template in workflow_dict['spec']['templates'] if 'container' in template]
+    for template in container_templates:
+      parameter_arguments_json = template['metadata']['annotations']['pipelines.kubeflow.org/arguments.parameters']
+      parameter_arguments = json.loads(parameter_arguments_json)
+      self.assertEqual(set(parameter_arguments.keys()), {'Input 1'})


### PR DESCRIPTION
ContainerOp has no concept of inputs, so it loses any information about them such as input names and in some cases even the passed argument values (which are just injected into the command line).
This commit fixes that issue by preserving the paramater arguments map and ultimately storing it in an Argo template annotation.

Fixes https://github.com/kubeflow/pipelines/issues/4556
