### PR TITLE
chore (sdk.v2): Error out on using InputPath placeholder for artifacts require importer.

### DIFF
--- a/sdk/python/kfp/v2/compiler/compiler_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_test.py
@@ -384,7 +384,7 @@ class CompilerTest(unittest.TestCase):
     with self.assertRaisesRegex(
         TypeError,
         'Input "model" with type "Model" is not connected to any upstream '
-        'output. But it is used with InputPathPlaceholder.'):
+        'output. However it is used with InputPathPlaceholder.'):
       compiler.Compiler().compile(
           pipeline_func=my_pipeline,
           pipeline_root='dummy',
@@ -403,7 +403,7 @@ class CompilerTest(unittest.TestCase):
     with self.assertRaisesRegex(
         TypeError,
         'Input "datasets" with type "Datasets" is not connected to any upstream '
-        'output. But it is used with InputPathPlaceholder.'):
+        'output. However it is used with InputPathPlaceholder.'):
       compiler.Compiler().compile(
           pipeline_func=my_pipeline,
           pipeline_root='dummy',

--- a/sdk/python/kfp/v2/compiler/compiler_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_test.py
@@ -289,8 +289,7 @@ class CompilerTest(unittest.TestCase):
       component_op(value=value)
 
     with self.assertRaisesRegex(
-        TypeError,
-        ' type "Float" cannot be paired with InputUriPlaceholder.'):
+        TypeError, ' type "Float" cannot be paired with InputUriPlaceholder.'):
       compiler.Compiler().compile(
           pipeline_func=my_pipeline,
           pipeline_root='dummy',
@@ -351,6 +350,7 @@ class CompilerTest(unittest.TestCase):
           """)
 
   def test_compile_pipeline_with_invalid_name_should_raise_error(self):
+
     def my_pipeline():
       pass
 
@@ -358,6 +358,52 @@ class CompilerTest(unittest.TestCase):
         ValueError,
         'Invalid pipeline name: .*\nPlease specify a pipeline name that matches'
     ):
+      compiler.Compiler().compile(
+          pipeline_func=my_pipeline,
+          pipeline_root='dummy',
+          output_path='output.json')
+
+  def test_compile_pipeline_with_importer_on_inputpath_should_raise_error(self):
+
+    # YAML componet authoring
+    component_op = components.load_component_from_text("""
+        name: compoent with misused placeholder
+        inputs:
+        - {name: model, type: Model}
+        implementation:
+          container:
+            image: dummy
+            args:
+            - {inputPath: model}
+        """)
+
+    @dsl.pipeline(name='my-component')
+    def my_pipeline(model):
+      component_op(model=model)
+
+    with self.assertRaisesRegex(
+        TypeError,
+        'Input "model" with type "Model" is not connected to any upstream '
+        'output. But it is used with InputPathPlaceholder.'):
+      compiler.Compiler().compile(
+          pipeline_func=my_pipeline,
+          pipeline_root='dummy',
+          output_path='output.json')
+
+    # Python function based component authoring
+    def my_component(datasets: components.InputPath('Datasets')):
+      pass
+
+    component_op = components.create_component_from_func(my_component)
+
+    @dsl.pipeline(name='my-component')
+    def my_pipeline(datasets):
+      component_op(datasets=datasets)
+
+    with self.assertRaisesRegex(
+        TypeError,
+        'Input "datasets" with type "Datasets" is not connected to any upstream '
+        'output. But it is used with InputPathPlaceholder.'):
       compiler.Compiler().compile(
           pipeline_func=my_pipeline,
           pipeline_root='dummy',

--- a/sdk/python/kfp/v2/dsl/component_bridge.py
+++ b/sdk/python/kfp/v2/dsl/component_bridge.py
@@ -150,7 +150,7 @@ def create_container_op_from_component_and_arguments(
     elif input_key in importer_spec:
       raise TypeError(
           'Input "{}" with type "{}" is not connected to any upstream output. '
-          'But it is used with InputPathPlaceholder. '
+          'However it is used with InputPathPlaceholder. '
           'If you want to import an existing artifact using a system-connected '
           'importer node, use InputUriPlaceholder instead. '
           'Or if you just want to pass a string parameter, use string type and '

--- a/sdk/python/kfp/v2/dsl/component_bridge.py
+++ b/sdk/python/kfp/v2/dsl/component_bridge.py
@@ -147,6 +147,15 @@ def create_container_op_from_component_and_arguments(
       raise TypeError(
           'Input "{}" with type "{}" cannot be paired with InputPathPlaceholder.'
           .format(input_key, inputs_dict[input_key].type))
+    elif input_key in importer_spec:
+      raise TypeError(
+          'Input "{}" with type "{}" is not connected to any upstream output. '
+          'But it is used with InputPathPlaceholder. '
+          'If you want to import an existing artifact using a system-connected '
+          'importer node, use InputUriPlaceholder instead. '
+          'Or if you just want to pass a string parameter, use string type and '
+          'InputValuePlaceholder instead.'
+          .format(input_key, inputs_dict[input_key].type))
     else:
       return "{{{{$.inputs.artifacts['{}'].path}}}}".format(input_key)
 


### PR DESCRIPTION
**Description of your changes:**
- Importer node will be auto attached only if InputUri placeholder is used.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
