### PR TITLE
fix(frontend): Fix the yaml cannot show in Safari browser issue. Fixes #4727

### DIFF
--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -187,12 +187,29 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
       versions,
     } = this.state;
 
+    // Since react-ace Editor doesn't support in Safari when height or width is a percentage.
+    // Fix the Yaml file cannot display issue via defining “width/height” does not not take percentage if it's Safari browser.
+    // The code of detecting wether isSafari is from: https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser/9851769#9851769
+    const isSafari =
+      /constructor/i.test(window.HTMLElement.toString()) ||
+      (function(p) {
+        return p.toString() === '[object SafariRemoteNotification]';
+      })(
+        !window['safari'] || (typeof 'safari' !== 'undefined' && window['safari'].pushNotification),
+      );
+
     let selectedNodeInfo: StaticGraphParser.SelectedNodeInfo | null = null;
     if (this.state.graph && this.state.graph.node(selectedNodeId)) {
       selectedNodeInfo = this.state.graph.node(selectedNodeId).info;
       if (!!selectedNodeId && !selectedNodeInfo) {
         logger.error(`Node with ID: ${selectedNodeId} was not found in the graph`);
       }
+    }
+
+    let editorHeightWidth = '100%';
+
+    if (isSafari) {
+      editorHeightWidth = '640px';
     }
 
     return (
@@ -325,8 +342,8 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
               <div className={css.containerCss}>
                 <Editor
                   value={templateString || ''}
-                  height='100%'
-                  width='100%'
+                  height={editorHeightWidth}
+                  width={editorHeightWidth}
                   mode='yaml'
                   theme='github'
                   editorProps={{ $blockScrolling: true }}

--- a/frontend/src/pages/__snapshots__/PipelineDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/PipelineDetails.test.tsx.snap
@@ -1150,7 +1150,7 @@ exports[`PipelineDetails shows pipeline source code when config tab is clicked 1
           enableSnippets={false}
           focus={false}
           fontSize={12}
-          height="100%"
+          height="640px"
           highlightActiveLine={true}
           maxLines={null}
           minLines={null}
@@ -1178,7 +1178,7 @@ exports[`PipelineDetails shows pipeline source code when config tab is clicked 1
           tabSize={4}
           theme="github"
           value="test template"
-          width="100%"
+          width="640px"
           wrapEnabled={false}
         />
       </div>


### PR DESCRIPTION
**Description of your changes:**
Yaml file cannot show with Safari browser, as below picture.
![image](https://user-images.githubusercontent.com/12505594/99970763-4132d100-2dd7-11eb-8af9-59032ba01b2c.png)

**Root-Cause**: react-ace Editor doesn't support in Safari when height or width is a percentage

After fixed, both Chrome and Safari browser are OK now:
![image](https://user-images.githubusercontent.com/12505594/99971225-dc2bab00-2dd7-11eb-9278-b85d4a3c1f44.png)


**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ x ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
