### PR TITLE
fix(sdk): fixes dsl.ContainerOp deprecation warning not shown

### DIFF
--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -1025,7 +1025,7 @@ class ContainerOp(BaseOp):
                 " The components can be created manually (or, in case of python, using kfp.components.create_component_from_func or func_to_container_op)"
                 " and then loaded using kfp.components.load_component_from_file, load_component_from_uri or load_component_from_text: "
                 "https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.components.html#kfp.components.load_component_from_file",
-                category=DeprecationWarning,
+                category=FutureWarning,
             )
 
         self.attrs_with_pipelineparams = BaseOp.attrs_with_pipelineparams + ['_container', 'artifact_arguments', '_parameter_arguments'] #Copying the BaseOp class variable!

--- a/sdk/python/tests/dsl/component_bridge_tests.py
+++ b/sdk/python/tests/dsl/component_bridge_tests.py
@@ -241,7 +241,7 @@ class TestComponentBridge(unittest.TestCase):
             deprecation_messages = list(str(message) for message in warning_messages if message.category == DeprecationWarning)
             self.assertListEqual(deprecation_messages, [])
 
-        with self.assertWarnsRegex(DeprecationWarning, expected_regex='reusable'):
+        with self.assertWarnsRegex(FutureWarning, expected_regex='reusable'):
             kfp.dsl.ContainerOp(name='name', image='image')
 
     def test_prevent_passing_container_op_as_argument(self):


### PR DESCRIPTION
**Description of your changes:**

The dsl.ContainerOp deprecation message should be visible to end users. Since Python3.2 Deprecation messages are ignored unless the at `__main__` stack level.  FutureWarnings should be used when the warning should be seen by the end users.

DeprecationWarning
> Base category for warnings about deprecated features when those warnings are intended for other Python developers (ignored by default, unless triggered by code in __main__).

FutureWarning
> Base category for warnings about deprecated features when those warnings are intended for end users of applications that are written in Python.

Ref : https://docs.python.org/3/library/warnings.html#warning-categories

PS: Deprecation can be seen if the python program(pipeline is compiled) is run with -Wall option. However I doubt that end users of kubeflow/pipelines use this option and would be caught unaware when dsl.ContainerOp is removed in a future version. If the code is going to break soon which I believe is the case a FutureWarning is more appropriate.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
