### PR TITLE
chore: Improve the error message when incompatible placeholders are connected

### DIFF
--- a/sdk/python/kfp/compiler/_data_passing_rewriter.py
+++ b/sdk/python/kfp/compiler/_data_passing_rewriter.py
@@ -502,6 +502,12 @@ def _refactor_inputs_if_uri_placeholder(
                         r'.*/{{kfp\.run_uid}}/{{inputs\.parameters\.'
                         + input_name + r'}}/(?P<filename>.*)', cmd)
                     if matched:
+                        if not artifact_input['name'] in output_to_filename:
+                            raise RuntimeError(
+                                'Cannot find %s in output to file name mapping.'
+                                'Please note currently connecting URI '
+                                'placeholder with path placeholder is not '
+                                'supported.' % artifact_input['name'])
                         new_command_lines.append(
                             cmd[:-len(matched.group('filename'))] +
                             output_to_filename[artifact_input['name']])


### PR DESCRIPTION
**Description of your changes:**
Make the error message more informative when the user tries to connect path placeholder with uri placeholder, which is not supported yet.


**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
