### PR TITLE
update kfp installation instructions for a number of gcp components

### DIFF
--- a/components/gcp/bigquery/query/sample.ipynb
+++ b/components/gcp/bigquery/query/sample.ipynb
@@ -84,8 +84,7 @@
    "source": [
     "%%capture --no-stderr\n",
     "\n",
-    "KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'\n",
-    "!pip3 install $KFP_PACKAGE --upgrade"
+    "!pip3 install kfp --upgrade"
    ]
   },
   {

--- a/components/gcp/bigquery/query/to_CSV/README.md
+++ b/components/gcp/bigquery/query/to_CSV/README.md
@@ -72,8 +72,7 @@ Note: The following sample code works in an IPython notebook or directly in Pyth
 ```python
 %%capture --no-stderr
 
-KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'
-!pip3 install $KFP_PACKAGE --upgrade
+!pip3 install kfp --upgrade
 ```
 
 2. Load the component using KFP SDK

--- a/components/gcp/bigquery/query/to_gcs/README.md
+++ b/components/gcp/bigquery/query/to_gcs/README.md
@@ -75,8 +75,7 @@ Note: The following sample code works in an IPython notebook or directly in Pyth
 ```python
 %%capture --no-stderr
 
-KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'
-!pip3 install $KFP_PACKAGE --upgrade
+!pip3 install kfp --upgrade
 ```
 
 2. Load the component using KFP SDK

--- a/components/gcp/bigquery/query/to_table/README.md
+++ b/components/gcp/bigquery/query/to_table/README.md
@@ -67,8 +67,7 @@ Note: The following sample code works in an IPython notebook or directly in Pyth
 ```python
 %%capture --no-stderr
 
-KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'
-!pip3 install $KFP_PACKAGE --upgrade
+!pip3 install kfp --upgrade
 ```
 
 2. Load the component using KFP SDK

--- a/components/gcp/dataflow/launch_python/README.md
+++ b/components/gcp/dataflow/launch_python/README.md
@@ -82,8 +82,7 @@ The steps to use the component in a pipeline are:
     ```python
     %%capture --no-stderr
 
-    KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'
-    !pip3 install $KFP_PACKAGE --upgrade
+    !pip3 install kfp --upgrade
     ```
 
 2. Load the component using the Kubeflow pipeline's SDK:

--- a/components/gcp/dataflow/launch_python/sample.ipynb
+++ b/components/gcp/dataflow/launch_python/sample.ipynb
@@ -72,8 +72,7 @@
    "source": [
     "%%capture --no-stderr\n",
     "\n",
-    "KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'\n",
-    "!pip3 install $KFP_PACKAGE --upgrade"
+    "!pip3 install kfp --upgrade"
    ]
   },
   {

--- a/components/gcp/dataflow/launch_template/README.md
+++ b/components/gcp/dataflow/launch_template/README.md
@@ -53,8 +53,7 @@ Follow these steps to use the component in a pipeline:
 ```python
 %%capture --no-stderr
 
-KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'
-!pip3 install $KFP_PACKAGE --upgrade
+!pip3 install kfp --upgrade
 ```
 
 2. Load the component using KFP SDK

--- a/components/gcp/dataflow/launch_template/sample.ipynb
+++ b/components/gcp/dataflow/launch_template/sample.ipynb
@@ -62,8 +62,7 @@
    "source": [
     "%%capture --no-stderr\n",
     "\n",
-    "KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'\n",
-    "!pip3 install $KFP_PACKAGE --upgrade"
+    "!pip3 install kfp --upgrade"
    ]
   },
   {

--- a/components/gcp/dataproc/create_cluster/README.md
+++ b/components/gcp/dataproc/create_cluster/README.md
@@ -78,8 +78,7 @@ Follow these steps to use the component in a pipeline:
     ```python
     %%capture --no-stderr
 
-    KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'
-    !pip3 install $KFP_PACKAGE --upgrade
+    !pip3 install kfp --upgrade
     ```
 
 2. Load the component using the Kubeflow pipeline's SDK

--- a/components/gcp/dataproc/create_cluster/sample.ipynb
+++ b/components/gcp/dataproc/create_cluster/sample.ipynb
@@ -68,8 +68,7 @@
    "source": [
     "%%capture --no-stderr\n",
     "\n",
-    "KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'\n",
-    "!pip3 install $KFP_PACKAGE --upgrade"
+    "!pip3 install kfp --upgrade"
    ]
   },
   {

--- a/components/gcp/dataproc/delete_cluster/README.md
+++ b/components/gcp/dataproc/delete_cluster/README.md
@@ -56,8 +56,7 @@ Follow these steps to use the component in a pipeline:
     ```python
     %%capture --no-stderr
 
-    KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'
-    !pip3 install $KFP_PACKAGE --upgrade
+    !pip3 install kfp --upgrade
     ```
 
 2. Load the component using the Kubeflow pipeline's SDK:

--- a/components/gcp/dataproc/delete_cluster/sample.ipynb
+++ b/components/gcp/dataproc/delete_cluster/sample.ipynb
@@ -51,8 +51,7 @@
    "source": [
     "%%capture --no-stderr\n",
     "\n",
-    "KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'\n",
-    "!pip3 install $KFP_PACKAGE --upgrade"
+    "!pip3 install kfp --upgrade"
    ]
   },
   {

--- a/components/gcp/dataproc/submit_hadoop_job/README.md
+++ b/components/gcp/dataproc/submit_hadoop_job/README.md
@@ -74,8 +74,7 @@ Follow these steps to use the component in a pipeline:
     ```python
     %%capture --no-stderr
 
-    KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'
-    !pip3 install $KFP_PACKAGE --upgrade
+    !pip3 install kfp --upgrade
     ```
 
 2. Load the component using the Kubeflow pipeline's SDK:

--- a/components/gcp/dataproc/submit_hadoop_job/sample.ipynb
+++ b/components/gcp/dataproc/submit_hadoop_job/sample.ipynb
@@ -66,8 +66,7 @@
    "source": [
     "%%capture --no-stderr\n",
     "\n",
-    "KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'\n",
-    "!pip3 install $KFP_PACKAGE --upgrade"
+    "!pip3 install kfp --upgrade"
    ]
   },
   {

--- a/components/gcp/dataproc/submit_hive_job/README.md
+++ b/components/gcp/dataproc/submit_hive_job/README.md
@@ -64,8 +64,7 @@ Follow these steps to use the component in a pipeline:
     ```python
     %%capture --no-stderr
 
-    KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'
-    !pip3 install $KFP_PACKAGE --upgrade
+    !pip3 install kfp --upgrade
     ```
 
 2. Load the component using the Kubeflow pipeline's SDK:

--- a/components/gcp/dataproc/submit_hive_job/sample.ipynb
+++ b/components/gcp/dataproc/submit_hive_job/sample.ipynb
@@ -57,8 +57,7 @@
    "source": [
     "%%capture --no-stderr\n",
     "\n",
-    "KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'\n",
-    "!pip3 install $KFP_PACKAGE --upgrade"
+    "!pip3 install kfp --upgrade"
    ]
   },
   {

--- a/components/gcp/dataproc/submit_pig_job/README.md
+++ b/components/gcp/dataproc/submit_pig_job/README.md
@@ -72,8 +72,7 @@ Follow these steps to use the component in a pipeline:
     ```python
     %%capture --no-stderr
 
-    KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'
-    !pip3 install $KFP_PACKAGE --upgrade
+    !pip3 install kfp --upgrade
     ```
 
 2. Load the component using the Kubeflow pipeline's SDK

--- a/components/gcp/dataproc/submit_pig_job/sample.ipynb
+++ b/components/gcp/dataproc/submit_pig_job/sample.ipynb
@@ -60,8 +60,7 @@
    "source": [
     "%%capture --no-stderr\n",
     "\n",
-    "KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'\n",
-    "!pip3 install $KFP_PACKAGE --upgrade"
+    "!pip3 install kfp --upgrade"
    ]
   },
   {

--- a/components/gcp/dataproc/submit_pyspark_job/README.md
+++ b/components/gcp/dataproc/submit_pyspark_job/README.md
@@ -69,8 +69,7 @@ Follow these steps to use the component in a pipeline:
     ```python
     %%capture --no-stderr
 
-    KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'
-    !pip3 install $KFP_PACKAGE --upgrade
+    !pip3 install kfp --upgrade
     ```
 
 2. Load the Kubeflow pipeline's SDK:

--- a/components/gcp/dataproc/submit_pyspark_job/sample.ipynb
+++ b/components/gcp/dataproc/submit_pyspark_job/sample.ipynb
@@ -62,8 +62,7 @@
    "source": [
     "%%capture --no-stderr\n",
     "\n",
-    "KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'\n",
-    "!pip3 install $KFP_PACKAGE --upgrade"
+    "!pip3 install kfp --upgrade"
    ]
   },
   {

--- a/components/gcp/dataproc/submit_spark_job/README.md
+++ b/components/gcp/dataproc/submit_spark_job/README.md
@@ -84,8 +84,7 @@ Follow these steps to use the component in a pipeline:
     ```python
     %%capture --no-stderr
 
-    KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'
-    !pip3 install $KFP_PACKAGE --upgrade
+    !pip3 install kfp --upgrade
     ```
 
 2. Load the component using the Kubeflow Pipeline's SDK

--- a/components/gcp/dataproc/submit_spark_job/sample.ipynb
+++ b/components/gcp/dataproc/submit_spark_job/sample.ipynb
@@ -73,8 +73,7 @@
    "source": [
     "%%capture --no-stderr\n",
     "\n",
-    "KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'\n",
-    "!pip3 install $KFP_PACKAGE --upgrade"
+    "!pip3 install kfp --upgrade"
    ]
   },
   {

--- a/components/gcp/dataproc/submit_sparksql_job/README.md
+++ b/components/gcp/dataproc/submit_sparksql_job/README.md
@@ -65,8 +65,7 @@ Follow these steps to use the component in a pipeline:
     ```python
     %%capture --no-stderr
 
-    KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'
-    !pip3 install $KFP_PACKAGE --upgrade
+    !pip3 install kfp --upgrade
     ```
 
 2. Load the component using the Kubeflow pipeline's SDK:

--- a/components/gcp/dataproc/submit_sparksql_job/sample.ipynb
+++ b/components/gcp/dataproc/submit_sparksql_job/sample.ipynb
@@ -58,8 +58,7 @@
    "source": [
     "%%capture --no-stderr\n",
     "\n",
-    "KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'\n",
-    "!pip3 install $KFP_PACKAGE --upgrade"
+    "!pip3 install kfp --upgrade"
    ]
   },
   {

--- a/components/gcp/ml_engine/batch_predict/README.md
+++ b/components/gcp/ml_engine/batch_predict/README.md
@@ -76,8 +76,7 @@ Follow these steps to use the component in a pipeline:
 ```python
 %%capture --no-stderr
 
-KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'
-!pip3 install $KFP_PACKAGE --upgrade
+!pip3 install kfp --upgrade
 ```
 
 2. Load the component using KFP SDK

--- a/components/gcp/ml_engine/batch_predict/sample.ipynb
+++ b/components/gcp/ml_engine/batch_predict/sample.ipynb
@@ -86,8 +86,7 @@
    "source": [
     "%%capture --no-stderr\n",
     "\n",
-    "KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'\n",
-    "!pip3 install $KFP_PACKAGE --upgrade"
+    "!pip3 install kfp --upgrade"
    ]
   },
   {

--- a/components/gcp/ml_engine/deploy/README.md
+++ b/components/gcp/ml_engine/deploy/README.md
@@ -93,8 +93,7 @@ Follow these steps to use the component in a pipeline:
 ```python
 %%capture --no-stderr
 
-KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'
-!pip3 install $KFP_PACKAGE --upgrade
+!pip3 install kfp --upgrade
 ```
 
 2. Load the component using KFP SDK

--- a/components/gcp/ml_engine/deploy/sample.ipynb
+++ b/components/gcp/ml_engine/deploy/sample.ipynb
@@ -101,8 +101,7 @@
    "source": [
     "%%capture --no-stderr\n",
     "\n",
-    "KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'\n",
-    "!pip3 install $KFP_PACKAGE --upgrade"
+    "!pip3 install kfp --upgrade"
    ]
   },
   {

--- a/components/gcp/ml_engine/train/README.md
+++ b/components/gcp/ml_engine/train/README.md
@@ -91,8 +91,7 @@ The steps to use the component in a pipeline are:
     ```python
     %%capture --no-stderr
 
-    KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'
-    !pip3 install $KFP_PACKAGE --upgrade
+    !pip3 install kfp --upgrade
     ```
 
 2. Load the component using the Kubeflow pipeline's SDK:

--- a/components/gcp/ml_engine/train/sample.ipynb
+++ b/components/gcp/ml_engine/train/sample.ipynb
@@ -80,8 +80,7 @@
    "source": [
     "%%capture --no-stderr\n",
     "\n",
-    "KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'\n",
-    "!pip3 install $KFP_PACKAGE --upgrade"
+    "!pip3 install kfp --upgrade"
    ]
   },
   {


### PR DESCRIPTION
Did a pass to replace all the instances of
`KFP_PACKAGE = 'https://storage.googleapis.com/ml-pipeline/release/0.1.14/kfp.tar.gz'`
and `!pip3 install $KFP_PACKAGE --upgrade`
with just a regular pip install of the kfp package.

However, I'm wondering about this snippet in the READMEs:
```
%%capture --no-stderr

!pip3 install kfp --upgrade
```
In this context (as opposed to the notebooks) the user would probably be doing the install from the command line.
While I'm at it should I remove the '%%' line and get rid of the '!'?  Or am I missing the point?
