### PR TITLE
feat(sdk): allow calling GroupOp.after with multiple ops

### DIFF
--- a/sdk/python/kfp/dsl/_ops_group.py
+++ b/sdk/python/kfp/dsl/_ops_group.py
@@ -93,9 +93,11 @@ class OpsGroup(object):
   def __exit__(self, *args):
     _pipeline.Pipeline.get_default_pipeline().pop_ops_group()
 
-  def after(self, dependency):
-    """Specify explicit dependency on another op."""
+  def after(self, dependency, *ops):
+    """Specify explicit dependency on another op or multiple ops."""
     self.dependencies.append(dependency)
+    for op in ops:
+      self.dependencies.append(op)
     return self
 
   def remove_op_recursive(self, op):

--- a/sdk/python/kfp/dsl/_ops_group.py
+++ b/sdk/python/kfp/dsl/_ops_group.py
@@ -93,9 +93,8 @@ class OpsGroup(object):
   def __exit__(self, *args):
     _pipeline.Pipeline.get_default_pipeline().pop_ops_group()
 
-  def after(self, dependency, *ops):
-    """Specify explicit dependency on another op or multiple ops."""
-    self.dependencies.append(dependency)
+  def after(self, *ops):
+    """Specify explicit dependency on other ops."""
     for op in ops:
       self.dependencies.append(op)
     return self


### PR DESCRIPTION
Adds variable argument list to `GroupOp`'s `after` method so that it supports calling with multiple arguments while staying backwards-compatible. As per issue #4787.

It seems it could be cherry-picked in the current release branch.
