### PR TITLE
chore(components): SageMaker integ test changes

### DIFF
--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_groundtruth_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_groundtruth_component.py
@@ -115,20 +115,31 @@ def test_groundtruth_labeling_job(
             f"Clean up workteam: {workteam_arn} and GT job: {ground_truth_train_job_name}"
         )
         if workteam_arn:
-            if ground_truth_train_job_name:
-                # Check if terminate failed, and stop the labeling job
-                labeling_jobs = sagemaker_utils.list_labeling_jobs_for_workteam(
-                    sagemaker_client, workteam_arn
-                )
-                if len(labeling_jobs["LabelingJobSummaryList"]) > 0:
-                    sagemaker_utils.stop_labeling_job(
-                        sagemaker_client, ground_truth_train_job_name
+            try:
+                if ground_truth_train_job_name:
+                    # Check if terminate failed, and stop the labeling job
+                    labeling_jobs = sagemaker_utils.list_labeling_jobs_for_workteam(
+                        sagemaker_client, workteam_arn
                     )
-            # Cleanup the workteam
-            workteams = sagemaker_utils.list_workteams(sagemaker_client)["Workteams"]
-            workteam_names = list(map((lambda x: x["WorkteamName"]), workteams))
-            if workteam_name in workteam_names:
-                sagemaker_utils.delete_workteam(sagemaker_client, workteam_name)
+                    # Check for status before terminating because list can return stopping jobs
+                    if (
+                        len(labeling_jobs["LabelingJobSummaryList"]) > 0
+                        and sagemaker_utils.describe_labeling_job(
+                            sagemaker_client, ground_truth_train_job_name
+                        )["LabelingJobStatus"]
+                        == "InProgress"
+                    ):
+                        sagemaker_utils.stop_labeling_job(
+                            sagemaker_client, ground_truth_train_job_name
+                        )
+            finally:
+                # Cleanup the workteam
+                workteams = sagemaker_utils.list_workteams(sagemaker_client)[
+                    "Workteams"
+                ]
+                workteam_names = list(map((lambda x: x["WorkteamName"]), workteams))
+                if workteam_name in workteam_names:
+                    sagemaker_utils.delete_workteam(sagemaker_client, workteam_name)
 
     # Delete generated files
     utils.remove_dir(download_dir)

--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_model_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_model_component.py
@@ -8,12 +8,7 @@ from utils import sagemaker_utils
 
 
 @pytest.mark.parametrize(
-    "test_file_dir",
-    [
-        pytest.param(
-            "resources/config/kmeans-mnist-model", marks=pytest.mark.canary_test
-        )
-    ],
+    "test_file_dir", ["resources/config/kmeans-mnist-model"],
 )
 def test_createmodel(kfp_client, experiment_id, sagemaker_client, test_file_dir):
 


### PR DESCRIPTION
**Description of your changes:**
- Remove canary marker from model test: Model Component is already covered as part of batch and endpoint test. Running multiple canaries simultaneously results in throttling from SageMaker
- List labelling jobs by workteam returns even if jobs are completed. Check in previous PR was wrong

**Testing**
```
pytest -n 7 -m "canary_test" --role-arn=<> --s3-data-bucket=<> --assume-role-arn=<>
```