### PR TITLE
fix(component): Use Python3.6 to build KFP launcher component

### DIFF
--- a/components/kubeflow/launcher/Dockerfile
+++ b/components/kubeflow/launcher/Dockerfile
@@ -11,12 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM ubuntu:16.04
 
-RUN apt-get update -y && \
-    apt-get install --no-install-recommends -y -q ca-certificates python-dev python-setuptools wget && \
-    easy_install pip && \
-    pip install pyyaml==3.12 kubernetes
+FROM python:3.6
+
+RUN pip install --no-cache-dir pyyaml kubernetes
 
 ADD build /ml
 


### PR DESCRIPTION
Post-submit build-each-commit is failing on building the KFP launcher component into Docker image:
https://pantheon.corp.google.com/cloud-build/builds/03befb37-3ff6-4283-aa1a-73dc9629ddb4;step=18?project=ml-pipeline-test

Because it uses Python 2.7 which doesn't recognize f-strings.

```
Installed /usr/local/lib/python2.7/dist-packages/pip-21.0-py2.7.egg
Processing dependencies for pip
Finished processing dependencies for pip
Traceback (most recent call last):
  File "/usr/local/bin/pip", line 9, in <module>
    load_entry_point('pip==21.0', 'console_scripts', 'pip')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 542, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2569, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2229, in load
    return self.resolve()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2235, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python2.7/dist-packages/pip-21.0-py2.7.egg/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")
                                   ^
SyntaxError: invalid syntax
The command '/bin/sh -c apt-get update -y &&     apt-get install --no-install-recommends -y -q ca-certificates python-dev python-setuptools wget &&     easy_install pip &&     pip install pyyaml==3.12 kubernetes' returned a non-zero code: 1

```

Fixes #5007