### PR TITLE
feat(sdk): Replace logging and print statements with click echo statements for cli

### DIFF
--- a/sdk/python/kfp/cli/cli.py
+++ b/sdk/python/kfp/cli/cli.py
@@ -57,5 +57,5 @@ def main():
     try:
         cli(obj={}, auto_envvar_prefix='KFP')
     except Exception as e:
-        logging.error(e)
+        click.echo(str(e), err=True)
         sys.exit(1)

--- a/sdk/python/kfp/cli/diagnose_me_cli.py
+++ b/sdk/python/kfp/cli/diagnose_me_cli.py
@@ -19,14 +19,17 @@ def diagnose_me():
 
 @diagnose_me.command()
 @click.option(
+    '-j',
     '--json',
     is_flag=True,
     help='Output in Json format, human readable format is set by default.')
 @click.option(
+    '-p',
     '--project-id',
     type=Text,
     help='Target project id. It will use environment default if not specified.')
 @click.option(
+    '-n',
     '--namespace',
     type=Text,
     help='Namespace to use for Kubernetes cluster.all-namespaces is used if not specified.'
@@ -46,13 +49,12 @@ def diagnose_me(ctx, json, project_id, namespace):
       human_readable=False)
   for app in ['Google Cloud SDK', 'gsutil', 'kubectl']:
     if app not in local_env_gcloud_sdk.json_output:
-      print(
-          '%s is not installed, gcloud, gsutil and kubectl are required' % app,
-          'for this app to run. Please follow instructions at',
+      raise RuntimeError(
+          '%s is not installed, gcloud, gsutil and kubectl are required ' % app +
+          'for this app to run. Please follow instructions at ' +
           'https://cloud.google.com/sdk/install to install the SDK.')
-      return
 
-  print('Collecting diagnostic information ...', file=sys.stderr)
+  click.echo('Collecting diagnostic information ...', file=sys.stderr)
 
   # default behaviour dump all configurations
   results = {}
@@ -102,4 +104,4 @@ def print_to_sdtout(results: Dict[str, utility.ExecutorResponse],
     result = json_library.dumps(
         output_dict, sort_keys=True, indent=2, separators=(',', ': '))
 
-  print(result)
+  click.echo(result)

--- a/sdk/python/kfp/cli/experiment.py
+++ b/sdk/python/kfp/cli/experiment.py
@@ -1,5 +1,5 @@
 import click
-import logging
+import json
 
 from .output import print_output, OutputFormat
 
@@ -47,7 +47,11 @@ def list(ctx, max_size):
     if response.experiments:
         _display_experiments(response.experiments, output_format)
     else:
-        logging.info("No experiments found")
+        if output_format == OutputFormat.json.name:
+            msg = json.dumps([])
+        else:
+            msg = "No experiments found"
+        click.echo(msg)
 
 
 @experiment.command()
@@ -77,7 +81,7 @@ def delete(ctx, experiment_id):
     client = ctx.obj["client"]
 
     client.experiments.delete_experiment(id=experiment_id)
-    print("{} is deleted.".format(experiment_id))
+    click.echo("{} is deleted.".format(experiment_id))
 
 
 def _display_experiments(experiments, output_format):

--- a/sdk/python/kfp/cli/output.py
+++ b/sdk/python/kfp/cli/output.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import click
 import json
 from enum import Enum, unique
 from typing import Union
@@ -44,7 +45,7 @@ def print_output(data: Union[list, dict], headers: list, output_format: str, tab
         NotImplementedError: If the ``output_format`` is unknown.
     """
     if output_format == OutputFormat.table.name:
-        print(tabulate(data, headers=headers, tablefmt=table_format))
+        click.echo(tabulate(data, headers=headers, tablefmt=table_format))
     elif output_format == OutputFormat.json.name:
         if not headers:
             output = data
@@ -52,6 +53,6 @@ def print_output(data: Union[list, dict], headers: list, output_format: str, tab
             output = []
             for row in data:
                 output.append(dict(zip(headers, row)))
-        print(json.dumps(output, indent=4))
+        click.echo(json.dumps(output, indent=4))
     else:
         raise NotImplementedError("Unknown Output Format: {}".format(output_format))

--- a/sdk/python/kfp/cli/pipeline.py
+++ b/sdk/python/kfp/cli/pipeline.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import click
-import logging
+import json
 
 from .output import print_output, OutputFormat
 
@@ -104,7 +104,11 @@ def list(ctx, max_size):
     if response.pipelines:
         _print_pipelines(response.pipelines, output_format)
     else:
-        logging.info("No pipelines found")
+        if output_format == OutputFormat.json.name:
+            msg = json.dumps([])
+        else:
+            msg = "No pipelines found"
+        click.echo(msg)
 
 
 @pipeline.command()
@@ -129,7 +133,11 @@ def list_versions(ctx, pipeline_id, max_size):
     if response.versions:
         _print_pipeline_versions(response.versions, output_format)
     else:
-        logging.info("No pipeline or version found")
+        if output_format == OutputFormat.json.name:
+            msg = json.dumps([])
+        else:
+            msg = "No pipeline or version found"
+        click.echo(msg)
 
 
 @pipeline.command()
@@ -152,7 +160,7 @@ def delete(ctx, pipeline_id):
     client = ctx.obj["client"]
 
     client.delete_pipeline(pipeline_id)
-    print("{} is deleted".format(pipeline_id))
+    click.echo("{} is deleted".format(pipeline_id))
 
 
 def _print_pipelines(pipelines, output_format):

--- a/sdk/python/kfp/cli/run.py
+++ b/sdk/python/kfp/cli/run.py
@@ -45,7 +45,7 @@ def list(ctx, experiment_id, max_size):
             msg = json.dumps([])
         else:
             msg = 'No runs found.'
-        print(msg)
+        click.echo(msg)
 
 
 @run.command()
@@ -73,14 +73,13 @@ def submit(ctx, experiment_name, run_name, package_file, pipeline_id, pipeline_n
         pipeline_id = client.get_pipeline_id(name=pipeline_name)
 
     if not package_file and not pipeline_id and not version:
-        print('You must provide one of [package_file, pipeline_id, version].')
+        click.echo('You must provide one of [package_file, pipeline_id, version].', err=True)
         sys.exit(1)
 
     arg_dict = dict(arg.split('=') for arg in args)
     experiment = client.create_experiment(experiment_name)
     run = client.run_pipeline(experiment.id, run_name, package_file, arg_dict, pipeline_id,
                               version_id=version)
-    print('Run {} is submitted'.format(run.id))
     _display_run(client, namespace, run.id, watch, output_format)
 
 
@@ -120,7 +119,7 @@ def _display_run(client, namespace, run_id, watch, output_format):
                 argo_workflow_name = manifest['metadata']['name']
                 break
         if run_detail.run.status in ['Succeeded', 'Skipped', 'Failed', 'Error']:
-            print('Run is finished with status {}.'.format(run_detail.run.status))
+            click.echo('Run is finished with status {}.'.format(run_detail.run.status))
             return
     if argo_workflow_name:
         subprocess.run([argo_path, 'watch', argo_workflow_name, '-n', namespace])


### PR DESCRIPTION
The current release of kfp cli prints all the command outputs via print or logging statements, this PR fixes that to use `click.echo` statements taking advantage of the same click cli library to handle command produced outputs/errors.

~~Currently, all the commands output is printed on the console without any style formatting which can be changed to ANSI colored text on the console.~~

~~The changes on this PR replace the print statements with click style echo statements that enable us to format the output to be printed on the console.~~

~~RED - Error~~
~~GREEN - Success~~
~~YELLOW - Warning~~

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [x] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
