### PR TITLE
feat(sdk): Components - Support annotations when creating components from python

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -30,11 +30,12 @@ from ._components import _create_task_factory_from_component_spec
 from ._data_passing import serialize_value, get_deserializer_code_for_type_struct, get_serializer_func_for_type_struct, get_canonical_type_struct_for_type
 from ._naming import _make_name_unique_by_adding_index
 from .structures import *
+from . import _structures as structures
 
 import inspect
 from pathlib import Path
 import textwrap
-from typing import Callable, List, Optional, TypeVar
+from typing import Callable, List, Mapping, Optional, TypeVar
 import warnings
 
 import docstring_parser
@@ -744,7 +745,9 @@ def func_to_container_op(
     extra_code: Optional[str] = '',
     packages_to_install: List[str] = None,
     modules_to_capture: List[str] = None,
-    use_code_pickling: bool = False):
+    use_code_pickling: bool = False,
+    annotations: Optional[Mapping[str, str]] = None,
+):
     '''Converts a Python function to a component and returns a task
       (:class:`kfp.dsl.ContainerOp`) factory.
 
@@ -765,6 +768,7 @@ def func_to_container_op(
         packages_to_install: Optional. List of [versioned] python packages to pip install before executing the user function.
         modules_to_capture: Optional. List of module names that will be captured (instead of just referencing) during the dependency scan. By default the :code:`func.__module__` is captured. The actual algorithm: Starting with the initial function, start traversing dependencies. If the :code:`dependency.__module__` is in the :code:`modules_to_capture` list then it's captured and it's dependencies are traversed. Otherwise the dependency is only referenced instead of capturing and its dependencies are not traversed.
         use_code_pickling: Specifies whether the function code should be captured using pickling as opposed to source code manipulation. Pickling has better support for capturing dependencies, but is sensitive to version mismatch between python in component creation environment and runtime image.
+        annotations: Optional. Allows adding arbitrary key-value data to the component specification.
 
     Returns:
         A factory function with a strongly-typed signature taken from the python function.
@@ -779,6 +783,10 @@ def func_to_container_op(
         modules_to_capture=modules_to_capture,
         use_code_pickling=use_code_pickling,
     )
+    if annotations:
+        component_spec.metadata = structures.MetadataSpec(
+            annotations=annotations,
+        )
 
     output_component_file = output_component_file or getattr(func, '_component_target_component_file', None)
     if output_component_file:
@@ -793,6 +801,7 @@ def create_component_from_func(
     output_component_file: str=None,
     base_image: str = None,
     packages_to_install: List[str] = None,
+    annotations: Optional[Mapping[str, str]] = None,
 ):
     '''Converts a Python function to a component and returns a task factory
     (a function that accepts arguments and returns a task object).
@@ -802,6 +811,7 @@ def create_component_from_func(
         base_image: Optional. Specify a custom Docker container image to use in the component. For lightweight components, the image needs to have python 3.5+. Default is the python image corresponding to the current python environment.
         output_component_file: Optional. Write a component definition to a local file. The produced component file can be loaded back by calling :code:`load_component_from_file` or :code:`load_component_from_uri`.
         packages_to_install: Optional. List of [versioned] python packages to pip install before executing the user function.
+        annotations: Optional. Allows adding arbitrary key-value data to the component specification.
 
     Returns:
         A factory function with a strongly-typed signature taken from the python function.
@@ -891,6 +901,10 @@ def create_component_from_func(
         base_image=base_image,
         packages_to_install=packages_to_install,
     )
+    if annotations:
+        component_spec.metadata = structures.MetadataSpec(
+            annotations=annotations,
+        )
 
     if output_component_file:
         component_spec.save(output_component_file)

--- a/sdk/python/kfp/components_tests/test_python_op.py
+++ b/sdk/python/kfp/components_tests/test_python_op.py
@@ -933,6 +933,17 @@ class PythonOpTestCase(unittest.TestCase):
         with self.assertRaises(Exception):
             self.helper_test_component_using_local_call(task_factory2, arguments={}, expected_output_values={})
 
+    def test_component_annotations(self):
+        def some_func():
+            pass
+
+        annotations = {
+            'key1': 'value1',
+            'key2': 'value2',
+        }
+        task_factory = comp.create_component_from_func(some_func, annotations=annotations)
+        component_spec = task_factory.component_spec
+        self.assertEqual(component_spec.metadata.annotations, annotations)
 
     def test_end_to_end_python_component_pipeline(self):
         #Defining the Python function


### PR DESCRIPTION
The component specification has always supported component annotations, but there was no way to specify them for the components generated from python. This PR fixes that.
