### PR TITLE
fix(katib-component) : experiment succeeded condition modify

### DIFF
--- a/components/kubeflow/katib-launcher/src/launch_experiment.py
+++ b/components/kubeflow/katib-launcher/src/launch_experiment.py
@@ -41,6 +41,9 @@ class Experiment(launch_crd.K8sCR):
     super(Experiment, self).__init__(ExperimentGroup, ExperimentPlural, version, client)
 
   def is_expected_conditions(self, inst, expected_conditions):
+    trials_running_count = inst.get('status', {}).get('trialsRunning')
+    if trials_running_count:
+      return False, ""
     conditions = inst.get('status', {}).get("conditions")
     if not conditions:
       return False, ""

--- a/components/kubeflow/katib-launcher/src/launch_experiment.py
+++ b/components/kubeflow/katib-launcher/src/launch_experiment.py
@@ -42,7 +42,8 @@ class Experiment(launch_crd.K8sCR):
 
   def is_expected_conditions(self, inst, expected_conditions):
     trials_running_count = inst.get('status', {}).get('trialsRunning')
-    if trials_running_count:
+    trials_pending_count = inst.get('status', {}).get('trialsPending')
+    if trials_running_count or trials_pending_count:
       return False, ""
     conditions = inst.get('status', {}).get("conditions")
     if not conditions:


### PR DESCRIPTION
**Description of your changes:**

katib-launcher component
One experiment will create multi trials, when one trials succeeded, the component will be finished. This is unreasonable.So, i judge this by the count of the running trial.

**Checklist:**
- [ yes] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [yes ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
