### PR TITLE
chore(test): attempt to fix sample test

### DIFF
--- a/test/sample-test/Dockerfile
+++ b/test/sample-test/Dockerfile
@@ -3,7 +3,7 @@
 FROM google/cloud-sdk:279.0.0
 
 RUN apt-get update -y
-RUN apt-get install --no-install-recommends -y -q libssl-dev libffi-dev wget ssh
+RUN apt-get install --no-install-recommends -y -q gcc-8-base libssl-dev libffi-dev wget ssh
 RUN apt-get install --no-install-recommends -y -q default-jre default-jdk python3-setuptools python3.7-dev gcc libpython3.7-dev zlib1g-dev
 
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py


### PR DESCRIPTION
sample-test is failing with error 
```
sample-test-tqwq8-3810967726: Step 3/17 : RUN apt-get install --no-install-recommends -y -q libssl-dev libffi-dev wget ssh
sample-test-tqwq8-3810967726:  ---> Running in 9118c00e1314
sample-test-tqwq8-3810967726: Reading package lists...
sample-test-tqwq8-3810967726: Building dependency tree...
sample-test-tqwq8-3810967726: Reading state information...
sample-test-tqwq8-3810967726: Some packages could not be installed. This may mean that you have
sample-test-tqwq8-3810967726: requested an impossible situation or if you are using the unstable
sample-test-tqwq8-3810967726: distribution that some required packages have not yet been created
sample-test-tqwq8-3810967726: or been moved out of Incoming.
sample-test-tqwq8-3810967726: The following information may help to resolve the situation:
sample-test-tqwq8-3810967726: 
sample-test-tqwq8-3810967726: The following packages have unmet dependencies:
sample-test-tqwq8-3810967726:  libc6-dev : Breaks: libgcc-8-dev (< 8.4.0-2~) but 8.3.0-6 is to be installed
sample-test-tqwq8-3810967726: E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
sample-test-tqwq8-3810967726: The command '/bin/sh -c apt-get install --no-install-recommends -y -q libssl-dev libffi-dev wget ssh' returned a non-zero code: 100
```

Installing `gcc-8-base` seems to be fix per https://unix.stackexchange.com/questions/592657/full-upgrade-to-debian-testing-fails-due-to-libc6-dev-breaks-libgcc-8-dev