### PR TITLE
fix(proxy): fixes GCP inverse proxy url priority. Fixes #4284

### DIFF
--- a/proxy/get_proxy_url.py
+++ b/proxy/get_proxy_url.py
@@ -52,18 +52,18 @@ def urls_for_zone(zone, location_to_urls_map):
 
   urls = []
   if region in location_to_urls_map:
-    urls.extend(location_to_urls_map[region])
+    urls.extend([url for url in location_to_urls_map[region] if url not in urls])
 
   region_regex = re.compile("([a-z]+-[a-z]+)\d+")
   for location in location_to_urls_map:
     region_match = region_regex.match(location)
     if region_match and region_match.group(1) == approx_region:
-      urls.extend(location_to_urls_map[location])
+      urls.extend([url for url in location_to_urls_map[location] if url not in urls])
 
   if country in location_to_urls_map:
-    urls.extend(location_to_urls_map[country])
+    urls.extend([url for url in location_to_urls_map[country] if url not in urls])
 
-  return set(urls)
+  return urls
 
 
 def main():

--- a/proxy/get_proxy_url.py
+++ b/proxy/get_proxy_url.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """CLI tool that returns URL of the proxy for particular zone and version."""
 import argparse
 import functools
@@ -22,12 +21,13 @@ import re
 import requests
 
 try:
-  unicode
+    unicode
 except NameError:
-  unicode = str
+    unicode = str
+
 
 def urls_for_zone(zone, location_to_urls_map):
-  """Returns list of potential proxy URLs for a given zone.
+    """Returns list of potential proxy URLs for a given zone.
 
   Returns:
     List of possible URLs, in order of proximity.
@@ -41,71 +41,79 @@ def urls_for_zone(zone, location_to_urls_map):
         ...
       }
   """
-  zone_match = re.match("((([a-z]+)-[a-z]+)\d+)-[a-z]", zone)
-  if not zone_match:
-    raise ValueError("Incorrect zone specified: {}".format(zone))
+    zone_match = re.match("((([a-z]+)-[a-z]+)\d+)-[a-z]", zone)
+    if not zone_match:
+        raise ValueError("Incorrect zone specified: {}".format(zone))
 
-  # e.g. zone = us-west1-b
-  region = zone_match.group(1)         # us-west1
-  approx_region = zone_match.group(2)  # us-west
-  country = zone_match.group(3)        # us
+    # e.g. zone = us-west1-b
+    region = zone_match.group(1)  # us-west1
+    approx_region = zone_match.group(2)  # us-west
+    country = zone_match.group(3)  # us
 
-  urls = []
-  if region in location_to_urls_map:
-    urls.extend([url for url in location_to_urls_map[region] if url not in urls])
+    urls = []
+    if region in location_to_urls_map:
+        urls.extend([
+            url for url in location_to_urls_map[region] if url not in urls
+        ])
 
-  region_regex = re.compile("([a-z]+-[a-z]+)\d+")
-  for location in location_to_urls_map:
-    region_match = region_regex.match(location)
-    if region_match and region_match.group(1) == approx_region:
-      urls.extend([url for url in location_to_urls_map[location] if url not in urls])
+    region_regex = re.compile("([a-z]+-[a-z]+)\d+")
+    for location in location_to_urls_map:
+        region_match = region_regex.match(location)
+        if region_match and region_match.group(1) == approx_region:
+            urls.extend([
+                url for url in location_to_urls_map[location] if url not in urls
+            ])
 
-  if country in location_to_urls_map:
-    urls.extend([url for url in location_to_urls_map[country] if url not in urls])
+    if country in location_to_urls_map:
+        urls.extend([
+            url for url in location_to_urls_map[country] if url not in urls
+        ])
 
-  return urls
+    return urls
 
 
 def main():
-  unicode_type = functools.partial(unicode, encoding="utf8")
-  parser = argparse.ArgumentParser(
-      description="Get proxy URL")
-  parser.add_argument("--config-file-path", required=True, type=unicode_type)
-  parser.add_argument("--location", required=True, type=unicode_type)
-  parser.add_argument("--version", required=True, type=unicode_type)
+    unicode_type = functools.partial(unicode, encoding="utf8")
+    parser = argparse.ArgumentParser(description="Get proxy URL")
+    parser.add_argument("--config-file-path", required=True, type=unicode_type)
+    parser.add_argument("--location", required=True, type=unicode_type)
+    parser.add_argument("--version", required=True, type=unicode_type)
 
-  args = parser.parse_args()
-  with open(args.config_file_path, "r") as config_file:
-    data = json.loads(config_file.read())
+    args = parser.parse_args()
+    with open(args.config_file_path, "r") as config_file:
+        data = json.loads(config_file.read())
 
-  agent_containers_config = data["agent-docker-containers"]
-  version = args.version
-  if version not in agent_containers_config:
-    version = "latest"
-  if version not in agent_containers_config:
-    raise ValueError("Version latest not found in the config file.")
-  container_config = agent_containers_config[version]
-  regional_urls = container_config["proxy-urls"]
+    agent_containers_config = data["agent-docker-containers"]
+    version = args.version
+    if version not in agent_containers_config:
+        version = "latest"
+    if version not in agent_containers_config:
+        raise ValueError("Version latest not found in the config file.")
+    container_config = agent_containers_config[version]
+    regional_urls = container_config["proxy-urls"]
 
-  location = args.location
-  urls = urls_for_zone(location, regional_urls)
-  if not urls:
-    raise ValueError("No valid URLs found for zone: {}".format(location))
+    location = args.location
+    urls = urls_for_zone(location, regional_urls)
+    if not urls:
+        raise ValueError("No valid URLs found for zone: {}".format(location))
 
-  for url in urls:
-    try:
-      status_code = requests.head(url).status_code
-    except requests.ConnectionError:
-      pass
-    expected_codes = frozenset([307])
-    # 307 - Temporary Redirect, Proxy server sends this if VM has access rights.
-    if status_code in expected_codes:
-      logging.debug("Status code from the url %s", status_code)
-      print(url)
-      exit(0)
-    logging.debug("Incorrect status_code from the server: %s. Expected: %s",
-                  status_code, expected_codes)
-  raise ValueError("No working URL found")
+    for url in urls:
+        try:
+            status_code = requests.head(url).status_code
+        except requests.ConnectionError:
+            pass
+        expected_codes = frozenset([307])
+        # 307 - Temporary Redirect, Proxy server sends this if VM has access rights.
+        if status_code in expected_codes:
+            logging.debug("Status code from the url %s", status_code)
+            print(url)
+            exit(0)
+        logging.debug(
+            "Incorrect status_code from the server: %s. Expected: %s",
+            status_code, expected_codes
+        )
+    raise ValueError("No working URL found")
+
 
 if __name__ == '__main__':
-  main()
+    main()

--- a/proxy/get_proxy_url_test.py
+++ b/proxy/get_proxy_url_test.py
@@ -22,6 +22,7 @@ url_map_json = """
     {
       "us": ["https://datalab-us-west1.cloud.google.com"],
       "us-west1": ["https://datalab-us-west1.cloud.google.com"],
+      "us-west2": ["https://datalab-us-west2.cloud.google.com"],
       "us-east1": ["https://datalab-us-east1.cloud.google.com"]
     }
     """
@@ -30,16 +31,21 @@ class TestUrlsForZone(unittest.TestCase):
 
   def test_get_urls(self):
     self.assertEqual(
-        set(["https://datalab-us-east1.cloud.google.com","https://datalab-us-west1.cloud.google.com"]),
+        ["https://datalab-us-east1.cloud.google.com","https://datalab-us-west1.cloud.google.com"],
         urls_for_zone("us-east1-a",json.loads(url_map_json)))
 
 
   def test_get_urls_no_match(self):
-    self.assertEqual(set([]), urls_for_zone("euro-west1-a",json.loads(url_map_json)))
+    self.assertEqual([], urls_for_zone("euro-west1-a",json.loads(url_map_json)))
 
   def test_get_urls_incorrect_format(self):
     with self.assertRaises(ValueError):
       urls_for_zone("weird-format-a",json.loads(url_map_json))
+  
+  def test_get_urls_priority(self):
+    self.assertEqual(
+      ["https://datalab-us-west1.cloud.google.com", "https://datalab-us-west2.cloud.google.com"],
+      urls_for_zone("us-west1-a", json.loads(url_map_json)))
 
 if __name__ == '__main__':
   unittest.main()

--- a/proxy/get_proxy_url_test.py
+++ b/proxy/get_proxy_url_test.py
@@ -27,25 +27,31 @@ url_map_json = """
     }
     """
 
+
 class TestUrlsForZone(unittest.TestCase):
 
-  def test_get_urls(self):
-    self.assertEqual(
-        ["https://datalab-us-east1.cloud.google.com","https://datalab-us-west1.cloud.google.com"],
-        urls_for_zone("us-east1-a",json.loads(url_map_json)))
+    def test_get_urls(self):
+        self.assertEqual([
+            "https://datalab-us-east1.cloud.google.com",
+            "https://datalab-us-west1.cloud.google.com"
+        ], urls_for_zone("us-east1-a", json.loads(url_map_json)))
 
+    def test_get_urls_no_match(self):
+        self.assertEqual([],
+                         urls_for_zone(
+                             "euro-west1-a", json.loads(url_map_json)
+                         ))
 
-  def test_get_urls_no_match(self):
-    self.assertEqual([], urls_for_zone("euro-west1-a",json.loads(url_map_json)))
+    def test_get_urls_incorrect_format(self):
+        with self.assertRaises(ValueError):
+            urls_for_zone("weird-format-a", json.loads(url_map_json))
 
-  def test_get_urls_incorrect_format(self):
-    with self.assertRaises(ValueError):
-      urls_for_zone("weird-format-a",json.loads(url_map_json))
-  
-  def test_get_urls_priority(self):
-    self.assertEqual(
-      ["https://datalab-us-west1.cloud.google.com", "https://datalab-us-west2.cloud.google.com"],
-      urls_for_zone("us-west1-a", json.loads(url_map_json)))
+    def test_get_urls_priority(self):
+        self.assertEqual([
+            "https://datalab-us-west1.cloud.google.com",
+            "https://datalab-us-west2.cloud.google.com"
+        ], urls_for_zone("us-west1-a", json.loads(url_map_json)))
+
 
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()


### PR DESCRIPTION
**Description of your changes:**
 - Fixed #4284
     - Priority of potential proxy urls is being lost by deduplicating them using `set()` and as sets don't preserve order. This fix fixes this issue by checking if the current url is present in the potential url list before adding the current to the potential list
     - Added `test_get_urls_priority` to validate this fix
     - Modified existing tests as `urls_for_zone` now returns a `list` instead of a `set`
 - Style formatted `proxy/*.py` with `yapf` using `.style.yapf` provided in the repo

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [x] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
