### PR TITLE
fix(sdk): compile ParallelFor in a deterministic manner

### DIFF
--- a/sdk/python/kfp/dsl/_ops_group.py
+++ b/sdk/python/kfp/dsl/_ops_group.py
@@ -53,7 +53,7 @@ class OpsGroup(object):
   def _get_matching_opsgroup_already_in_pipeline(group_type, name):
     """Retrieves the opsgroup when the pipeline already contains it.
     the opsgroup might be already in the pipeline in case of recursive calls.
-  
+
     Args:
       group_type (str): one of 'pipeline', 'exit_handler', 'condition', and 'graph'.
       name (str): the name before conversion.
@@ -193,10 +193,6 @@ class ParallelFor(OpsGroup):
   """
   TYPE_NAME = 'for_loop'
 
-  @staticmethod
-  def _get_unique_id_code():
-    return uuid.uuid4().hex[:_for_loop.LoopArguments.NUM_CODE_CHARS]
-
   def __init__(self,  loop_args: Union[_for_loop.ItemList, _pipeline_param.PipelineParam],
                parallelism: int=None):
     if parallelism and parallelism < 1:
@@ -204,16 +200,16 @@ class ParallelFor(OpsGroup):
     
     self.items_is_pipeline_param = isinstance(loop_args, _pipeline_param.PipelineParam)
 
-    # use a random code to uniquely identify this loop
-    code = self._get_unique_id_code()
-    group_name = 'for-loop-{}'.format(code)
-    super().__init__(self.TYPE_NAME, name=group_name, parallelism=parallelism)
+    super().__init__(self.TYPE_NAME, parallelism=parallelism)
 
     if self.items_is_pipeline_param:
       loop_args = _for_loop.LoopArguments.from_pipeline_param(loop_args)
     elif not self.items_is_pipeline_param and not isinstance(loop_args, _for_loop.LoopArguments):
       # we were passed a raw list, wrap it in loop args
-      loop_args = _for_loop.LoopArguments(loop_args, code)
+      loop_args = _for_loop.LoopArguments(
+        loop_args,
+        code=str(_pipeline.Pipeline.get_default_pipeline().get_next_group_id()),
+      )
 
     self.loop_args = loop_args
 

--- a/sdk/python/tests/compiler/testdata/loop_over_lightweight_output.py
+++ b/sdk/python/tests/compiler/testdata/loop_over_lightweight_output.py
@@ -17,17 +17,6 @@ import kfp
 from kfp import dsl
 from kfp.dsl import _for_loop
 
-class Coder:
-  def __init__(self, ):
-    self._code_id = 0
-
-  def get_code(self, ):
-    self._code_id += 1
-    return '{code:0{num_chars:}d}'.format(code=self._code_id, num_chars=_for_loop.LoopArguments.NUM_CODE_CHARS)
-
-
-dsl.ParallelFor._get_unique_id_code = Coder().get_code
-
 produce_op = kfp.components.load_component_from_text('''\
 name: Produce list
 outputs:

--- a/sdk/python/tests/compiler/testdata/loop_over_lightweight_output.yaml
+++ b/sdk/python/tests/compiler/testdata/loop_over_lightweight_output.yaml
@@ -66,7 +66,7 @@
           - "name": |-
               produce-list-data_list-loop-item
       "name": |-
-        for-loop-for-loop-00000001-1
+        for-loop-1
     - "dag":
         "tasks":
           - "arguments":
@@ -79,9 +79,9 @@
               - |-
                 produce-list
             "name": |-
-              for-loop-for-loop-00000001-1
+              for-loop-1
             "template": |-
-              for-loop-for-loop-00000001-1
+              for-loop-1
             "withParam": |-
               {{tasks.produce-list.outputs.parameters.produce-list-data_list}}
           - "name": |-

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.py
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.py
@@ -13,22 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import NamedTuple
-
 import kfp
 from kfp.components import func_to_container_op
-
-
-# Stabilizing the test output
-class StableIDGenerator:
-    def __init__(self, ):
-        self._index = 0
-
-    def get_next_id(self, ):
-        self._index += 1
-        return '{code:0{num_chars:}d}'.format(code=self._index, num_chars=kfp.dsl._for_loop.LoopArguments.NUM_CODE_CHARS)
-
-kfp.dsl.ParallelFor._get_unique_id_code = StableIDGenerator().get_next_id
 
 
 @func_to_container_op
@@ -76,6 +62,11 @@ def parallelfor_item_argument_resolving():
         consume(produce_list_of_dicts_task.output)
         #consume(loop_item) # Cannot use the full loop item when it's a dict
         consume(loop_item.aaa)
+
+    loop_args = [{'a': 1, 'b': 2}, {'a': 10, 'b': 20}]
+    with kfp.dsl.ParallelFor(loop_args) as loop_item:
+        consume(loop_args)
+        consume(loop_item)
 
 
 if __name__ == '__main__':

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
@@ -1,703 +1,722 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  annotations:
-    pipelines.kubeflow.org/pipeline_spec: "{\"name\": \"Parallelfor item argument resolving pipeline\"}"
   generateName: parallelfor-item-argument-resolving-
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.3.0, pipelines.kubeflow.org/pipeline_compilation_time: '2021-01-20T11:30:05.340345',
+    pipelines.kubeflow.org/pipeline_spec: '{"name": "Parallelfor item argument resolving"}'}
+  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.3.0}
 spec:
+  entrypoint: parallelfor-item-argument-resolving
+  templates:
+  - name: consume
+    container:
+      args: [--param1, '{{inputs.parameters.produce-list-of-strings-Output}}']
+      command:
+      - sh
+      - -ec
+      - |
+        program_path=$(mktemp)
+        printf "%s" "$0" > "$program_path"
+        python3 -u "$program_path" "$@"
+      - |
+        def consume(param1):
+            print(param1)
+
+        import argparse
+        _parser = argparse.ArgumentParser(prog='Consume', description='')
+        _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
+        _parsed_args = vars(_parser.parse_args())
+
+        _outputs = consume(**_parsed_args)
+      image: python:3.7
+    inputs:
+      parameters:
+      - {name: produce-list-of-strings-Output}
+    metadata:
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": ["--param1", {"inputValue": "param1"}], "command": ["sh", "-ec",
+          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
+          argparse\n_parser = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
+          dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
+          = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
+          "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name": "Consume"}',
+        pipelines.kubeflow.org/component_ref: '{}', pipelines.kubeflow.org/arguments.parameters: '{"param1":
+          "{{inputs.parameters.produce-list-of-strings-Output}}"}'}
+  - name: consume-2
+    container:
+      args: [--param1, '{{inputs.parameters.produce-list-of-strings-Output-loop-item}}']
+      command:
+      - sh
+      - -ec
+      - |
+        program_path=$(mktemp)
+        printf "%s" "$0" > "$program_path"
+        python3 -u "$program_path" "$@"
+      - |
+        def consume(param1):
+            print(param1)
+
+        import argparse
+        _parser = argparse.ArgumentParser(prog='Consume', description='')
+        _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
+        _parsed_args = vars(_parser.parse_args())
+
+        _outputs = consume(**_parsed_args)
+      image: python:3.7
+    inputs:
+      parameters:
+      - {name: produce-list-of-strings-Output-loop-item}
+    metadata:
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": ["--param1", {"inputValue": "param1"}], "command": ["sh", "-ec",
+          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
+          argparse\n_parser = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
+          dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
+          = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
+          "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name": "Consume"}',
+        pipelines.kubeflow.org/component_ref: '{}', pipelines.kubeflow.org/arguments.parameters: '{"param1":
+          "{{inputs.parameters.produce-list-of-strings-Output-loop-item}}"}'}
+  - name: consume-3
+    container:
+      args: [--param1, '{{inputs.parameters.produce-str-Output}}']
+      command:
+      - sh
+      - -ec
+      - |
+        program_path=$(mktemp)
+        printf "%s" "$0" > "$program_path"
+        python3 -u "$program_path" "$@"
+      - |
+        def consume(param1):
+            print(param1)
+
+        import argparse
+        _parser = argparse.ArgumentParser(prog='Consume', description='')
+        _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
+        _parsed_args = vars(_parser.parse_args())
+
+        _outputs = consume(**_parsed_args)
+      image: python:3.7
+    inputs:
+      parameters:
+      - {name: produce-str-Output}
+    metadata:
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": ["--param1", {"inputValue": "param1"}], "command": ["sh", "-ec",
+          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
+          argparse\n_parser = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
+          dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
+          = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
+          "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name": "Consume"}',
+        pipelines.kubeflow.org/component_ref: '{}', pipelines.kubeflow.org/arguments.parameters: '{"param1":
+          "{{inputs.parameters.produce-str-Output}}"}'}
+  - name: consume-4
+    container:
+      args: [--param1, '{{inputs.parameters.produce-list-of-ints-Output}}']
+      command:
+      - sh
+      - -ec
+      - |
+        program_path=$(mktemp)
+        printf "%s" "$0" > "$program_path"
+        python3 -u "$program_path" "$@"
+      - |
+        def consume(param1):
+            print(param1)
+
+        import argparse
+        _parser = argparse.ArgumentParser(prog='Consume', description='')
+        _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
+        _parsed_args = vars(_parser.parse_args())
+
+        _outputs = consume(**_parsed_args)
+      image: python:3.7
+    inputs:
+      parameters:
+      - {name: produce-list-of-ints-Output}
+    metadata:
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": ["--param1", {"inputValue": "param1"}], "command": ["sh", "-ec",
+          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
+          argparse\n_parser = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
+          dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
+          = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
+          "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name": "Consume"}',
+        pipelines.kubeflow.org/component_ref: '{}', pipelines.kubeflow.org/arguments.parameters: '{"param1":
+          "{{inputs.parameters.produce-list-of-ints-Output}}"}'}
+  - name: consume-5
+    container:
+      args: [--param1, '{{inputs.parameters.produce-list-of-ints-Output-loop-item}}']
+      command:
+      - sh
+      - -ec
+      - |
+        program_path=$(mktemp)
+        printf "%s" "$0" > "$program_path"
+        python3 -u "$program_path" "$@"
+      - |
+        def consume(param1):
+            print(param1)
+
+        import argparse
+        _parser = argparse.ArgumentParser(prog='Consume', description='')
+        _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
+        _parsed_args = vars(_parser.parse_args())
+
+        _outputs = consume(**_parsed_args)
+      image: python:3.7
+    inputs:
+      parameters:
+      - {name: produce-list-of-ints-Output-loop-item}
+    metadata:
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": ["--param1", {"inputValue": "param1"}], "command": ["sh", "-ec",
+          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
+          argparse\n_parser = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
+          dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
+          = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
+          "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name": "Consume"}',
+        pipelines.kubeflow.org/component_ref: '{}', pipelines.kubeflow.org/arguments.parameters: '{"param1":
+          "{{inputs.parameters.produce-list-of-ints-Output-loop-item}}"}'}
+  - name: consume-6
+    container:
+      args: [--param1, '{{inputs.parameters.produce-list-of-dicts-Output}}']
+      command:
+      - sh
+      - -ec
+      - |
+        program_path=$(mktemp)
+        printf "%s" "$0" > "$program_path"
+        python3 -u "$program_path" "$@"
+      - |
+        def consume(param1):
+            print(param1)
+
+        import argparse
+        _parser = argparse.ArgumentParser(prog='Consume', description='')
+        _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
+        _parsed_args = vars(_parser.parse_args())
+
+        _outputs = consume(**_parsed_args)
+      image: python:3.7
+    inputs:
+      parameters:
+      - {name: produce-list-of-dicts-Output}
+    metadata:
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": ["--param1", {"inputValue": "param1"}], "command": ["sh", "-ec",
+          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
+          argparse\n_parser = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
+          dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
+          = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
+          "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name": "Consume"}',
+        pipelines.kubeflow.org/component_ref: '{}', pipelines.kubeflow.org/arguments.parameters: '{"param1":
+          "{{inputs.parameters.produce-list-of-dicts-Output}}"}'}
+  - name: consume-7
+    container:
+      args: [--param1, '{{inputs.parameters.produce-list-of-dicts-Output-loop-item-subvar-aaa}}']
+      command:
+      - sh
+      - -ec
+      - |
+        program_path=$(mktemp)
+        printf "%s" "$0" > "$program_path"
+        python3 -u "$program_path" "$@"
+      - |
+        def consume(param1):
+            print(param1)
+
+        import argparse
+        _parser = argparse.ArgumentParser(prog='Consume', description='')
+        _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
+        _parsed_args = vars(_parser.parse_args())
+
+        _outputs = consume(**_parsed_args)
+      image: python:3.7
+    inputs:
+      parameters:
+      - {name: produce-list-of-dicts-Output-loop-item-subvar-aaa}
+    metadata:
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": ["--param1", {"inputValue": "param1"}], "command": ["sh", "-ec",
+          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
+          argparse\n_parser = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
+          dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
+          = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
+          "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name": "Consume"}',
+        pipelines.kubeflow.org/component_ref: '{}', pipelines.kubeflow.org/arguments.parameters: '{"param1":
+          "{{inputs.parameters.produce-list-of-dicts-Output-loop-item-subvar-aaa}}"}'}
+  - name: consume-8
+    container:
+      args: [--param1, '[{"a": 1, "b": 2}, {"a": 10, "b": 20}]']
+      command:
+      - sh
+      - -ec
+      - |
+        program_path=$(mktemp)
+        printf "%s" "$0" > "$program_path"
+        python3 -u "$program_path" "$@"
+      - |
+        def consume(param1):
+            print(param1)
+
+        import argparse
+        _parser = argparse.ArgumentParser(prog='Consume', description='')
+        _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
+        _parsed_args = vars(_parser.parse_args())
+
+        _outputs = consume(**_parsed_args)
+      image: python:3.7
+    metadata:
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": ["--param1", {"inputValue": "param1"}], "command": ["sh", "-ec",
+          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
+          argparse\n_parser = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
+          dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
+          = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
+          "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name": "Consume"}',
+        pipelines.kubeflow.org/component_ref: '{}', pipelines.kubeflow.org/arguments.parameters: '{"param1":
+          "[{\"a\": 1, \"b\": 2}, {\"a\": 10, \"b\": 20}]"}'}
+  - name: consume-9
+    container:
+      args: [--param1, '{{inputs.parameters.loop-item-param-4}}']
+      command:
+      - sh
+      - -ec
+      - |
+        program_path=$(mktemp)
+        printf "%s" "$0" > "$program_path"
+        python3 -u "$program_path" "$@"
+      - |
+        def consume(param1):
+            print(param1)
+
+        import argparse
+        _parser = argparse.ArgumentParser(prog='Consume', description='')
+        _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
+        _parsed_args = vars(_parser.parse_args())
+
+        _outputs = consume(**_parsed_args)
+      image: python:3.7
+    inputs:
+      parameters:
+      - {name: loop-item-param-4}
+    metadata:
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": ["--param1", {"inputValue": "param1"}], "command": ["sh", "-ec",
+          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
+          argparse\n_parser = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
+          dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
+          = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
+          "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name": "Consume"}',
+        pipelines.kubeflow.org/component_ref: '{}', pipelines.kubeflow.org/arguments.parameters: '{"param1":
+          "{{inputs.parameters.loop-item-param-4}}"}'}
+  - name: for-loop-1
+    inputs:
+      parameters:
+      - {name: produce-list-of-strings-Output}
+      - {name: produce-list-of-strings-Output-loop-item}
+      - {name: produce-str-Output}
+    dag:
+      tasks:
+      - name: consume
+        template: consume
+        arguments:
+          parameters:
+          - {name: produce-list-of-strings-Output, value: '{{inputs.parameters.produce-list-of-strings-Output}}'}
+      - name: consume-2
+        template: consume-2
+        arguments:
+          parameters:
+          - {name: produce-list-of-strings-Output-loop-item, value: '{{inputs.parameters.produce-list-of-strings-Output-loop-item}}'}
+      - name: consume-3
+        template: consume-3
+        arguments:
+          parameters:
+          - {name: produce-str-Output, value: '{{inputs.parameters.produce-str-Output}}'}
+  - name: for-loop-2
+    inputs:
+      parameters:
+      - {name: produce-list-of-ints-Output}
+      - {name: produce-list-of-ints-Output-loop-item}
+    dag:
+      tasks:
+      - name: consume-4
+        template: consume-4
+        arguments:
+          parameters:
+          - {name: produce-list-of-ints-Output, value: '{{inputs.parameters.produce-list-of-ints-Output}}'}
+      - name: consume-5
+        template: consume-5
+        arguments:
+          parameters:
+          - {name: produce-list-of-ints-Output-loop-item, value: '{{inputs.parameters.produce-list-of-ints-Output-loop-item}}'}
+  - name: for-loop-3
+    inputs:
+      parameters:
+      - {name: produce-list-of-dicts-Output}
+      - {name: produce-list-of-dicts-Output-loop-item-subvar-aaa}
+    dag:
+      tasks:
+      - name: consume-6
+        template: consume-6
+        arguments:
+          parameters:
+          - {name: produce-list-of-dicts-Output, value: '{{inputs.parameters.produce-list-of-dicts-Output}}'}
+      - name: consume-7
+        template: consume-7
+        arguments:
+          parameters:
+          - {name: produce-list-of-dicts-Output-loop-item-subvar-aaa, value: '{{inputs.parameters.produce-list-of-dicts-Output-loop-item-subvar-aaa}}'}
+  - name: for-loop-5
+    inputs:
+      parameters:
+      - {name: loop-item-param-4}
+    dag:
+      tasks:
+      - {name: consume-8, template: consume-8}
+      - name: consume-9
+        template: consume-9
+        arguments:
+          parameters:
+          - {name: loop-item-param-4, value: '{{inputs.parameters.loop-item-param-4}}'}
+  - name: parallelfor-item-argument-resolving
+    dag:
+      tasks:
+      - name: for-loop-1
+        template: for-loop-1
+        dependencies: [produce-list-of-strings, produce-str]
+        arguments:
+          parameters:
+          - {name: produce-list-of-strings-Output, value: '{{tasks.produce-list-of-strings.outputs.parameters.produce-list-of-strings-Output}}'}
+          - {name: produce-list-of-strings-Output-loop-item, value: '{{item}}'}
+          - {name: produce-str-Output, value: '{{tasks.produce-str.outputs.parameters.produce-str-Output}}'}
+        withParam: '{{tasks.produce-list-of-strings.outputs.parameters.produce-list-of-strings-Output}}'
+      - name: for-loop-2
+        template: for-loop-2
+        dependencies: [produce-list-of-ints]
+        arguments:
+          parameters:
+          - {name: produce-list-of-ints-Output, value: '{{tasks.produce-list-of-ints.outputs.parameters.produce-list-of-ints-Output}}'}
+          - {name: produce-list-of-ints-Output-loop-item, value: '{{item}}'}
+        withParam: '{{tasks.produce-list-of-ints.outputs.parameters.produce-list-of-ints-Output}}'
+      - name: for-loop-3
+        template: for-loop-3
+        dependencies: [produce-list-of-dicts]
+        arguments:
+          parameters:
+          - {name: produce-list-of-dicts-Output, value: '{{tasks.produce-list-of-dicts.outputs.parameters.produce-list-of-dicts-Output}}'}
+          - {name: produce-list-of-dicts-Output-loop-item-subvar-aaa, value: '{{item.aaa}}'}
+        withParam: '{{tasks.produce-list-of-dicts.outputs.parameters.produce-list-of-dicts-Output}}'
+      - name: for-loop-5
+        template: for-loop-5
+        arguments:
+          parameters:
+          - {name: loop-item-param-4, value: '{{item}}'}
+        withItems:
+        - {a: 1, b: 2}
+        - {a: 10, b: 20}
+      - {name: produce-list-of-dicts, template: produce-list-of-dicts}
+      - {name: produce-list-of-ints, template: produce-list-of-ints}
+      - {name: produce-list-of-strings, template: produce-list-of-strings}
+      - {name: produce-str, template: produce-str}
+  - name: produce-list-of-dicts
+    container:
+      args: ['----output-paths', /tmp/outputs/Output/data]
+      command:
+      - sh
+      - -ec
+      - |
+        program_path=$(mktemp)
+        printf "%s" "$0" > "$program_path"
+        python3 -u "$program_path" "$@"
+      - |
+        def produce_list_of_dicts():
+            return ([{"aaa": "aaa1", "bbb": "bbb1"}, {"aaa": "aaa2", "bbb": "bbb2"}],)
+
+        def _serialize_json(obj) -> str:
+            if isinstance(obj, str):
+                return obj
+            import json
+            def default_serializer(obj):
+                if hasattr(obj, 'to_struct'):
+                    return obj.to_struct()
+                else:
+                    raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
+            return json.dumps(obj, default=default_serializer, sort_keys=True)
+
+        import argparse
+        _parser = argparse.ArgumentParser(prog='Produce list of dicts', description='')
+        _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
+        _parsed_args = vars(_parser.parse_args())
+        _output_files = _parsed_args.pop("_output_paths", [])
+
+        _outputs = produce_list_of_dicts(**_parsed_args)
+
+        _outputs = [_outputs]
+
+        _output_serializers = [
+            _serialize_json,
+
+        ]
+
+        import os
+        for idx, output_file in enumerate(_output_files):
+            try:
+                os.makedirs(os.path.dirname(output_file))
+            except OSError:
+                pass
+            with open(output_file, 'w') as f:
+                f.write(_output_serializers[idx](_outputs[idx]))
+      image: python:3.7
+    outputs:
+      parameters:
+      - name: produce-list-of-dicts-Output
+        valueFrom: {path: /tmp/outputs/Output/data}
+      artifacts:
+      - {name: produce-list-of-dicts-Output, path: /tmp/outputs/Output/data}
+    metadata:
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": ["----output-paths", {"outputPath": "Output"}], "command": ["sh",
+          "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def produce_list_of_dicts():\n    return
+          ([{\"aaa\": \"aaa1\", \"bbb\": \"bbb1\"}, {\"aaa\": \"aaa2\", \"bbb\": \"bbb2\"}],)\n\ndef
+          _serialize_json(obj) -> str:\n    if isinstance(obj, str):\n        return
+          obj\n    import json\n    def default_serializer(obj):\n        if hasattr(obj,
+          ''to_struct''):\n            return obj.to_struct()\n        else:\n            raise
+          TypeError(\"Object of type ''%s'' is not JSON serializable and does not
+          have .to_struct() method.\" % obj.__class__.__name__)\n    return json.dumps(obj,
+          default=default_serializer, sort_keys=True)\n\nimport argparse\n_parser
+          = argparse.ArgumentParser(prog=''Produce list of dicts'', description='''')\n_parser.add_argument(\"----output-paths\",
+          dest=\"_output_paths\", type=str, nargs=1)\n_parsed_args = vars(_parser.parse_args())\n_output_files
+          = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = produce_list_of_dicts(**_parsed_args)\n\n_outputs
+          = [_outputs]\n\n_output_serializers = [\n    _serialize_json,\n\n]\n\nimport
+          os\nfor idx, output_file in enumerate(_output_files):\n    try:\n        os.makedirs(os.path.dirname(output_file))\n    except
+          OSError:\n        pass\n    with open(output_file, ''w'') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"],
+          "image": "python:3.7"}}, "name": "Produce list of dicts", "outputs": [{"name":
+          "Output", "type": "JsonArray"}]}', pipelines.kubeflow.org/component_ref: '{}'}
+  - name: produce-list-of-ints
+    container:
+      args: ['----output-paths', /tmp/outputs/Output/data]
+      command:
+      - sh
+      - -ec
+      - |
+        program_path=$(mktemp)
+        printf "%s" "$0" > "$program_path"
+        python3 -u "$program_path" "$@"
+      - |
+        def produce_list_of_ints():
+            return ([1234567890, 987654321],)
+
+        def _serialize_json(obj) -> str:
+            if isinstance(obj, str):
+                return obj
+            import json
+            def default_serializer(obj):
+                if hasattr(obj, 'to_struct'):
+                    return obj.to_struct()
+                else:
+                    raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
+            return json.dumps(obj, default=default_serializer, sort_keys=True)
+
+        import argparse
+        _parser = argparse.ArgumentParser(prog='Produce list of ints', description='')
+        _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
+        _parsed_args = vars(_parser.parse_args())
+        _output_files = _parsed_args.pop("_output_paths", [])
+
+        _outputs = produce_list_of_ints(**_parsed_args)
+
+        _outputs = [_outputs]
+
+        _output_serializers = [
+            _serialize_json,
+
+        ]
+
+        import os
+        for idx, output_file in enumerate(_output_files):
+            try:
+                os.makedirs(os.path.dirname(output_file))
+            except OSError:
+                pass
+            with open(output_file, 'w') as f:
+                f.write(_output_serializers[idx](_outputs[idx]))
+      image: python:3.7
+    outputs:
+      parameters:
+      - name: produce-list-of-ints-Output
+        valueFrom: {path: /tmp/outputs/Output/data}
+      artifacts:
+      - {name: produce-list-of-ints-Output, path: /tmp/outputs/Output/data}
+    metadata:
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": ["----output-paths", {"outputPath": "Output"}], "command": ["sh",
+          "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def produce_list_of_ints():\n    return
+          ([1234567890, 987654321],)\n\ndef _serialize_json(obj) -> str:\n    if isinstance(obj,
+          str):\n        return obj\n    import json\n    def default_serializer(obj):\n        if
+          hasattr(obj, ''to_struct''):\n            return obj.to_struct()\n        else:\n            raise
+          TypeError(\"Object of type ''%s'' is not JSON serializable and does not
+          have .to_struct() method.\" % obj.__class__.__name__)\n    return json.dumps(obj,
+          default=default_serializer, sort_keys=True)\n\nimport argparse\n_parser
+          = argparse.ArgumentParser(prog=''Produce list of ints'', description='''')\n_parser.add_argument(\"----output-paths\",
+          dest=\"_output_paths\", type=str, nargs=1)\n_parsed_args = vars(_parser.parse_args())\n_output_files
+          = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = produce_list_of_ints(**_parsed_args)\n\n_outputs
+          = [_outputs]\n\n_output_serializers = [\n    _serialize_json,\n\n]\n\nimport
+          os\nfor idx, output_file in enumerate(_output_files):\n    try:\n        os.makedirs(os.path.dirname(output_file))\n    except
+          OSError:\n        pass\n    with open(output_file, ''w'') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"],
+          "image": "python:3.7"}}, "name": "Produce list of ints", "outputs": [{"name":
+          "Output", "type": "JsonArray"}]}', pipelines.kubeflow.org/component_ref: '{}'}
+  - name: produce-list-of-strings
+    container:
+      args: ['----output-paths', /tmp/outputs/Output/data]
+      command:
+      - sh
+      - -ec
+      - |
+        program_path=$(mktemp)
+        printf "%s" "$0" > "$program_path"
+        python3 -u "$program_path" "$@"
+      - |
+        def produce_list_of_strings():
+            return (["a", "z"],)
+
+        def _serialize_json(obj) -> str:
+            if isinstance(obj, str):
+                return obj
+            import json
+            def default_serializer(obj):
+                if hasattr(obj, 'to_struct'):
+                    return obj.to_struct()
+                else:
+                    raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
+            return json.dumps(obj, default=default_serializer, sort_keys=True)
+
+        import argparse
+        _parser = argparse.ArgumentParser(prog='Produce list of strings', description='')
+        _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
+        _parsed_args = vars(_parser.parse_args())
+        _output_files = _parsed_args.pop("_output_paths", [])
+
+        _outputs = produce_list_of_strings(**_parsed_args)
+
+        _outputs = [_outputs]
+
+        _output_serializers = [
+            _serialize_json,
+
+        ]
+
+        import os
+        for idx, output_file in enumerate(_output_files):
+            try:
+                os.makedirs(os.path.dirname(output_file))
+            except OSError:
+                pass
+            with open(output_file, 'w') as f:
+                f.write(_output_serializers[idx](_outputs[idx]))
+      image: python:3.7
+    outputs:
+      parameters:
+      - name: produce-list-of-strings-Output
+        valueFrom: {path: /tmp/outputs/Output/data}
+      artifacts:
+      - {name: produce-list-of-strings-Output, path: /tmp/outputs/Output/data}
+    metadata:
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": ["----output-paths", {"outputPath": "Output"}], "command": ["sh",
+          "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def produce_list_of_strings():\n    return
+          ([\"a\", \"z\"],)\n\ndef _serialize_json(obj) -> str:\n    if isinstance(obj,
+          str):\n        return obj\n    import json\n    def default_serializer(obj):\n        if
+          hasattr(obj, ''to_struct''):\n            return obj.to_struct()\n        else:\n            raise
+          TypeError(\"Object of type ''%s'' is not JSON serializable and does not
+          have .to_struct() method.\" % obj.__class__.__name__)\n    return json.dumps(obj,
+          default=default_serializer, sort_keys=True)\n\nimport argparse\n_parser
+          = argparse.ArgumentParser(prog=''Produce list of strings'', description='''')\n_parser.add_argument(\"----output-paths\",
+          dest=\"_output_paths\", type=str, nargs=1)\n_parsed_args = vars(_parser.parse_args())\n_output_files
+          = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = produce_list_of_strings(**_parsed_args)\n\n_outputs
+          = [_outputs]\n\n_output_serializers = [\n    _serialize_json,\n\n]\n\nimport
+          os\nfor idx, output_file in enumerate(_output_files):\n    try:\n        os.makedirs(os.path.dirname(output_file))\n    except
+          OSError:\n        pass\n    with open(output_file, ''w'') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"],
+          "image": "python:3.7"}}, "name": "Produce list of strings", "outputs": [{"name":
+          "Output", "type": "JsonArray"}]}', pipelines.kubeflow.org/component_ref: '{}'}
+  - name: produce-str
+    container:
+      args: ['----output-paths', /tmp/outputs/Output/data]
+      command:
+      - sh
+      - -ec
+      - |
+        program_path=$(mktemp)
+        printf "%s" "$0" > "$program_path"
+        python3 -u "$program_path" "$@"
+      - |
+        def produce_str():
+            return "Hello"
+
+        def _serialize_str(str_value: str) -> str:
+            if not isinstance(str_value, str):
+                raise TypeError('Value "{}" has type "{}" instead of str.'.format(str(str_value), str(type(str_value))))
+            return str_value
+
+        import argparse
+        _parser = argparse.ArgumentParser(prog='Produce str', description='')
+        _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
+        _parsed_args = vars(_parser.parse_args())
+        _output_files = _parsed_args.pop("_output_paths", [])
+
+        _outputs = produce_str(**_parsed_args)
+
+        _outputs = [_outputs]
+
+        _output_serializers = [
+            _serialize_str,
+
+        ]
+
+        import os
+        for idx, output_file in enumerate(_output_files):
+            try:
+                os.makedirs(os.path.dirname(output_file))
+            except OSError:
+                pass
+            with open(output_file, 'w') as f:
+                f.write(_output_serializers[idx](_outputs[idx]))
+      image: python:3.7
+    outputs:
+      parameters:
+      - name: produce-str-Output
+        valueFrom: {path: /tmp/outputs/Output/data}
+      artifacts:
+      - {name: produce-str-Output, path: /tmp/outputs/Output/data}
+    metadata:
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": ["----output-paths", {"outputPath": "Output"}], "command": ["sh",
+          "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def produce_str():\n    return \"Hello\"\n\ndef
+          _serialize_str(str_value: str) -> str:\n    if not isinstance(str_value,
+          str):\n        raise TypeError(''Value \"{}\" has type \"{}\" instead of
+          str.''.format(str(str_value), str(type(str_value))))\n    return str_value\n\nimport
+          argparse\n_parser = argparse.ArgumentParser(prog=''Produce str'', description='''')\n_parser.add_argument(\"----output-paths\",
+          dest=\"_output_paths\", type=str, nargs=1)\n_parsed_args = vars(_parser.parse_args())\n_output_files
+          = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = produce_str(**_parsed_args)\n\n_outputs
+          = [_outputs]\n\n_output_serializers = [\n    _serialize_str,\n\n]\n\nimport
+          os\nfor idx, output_file in enumerate(_output_files):\n    try:\n        os.makedirs(os.path.dirname(output_file))\n    except
+          OSError:\n        pass\n    with open(output_file, ''w'') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"],
+          "image": "python:3.7"}}, "name": "Produce str", "outputs": [{"name": "Output",
+          "type": "String"}]}', pipelines.kubeflow.org/component_ref: '{}'}
   arguments:
     parameters: []
-  entrypoint: parallelfor-item-argument-resolving
   serviceAccountName: pipeline-runner
-  templates:
-    -
-      container:
-        args:
-          - "--param1"
-          - "{{inputs.parameters.produce-list-of-strings-Output}}"
-        command:
-          - sh
-          - "-ec"
-          - |
-              program_path=$(mktemp)
-              printf "%s" "$0" > "$program_path"
-              python3 -u "$program_path" "$@"
-          - |
-              def consume(param1):
-                  print(param1)
-
-              import argparse
-              _parser = argparse.ArgumentParser(prog='Consume', description='')
-              _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
-              _parsed_args = vars(_parser.parse_args())
-
-              _outputs = consume(**_parsed_args)
-        image: "python:3.7"
-      inputs:
-        parameters:
-          -
-            name: produce-list-of-strings-Output
-      metadata:
-        annotations:
-          pipelines.kubeflow.org/component_spec: "{\"inputs\": [{\"name\": \"param1\"}], \"name\": \"Consume\"}"
-      name: consume
-    -
-      container:
-        args:
-          - "--param1"
-          - "{{inputs.parameters.produce-list-of-strings-Output-loop-item}}"
-        command:
-          - sh
-          - "-ec"
-          - |
-              program_path=$(mktemp)
-              printf "%s" "$0" > "$program_path"
-              python3 -u "$program_path" "$@"
-          - |
-              def consume(param1):
-                  print(param1)
-
-              import argparse
-              _parser = argparse.ArgumentParser(prog='Consume', description='')
-              _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
-              _parsed_args = vars(_parser.parse_args())
-
-              _outputs = consume(**_parsed_args)
-        image: "python:3.7"
-      inputs:
-        parameters:
-          -
-            name: produce-list-of-strings-Output-loop-item
-      metadata:
-        annotations:
-          pipelines.kubeflow.org/component_spec: "{\"inputs\": [{\"name\": \"param1\"}], \"name\": \"Consume\"}"
-      name: consume-2
-    -
-      container:
-        args:
-          - "--param1"
-          - "{{inputs.parameters.produce-str-Output}}"
-        command:
-          - sh
-          - "-ec"
-          - |
-              program_path=$(mktemp)
-              printf "%s" "$0" > "$program_path"
-              python3 -u "$program_path" "$@"
-          - |
-              def consume(param1):
-                  print(param1)
-
-              import argparse
-              _parser = argparse.ArgumentParser(prog='Consume', description='')
-              _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
-              _parsed_args = vars(_parser.parse_args())
-
-              _outputs = consume(**_parsed_args)
-        image: "python:3.7"
-      inputs:
-        parameters:
-          -
-            name: produce-str-Output
-      metadata:
-        annotations:
-          pipelines.kubeflow.org/component_spec: "{\"inputs\": [{\"name\": \"param1\"}], \"name\": \"Consume\"}"
-      name: consume-3
-    -
-      container:
-        args:
-          - "--param1"
-          - "{{inputs.parameters.produce-list-of-ints-Output}}"
-        command:
-          - sh
-          - "-ec"
-          - |
-              program_path=$(mktemp)
-              printf "%s" "$0" > "$program_path"
-              python3 -u "$program_path" "$@"
-          - |
-              def consume(param1):
-                  print(param1)
-
-              import argparse
-              _parser = argparse.ArgumentParser(prog='Consume', description='')
-              _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
-              _parsed_args = vars(_parser.parse_args())
-
-              _outputs = consume(**_parsed_args)
-        image: "python:3.7"
-      inputs:
-        parameters:
-          -
-            name: produce-list-of-ints-Output
-      metadata:
-        annotations:
-          pipelines.kubeflow.org/component_spec: "{\"inputs\": [{\"name\": \"param1\"}], \"name\": \"Consume\"}"
-      name: consume-4
-    -
-      container:
-        args:
-          - "--param1"
-          - "{{inputs.parameters.produce-list-of-ints-Output-loop-item}}"
-        command:
-          - sh
-          - "-ec"
-          - |
-              program_path=$(mktemp)
-              printf "%s" "$0" > "$program_path"
-              python3 -u "$program_path" "$@"
-          - |
-              def consume(param1):
-                  print(param1)
-
-              import argparse
-              _parser = argparse.ArgumentParser(prog='Consume', description='')
-              _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
-              _parsed_args = vars(_parser.parse_args())
-
-              _outputs = consume(**_parsed_args)
-        image: "python:3.7"
-      inputs:
-        parameters:
-          -
-            name: produce-list-of-ints-Output-loop-item
-      metadata:
-        annotations:
-          pipelines.kubeflow.org/component_spec: "{\"inputs\": [{\"name\": \"param1\"}], \"name\": \"Consume\"}"
-      name: consume-5
-    -
-      container:
-        args:
-          - "--param1"
-          - "{{inputs.parameters.produce-list-of-dicts-Output}}"
-        command:
-          - sh
-          - "-ec"
-          - |
-              program_path=$(mktemp)
-              printf "%s" "$0" > "$program_path"
-              python3 -u "$program_path" "$@"
-          - |
-              def consume(param1):
-                  print(param1)
-
-              import argparse
-              _parser = argparse.ArgumentParser(prog='Consume', description='')
-              _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
-              _parsed_args = vars(_parser.parse_args())
-
-              _outputs = consume(**_parsed_args)
-        image: "python:3.7"
-      inputs:
-        parameters:
-          -
-            name: produce-list-of-dicts-Output
-      metadata:
-        annotations:
-          pipelines.kubeflow.org/component_spec: "{\"inputs\": [{\"name\": \"param1\"}], \"name\": \"Consume\"}"
-      name: consume-6
-    -
-      container:
-        args:
-          - "--param1"
-          - "{{inputs.parameters.produce-list-of-dicts-Output-loop-item-subvar-aaa}}"
-        command:
-          - sh
-          - "-ec"
-          - |
-              program_path=$(mktemp)
-              printf "%s" "$0" > "$program_path"
-              python3 -u "$program_path" "$@"
-          - |
-              def consume(param1):
-                  print(param1)
-
-              import argparse
-              _parser = argparse.ArgumentParser(prog='Consume', description='')
-              _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
-              _parsed_args = vars(_parser.parse_args())
-
-              _outputs = consume(**_parsed_args)
-        image: "python:3.7"
-      inputs:
-        parameters:
-          -
-            name: produce-list-of-dicts-Output-loop-item-subvar-aaa
-      metadata:
-        annotations:
-          pipelines.kubeflow.org/component_spec: "{\"inputs\": [{\"name\": \"param1\"}], \"name\": \"Consume\"}"
-      name: consume-7
-    - container:
-        args:
-          - "--param1"
-          - '[{"a": 1, "b": 2}, {"a": 10, "b": 20}]'
-        command:
-          - sh
-          - "-ec"
-          - |
-            program_path=$(mktemp)
-            echo -n "$0" > "$program_path"
-            python3 -u "$program_path" "$@"
-          - |
-            def consume(param1):
-                print(param1)
-
-            import argparse
-            _parser = argparse.ArgumentParser(prog='Consume', description='')
-            _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
-            _parsed_args = vars(_parser.parse_args())
-
-            _outputs = consume(**_parsed_args)
-        image: "python:3.7"
-      name: consume-8
-    - container:
-        args:
-          - "--param1"
-          - "{{inputs.parameters.loop-item-param-4}}"
-        command:
-          - sh
-          - "-ec"
-          - |
-            program_path=$(mktemp)
-            echo -n "$0" > "$program_path"
-            python3 -u "$program_path" "$@"
-          - |
-            def consume(param1):
-                print(param1)
-
-            import argparse
-            _parser = argparse.ArgumentParser(prog='Consume', description='')
-            _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
-            _parsed_args = vars(_parser.parse_args())
-
-            _outputs = consume(**_parsed_args)
-        image: "python:3.7"
-      inputs:
-        parameters:
-          - name: loop-item-param-4
-      name: consume-9
-    -
-      dag:
-        tasks:
-          -
-            arguments:
-              parameters:
-                -
-                  name: produce-list-of-strings-Output
-                  value: "{{inputs.parameters.produce-list-of-strings-Output}}"
-            name: consume
-            template: consume
-          -
-            arguments:
-              parameters:
-                -
-                  name: produce-list-of-strings-Output-loop-item
-                  value: "{{inputs.parameters.produce-list-of-strings-Output-loop-item}}"
-            name: consume-2
-            template: consume-2
-          -
-            arguments:
-              parameters:
-                -
-                  name: produce-str-Output
-                  value: "{{inputs.parameters.produce-str-Output}}"
-            name: consume-3
-            template: consume-3
-      inputs:
-        parameters:
-          -
-            name: produce-list-of-strings-Output
-          -
-            name: produce-list-of-strings-Output-loop-item
-          -
-            name: produce-str-Output
-      name: for-loop-1
-    -
-      dag:
-        tasks:
-          -
-            arguments:
-              parameters:
-                -
-                  name: produce-list-of-ints-Output
-                  value: "{{inputs.parameters.produce-list-of-ints-Output}}"
-            name: consume-4
-            template: consume-4
-          -
-            arguments:
-              parameters:
-                -
-                  name: produce-list-of-ints-Output-loop-item
-                  value: "{{inputs.parameters.produce-list-of-ints-Output-loop-item}}"
-            name: consume-5
-            template: consume-5
-      inputs:
-        parameters:
-          -
-            name: produce-list-of-ints-Output
-          -
-            name: produce-list-of-ints-Output-loop-item
-      name: for-loop-2
-    -
-      dag:
-        tasks:
-          -
-            arguments:
-              parameters:
-                -
-                  name: produce-list-of-dicts-Output
-                  value: "{{inputs.parameters.produce-list-of-dicts-Output}}"
-            name: consume-6
-            template: consume-6
-          -
-            arguments:
-              parameters:
-                -
-                  name: produce-list-of-dicts-Output-loop-item-subvar-aaa
-                  value: "{{inputs.parameters.produce-list-of-dicts-Output-loop-item-subvar-aaa}}"
-            name: consume-7
-            template: consume-7
-      inputs:
-        parameters:
-          -
-            name: produce-list-of-dicts-Output
-          -
-            name: produce-list-of-dicts-Output-loop-item-subvar-aaa
-      name: for-loop-3
-    - dag:
-        tasks:
-          - name: consume-8
-            template: consume-8
-          - arguments:
-              parameters:
-                - name: loop-item-param-4
-                  value: "{{inputs.parameters.loop-item-param-4}}"
-            name: consume-9
-            template: consume-9
-      inputs:
-        parameters:
-          - name: loop-item-param-4
-      name: for-loop-5
-    -
-      dag:
-        tasks:
-          -
-            arguments:
-              parameters:
-                -
-                  name: produce-list-of-strings-Output
-                  value: "{{tasks.produce-list-of-strings.outputs.parameters.produce-list-of-strings-Output}}"
-                -
-                  name: produce-list-of-strings-Output-loop-item
-                  value: "{{item}}"
-                -
-                  name: produce-str-Output
-                  value: "{{tasks.produce-str.outputs.parameters.produce-str-Output}}"
-            dependencies:
-              - produce-list-of-strings
-              - produce-str
-            name: for-loop-1
-            template: for-loop-1
-            withParam: "{{tasks.produce-list-of-strings.outputs.parameters.produce-list-of-strings-Output}}"
-          -
-            arguments:
-              parameters:
-                -
-                  name: produce-list-of-ints-Output
-                  value: "{{tasks.produce-list-of-ints.outputs.parameters.produce-list-of-ints-Output}}"
-                -
-                  name: produce-list-of-ints-Output-loop-item
-                  value: "{{item}}"
-            dependencies:
-              - produce-list-of-ints
-            name: for-loop-2
-            template: for-loop-2
-            withParam: "{{tasks.produce-list-of-ints.outputs.parameters.produce-list-of-ints-Output}}"
-          -
-            arguments:
-              parameters:
-                -
-                  name: produce-list-of-dicts-Output
-                  value: "{{tasks.produce-list-of-dicts.outputs.parameters.produce-list-of-dicts-Output}}"
-                -
-                  name: produce-list-of-dicts-Output-loop-item-subvar-aaa
-                  value: "{{item.aaa}}"
-            dependencies:
-              - produce-list-of-dicts
-            name: for-loop-3
-            template: for-loop-3
-            withParam: "{{tasks.produce-list-of-dicts.outputs.parameters.produce-list-of-dicts-Output}}"
-          - arguments:
-              parameters:
-                - name: loop-item-param-4
-                  value: "{{item}}"
-            name: for-loop-5
-            template: for-loop-5
-            withItems: [{"a": 1, "b": 2}, {"a": 10, "b": 20}]
-          -
-            name: produce-list-of-dicts
-            template: produce-list-of-dicts
-          -
-            name: produce-list-of-ints
-            template: produce-list-of-ints
-          -
-            name: produce-list-of-strings
-            template: produce-list-of-strings
-          -
-            name: produce-str
-            template: produce-str
-      name: parallelfor-item-argument-resolving
-    -
-      container:
-        args:
-          - "----output-paths"
-          - /tmp/outputs/Output/data
-        command:
-          - sh
-          - "-ec"
-          - |
-              program_path=$(mktemp)
-              printf "%s" "$0" > "$program_path"
-              python3 -u "$program_path" "$@"
-          - |
-              def produce_list_of_dicts():
-                  return ([{"aaa": "aaa1", "bbb": "bbb1"}, {"aaa": "aaa2", "bbb": "bbb2"}],)
-
-              def _serialize_json(obj) -> str:
-                  if isinstance(obj, str):
-                      return obj
-                  import json
-                  def default_serializer(obj):
-                      if hasattr(obj, 'to_struct'):
-                          return obj.to_struct()
-                      else:
-                          raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
-                  return json.dumps(obj, default=default_serializer, sort_keys=True)
-
-              import argparse
-              _parser = argparse.ArgumentParser(prog='Produce list of dicts', description='')
-              _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
-              _parsed_args = vars(_parser.parse_args())
-              _output_files = _parsed_args.pop("_output_paths", [])
-
-              _outputs = produce_list_of_dicts(**_parsed_args)
-
-              _outputs = [_outputs]
-
-              _output_serializers = [
-                  _serialize_json,
-
-              ]
-
-              import os
-              for idx, output_file in enumerate(_output_files):
-                  try:
-                      os.makedirs(os.path.dirname(output_file))
-                  except OSError:
-                      pass
-                  with open(output_file, 'w') as f:
-                      f.write(_output_serializers[idx](_outputs[idx]))
-        image: "python:3.7"
-      metadata:
-        annotations:
-          pipelines.kubeflow.org/component_spec: "{\"name\": \"Produce list of dicts\", \"outputs\": [{\"name\": \"Output\", \"type\": \"JsonArray\"}]}"
-      name: produce-list-of-dicts
-      outputs:
-        artifacts:
-          -
-            name: produce-list-of-dicts-Output
-            path: /tmp/outputs/Output/data
-        parameters:
-          -
-            name: produce-list-of-dicts-Output
-            valueFrom:
-              path: /tmp/outputs/Output/data
-    -
-      container:
-        args:
-          - "----output-paths"
-          - /tmp/outputs/Output/data
-        command:
-          - sh
-          - "-ec"
-          - |
-              program_path=$(mktemp)
-              printf "%s" "$0" > "$program_path"
-              python3 -u "$program_path" "$@"
-          - |
-              def produce_list_of_ints():
-                  return ([1234567890, 987654321],)
-
-              def _serialize_json(obj) -> str:
-                  if isinstance(obj, str):
-                      return obj
-                  import json
-                  def default_serializer(obj):
-                      if hasattr(obj, 'to_struct'):
-                          return obj.to_struct()
-                      else:
-                          raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
-                  return json.dumps(obj, default=default_serializer, sort_keys=True)
-
-              import argparse
-              _parser = argparse.ArgumentParser(prog='Produce list of ints', description='')
-              _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
-              _parsed_args = vars(_parser.parse_args())
-              _output_files = _parsed_args.pop("_output_paths", [])
-
-              _outputs = produce_list_of_ints(**_parsed_args)
-
-              _outputs = [_outputs]
-
-              _output_serializers = [
-                  _serialize_json,
-
-              ]
-
-              import os
-              for idx, output_file in enumerate(_output_files):
-                  try:
-                      os.makedirs(os.path.dirname(output_file))
-                  except OSError:
-                      pass
-                  with open(output_file, 'w') as f:
-                      f.write(_output_serializers[idx](_outputs[idx]))
-        image: "python:3.7"
-      metadata:
-        annotations:
-          pipelines.kubeflow.org/component_spec: "{\"name\": \"Produce list of ints\", \"outputs\": [{\"name\": \"Output\", \"type\": \"JsonArray\"}]}"
-      name: produce-list-of-ints
-      outputs:
-        artifacts:
-          -
-            name: produce-list-of-ints-Output
-            path: /tmp/outputs/Output/data
-        parameters:
-          -
-            name: produce-list-of-ints-Output
-            valueFrom:
-              path: /tmp/outputs/Output/data
-    -
-      container:
-        args:
-          - "----output-paths"
-          - /tmp/outputs/Output/data
-        command:
-          - sh
-          - "-ec"
-          - |
-              program_path=$(mktemp)
-              printf "%s" "$0" > "$program_path"
-              python3 -u "$program_path" "$@"
-          - |
-              def produce_list_of_strings():
-                  return (["a", "z"],)
-
-              def _serialize_json(obj) -> str:
-                  if isinstance(obj, str):
-                      return obj
-                  import json
-                  def default_serializer(obj):
-                      if hasattr(obj, 'to_struct'):
-                          return obj.to_struct()
-                      else:
-                          raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
-                  return json.dumps(obj, default=default_serializer, sort_keys=True)
-
-              import argparse
-              _parser = argparse.ArgumentParser(prog='Produce list of strings', description='')
-              _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
-              _parsed_args = vars(_parser.parse_args())
-              _output_files = _parsed_args.pop("_output_paths", [])
-
-              _outputs = produce_list_of_strings(**_parsed_args)
-
-              _outputs = [_outputs]
-
-              _output_serializers = [
-                  _serialize_json,
-
-              ]
-
-              import os
-              for idx, output_file in enumerate(_output_files):
-                  try:
-                      os.makedirs(os.path.dirname(output_file))
-                  except OSError:
-                      pass
-                  with open(output_file, 'w') as f:
-                      f.write(_output_serializers[idx](_outputs[idx]))
-        image: "python:3.7"
-      metadata:
-        annotations:
-          pipelines.kubeflow.org/component_spec: "{\"name\": \"Produce list of strings\", \"outputs\": [{\"name\": \"Output\", \"type\": \"JsonArray\"}]}"
-      name: produce-list-of-strings
-      outputs:
-        artifacts:
-          -
-            name: produce-list-of-strings-Output
-            path: /tmp/outputs/Output/data
-        parameters:
-          -
-            name: produce-list-of-strings-Output
-            valueFrom:
-              path: /tmp/outputs/Output/data
-    -
-      container:
-        args:
-          - "----output-paths"
-          - /tmp/outputs/Output/data
-        command:
-          - sh
-          - "-ec"
-          - |
-              program_path=$(mktemp)
-              printf "%s" "$0" > "$program_path"
-              python3 -u "$program_path" "$@"
-          - |
-              def produce_str():
-                  return "Hello"
-
-              def _serialize_str(str_value: str) -> str:
-                  if not isinstance(str_value, str):
-                      raise TypeError('Value "{}" has type "{}" instead of str.'.format(str(str_value), str(type(str_value))))
-                  return str_value
-
-              import argparse
-              _parser = argparse.ArgumentParser(prog='Produce str', description='')
-              _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
-              _parsed_args = vars(_parser.parse_args())
-              _output_files = _parsed_args.pop("_output_paths", [])
-
-              _outputs = produce_str(**_parsed_args)
-
-              _outputs = [_outputs]
-
-              _output_serializers = [
-                  _serialize_str,
-
-              ]
-
-              import os
-              for idx, output_file in enumerate(_output_files):
-                  try:
-                      os.makedirs(os.path.dirname(output_file))
-                  except OSError:
-                      pass
-                  with open(output_file, 'w') as f:
-                      f.write(_output_serializers[idx](_outputs[idx]))
-        image: "python:3.7"
-      metadata:
-        annotations:
-          pipelines.kubeflow.org/component_spec: "{\"name\": \"Produce str\", \"outputs\": [{\"name\": \"Output\", \"type\": \"String\"}]}"
-      name: produce-str
-      outputs:
-        artifacts:
-          -
-            name: produce-str-Output
-            path: /tmp/outputs/Output/data
-        parameters:
-          -
-            name: produce-str-Output
-            valueFrom:
-              path: /tmp/outputs/Output/data

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
@@ -1,21 +1,21 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
-metadata: 
-  annotations: 
+metadata:
+  annotations:
     pipelines.kubeflow.org/pipeline_spec: "{\"name\": \"Parallelfor item argument resolving pipeline\"}"
   generateName: parallelfor-item-argument-resolving-
-spec: 
-  arguments: 
+spec:
+  arguments:
     parameters: []
   entrypoint: parallelfor-item-argument-resolving
   serviceAccountName: pipeline-runner
-  templates: 
-    - 
-      container: 
-        args: 
+  templates:
+    -
+      container:
+        args:
           - "--param1"
           - "{{inputs.parameters.produce-list-of-strings-Output}}"
-        command: 
+        command:
           - sh
           - "-ec"
           - |
@@ -25,28 +25,28 @@ spec:
           - |
               def consume(param1):
                   print(param1)
-              
+
               import argparse
               _parser = argparse.ArgumentParser(prog='Consume', description='')
               _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
               _parsed_args = vars(_parser.parse_args())
-              
+
               _outputs = consume(**_parsed_args)
         image: "python:3.7"
-      inputs: 
-        parameters: 
-          - 
+      inputs:
+        parameters:
+          -
             name: produce-list-of-strings-Output
       metadata:
-        annotations: 
+        annotations:
           pipelines.kubeflow.org/component_spec: "{\"inputs\": [{\"name\": \"param1\"}], \"name\": \"Consume\"}"
       name: consume
-    - 
-      container: 
-        args: 
+    -
+      container:
+        args:
           - "--param1"
           - "{{inputs.parameters.produce-list-of-strings-Output-loop-item}}"
-        command: 
+        command:
           - sh
           - "-ec"
           - |
@@ -56,28 +56,28 @@ spec:
           - |
               def consume(param1):
                   print(param1)
-              
+
               import argparse
               _parser = argparse.ArgumentParser(prog='Consume', description='')
               _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
               _parsed_args = vars(_parser.parse_args())
-              
+
               _outputs = consume(**_parsed_args)
         image: "python:3.7"
-      inputs: 
-        parameters: 
-          - 
+      inputs:
+        parameters:
+          -
             name: produce-list-of-strings-Output-loop-item
       metadata:
-        annotations: 
+        annotations:
           pipelines.kubeflow.org/component_spec: "{\"inputs\": [{\"name\": \"param1\"}], \"name\": \"Consume\"}"
       name: consume-2
-    - 
-      container: 
-        args: 
+    -
+      container:
+        args:
           - "--param1"
           - "{{inputs.parameters.produce-str-Output}}"
-        command: 
+        command:
           - sh
           - "-ec"
           - |
@@ -87,28 +87,28 @@ spec:
           - |
               def consume(param1):
                   print(param1)
-              
+
               import argparse
               _parser = argparse.ArgumentParser(prog='Consume', description='')
               _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
               _parsed_args = vars(_parser.parse_args())
-              
+
               _outputs = consume(**_parsed_args)
         image: "python:3.7"
-      inputs: 
-        parameters: 
-          - 
+      inputs:
+        parameters:
+          -
             name: produce-str-Output
       metadata:
-        annotations: 
+        annotations:
           pipelines.kubeflow.org/component_spec: "{\"inputs\": [{\"name\": \"param1\"}], \"name\": \"Consume\"}"
       name: consume-3
-    - 
-      container: 
-        args: 
+    -
+      container:
+        args:
           - "--param1"
           - "{{inputs.parameters.produce-list-of-ints-Output}}"
-        command: 
+        command:
           - sh
           - "-ec"
           - |
@@ -118,28 +118,28 @@ spec:
           - |
               def consume(param1):
                   print(param1)
-              
+
               import argparse
               _parser = argparse.ArgumentParser(prog='Consume', description='')
               _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
               _parsed_args = vars(_parser.parse_args())
-              
+
               _outputs = consume(**_parsed_args)
         image: "python:3.7"
-      inputs: 
-        parameters: 
-          - 
+      inputs:
+        parameters:
+          -
             name: produce-list-of-ints-Output
       metadata:
-        annotations: 
+        annotations:
           pipelines.kubeflow.org/component_spec: "{\"inputs\": [{\"name\": \"param1\"}], \"name\": \"Consume\"}"
       name: consume-4
-    - 
-      container: 
-        args: 
+    -
+      container:
+        args:
           - "--param1"
           - "{{inputs.parameters.produce-list-of-ints-Output-loop-item}}"
-        command: 
+        command:
           - sh
           - "-ec"
           - |
@@ -149,28 +149,28 @@ spec:
           - |
               def consume(param1):
                   print(param1)
-              
+
               import argparse
               _parser = argparse.ArgumentParser(prog='Consume', description='')
               _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
               _parsed_args = vars(_parser.parse_args())
-              
+
               _outputs = consume(**_parsed_args)
         image: "python:3.7"
-      inputs: 
-        parameters: 
-          - 
+      inputs:
+        parameters:
+          -
             name: produce-list-of-ints-Output-loop-item
       metadata:
-        annotations: 
+        annotations:
           pipelines.kubeflow.org/component_spec: "{\"inputs\": [{\"name\": \"param1\"}], \"name\": \"Consume\"}"
       name: consume-5
-    - 
-      container: 
-        args: 
+    -
+      container:
+        args:
           - "--param1"
           - "{{inputs.parameters.produce-list-of-dicts-Output}}"
-        command: 
+        command:
           - sh
           - "-ec"
           - |
@@ -180,28 +180,28 @@ spec:
           - |
               def consume(param1):
                   print(param1)
-              
+
               import argparse
               _parser = argparse.ArgumentParser(prog='Consume', description='')
               _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
               _parsed_args = vars(_parser.parse_args())
-              
+
               _outputs = consume(**_parsed_args)
         image: "python:3.7"
-      inputs: 
-        parameters: 
-          - 
+      inputs:
+        parameters:
+          -
             name: produce-list-of-dicts-Output
       metadata:
-        annotations: 
+        annotations:
           pipelines.kubeflow.org/component_spec: "{\"inputs\": [{\"name\": \"param1\"}], \"name\": \"Consume\"}"
       name: consume-6
-    - 
-      container: 
-        args: 
+    -
+      container:
+        args:
           - "--param1"
           - "{{inputs.parameters.produce-list-of-dicts-Output-loop-item-subvar-aaa}}"
-        command: 
+        command:
           - sh
           - "-ec"
           - |
@@ -211,178 +211,248 @@ spec:
           - |
               def consume(param1):
                   print(param1)
-              
+
               import argparse
               _parser = argparse.ArgumentParser(prog='Consume', description='')
               _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
               _parsed_args = vars(_parser.parse_args())
-              
+
               _outputs = consume(**_parsed_args)
         image: "python:3.7"
-      inputs: 
-        parameters: 
-          - 
+      inputs:
+        parameters:
+          -
             name: produce-list-of-dicts-Output-loop-item-subvar-aaa
       metadata:
-        annotations: 
+        annotations:
           pipelines.kubeflow.org/component_spec: "{\"inputs\": [{\"name\": \"param1\"}], \"name\": \"Consume\"}"
       name: consume-7
-    - 
-      dag: 
-        tasks: 
-          - 
-            arguments: 
-              parameters: 
-                - 
+    - container:
+        args:
+          - "--param1"
+          - '[{"a": 1, "b": 2}, {"a": 10, "b": 20}]'
+        command:
+          - sh
+          - "-ec"
+          - |
+            program_path=$(mktemp)
+            echo -n "$0" > "$program_path"
+            python3 -u "$program_path" "$@"
+          - |
+            def consume(param1):
+                print(param1)
+
+            import argparse
+            _parser = argparse.ArgumentParser(prog='Consume', description='')
+            _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
+            _parsed_args = vars(_parser.parse_args())
+
+            _outputs = consume(**_parsed_args)
+        image: "python:3.7"
+      name: consume-8
+    - container:
+        args:
+          - "--param1"
+          - "{{inputs.parameters.loop-item-param-4}}"
+        command:
+          - sh
+          - "-ec"
+          - |
+            program_path=$(mktemp)
+            echo -n "$0" > "$program_path"
+            python3 -u "$program_path" "$@"
+          - |
+            def consume(param1):
+                print(param1)
+
+            import argparse
+            _parser = argparse.ArgumentParser(prog='Consume', description='')
+            _parser.add_argument("--param1", dest="param1", type=str, required=True, default=argparse.SUPPRESS)
+            _parsed_args = vars(_parser.parse_args())
+
+            _outputs = consume(**_parsed_args)
+        image: "python:3.7"
+      inputs:
+        parameters:
+          - name: loop-item-param-4
+      name: consume-9
+    -
+      dag:
+        tasks:
+          -
+            arguments:
+              parameters:
+                -
                   name: produce-list-of-strings-Output
                   value: "{{inputs.parameters.produce-list-of-strings-Output}}"
             name: consume
             template: consume
-          - 
-            arguments: 
-              parameters: 
-                - 
+          -
+            arguments:
+              parameters:
+                -
                   name: produce-list-of-strings-Output-loop-item
                   value: "{{inputs.parameters.produce-list-of-strings-Output-loop-item}}"
             name: consume-2
             template: consume-2
-          - 
-            arguments: 
-              parameters: 
-                - 
+          -
+            arguments:
+              parameters:
+                -
                   name: produce-str-Output
                   value: "{{inputs.parameters.produce-str-Output}}"
             name: consume-3
             template: consume-3
-      inputs: 
-        parameters: 
-          - 
+      inputs:
+        parameters:
+          -
             name: produce-list-of-strings-Output
-          - 
+          -
             name: produce-list-of-strings-Output-loop-item
-          - 
+          -
             name: produce-str-Output
-      name: for-loop-for-loop-00000001-1
-    - 
-      dag: 
-        tasks: 
-          - 
-            arguments: 
-              parameters: 
-                - 
+      name: for-loop-1
+    -
+      dag:
+        tasks:
+          -
+            arguments:
+              parameters:
+                -
                   name: produce-list-of-ints-Output
                   value: "{{inputs.parameters.produce-list-of-ints-Output}}"
             name: consume-4
             template: consume-4
-          - 
-            arguments: 
-              parameters: 
-                - 
+          -
+            arguments:
+              parameters:
+                -
                   name: produce-list-of-ints-Output-loop-item
                   value: "{{inputs.parameters.produce-list-of-ints-Output-loop-item}}"
             name: consume-5
             template: consume-5
-      inputs: 
-        parameters: 
-          - 
+      inputs:
+        parameters:
+          -
             name: produce-list-of-ints-Output
-          - 
+          -
             name: produce-list-of-ints-Output-loop-item
-      name: for-loop-for-loop-00000002-2
-    - 
-      dag: 
-        tasks: 
-          - 
-            arguments: 
-              parameters: 
-                - 
+      name: for-loop-2
+    -
+      dag:
+        tasks:
+          -
+            arguments:
+              parameters:
+                -
                   name: produce-list-of-dicts-Output
                   value: "{{inputs.parameters.produce-list-of-dicts-Output}}"
             name: consume-6
             template: consume-6
-          - 
-            arguments: 
-              parameters: 
-                - 
+          -
+            arguments:
+              parameters:
+                -
                   name: produce-list-of-dicts-Output-loop-item-subvar-aaa
                   value: "{{inputs.parameters.produce-list-of-dicts-Output-loop-item-subvar-aaa}}"
             name: consume-7
             template: consume-7
-      inputs: 
-        parameters: 
-          - 
+      inputs:
+        parameters:
+          -
             name: produce-list-of-dicts-Output
-          - 
+          -
             name: produce-list-of-dicts-Output-loop-item-subvar-aaa
-      name: for-loop-for-loop-00000003-3
-    - 
-      dag: 
-        tasks: 
-          - 
-            arguments: 
-              parameters: 
-                - 
+      name: for-loop-3
+    - dag:
+        tasks:
+          - name: consume-8
+            template: consume-8
+          - arguments:
+              parameters:
+                - name: loop-item-param-4
+                  value: "{{inputs.parameters.loop-item-param-4}}"
+            name: consume-9
+            template: consume-9
+      inputs:
+        parameters:
+          - name: loop-item-param-4
+      name: for-loop-5
+    -
+      dag:
+        tasks:
+          -
+            arguments:
+              parameters:
+                -
                   name: produce-list-of-strings-Output
                   value: "{{tasks.produce-list-of-strings.outputs.parameters.produce-list-of-strings-Output}}"
-                - 
+                -
                   name: produce-list-of-strings-Output-loop-item
                   value: "{{item}}"
-                - 
+                -
                   name: produce-str-Output
                   value: "{{tasks.produce-str.outputs.parameters.produce-str-Output}}"
-            dependencies: 
+            dependencies:
               - produce-list-of-strings
               - produce-str
-            name: for-loop-for-loop-00000001-1
-            template: for-loop-for-loop-00000001-1
+            name: for-loop-1
+            template: for-loop-1
             withParam: "{{tasks.produce-list-of-strings.outputs.parameters.produce-list-of-strings-Output}}"
-          - 
-            arguments: 
-              parameters: 
-                - 
+          -
+            arguments:
+              parameters:
+                -
                   name: produce-list-of-ints-Output
                   value: "{{tasks.produce-list-of-ints.outputs.parameters.produce-list-of-ints-Output}}"
-                - 
+                -
                   name: produce-list-of-ints-Output-loop-item
                   value: "{{item}}"
-            dependencies: 
+            dependencies:
               - produce-list-of-ints
-            name: for-loop-for-loop-00000002-2
-            template: for-loop-for-loop-00000002-2
+            name: for-loop-2
+            template: for-loop-2
             withParam: "{{tasks.produce-list-of-ints.outputs.parameters.produce-list-of-ints-Output}}"
-          - 
-            arguments: 
-              parameters: 
-                - 
+          -
+            arguments:
+              parameters:
+                -
                   name: produce-list-of-dicts-Output
                   value: "{{tasks.produce-list-of-dicts.outputs.parameters.produce-list-of-dicts-Output}}"
-                - 
+                -
                   name: produce-list-of-dicts-Output-loop-item-subvar-aaa
                   value: "{{item.aaa}}"
-            dependencies: 
+            dependencies:
               - produce-list-of-dicts
-            name: for-loop-for-loop-00000003-3
-            template: for-loop-for-loop-00000003-3
+            name: for-loop-3
+            template: for-loop-3
             withParam: "{{tasks.produce-list-of-dicts.outputs.parameters.produce-list-of-dicts-Output}}"
-          - 
+          - arguments:
+              parameters:
+                - name: loop-item-param-4
+                  value: "{{item}}"
+            name: for-loop-5
+            template: for-loop-5
+            withItems: [{"a": 1, "b": 2}, {"a": 10, "b": 20}]
+          -
             name: produce-list-of-dicts
             template: produce-list-of-dicts
-          - 
+          -
             name: produce-list-of-ints
             template: produce-list-of-ints
-          - 
+          -
             name: produce-list-of-strings
             template: produce-list-of-strings
-          - 
+          -
             name: produce-str
             template: produce-str
       name: parallelfor-item-argument-resolving
-    - 
-      container: 
-        args: 
+    -
+      container:
+        args:
           - "----output-paths"
           - /tmp/outputs/Output/data
-        command: 
+        command:
           - sh
           - "-ec"
           - |
@@ -392,7 +462,7 @@ spec:
           - |
               def produce_list_of_dicts():
                   return ([{"aaa": "aaa1", "bbb": "bbb1"}, {"aaa": "aaa2", "bbb": "bbb2"}],)
-              
+
               def _serialize_json(obj) -> str:
                   if isinstance(obj, str):
                       return obj
@@ -403,22 +473,22 @@ spec:
                       else:
                           raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
                   return json.dumps(obj, default=default_serializer, sort_keys=True)
-              
+
               import argparse
               _parser = argparse.ArgumentParser(prog='Produce list of dicts', description='')
               _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
               _parsed_args = vars(_parser.parse_args())
               _output_files = _parsed_args.pop("_output_paths", [])
-              
+
               _outputs = produce_list_of_dicts(**_parsed_args)
-              
+
               _outputs = [_outputs]
-              
+
               _output_serializers = [
                   _serialize_json,
-              
+
               ]
-              
+
               import os
               for idx, output_file in enumerate(_output_files):
                   try:
@@ -429,25 +499,25 @@ spec:
                       f.write(_output_serializers[idx](_outputs[idx]))
         image: "python:3.7"
       metadata:
-        annotations: 
+        annotations:
           pipelines.kubeflow.org/component_spec: "{\"name\": \"Produce list of dicts\", \"outputs\": [{\"name\": \"Output\", \"type\": \"JsonArray\"}]}"
       name: produce-list-of-dicts
-      outputs: 
-        artifacts: 
-          - 
+      outputs:
+        artifacts:
+          -
             name: produce-list-of-dicts-Output
             path: /tmp/outputs/Output/data
-        parameters: 
-          - 
+        parameters:
+          -
             name: produce-list-of-dicts-Output
-            valueFrom: 
+            valueFrom:
               path: /tmp/outputs/Output/data
-    - 
-      container: 
-        args: 
+    -
+      container:
+        args:
           - "----output-paths"
           - /tmp/outputs/Output/data
-        command: 
+        command:
           - sh
           - "-ec"
           - |
@@ -457,7 +527,7 @@ spec:
           - |
               def produce_list_of_ints():
                   return ([1234567890, 987654321],)
-              
+
               def _serialize_json(obj) -> str:
                   if isinstance(obj, str):
                       return obj
@@ -468,22 +538,22 @@ spec:
                       else:
                           raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
                   return json.dumps(obj, default=default_serializer, sort_keys=True)
-              
+
               import argparse
               _parser = argparse.ArgumentParser(prog='Produce list of ints', description='')
               _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
               _parsed_args = vars(_parser.parse_args())
               _output_files = _parsed_args.pop("_output_paths", [])
-              
+
               _outputs = produce_list_of_ints(**_parsed_args)
-              
+
               _outputs = [_outputs]
-              
+
               _output_serializers = [
                   _serialize_json,
-              
+
               ]
-              
+
               import os
               for idx, output_file in enumerate(_output_files):
                   try:
@@ -494,25 +564,25 @@ spec:
                       f.write(_output_serializers[idx](_outputs[idx]))
         image: "python:3.7"
       metadata:
-        annotations: 
+        annotations:
           pipelines.kubeflow.org/component_spec: "{\"name\": \"Produce list of ints\", \"outputs\": [{\"name\": \"Output\", \"type\": \"JsonArray\"}]}"
       name: produce-list-of-ints
-      outputs: 
-        artifacts: 
-          - 
+      outputs:
+        artifacts:
+          -
             name: produce-list-of-ints-Output
             path: /tmp/outputs/Output/data
-        parameters: 
-          - 
+        parameters:
+          -
             name: produce-list-of-ints-Output
-            valueFrom: 
+            valueFrom:
               path: /tmp/outputs/Output/data
-    - 
-      container: 
-        args: 
+    -
+      container:
+        args:
           - "----output-paths"
           - /tmp/outputs/Output/data
-        command: 
+        command:
           - sh
           - "-ec"
           - |
@@ -522,7 +592,7 @@ spec:
           - |
               def produce_list_of_strings():
                   return (["a", "z"],)
-              
+
               def _serialize_json(obj) -> str:
                   if isinstance(obj, str):
                       return obj
@@ -533,22 +603,22 @@ spec:
                       else:
                           raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
                   return json.dumps(obj, default=default_serializer, sort_keys=True)
-              
+
               import argparse
               _parser = argparse.ArgumentParser(prog='Produce list of strings', description='')
               _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
               _parsed_args = vars(_parser.parse_args())
               _output_files = _parsed_args.pop("_output_paths", [])
-              
+
               _outputs = produce_list_of_strings(**_parsed_args)
-              
+
               _outputs = [_outputs]
-              
+
               _output_serializers = [
                   _serialize_json,
-              
+
               ]
-              
+
               import os
               for idx, output_file in enumerate(_output_files):
                   try:
@@ -559,25 +629,25 @@ spec:
                       f.write(_output_serializers[idx](_outputs[idx]))
         image: "python:3.7"
       metadata:
-        annotations: 
+        annotations:
           pipelines.kubeflow.org/component_spec: "{\"name\": \"Produce list of strings\", \"outputs\": [{\"name\": \"Output\", \"type\": \"JsonArray\"}]}"
       name: produce-list-of-strings
-      outputs: 
-        artifacts: 
-          - 
+      outputs:
+        artifacts:
+          -
             name: produce-list-of-strings-Output
             path: /tmp/outputs/Output/data
-        parameters: 
-          - 
+        parameters:
+          -
             name: produce-list-of-strings-Output
-            valueFrom: 
+            valueFrom:
               path: /tmp/outputs/Output/data
-    - 
-      container: 
-        args: 
+    -
+      container:
+        args:
           - "----output-paths"
           - /tmp/outputs/Output/data
-        command: 
+        command:
           - sh
           - "-ec"
           - |
@@ -587,27 +657,27 @@ spec:
           - |
               def produce_str():
                   return "Hello"
-              
+
               def _serialize_str(str_value: str) -> str:
                   if not isinstance(str_value, str):
                       raise TypeError('Value "{}" has type "{}" instead of str.'.format(str(str_value), str(type(str_value))))
                   return str_value
-              
+
               import argparse
               _parser = argparse.ArgumentParser(prog='Produce str', description='')
               _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
               _parsed_args = vars(_parser.parse_args())
               _output_files = _parsed_args.pop("_output_paths", [])
-              
+
               _outputs = produce_str(**_parsed_args)
-              
+
               _outputs = [_outputs]
-              
+
               _output_serializers = [
                   _serialize_str,
-              
+
               ]
-              
+
               import os
               for idx, output_file in enumerate(_output_files):
                   try:
@@ -618,16 +688,16 @@ spec:
                       f.write(_output_serializers[idx](_outputs[idx]))
         image: "python:3.7"
       metadata:
-        annotations: 
+        annotations:
           pipelines.kubeflow.org/component_spec: "{\"name\": \"Produce str\", \"outputs\": [{\"name\": \"Output\", \"type\": \"String\"}]}"
       name: produce-str
-      outputs: 
-        artifacts: 
-          - 
+      outputs:
+        artifacts:
+          -
             name: produce-str-Output
             path: /tmp/outputs/Output/data
-        parameters: 
-          - 
+        parameters:
+          -
             name: produce-str-Output
-            valueFrom: 
+            valueFrom:
               path: /tmp/outputs/Output/data

--- a/sdk/python/tests/compiler/testdata/parallelfor_pipeline_param_in_items_resolving.py
+++ b/sdk/python/tests/compiler/testdata/parallelfor_pipeline_param_in_items_resolving.py
@@ -13,28 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import NamedTuple
-
 import kfp
-import kfp.compiler as compiler
 from kfp.components import func_to_container_op
-
-
-# Stabilizing the test output
-class StableIDGenerator:
-    def __init__(self, ):
-        self._index = 0
-
-    def get_next_id(self, ):
-        self._index += 1
-        return '{code:0{num_chars:}d}'.format(code=self._index, num_chars=kfp.dsl._for_loop.LoopArguments.NUM_CODE_CHARS)
-
-kfp.dsl.ParallelFor._get_unique_id_code = StableIDGenerator().get_next_id
 
 
 @func_to_container_op
 def produce_message(fname1: str) -> str:
     return "My name is %s" % fname1
+
 
 @func_to_container_op
 def consume(param1):
@@ -53,7 +39,7 @@ def parallelfor_pipeline_param_in_items_resolving(fname1: str, fname2: str):
     list_of_complex_dict = [
         {"first_name": fname1, "message": produce_message(fname1).output},
         {"first_name": fname2, "message": produce_message(fname2).output}]
-    
+
     with kfp.dsl.ParallelFor(simple_list) as loop_item:
         consume(loop_item)
 

--- a/sdk/python/tests/compiler/testdata/parallelfor_pipeline_param_in_items_resolving.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_pipeline_param_in_items_resolving.yaml
@@ -2,17 +2,17 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: parallelfor-pipeline-param-in-items-resolving-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.2.0, pipelines.kubeflow.org/pipeline_compilation_time: '2020-12-22T10:30:28.553559',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.3.0, pipelines.kubeflow.org/pipeline_compilation_time: '2021-01-20T11:26:39.409358',
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"name": "fname1", "type":
       "String"}, {"name": "fname2", "type": "String"}], "name": "Parallelfor pipeline
       param in items resolving"}'}
-  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.2.0}
+  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.3.0}
 spec:
   entrypoint: parallelfor-pipeline-param-in-items-resolving
   templates:
   - name: consume
     container:
-      args: [--param1, '{{inputs.parameters.loop-item-param-00000001}}']
+      args: [--param1, '{{inputs.parameters.loop-item-param-1}}']
       command:
       - sh
       - -ec
@@ -33,21 +33,21 @@ spec:
       image: python:3.7
     inputs:
       parameters:
-      - {name: loop-item-param-00000001}
+      - {name: loop-item-param-1}
     metadata:
       annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
           {"args": ["--param1", {"inputValue": "param1"}], "command": ["sh", "-ec",
-          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3 -u
-          \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
+          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
           argparse\n_parser = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
           dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
           = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
           "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name": "Consume"}',
         pipelines.kubeflow.org/component_ref: '{}', pipelines.kubeflow.org/arguments.parameters: '{"param1":
-          "{{inputs.parameters.loop-item-param-00000001}}"}'}
+          "{{inputs.parameters.loop-item-param-1}}"}'}
   - name: consume-2
     container:
-      args: [--param1, '{{inputs.parameters.loop-item-param-00000002-subvar-first_name}}']
+      args: [--param1, '{{inputs.parameters.loop-item-param-3-subvar-first_name}}']
       command:
       - sh
       - -ec
@@ -68,21 +68,21 @@ spec:
       image: python:3.7
     inputs:
       parameters:
-      - {name: loop-item-param-00000002-subvar-first_name}
+      - {name: loop-item-param-3-subvar-first_name}
     metadata:
       annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
           {"args": ["--param1", {"inputValue": "param1"}], "command": ["sh", "-ec",
-          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3 -u
-          \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
+          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
           argparse\n_parser = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
           dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
           = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
           "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name": "Consume"}',
         pipelines.kubeflow.org/component_ref: '{}', pipelines.kubeflow.org/arguments.parameters: '{"param1":
-          "{{inputs.parameters.loop-item-param-00000002-subvar-first_name}}"}'}
+          "{{inputs.parameters.loop-item-param-3-subvar-first_name}}"}'}
   - name: consume-3
     container:
-      args: [--param1, '{{inputs.parameters.loop-item-param-00000002-subvar-message}}']
+      args: [--param1, '{{inputs.parameters.loop-item-param-3-subvar-message}}']
       command:
       - sh
       - -ec
@@ -103,21 +103,21 @@ spec:
       image: python:3.7
     inputs:
       parameters:
-      - {name: loop-item-param-00000002-subvar-message}
+      - {name: loop-item-param-3-subvar-message}
     metadata:
       annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
           {"args": ["--param1", {"inputValue": "param1"}], "command": ["sh", "-ec",
-          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3 -u
-          \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
+          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
           argparse\n_parser = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
           dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
           = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
           "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name": "Consume"}',
         pipelines.kubeflow.org/component_ref: '{}', pipelines.kubeflow.org/arguments.parameters: '{"param1":
-          "{{inputs.parameters.loop-item-param-00000002-subvar-message}}"}'}
+          "{{inputs.parameters.loop-item-param-3-subvar-message}}"}'}
   - name: consume-4
     container:
-      args: [--param1, '{{inputs.parameters.loop-item-param-00000003-subvar-first_name}}']
+      args: [--param1, '{{inputs.parameters.loop-item-param-5-subvar-first_name}}']
       command:
       - sh
       - -ec
@@ -138,21 +138,21 @@ spec:
       image: python:3.7
     inputs:
       parameters:
-      - {name: loop-item-param-00000003-subvar-first_name}
+      - {name: loop-item-param-5-subvar-first_name}
     metadata:
       annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
           {"args": ["--param1", {"inputValue": "param1"}], "command": ["sh", "-ec",
-          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3 -u
-          \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
+          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
           argparse\n_parser = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
           dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
           = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
           "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name": "Consume"}',
         pipelines.kubeflow.org/component_ref: '{}', pipelines.kubeflow.org/arguments.parameters: '{"param1":
-          "{{inputs.parameters.loop-item-param-00000003-subvar-first_name}}"}'}
+          "{{inputs.parameters.loop-item-param-5-subvar-first_name}}"}'}
   - name: consume-5
     container:
-      args: [--param1, '{{inputs.parameters.loop-item-param-00000003-subvar-message}}']
+      args: [--param1, '{{inputs.parameters.loop-item-param-5-subvar-message}}']
       command:
       - sh
       - -ec
@@ -173,63 +173,63 @@ spec:
       image: python:3.7
     inputs:
       parameters:
-      - {name: loop-item-param-00000003-subvar-message}
+      - {name: loop-item-param-5-subvar-message}
     metadata:
       annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
           {"args": ["--param1", {"inputValue": "param1"}], "command": ["sh", "-ec",
-          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3 -u
-          \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
+          "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
+          -u \"$program_path\" \"$@\"\n", "def consume(param1):\n    print(param1)\n\nimport
           argparse\n_parser = argparse.ArgumentParser(prog=''Consume'', description='''')\n_parser.add_argument(\"--param1\",
           dest=\"param1\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
           = vars(_parser.parse_args())\n\n_outputs = consume(**_parsed_args)\n"],
           "image": "python:3.7"}}, "inputs": [{"name": "param1"}], "name": "Consume"}',
         pipelines.kubeflow.org/component_ref: '{}', pipelines.kubeflow.org/arguments.parameters: '{"param1":
-          "{{inputs.parameters.loop-item-param-00000003-subvar-message}}"}'}
-  - name: for-loop-for-loop-00000001-1
+          "{{inputs.parameters.loop-item-param-5-subvar-message}}"}'}
+  - name: for-loop-2
     inputs:
       parameters:
-      - {name: loop-item-param-00000001}
+      - {name: loop-item-param-1}
     dag:
       tasks:
       - name: consume
         template: consume
         arguments:
           parameters:
-          - {name: loop-item-param-00000001, value: '{{inputs.parameters.loop-item-param-00000001}}'}
-  - name: for-loop-for-loop-00000002-2
+          - {name: loop-item-param-1, value: '{{inputs.parameters.loop-item-param-1}}'}
+  - name: for-loop-4
     inputs:
       parameters:
-      - {name: loop-item-param-00000002-subvar-first_name}
-      - {name: loop-item-param-00000002-subvar-message}
+      - {name: loop-item-param-3-subvar-first_name}
+      - {name: loop-item-param-3-subvar-message}
     dag:
       tasks:
       - name: consume-2
         template: consume-2
         arguments:
           parameters:
-          - {name: loop-item-param-00000002-subvar-first_name, value: '{{inputs.parameters.loop-item-param-00000002-subvar-first_name}}'}
+          - {name: loop-item-param-3-subvar-first_name, value: '{{inputs.parameters.loop-item-param-3-subvar-first_name}}'}
       - name: consume-3
         template: consume-3
         arguments:
           parameters:
-          - {name: loop-item-param-00000002-subvar-message, value: '{{inputs.parameters.loop-item-param-00000002-subvar-message}}'}
-  - name: for-loop-for-loop-00000003-3
+          - {name: loop-item-param-3-subvar-message, value: '{{inputs.parameters.loop-item-param-3-subvar-message}}'}
+  - name: for-loop-6
     inputs:
       parameters:
-      - {name: loop-item-param-00000003-subvar-first_name}
-      - {name: loop-item-param-00000003-subvar-message}
+      - {name: loop-item-param-5-subvar-first_name}
+      - {name: loop-item-param-5-subvar-message}
     dag:
       tasks:
       - name: consume-4
         template: consume-4
         arguments:
           parameters:
-          - {name: loop-item-param-00000003-subvar-first_name, value: '{{inputs.parameters.loop-item-param-00000003-subvar-first_name}}'}
+          - {name: loop-item-param-5-subvar-first_name, value: '{{inputs.parameters.loop-item-param-5-subvar-first_name}}'}
       - name: consume-5
         template: consume-5
         arguments:
           parameters:
-          - {name: loop-item-param-00000003-subvar-message, value: '{{inputs.parameters.loop-item-param-00000003-subvar-message}}'}
+          - {name: loop-item-param-5-subvar-message, value: '{{inputs.parameters.loop-item-param-5-subvar-message}}'}
   - name: parallelfor-pipeline-param-in-items-resolving
     inputs:
       parameters:
@@ -237,27 +237,27 @@ spec:
       - {name: fname2}
     dag:
       tasks:
-      - name: for-loop-for-loop-00000001-1
-        template: for-loop-for-loop-00000001-1
+      - name: for-loop-2
+        template: for-loop-2
         arguments:
           parameters:
-          - {name: loop-item-param-00000001, value: '{{item}}'}
+          - {name: loop-item-param-1, value: '{{item}}'}
         withItems: ['My name is {{workflow.parameters.fname1}}', 'My name is {{workflow.parameters.fname2}}']
-      - name: for-loop-for-loop-00000002-2
-        template: for-loop-for-loop-00000002-2
+      - name: for-loop-4
+        template: for-loop-4
         arguments:
           parameters:
-          - {name: loop-item-param-00000002-subvar-first_name, value: '{{item.first_name}}'}
-          - {name: loop-item-param-00000002-subvar-message, value: '{{item.message}}'}
+          - {name: loop-item-param-3-subvar-first_name, value: '{{item.first_name}}'}
+          - {name: loop-item-param-3-subvar-message, value: '{{item.message}}'}
         withItems:
         - {first_name: '{{workflow.parameters.fname1}}', message: 'My name is {{workflow.parameters.fname1}}'}
         - {first_name: '{{workflow.parameters.fname2}}', message: 'My name is {{workflow.parameters.fname2}}'}
-      - name: for-loop-for-loop-00000003-3
-        template: for-loop-for-loop-00000003-3
+      - name: for-loop-6
+        template: for-loop-6
         arguments:
           parameters:
-          - {name: loop-item-param-00000003-subvar-first_name, value: '{{item.first_name}}'}
-          - {name: loop-item-param-00000003-subvar-message, value: '{{item.message}}'}
+          - {name: loop-item-param-5-subvar-first_name, value: '{{item.first_name}}'}
+          - {name: loop-item-param-5-subvar-message, value: '{{item.message}}'}
         dependencies: [produce-message, produce-message-2]
         withItems:
         - {first_name: '{{workflow.parameters.fname1}}', message: '{{tasks.produce-message.outputs.parameters.produce-message-Output}}'}
@@ -328,11 +328,11 @@ spec:
     metadata:
       annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
           {"args": ["--fname1", {"inputValue": "fname1"}, "----output-paths", {"outputPath":
-          "Output"}], "command": ["sh", "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\"
-          > \"$program_path\"\npython3 -u \"$program_path\" \"$@\"\n", "def produce_message(fname1):\n    return
-          \"My name is %s\" % fname1\n\ndef _serialize_str(str_value: str) -> str:\n    if
-          not isinstance(str_value, str):\n        raise TypeError(''Value \"{}\"
-          has type \"{}\" instead of str.''.format(str(str_value), str(type(str_value))))\n    return
+          "Output"}], "command": ["sh", "-ec", "program_path=$(mktemp)\nprintf \"%s\"
+          \"$0\" > \"$program_path\"\npython3 -u \"$program_path\" \"$@\"\n", "def
+          produce_message(fname1):\n    return \"My name is %s\" % fname1\n\ndef _serialize_str(str_value:
+          str) -> str:\n    if not isinstance(str_value, str):\n        raise TypeError(''Value
+          \"{}\" has type \"{}\" instead of str.''.format(str(str_value), str(type(str_value))))\n    return
           str_value\n\nimport argparse\n_parser = argparse.ArgumentParser(prog=''Produce
           message'', description='''')\n_parser.add_argument(\"--fname1\", dest=\"fname1\",
           type=str, required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"----output-paths\",
@@ -401,11 +401,11 @@ spec:
     metadata:
       annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
           {"args": ["--fname1", {"inputValue": "fname1"}, "----output-paths", {"outputPath":
-          "Output"}], "command": ["sh", "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\"
-          > \"$program_path\"\npython3 -u \"$program_path\" \"$@\"\n", "def produce_message(fname1):\n    return
-          \"My name is %s\" % fname1\n\ndef _serialize_str(str_value: str) -> str:\n    if
-          not isinstance(str_value, str):\n        raise TypeError(''Value \"{}\"
-          has type \"{}\" instead of str.''.format(str(str_value), str(type(str_value))))\n    return
+          "Output"}], "command": ["sh", "-ec", "program_path=$(mktemp)\nprintf \"%s\"
+          \"$0\" > \"$program_path\"\npython3 -u \"$program_path\" \"$@\"\n", "def
+          produce_message(fname1):\n    return \"My name is %s\" % fname1\n\ndef _serialize_str(str_value:
+          str) -> str:\n    if not isinstance(str_value, str):\n        raise TypeError(''Value
+          \"{}\" has type \"{}\" instead of str.''.format(str(str_value), str(type(str_value))))\n    return
           str_value\n\nimport argparse\n_parser = argparse.ArgumentParser(prog=''Produce
           message'', description='''')\n_parser.add_argument(\"--fname1\", dest=\"fname1\",
           type=str, required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"----output-paths\",

--- a/sdk/python/tests/compiler/testdata/uri_artifacts.yaml
+++ b/sdk/python/tests/compiler/testdata/uri_artifacts.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   entrypoint: uri-artifact-pipeline
   templates:
-  - name: condition-2
+  - name: condition-3
     inputs:
       parameters:
       - {name: input_gcs_path-producer-pod-id-}
@@ -32,7 +32,7 @@ spec:
         valueFrom: {path: /tmp/output}
       artifacts:
       - {name: flip-coin-output, path: /tmp/output}
-  - name: for-loop-for-loop-00000001-1
+  - name: for-loop-2
     inputs:
       parameters:
       - {name: input_gcs_path-producer-pod-id-}
@@ -109,16 +109,16 @@ spec:
       - {name: text}
     dag:
       tasks:
-      - name: condition-2
-        template: condition-2
+      - name: condition-3
+        template: condition-3
         when: '"{{tasks.flip-coin.outputs.parameters.flip-coin-output}}" == "heads"'
         dependencies: [flip-coin, write-to-gcs]
         arguments:
           parameters:
           - {name: input_gcs_path-producer-pod-id-, value: '{{tasks.write-to-gcs.outputs.parameters.write-to-gcs-output_gcs_path-producer-pod-id-}}'}
       - {name: flip-coin, template: flip-coin}
-      - name: for-loop-for-loop-00000001-1
-        template: for-loop-for-loop-00000001-1
+      - name: for-loop-2
+        template: for-loop-2
         dependencies: [write-to-gcs]
         arguments:
           parameters:

--- a/sdk/python/tests/compiler/testdata/withitem_basic.py
+++ b/sdk/python/tests/compiler/testdata/withitem_basic.py
@@ -16,18 +16,6 @@ import kfp.dsl as dsl
 from kfp.dsl import _for_loop
 
 
-class Coder:
-    def __init__(self, ):
-        self._code_id = 0
-
-    def get_code(self, ):
-        self._code_id += 1
-        return '{code:0{num_chars:}d}'.format(code=self._code_id, num_chars=_for_loop.LoopArguments.NUM_CODE_CHARS)
-
-
-dsl.ParallelFor._get_unique_id_code = Coder().get_code
-
-
 @dsl.pipeline(name='my-pipeline')
 def pipeline(my_pipe_param: int = 10):
     loop_args = [{'a': 1, 'b': 2}, {'a': 10, 'b': 20}]

--- a/sdk/python/tests/compiler/testdata/withitem_basic.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_basic.yaml
@@ -17,46 +17,46 @@ spec:
       tasks:
       - arguments:
           parameters:
-          - name: loop-item-param-00000001-subvar-a
-            value: '{{inputs.parameters.loop-item-param-00000001-subvar-a}}'
+          - name: loop-item-param-1-subvar-a
+            value: '{{inputs.parameters.loop-item-param-1-subvar-a}}'
           - name: my_pipe_param
             value: '{{inputs.parameters.my_pipe_param}}'
         name: my-in-coop1
         template: my-in-coop1
       - arguments:
           parameters:
-          - name: loop-item-param-00000001-subvar-b
-            value: '{{inputs.parameters.loop-item-param-00000001-subvar-b}}'
+          - name: loop-item-param-1-subvar-b
+            value: '{{inputs.parameters.loop-item-param-1-subvar-b}}'
         name: my-in-coop2
         template: my-in-coop2
     inputs:
       parameters:
-      - name: loop-item-param-00000001-subvar-a
-      - name: loop-item-param-00000001-subvar-b
+      - name: loop-item-param-1-subvar-a
+      - name: loop-item-param-1-subvar-b
       - name: my_pipe_param
-    name: for-loop-for-loop-00000001-1
+    name: for-loop-2
   - container:
       args:
-      - echo op1 {{inputs.parameters.loop-item-param-00000001-subvar-a}} {{inputs.parameters.my_pipe_param}}
+      - echo op1 {{inputs.parameters.loop-item-param-1-subvar-a}} {{inputs.parameters.my_pipe_param}}
       command:
       - sh
       - -c
       image: library/bash:4.4.23
     inputs:
       parameters:
-      - name: loop-item-param-00000001-subvar-a
+      - name: loop-item-param-1-subvar-a
       - name: my_pipe_param
     name: my-in-coop1
   - container:
       args:
-      - echo op2 {{inputs.parameters.loop-item-param-00000001-subvar-b}}
+      - echo op2 {{inputs.parameters.loop-item-param-1-subvar-b}}
       command:
       - sh
       - -c
       image: library/bash:4.4.23
     inputs:
       parameters:
-      - name: loop-item-param-00000001-subvar-b
+      - name: loop-item-param-1-subvar-b
     name: my-in-coop2
   - container:
       args:
@@ -73,14 +73,14 @@ spec:
       tasks:
       - arguments:
           parameters:
-          - name: loop-item-param-00000001-subvar-a
+          - name: loop-item-param-1-subvar-a
             value: '{{item.a}}'
-          - name: loop-item-param-00000001-subvar-b
+          - name: loop-item-param-1-subvar-b
             value: '{{item.b}}'
           - name: my_pipe_param
             value: '{{inputs.parameters.my_pipe_param}}'
-        name: for-loop-for-loop-00000001-1
-        template: for-loop-for-loop-00000001-1
+        name: for-loop-2
+        template: for-loop-2
         withItems:
         - a: 1
           b: 2

--- a/sdk/python/tests/compiler/testdata/withitem_nested.py
+++ b/sdk/python/tests/compiler/testdata/withitem_nested.py
@@ -16,18 +16,6 @@ import kfp.dsl as dsl
 from kfp.dsl import _for_loop
 
 
-class Coder:
-    def __init__(self, ):
-        self._code_id = 0
-
-    def get_code(self, ):
-        self._code_id += 1
-        return '{code:0{num_chars:}d}'.format(code=self._code_id, num_chars=_for_loop.LoopArguments.NUM_CODE_CHARS)
-
-
-dsl.ParallelFor._get_unique_id_code = Coder().get_code
-
-
 @dsl.pipeline(name='my-pipeline')
 def pipeline(my_pipe_param: int = 10):
     loop_args = [{'a': 1, 'b': 2}, {'a': 10, 'b': 20}]

--- a/sdk/python/tests/compiler/testdata/withitem_nested.yaml
+++ b/sdk/python/tests/compiler/testdata/withitem_nested.yaml
@@ -17,82 +17,82 @@ spec:
       tasks:
       - arguments:
           parameters:
-          - name: loop-item-param-00000001-subvar-a
-            value: '{{inputs.parameters.loop-item-param-00000001-subvar-a}}'
-          - name: loop-item-param-00000002
+          - name: loop-item-param-1-subvar-a
+            value: '{{inputs.parameters.loop-item-param-1-subvar-a}}'
+          - name: loop-item-param-3
             value: '{{item}}'
           - name: my_pipe_param
             value: '{{inputs.parameters.my_pipe_param}}'
-        name: for-loop-for-loop-00000002-2
-        template: for-loop-for-loop-00000002-2
+        name: for-loop-4
+        template: for-loop-4
         withItems:
         - 100
         - 200
         - 300
       - arguments:
           parameters:
-          - name: loop-item-param-00000001-subvar-a
-            value: '{{inputs.parameters.loop-item-param-00000001-subvar-a}}'
+          - name: loop-item-param-1-subvar-a
+            value: '{{inputs.parameters.loop-item-param-1-subvar-a}}'
           - name: my_pipe_param
             value: '{{inputs.parameters.my_pipe_param}}'
         name: my-in-coop1
         template: my-in-coop1
       - arguments:
           parameters:
-          - name: loop-item-param-00000001-subvar-b
-            value: '{{inputs.parameters.loop-item-param-00000001-subvar-b}}'
+          - name: loop-item-param-1-subvar-b
+            value: '{{inputs.parameters.loop-item-param-1-subvar-b}}'
         name: my-in-coop2
         template: my-in-coop2
     inputs:
       parameters:
-      - name: loop-item-param-00000001-subvar-a
-      - name: loop-item-param-00000001-subvar-b
+      - name: loop-item-param-1-subvar-a
+      - name: loop-item-param-1-subvar-b
       - name: my_pipe_param
-    name: for-loop-for-loop-00000001-1
+    name: for-loop-2
   - dag:
       tasks:
       - arguments:
           parameters:
-          - name: loop-item-param-00000001-subvar-a
-            value: '{{inputs.parameters.loop-item-param-00000001-subvar-a}}'
-          - name: loop-item-param-00000002
-            value: '{{inputs.parameters.loop-item-param-00000002}}'
+          - name: loop-item-param-1-subvar-a
+            value: '{{inputs.parameters.loop-item-param-1-subvar-a}}'
+          - name: loop-item-param-3
+            value: '{{inputs.parameters.loop-item-param-3}}'
           - name: my_pipe_param
             value: '{{inputs.parameters.my_pipe_param}}'
         name: my-inner-inner-coop
         template: my-inner-inner-coop
     inputs:
       parameters:
-      - name: loop-item-param-00000001-subvar-a
-      - name: loop-item-param-00000002
+      - name: loop-item-param-1-subvar-a
+      - name: loop-item-param-3
       - name: my_pipe_param
-    name: for-loop-for-loop-00000002-2
+    name: for-loop-4
   - container:
       args:
-      - echo op1 {{inputs.parameters.loop-item-param-00000001-subvar-a}} {{inputs.parameters.my_pipe_param}}
+      - echo op1 {{inputs.parameters.loop-item-param-1-subvar-a}} {{inputs.parameters.my_pipe_param}}
       command:
       - sh
       - -c
       image: library/bash:4.4.23
     inputs:
       parameters:
-      - name: loop-item-param-00000001-subvar-a
+      - name: loop-item-param-1-subvar-a
       - name: my_pipe_param
     name: my-in-coop1
   - container:
       args:
-      - echo op2 {{inputs.parameters.loop-item-param-00000001-subvar-b}}
+      - echo op2 {{inputs.parameters.loop-item-param-1-subvar-b}}
       command:
       - sh
       - -c
       image: library/bash:4.4.23
     inputs:
       parameters:
-      - name: loop-item-param-00000001-subvar-b
+      - name: loop-item-param-1-subvar-b
     name: my-in-coop2
   - container:
       args:
-      - echo op1 {{inputs.parameters.loop-item-param-00000001-subvar-a}} {{inputs.parameters.loop-item-param-00000002}}
+      - echo op1 {{inputs.parameters.loop-item-param-1-subvar-a}} {{inputs.parameters.loop-item-param-3}}
         {{inputs.parameters.my_pipe_param}}
       command:
       - sh
@@ -100,8 +100,8 @@ spec:
       image: library/bash:4.4.23
     inputs:
       parameters:
-      - name: loop-item-param-00000001-subvar-a
-      - name: loop-item-param-00000002
+      - name: loop-item-param-1-subvar-a
+      - name: loop-item-param-3
       - name: my_pipe_param
     name: my-inner-inner-coop
   - container:
@@ -119,14 +119,14 @@ spec:
       tasks:
       - arguments:
           parameters:
-          - name: loop-item-param-00000001-subvar-a
+          - name: loop-item-param-1-subvar-a
             value: '{{item.a}}'
-          - name: loop-item-param-00000001-subvar-b
+          - name: loop-item-param-1-subvar-b
             value: '{{item.b}}'
           - name: my_pipe_param
             value: '{{inputs.parameters.my_pipe_param}}'
-        name: for-loop-for-loop-00000001-1
-        template: for-loop-for-loop-00000001-1
+        name: for-loop-2
+        template: for-loop-2
         withItems:
         - a: 1
           b: 2

--- a/sdk/python/tests/compiler/testdata/withparam_global.py
+++ b/sdk/python/tests/compiler/testdata/withparam_global.py
@@ -16,18 +16,6 @@ import kfp.dsl as dsl
 from kfp.dsl import _for_loop
 
 
-class Coder:
-    def __init__(self, ):
-        self._code_id = 0
-
-    def get_code(self, ):
-        self._code_id += 1
-        return '{code:0{num_chars:}d}'.format(code=self._code_id, num_chars=_for_loop.LoopArguments.NUM_CODE_CHARS)
-
-
-dsl.ParallelFor._get_unique_id_code = Coder().get_code
-
-
 @dsl.pipeline(name='my-pipeline')
 def pipeline(loopidy_doop: list = [3, 5, 7, 9]):
     op0 = dsl.ContainerOp(

--- a/sdk/python/tests/compiler/testdata/withparam_global.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_global.yaml
@@ -24,7 +24,7 @@ spec:
     inputs:
       parameters:
       - name: loopidy_doop-loop-item
-    name: for-loop-for-loop-00000001-1
+    name: for-loop-1
   - container:
       args:
       - 'echo no output global op1, item: {{inputs.parameters.loopidy_doop-loop-item}}'
@@ -72,8 +72,8 @@ spec:
             value: '{{item}}'
         dependencies:
         - my-out-cop0
-        name: for-loop-for-loop-00000001-1
-        template: for-loop-for-loop-00000001-1
+        name: for-loop-1
+        template: for-loop-1
         withParam: '{{workflow.parameters.loopidy_doop}}'
       - name: my-out-cop0
         template: my-out-cop0

--- a/sdk/python/tests/compiler/testdata/withparam_global_dict.py
+++ b/sdk/python/tests/compiler/testdata/withparam_global_dict.py
@@ -16,18 +16,6 @@ import kfp.dsl as dsl
 from kfp.dsl import _for_loop
 
 
-class Coder:
-    def __init__(self, ):
-        self._code_id = 0
-
-    def get_code(self, ):
-        self._code_id += 1
-        return '{code:0{num_chars:}d}'.format(code=self._code_id, num_chars=_for_loop.LoopArguments.NUM_CODE_CHARS)
-
-
-dsl.ParallelFor._get_unique_id_code = Coder().get_code
-
-
 @dsl.pipeline(name='my-pipeline')
 def pipeline(loopidy_doop: dict = [{'a': 1, 'b': 2}, {'a': 10, 'b': 20}]):
     op0 = dsl.ContainerOp(

--- a/sdk/python/tests/compiler/testdata/withparam_global_dict.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_global_dict.yaml
@@ -24,7 +24,7 @@ spec:
     inputs:
       parameters:
       - name: loopidy_doop-loop-item-subvar-a
-    name: for-loop-for-loop-00000001-1
+    name: for-loop-1
   - container:
       args:
       - 'echo no output global op1, item.a: {{inputs.parameters.loopidy_doop-loop-item-subvar-a}}'
@@ -72,8 +72,8 @@ spec:
             value: '{{item.a}}'
         dependencies:
         - my-out-cop0
-        name: for-loop-for-loop-00000001-1
-        template: for-loop-for-loop-00000001-1
+        name: for-loop-1
+        template: for-loop-1
         withParam: '{{workflow.parameters.loopidy_doop}}'
       - name: my-out-cop0
         template: my-out-cop0

--- a/sdk/python/tests/compiler/testdata/withparam_output.py
+++ b/sdk/python/tests/compiler/testdata/withparam_output.py
@@ -16,18 +16,6 @@ import kfp.dsl as dsl
 from kfp.dsl import _for_loop
 
 
-class Coder:
-    def __init__(self, ):
-        self._code_id = 0
-
-    def get_code(self, ):
-        self._code_id += 1
-        return '{code:0{num_chars:}d}'.format(code=self._code_id, num_chars=_for_loop.LoopArguments.NUM_CODE_CHARS)
-
-
-dsl.ParallelFor._get_unique_id_code = Coder().get_code
-
-
 @dsl.pipeline(name='my-pipeline')
 def pipeline():
     op0 = dsl.ContainerOp(

--- a/sdk/python/tests/compiler/testdata/withparam_output.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_output.yaml
@@ -21,7 +21,7 @@ spec:
     inputs:
       parameters:
       - name: my-out-cop0-out-loop-item
-    name: for-loop-for-loop-00000001-1
+    name: for-loop-1
   - container:
       args:
       - 'echo do output op1 item: {{inputs.parameters.my-out-cop0-out-loop-item}}'
@@ -69,8 +69,8 @@ spec:
             value: '{{item}}'
         dependencies:
         - my-out-cop0
-        name: for-loop-for-loop-00000001-1
-        template: for-loop-for-loop-00000001-1
+        name: for-loop-1
+        template: for-loop-1
         withParam: '{{tasks.my-out-cop0.outputs.parameters.my-out-cop0-out}}'
       - name: my-out-cop0
         template: my-out-cop0

--- a/sdk/python/tests/compiler/testdata/withparam_output_dict.py
+++ b/sdk/python/tests/compiler/testdata/withparam_output_dict.py
@@ -16,18 +16,6 @@ import kfp.dsl as dsl
 from kfp.dsl import _for_loop
 
 
-class Coder:
-    def __init__(self, ):
-        self._code_id = 0
-
-    def get_code(self, ):
-        self._code_id += 1
-        return '{code:0{num_chars:}d}'.format(code=self._code_id, num_chars=_for_loop.LoopArguments.NUM_CODE_CHARS)
-
-
-dsl.ParallelFor._get_unique_id_code = Coder().get_code
-
-
 @dsl.pipeline(name='my-pipeline')
 def pipeline():
     op0 = dsl.ContainerOp(

--- a/sdk/python/tests/compiler/testdata/withparam_output_dict.yaml
+++ b/sdk/python/tests/compiler/testdata/withparam_output_dict.yaml
@@ -21,7 +21,7 @@ spec:
     inputs:
       parameters:
       - name: my-out-cop0-out-loop-item-subvar-a
-    name: for-loop-for-loop-00000001-1
+    name: for-loop-1
   - container:
       args:
       - 'echo do output op1 item.a: {{inputs.parameters.my-out-cop0-out-loop-item-subvar-a}}'
@@ -69,8 +69,8 @@ spec:
             value: '{{item.a}}'
         dependencies:
         - my-out-cop0
-        name: for-loop-for-loop-00000001-1
-        template: for-loop-for-loop-00000001-1
+        name: for-loop-1
+        template: for-loop-1
         withParam: '{{tasks.my-out-cop0.outputs.parameters.my-out-cop0-out}}'
       - name: my-out-cop0
         template: my-out-cop0


### PR DESCRIPTION
During compilataion ParallelFor components end up with randomized names,
which makes it very inconvenient to compare two versions of a pipeline.
This commit fixes this issue.

**Description of your changes:**


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [x] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
