### PR TITLE
chore: set npm rangeStrategy in separate rule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,10 +25,13 @@
     },
     {
       "datasources": ["npm"],
+      "rangeStrategy": "update-lockfile",
+    },
+    {
+      "datasources": ["npm"],
       "updateTypes": ["patch", "minor"],
       "groupName": "npm dependencies",
       "groupSlug": "npm-updates",
-      "rangeStrategy": "update-lockfile",
     },
     { // major updates do not create PRs automatically
       "updateTypes": ["major"],


### PR DESCRIPTION
**Description of your changes:**

Moves `rangeStrategy` into a separate rule. It won't work as intended if combined with `updateTypes`.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
