### PR TITLE
fix(samples): Bump dataproc image version to 1.5 in xgboost_training_cm.py

### DIFF
--- a/samples/core/xgboost_training_cm/xgboost_training_cm.py
+++ b/samples/core/xgboost_training_cm/xgboost_training_cm.py
@@ -250,7 +250,7 @@ def xgb_train_pipeline(
               os.path.join(_PYSRC_PREFIX,
                            'initialization_actions.sh'),
             ],
-            image_version='1.2'
+            image_version='1.4'
         ).after(_diagnose_me_op)
 
         _analyze_op = dataproc_analyze_op(

--- a/samples/core/xgboost_training_cm/xgboost_training_cm.py
+++ b/samples/core/xgboost_training_cm/xgboost_training_cm.py
@@ -250,7 +250,7 @@ def xgb_train_pipeline(
               os.path.join(_PYSRC_PREFIX,
                            'initialization_actions.sh'),
             ],
-            image_version='1.4'
+            image_version='1.5'
         ).after(_diagnose_me_op)
 
         _analyze_op = dataproc_analyze_op(


### PR DESCRIPTION
**Description of your changes:**
1.2 is unsupported per: https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-versions
It comes with Python 2.7 which is causing issue as described here: https://github.com/kubeflow/pipelines/issues/5007#issuecomment-769637030

Bump it to 1.5 which comes with Python 3.7, and has a support lifecycle until 2022/04.
Will update the content of gs://ml-pipeline/sample-pipeline/xgboost/initialization_actions.sh separately.

Fixes part of #5007

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
