### PR TITLE
chore(sdk.v2): Error out on invalid pipeline name

### DIFF
--- a/sdk/python/kfp/v2/compiler/compiler.py
+++ b/sdk/python/kfp/v2/compiler/compiler.py
@@ -73,8 +73,7 @@ class Compiler(object):
     Raises:
       NotImplementedError if the argument is of unsupported types.
     """
-    if not pipeline.name:
-      raise ValueError('Pipeline name is required.')
+    compiler_utils.validate_pipeline_name(pipeline.name)
 
     pipeline_spec = pipeline_spec_pb2.PipelineSpec(
         runtime_parameters=compiler_utils.build_runtime_parameter_spec(args))

--- a/sdk/python/kfp/v2/compiler/compiler_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_test.py
@@ -350,6 +350,19 @@ class CompilerTest(unittest.TestCase):
               - {inputPath: data}
           """)
 
+  def test_compile_pipeline_with_invalid_name_should_raise_error(self):
+    def my_pipeline():
+      pass
+
+    with self.assertRaisesRegex(
+        ValueError,
+        'Invalid pipeline name: .*\nPlease specify a pipeline name that matches'
+    ):
+      compiler.Compiler().compile(
+          pipeline_func=my_pipeline,
+          pipeline_root='dummy',
+          output_path='output.json')
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/sdk/python/kfp/v2/compiler/compiler_utils.py
+++ b/sdk/python/kfp/v2/compiler/compiler_utils.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 """KFP v2 DSL compiler utility functions."""
 
+import re
 from typing import Any, List, Mapping, Optional, Union
+
 from kfp.v2 import dsl
 from kfp.pipeline_spec import pipeline_spec_pb2
 
@@ -91,3 +93,22 @@ def build_runtime_config_spec(
   return pipeline_spec_pb2.PipelineJob.RuntimeConfig(
       gcs_output_directory=pipeline_root,
       parameters={k: _get_value(v) for k, v in parameter_values.items()})
+
+
+def validate_pipeline_name(name: str) -> None:
+  """Validate pipeline name.
+
+  A valid pipeline name should match ^[a-z0-9][a-z0-9-]{0,127}$.
+
+  Args:
+    name: The pipeline name.
+
+  Raises:
+    ValueError if the pipeline name doesn't conform to the regular expression.
+  """
+  pattern = re.compile(r'^[a-z0-9][a-z0-9-]{0,127}$')
+  if not pattern.match(name):
+    raise ValueError('Invalid pipeline name: %s.\n'
+                     'Please specify a pipeline name that matches the regular '
+                     'expression "^[a-z0-9][a-z0-9-]{0,127}$" using '
+                     '`dsl.pipeline(name=...)` decorator.' % name)

--- a/sdk/python/kfp/v2/compiler/compiler_utils_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_utils_test.py
@@ -88,6 +88,22 @@ class CompilerUtilsTest(unittest.TestCase):
         'gs://path', {'input1': 'test'})
     self.assertEqual(expected_spec, runtime_config)
 
+  def test_validate_pipeline_name(self):
+    compiler_utils.validate_pipeline_name('my-pipeline')
+
+    compiler_utils.validate_pipeline_name('p' * 128)
+
+    with self.assertRaisesRegex(ValueError, 'Invalid pipeline name: '):
+      compiler_utils.validate_pipeline_name('my_pipeline')
+
+    with self.assertRaisesRegex(ValueError, 'Invalid pipeline name: '):
+      compiler_utils.validate_pipeline_name('My pipeline')
+
+    with self.assertRaisesRegex(ValueError, 'Invalid pipeline name: '):
+      compiler_utils.validate_pipeline_name('-my-pipeline')
+
+    with self.assertRaisesRegex(ValueError, 'Invalid pipeline name: '):
+      compiler_utils.validate_pipeline_name('p' * 129)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
**Description of your changes:**
Raise an error if pipeline.name doesn't conform to [a-z0-9][a-z0-9-]{0,127}.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
