### PR TITLE
chore(deployment): Add app=minio label to minio service

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/minio.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/minio.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: minio-service
   labels:
+    app: minio
     app.kubernetes.io/name: {{ .Release.Name }}
 spec:
   ports:


### PR DESCRIPTION
**Description of your changes:**
This keeps the minio service similar to the other minio resources and helps e.g. when defining a ServiceMonitor for the prometheus-operator.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [x] Do you want this pull request (PR) cherry-picked into the current release branch?
  - not really needed, just a minor change

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
