### PR TITLE
fix(components): use default python version for launching dataflow jobs. Fixes #2601

### DIFF
--- a/components/gcp/container/component_sdk/python/kfp_component/google/dataflow/_launch_python.py
+++ b/components/gcp/container/component_sdk/python/kfp_component/google/dataflow/_launch_python.py
@@ -97,7 +97,7 @@ def _prepare_cmd(project_id, python_file_path, args, staging_location):
         '--project', project_id]
     if staging_location:
         dataflow_args += ['--staging_location', staging_location, '--temp_location', staging_location]
-    return (['python2', '-u', python_file_path] + 
+    return (['python', '-u', python_file_path] + 
         dataflow_args + args)
 
 def _extract_job_id_and_location(line):
@@ -114,4 +114,4 @@ def _install_requirements(requirements_file_path):
     if not requirements_file_path:
         return
     requirements_file_path = stage_file(requirements_file_path)
-    subprocess.check_call(['pip2', 'install', '-r', requirements_file_path])
+    subprocess.check_call(['pip', 'install', '-r', requirements_file_path])


### PR DESCRIPTION
Dataflow will stop supporting Python 3 jobs before the end of the year [1]. Apache Beam EOLed its python3, Beam 2.24.0 was the last version with python 2 support [2].

This PR changes the python launcher to use the default python version instead of hardcoding to python2 and pip2. It will not impact users who are already using python2 in their virtual environments. It will allow users to also use python3 for their Dataflow pipelines. This fixes #2601, fixes https://github.com/kubeflow/kubeflow/issues/4894.

[1] https://cloud.google.com/python/docs/python2-sunset/#dataflow
[2] https://beam.apache.org/blog/beam-2.24.0/


**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
