### PR TITLE
[IR] Add deployment spec to IR spec.

### DIFF
--- a/api/v2alpha1/pipeline_spec.proto
+++ b/api/v2alpha1/pipeline_spec.proto
@@ -51,7 +51,12 @@ message PipelineSpec {
   // The deployment config of the pipeline.
   // The deployment config can be extended to provide platform specific configs.
   // The supported config is [PipelineDeploymentConifg]().
-  google.protobuf.Any deployment_config = 3;
+  // Deprecated in favor of deployment_spec.
+  google.protobuf.Any deployment_config = 3 [deprecated = true];
+
+  // The deployment config of the pipeline.
+  // The deployment config can be extended to provide platform specific configs.
+  google.protobuf.Struct deployment_spec = 7;
 
   // The version of the sdk, which compiles the spec.
   string sdk_version = 4;

--- a/api/v2alpha1/python/setup.py
+++ b/api/v2alpha1/python/setup.py
@@ -22,7 +22,7 @@ except ImportError:
   from shutil import which as find_executable
 
 NAME = "kfp-pipeline-spec"
-VERSION = "0.1.2"
+VERSION = "0.1.3"
 
 PROTO_DIR = os.path.realpath(
     os.path.join(os.path.dirname(__file__), os.pardir))


### PR DESCRIPTION
**Description of your changes:**

Add `deployment_spec` field which is a structure-typed field, and mark the old `deployment_config` field as deprecated in favor of the new field.

The problem with Any-typed field is that when multiple copies of the Python proto libraries are imported to the same Python environment, there will be a conflict because they share the namespace. And this is inevitable because in Any field we'll need the type url which encodes the proto package name.


**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
