### PR TITLE
feat(sdk): Add settings of the dnsConfig field. Fixes #4836

### DIFF
--- a/samples/core/dns_config/dns_config.py
+++ b/samples/core/dns_config/dns_config.py
@@ -43,4 +43,8 @@ if __name__ == '__main__':
         options=[V1PodDNSConfigOption(name="ndots", value="2")]
     ))
 
-    kfp.compiler.Compiler().compile(dns_config_pipeline, __file__ + '.yaml', pipeline_conf=pipeline_conf)
+    kfp.compiler.Compiler().compile(
+        dns_config_pipeline,
+        __file__ + '.yaml',
+        pipeline_conf=pipeline_conf
+    )

--- a/samples/core/dns_config/dns_config.py
+++ b/samples/core/dns_config/dns_config.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import kfp
+from kfp import dsl
+from kubernetes.client.models import V1PodDNSConfig, V1PodDNSConfigOption
+
+
+def echo_op():
+    return dsl.ContainerOp(
+        name='echo',
+        image='library/bash:4.4.23',
+        command=['sh', '-c'],
+        arguments=['echo "hello world"']
+    )
+
+
+@dsl.pipeline(
+    name='dnsConfig setting',
+    description='Passes dnsConfig setting to workflow.'
+)
+def dns_config_pipeline():
+    echo_task = echo_op()
+
+
+if __name__ == '__main__':
+    pipeline_conf = kfp.dsl.PipelineConf()
+    pipeline_conf.set_dns_config(dns_config=V1PodDNSConfig(
+        nameservers=["1.2.3.4"],
+        options=[V1PodDNSConfigOption(name="ndots", value="2")]
+    ))
+
+    kfp.compiler.Compiler().compile(dns_config_pipeline, __file__ + '.yaml', pipeline_conf=pipeline_conf)

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -702,6 +702,9 @@ class Compiler(object):
     if pipeline_conf.default_pod_node_selector:
       workflow['spec']['nodeSelector'] = pipeline_conf.default_pod_node_selector
 
+    if pipeline_conf.dns_config:
+      workflow['spec']['dnsConfig'] = convert_k8s_obj_to_json(pipeline_conf.dns_config)
+
     if pipeline_conf.image_pull_policy != None:
       if pipeline_conf.image_pull_policy in ["Always", "Never", "IfNotPresent"]:
         for template in workflow["spec"]["templates"]:

--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -157,6 +157,17 @@ class PipelineConf():
       dns_config: Kubernetes V1PodDNSConfig
         For detailed description, check Kubernetes V1PodDNSConfig definition
         https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1PodDNSConfig.md
+
+    Example:
+
+      ::
+        import kfp
+        from kubernetes.client.models import V1PodDNSConfig, V1PodDNSConfigOption
+        pipeline_conf = kfp.dsl.PipelineConf()
+        pipeline_conf.set_dns_config(dns_config=V1PodDNSConfig(
+          nameservers=["1.2.3.4"],
+          options=[V1PodDNSConfigOption(name="ndots", value="2")]
+        ))
     """
     self.dns_config = dns_config
 

--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import Union
+from kubernetes.client.models import V1PodDNSConfig
 from . import _container_op
 from . import _resource_op
 from . import _ops_group
@@ -150,7 +151,7 @@ class PipelineConf():
     """
     self.op_transformers.append(transformer)
 
-  def set_dns_config(self, dns_config):
+  def set_dns_config(self, dns_config: V1PodDNSConfig):
     """Set the dnsConfig to be given to each pod.
 
     Args:

--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -66,6 +66,7 @@ class PipelineConf():
     self.image_pull_policy = None
     self.parallelism = None
     self._data_passing_method = None
+    self.dns_config = None
 
   def set_image_pull_secrets(self, image_pull_secrets):
     """Configures the pipeline level imagepullsecret
@@ -148,6 +149,16 @@ class PipelineConf():
       transformer: A function that takes a kfp Op as input and returns a kfp Op
     """
     self.op_transformers.append(transformer)
+
+  def set_dns_config(self, dns_config):
+    """Set the dnsConfig to be given to each pod.
+
+    Args:
+      dns_config: Kubernetes V1PodDNSConfig
+        For detailed description, check Kubernetes V1PodDNSConfig definition
+        https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1PodDNSConfig.md
+    """
+    self.dns_config = dns_config
 
   @property
   def data_passing_method(self):

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -805,10 +805,16 @@ implementation:
     @dsl.pipeline()
     def some_pipeline():
       some_op()
-      dsl.get_pipeline_conf().set_dns_config(V1PodDNSConfig(nameservers=["1.2.3.4"], options=[V1PodDNSConfigOption(name="ndots", value="2")]))
+      dsl.get_pipeline_conf().set_dns_config(V1PodDNSConfig(
+        nameservers=["1.2.3.4"],
+        options=[V1PodDNSConfigOption(name="ndots", value="2")]
+      ))
 
     workflow_dict = kfp.compiler.Compiler()._compile(some_pipeline)
-    self.assertEqual(workflow_dict['spec']['dnsConfig'], {"nameservers": ["1.2.3.4"], "options": [{"name": "ndots", "value": "2"}]})
+    self.assertEqual(
+      workflow_dict['spec']['dnsConfig'],
+      {"nameservers": ["1.2.3.4"], "options": [{"name": "ndots", "value": "2"}]}
+    )
 
   def test_container_op_output_error_when_no_or_multiple_outputs(self):
 

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -30,7 +30,7 @@ from kfp.dsl._component import component
 from kfp.dsl import ContainerOp, pipeline
 from kfp.dsl.types import Integer, InconsistentTypeException
 from kubernetes.client import V1Toleration, V1Affinity, V1NodeSelector, V1NodeSelectorRequirement, V1NodeSelectorTerm, \
-  V1NodeAffinity
+  V1NodeAffinity, V1PodDNSConfig, V1PodDNSConfigOption
 
 
 def some_op():
@@ -799,6 +799,16 @@ implementation:
 
     workflow_dict = kfp.compiler.Compiler()._compile(some_pipeline)
     self.assertEqual(workflow_dict['spec']['nodeSelector'], {"cloud.google.com/gke-accelerator":"nvidia-tesla-p4"})
+
+  def test_set_dns_config(self):
+    """Test a pipeline with node selector."""
+    @dsl.pipeline()
+    def some_pipeline():
+      some_op()
+      dsl.get_pipeline_conf().set_dns_config(V1PodDNSConfig(nameservers=["1.2.3.4"], options=[V1PodDNSConfigOption(name="ndots", value="2")]))
+
+    workflow_dict = kfp.compiler.Compiler()._compile(some_pipeline)
+    self.assertEqual(workflow_dict['spec']['dnsConfig'], {"nameservers": ["1.2.3.4"], "options": [{"name": "ndots", "value": "2"}]})
 
   def test_container_op_output_error_when_no_or_multiple_outputs(self):
 


### PR DESCRIPTION
Enable to set `dnsConfig` by SDK.

**Description of your changes:**
- Added a `dns_config` attribute to PipelineConf
- If dns_config is set, convert dns_config to k8s object at compile time

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
