### PR TITLE
chore: update kustomize manifests to be kustomize v3 compatible

### DIFF
--- a/manifests/kustomize/base/kustomization.yaml
+++ b/manifests/kustomize/base/kustomization.yaml
@@ -1,22 +1,23 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
-bases:
+resources:
 - application
 - argo
 - pipeline
 - metadata
 - cache
 - cache-deployer
-resources:
 - pipeline-application.yaml
 # Used by Kustomize
 configMapGenerator:
 - name: pipeline-install-config
-  env: params.env
+  envs:
+  - params.env
 secretGenerator:
 - name: mysql-secret
-  env: params-db-secret.env
+  envs:
+  - params-db-secret.env
 vars:
 - name: kfp-namespace
   objref:

--- a/manifests/kustomize/base/pipeline/kustomization.yaml
+++ b/manifests/kustomize/base/pipeline/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-- metadata-writer
 resources:
+- metadata-writer
 - ml-pipeline-apiserver-deployment.yaml
 - ml-pipeline-apiserver-role.yaml
 - ml-pipeline-apiserver-rolebinding.yaml

--- a/manifests/kustomize/cluster-scoped-resources/kustomization.yaml
+++ b/manifests/kustomize/cluster-scoped-resources/kustomization.yaml
@@ -4,12 +4,11 @@ kind: Kustomization
 namespace: kubeflow
 
 resources:
-- namespace.yaml
-bases:
 - ../base/application/cluster-scoped
 - ../base/argo/cluster-scoped
 - ../base/pipeline/cluster-scoped
 - ../base/cache-deployer/cluster-scoped
+- namespace.yaml
 vars:
 # NOTE: var name must be unique globally to allow composition of multiple kustomize
 # packages. Therefore, we added prefix `kfp-cluster-scoped-` to distinguish it from

--- a/manifests/kustomize/env/aws/kustomization.yaml
+++ b/manifests/kustomize/env/aws/kustomization.yaml
@@ -1,26 +1,29 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
-bases:
+resources:
 - ../../env/platform-agnostic
 configMapGenerator:
 - name: pipeline-install-config
-  env: params.env
+  envs:
+  - params.env
   behavior: merge
 - name: workflow-controller-configmap
   behavior: replace
-  files:
+  envs:
   - config
 - name: ml-pipeline-ui-configmap
   behavior: replace
-  files:
+  envs:
   - viewer-pod-template.json
 secretGenerator:
 - name: mysql-secret
-  env: secret.env
+  envs:
+  - secret.env
   behavior: merge
 - name: mlpipeline-minio-artifact
-  env: minio-artifact-secret-patch.env
+  envs:
+  - minio-artifact-secret-patch.env
   behavior: merge
 generatorOptions:
   disableNameSuffixHash: true

--- a/manifests/kustomize/env/azure/kustomization.yaml
+++ b/manifests/kustomize/env/azure/kustomization.yaml
@@ -2,18 +2,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
 
-bases:
+resources:
 - ../../base
 - minio-azure-gateway
 
 configMapGenerator:
 - name: pipeline-install-config
-  env: params.env
+  envs:
+  - params.env
   behavior: merge
 
 secretGenerator:
 - name: mysql-secret
-  env: mysql-secret.env
+  envs:
+  - mysql-secret.env
   behavior: merge
 
 # Identifier for application manager to apply ownerReference.

--- a/manifests/kustomize/env/azure/minio-azure-gateway/kustomization.yaml
+++ b/manifests/kustomize/env/azure/minio-azure-gateway/kustomization.yaml
@@ -7,7 +7,8 @@ resources:
 
 secretGenerator:
 - name: mlpipeline-minio-artifact
-  env: minio-artifact-secret.env
+  envs:
+  - minio-artifact-secret.env
 generatorOptions:
   # mlpipeline-minio-artifact needs to be referred by exact name
   disableNameSuffixHash: true

--- a/manifests/kustomize/env/dev/kustomization.yaml
+++ b/manifests/kustomize/env/dev/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
   - ../platform-agnostic
   - ../gcp/inverse-proxy
 

--- a/manifests/kustomize/env/gcp/kustomization.yaml
+++ b/manifests/kustomize/env/gcp/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
   - ../../base
   - inverse-proxy
   - minio-gcs-gateway
@@ -23,5 +23,6 @@ patchesStrategicMerge:
 # Used by Kustomize
 configMapGenerator:
   - name: pipeline-install-config
-    env: params.env
+    envs:
+      - params.env
     behavior: merge

--- a/manifests/kustomize/env/gcp/minio-gcs-gateway/kustomization.yaml
+++ b/manifests/kustomize/env/gcp/minio-gcs-gateway/kustomization.yaml
@@ -8,7 +8,8 @@ resources:
 
 secretGenerator:
 - name: mlpipeline-minio-artifact
-  env: minio-artifact-secret.env
+  envs:
+  - minio-artifact-secret.env
 generatorOptions:
   # mlpipeline-minio-artifact needs to be referred by exact name
   disableNameSuffixHash: true

--- a/manifests/kustomize/env/platform-agnostic-pns/kustomization.yaml
+++ b/manifests/kustomize/env/platform-agnostic-pns/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
   - ../platform-agnostic
 
 # Identifier for application manager to apply ownerReference.
@@ -17,5 +17,6 @@ namespace: kubeflow
 # Used by Kustomize
 configMapGenerator:
   - name: pipeline-install-config
-    env: params.env
+    envs:
+      - params.env
     behavior: merge

--- a/manifests/kustomize/env/platform-agnostic/kustomization.yaml
+++ b/manifests/kustomize/env/platform-agnostic/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
   - ../../base
   - minio
   - mysql

--- a/manifests/kustomize/env/platform-agnostic/minio/kustomization.yaml
+++ b/manifests/kustomize/env/platform-agnostic/minio/kustomization.yaml
@@ -8,7 +8,8 @@ resources:
 
 secretGenerator:
 - name: mlpipeline-minio-artifact
-  env: minio-artifact-secret.env
+  envs:
+  - minio-artifact-secret.env
 generatorOptions:
   # mlpipeline-minio-artifact needs to be referred by exact name
   disableNameSuffixHash: true

--- a/manifests/kustomize/sample/cluster-scoped-resources/kustomization.yaml
+++ b/manifests/kustomize/sample/cluster-scoped-resources/kustomization.yaml
@@ -5,6 +5,6 @@ kind: Kustomization
 # please also update sample/kustomization.yaml's namespace field to the same value
 namespace: kubeflow
 
-bases:
+resources:
   # Or github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref=1.0.0
   - ../../cluster-scoped-resources

--- a/manifests/kustomize/sample/kustomization.yaml
+++ b/manifests/kustomize/sample/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
   # Or github.com/kubeflow/pipelines/manifests/kustomize/env/gcp?ref=1.0.0
   - ../env/gcp
   # Kubeflow Pipelines servers are capable of collecting Prometheus metrics.
@@ -20,12 +20,14 @@ commonLabels:
 # Used by Kustomize
 configMapGenerator:
   - name: pipeline-install-config
-    env: params.env
+    envs:
+      - params.env
     behavior: merge
 
 secretGenerator:
   - name: mysql-secret
-    env: params-db-secret.env
+    envs:
+      - params-db-secret.env
     behavior: merge
 
 # !!! If you want to customize the namespace,


### PR DESCRIPTION
**Description of your changes:**

Update kustomize manifests to be kustomize `v3` compatible. Included changes:

1. `bases` -> `resources` (bases is deprecated)
2. `env` -> `envs` in configMapGenerator and secretGenerator

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
