### PR TITLE
fix(sdk): Components - Fixed python components that use \n. Fixes #4939

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -646,7 +646,7 @@ _outputs = {func_name}(**_parsed_args)
                 # This is needed for Python to show stack traces and for `inspect.getsource` to work (used by PyTorch JIT and this module for example).
                 textwrap.dedent('''\
                     program_path=$(mktemp)
-                    echo -n "$0" > "$program_path"
+                    printf "%s" "$0" > "$program_path"
                     python3 -u "$program_path" "$@"
                 '''),
                 full_source,

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
@@ -20,7 +20,7 @@ spec:
           - "-ec"
           - |
               program_path=$(mktemp)
-              echo -n "$0" > "$program_path"
+              printf "%s" "$0" > "$program_path"
               python3 -u "$program_path" "$@"
           - |
               def consume(param1):
@@ -51,7 +51,7 @@ spec:
           - "-ec"
           - |
               program_path=$(mktemp)
-              echo -n "$0" > "$program_path"
+              printf "%s" "$0" > "$program_path"
               python3 -u "$program_path" "$@"
           - |
               def consume(param1):
@@ -82,7 +82,7 @@ spec:
           - "-ec"
           - |
               program_path=$(mktemp)
-              echo -n "$0" > "$program_path"
+              printf "%s" "$0" > "$program_path"
               python3 -u "$program_path" "$@"
           - |
               def consume(param1):
@@ -113,7 +113,7 @@ spec:
           - "-ec"
           - |
               program_path=$(mktemp)
-              echo -n "$0" > "$program_path"
+              printf "%s" "$0" > "$program_path"
               python3 -u "$program_path" "$@"
           - |
               def consume(param1):
@@ -144,7 +144,7 @@ spec:
           - "-ec"
           - |
               program_path=$(mktemp)
-              echo -n "$0" > "$program_path"
+              printf "%s" "$0" > "$program_path"
               python3 -u "$program_path" "$@"
           - |
               def consume(param1):
@@ -175,7 +175,7 @@ spec:
           - "-ec"
           - |
               program_path=$(mktemp)
-              echo -n "$0" > "$program_path"
+              printf "%s" "$0" > "$program_path"
               python3 -u "$program_path" "$@"
           - |
               def consume(param1):
@@ -206,7 +206,7 @@ spec:
           - "-ec"
           - |
               program_path=$(mktemp)
-              echo -n "$0" > "$program_path"
+              printf "%s" "$0" > "$program_path"
               python3 -u "$program_path" "$@"
           - |
               def consume(param1):
@@ -387,7 +387,7 @@ spec:
           - "-ec"
           - |
               program_path=$(mktemp)
-              echo -n "$0" > "$program_path"
+              printf "%s" "$0" > "$program_path"
               python3 -u "$program_path" "$@"
           - |
               def produce_list_of_dicts():
@@ -452,7 +452,7 @@ spec:
           - "-ec"
           - |
               program_path=$(mktemp)
-              echo -n "$0" > "$program_path"
+              printf "%s" "$0" > "$program_path"
               python3 -u "$program_path" "$@"
           - |
               def produce_list_of_ints():
@@ -517,7 +517,7 @@ spec:
           - "-ec"
           - |
               program_path=$(mktemp)
-              echo -n "$0" > "$program_path"
+              printf "%s" "$0" > "$program_path"
               python3 -u "$program_path" "$@"
           - |
               def produce_list_of_strings():
@@ -582,7 +582,7 @@ spec:
           - "-ec"
           - |
               program_path=$(mktemp)
-              echo -n "$0" > "$program_path"
+              printf "%s" "$0" > "$program_path"
               python3 -u "$program_path" "$@"
           - |
               def produce_str():


### PR DESCRIPTION
The escape sequence was being replaced by the `echo` command.

Apparently, unlike in the `bash` shell, the `echo` command of the `sh` shell expands the escape sequences by default and does not support an option to turn it off. (For some reason the -n option works properly even though it should not).

Fixes https://github.com/kubeflow/pipelines/issues/4939
