### PR TITLE
fix(SDK): require PyYAML>=5.3

### DIFF
--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -1,5 +1,4 @@
 Deprecated
-PyYAML
 
 # kfp.components
 cloudpickle
@@ -7,6 +6,7 @@ strip-hints>=0.1.8
 docstring-parser>=0.7.3
 
 # kfp.dsl
+PyYAML>=5.3
 jsonschema>=3.0.1
 kubernetes>=8.0.0, <12.0.0
 

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -4,44 +4,115 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-absl-py==0.11.0           # via -r requirements.in
-attrs==19.3.0             # via jsonschema
-cachetools==4.0.0         # via google-auth
-certifi==2019.11.28       # via kfp-server-api, kubernetes, requests
-chardet==3.0.4            # via requests
-click==7.1.1              # via -r requirements.in
-cloudpickle==1.3.0        # via -r requirements.in
-deprecated==1.2.7         # via -r requirements.in
-docstring-parser==0.7.3   # via -r requirements.in
-google-api-core==1.16.0   # via google-cloud-core
-google-auth==1.11.3       # via -r requirements.in, google-api-core, google-cloud-storage, kubernetes
-google-cloud-core==1.3.0  # via google-cloud-storage
-google-cloud-storage==1.26.0  # via -r requirements.in
-google-resumable-media==0.5.0  # via google-cloud-storage
-googleapis-common-protos==1.51.0  # via google-api-core
-idna==2.9                 # via requests
-jsonschema==3.2.0         # via -r requirements.in
-kfp-server-api==1.2.0     # via -r requirements.in
-kubernetes==11.0.0        # via -r requirements.in
-oauthlib==3.1.0           # via requests-oauthlib
-protobuf==3.11.3          # via google-api-core, googleapis-common-protos
-pyasn1-modules==0.2.8     # via google-auth
-pyasn1==0.4.8             # via pyasn1-modules, rsa
-pyrsistent==0.15.7        # via jsonschema
-python-dateutil==2.8.1    # via kfp-server-api, kubernetes
-pytz==2019.3              # via google-api-core
-pyyaml==5.3.1             # via -r requirements.in, kubernetes
-requests-oauthlib==1.3.0  # via kubernetes
-requests-toolbelt==0.9.1  # via -r requirements.in
-requests==2.23.0          # via google-api-core, kubernetes, requests-oauthlib, requests-toolbelt
-rsa==4.0                  # via google-auth
-six==1.14.0               # via absl-py, google-api-core, google-auth, google-resumable-media, jsonschema, kfp-server-api, kubernetes, protobuf, pyrsistent, python-dateutil, websocket-client
-strip-hints==0.1.8        # via -r requirements.in
-tabulate==0.8.6           # via -r requirements.in
-urllib3==1.25.8           # via kfp-server-api, kubernetes, requests
-websocket-client==0.57.0  # via kubernetes
-wheel==0.34.2             # via strip-hints
-wrapt==1.12.1             # via deprecated
+absl-py==0.11.0
+    # via -r requirements.in
+attrs==19.3.0
+    # via jsonschema
+cachetools==4.0.0
+    # via google-auth
+certifi==2019.11.28
+    # via
+    #   kfp-server-api
+    #   kubernetes
+    #   requests
+chardet==3.0.4
+    # via requests
+click==7.1.1
+    # via -r requirements.in
+cloudpickle==1.3.0
+    # via -r requirements.in
+deprecated==1.2.7
+    # via -r requirements.in
+docstring-parser==0.7.3
+    # via -r requirements.in
+google-api-core==1.16.0
+    # via google-cloud-core
+google-auth==1.11.3
+    # via
+    #   -r requirements.in
+    #   google-api-core
+    #   google-cloud-storage
+    #   kubernetes
+google-cloud-core==1.3.0
+    # via google-cloud-storage
+google-cloud-storage==1.26.0
+    # via -r requirements.in
+google-resumable-media==0.5.0
+    # via google-cloud-storage
+googleapis-common-protos==1.51.0
+    # via google-api-core
+idna==2.9
+    # via requests
+jsonschema==3.2.0
+    # via -r requirements.in
+kfp-server-api==1.2.0
+    # via -r requirements.in
+kubernetes==11.0.0
+    # via -r requirements.in
+oauthlib==3.1.0
+    # via requests-oauthlib
+protobuf==3.11.3
+    # via
+    #   google-api-core
+    #   googleapis-common-protos
+pyasn1-modules==0.2.8
+    # via google-auth
+pyasn1==0.4.8
+    # via
+    #   pyasn1-modules
+    #   rsa
+pyrsistent==0.15.7
+    # via jsonschema
+python-dateutil==2.8.1
+    # via
+    #   kfp-server-api
+    #   kubernetes
+pytz==2019.3
+    # via google-api-core
+pyyaml==5.3.1
+    # via
+    #   -r requirements.in
+    #   kubernetes
+requests-oauthlib==1.3.0
+    # via kubernetes
+requests-toolbelt==0.9.1
+    # via -r requirements.in
+requests==2.23.0
+    # via
+    #   google-api-core
+    #   kubernetes
+    #   requests-oauthlib
+    #   requests-toolbelt
+rsa==4.0
+    # via google-auth
+six==1.14.0
+    # via
+    #   absl-py
+    #   google-api-core
+    #   google-auth
+    #   google-resumable-media
+    #   jsonschema
+    #   kfp-server-api
+    #   kubernetes
+    #   protobuf
+    #   pyrsistent
+    #   python-dateutil
+    #   websocket-client
+strip-hints==0.1.8
+    # via -r requirements.in
+tabulate==0.8.6
+    # via -r requirements.in
+urllib3==1.25.8
+    # via
+    #   kfp-server-api
+    #   kubernetes
+    #   requests
+websocket-client==0.57.0
+    # via kubernetes
+wheel==0.34.2
+    # via strip-hints
+wrapt==1.12.1
+    # via deprecated
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -20,7 +20,7 @@ NAME = 'kfp'
 #VERSION = .... Change the version in kfp/__init__.py
 
 REQUIRES = [
-    'PyYAML',
+    'PyYAML>=5.3',
     'google-cloud-storage>=1.13.0',
     'kubernetes>=8.0.0, <12.0.0',
     'google-auth>=1.6.1',


### PR DESCRIPTION
**Description of your changes:**
I was playing with KFP in Google Colab with Python 3.6.9 and PyYAML 3.13, hit a bug where artifact instanceSchema was generated as:
`"instanceSchema": "{properties: !!null '', title: kfp.Artifact, type: object}\n"`
instead of what we would expect:
`"instanceSchema": "properties:\ntitle: kfp.Artifact\ntype: object\n"`

Seems like this piece of [code](https://github.com/kubeflow/pipelines/blob/2f1db59798d1a4c49e5cba7ec60644eca3fe5175/sdk/python/kfp/dsl/serialization_utils.py#L16-L37) doesn't work as expect under PyYAML 3.13.
Installing PyYAML 5.3 fixed the problem.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
