### PR TITLE
chore(sdk): Bring back kfp.v2.components as an alias to kfp.components

### DIFF
--- a/sdk/python/kfp/v2/compiler/compiler_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_test.py
@@ -379,6 +379,11 @@ class CompilerTest(unittest.TestCase):
           pipeline_root='dummy',
           output_path='output.json')
 
+  def test_import_kfp_v2_component_raise_warning(self):
+    with self.assertWarnsRegex(DeprecationWarning,
+                               'Module `kfp.v2.compoennts` is deprecated'):
+      from kfp.v2 import components
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/sdk/python/kfp/v2/compiler/compiler_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_test.py
@@ -17,7 +17,7 @@ import shutil
 import tempfile
 import unittest
 
-from kfp import components
+from kfp.v2 import components
 from kfp.v2 import compiler
 from kfp.v2 import dsl
 
@@ -382,7 +382,11 @@ class CompilerTest(unittest.TestCase):
   def test_import_kfp_v2_component_raise_warning(self):
     with self.assertWarnsRegex(DeprecationWarning,
                                'Module `kfp.v2.compoennts` is deprecated'):
-      from kfp.v2 import components
+      import kfp
+      import importlib
+      # Need to reload the module, or DeprecationWarning may not be raised due
+      # to earlier importing, e.g.: from the top of this test file.
+      importlib.reload(kfp.v2.components)
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/v2/compiler/compiler_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_test.py
@@ -379,15 +379,6 @@ class CompilerTest(unittest.TestCase):
           pipeline_root='dummy',
           output_path='output.json')
 
-  def test_import_kfp_v2_component_raise_warning(self):
-    with self.assertWarnsRegex(DeprecationWarning,
-                               'Module `kfp.v2.compoennts` is deprecated'):
-      import kfp
-      import importlib
-      # Need to reload the module, or DeprecationWarning may not be raised due
-      # to earlier importing, e.g.: from the top of this test file.
-      importlib.reload(kfp.v2.components)
-
 
 if __name__ == '__main__':
   unittest.main()

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/two_step_pipeline_with_importer.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/two_step_pipeline_with_importer.py
@@ -14,7 +14,7 @@
 
 import pathlib
 
-from kfp.v2 import components
+from kfp import components
 from kfp.v2 import dsl
 import kfp.v2.compiler as compiler
 

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/two_step_pipeline_with_importer.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/two_step_pipeline_with_importer.py
@@ -14,7 +14,7 @@
 
 import pathlib
 
-from kfp import components
+from kfp.v2 import components
 from kfp.v2 import dsl
 import kfp.v2.compiler as compiler
 

--- a/sdk/python/kfp/v2/components/__init__.py
+++ b/sdk/python/kfp/v2/components/__init__.py
@@ -12,9 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
-warnings.simplefilter('always', DeprecationWarning)
-warnings.warn(
-    'Module `kfp.v2.compoennts` is deprecated, use `kfp.components` instead.',
-    DeprecationWarning)
 from kfp.components import *

--- a/sdk/python/kfp/v2/components/__init__.py
+++ b/sdk/python/kfp/v2/components/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+warnings.simplefilter('always', DeprecationWarning)
+warnings.warn(
+    'Module `kfp.v2.compoennts` is deprecated, use `kfp.components` instead.',
+    DeprecationWarning)
+from kfp.components import *


### PR DESCRIPTION
**Description of your changes:**
- This will be included in KFP SDK 1.4.0 release.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
