### PR TITLE
feat(sdk): Support backoffs in retry strategy

### DIFF
--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -261,6 +261,15 @@ def _op_to_template(op: BaseOp):
             template['retryStrategy']['retryPolicy'] = processed_op.retry_policy
             if not processed_op.num_retries:
                 warnings.warn('retry_policy is set, but num_retries is not')
+        backoff_dict = {}
+        if processed_op.backoff_duration:
+            backoff_dict['duration'] = processed_op.backoff_duration
+        if processed_op.backoff_factor:
+            backoff_dict['factor'] = processed_op.backoff_factor
+        if processed_op.backoff_max_duration:
+            backoff_dict['maxDuration'] = processed_op.backoff_max_duration
+        if backoff_dict:
+            template['retryStrategy']['backoff'] = backoff_dict
 
     # timeout
     if processed_op.timeout:

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -747,8 +747,14 @@ class BaseOp(object):
     self.affinity = {}
     self.pod_annotations = {}
     self.pod_labels = {}
-    self.retry_policy = None
+
+    # Retry strategy
     self.num_retries = 0
+    self.retry_policy = None
+    self.backoff_factor = None
+    self.backoff_duration = None
+    self.backoff_max_duration = None
+
     self.timeout = 0
     self.init_containers = init_containers or []
     self.sidecars = sidecars or []
@@ -887,18 +893,37 @@ class BaseOp(object):
     self.pod_labels[name] = value
     return self
 
-  def set_retry(self, num_retries: int, policy: str = None):
+  def set_retry(self,
+                num_retries: int,
+                policy: str = None,
+                backoff_duration: str = None,
+                backoff_factor: float = None,
+                backoff_max_duration: str = None):
     """Sets the number of times the task is retried until it's declared failed.
 
     Args:
       num_retries: Number of times to retry on failures.
       policy: Retry policy name.
+      backoff_duration: The time interval between retries. Defaults to an
+        immediate retry. In case you specify a simple number, the unit
+        defaults to seconds. You can also specify a different unit, for
+        instance, 2m (2 minutes), 1h (1 hour).
+      backoff_factor: The exponential backoff factor applied to
+        backoff_duration. For example, if backoff_duration="60"
+        (60 seconds) and backoff_factor=2, the first retry will happen
+        after 60 seconds, then after 120, 240, and so on.
+      backoff_max_duration: The maximum interval that can be reached with
+        the backoff strategy.
     """
     if policy is not None and policy not in ALLOWED_RETRY_POLICIES:
-      raise ValueError('policy must be one of: %r' % (ALLOWED_RETRY_POLICIES,))
+        raise ValueError('policy must be one of: %r'
+                         % (ALLOWED_RETRY_POLICIES,))
 
     self.num_retries = num_retries
     self.retry_policy = policy
+    self.backoff_factor = backoff_factor
+    self.backoff_duration = backoff_duration
+    self.backoff_max_duration = backoff_max_duration
     return self
 
   def set_timeout(self, seconds: int):

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -895,10 +895,10 @@ class BaseOp(object):
 
   def set_retry(self,
                 num_retries: int,
-                policy: str = None,
-                backoff_duration: str = None,
-                backoff_factor: float = None,
-                backoff_max_duration: str = None):
+                policy: Optional[str] = None,
+                backoff_duration: Optional[str] = None,
+                backoff_factor: Optional[float] = None,
+                backoff_max_duration: Optional[str] = None):
     """Sets the number of times the task is retried until it's declared failed.
 
     Args:

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -377,9 +377,13 @@ class TestCompiler(unittest.TestCase):
       """Test retry policy is set."""
 
       policy = 'Always'
+      backoff_duration = '2m'
+      backoff_factor = 1.5
+      backoff_max_duration = '3m'
 
       def my_pipeline():
-        some_op().set_retry(2, policy)
+        some_op().set_retry(2, policy, backoff_duration, backoff_factor,
+                            backoff_max_duration)
 
       workflow = kfp.compiler.Compiler()._compile(my_pipeline)
       name_to_template = {template['name']: template for template in workflow['spec']['templates']}
@@ -387,6 +391,10 @@ class TestCompiler(unittest.TestCase):
       template = name_to_template[main_dag_tasks[0]['template']]
 
       self.assertEqual(template['retryStrategy']['retryPolicy'], policy)
+      self.assertEqual(template['retryStrategy']['backoff']['duration'], backoff_duration)
+      self.assertEqual(template['retryStrategy']['backoff']['factor'], backoff_factor)
+      self.assertEqual(template['retryStrategy']['backoff']['maxDuration'], backoff_max_duration)
+
 
   def test_py_retry_policy_invalid(self):
       def my_pipeline():


### PR DESCRIPTION
**Description of your changes:**

This PR adds support for a backoff strategy in the retry policy of ContainerOps. A backoff strategy describes how the node retry should be delayed, between failures.

This work is based on the initial design of https://github.com/kubeflow/pipelines/pull/3880, which has been stuck for some time two to lack of activity from the original contributor. There is no intention at all to plagiarize the original work and get credit for that, so feel free to resume the discussion in the original PR, if you want.

Closes https://github.com/kubeflow/pipelines/issues/3590


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
