### PR TITLE
feat(manifests): Add namespaced installation manifests

### DIFF
--- a/manifests/kustomize/README.md
+++ b/manifests/kustomize/README.md
@@ -57,6 +57,14 @@ Please following [AWS Instructions](env/aws/README.md) for installation.
 
 Note: Community maintains a repo [e2fyi/kubeflow-aws](https://github.com/e2fyi/kubeflow-aws/tree/master/pipelines) for AWS.
 
+### Option-5 Multiple namespaced installations
+
+The major difference between this one and Option-1 is this manifest doesn't contain KFP `cache` component
+which sets up mutating webhook for execution cache. Since `MutatingWebhookConfiguration` is cluster scope resource,
+`cache` component requires `ClusterRole` which is hard to limit all KFP in given namespace.
+
+Please following [Instructions](env/namespaced-installation/README.md) for installation to install multiple KFP in your cluster.
+
 ## Uninstall
 
 If the installation is based on CloudSQL/GCS, after the uninstall, the data is still there,

--- a/manifests/kustomize/env/namespaced-installation/OWNERS
+++ b/manifests/kustomize/env/namespaced-installation/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - Jeffwan

--- a/manifests/kustomize/env/namespaced-installation/README.md
+++ b/manifests/kustomize/env/namespaced-installation/README.md
@@ -1,0 +1,29 @@
+## Namespaced Installation
+
+You can follow this guidance to have multiple Kubeflow pipeline installations in your cluster.
+
+Beside multi-user Kubeflow Pipeline, there's another way to support multi-tenancy case. 
+You can deploy KFP for every user/team in the shared cluster. Everyone will have their own KFP control plane.
+
+Another thing user should be aware is this manifest doesn't contain KFP `cache` component
+which sets up mutating webhook for execution cache. Since `MutatingWebhookConfiguration` is cluster scope resource,
+`cache` component requires `ClusterRole` which is hard to limit all KFP in given namespace.
+See [#4781](https://github.com/kubeflow/pipelines/issues/4781) for more details.
+
+
+```
+cd ${PIPELINE_PROJECT}/manifests/kustomize/env/namespaced-installation
+
+1. Install cluster scoped resources
+kubectl apply -k crd
+
+2. Install KFP to one namespace
+# Update `namespace` in env/namespaced-installation/kustomization.yaml
+kustomize edit set namespace alice
+kubectl apply -k .
+
+3. Install KFP to a different namespace
+# Update `namespace` in env/namespaced-installation/kustomization.yaml
+kustomize edit set namespace bob
+kubectl apply -k .
+```

--- a/manifests/kustomize/env/namespaced-installation/crd/kustomization.yaml
+++ b/manifests/kustomize/env/namespaced-installation/crd/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../../../base/argo/cluster-scoped
+- ../../../base/pipeline/cluster-scoped

--- a/manifests/kustomize/env/namespaced-installation/kustomization.yaml
+++ b/manifests/kustomize/env/namespaced-installation/kustomization.yaml
@@ -1,0 +1,54 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../platform-agnostic/minio
+- ../platform-agnostic/mysql
+- ../../base/argo
+- ../../base/pipeline
+- ../../base/metadata
+
+resources:
+- namespace.yaml
+
+namespace: kubeflow
+
+images:
+- name: mysql
+  newTag: "5.6"
+- name: minio/minio
+  newTag: RELEASE.2018-02-09T22-40-05Z
+
+configMapGenerator:
+- name: pipeline-install-config
+  env: params.env
+
+secretGenerator:
+- name: mysql-secret
+  env: params-db-secret.env
+
+vars:
+- fieldref:
+    fieldPath: metadata.namespace
+  name: kfp-namespace
+  objref:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ml-pipeline
+- fieldref:
+    fieldPath: data.bucketName
+  name: kfp-artifact-bucket-name
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: pipeline-install-config
+- fieldref:
+    fieldPath: data.containerRuntimeExecutor
+  name: kfp-container-runtime-executor
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: pipeline-install-config
+
+configurations:
+- params.yaml

--- a/manifests/kustomize/env/namespaced-installation/namespace.yaml
+++ b/manifests/kustomize/env/namespaced-installation/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: '$(kfp-namespace)'

--- a/manifests/kustomize/env/namespaced-installation/params-db-secret.env
+++ b/manifests/kustomize/env/namespaced-installation/params-db-secret.env
@@ -1,0 +1,2 @@
+username=root
+password=

--- a/manifests/kustomize/env/namespaced-installation/params.env
+++ b/manifests/kustomize/env/namespaced-installation/params.env
@@ -1,0 +1,20 @@
+appName=pipeline
+appVersion=1.1.0-alpha.1
+dbHost=mysql
+dbPort=3306
+mlmdDb=metadb
+cacheDb=cachedb
+pipelineDb=mlpipeline
+bucketName=mlpipeline
+
+
+## containerRuntimeExecutor: A workflow executor is a process
+## that allows Argo to perform certain actions like monitoring pod logs,
+## artifacts, container lifecycles, etc..
+## Doc: https://github.com/argoproj/argo/blob/master/docs/workflow-executors.md
+containerRuntimeExecutor=docker
+
+## autoUpdatePipelineDefaultVersion: States if the pipeline version
+## should be updated by defult for a versioned pipeline or not when a new
+## version is uploaded. This sets the deployment wide definition.
+autoUpdatePipelineDefaultVersion=true

--- a/manifests/kustomize/env/namespaced-installation/params.yaml
+++ b/manifests/kustomize/env/namespaced-installation/params.yaml
@@ -1,0 +1,6 @@
+# Allow Kustomize var to replace following fields.
+varReference:
+- path: metadata/name
+  kind: Namespace
+- path: data/config
+  kind: ConfigMap

--- a/manifests/kustomize/env/namespaced-installation/pipeline-application.yaml
+++ b/manifests/kustomize/env/namespaced-installation/pipeline-application.yaml
@@ -1,0 +1,47 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: $(kfp-app-name)
+  annotations:
+    kubernetes-engine.cloud.google.com/icon: >-
+      data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAyCAYAAADx/eOPAAALuUlEQVRogd2afWxd9XnHP99bK4pS3yhiGUIRiiJUVVVqbq8ppdR20ibqpuIMtDRkUYERp29J57gMZVuxsrZiK7oZXVv5re1AiOuoG+N1DMkuytprsGPEVMouxqQZJVHEWIdQlGVxZlmZdb/747zcc869jpMO+seOdPz7nd/L83tev89zzjX8Bq795Rq9o17zXp+Tey+Ijkyboela29DRWkhffyT733pH/Z3este9F2cC6N0kNjxtjD+FdRD8UF9X7u97y7UbQFPAivC0BdllS381slun3s3z3xVhhqeds90tqR/oMB7u68z19ZZra0E/l1if3WOziPx3skrDPTr+bvDxfxImEIJbgX6gGBJ7EfHJX/ySReDHwO9KYAenyWCMFKw21GSeslwa2Z17+TcuzPBRr7B8m6Df5oOJqdPAR/u6cm/2lmv3At+IT3GiXZqbcaxSLsfRoTsvn7XL2jE87ZXGnwf+VGiDY86ETM1wU1+XjvSW/RlgTJADQ2QaCZKWcX1/aDIcjE8i3SdzZLjn0lm8pJXD02417BM+gLmq2Rqjr/d16Vu95dp6wc8Ra5O8NrPIcoZCvIR1H+KZkd2qLcfnRYUZOuorJO+3uQt0RerolGYZR7r5+C9ZATwPviGyQprd6Liszy3bnwVKwGMjPbnFyxJmeNpX2T4gaR/QmmSpyYZTho/2depMb9k/kNh3KawuJ1bWauHzUcyXRpZAv5Zmg7aHBLcmNN9ECAFeAO3s69KZ3nLtDuF9dnBs0IT9JO24rbPb0JfP2syCZpFfE5q1mRWcvlgMNcwMTRq9z/+OWXdx4AGjvX1deqC37DbwPwOrMgsufol5mWMWs1ivEbjTrOCtLNNb+udygqsNbUBtopR/NkuuwTJ6Hxsw67KSuvH5MPDA/nJttfGTdUFCMUlp/ALwOtIs9muBxpnFnBzuSQf21oP/BbXclVvumWuTaDN8WNBm2GizJkxPM0CDMA2WGZ72bbb/Njue2TRj9Il/PcG87SeBz4ZTNaSTsmctHcO8SqDp14d7dCFLZ2v/3OpQ023Ah4n65kohvETUCdcsfmuilD+bpNdgGZvOODuHqYGIVGCec9g7+7o031v2jaBTiD0ysxbHRnZrPktzyz1zK7f0z10nh5pWwLRhvZro1KqznVJhNB8UyDeSsU4zAOiIXV1OuEqQ2AR79nflXgcY6dGLwIvR8q39cy1b+uc2Emo6dI824BpMSxz8iVhy4m/2WiYHdV5UmOHp2mpwm52ESCdwRn+9v0tPAWzpn9sAFAQbMdc60PaHsFZEWd9uxk4z8G3seykECfObTEd2KmuZG4CWyLXkYLMwtiYt+hMsTUdAEZQzjs9apv66SHJRk73ZjBQ+iRu29s+1VEr5OImmXs4MHUahVoLWgK23wbv6OrU4OulcuHYehWsVHhpXwpE2FNRayTszX2cwDpQEzTB+QvrJHCXUaigk+c++aXZiE98YmUVgV19X7u3ypH/fgfUA5h2usY2jNjmWoGVn50nvC9T2NviA5OPBGPW91OlG+0Xa1WJhhqadk3WjpKCilQIQFP19XZocnfIHgIeFWyNh6goXyX6gdNWfU8aJ5tNjEheAHZVS/ruGj0s8k6VPhh6ms6kwgoLl1aGuCEuSpwXfHZ2qrTJ+HHkNCpOjmbdFcEcGUIhUSj/H65rPO6j+766U8i/QXV0z8cqJc4btwF8AtWgtMb1wj+j41Df/s1EYQwdEDiqM3hDes9quGY3IKoYOvCrU7HlCoZtEWapPkzEpsU8uq8b36a6uBqaBv5l45URLpZT/pmGH8LnkvlAdAOt1oeXqRsuYTjlEMJiXvWN/Z+5szfqioKcOKo7qr/nAEesKiOyv2A/q88rOx8+8bPhK5dUTAA8jbUT6MuKnbKteNVHKP23xCeD1LC0F2TWOmzoAKEiWxmC+sr8rN1OerF2HGaqXFcZhDWaYj11S4ZxcXxVqyKqPZOeNTwM7Jkr5BeDPQJ8NFQaoC/gZ26rXT5TyxxAfRx6P94d0gU0pYYama+tsbwix/AHM4fKUrwAeB68kRJ5AZsWWieGTjLipsVCgrKCwKHF7pZQ/RXf104j76i4ZMmquxkzRXb2zUsqfxdxsfCiA70hRjZbpCDHmJcRdeZPDHkVck0Ul5PeHZ81DgHxKtglXaHCxVN9fr5TyR9hW3QA8Amqp5526SyKtBEbZVv1eZeZkbqKU7xfsFJwPqRW29s+11oUxnUhnkHf2dWoB+R5Jv5dNaGHh1wog8d/ZAI+0GgVpFPTp4AfJT2Hup7u6EvMk0tpkboutEz0HMPzHyD+mu3pFpZR/Aug0Pgm0RLkvFzLWYfjDvs7cqfKUt2LuXTLhue5mdWhVDJdEzxDDcRKawceN9lRePVkDfgBcR/LKVqNpz/s08DO6q4VKKT8j8zHgJ1HyzA1P11YZjfV1arw85auBR4RalDB5lEjDKi0CgPPphKZ0QiNRwUQeg88B2ydKreew9yH1NCxe/r4GaZpt1Vsrh/JnDDcBLwPkbLVgf6s86RXYj4KvtJKJM8KsGLkSlsmUL6mSg1RJY1xD7KmU8sfprnYgBqJsGVsiEfupsca7FfMo26p/OfHKiVqllB8HyPV16VxfV66G/G1QBwY5xvCgTT7X3/MTaBbFVr0fJvqw2ASZ+yul/FN0V68CHsesiDl3UopM3CwhDZDD/Dnwj3S/sjoYAMqTtc1YX02jVqYOiuuqsAKIkqZCfFIz/IrfFY8gDrKt2gI8irSuwQezyTeNaOl+6qYb+fpYGKEXJE9GSTObK5ItrheaLHE5/XRKcHul+kYN8x2kzWlLNNuVtUqibzKW5CBjxUoszO7NWrS1E/xWvMeJjck2WQHEKJeMD+qH4gWCSvg00m3AVxv5TMRKsp9Cs0Q/Ka/1BOZQNBSXMz2b9Q5oO9JCKgkqg2aKofl8uvTPeE1w3t5KKf8y26pFxINhLRa5R9JV6huT/aZuFu7Ds+A9jBdj+VIvZz2b9BL2Xi5yJQEgUFqinI9SZBDx358o5Q/HiRGtquOEmxJu6DcbC/afQWxnvHg+Odrwm2bP5txh5OEYjOM3vaiu8qqHJw1mPmK/Xs7HJf0LRncDMF5cAL6NWUxDrX/duwbczljxjSzvTX+gtXU3MBlrRCltrsxBTgorACKrRGf5bczOiVLrhUL74B2F9oHVjBd/iLwTWEhr+CIWaLYumDjIWLHha+aSwvRs1iJmJ9Kb9ZJRETS3ACsMC8i1ZNwgXZDYWTmU/1WhfeAW8Cjo+UL7wDrGik8jfid0kYz/Z2ODepv+GPIY+FAznpcUJhAo9w5mh81CFtEsWieCTzwXkogmfKBSyh8ttA98EDPqoPouYqYLxYEPMVY8itmEeTM+KEaqZhVAkiPPIL6QDPhLFiYQSC9J7M3mGlF/24zWSvwIM1xoH2gF/sFiTcSPxQakqUJxsIPx4jGCr0AzCUYTbROJ7DPAdsbSAX9ZwgDs3qTDiMGUOxF/1DgfekLVsPf0sw8DPARsDNwy8iYBXov4p0L7wC2MF99CfBJ4rqmbJbO/qYE+x1jx5HK8Xtp/aFgHDM/FX+RM9FFjHjjj4NV3HvlPsP4g+SqQgm6zCuvJQnHgi4wVz2JuAj8RnLGEVaCf8Y8cuRQ2L0mYEBB2Gb8ZHKD4NQBx+0Qpf7LQPrAVVGqiiWTpCcEn4QcLxcF7C7+aXMDahT1YX5IS5DHE/ZfC4yULEwr0DtIOWwuuvwZ8rVLKP1soDqzHPGJoyRao9b4SXiQQ30A8eO1/PJ8D7gK+BtQSJcQM8AXGlg747LUkmi91lad8J3CuZ5OeBii0D64ET2FdH1N0omWJvgLPkvwM8LmZf7lrnm3VO4CHsM4DH2P8I8vGSfK67P9q8v9wWPAcQLH4PbBHbK6Pq+3M9+Ml+6FL2dyC+WmhOLiWseKPMDeDd12uIPBrWCZ5Xds++AHsAwGlBKnoB5747c2J+aSJEuvRL8CDv/2Zz+cqh/LL/gPD//vrfwFjcI5oX6jDBwAAAABJRU5ErkJggg==
+    marketplace.cloud.google.com/deploy-info: '{"partner_id": "google-cloud-ai-platform", "product_id": "kubeflow-pipelines", "partner_name": "Google Cloud AI Platform"}'
+spec:
+  addOwnerRef: true
+  selector:
+    matchLabels:
+      application-crd-id: kubeflow-pipelines
+  descriptor:
+    version: $(kfp-app-version)
+    type: Kubeflow Pipelines
+    description: |-
+      Reusable end-to-end ML workflow
+    maintainers:
+      - name: Google Cloud AI Platform
+        url: https://cloud.google.com/ai-platform/
+      - name: Kubeflow Pipelines
+        url: https://github.com/kubeflow/pipelines
+    links:
+      - description: 'Kubeflow Pipelines Documentation'
+        url: https://www.kubeflow.org/docs/pipelines/
+    notes: |-
+      Please go to [Hosted Kubeflow Pipelines Console](https://console.cloud.google.com/ai-platform/pipelines/clusters).
+
+  info:
+    - name: Console
+      value: 'https://console.cloud.google.com/ai-platform/pipelines/clusters'
+  componentKinds:
+    - group: v1
+      kind: ServiceAccount
+    - group: rbac.authorization.k8s.io/v1
+      kind: Role
+    - group: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+    - group: v1
+      kind: Service
+    - group: v1
+      kind: ConfigMap
+    - group: v1
+      kind: Secret
+    - group: apps/v1
+      kind: Deployment


### PR DESCRIPTION
Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>

**Description of your changes:**
Address https://github.com/kubeflow/pipelines/issues/4781

Support to install multiple Kubeflow Pipeline control plane in the cluster.  The use case is if cluster admin want to deploy standalone KFP for reach namespace. They can use this manifest to limit KFP in given namespace


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
