### PR TITLE
chore(components) - Add SageMaker component owners to AWS owners list

### DIFF
--- a/components/aws/OWNERS
+++ b/components/aws/OWNERS
@@ -1,6 +1,14 @@
 reviewers:
   - jeffwan
+  - surajkota
+  - RedbackThomson
+  - akartsky
+  - mbaijal
   - mameshini
 approvers:
   - jeffwan
+  - surajkota
+  - RedbackThomson
+  - akartsky
+  - mbaijal
   - mameshini

--- a/components/aws/OWNERS
+++ b/components/aws/OWNERS
@@ -5,6 +5,7 @@ reviewers:
   - akartsky
   - mbaijal
   - mameshini
+  - PatrickXYS
 approvers:
   - jeffwan
   - surajkota
@@ -12,3 +13,4 @@ approvers:
   - akartsky
   - mbaijal
   - mameshini
+  - PatrickXYS

--- a/components/aws/sagemaker/OWNERS
+++ b/components/aws/sagemaker/OWNERS
@@ -2,3 +2,4 @@ approvers:
   - surajkota
   - RedbackThomson
   - akartsky
+  - mbaijal

--- a/samples/contrib/aws-samples/OWNERS
+++ b/samples/contrib/aws-samples/OWNERS
@@ -1,9 +1,14 @@
 reviewers:
   - jeffwan
   - mameshini
+  - surajkota
+  - RedbackThomson
+  - akartsky
+  - mbaijal
 approvers:
   - jeffwan
   - mameshini
   - surajkota
   - RedbackThomson
   - akartsky
+  - mbaijal


### PR DESCRIPTION
**Description of your changes:**
Adds all of the current maintainers for the AWS components to the greater AWS components OWNERS list. Also adds all of these maintainers to the list of AWS samples OWNERS.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
