### PR TITLE
feat(sdk): Components - Restored stack traces in lightweight python components. Fixes #4273, #4849

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -33,6 +33,7 @@ from .structures import *
 
 import inspect
 from pathlib import Path
+import textwrap
 from typing import Callable, List, Optional, TypeVar
 import warnings
 
@@ -234,8 +235,6 @@ def _strip_type_hints_using_lib2to3(source_code: str) -> str:
 
 
 def _capture_function_code_using_source_copy(func) -> str:	
-    import textwrap
-
     func_code = inspect.getsource(func)
 
     #Function might be defined in some indented scope (e.g. in another function).
@@ -640,7 +639,18 @@ _outputs = {func_name}(**_parsed_args)
     component_spec.implementation=ContainerImplementation(
         container=ContainerSpec(
             image=base_image,
-            command=package_preinstallation_command + ['python3', '-u', '-c', full_source],
+            command=package_preinstallation_command + [
+                'sh',
+                '-ec',
+                # Writing the program code to a file.
+                # This is needed for Python to show stack traces and for `inspect.getsource` to work (used by PyTorch JIT and this module for example).
+                textwrap.dedent('''\
+                    program_path=$(mktemp)
+                    echo -n "$0" > "$program_path"
+                    python3 -u "$program_path" "$@"
+                '''),
+                full_source,
+            ],
             args=arguments,
         )
     )

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
@@ -16,9 +16,12 @@ spec:
           - "--param1"
           - "{{inputs.parameters.produce-list-of-strings-Output}}"
         command: 
-          - python3
-          - "-u"
-          - "-c"
+          - sh
+          - "-ec"
+          - |
+              program_path=$(mktemp)
+              echo -n "$0" > "$program_path"
+              python3 -u "$program_path" "$@"
           - |
               def consume(param1):
                   print(param1)
@@ -44,9 +47,12 @@ spec:
           - "--param1"
           - "{{inputs.parameters.produce-list-of-strings-Output-loop-item}}"
         command: 
-          - python3
-          - "-u"
-          - "-c"
+          - sh
+          - "-ec"
+          - |
+              program_path=$(mktemp)
+              echo -n "$0" > "$program_path"
+              python3 -u "$program_path" "$@"
           - |
               def consume(param1):
                   print(param1)
@@ -72,9 +78,12 @@ spec:
           - "--param1"
           - "{{inputs.parameters.produce-str-Output}}"
         command: 
-          - python3
-          - "-u"
-          - "-c"
+          - sh
+          - "-ec"
+          - |
+              program_path=$(mktemp)
+              echo -n "$0" > "$program_path"
+              python3 -u "$program_path" "$@"
           - |
               def consume(param1):
                   print(param1)
@@ -100,9 +109,12 @@ spec:
           - "--param1"
           - "{{inputs.parameters.produce-list-of-ints-Output}}"
         command: 
-          - python3
-          - "-u"
-          - "-c"
+          - sh
+          - "-ec"
+          - |
+              program_path=$(mktemp)
+              echo -n "$0" > "$program_path"
+              python3 -u "$program_path" "$@"
           - |
               def consume(param1):
                   print(param1)
@@ -128,9 +140,12 @@ spec:
           - "--param1"
           - "{{inputs.parameters.produce-list-of-ints-Output-loop-item}}"
         command: 
-          - python3
-          - "-u"
-          - "-c"
+          - sh
+          - "-ec"
+          - |
+              program_path=$(mktemp)
+              echo -n "$0" > "$program_path"
+              python3 -u "$program_path" "$@"
           - |
               def consume(param1):
                   print(param1)
@@ -156,9 +171,12 @@ spec:
           - "--param1"
           - "{{inputs.parameters.produce-list-of-dicts-Output}}"
         command: 
-          - python3
-          - "-u"
-          - "-c"
+          - sh
+          - "-ec"
+          - |
+              program_path=$(mktemp)
+              echo -n "$0" > "$program_path"
+              python3 -u "$program_path" "$@"
           - |
               def consume(param1):
                   print(param1)
@@ -184,9 +202,12 @@ spec:
           - "--param1"
           - "{{inputs.parameters.produce-list-of-dicts-Output-loop-item-subvar-aaa}}"
         command: 
-          - python3
-          - "-u"
-          - "-c"
+          - sh
+          - "-ec"
+          - |
+              program_path=$(mktemp)
+              echo -n "$0" > "$program_path"
+              python3 -u "$program_path" "$@"
           - |
               def consume(param1):
                   print(param1)
@@ -362,9 +383,12 @@ spec:
           - "----output-paths"
           - /tmp/outputs/Output/data
         command: 
-          - python3
-          - "-u"
-          - "-c"
+          - sh
+          - "-ec"
+          - |
+              program_path=$(mktemp)
+              echo -n "$0" > "$program_path"
+              python3 -u "$program_path" "$@"
           - |
               def produce_list_of_dicts():
                   return ([{"aaa": "aaa1", "bbb": "bbb1"}, {"aaa": "aaa2", "bbb": "bbb2"}],)
@@ -424,9 +448,12 @@ spec:
           - "----output-paths"
           - /tmp/outputs/Output/data
         command: 
-          - python3
-          - "-u"
-          - "-c"
+          - sh
+          - "-ec"
+          - |
+              program_path=$(mktemp)
+              echo -n "$0" > "$program_path"
+              python3 -u "$program_path" "$@"
           - |
               def produce_list_of_ints():
                   return ([1234567890, 987654321],)
@@ -486,9 +513,12 @@ spec:
           - "----output-paths"
           - /tmp/outputs/Output/data
         command: 
-          - python3
-          - "-u"
-          - "-c"
+          - sh
+          - "-ec"
+          - |
+              program_path=$(mktemp)
+              echo -n "$0" > "$program_path"
+              python3 -u "$program_path" "$@"
           - |
               def produce_list_of_strings():
                   return (["a", "z"],)
@@ -548,9 +578,12 @@ spec:
           - "----output-paths"
           - /tmp/outputs/Output/data
         command: 
-          - python3
-          - "-u"
-          - "-c"
+          - sh
+          - "-ec"
+          - |
+              program_path=$(mktemp)
+              echo -n "$0" > "$program_path"
+              python3 -u "$program_path" "$@"
           - |
               def produce_str():
                   return "Hello"


### PR DESCRIPTION
Currently were running the python code inline using `python -c <code>`.
This has two issues:
1) Python does not show source code line in exception stack traces
2) inspect.getsource does not work. This method is used in PyTorch JIT for example.

We solve these issues by writing the code into a file before executing it.

The disadvantage of the new approach is that it adds complexity, a filesystem write operation and also requires the `sh` executable to be present (we could replace it with python-based program if needed).
Fixes https://github.com/kubeflow/pipelines/issues/4273
Fixes https://github.com/kubeflow/pipelines/issues/4849
