### PR TITLE
fix(sdk.v2): Fix the bug where pipeline_parameters is not used.

### DIFF
--- a/sdk/python/kfp/v2/compiler/compiler.py
+++ b/sdk/python/kfp/v2/compiler/compiler.py
@@ -193,7 +193,7 @@ class Compiler(object):
       A PipelineJob proto representing the compiled pipeline.
     """
     runtime_config = compiler_utils.build_runtime_config_spec(
-        pipeline_root=pipeline_root)
+        pipeline_root=pipeline_root, pipeline_parameters=pipeline_parameters)
     pipeline_job = pipeline_spec_pb2.PipelineJob(runtime_config=runtime_config)
     pipeline_job.pipeline_spec.update(json_format.MessageToDict(pipeline_spec))
 

--- a/sdk/python/kfp/v2/compiler_cli_tests/compiler_cli_tests.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/compiler_cli_tests.py
@@ -23,7 +23,7 @@ import kfp
 
 class CompilerCliTests(unittest.TestCase):
 
-  def _test_compile_py_to_json(self, file_base_name):
+  def _test_compile_py_to_json(self, file_base_name, additional_arguments = []):
     test_data_dir = os.path.join(os.path.dirname(__file__), 'test_data')
     py_file = os.path.join(test_data_dir, '{}.py'.format(file_base_name))
     tmpdir = tempfile.mkdtemp()
@@ -32,7 +32,7 @@ class CompilerCliTests(unittest.TestCase):
       subprocess.check_call([
           'dsl-compile-v2', '--py', py_file, '--pipeline-root', 'dummy_root',
           '--output', target_json
-      ])
+      ] + additional_arguments)
       with open(os.path.join(test_data_dir, file_base_name + '.json'),
                 'r') as f:
         golden = json.load(f)
@@ -55,7 +55,7 @@ class CompilerCliTests(unittest.TestCase):
     self._test_compile_py_to_json('two_step_pipeline_with_importer')
 
   def test_simple_pipeline_without_importer(self):
-    self._test_compile_py_to_json('simple_pipeline_without_importer')
+    self._test_compile_py_to_json('simple_pipeline_without_importer', ['--pipeline-parameters', '{"text":"Hello KFP!"}'])
 
   def test_pipeline_with_ontology(self):
     self._test_compile_py_to_json('pipeline_with_ontology')

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/simple_pipeline_without_importer.json
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/simple_pipeline_without_importer.json
@@ -83,6 +83,11 @@
     "schemaVersion": "v2alpha1"
   },
   "runtimeConfig": {
-    "gcsOutputDirectory": "dummy_root"
-  }
+    "gcsOutputDirectory": "dummy_root",
+    "parameters": {
+      "text": {
+        "stringValue": "Hello KFP!"
+      }
+    }
+ }
 }

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/simple_pipeline_without_importer.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/simple_pipeline_without_importer.py
@@ -55,7 +55,7 @@ implementation:
 
 
 @dsl.pipeline(name='simple-two-step-pipeline')
-def my_pipeline(text='Hello world!',):
+def my_pipeline(text='Hello world!'):
   component_1 = component_op_1(text=text)
   component_2 = component_op_2(
       input_gcs_path=component_1.outputs['output_gcs_path'])
@@ -65,4 +65,5 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=my_pipeline,
       pipeline_root='dummy_root',
+      pipeline_parameters={'text': 'Hello KFP!'},
       output_path=__file__ + '.json')


### PR DESCRIPTION
**Description of your changes:**
Fixes:
- The `Compiler().compile` method accepts `pipeline_parameters` as an argument but doesn't actually use it.
- The compiler CLI tool does not even expose an interface to accept pipeline parameters.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [x] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
