### PR TITLE
fix(sdk): make healthz exception visible in logs by default

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -311,7 +311,7 @@ class Client(object):
       try:
         response = self._healthz_api.get_healthz()
         return response
-      except:
+      except Exception:
         logging.exception('Failed to get healthz info attempt {} of 5.'.format(count))
         time.sleep(5)
 

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -307,12 +307,12 @@ class Client(object):
     while not response:
       count += 1
       if count > max_attempts:
-        raise TimeoutError('API call timeout')
+        raise TimeoutError('Failed getting healthz endpoint after {} attempts.'.format(max_attempts))
       try:
         response = self._healthz_api.get_healthz()
         return response
       except:
-        logging.info('Failed to get healthz info attempt {} of 5.'.format(count))
+        logging.exception('Failed to get healthz info attempt {} of 5.'.format(count))
         time.sleep(5)
 
   def get_user_namespace(self):

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -311,7 +311,10 @@ class Client(object):
       try:
         response = self._healthz_api.get_healthz()
         return response
-      except Exception:
+      # ApiException, including network errors, is the only type that may
+      # recover after retry.
+      except kfp_server_api.ApiException:
+        # logging.exception also logs detailed info about the ApiException
         logging.exception('Failed to get healthz info attempt {} of 5.'.format(count))
         time.sleep(5)
 


### PR DESCRIPTION
**Description of your changes:**
make healthz exception visible in logs by default.
I noticed that `logging.info` do not show in logs by default, it's better to change it to exception, so that we can also see the exact exception information to facilitate debugging.

Context:
in https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/kubeflow-pipelines-periodic-functional-test/1339054226130604032#1:build-log.txt%3A271, the client fails with authz errors, but logs are empty when trying

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
