### PR TITLE
fix(frontend): Change CachedIcon to something more intuitive

### DIFF
--- a/frontend/src/icons/statusCached.tsx
+++ b/frontend/src/icons/statusCached.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import SuccessIcon from '@material-ui/icons/CheckCircle';
+import CachedIcon from '@material-ui/icons/Cached';
+
+export default class StatusCached extends React.Component<{ style: any }> {
+  public render(): JSX.Element {
+    const { style } = this.props;
+    return (
+      <div
+        style={{
+          display: 'flex',
+          height: '100%',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+        }}
+      >
+        <SuccessIcon style={{ ...style }} />
+        <div>
+          {/* We use this div because parent element has weird padding and this seems to workaround it */}
+          <CachedIcon style={{ ...style }} />
+        </div>
+      </div>
+    );
+  }
+}

--- a/frontend/src/pages/Status.tsx
+++ b/frontend/src/pages/Status.tsx
@@ -20,7 +20,7 @@ import PendingIcon from '@material-ui/icons/Schedule';
 import RunningIcon from '../icons/statusRunning';
 import SkippedIcon from '@material-ui/icons/SkipNext';
 import SuccessIcon from '@material-ui/icons/CheckCircle';
-import CachedIcon from '@material-ui/icons/Cached';
+import CachedIcon from '../icons/statusCached';
 import TerminatedIcon from '../icons/statusTerminated';
 import Tooltip from '@material-ui/core/Tooltip';
 import UnknownIcon from '@material-ui/icons/Help';

--- a/frontend/src/pages/__snapshots__/Status.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/Status.test.tsx.snap
@@ -2901,7 +2901,7 @@ exports[`Status statusToIcon renders an icon with tooltip for phase: CACHED 1`] 
       }
     }
   >
-    <pure(CachedIcon)
+    <StatusCached
       style={
         Object {
           "color": "#34a853",


### PR DESCRIPTION
**Description of your changes:**

Change the icon used on cached steps to make them more intuitive.
The previously used CachedIcon (from material UI) can be easily confused
with some kind of 'loop' or 'sync'.

This commit changes the icon used to a combination of SuccessIcon and
CachedIcon from the material UI library. This clarifies that the step
actually ran successfully and its execution was cached.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
