### PR TITLE
feat(backend): support separate artifact repository per namespace. Fixes #4649

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -364,6 +364,9 @@ func (r *ResourceManager) CreateRun(apiRun *api.Run) (*model.RunDetail, error) {
 		return nil, err
 	}
 
+	//  Add artifactRepositoryRef so that artifact repository can have namespace separation
+	workflow.SetArtifactRepositoryRef(util.ArtifactRepositoryRefConfigMap, util.ArtifactRepositoryRefKey)
+
 	// Add label to the workflow so it can be persisted by persistent agent later.
 	workflow.SetLabels(util.LabelKeyWorkflowRunId, runId)
 	// Add run name annotation to the workflow so that it can be logged by the Metadata Writer.
@@ -668,6 +671,9 @@ func (r *ResourceManager) CreateJob(apiJob *api.Job) (*model.Job, error) {
 
 	// Disable istio sidecar injection
 	workflow.SetAnnotationsToAllTemplates(util.AnnotationKeyIstioSidecarInject, util.AnnotationValueIstioSidecarInjectDisabled)
+
+	//  Add artifactRepositoryRef so that artifact repository can have namespace separation
+	workflow.SetArtifactRepositoryRef(util.ArtifactRepositoryRefConfigMap, util.ArtifactRepositoryRefKey)
 
 	swfGeneratedName, err := toSWFCRDResourceGeneratedName(apiJob.Name)
 	if err != nil {

--- a/backend/src/common/util/consts.go
+++ b/backend/src/common/util/consts.go
@@ -55,4 +55,7 @@ const (
 	// It captures whether this step will be selected by cache service.
 	// To disable/enable cache for a single run, this label needs to be added in every step under a run.
 	LabelKeyCacheEnabled = "pipelines.kubeflow.org/cache_enabled"
+
+	ArtifactRepositoryRefConfigMap = "artifact-repositories"
+	ArtifactRepositoryRefKey = "mlpipeline-repository"
 )

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -226,6 +226,13 @@ func (w *Workflow) SetOwnerReferences(schedule *swfapi.ScheduledWorkflow) {
 	}
 }
 
+func (w *Workflow) SetArtifactRepositoryRef(configMap string, key string) {
+	w.Spec.ArtifactRepositoryRef = &workflowapi.ArtifactRepositoryRef{
+		ConfigMap: configMap,
+		Key: key,
+	}
+}
+
 func (w *Workflow) SetLabels(key string, value string) {
 	if w.Labels == nil {
 		w.Labels = make(map[string]string)

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -324,6 +324,8 @@ func TestGetWorkflowSpec(t *testing.T) {
 		},
 	})
 
+	workflow.SetArtifactRepositoryRef("MYCONFIGMAP", "MYKEY")
+
 	expected := &workflowapi.Workflow{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "WORKFLOW_NAME",
@@ -333,6 +335,10 @@ func TestGetWorkflowSpec(t *testing.T) {
 				Parameters: []workflowapi.Parameter{
 					{Name: "PARAM", Value: StringPointer("VALUE")},
 				},
+			},
+			ArtifactRepositoryRef: &workflowapi.ArtifactRepositoryRef{
+				ConfigMap: "MYCONFIGMAP",
+				Key: "MYKEY",
 			},
 		},
 	}


### PR DESCRIPTION
**Description of your changes:**

Support configuring separate artifact repository for each namespace. 
 * Modify backend methods that submits Pipelines Runs, so that artifactRepositoryRef field is injected in the Argo workflow spec before workflow is submitted to the K8s API

Note: as mentioned in the linked issue #4649 this feature depends on upgrading Argo to version 2.9 or later

/cc @Bobgy