### PR TITLE
fix(frontend): Fix logic deciding if a node was cached. Fixes #4814

### DIFF
--- a/frontend/src/lib/StatusUtils.test.tsx
+++ b/frontend/src/lib/StatusUtils.test.tsx
@@ -175,6 +175,7 @@ describe('StatusUtils', () => {
         parseNodePhase({
           ...DEFAULT_NODE_STATUS,
           id: 'file-passing-pipelines-55slt-2894085459',
+          type: 'Pod',
           phase: 'Succeeded', // Cached nodes have phase == 'Succeeded'
           outputs: {
             artifacts: [
@@ -189,6 +190,28 @@ describe('StatusUtils', () => {
           },
         }),
       ).toEqual('Cached');
+    });
+
+    it('returns succeeded phase for a retry node', () => {
+      expect(
+        parseNodePhase({
+          ...DEFAULT_NODE_STATUS,
+          id: 'file-passing-pipelines-55slt-2894085459',
+          type: 'Retry',
+          phase: 'Succeeded', // Cached nodes have phase == 'Succeeded'
+          outputs: {
+            artifacts: [
+              {
+                s3: {
+                  // HACK: A cached node's artifacts will refer to a path that doesn't match its own id.
+                  key:
+                    'artifacts/file-passing-pipelines-mjpph/file-passing-pipelines-mjpph-1802581193/sum-numbers-output.tgz',
+                },
+              } as Artifact,
+            ],
+          },
+        }),
+      ).toEqual('Succeeded');
     });
   });
 });

--- a/frontend/src/lib/StatusUtils.ts
+++ b/frontend/src/lib/StatusUtils.ts
@@ -106,12 +106,11 @@ export function parseNodePhase(node: NodeStatus): NodePhase {
 
 function wasNodeCached(node: NodeStatus): boolean {
   const artifacts = node.outputs?.artifacts;
-  if (!artifacts || !node.id) {
-    return false;
-  }
   // HACK: There is a way to detect the skipped pods based on the WorkflowStatus alone.
   // All output artifacts have the pod name (same as node ID) in the URI. But for skipped
   // pods, the pod name does not match the URIs.
   // (And now there are always some output artifacts since we've enabled log archiving).
-  return artifacts.some(artifact => artifact.s3 && !artifact.s3.key.includes(node.id));
+  return !artifacts || !node.id || node.type !== 'Pod'
+    ? false
+    : artifacts.some(artifact => artifact.s3 && !artifact.s3.key.includes(node.id));
 }


### PR DESCRIPTION
The UI was deciding whether a node was cached based on whether it was
pointing to some other node's output artifacts.

This works for nodes that correspond to pods, but leads to a wrong
decision for the rest of the nodes. For example, if the node is a Retry
one, it points to another node's outputs because it is that other node
that actually produced them.

We now apply this logic on pod-type nodes only.

Fixes #4814

Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>

/assign @Bobgy 
/assign @Ark-kun 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
