### PR TITLE
test: pin pip to fix a weird version resolution logic

### DIFF
--- a/test/presubmit-tests-tfx.sh
+++ b/test/presubmit-tests-tfx.sh
@@ -15,6 +15,7 @@
 
 source_root=$(pwd)
 
+# TODO(#4853) Skipping pip 20.3 due to a bad version resolution logic.
 python3 -m pip install --upgrade pip!=20.3.*
 python3 -m pip install -r "$source_root/sdk/python/requirements.txt"
 # Additional dependencies
@@ -43,7 +44,7 @@ chmod +x bazel_installer.sh
 cd $source_root
 git clone --depth 1 https://github.com/tensorflow/tfx.git
 cd $source_root/tfx
-python3 -m pip install . --upgrade \
+python3 -m pip install . --upgrade --use-feature=2020-resolver \
   --extra-index-url https://pypi-nightly.tensorflow.org/simple
 
 # Three KFP-related unittests

--- a/test/presubmit-tests-tfx.sh
+++ b/test/presubmit-tests-tfx.sh
@@ -43,7 +43,7 @@ chmod +x bazel_installer.sh
 cd $source_root
 git clone --depth 1 https://github.com/tensorflow/tfx.git
 cd $source_root/tfx
-python3 -m pip install . --upgrade --use-feature=2020-resolver \
+python3 -m pip install . --upgrade \
   --extra-index-url https://pypi-nightly.tensorflow.org/simple
 
 # Three KFP-related unittests

--- a/test/presubmit-tests-tfx.sh
+++ b/test/presubmit-tests-tfx.sh
@@ -15,7 +15,7 @@
 
 source_root=$(pwd)
 
-python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade pip!=20.3.*
 python3 -m pip install -r "$source_root/sdk/python/requirements.txt"
 # Additional dependencies
 #pip3 install coverage==4.5.4 coveralls==1.9.2 six>=1.13.0
@@ -43,7 +43,7 @@ chmod +x bazel_installer.sh
 cd $source_root
 git clone --depth 1 https://github.com/tensorflow/tfx.git
 cd $source_root/tfx
-python3 -m pip install . promise!=0.2.2 --upgrade \
+python3 -m pip install . --upgrade \
   --extra-index-url https://pypi-nightly.tensorflow.org/simple
 
 # Three KFP-related unittests

--- a/test/presubmit-tests-tfx.sh
+++ b/test/presubmit-tests-tfx.sh
@@ -43,7 +43,7 @@ chmod +x bazel_installer.sh
 cd $source_root
 git clone --depth 1 https://github.com/tensorflow/tfx.git
 cd $source_root/tfx
-python3 -m pip install . --upgrade \
+python3 -m pip install . promise!=0.2.2 --upgrade \
   --extra-index-url https://pypi-nightly.tensorflow.org/simple
 
 # Three KFP-related unittests


### PR DESCRIPTION
**Description of your changes:**

It looks like in `pip 20.3` it will scan through all available version of `promise` in order to get a compatible one. Then the test process failed due to a bad `promise` version. 


**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
