### PR TITLE
fix(frontend): Use task_display_name annotation when displaying run metrics

### DIFF
--- a/frontend/src/lib/CompareUtils.test.ts
+++ b/frontend/src/lib/CompareUtils.test.ts
@@ -429,7 +429,7 @@ describe('CompareUtils', () => {
           { name: 'some-metric-name', node_id: 'node-1', number_value: 0.12 },
           { name: 'some-metric-name', node_id: 'node-2', number_value: 0.34 },
         ],
-      } as ApiRun
+      } as ApiRun;
       const workflow = {
         spec: {
           templates: [
@@ -438,14 +438,14 @@ describe('CompareUtils', () => {
               metadata: {
                 annotations: {
                   'pipelines.kubeflow.org/task_display_name': 'Some display annotation',
-                }
-              }
+                },
+              },
             },
             {
               name: 'template-2',
               metadata: {
                 annotations: {},
-              }
+              },
             },
           ],
         },
@@ -463,12 +463,12 @@ describe('CompareUtils', () => {
             },
           },
         },
-      } as any
+      } as any;
       expect(CompareUtils.singleRunToMetricsCompareProps(run, workflow)).toEqual({
         rows: [['0.120'], ['0.340']],
         xLabels: ['some-metric-name'],
-        yLabels: ['Some display annotation', 'node-2-display']
-      })
-    })
+        yLabels: ['Some display annotation', 'node-2-display'],
+      });
+    });
   });
 });

--- a/frontend/src/lib/CompareUtils.test.ts
+++ b/frontend/src/lib/CompareUtils.test.ts
@@ -422,5 +422,53 @@ describe('CompareUtils', () => {
         yLabels: ['someNodeId', 'anotherNodeId'],
       });
     });
+
+    it('displays the correct row name when task_display_name annotation is present on the template', () => {
+      const run = {
+        metrics: [
+          { name: 'some-metric-name', node_id: 'node-1', number_value: 0.12 },
+          { name: 'some-metric-name', node_id: 'node-2', number_value: 0.34 },
+        ],
+      } as ApiRun
+      const workflow = {
+        spec: {
+          templates: [
+            {
+              name: 'template-1',
+              metadata: {
+                annotations: {
+                  'pipelines.kubeflow.org/task_display_name': 'Some display annotation',
+                }
+              }
+            },
+            {
+              name: 'template-2',
+              metadata: {
+                annotations: {},
+              }
+            },
+          ],
+        },
+        status: {
+          nodes: {
+            'node-1': {
+              id: 'node-1',
+              displayName: 'node-1-display',
+              templateName: 'template-1',
+            },
+            'node-2': {
+              id: 'node-2',
+              displayName: 'node-2-display',
+              templateName: 'template-2',
+            },
+          },
+        },
+      } as any
+      expect(CompareUtils.singleRunToMetricsCompareProps(run, workflow)).toEqual({
+        rows: [['0.120'], ['0.340']],
+        xLabels: ['some-metric-name'],
+        yLabels: ['Some display annotation', 'node-2-display']
+      })
+    })
   });
 });

--- a/frontend/src/lib/CompareUtils.ts
+++ b/frontend/src/lib/CompareUtils.ts
@@ -22,6 +22,7 @@ import WorkflowParser from './WorkflowParser';
 import { logger } from './Utils';
 import RunUtils from './RunUtils';
 import MetricUtils from './MetricUtils';
+import { parseNodeDisplayName } from './ParserUtils';
 
 export default class CompareUtils {
   /**
@@ -118,7 +119,7 @@ export default class CompareUtils {
       xLabels = Array.from(namesToNodesToValues.keys());
 
       rows = Array.from(nodeIds.keys()).map(nodeId => {
-        yLabels.push((workflow && workflow.status.nodes[nodeId].displayName) || nodeId);
+        yLabels.push(parseNodeDisplayName(nodeId, workflow));
         return xLabels.map(metricName => namesToNodesToValues.get(metricName)!.get(nodeId) || '');
       });
     }

--- a/frontend/src/lib/CompareUtils.ts
+++ b/frontend/src/lib/CompareUtils.ts
@@ -22,7 +22,7 @@ import WorkflowParser from './WorkflowParser';
 import { logger } from './Utils';
 import RunUtils from './RunUtils';
 import MetricUtils from './MetricUtils';
-import { parseNodeDisplayName } from './ParserUtils';
+import { parseTaskDisplayNameByNodeId } from './ParserUtils';
 
 export default class CompareUtils {
   /**
@@ -119,7 +119,7 @@ export default class CompareUtils {
       xLabels = Array.from(namesToNodesToValues.keys());
 
       rows = Array.from(nodeIds.keys()).map(nodeId => {
-        yLabels.push(parseNodeDisplayName(nodeId, workflow));
+        yLabels.push(parseTaskDisplayNameByNodeId(nodeId, workflow));
         return xLabels.map(metricName => namesToNodesToValues.get(metricName)!.get(nodeId) || '');
       });
     }

--- a/frontend/src/lib/ParserUtils.ts
+++ b/frontend/src/lib/ParserUtils.ts
@@ -16,9 +16,9 @@ export function parseTaskDisplayName(metadata?: Metadata): string | undefined {
 }
 
 export function parseNodeDisplayName(nodeId: string, workflow?: Workflow): string {
-  const node = workflow?.status.nodes[nodeId]
-  if(!node) {
-    return nodeId
+  const node = workflow?.status.nodes[nodeId];
+  if (!node) {
+    return nodeId;
   }
   const workflowName = (workflow?.metadata && workflow?.metadata.name) || '';
   let displayName = node.displayName || node.id;
@@ -26,10 +26,8 @@ export function parseNodeDisplayName(nodeId: string, workflow?: Workflow): strin
     displayName = `onExit - ${node.templateName}`;
   }
   if (workflow?.spec && workflow?.spec.templates) {
-    const tmpl = workflow.spec.templates.find(
-      t => !!t && !!t.name && t.name === node.templateName,
-    );
+    const tmpl = workflow.spec.templates.find(t => !!t && !!t.name && t.name === node.templateName);
     displayName = parseTaskDisplayName(tmpl?.metadata) || displayName;
   }
-  return displayName
+  return displayName;
 }

--- a/frontend/src/lib/ParserUtils.ts
+++ b/frontend/src/lib/ParserUtils.ts
@@ -15,18 +15,18 @@ export function parseTaskDisplayName(metadata?: Metadata): string | undefined {
   return taskDisplayName || componentDisplayName;
 }
 
-export function parseNodeDisplayName(nodeId: string, workflow?: Workflow): string {
+export function parseTaskDisplayNameByNodeId(nodeId: string, workflow?: Workflow): string {
   const node = workflow?.status.nodes[nodeId];
   if (!node) {
     return nodeId;
   }
-  const workflowName = (workflow?.metadata && workflow?.metadata.name) || '';
+  const workflowName = workflow?.metadata?.name || '';
   let displayName = node.displayName || node.id;
   if (node.name === `${workflowName}.onExit`) {
     displayName = `onExit - ${node.templateName}`;
   }
   if (workflow?.spec && workflow?.spec.templates) {
-    const tmpl = workflow.spec.templates.find(t => !!t && !!t.name && t.name === node.templateName);
+    const tmpl = workflow.spec.templates.find(t => t?.name === node.templateName);
     displayName = parseTaskDisplayName(tmpl?.metadata) || displayName;
   }
   return displayName;

--- a/frontend/src/lib/ParserUtils.ts
+++ b/frontend/src/lib/ParserUtils.ts
@@ -1,4 +1,4 @@
-import { Metadata, NodeStatus, Workflow } from 'third_party/argo-ui/argo_template';
+import { Metadata, Workflow } from 'third_party/argo-ui/argo_template';
 
 export function parseTaskDisplayName(metadata?: Metadata): string | undefined {
   if (!metadata?.annotations) {

--- a/frontend/src/lib/ParserUtils.ts
+++ b/frontend/src/lib/ParserUtils.ts
@@ -1,4 +1,4 @@
-import { Metadata } from 'third_party/argo-ui/argo_template';
+import { Metadata, NodeStatus, Workflow } from 'third_party/argo-ui/argo_template';
 
 export function parseTaskDisplayName(metadata?: Metadata): string | undefined {
   if (!metadata?.annotations) {
@@ -13,4 +13,23 @@ export function parseTaskDisplayName(metadata?: Metadata): string | undefined {
     // Expected error: metadata is missing or malformed
   }
   return taskDisplayName || componentDisplayName;
+}
+
+export function parseNodeDisplayName(nodeId: string, workflow?: Workflow): string {
+  const node = workflow?.status.nodes[nodeId]
+  if(!node) {
+    return nodeId
+  }
+  const workflowName = (workflow?.metadata && workflow?.metadata.name) || '';
+  let displayName = node.displayName || node.id;
+  if (node.name === `${workflowName}.onExit`) {
+    displayName = `onExit - ${node.templateName}`;
+  }
+  if (workflow?.spec && workflow?.spec.templates) {
+    const tmpl = workflow.spec.templates.find(
+      t => !!t && !!t.name && t.name === node.templateName,
+    );
+    displayName = parseTaskDisplayName(tmpl?.metadata) || displayName;
+  }
+  return displayName
 }

--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -90,7 +90,7 @@ export default class WorkflowParser {
 
     // Create dagre graph nodes from workflow nodes.
     (Object as any).values(workflowNodes).forEach((node: NodeStatus) => {
-      const nodeLabel = parseNodeDisplayName(node.id, workflow)
+      const nodeLabel = parseNodeDisplayName(node.id, workflow);
 
       g.setNode(node.id, {
         height: Constants.NODE_HEIGHT,

--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -28,7 +28,7 @@ import { statusToIcon } from '../pages/Status';
 import { Constants } from './Constants';
 import { KeyValue } from './StaticGraphParser';
 import { hasFinished, NodePhase, statusToBgColor, parseNodePhase } from './StatusUtils';
-import { parseTaskDisplayName } from './ParserUtils';
+import { parseNodeDisplayName } from './ParserUtils';
 import { isS3Endpoint } from './AwsHelper';
 
 export enum StorageService {
@@ -90,17 +90,7 @@ export default class WorkflowParser {
 
     // Create dagre graph nodes from workflow nodes.
     (Object as any).values(workflowNodes).forEach((node: NodeStatus) => {
-      let nodeLabel = node.displayName || node.id;
-      if (node.name === `${workflowName}.onExit`) {
-        nodeLabel = `onExit - ${node.templateName}`;
-      }
-
-      if (workflow.spec && workflow.spec.templates) {
-        const tmpl = workflow.spec.templates.find(
-          t => !!t && !!t.name && t.name === node.templateName,
-        );
-        nodeLabel = parseTaskDisplayName(tmpl?.metadata) || nodeLabel;
-      }
+      const nodeLabel = parseNodeDisplayName(node.id, workflow)
 
       g.setNode(node.id, {
         height: Constants.NODE_HEIGHT,

--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -28,7 +28,7 @@ import { statusToIcon } from '../pages/Status';
 import { Constants } from './Constants';
 import { KeyValue } from './StaticGraphParser';
 import { hasFinished, NodePhase, statusToBgColor, parseNodePhase } from './StatusUtils';
-import { parseNodeDisplayName } from './ParserUtils';
+import { parseTaskDisplayNameByNodeId } from './ParserUtils';
 import { isS3Endpoint } from './AwsHelper';
 
 export enum StorageService {
@@ -90,7 +90,7 @@ export default class WorkflowParser {
 
     // Create dagre graph nodes from workflow nodes.
     (Object as any).values(workflowNodes).forEach((node: NodeStatus) => {
-      const nodeLabel = parseNodeDisplayName(node.id, workflow);
+      const nodeLabel = parseTaskDisplayNameByNodeId(node.id, workflow);
 
       g.setNode(node.id, {
         height: Constants.NODE_HEIGHT,


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/4107 and additionally ensures the display names used for the node in the graph UI and metrics UI match
