### PR TITLE
feat(sdk): Add in ability to override the template handler for a BaseOp.

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -638,7 +638,8 @@ class Compiler(object):
       templates.append(template)
 
     for op in pipeline.ops.values():
-      templates.extend(op_to_templates_handler(op))
+      op_to_template_handler = op.template_handler or op_to_templates_handler
+      templates.extend(op_to_template_handler(op))
 
     return templates
 

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -727,6 +727,7 @@ class BaseOp(object):
             warnings.warn('is_exit_handler=True is no longer needed.', DeprecationWarning)
 
         self.is_exit_handler = is_exit_handler
+        self.template_handler = None
 
         # human_name must exist to construct operator's name
         self.human_name = name
@@ -924,6 +925,16 @@ class BaseOp(object):
 
     def set_display_name(self, name: str):
         self.display_name = name
+        return self
+
+    def set_template_handler(self, template_handler: Callable[['BaseOp'], Dict]):
+        """Set the template handler for converting Op into Argo template.
+
+        Args:
+          template_handler: A callable for converting the BaseOp into an Argo template during
+            pipeline compilation.
+        """
+        self.template_handler = template_handler
         return self
 
     def __repr__(self):

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -927,11 +927,11 @@ class BaseOp(object):
         self.display_name = name
         return self
 
-    def set_template_handler(self, template_handler: Callable[['BaseOp'], Dict]):
+    def set_template_handler(self, template_handler: Callable[['BaseOp'], List[Dict]]):
         """Set the template handler for converting Op into Argo template.
 
         Args:
-          template_handler: A callable for converting the BaseOp into an Argo template during
+          template_handler: A callable for converting the BaseOp into Argo templates during
             pipeline compilation.
         """
         self.template_handler = template_handler


### PR DESCRIPTION
**Description of your changes:**

Argo has some great functionality the SDK doesn't expose by default. In particular, we're interested in using the `PodSecurityContext` and `podSpecPatch` functionality but needing to get in an upstream PR to leverage the functionality seems a little slow so wondering if this is an approach is something maintainers would consider.

No cherry-picking required.

----

Example usage:

```python
from typing import Dict
from kfp.compiler._op_to_template import _op_to_template
from kfp.dsl._container_op import BaseOp, ContainerOp

def my_template_handler(op: BaseOp) -> Dict:
    template = _op_to_template(op)
    # See https://argoproj.github.io/argo/fields/#podsecuritycontext
    template['securityContext'] = {"fsGroup": 2000}
    return template

...

op = ContainerOp(...)
op.set_template_handler(my_template_handler)
```

Going to guess this may not pass review given a desire to hide away the underlying scheduler but open to improving this as needed. 