### PR TITLE
feat(components): Change Katib component output to JsonObject

### DIFF
--- a/components/kubeflow/katib-launcher/component.yaml
+++ b/components/kubeflow/katib-launcher/component.yaml
@@ -7,7 +7,7 @@ inputs:
 - {name: Experiment Timeout Minutes, type: Integer,      default: 1440,      description: 'Time in minutes to wait for the Experiment to complete'}
 - {name: Delete Finished Experiment, type: Bool,         default: 'True',    description: 'Whether to delete the Experiment after it is finished'}
 outputs:
-- {name: Best Parameter Set,         type: JSON,                             description: 'The hyperparameter set of the best Experiment Trial'}
+- {name: Best Parameter Set,         type: JsonObject,                       description: 'The hyperparameter set of the best Experiment Trial'}
 implementation:
   container:
     image: docker.io/kubeflowkatib/kubeflow-pipelines-launcher


### PR DESCRIPTION
**Description of your changes:**
See comment: https://github.com/kubeflow/pipelines/pull/4798#discussion_r528179256.

We can use `JsonObject` instead of `JSON` for Katib component output.

/assign @Ark-kun @Bobgy 
/cc @gaocegege @johnugeorge 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
