### PR TITLE
fix(components): sending pyspark jobs and set generated step_id to /output.txt from the generated EMR step

### DIFF
--- a/components/aws/emr/submit_pyspark_job/src/submit_pyspark_job.py
+++ b/components/aws/emr/submit_pyspark_job/src/submit_pyspark_job.py
@@ -56,7 +56,7 @@ def main(argv=None):
   logging.info('Job request submitted. Waiting for completion...')
   _utils.wait_for_job(client, args.jobflow_id, step_id)
 
-  Path('/output.txt').write_text(unicode(args.step_id))
+  Path('/output.txt').write_text(unicode(step_id))
   Path(args.output_file).parent.mkdir(parents=True, exist_ok=True)
   Path(args.output_file).write_text(unicode(args.output))
   logging.info('Job completed.')


### PR DESCRIPTION
**Description of your changes:**
When the pyspark job is sent to EMR, an ID is returned and is saved into the variable step_id. This variable was not passed correctly when writing this value into the /output.txt file