### PR TITLE
fix(components): fix ml_engine/train interface

### DIFF
--- a/components/gcp/container/component_sdk/python/kfp_component/google/ml_engine/_train.py
+++ b/components/gcp/container/component_sdk/python/kfp_component/google/ml_engine/_train.py
@@ -15,45 +15,60 @@
 from fire import decorators
 from ._create_job import create_job
 
+
 @decorators.SetParseFns(python_version=str, runtime_version=str)
-def train(project_id, job_id_output_path, python_module=None, package_uris=None, 
-    region=None, args=None, job_dir=None, python_version=None, 
-    runtime_version=None, master_image_uri=None, worker_image_uri=None, 
-    training_input=None, job_id_prefix=None, job_id=None, wait_interval=30):
+def train(project_id,
+          job_id_output_path,
+          job_dir_output_path,
+          python_module=None,
+          package_uris=None,
+          region=None,
+          args=None,
+          job_dir=None,
+          python_version=None,
+          runtime_version=None,
+          master_image_uri=None,
+          worker_image_uri=None,
+          training_input=None,
+          job_id_prefix=None,
+          job_id=None,
+          wait_interval=30):
     """Creates a MLEngine training job.
 
     Args:
         project_id (str): Required. The ID of the parent project of the job.
-        python_module (str): Required. The Python module name to run after 
+        job_id_output_path (str): Required. Path for the ID of the created job.
+        job_dir_output_path (str): Required. Path for the directory of the job.
+        python_module (str): Required. The Python module name to run after
             installing the packages.
-        package_uris (list): Required. The Google Cloud Storage location of 
-            the packages with the training program and any additional 
+        package_uris (list): Required. The Google Cloud Storage location of
+            the packages with the training program and any additional
             dependencies. The maximum number of package URIs is 100.
-        region (str): Required. The Google Compute Engine region to run the 
+        region (str): Required. The Google Compute Engine region to run the
             training job in
         args (list): Command line arguments to pass to the program.
-        job_dir (str): A Google Cloud Storage path in which to store training 
-            outputs and other data needed for training. This path is passed 
-            to your TensorFlow program as the '--job-dir' command-line 
-            argument. The benefit of specifying this field is that Cloud ML 
-            validates the path for use in training.
-        python_version (str): Optional. The version of Python used in training. 
-            If not set, the default version is '2.7'. Python '3.5' is 
-            available when runtimeVersion is set to '1.4' and above. 
-            Python '2.7' works with all supported runtime versions.
-        runtime_version (str): Optional. The Cloud ML Engine runtime version 
-            to use for training. If not set, Cloud ML Engine uses the 
-            default stable version, 1.0. 
-        master_image_uri (str): The Docker image to run on the master replica. 
+        job_dir (str): A Google Cloud Storage path in which to store training
+            outputs and other data needed for training. This path is passed to
+            your TensorFlow program as the '--job-dir' command-line argument.
+            The benefit of specifying this field is that Cloud ML validates the
+            path for use in training.
+        python_version (str): Optional. The version of Python used in
+            training. If not set, the default version is '2.7'. Python '3.5' is
+            available when runtimeVersion is set to '1.4' and above. Python
+            '2.7' works with all supported runtime versions.
+        runtime_version (str): Optional. The Cloud ML Engine runtime version
+            to use for training. If not set, Cloud ML Engine uses the default
+            stable version, 1.0.
+        master_image_uri (str): The Docker image to run on the master replica.
             This image must be in Container Registry.
-        worker_image_uri (str): The Docker image to run on the worker replica. 
+        worker_image_uri (str): The Docker image to run on the worker replica.
             This image must be in Container Registry.
         training_input (dict): Input parameters to create a training job.
         job_id_prefix (str): the prefix of the generated job id.
         job_id (str): the created job_id, takes precedence over generated job
             id if set.
-        wait_interval (int): optional wait interval between calls
-            to get job status. Defaults to 30.
+        wait_interval (int): optional wait interval between calls to get job
+            status. Defaults to 30.
     """
     if not training_input:
         training_input = {}
@@ -79,9 +94,7 @@ def train(project_id, job_id_output_path, python_module=None, package_uris=None,
         if 'workerConfig' not in training_input:
             training_input['workerConfig'] = {}
         training_input['workerConfig']['imageUri'] = worker_image_uri
-    job = {
-        'trainingInput': training_input
-    }
+    job = {'trainingInput': training_input}
     return create_job(
         project_id=project_id,
         job=job,
@@ -89,4 +102,4 @@ def train(project_id, job_id_output_path, python_module=None, package_uris=None,
         job_id=job_id,
         wait_interval=wait_interval,
         job_id_output_path=job_id_output_path,
-    )
+        job_dir_output_path=job_dir_output_path)

--- a/components/gcp/container/component_sdk/python/tests/google/ml_engine/test__train.py
+++ b/components/gcp/container/component_sdk/python/tests/google/ml_engine/test__train.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import mock
 import unittest
 
 from kfp_component.google.ml_engine import train
 
 CREATE_JOB_MODULE = 'kfp_component.google.ml_engine._train'
+
 
 @mock.patch(CREATE_JOB_MODULE + '.create_job')
 class TestCreateTrainingJob(unittest.TestCase):
@@ -29,30 +29,40 @@ class TestCreateTrainingJob(unittest.TestCase):
             python_module='mock.module',
             package_uris=['gs://test/package'],
             region='region-1',
-            args=['arg-1', 'arg-2'], job_dir='gs://test/job/dir', 
+            args=['arg-1', 'arg-2'],
+            job_dir='gs://test/job/dir',
             training_input={
                 'runtimeVersion': '1.10',
                 'pythonVersion': '2.7'
-            }, job_id_prefix='job-', job_id='job-1',
+            },
+            job_id_prefix='job-',
+            job_id='job-1',
             master_image_uri='tensorflow:latest',
             worker_image_uri='debian:latest',
             job_id_output_path='/tmp/kfp/output/ml_engine/job_id.txt',
-        )
-        
-        mock_create_job.assert_called_with(project_id='proj-1', job={
-            'trainingInput': {
-                'pythonModule': 'mock.module',
-                'packageUris': ['gs://test/package'],
-                'region': 'region-1',
-                'args': ['arg-1', 'arg-2'],
-                'jobDir': 'gs://test/job/dir',
-                'runtimeVersion': '1.10',
-                'pythonVersion': '2.7',
-                'masterConfig': {
-                    'imageUri': 'tensorflow:latest'
-                },
-                'workerConfig': {
-                    'imageUri': 'debian:latest'
+            job_dir_output_path='/tmp/kfp/output/ml_engine/job_dir.txt')
+
+        mock_create_job.assert_called_with(
+            project_id='proj-1',
+            job={
+                'trainingInput': {
+                    'pythonModule': 'mock.module',
+                    'packageUris': ['gs://test/package'],
+                    'region': 'region-1',
+                    'args': ['arg-1', 'arg-2'],
+                    'jobDir': 'gs://test/job/dir',
+                    'runtimeVersion': '1.10',
+                    'pythonVersion': '2.7',
+                    'masterConfig': {
+                        'imageUri': 'tensorflow:latest'
+                    },
+                    'workerConfig': {
+                        'imageUri': 'debian:latest'
+                    }
                 }
-            }
-        }, job_id_prefix='job-', job_id='job-1', wait_interval=30, job_id_output_path='/tmp/kfp/output/ml_engine/job_id.txt')
+            },
+            job_id_prefix='job-',
+            job_id='job-1',
+            wait_interval=30,
+            job_id_output_path='/tmp/kfp/output/ml_engine/job_id.txt',
+            job_dir_output_path='/tmp/kfp/output/ml_engine/job_dir.txt')


### PR DESCRIPTION
**Description of your changes:**
[ai_platform.ipynb](https://github.com/kubeflow/pipelines/blob/master/samples/core/ai_platform/ai_platform.ipynb) is broken with the following runtime error:
```
Fire trace:
1. Initial component
2. Accessed property "train" (kfp_component/google/ml_engine/_train.py:18)
3. Called routine "train" (kfp_component/google/ml_engine/_train.py:18)
4. ('Cannot find target in dict:', '--job_dir_output_path', {u'trainingOutput': {u'consumedMLUnits': 0.06}, u'trainingInput': {u'runtimeVersion': u'1.13', u'region': u'us-central1', u'args': [u'--data-file-url', u'gs://chesu-kfp/reports.csv', u'--job-dir', u'gs://chesu-kfp'], u'pythonModule': u'trainer.task', u'jobDir': u'gs://chesu-kfp/train/output/1601963201/', u'packageUris': [u'gs://chicago-crime/chicago_crime_trainer-0.0.tar.gz']}, u'jobId': u'job_d59abdaca2e22615a2d4916a3072ac16', u'state': u'SUCCEEDED', u'etag': u'2sK+UnbUkAI=', u'startTime': u'2020-10-06T05:47:45Z', u'endTime': u'2020-10-06T05:53:48Z', u'createTime': u'2020-10-06T05:47:10Z'})
```
In #4123, `--job_dir_output_path, {outputPath: job_dir},` was added to components/gcp/ml_engine/train/component.yaml, but the `job_dir_output_path` is missing from the interface of ml_engine/train.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [x] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->

/assign @Ark-kun @numerology