### PR TITLE
chore(sdk): allow serializing pipeline params with `typing` type hints

### DIFF
--- a/sdk/python/kfp/components/_data_passing.py
+++ b/sdk/python/kfp/components/_data_passing.py
@@ -23,7 +23,7 @@ __all__ = [
 
 import inspect
 import re
-from typing import Any, Callable, NamedTuple, Optional, Sequence
+from typing import Any, Callable, NamedTuple, Sequence
 import warnings
 
 
@@ -168,8 +168,7 @@ def serialize_value(value, type_name: str) -> str:
         type_name = type_to_type_name.get(type(value), type(value).__name__)
         warnings.warn('Missing type name was inferred as "{}" based on the value "{}".'.format(type_name, str(value)))
 
-    serializer = type_name_to_serializer.get(
-        _get_collection_type_name(type_name) or type_name, None)
+    serializer = type_name_to_serializer.get(_get_short_type_name(type_name))
     if serializer:
         try:
             serialized_value = serializer(value)
@@ -188,22 +187,26 @@ def serialize_value(value, type_name: str) -> str:
         str(type_name),
     ))
 
-def _get_collection_type_name(type_name: str) -> Optional[str]:
-    """Extracts the collection type name if it exists.
+def _get_short_type_name(type_name: str) -> str:
+    """Extracts the short form type name.
+
+    This method is used for looking up serializer for a given type.
 
     For example:
       typing.List -> List
       typing.List[int] -> List
       typing.Dict[str, str] -> Dict
+      List -> List
+      str -> str
 
     Args:
       type_name: The original type name.
 
     Returns:
-      The collection type name if it exists otherwise None.
+      The short form type name or the original name if pattern doesn't match.
     """
-    match = re.match('typing\.(?P<type>\w+)(?:\[.+\])?', type_name)
+    match = re.match('(typing\.)?(?P<type>\w+)(?:\[.+\])?', type_name)
     if match:
         return match.group('type')
     else:
-        return None
+        return type_name

--- a/sdk/python/kfp/components_tests/test_data_passing.py
+++ b/sdk/python/kfp/components_tests/test_data_passing.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from kfp.components import _data_passing
+from ..components import _data_passing
 
 
 class DataPassingTest(unittest.TestCase):

--- a/sdk/python/kfp/components_tests/test_data_passing.py
+++ b/sdk/python/kfp/components_tests/test_data_passing.py
@@ -19,18 +19,18 @@ from ..components import _data_passing
 
 class DataPassingTest(unittest.TestCase):
 
-  def test_get_collection_type_name(self):
-    self.assertEqual(None, _data_passing._get_collection_type_name('str'))
-
-    self.assertEqual(
-        'List', _data_passing._get_collection_type_name('typing.List[int]'))
+  def test_get_short_type_name(self):
+    self.assertEqual('str', _data_passing._get_short_type_name('str'))
 
     self.assertEqual('List',
-                     _data_passing._get_collection_type_name('typing.List'))
+                     _data_passing._get_short_type_name('typing.List[int]'))
+
+    self.assertEqual('List', _data_passing._get_short_type_name('typing.List'))
+
+    self.assertEqual('List', _data_passing._get_short_type_name('List[int]'))
 
     self.assertEqual(
-        'Dict',
-        _data_passing._get_collection_type_name('typing.Dict[str, str]'))
+        'Dict', _data_passing._get_short_type_name('typing.Dict[str, str]'))
 
   def test_serialize_value(self):
     self.assertEqual(

--- a/sdk/python/kfp/components_tests/test_data_passing.py
+++ b/sdk/python/kfp/components_tests/test_data_passing.py
@@ -1,0 +1,47 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from kfp.components import _data_passing
+
+
+class DataPassingTest(unittest.TestCase):
+
+  def test_get_collection_type_name(self):
+    self.assertEqual(None, _data_passing._get_collection_type_name('str'))
+
+    self.assertEqual(
+        'List', _data_passing._get_collection_type_name('typing.List[int]'))
+
+    self.assertEqual('List',
+                     _data_passing._get_collection_type_name('typing.List'))
+
+    self.assertEqual(
+        'Dict',
+        _data_passing._get_collection_type_name('typing.Dict[str, str]'))
+
+  def test_serialize_value(self):
+    self.assertEqual(
+        '[1, 2, 3]',
+        _data_passing.serialize_value(
+            value=[1, 2, 3], type_name='typing.List[int]'))
+
+    self.assertEqual(
+        '[4, 5, 6]',
+        _data_passing.serialize_value(value=[4, 5, 6], type_name='List'))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdk/python/kfp/components_tests/test_python_op.py
+++ b/sdk/python/kfp/components_tests/test_python_op.py
@@ -987,10 +987,10 @@ class PythonOpTestCase(unittest.TestCase):
         def my_func(args: Sequence[int]):
             print(args)
 
+        task_factory = comp.create_component_from_func(my_func)
         with self.assertRaisesRegex(
             TypeError,
-            'There are no registered serializers for type "typing.Sequence\[int\]"'):
-            task_factory = comp.create_component_from_func(my_func)
+            'There are no registered serializers for type "(typing.)?Sequence(\[int\])?"'):
             self.helper_test_component_using_local_call(
                 task_factory, arguments={'args': [1,2,3]})
 

--- a/sdk/python/kfp/components_tests/test_python_op.py
+++ b/sdk/python/kfp/components_tests/test_python_op.py
@@ -982,5 +982,26 @@ class PythonOpTestCase(unittest.TestCase):
             calc_pipeline(42)
 
 
+    def test_argument_serialization_failure(self):
+        from typing import Sequence
+        def my_func(args: Sequence[int]):
+            print(args)
+
+        with self.assertRaisesRegex(
+            TypeError,
+            'There are no registered serializers for type "typing.Sequence\[int\]"'):
+            task_factory = comp.create_component_from_func(my_func)
+            self.helper_test_component_using_local_call(
+                task_factory, arguments={'args': [1,2,3]})
+
+    def test_argument_serialization_success(self):
+        from typing import List
+        def my_func(args: List[int]):
+            print(args)
+
+        task_factory = comp.create_component_from_func(my_func)
+        self.helper_test_component_using_local_call(
+            task_factory, arguments={'args': [1,2,3]})
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of your changes:**
KFP SDK supports serializing pipeline parameters with the following types:
https://github.com/kubeflow/pipelines/blob/706c105c8ca3977a91b54d74caebe8ffb39f6aa7/sdk/python/kfp/components/_data_passing.py#L107-L116
However, it doesn't recognize type hints using `typing` module. For example:
```
from typing import List
def my_func(args: List[int]):
    print(args)
```
This example results compile time error: `There are no registered serializers for type "typing.List[int]"`, even though we have serializer for `List`.

This change allows recognizing `typing.List[int]` as `List` and `typing.Dict[str, Any]` as `Dict`, etc.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
