### PR TITLE
fix(backend): fixes metadata writer watching argo pods in all namespaces (#5175)

### DIFF
--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -24,7 +24,7 @@ from time import sleep
 from metadata_helpers import *
 
 
-namespace_to_watch = os.environ.get('NAMESPACE_TO_WATCH', 'default')
+namespace_to_watch = os.environ.get('NAMESPACE_TO_WATCH', '')
 
 
 kubernetes.config.load_incluster_config()


### PR DESCRIPTION
**Description of your changes:**
Setting the namespace_to_watch to an empty string will make the metadata writer to watch argo pods in all namespaces. There is still an option to override the value using the NAMESPACE_TO_WATCH env variable in container

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [x] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
