### PR TITLE
feat(sdk.v2): Allow set pipeline_root via @dsl.pipeline decorator. Make pipeline_root optional.

### DIFF
--- a/sdk/python/kfp/dsl/_pipeline.py
+++ b/sdk/python/kfp/dsl/_pipeline.py
@@ -32,7 +32,7 @@ _pipeline_decorator_handler = None
 def pipeline(
     name: Optional[str] = None,
     description: Optional[str] = None,
-    output_directory: Optional[str] = None):
+    pipeline_root: Optional[str] = None):
   """Decorator of pipeline functions.
 
   Example
@@ -41,7 +41,7 @@ def pipeline(
       @pipeline(
         name='my awesome pipeline',
         description='Is it really awesome?'
-        output_directory='gs://my-bucket/my-output-path'
+        pipeline_root='gs://my-bucket/my-output-path'
       )
       def my_pipeline(a: PipelineParam, b: PipelineParam):
         ...
@@ -50,7 +50,7 @@ def pipeline(
     name: The pipeline name. Default to a sanitized version of the function
       name.
     description: Optionally, a human-readable description of the pipeline.
-    output_directory: The root directory to generate input/output URI under this
+    pipeline_root: The root directory to generate input/output URI under this
       pipeline. This is required if input/output URI placeholder is used in this
       pipeline.
   """
@@ -60,8 +60,8 @@ def pipeline(
       func._component_human_name = name
     if description:
       func._component_description = description
-    if output_directory:
-      func.output_directory = output_directory
+    if pipeline_root:
+      func.output_directory = pipeline_root
 
     if _pipeline_decorator_handler:
       return _pipeline_decorator_handler(func) or func

--- a/sdk/python/kfp/v2/compiler/compiler.py
+++ b/sdk/python/kfp/v2/compiler/compiler.py
@@ -19,6 +19,7 @@ https://docs.google.com/document/d/1PUDuSQ8vmeKSBloli53mp7GIvzekaY7sggg6ywy35Dk/
 """
 
 import inspect
+import warnings
 from typing import Any, Callable, List, Mapping, Optional
 
 import kfp
@@ -151,7 +152,7 @@ class Compiler(object):
   def _create_pipeline(
       self,
       pipeline_func: Callable[..., Any],
-      output_directory: str,
+      pipeline_root: Optional[str] = None,
       pipeline_name: Optional[str] = None,
       pipeline_parameters_override: Optional[Mapping[str, Any]] = None,
   ) -> pipeline_spec_pb2.PipelineJob:
@@ -159,8 +160,8 @@ class Compiler(object):
 
     Args:
       pipeline_func: Pipeline function with @dsl.pipeline decorator.
+      pipeline_root: The root of the pipeline outputs. Optional.
       pipeline_name: The name of the pipeline. Optional.
-      output_directory: The root of the pipeline outputs.
       pipeline_parameters_override: The mapping from parameter names to values.
         Optional.
 
@@ -172,6 +173,12 @@ class Compiler(object):
     # Assign type information to the PipelineParam
     pipeline_meta = _python_op._extract_component_interface(pipeline_func)
     pipeline_name = pipeline_name or pipeline_meta.name
+
+    pipeline_root = pipeline_root or getattr(pipeline_func, 'output_directory',
+                                             None)
+    if not pipeline_root:
+      warnings.warn('pipeline_root is None or empty. A valid pipeline_root '
+                    'must be provided at job submission.')
 
     args_list = []
     signature = inspect.signature(pipeline_func)
@@ -209,8 +216,7 @@ class Compiler(object):
     # Update pipeline parameters override if there were any.
     pipeline_parameters.update(pipeline_parameters_override or {})
     runtime_config = compiler_utils.build_runtime_config_spec(
-        output_directory=output_directory,
-        pipeline_parameters=pipeline_parameters)
+        output_directory=pipeline_root, pipeline_parameters=pipeline_parameters)
     pipeline_job = pipeline_spec_pb2.PipelineJob(runtime_config=runtime_config)
     pipeline_job.pipeline_spec.update(json_format.MessageToDict(pipeline_spec))
 
@@ -218,8 +224,8 @@ class Compiler(object):
 
   def compile(self,
               pipeline_func: Callable[..., Any],
-              pipeline_root: str,
               output_path: str,
+              pipeline_root: Optional[str] = None,
               pipeline_name: Optional[str] = None,
               pipeline_parameters: Optional[Mapping[str, Any]] = None,
               type_check: bool = True) -> None:
@@ -227,9 +233,12 @@ class Compiler(object):
 
     Args:
       pipeline_func: Pipeline function with @dsl.pipeline decorator.
-      pipeline_root: The root of the pipeline ouputs.
-      output_path: The output pipeline spec .json file path. for example,
-        "~/a.json"
+      output_path: The output pipeline job .json file path. for example,
+        "~/pipeline_job.json"
+      pipeline_root: The root of the pipeline outputs. Optional. The
+        pipeline_root value can be specified either from this `compile()` method
+        or through the `@dsl.pipeline` decorator. If it's specified in both
+        places, the value provided here prevails.
       pipeline_name: The name of the pipeline. Optional.
       pipeline_parameters: The mapping from parameter names to values. Optional.
       type_check: Whether to enable the type check or not, default: True.
@@ -239,7 +248,7 @@ class Compiler(object):
       kfp.TYPE_CHECK = type_check
       pipeline_job = self._create_pipeline(
           pipeline_func=pipeline_func,
-          output_directory=pipeline_root,
+          pipeline_root=pipeline_root,
           pipeline_name=pipeline_name,
           pipeline_parameters_override=pipeline_parameters)
       self._write_pipeline(pipeline_job, output_path)

--- a/sdk/python/kfp/v2/compiler/compiler_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_test.py
@@ -384,14 +384,14 @@ class CompilerTest(unittest.TestCase):
 
     tmpdir = tempfile.mkdtemp()
     try:
+
       @dsl.pipeline(name='my-pipeline', pipeline_root='gs://path')
       def my_pipeline():
         pass
 
       target_json_file = os.path.join(tmpdir, 'result.json')
       compiler.Compiler().compile(
-          pipeline_func=my_pipeline,
-          output_path=target_json_file)
+          pipeline_func=my_pipeline, output_path=target_json_file)
 
       self.assertTrue(os.path.exists(target_json_file))
       with open(target_json_file) as f:
@@ -405,6 +405,7 @@ class CompilerTest(unittest.TestCase):
 
     tmpdir = tempfile.mkdtemp()
     try:
+
       @dsl.pipeline(name='my-pipeline', pipeline_root='gs://path')
       def my_pipeline():
         pass
@@ -420,6 +421,27 @@ class CompilerTest(unittest.TestCase):
         job_spec = json.load(f)
       self.assertEqual('gs://path-override',
                        job_spec['runtimeConfig']['gcsOutputDirectory'])
+    finally:
+      shutil.rmtree(tmpdir)
+
+  def test_missing_pipeline_root_is_allowed_but_warned(self):
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+
+      @dsl.pipeline(name='my-pipeline')
+      def my_pipeline():
+        pass
+
+      target_json_file = os.path.join(tmpdir, 'result.json')
+      with self.assertWarnsRegex(UserWarning, 'pipeline_root is None or empty'):
+        compiler.Compiler().compile(
+            pipeline_func=my_pipeline, output_path=target_json_file)
+
+      self.assertTrue(os.path.exists(target_json_file))
+      with open(target_json_file) as f:
+        job_spec = json.load(f)
+      self.assertTrue('gcsOutputDirectory' not in job_spec['runtimeConfig'])
     finally:
       shutil.rmtree(tmpdir)
 

--- a/sdk/python/kfp/v2/compiler/compiler_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 import shutil
 import tempfile
@@ -378,6 +379,49 @@ class CompilerTest(unittest.TestCase):
           pipeline_func=my_pipeline,
           pipeline_root='dummy',
           output_path='output.json')
+
+  def test_set_pipeline_root_through_pipeline_decorator(self):
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+      @dsl.pipeline(name='my-pipeline', pipeline_root='gs://path')
+      def my_pipeline():
+        pass
+
+      target_json_file = os.path.join(tmpdir, 'result.json')
+      compiler.Compiler().compile(
+          pipeline_func=my_pipeline,
+          output_path=target_json_file)
+
+      self.assertTrue(os.path.exists(target_json_file))
+      with open(target_json_file) as f:
+        job_spec = json.load(f)
+      self.assertEqual('gs://path',
+                       job_spec['runtimeConfig']['gcsOutputDirectory'])
+    finally:
+      shutil.rmtree(tmpdir)
+
+  def test_set_pipeline_root_through_compile_method(self):
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+      @dsl.pipeline(name='my-pipeline', pipeline_root='gs://path')
+      def my_pipeline():
+        pass
+
+      target_json_file = os.path.join(tmpdir, 'result.json')
+      compiler.Compiler().compile(
+          pipeline_func=my_pipeline,
+          pipeline_root='gs://path-override',
+          output_path=target_json_file)
+
+      self.assertTrue(os.path.exists(target_json_file))
+      with open(target_json_file) as f:
+        job_spec = json.load(f)
+      self.assertEqual('gs://path-override',
+                       job_spec['runtimeConfig']['gcsOutputDirectory'])
+    finally:
+      shutil.rmtree(tmpdir)
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/v2/compiler/main.py
+++ b/sdk/python/kfp/v2/compiler/main.py
@@ -36,7 +36,6 @@ def parse_arguments() -> argparse.Namespace:
   parser.add_argument(
       '--pipeline-root',
       type=str,
-      required=True,
       help='The root of the pipeline outputs.')
   parser.add_argument(
       '--pipeline-parameters',
@@ -76,11 +75,6 @@ def _compile_pipeline_function(pipeline_funcs: List[Callable],
   if len(pipeline_funcs) == 0:
     raise ValueError(
         'A function with @dsl.pipeline decorator is required in the py file.')
-
-  if len(pipeline_root) == 0:
-    raise ValueError(
-        'A pipeline-root (e.g.: a GCS URI) is required. Please specify --pipeline-root.'
-    )
 
   if len(pipeline_funcs) > 1 and not function_name:
     func_names = [x.__name__ for x in pipeline_funcs]

--- a/sdk/python/tests/compiler/testdata/uri_artifacts.py
+++ b/sdk/python/tests/compiler/testdata/uri_artifacts.py
@@ -82,7 +82,7 @@ def flip_coin_op():
 
 @dsl.pipeline(
     name='uri-artifact-pipeline',
-    output_directory='gs://my-bucket/my-output-dir')
+    pipeline_root='gs://my-bucket/my-output-dir')
 def uri_artifact(text='Hello world!'):
   task_1 = write_to_gcs(text=text)
   task_2 = read_from_gcs(


### PR DESCRIPTION
**Description of your changes:**
- Setting `pipeline_root`/`output_directory` via `@dsl.pipeline` decorator was added in v1 but not used in v2. Make it available in v2.
- Rename `output_directory` to `pipeline_root` in `@dsl.pipeline` decorator, so that it's consistent with `pipeline_root` argument in `Compiler.compiler()` method (also consistent with TFX if that matters).
- The `pipeline_root` in `Compiler.compile()` was previously a required argument, change it to optional as it no longer makes sense to enforce it when user can also set it via `@dsl.pipeline` decorator. Similarly, make it optional for compiler cli.

BREAKING CHANGE:
- Renaming `output_directory` to `pipeline_root` in `@dsl.pipeline` decorator. The background for naming it `output_directory` was to [avoid possible confusion with pipeline root spec](https://github.com/kubeflow/pipelines/pull/4927#discussion_r546946026). However, on a second thought, the pipeline root spec (IR) is non-user-facing implementation details, whereas using `output_directory` in one place and `pipeline_root` in other places is probably more confusing. 
- Changing `pipeline_root` to an optional argument in `Compiler.compile()` requires swapping its position with `output_path` (the path to compiler output, i.e., pipeline job json). This could break existing v2 users if they call the `compile()` method with positional arguments. No breakage if they use keyword arguments though.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
