### PR TITLE
chore(sdk): fix bug around assertion and test

### DIFF
--- a/sdk/python/kfp/v2/dsl/importer_node.py
+++ b/sdk/python/kfp/v2/dsl/importer_node.py
@@ -38,7 +38,7 @@ def build_importer_spec(
     An importer spec.
   """
   assert bool(pipeline_param_name) != bool(constant_value), (
-      'importer spec should be built using either pipeline_param_name or'
+      'importer spec should be built using either pipeline_param_name or '
       'constant_value.')
   importer_spec = pipeline_spec_pb2.PipelineDeploymentConfig.ImporterSpec()
   importer_spec.type_schema.instance_schema = input_type_schema

--- a/sdk/python/kfp/v2/dsl/importer_node.py
+++ b/sdk/python/kfp/v2/dsl/importer_node.py
@@ -37,11 +37,9 @@ def build_importer_spec(
   Returns:
     An importer spec.
   """
-  assert (
-      bool(pipeline_param_name) != bool(constant_value),
+  assert bool(pipeline_param_name) != bool(constant_value), (
       'importer spec should be built using either pipeline_param_name or'
-      'constant_value.'
-  )
+      'constant_value.')
   importer_spec = pipeline_spec_pb2.PipelineDeploymentConfig.ImporterSpec()
   importer_spec.type_schema.instance_schema = input_type_schema
   if pipeline_param_name:

--- a/sdk/python/kfp/v2/dsl/importer_node_test.py
+++ b/sdk/python/kfp/v2/dsl/importer_node_test.py
@@ -100,22 +100,20 @@ class ImporterNodeTest(unittest.TestCase):
     self.assertEqual(expected_importer_spec, importer_spec)
 
   def test_build_importer_spec_with_invalid_inputs_should_fail(self):
-    with self.assertRaises(AssertionError) as cm:
+    with self.assertRaisesRegexp(
+        AssertionError,
+        'importer spec should be built using either pipeline_param_name or '
+        'constant_value'):
       importer_node.build_importer_spec(
           input_type_schema='title: kfp.Artifact',
           pipeline_param_name='param1',
           constant_value='some_uri')
-    self.assertEqual(
-        'importer spec should be built using either pipeline_param_name or'
-        'constant_value.',
-        str(cm.exception))
 
-    with self.assertRaises(AssertionError) as cm:
+    with self.assertRaisesRegexp(
+        AssertionError,
+        'importer spec should be built using either pipeline_param_name or '
+        'constant_value'):
       importer_node.build_importer_spec(input_type_schema='title: kfp.Artifact')
-    self.assertEqual(
-        'importer spec should be built using either pipeline_param_name or'
-        'constant_value.',
-        str(cm.exception))
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/v2/dsl/importer_node_test.py
+++ b/sdk/python/kfp/v2/dsl/importer_node_test.py
@@ -105,17 +105,17 @@ class ImporterNodeTest(unittest.TestCase):
           input_type_schema='title: kfp.Artifact',
           pipeline_param_name='param1',
           constant_value='some_uri')
-      self.assertEqual(
-          'importer spec should be built using either pipeline_param_name or'
-          'constant_value.',
-          str(cm))
+    self.assertEqual(
+        'importer spec should be built using either pipeline_param_name or'
+        'constant_value.',
+        str(cm.exception))
 
     with self.assertRaises(AssertionError) as cm:
       importer_node.build_importer_spec(input_type_schema='title: kfp.Artifact')
-      self.assertEqual(
-          'importer spec should be built using either pipeline_param_name or'
-          'constant_value.',
-          str(cm))
+    self.assertEqual(
+        'importer spec should be built using either pipeline_param_name or'
+        'constant_value.',
+        str(cm.exception))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of your changes:**
There was a bug around assertion. Parentheses were added for line-breaking, but it made assertion always true, since a non-empty tuple evaluates to `True`. There was also bugs in unit tests, so we didn't catch this. This PR fixes both.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
