### PR TITLE
fix(sdk): Do not wait for resource deletion

### DIFF
--- a/sdk/python/kfp/dsl/_resource_op.py
+++ b/sdk/python/kfp/dsl/_resource_op.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Dict
+from typing import Dict, List, Optional
 import warnings
 
 from ._container_op import BaseOp, ContainerOp
@@ -32,21 +32,24 @@ class Resource(object):
         "merge_strategy": "str",
         "success_condition": "str",
         "failure_condition": "str",
-        "manifest": "str"
+        "manifest": "str",
+        "flags": "list[str]"
     }
     openapi_types = {
         "action": "str",
         "merge_strategy": "str",
         "success_condition": "str",
         "failure_condition": "str",
-        "manifest": "str"
+        "manifest": "str",
+        "flags": "list[str]"
     }
     attribute_map = {
         "action": "action",
         "merge_strategy": "mergeStrategy",
         "success_condition": "successCondition",
         "failure_condition": "failureCondition",
-        "manifest": "manifest"
+        "manifest": "manifest",
+        "flags": "flags"
     }
 
     def __init__(self,
@@ -54,13 +57,15 @@ class Resource(object):
                  merge_strategy: str = None,
                  success_condition: str = None,
                  failure_condition: str = None,
-                 manifest: str = None):
+                 manifest: str = None,
+                 flags: Optional[List[str]] = None):
         """Create a new instance of Resource"""
         self.action = action
         self.merge_strategy = merge_strategy
         self.success_condition = success_condition
         self.failure_condition = failure_condition
         self.manifest = manifest
+        self.flags = flags
 
 
 class ResourceOp(BaseOp):
@@ -92,7 +97,8 @@ class ResourceOp(BaseOp):
                  merge_strategy: str = None,
                  success_condition: str = None,
                  failure_condition: str = None,
-                 attribute_outputs: Dict[str, str] = None,
+                 attribute_outputs: Optional[Dict[str, str]] = None,
+                 flags: Optional[List[str]] = None,
                  **kwargs):
 
         super().__init__(**kwargs)
@@ -114,11 +120,14 @@ class ResourceOp(BaseOp):
         if action == "delete" and (success_condition or failure_condition or attribute_outputs):
             raise ValueError("You can't set success_condition, failure_condition, or attribute_outputs when action == 'delete'")
 
+        if action == "delete" and flags is None:
+            flags = ["--wait=false"]
         init_resource = {
             "action": action,
             "merge_strategy": merge_strategy,
             "success_condition": success_condition,
-            "failure_condition": failure_condition
+            "failure_condition": failure_condition,
+            "flags": flags
         }
         # `resource` prop in `io.argoproj.workflow.v1alpha1.Template`
         self._resource = Resource(**init_resource)
@@ -163,7 +172,7 @@ class ResourceOp(BaseOp):
         """
         return self._resource
 
-    def delete(self):
+    def delete(self, flags: Optional[List[str]] = None):
         """Returns a ResourceOp which deletes the resource."""
         if self.resource.action == "delete":
             raise ValueError("This operation is already a resource deletion.")
@@ -175,7 +184,8 @@ class ResourceOp(BaseOp):
 
         return kubernetes_resource_delete_op(
             name=self.outputs["name"],
-            kind=kind
+            kind=kind,
+            flags=flags or ["--wait=false"]
         )
 
 
@@ -183,9 +193,10 @@ def kubernetes_resource_delete_op(
     name: str,
     kind: str,
     namespace: str = None,
+    flags: Optional[List[str]] = None,
 ) -> ContainerOp:
     """Operation that deletes a Kubernetes resource.
-    
+
     Outputs:
         name: The name of the deleted resource
     """
@@ -195,6 +206,8 @@ def kubernetes_resource_delete_op(
     ]
     if namespace:
         command.extend(['--namespace', str(namespace)])
+    if flags:
+        command.extend(flags)
 
     result = ContainerOp(
         name='kubernetes_resource_delete',

--- a/sdk/python/tests/dsl/resource_op_tests.py
+++ b/sdk/python/tests/dsl/resource_op_tests.py
@@ -85,5 +85,8 @@ class TestResourceOp(unittest.TestCase):
 
         expected_name = str(res.outputs['name'])
 
-        self.assertEqual(delete_res.command, ['kubectl', 'delete', 'CustomResource', expected_name, '--ignore-not-found', '--output', 'name'])
+        self.assertEqual(delete_res.command,
+                         ['kubectl', 'delete', 'CustomResource', expected_name,
+                          '--ignore-not-found', '--output', 'name',
+                          '--wait=false'])
         self.assertEqual(delete_res.outputs, {})

--- a/sdk/python/tests/dsl/volume_op_tests.py
+++ b/sdk/python/tests/dsl/volume_op_tests.py
@@ -75,5 +75,8 @@ class TestVolumeOp(unittest.TestCase):
 
         expected_name = str(vop.outputs['name'])
 
-        self.assertEqual(delete_vop.command, ['kubectl', 'delete', 'PersistentVolumeClaim', expected_name, '--ignore-not-found', '--output', 'name'])
+        self.assertEqual(delete_vop.command,
+                         ['kubectl', 'delete', 'PersistentVolumeClaim',
+                          expected_name, '--ignore-not-found', '--output',
+                          'name', '--wait=false'])
         self.assertEqual(delete_vop.outputs, {})


### PR DESCRIPTION
When calling the delete() method of a ResourceOp we need to ensure we do
not wait for its deletion.

The reason for this is described in [1]: If a pipeline creates a
resource which is being consumed by its steps (e.g., a PVC), the step
deleting the resource will hang waiting for the Kubernetes resource
deletion which, in turn, is waiting for the other steps to get deleted.
As a result, the pipeline never finishes.

This commit allows specifying flags for the ResourceOp kubectl commands
and defaults to the '--wait=false' flag for the deletion.

Specifying flags for a ResourceTemplate is not supported in Argo v2.7
that we currently deploy. But they will be once we upgrade to v2.11+
[2]. This does not affect the delete() method because we don't rely on
Argo's ResourceTemplate for it.

[1] https://github.com/kubeflow/pipelines/issues/4506
[2] https://github.com/kubeflow/pipelines/issues/4553

Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
