### PR TITLE
Adds the API for Metrics logging

### DIFF
--- a/sdk/python/kfp/dsl/metrics.py
+++ b/sdk/python/kfp/dsl/metrics.py
@@ -1,0 +1,100 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Metric classes in MLMD ontology for KFP SDK."""
+
+from typing import Any, Dict, List
+
+from kfp.dsl import artifact
+
+class Metrics(artifact.Artifact):
+  """Supports capturing summary metrics for a model from components such as ModelEvaluation."""
+
+  TYPE_NAME="METRICS"
+
+  def __init__(self):
+    #TODO: call super init with metrics schema
+    pass
+
+  def log_accuracy(self, value: float) -> None:
+    """Logs Model's accuracy metric."""
+    pass
+
+  def log_precision(self, value: float) -> None:
+    """Logs Model's precision metric."""
+    pass
+
+  def log_metric(self, metric: str, value: float) -> None:
+    """Log a single custom metric key-value pair"""
+    pass
+
+
+class ClassificationMetrics(artifact.Artifact):
+  """Base class for Classification Metrics types such as ROC-Curve, ConfusionMatrix."""
+
+  TYPE_NAME="CLASSIFICATION_METRICS"
+
+  def __init__(self):
+    #TODO: call super init with classification metrics schema
+
+  def load_classification_metrics(self, metrics_data:str) -> None:
+    # Expects the classification metrics data to be stored in a json string
+    # that adheres to the classification metrics schema.
+
+class ROCCurve(ClassificationMetrics):
+  """Metric class to support logging ROC curve.
+
+  class maintains an internal store to keep track of the logged data points.
+  Each update to this internal store will update the metadata field of the MLMd
+  Artifact.
+  """
+
+  def __init__(self):
+    #TODO: call super init with setting metric type.
+
+  def log_roc_reading(self, tpr: float, fpr: float, threshold: float) -> None:
+    """Logs a single ROC Curve data point."""
+
+  def load_roc_readings(self, readings: List[List[float]]) -> None:
+    """Bulk log ROC Curve"""
+    # Verifies passed data conforms ROC data point format and update the
+    # internal store and metadata.
+
+
+class ConfusionMatrix(ClassificationMetrics):
+  """Metric class to support logging ConfusionMatrix
+
+  Class maintains an internal store to keep track of the logged data points.
+  Each update to this internal store will update the metadata field in the MLMD
+  artifact.
+  """
+
+  def set_categories(self, categories: List[str]) -> None:
+    """Defines the categories for the confusion matrix"""
+    pass
+
+  def log_cell(self, row_category: str, column_category: str, value: Any) -> None:
+    """Logs a single cell value"""
+    pass
+
+  def log_row(self, row_category: str, cells: List[Any]) -> None:
+    """Logs a single row value"""
+    pass
+
+  def log_column(self, column_category: str, cells: List[Any]) -> None:
+    """Logs a single column value"""
+    pass
+
+  def load_matrix(self, categories: List[str], cells: List[List[Any]]) -> None:
+    """Logs a complete confusion matrix"""
+    pass

--- a/sdk/python/kfp/dsl/schemas/classification_metrics.yaml
+++ b/sdk/python/kfp/dsl/schemas/classification_metrics.yaml
@@ -1,0 +1,145 @@
+title: ClassificationEvaluationMetrics
+type: object
+properties:
+  auPrc:
+    type: number
+    format: float
+    description: >
+      The Area Under Precision-Recall Curve metric. Micro-averaged for the overall evaluation.
+  auRoc:
+    type: number
+    format: float
+    description: >
+      The Area Under Receiver Operating Characteristic curve metric. Micro-averaged for
+      the overall evaluation.
+  logLoss:
+    type: number
+    format: float
+    description: >
+      The Log Loss metric.
+  confidenceMetrics:
+    type: array
+    description: >
+      Metrics for each confidenceThreshold in 0.00,0.05,0.10,...,0.95,0.96,0.97,0.98,0.99 and
+      `positionThreshold` = INT32_MAX_VALUE.
+      ROC and precision-recall curves, and other aggregated metrics are derived from them. The
+      confidence metrics entries may also be supplied for additional values of `positionThreshold`,
+      but from these no aggregated metrics are computed.
+    items:
+      type: object
+      properties:
+        confidenceThreshold:
+          type: number
+          format: float
+          description: >
+            Metrics are computed with an assumption that the Model never returns predictions with
+            score lower than this value.
+        maxPredictions:
+          type: integer
+          format: int32
+          description: >
+            Metrics are computed with an assumption that the Model always returns at most this many
+            predictions (ordered by their score, descendingly), but they all still need to meet the
+            `confidenceThreshold`.
+        recall:
+          type: number
+          format: float
+          description: >
+            Recall (True Positive Rate) for the given confidence threshold.
+        precision:
+          type: number
+          format: float
+          description: >
+            Precision for the given confidence threshold.
+        falsePositiveRate:
+          type: number
+          format: float
+          description: >
+            False Positive Rate for the given confidence threshold.
+        f1Score:
+          type: number
+          format: float
+          description: >
+            The harmonic mean of recall and precision.
+        recallAt1:
+          type: number
+          format: float
+          description: >
+            The Recall (True Positive Rate) when only considering the
+            label that has the highest prediction score and not below the confidence
+            threshold for each example.
+        precisionAt1:
+          type: number
+          format: float
+          description: >
+            The precision when only considering the label that has the
+            highest prediction score and not below the confidence threshold for each
+            example.
+        falsePositiveRateAt1:
+          type: number
+          format: float
+          description: >
+            The False Positive Rate when only considering the label that
+            has the highest prediction score and not below the confidence threshold
+            for each example.
+        f1ScoreAt1:
+          type: number
+          format: float
+          description: >
+            The harmonic mean of recallAt1 and precisionAt1.
+        truePositiveCount:
+          type: integer
+          format: int64
+          description: >
+            The number of Model created labels that match a ground truth label.
+        falsePositiveCount:
+          type: integer
+          format: int64
+          description: >
+            The number of Model created labels that do not match a
+            ground truth label.
+        falseNegativeCount:
+          type: integer
+          format: int64
+          description: >
+            The number of ground truth labels that are not matched by a Model created label.
+        trueNegativeCount:
+          type: integer
+          format: int64
+          description: >
+            The number of labels that were not created by the Model,
+            but if they would, they would not match a ground truth label.
+  confusionMatrix:
+    type: object
+    description: >
+      OPTIONAL. Confusion matrix of the evaluation.
+    properties:
+      annotationSpecs:
+        type: array
+        description: >
+          AnnotationSpecs used in the confusion matrix.
+        items:
+          type: object
+          properties:
+            id:
+              type: string
+              description: >
+                OPTIONAL. ID of the AnnotationSpec.
+            displayName:
+              type: string
+              description: >
+                Display name of the AnnotationSpec.
+      rows:
+        type: array
+        description: >
+          Rows in the confusion matrix. The number of rows is equal to the size of `annotationSpecs`.
+          `row[i][j]` is the number of DataItems that have ground truth of the `annotationSpecs[i]`
+          and are predicted as `annotationSpecs[j]` by the Model being evaluated.
+        items:
+          type: object
+          properties:
+            row:
+              type: array
+              items:
+                type: integer
+                format: int64

--- a/sdk/python/kfp/dsl/schemas/metrics.yaml
+++ b/sdk/python/kfp/dsl/schemas/metrics.yaml
@@ -1,0 +1,26 @@
+title: Metrics
+type: object
+description:
+  Supports capturing summary metrics for a model from components such as ModelEvaluation.
+properties:
+  accuracy:
+    type: number
+    format: float
+    description: Capture's a Model's accuracy metric.
+  precision:
+    type: number
+    format: float
+    description: Capture's a Model's precision metric.
+  custom_metrics:
+    type: array
+    description: The scalar values for metrics
+    items:
+      type: object
+      properties:
+        metric:
+          type: string
+          description: Name of the metric.
+        value:
+          type: number
+          format: float
+          description: Metric value.


### PR DESCRIPTION
Change only adds the Metrics class that extends Artifact and defines the API the class provides.

The API will be implemented once Artifact class supports the Metadata based Artifact schemas. 