### PR TITLE
fix(components): Add default V1ContainerPort protocol value for the kfserving component

### DIFF
--- a/components/kubeflow/kfserving/src/kfservingdeployer.py
+++ b/components/kubeflow/kfserving/src/kfservingdeployer.py
@@ -102,7 +102,7 @@ def customEndpointSpec(custom_model_spec, service_account):
         else None
     )
     ports = (
-        [client.V1ContainerPort(container_port=int(custom_model_spec.get("port", "")))]
+        [client.V1ContainerPort(container_port=int(custom_model_spec.get("port", "")), protocol="TCP")]
         if custom_model_spec.get("port", "")
         else None
     )


### PR DESCRIPTION
**Description of your changes:**
In the recent Kubernetes version, V1ContainerPort protocol is no longer optional in some Kubernetes deployment. Thus we are seeing the below errors:
```
"causes":[{"reason":"FieldValueRequired","message":"Required value","field":"spec.default.predictor.custom.container.ports.protocol"}]
```

Add the default protocol value from k8s (TCP) will solve this issue. 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
