### PR TITLE
fix(cache): do not cache TFX pods for newer TFX versions. Part of #5137

### DIFF
--- a/backend/src/cache/server/mutation.go
+++ b/backend/src/cache/server/mutation.go
@@ -47,6 +47,8 @@ const (
 	SpecContainersPath        string = "/spec/containers"
 	SpecInitContainersPath    string = "/spec/initContainers"
 	TFXPodSuffix              string = "tfx/orchestration/kubeflow/container_entrypoint.py"
+	SdkTypeLabel              string = "pipelines.kubeflow.org/pipeline-sdk-type"
+	TfxSdkTypeLabel           string = "tfx"
 )
 
 var (
@@ -126,7 +128,7 @@ func MutatePodIfCached(req *v1beta1.AdmissionRequest, clientMgr ClientManagerInt
 		annotations[ArgoWorkflowOutputs] = getValueFromSerializedMap(cachedExecution.ExecutionOutput, ArgoWorkflowOutputs)
 		labels[CacheIDLabelKey] = strconv.FormatInt(cachedExecution.ID, 10)
 		labels[KFPCachedLabelKey] = KFPCachedLabelValue // This label indicates the pod is taken from cache.
-		
+
 		// These labels cache results for metadata-writer.
 		labels[MetadataExecutionIDKey] = getValueFromSerializedMap(cachedExecution.ExecutionOutput, MetadataExecutionIDKey)
 		labels[MetadataWrittenKey] = "true"
@@ -246,6 +248,9 @@ func isKFPCacheEnabled(pod *corev1.Pod) bool {
 }
 
 func isTFXPod(pod *corev1.Pod) bool {
+	if pod.Labels[SdkTypeLabel] == TfxSdkTypeLabel {
+		return true
+	}
 	containers := pod.Spec.Containers
 	if containers == nil || len(containers) == 0 {
 		log.Printf("This pod container does not exist.")

--- a/backend/src/cache/server/mutation_test.go
+++ b/backend/src/cache/server/mutation_test.go
@@ -124,6 +124,14 @@ func TestMutatePodIfCachedWithTFXPod(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestMutatePodIfCachedWithTFXPod2(t *testing.T) {
+	tfxPod := *fakePod.DeepCopy()
+	tfxPod.Labels["pipelines.kubeflow.org/pipeline-sdk-type"] = "tfx"
+	patchOperation, err := MutatePodIfCached(GetFakeRequestFromPod(&tfxPod), fakeClientManager)
+	assert.Nil(t, patchOperation)
+	assert.Nil(t, err)
+}
+
 func TestMutatePodIfCached(t *testing.T) {
 	patchOperation, err := MutatePodIfCached(&fakeAdmissionRequest, fakeClientManager)
 	assert.Nil(t, err)


### PR DESCRIPTION
**Description of your changes:**
Resolves this issue https://github.com/kubeflow/pipelines/issues/5137#issuecomment-785653750

Note, latest tfx pods no longer use the same command suffix like before, so we need a new signal to filter them out for caching.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
