### PR TITLE
fix(visualization): downgrade tfma to 0.26

### DIFF
--- a/backend/src/apiserver/visualization/requirements.in
+++ b/backend/src/apiserver/visualization/requirements.in
@@ -8,6 +8,6 @@ jupyter_client==5.3.*
 nbconvert==5.5.0
 nbformat==4.4.0
 scikit_learn==0.21.2
-tensorflow-metadata==0.27.*
-tensorflow-model-analysis==0.27.*
-tensorflow-data-validation==0.27.*
+tensorflow-metadata==0.26.*
+tensorflow-model-analysis==0.26.*
+tensorflow-data-validation==0.26.*

--- a/backend/src/apiserver/visualization/requirements.txt
+++ b/backend/src/apiserver/visualization/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --output-file=- -
 #
-absl-py==0.10.0           # via tensorboard, tensorflow, tensorflow-data-validation, tensorflow-metadata, tensorflow-model-analysis, tfx-bsl
-apache-beam[gcp]==2.28.0  # via tensorflow-data-validation, tensorflow-model-analysis, tfx-bsl
+absl-py==0.10.0           # via tensorboard, tensorflow, tensorflow-data-validation, tensorflow-metadata, tensorflow-model-analysis, tensorflow-transform, tfx-bsl
+apache-beam[gcp]==2.28.0  # via tensorflow-data-validation, tensorflow-model-analysis, tensorflow-transform, tfx-bsl
 argon2-cffi==20.1.0       # via notebook
 astunparse==1.6.3         # via tensorflow
 attrs==20.3.0             # via jsonschema
@@ -26,7 +26,6 @@ docopt==0.6.2             # via hdfs
 entrypoints==0.3          # via nbconvert
 fastavro==1.3.2           # via apache-beam
 fasteners==0.16           # via google-apitools
-flatbuffers==1.12         # via tensorflow
 future==0.18.2            # via apache-beam
 gast==0.3.3               # via tensorflow
 gcsfs==0.2.3              # via -r -
@@ -53,12 +52,12 @@ google-resumable-media==1.2.0  # via google-cloud-bigquery
 googleapis-common-protos[grpc]==1.52.0  # via google-api-core, grpc-google-iam-v1, tensorflow-metadata
 grpc-google-iam-v1==0.12.3  # via google-cloud-bigtable, google-cloud-pubsub, google-cloud-spanner
 grpcio-gcp==0.2.2         # via apache-beam, google-api-core
-grpcio==1.32.0            # via apache-beam, google-api-core, googleapis-common-protos, grpc-google-iam-v1, grpcio-gcp, tensorboard, tensorflow, tensorflow-serving-api
+grpcio==1.35.0            # via apache-beam, google-api-core, googleapis-common-protos, grpc-google-iam-v1, grpcio-gcp, tensorboard, tensorflow, tensorflow-serving-api
 h5py==2.10.0              # via tensorflow
 hdfs==2.6.0               # via apache-beam
 httplib2==0.17.4          # via apache-beam, google-api-python-client, google-apitools, google-auth-httplib2, oauth2client
 idna==2.10                # via requests
-importlib-metadata==3.6.0  # via jsonschema, markdown
+importlib-metadata==3.7.0  # via jsonschema, markdown
 ipykernel==5.1.1          # via -r -, ipywidgets, notebook
 ipython-genutils==0.2.0   # via nbformat, notebook, traitlets
 ipython==7.12.0           # via -r -, ipykernel, ipywidgets, tensorflow-model-analysis
@@ -73,7 +72,7 @@ jupyter-core==4.7.1       # via jupyter-client, nbconvert, nbformat, notebook
 jupyterlab-widgets==1.0.0  # via ipywidgets
 keras-preprocessing==1.1.2  # via tensorflow
 libcst==0.3.17            # via google-cloud-build
-markdown==3.3.3           # via tensorboard
+markdown==3.3.4           # via tensorboard
 markupsafe==1.1.1         # via jinja2
 mistune==0.8.4            # via nbconvert
 mock==2.0.0               # via apache-beam
@@ -81,7 +80,7 @@ mypy-extensions==0.4.3    # via typing-inspect
 nbconvert==5.5.0          # via -r -, notebook
 nbformat==4.4.0           # via -r -, ipywidgets, nbconvert, notebook
 notebook==6.2.0           # via widgetsnbextension
-numpy==1.19.5             # via apache-beam, bokeh, h5py, keras-preprocessing, opt-einsum, pandas, pyarrow, scikit-learn, scipy, tensorboard, tensorflow, tensorflow-data-validation, tensorflow-model-analysis, tfx-bsl
+numpy==1.18.5             # via apache-beam, bokeh, h5py, keras-preprocessing, opt-einsum, pandas, pyarrow, scikit-learn, scipy, tensorboard, tensorflow, tensorflow-data-validation, tensorflow-model-analysis, tensorflow-transform, tfx-bsl
 oauth2client==4.1.3       # via apache-beam, google-apitools
 oauthlib==3.1.0           # via requests-oauthlib
 opt-einsum==3.3.0         # via tensorflow
@@ -96,13 +95,13 @@ pillow==8.1.0             # via bokeh
 prometheus-client==0.9.0  # via notebook
 prompt-toolkit==3.0.16    # via ipython
 proto-plus==1.13.0        # via google-cloud-build
-protobuf==3.15.2          # via apache-beam, google-api-core, googleapis-common-protos, proto-plus, tensorboard, tensorflow, tensorflow-data-validation, tensorflow-metadata, tensorflow-model-analysis, tensorflow-serving-api, tfx-bsl
+protobuf==3.15.2          # via apache-beam, google-api-core, googleapis-common-protos, proto-plus, tensorboard, tensorflow, tensorflow-data-validation, tensorflow-metadata, tensorflow-model-analysis, tensorflow-serving-api, tensorflow-transform, tfx-bsl
 ptyprocess==0.7.0         # via pexpect, terminado
-pyarrow==2.0.0            # via apache-beam, tensorflow-data-validation, tensorflow-model-analysis, tfx-bsl
+pyarrow==0.17.1           # via apache-beam, tensorflow-data-validation, tensorflow-model-analysis, tensorflow-transform, tfx-bsl
 pyasn1-modules==0.2.8     # via google-auth, oauth2client
 pyasn1==0.4.8             # via oauth2client, pyasn1-modules, rsa
 pycparser==2.20           # via cffi
-pydot==1.4.2              # via apache-beam
+pydot==1.4.2              # via apache-beam, tensorflow-transform
 pygments==2.8.0           # via ipython, nbconvert
 pymongo==3.11.3           # via apache-beam
 pyparsing==2.4.7          # via packaging, pydot
@@ -113,26 +112,27 @@ pyyaml==5.4.1             # via bokeh, libcst
 pyzmq==22.0.3             # via jupyter-client, notebook
 requests-oauthlib==1.3.0  # via google-auth-oauthlib
 requests==2.25.1          # via apache-beam, gcsfs, google-api-core, hdfs, requests-oauthlib, tensorboard
-rsa==4.7.1                # via google-auth, oauth2client
+rsa==4.7.2                # via google-auth, oauth2client
 scikit_learn==0.21.2      # via -r -
 scipy==1.5.4              # via scikit-learn, tensorflow-model-analysis
 send2trash==1.5.0         # via notebook
-six==1.15.0               # via absl-py, argon2-cffi, astunparse, bleach, bokeh, fasteners, google-api-core, google-api-python-client, google-apitools, google-auth, google-auth-httplib2, google-cloud-bigquery, google-cloud-core, google-pasta, google-resumable-media, grpcio, h5py, hdfs, jsonschema, keras-preprocessing, mock, oauth2client, protobuf, python-dateutil, tensorboard, tensorflow, tensorflow-data-validation, tensorflow-model-analysis, traitlets
+six==1.15.0               # via absl-py, argon2-cffi, astunparse, bleach, bokeh, fasteners, google-api-core, google-api-python-client, google-apitools, google-auth, google-auth-httplib2, google-cloud-bigquery, google-cloud-core, google-pasta, google-resumable-media, grpcio, h5py, hdfs, jsonschema, keras-preprocessing, mock, oauth2client, protobuf, python-dateutil, tensorboard, tensorflow, tensorflow-data-validation, tensorflow-model-analysis, tensorflow-transform, traitlets
 tensorboard-plugin-wit==1.8.0  # via tensorboard
 tensorboard==2.4.1        # via tensorflow
-tensorflow-data-validation==0.27.0  # via -r -
-tensorflow-estimator==2.4.0  # via tensorflow
-tensorflow-metadata==0.27.0  # via -r -, tensorflow-data-validation, tensorflow-model-analysis, tfx-bsl
-tensorflow-model-analysis==0.27.0  # via -r -
-tensorflow-serving-api==2.4.1  # via tfx-bsl
-tensorflow==2.4.1         # via tensorflow-data-validation, tensorflow-model-analysis, tensorflow-serving-api, tfx-bsl
+tensorflow-data-validation==0.26.0  # via -r -
+tensorflow-estimator==2.3.0  # via tensorflow
+tensorflow-metadata==0.26.0  # via -r -, tensorflow-data-validation, tensorflow-model-analysis, tensorflow-transform, tfx-bsl
+tensorflow-model-analysis==0.26.0  # via -r -
+tensorflow-serving-api==2.3.0  # via tfx-bsl
+tensorflow-transform==0.26.0  # via tensorflow-data-validation
+tensorflow==2.3.2         # via tensorflow-data-validation, tensorflow-model-analysis, tensorflow-serving-api, tensorflow-transform, tfx-bsl
 termcolor==1.1.0          # via tensorflow
 terminado==0.9.2          # via notebook
 testpath==0.4.4           # via nbconvert
-tfx-bsl==0.27.1           # via tensorflow-data-validation, tensorflow-model-analysis
+tfx-bsl==0.26.1           # via tensorflow-data-validation, tensorflow-model-analysis, tensorflow-transform
 tornado==6.1              # via bokeh, ipykernel, jupyter-client, notebook, terminado
 traitlets==4.3.3          # via ipykernel, ipython, ipywidgets, jupyter-client, jupyter-core, nbconvert, nbformat, notebook
-typing-extensions==3.7.4.3  # via apache-beam, importlib-metadata, libcst, tensorflow, typing-inspect
+typing-extensions==3.7.4.3  # via apache-beam, importlib-metadata, libcst, typing-inspect
 typing-inspect==0.6.0     # via libcst
 uritemplate==3.0.1        # via google-api-python-client
 urllib3==1.26.3           # via requests


### PR DESCRIPTION
**Description of your changes:**
@Ark-kun thanks, I verified TFMA 0.26 can correctly render evaluator artifact for TFX 0.27. I think we can go with this for release.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
