### PR TITLE
feat(sdk): Added optional argument to specify description for pipeline upload

### DIFF
--- a/sdk/python/kfp/cli/pipeline.py
+++ b/sdk/python/kfp/cli/pipeline.py
@@ -30,16 +30,21 @@ def pipeline():
     "--pipeline-name",
     help="Name of the pipeline."
 )
+@click.option(
+    "-d",
+    "--description",
+    help="Description for the pipeline."
+)
 @click.argument("package-file")
 @click.pass_context
-def upload(ctx, pipeline_name, package_file):
+def upload(ctx, pipeline_name, package_file, description=None):
     """Upload a KFP pipeline"""
     client = ctx.obj["client"]
     output_format = ctx.obj["output"]
     if not pipeline_name:
         pipeline_name = package_file.split(".")[0]
 
-    pipeline = client.upload_pipeline(package_file, pipeline_name)
+    pipeline = client.upload_pipeline(package_file, pipeline_name, description)
     _display_pipeline(pipeline, output_format)
 
 


### PR DESCRIPTION
Added optional argument `-d, --pipeline-description` to provide value for the pipeline description to be uploaded

```bash
$ kfp pipeline upload --help
Usage: kfp pipeline upload [OPTIONS] PACKAGE_FILE

  Upload a KFP pipeline

Options:
  -p, --pipeline-name TEXT        Name of the pipeline.
  -d, --pipeline-description TEXT
                                  Description for the pipeline.
  --help                          Show this message and exit.
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [x] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
