### PR TITLE
feat(sdk): Enable setting OwnerReference on ResourceOps. Fixes #1779

### DIFF
--- a/sdk/python/kfp/dsl/_resource_op.py
+++ b/sdk/python/kfp/dsl/_resource_op.py
@@ -31,6 +31,7 @@ class Resource(object):
       "merge_strategy": "str",
       "success_condition": "str",
       "failure_condition": "str",
+      "set_owner_reference": "bool",
       "manifest": "str",
       "flags": "list[str]"
   }
@@ -39,6 +40,7 @@ class Resource(object):
       "merge_strategy": "str",
       "success_condition": "str",
       "failure_condition": "str",
+      "set_owner_reference": "bool",
       "manifest": "str",
       "flags": "list[str]"
   }
@@ -47,6 +49,7 @@ class Resource(object):
       "merge_strategy": "mergeStrategy",
       "success_condition": "successCondition",
       "failure_condition": "failureCondition",
+      "set_owner_reference": "setOwnerReference",
       "manifest": "manifest",
       "flags": "flags"
   }
@@ -56,6 +59,7 @@ class Resource(object):
                merge_strategy: str = None,
                success_condition: str = None,
                failure_condition: str = None,
+               set_owner_reference: bool = None,
                manifest: str = None,
                flags: Optional[List[str]] = None):
     """Create a new instance of Resource"""
@@ -63,6 +67,7 @@ class Resource(object):
     self.merge_strategy = merge_strategy
     self.success_condition = success_condition
     self.failure_condition = failure_condition
+    self.set_owner_reference = set_owner_reference
     self.manifest = manifest
     self.flags = flags
 
@@ -98,6 +103,7 @@ class ResourceOp(BaseOp):
                merge_strategy: str = None,
                success_condition: str = None,
                failure_condition: str = None,
+               set_owner_reference: bool = None,
                attribute_outputs: Optional[Dict[str, str]] = None,
                flags: Optional[List[str]] = None,
                **kwargs):
@@ -135,6 +141,7 @@ class ResourceOp(BaseOp):
         "merge_strategy": merge_strategy,
         "success_condition": success_condition,
         "failure_condition": failure_condition,
+        "set_owner_reference": set_owner_reference,
         "flags": flags
     }
     # `resource` prop in `io.argoproj.workflow.v1alpha1.Template`

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -72,7 +72,8 @@ class TestCompiler(unittest.TestCase):
             name="resource"
           )
         ),
-        attribute_outputs={"out": json}
+        attribute_outputs={"out": json},
+        set_owner_reference=True
       )
       golden_output = {
         'container': {
@@ -147,7 +148,8 @@ class TestCompiler(unittest.TestCase):
             "kind: '{{inputs.parameters.kind}}'\n"
             "metadata:\n"
             "  name: resource\n"
-          )
+          ),
+          'setOwnerReference': True
         }
       }
 


### PR DESCRIPTION
Argo supports a field in the ResourceTemplate that makes the controller
add an owner reference of the workflow to the created resource since
v2.4.0 [1].
With the upgrade of Argo client [2] and deployment [3] we are now able
to exploit it.

We set it to 'false' by default on all ResourceOps (actually, leave it
empty) and 'true' for VolumeOps. This allows the garbage collection of
PVCs upon workflow cleanup without any further change [4].

[1] https://github.com/argoproj/argo/blob/v2.4.0/pkg/apis/workflow/v1alpha1/workflow_types.go#L1044-L1045
[2] https://github.com/kubeflow/pipelines/pull/4498
[3] https://github.com/kubeflow/pipelines/pull/3537
[4] https://github.com/kubeflow/pipelines/issues/1779

Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>

Closes #1779 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
