### PR TITLE
chore(sdk): pin kfp-pipeline-spec version

### DIFF
--- a/sdk/python/kfp/__init__.py
+++ b/sdk/python/kfp/__init__.py
@@ -16,7 +16,7 @@
 # https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
-__version__ = '1.1.1rc0'
+__version__ = '1.1.1rc1'
 
 from . import components
 from . import containers

--- a/sdk/python/kfp/__init__.py
+++ b/sdk/python/kfp/__init__.py
@@ -16,7 +16,7 @@
 # https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
-__version__ = '1.1.1rc1'
+__version__ = '1.1.1'
 
 from . import components
 from . import containers

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -38,12 +38,12 @@ REQUIRES = [
     'Deprecated',
     'strip-hints',
     'docstring-parser>=0.7.3',
-    'kfp-pipeline-spec',
+    'kfp-pipeline-spec>=0.1.0, <0.2.0',
 ]
 
 TESTS_REQUIRE = [
     'mock',
-    'kfp-pipeline-spec',
+    'kfp-pipeline-spec>=0.1.0, <0.2.0',
 ]
 
 


### PR DESCRIPTION
**Description of your changes:**
- Bound kfp-pipeline-spec version to >=0.1.0, <0.2.0
- Tentatively release kfp 1.1.1rc1 (or we can skip and wait?)

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
