### PR TITLE
feat(sdk): Components - Added Bool as a known type name

### DIFF
--- a/sdk/python/kfp/components/_data_passing.py
+++ b/sdk/python/kfp/components/_data_passing.py
@@ -108,7 +108,7 @@ _converters = [
     Converter([str], ['String', 'str'], _serialize_str, 'str', None),
     Converter([int], ['Integer', 'int'], _serialize_int, 'int', None),
     Converter([float], ['Float', 'float'], _serialize_float, 'float', None),
-    Converter([bool], ['Boolean', 'Bool' 'bool'], _serialize_bool, _bool_deserializer_code, _bool_deserializer_definitions),
+    Converter([bool], ['Boolean', 'Bool', 'bool'], _serialize_bool, _bool_deserializer_code, _bool_deserializer_definitions),
     Converter([list], ['JsonArray', 'List', 'list'], _serialize_json, 'json.loads', 'import json'), # ! JSON map keys are always strings. Python converts all keys to strings without warnings
     Converter([dict], ['JsonObject', 'Dictionary', 'Dict', 'dict'], _serialize_json, 'json.loads', 'import json'), # ! JSON map keys are always strings. Python converts all keys to strings without warnings
     Converter([], ['Json'], _serialize_json, 'json.loads', 'import json'),

--- a/sdk/python/kfp/components/_data_passing.py
+++ b/sdk/python/kfp/components/_data_passing.py
@@ -108,7 +108,7 @@ _converters = [
     Converter([str], ['String', 'str'], _serialize_str, 'str', None),
     Converter([int], ['Integer', 'int'], _serialize_int, 'int', None),
     Converter([float], ['Float', 'float'], _serialize_float, 'float', None),
-    Converter([bool], ['Boolean', 'bool'], _serialize_bool, _bool_deserializer_code, _bool_deserializer_definitions),
+    Converter([bool], ['Boolean', 'Bool' 'bool'], _serialize_bool, _bool_deserializer_code, _bool_deserializer_definitions),
     Converter([list], ['JsonArray', 'List', 'list'], _serialize_json, 'json.loads', 'import json'), # ! JSON map keys are always strings. Python converts all keys to strings without warnings
     Converter([dict], ['JsonObject', 'Dictionary', 'Dict', 'dict'], _serialize_json, 'json.loads', 'import json'), # ! JSON map keys are always strings. Python converts all keys to strings without warnings
     Converter([], ['Json'], _serialize_json, 'json.loads', 'import json'),


### PR DESCRIPTION
Some components are already using this type name and are starting to fail due to more strict type checking during constant argument serialization.
