### PR TITLE
fix(backend): Caching - Fixed deployer failure on Kubernetes v1.16+. Fixes #4627

### DIFF
--- a/backend/src/cache/deployer/cache-webhook-config.v1.yaml.template
+++ b/backend/src/cache/deployer/cache-webhook-config.v1.yaml.template
@@ -10,11 +10,13 @@ webhooks:
         namespace: ${NAMESPACE}
         path: "/mutate"
       caBundle: ${CA_BUNDLE}
+    failurePolicy: Ignore
     rules:
     - operations: [ "CREATE" ]
       apiGroups: [""]
       apiVersions: ["v1"]
       resources: ["pods"]
+    sideEffects: None
     timeoutSeconds: 5
     objectSelector:
       matchLabels:

--- a/backend/src/cache/deployer/cache-webhook-config.v1.yaml.template
+++ b/backend/src/cache/deployer/cache-webhook-config.v1.yaml.template
@@ -21,4 +21,4 @@ webhooks:
     objectSelector:
       matchLabels:
         pipelines.kubeflow.org/cache_enabled: "true"
-
+    admissionReviewVersions: ["v1beta1"]

--- a/backend/src/cache/deployer/cache-webhook-config.v1beta1.v1.15.yaml.template
+++ b/backend/src/cache/deployer/cache-webhook-config.v1beta1.v1.15.yaml.template
@@ -10,11 +10,13 @@ webhooks:
         namespace: ${NAMESPACE}
         path: "/mutate"
       caBundle: ${CA_BUNDLE}
+    failurePolicy: Ignore
     rules:
     - operations: [ "CREATE" ]
       apiGroups: [""]
       apiVersions: ["v1"]
       resources: ["pods"]
+    sideEffects: None
     timeoutSeconds: 5
     objectSelector:
       matchLabels:

--- a/backend/src/cache/deployer/cache-webhook-config.v1beta1.yaml.template
+++ b/backend/src/cache/deployer/cache-webhook-config.v1beta1.yaml.template
@@ -10,9 +10,11 @@ webhooks:
         namespace: ${NAMESPACE}
         path: "/mutate"
       caBundle: ${CA_BUNDLE}
+    failurePolicy: Ignore
     rules:
     - operations: [ "CREATE" ]
       apiGroups: [""]
       apiVersions: ["v1"]
       resources: ["pods"]
+    sideEffects: None
     timeoutSeconds: 5


### PR DESCRIPTION
The sideEffects field field became required in v1 version of the resource https://github.com/kubernetes/kubernetes/pull/79549

Also adding failurePolicy: Ignore, because the default value has changed to Fail in v1.16.

These changes are not needed for v1beta1, but I still add them for those cases as well for consistency.

Fixes https://github.com/kubeflow/pipelines/issues/4627