### PR TITLE
feat(sdk): Components - Added the inputUri and outputUri placeholders to ComponentSpec

### DIFF
--- a/sdk/python/kfp/components/_structures.py
+++ b/sdk/python/kfp/components/_structures.py
@@ -19,6 +19,8 @@ __all__ = [
     'InputValuePlaceholder',
     'InputPathPlaceholder',
     'OutputPathPlaceholder',
+    'InputUriPlaceholder',
+    'OutputUriPlaceholder',
     'ConcatPlaceholder',
     'IsPresentPlaceholder',
     'IfPlaceholderStructure',
@@ -130,11 +132,64 @@ class OutputPathPlaceholder(ModelBase): #Non-standard attr names
         super().__init__(locals())
 
 
+class InputUriSpec(ModelBase):
+    '''Used in the InputUriPlaceholder.'''
+    _serialized_names = {
+        'input_name': 'inputName',
+        'supported_schemes': 'supportedSchemes'
+    }
+
+    def __init__(self,
+        input_name: str,
+        supported_schemes: Optional[List[str]],
+    ):
+        super().__init__(locals())
+
+
+class OutputUriSpec(ModelBase):
+    '''Used in the OutputUriPlaceholder.'''
+    _serialized_names = {
+        'output_name': 'outputName',
+        'supported_schemes': 'supportedSchemes'
+    }
+
+    def __init__(self,
+        output_name: str,
+        supported_schemes: Optional[List[str]],
+    ):
+        super().__init__(locals())
+
+class InputUriPlaceholder(ModelBase):
+    '''Represents the command-line argument placeholder that will be replaced at run-time by a URI pointing to a the input argument data.'''
+    _serialized_names = {
+        'input_uri_spec': 'inputUri',
+    }
+
+    def __init__(self,
+        input_uri_spec: InputUriSpec,
+    ):
+        super().__init__(locals())
+
+
+class OutputUriPlaceholder(ModelBase):
+    '''Represents the command-line argument placeholder that will be replaced at run-time by a URI pointing to a location where the program should write its output data.'''
+    _serialized_names = {
+        'output_uri_spec': 'outputUri',
+    }
+
+    def __init__(self,
+        output_uri_spec: OutputUriSpec,
+    ):
+        super().__init__(locals())
+
+
 CommandlineArgumentType = Union[
     str,
     InputValuePlaceholder,
     InputPathPlaceholder,
     OutputPathPlaceholder,
+    InputUriPlaceholder,
+    OutputUriPlaceholder,
     'ConcatPlaceholder',
     'IfPlaceholder',
 ]
@@ -284,6 +339,12 @@ class ComponentSpec(ModelBase):
                         raise TypeError('Argument "{}" references non-existing input.'.format(arg))
                 elif isinstance(arg, OutputPathPlaceholder):
                     if arg.output_name not in self._outputs_dict:
+                        raise TypeError('Argument "{}" references non-existing output.'.format(arg))
+                elif isinstance(arg, InputUriPlaceholder):
+                    if arg.input_uri_spec.input_name not in self._inputs_dict:
+                        raise TypeError('Argument "{}" references non-existing input.'.format(arg))
+                elif isinstance(arg, OutputUriPlaceholder):
+                    if arg.output_uri_spec.output_name not in self._outputs_dict:
                         raise TypeError('Argument "{}" references non-existing output.'.format(arg))
                 elif isinstance(arg, ConcatPlaceholder):
                     for arg2 in arg.items:

--- a/sdk/python/kfp/components_tests/test_components.py
+++ b/sdk/python/kfp/components_tests/test_components.py
@@ -720,6 +720,43 @@ implementation:
         with self.assertRaises(TypeError):
             component(input_1="value 1", input_2=open)
 
+    def test_input_output_uri_resolving(self):
+        component_text = textwrap.dedent('''\
+            inputs:
+            - {name: In1}
+            outputs:
+            - {name: Out1}
+            implementation:
+              container:
+                image: busybox
+                command:
+                - program
+                - --in1-uri
+                - {inputUri: {inputName: In1, supportedSchemes: [GoogleCloudStorage]}}
+                - --out1-uri
+                - {outputUri: {outputName: Out1, supportedSchemes: [GoogleCloudStorage]}}
+            '''
+        )
+        op = comp.load_component_from_text(text=component_text)
+        task = op(in1='foo')
+        resolved_cmd = _resolve_command_line_and_paths(
+            component_spec=task.component_ref.spec,
+            arguments=task.arguments,
+            input_uri_generator=lambda name: f"{{{{inputs[{name}].uri}}}}",
+            output_uri_generator=lambda name: f"{{{{outputs[{name}].uri}}}}",
+        )
+
+        self.assertEqual(
+            resolved_cmd.command,
+            [
+                'program',
+                '--in1-uri',
+                '{{inputs[In1].uri}}',
+                '--out1-uri',
+                '{{outputs[Out1].uri}}',
+            ]
+        )
+
     def test_check_type_validation_of_task_spec_outputs(self):
         producer_component_text = '''\
 outputs:


### PR DESCRIPTION
Added the `inputUri` placeholder which represents the command-line argument placeholder that will be replaced at run-time by a URI pointing to a the input argument data.
Added the `outputUri` placeholder which represents the command-line argument placeholder that will be replaced at run-time by a URI pointing to a location where the program should write its output data.

The placeholder also allows specifying the URI schemes supported by the component code.
The placeholder logic is implemented by the compilers that can support these placeholders.

Example component:
```yaml
            inputs:
            - {name: In1}
            outputs:
            - {name: Out1}
            implementation:
              container:
                image: busybox
                command:
                - program
                - --in1-uri
                - {inputUri: {inputName: In1, supportedSchemes: [GoogleCloudStorage]}}
                - --out1-uri
                - {outputUri: {outputName: Out1, supportedSchemes: [GoogleCloudStorage]}}
```