### PR TITLE
chore: restore the clone step in release.sh

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -25,6 +25,12 @@ if [[ -z "$BRANCH" || -z "$TAG_NAME" ]]; then
   exit 1
 fi
 
+# Checking out the repo's release branch
+clone_dir=$(mktemp -d)
+git clone "git@github.com:${REPO}.git" "$clone_dir"
+cd "$clone_dir"
+git checkout "$BRANCH"
+
 echo "Preparing local git tags used by changelog generation."
 # tags with "-" are pre-releases, e.g. 1.0.0-rc.1
 if [[ "$TAG_NAME" =~ "-" ]]; then


### PR DESCRIPTION

Looks like this piece of code was possibly accidentally deleted from [the last change](https://github.com/kubeflow/pipelines/commit/c484cfa46cfae1e9d11b5d00e0799b8e52c15e33#diff-051375546db9782e3debc25e0241edf1d5e5e2ec0f183dd8634ca5b2c8968bb8) on this file. But it was intentional to clone 
into a temporary location so that it doesn't interfere with your local repo per [release.md](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#L201)
![image](https://user-images.githubusercontent.com/2043310/107717683-172bd500-6c89-11eb-9e57-19f409ad5761.png)

