### PR TITLE
fix(sdk): Fixed UI metadata and metrics

### DIFF
--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -185,7 +185,7 @@ def _op_to_template(op: BaseOp):
     processed_op = _process_base_ops(op)
 
     if isinstance(op, dsl.ContainerOp):
-        output_artifact_paths = OrderedDict()
+        output_artifact_paths = OrderedDict(op.output_artifact_paths)
         # This should have been as easy as output_artifact_paths.update(op.file_outputs), but the _outputs_to_json function changes the output names and we must do the same here, so that the names are the same
         output_artifact_paths.update(sorted(((param.full_name, processed_op.file_outputs[param.name]) for param in processed_op.outputs.values()), key=lambda x: x[0]))
 

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -1090,6 +1090,9 @@ class ContainerOp(BaseOp):
                 # only proxy public callables
                 setattr(self, attr_to_proxy, _proxy(attr_to_proxy))
 
+        if output_artifact_paths:
+            warnings.warn('The output_artifact_paths parameter is deprecated since SDK v0.1.32. Use the file_outputs parameter instead. file_outputs now supports outputting big data.', DeprecationWarning)
+
         # Special handling for the mlpipeline-ui-metadata and mlpipeline-metrics outputs that should always be saved as artifacts
         # TODO: Remove when outputs are always saved as artifacts
         for output_name, path in dict(file_outputs).items():
@@ -1103,9 +1106,6 @@ class ContainerOp(BaseOp):
         self.artifact_arguments = artifact_arguments
         self.file_outputs = file_outputs
         self.output_artifact_paths = output_artifact_paths or {}
-        if output_artifact_paths:
-            file_outputs.update(output_artifact_paths)
-            warnings.warn('The output_artifact_paths parameter is deprecated since SDK v0.1.32. Use the file_outputs parameter instead. file_outputs now supports outputting big data.', DeprecationWarning)
 
         self._metadata = None
         self._parameter_arguments = None


### PR DESCRIPTION
Reverting most of the #2334 which inadvertently broke those artifacts by causing the names to be mangled.

KFP's DSL compiler prepends template names to output names to ensure global uniqueness of *input* names (DSL's ContainerOp does not have concept of inputs, so the inputs are generated during the compilation including input names). But prepending template names to the output names stops the backend from recognizing the `mlpipeline-ui-metadata` and `mlpipeline-metrics` artifacts.
