### PR TITLE
fix(components): sending pyspark jobs to aws EMR with the correct py …

### DIFF
--- a/components/aws/emr/common/_utils.py
+++ b/components/aws/emr/common/_utils.py
@@ -149,6 +149,4 @@ def wait_for_job(client, jobflow_id, step_id):
 
 def submit_pyspark_job(client, jobflow_id, job_name, py_file, extra_args):
   """Submits single spark job to a running cluster"""
-
-  pyspark_args = [py_file, extra_args]
-  return submit_spark_job(client, jobflow_id, job_name, '', '', pyspark_args)
+  return submit_spark_job(client, jobflow_id, job_name, py_file, '', extra_args)


### PR DESCRIPTION
fix(components): sending pyspark jobs to aws EMR with the correct py file

**Description**
`spark-submit` accepts jar files as well as python files. In this case, the `py_file` parameter should be passed as the `jar_path` parameter when calling to method `submit_spark_job` in order to call the EMR step correctly.

For this to work properly, the file `components/aws/emr/submit_pyspark_job/component.yaml` should be updated with the correct docker image generated based on this fixed python file. I guess the docker image `seedjeffwan/kubeflow-pipeline-aws-emr` should be referenced with another tag