### PR TITLE
feat(backend) Update argo from 2.7.5 to 2.11.6

### DIFF
--- a/manifests/kustomize/base/argo/workflow-controller-configmap.yaml
+++ b/manifests/kustomize/base/argo/workflow-controller-configmap.yaml
@@ -6,7 +6,6 @@ data:
   config: |
     {
     namespace: $(kfp-namespace),
-    executorImage: gcr.io/ml-pipeline/argoexec:v2.7.5-license-compliance,
     containerRuntimeExecutor: $(kfp-container-runtime-executor),
     artifactRepository:
     {

--- a/manifests/kustomize/base/argo/workflow-controller-deployment.yaml
+++ b/manifests/kustomize/base/argo/workflow-controller-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - gcr.io/ml-pipeline/argoexec:v2.7.5-license-compliance
+        - docker.io/argoproj/argoexec:v2.11.6
         command:
         - workflow-controller
         env:
@@ -36,7 +36,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: gcr.io/ml-pipeline/workflow-controller:v2.7.5-license-compliance
+        image: docker.io/argoproj/workflow-controller:v2.11.6
         imagePullPolicy: IfNotPresent
         name: workflow-controller
         resources: {}


### PR DESCRIPTION
**Description of your changes:**

Update argo from 2.7.5 to 2.11.6

THis helps to run dsl.ressourceops on k8sapi. See https://github.com/kubeflow/pipelines/pull/4645#issuecomment-717084815
