### PR TITLE
feat(backend): Add qps & burst options in clientset. Fix #5095

### DIFF
--- a/backend/src/agent/persistence/main.go
+++ b/backend/src/agent/persistence/main.go
@@ -134,6 +134,6 @@ func init() {
 	flag.StringVar(&namespace, namespaceFlagName, "", "The namespace name used for Kubernetes informers to obtain the listers.")
 	flag.Int64Var(&ttlSecondsAfterWorkflowFinish, ttlSecondsAfterWorkflowFinishFlagName, 604800 /* 7 days */, "The TTL for Argo workflow to persist after workflow finish.")
 	flag.IntVar(&numWorker, numWorkerName, 2, "Number of worker for sync job.")
-	flag.Float64Var(&clientQPS, clientQPSFlagName, 5, "QPS of clientset.")
-	flag.IntVar(&clientBurst, clientBurstFlagName, 10, "Burst of clientset.")
+	flag.Float64Var(&clientQPS, clientQPSFlagName, 5, "The maximum QPS to the master from this client.")
+	flag.IntVar(&clientBurst, clientBurstFlagName, 10, "Maximum burst for throttle from this client.")
 }

--- a/backend/src/agent/persistence/main.go
+++ b/backend/src/agent/persistence/main.go
@@ -43,6 +43,8 @@ var (
 	namespace                     string
 	ttlSecondsAfterWorkflowFinish int64
 	numWorker                     int
+	clientQPS                     float64
+	clientBurst                   int
 )
 
 const (
@@ -57,6 +59,8 @@ const (
 	namespaceFlagName                     = "namespace"
 	ttlSecondsAfterWorkflowFinishFlagName = "ttlSecondsAfterWorkflowFinish"
 	numWorkerName                         = "numWorker"
+	clientQPSFlagName                     = "clientQPS"
+	clientBurstFlagName                   = "clientBurst"
 )
 
 func main() {
@@ -69,6 +73,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error building kubeconfig: %s", err.Error())
 	}
+	cfg.QPS = float32(clientQPS)
+	cfg.Burst = clientBurst
 
 	swfClient, err := swfclientset.NewForConfig(cfg)
 	if err != nil {
@@ -128,4 +134,6 @@ func init() {
 	flag.StringVar(&namespace, namespaceFlagName, "", "The namespace name used for Kubernetes informers to obtain the listers.")
 	flag.Int64Var(&ttlSecondsAfterWorkflowFinish, ttlSecondsAfterWorkflowFinishFlagName, 604800 /* 7 days */, "The TTL for Argo workflow to persist after workflow finish.")
 	flag.IntVar(&numWorker, numWorkerName, 2, "Number of worker for sync job.")
+	flag.Float64Var(&clientQPS, clientQPSFlagName, 5, "QPS of clientset.")
+	flag.IntVar(&clientBurst, clientBurstFlagName, 10, "Burst of clientset.")
 }

--- a/backend/src/agent/persistence/main.go
+++ b/backend/src/agent/persistence/main.go
@@ -134,6 +134,8 @@ func init() {
 	flag.StringVar(&namespace, namespaceFlagName, "", "The namespace name used for Kubernetes informers to obtain the listers.")
 	flag.Int64Var(&ttlSecondsAfterWorkflowFinish, ttlSecondsAfterWorkflowFinishFlagName, 604800 /* 7 days */, "The TTL for Argo workflow to persist after workflow finish.")
 	flag.IntVar(&numWorker, numWorkerName, 2, "Number of worker for sync job.")
+	// Use default value of client QPS (5) & burst (10) defined in
+	// k8s.io/client-go/rest/config.go#RESTClientFor
 	flag.Float64Var(&clientQPS, clientQPSFlagName, 5, "The maximum QPS to the master from this client.")
 	flag.IntVar(&clientBurst, clientBurstFlagName, 10, "Maximum burst for throttle from this client.")
 }

--- a/backend/src/apiserver/client/argo.go
+++ b/backend/src/apiserver/client/argo.go
@@ -37,13 +37,15 @@ func (argoClient *ArgoClient) Workflow(namespace string) argoprojv1alpha1.Workfl
 	return argoClient.argoProjClient.Workflows(namespace)
 }
 
-func NewArgoClientOrFatal(initConnectionTimeout time.Duration) *ArgoClient {
+func NewArgoClientOrFatal(initConnectionTimeout time.Duration, clientQPS float32, clientBurst int) *ArgoClient {
 	var argoProjClient argoprojv1alpha1.ArgoprojV1alpha1Interface
 	var operation = func() error {
 		restConfig, err := rest.InClusterConfig()
 		if err != nil {
 			return errors.Wrap(err, "Failed to initialize the RestConfig")
 		}
+		restConfig.QPS = clientQPS
+		restConfig.Burst = clientBurst
 		argoProjClient = argoclient.NewForConfigOrDie(restConfig).ArgoprojV1alpha1()
 		return nil
 	}

--- a/backend/src/apiserver/client/argo.go
+++ b/backend/src/apiserver/client/argo.go
@@ -21,6 +21,7 @@ import (
 	argoprojv1alpha1 "github.com/argoproj/argo/pkg/client/clientset/versioned/typed/workflow/v1alpha1"
 	"github.com/cenkalti/backoff"
 	"github.com/golang/glog"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/rest"
 )
@@ -37,15 +38,15 @@ func (argoClient *ArgoClient) Workflow(namespace string) argoprojv1alpha1.Workfl
 	return argoClient.argoProjClient.Workflows(namespace)
 }
 
-func NewArgoClientOrFatal(initConnectionTimeout time.Duration, clientQPS float32, clientBurst int) *ArgoClient {
+func NewArgoClientOrFatal(initConnectionTimeout time.Duration, clientParams util.ClientParameters) *ArgoClient {
 	var argoProjClient argoprojv1alpha1.ArgoprojV1alpha1Interface
 	var operation = func() error {
 		restConfig, err := rest.InClusterConfig()
 		if err != nil {
 			return errors.Wrap(err, "Failed to initialize the RestConfig")
 		}
-		restConfig.QPS = clientQPS
-		restConfig.Burst = clientBurst
+		restConfig.QPS = float32(clientParams.QPS)
+		restConfig.Burst = clientParams.Burst
 		argoProjClient = argoclient.NewForConfigOrDie(restConfig).ArgoprojV1alpha1()
 		return nil
 	}

--- a/backend/src/apiserver/client/swf.go
+++ b/backend/src/apiserver/client/swf.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cenkalti/backoff"
 	"github.com/golang/glog"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
 	swfclient "github.com/kubeflow/pipelines/backend/src/crd/pkg/client/clientset/versioned"
 	"github.com/kubeflow/pipelines/backend/src/crd/pkg/client/clientset/versioned/typed/scheduledworkflow/v1beta1"
 	"github.com/pkg/errors"
@@ -41,15 +42,15 @@ func (swfClient *SwfClient) ScheduledWorkflow(namespace string) v1beta1.Schedule
 }
 
 // creates a new client for the Kubernetes ScheduledWorkflow CRD.
-func NewScheduledWorkflowClientOrFatal(initConnectionTimeout time.Duration, clientQPS float32, clientBurst int) *SwfClient {
+func NewScheduledWorkflowClientOrFatal(initConnectionTimeout time.Duration, clientParams util.ClientParameters) *SwfClient {
 	var swfClient v1beta1.ScheduledworkflowV1beta1Interface
 	var operation = func() error {
 		restConfig, err := rest.InClusterConfig()
 		if err != nil {
 			return err
 		}
-		restConfig.QPS = clientQPS
-		restConfig.Burst = clientBurst
+		restConfig.QPS = float32(clientParams.QPS)
+		restConfig.Burst = clientParams.Burst
 		swfClientSet := swfclient.NewForConfigOrDie(restConfig)
 		swfClient = swfClientSet.ScheduledworkflowV1beta1()
 		return nil

--- a/backend/src/apiserver/client/swf.go
+++ b/backend/src/apiserver/client/swf.go
@@ -41,13 +41,15 @@ func (swfClient *SwfClient) ScheduledWorkflow(namespace string) v1beta1.Schedule
 }
 
 // creates a new client for the Kubernetes ScheduledWorkflow CRD.
-func NewScheduledWorkflowClientOrFatal(initConnectionTimeout time.Duration) *SwfClient {
+func NewScheduledWorkflowClientOrFatal(initConnectionTimeout time.Duration, clientQPS float32, clientBurst int) *SwfClient {
 	var swfClient v1beta1.ScheduledworkflowV1beta1Interface
 	var operation = func() error {
 		restConfig, err := rest.InClusterConfig()
 		if err != nil {
 			return err
 		}
+		restConfig.QPS = clientQPS
+		restConfig.Burst = clientBurst
 		swfClientSet := swfclient.NewForConfigOrDie(restConfig)
 		swfClient = swfClientSet.ScheduledworkflowV1beta1()
 		return nil

--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -158,20 +158,18 @@ func (c *ClientManager) init() {
 	c.defaultExperimentStore = storage.NewDefaultExperimentStore(db)
 	c.objectStore = initMinioClient(common.GetDurationConfig(initConnectionTimeout))
 
-	c.argoClient = client.NewArgoClientOrFatal(
-		common.GetDurationConfig(initConnectionTimeout),
-		float32(common.GetFloat64ConfigWithDefault(clientQPS, 5)),
-		common.GetIntConfigWithDefault(clientBurst, 10))
+	// Use default value of client QPS (5) & burst (10) defined in
+	// k8s.io/client-go/rest/config.go#RESTClientFor
+	clientParams := util.ClientParameters{
+		QPS:   common.GetFloat64ConfigWithDefault(clientQPS, 5),
+		Burst: common.GetIntConfigWithDefault(clientBurst, 10),
+	}
 
-	c.swfClient = client.NewScheduledWorkflowClientOrFatal(
-		common.GetDurationConfig(initConnectionTimeout),
-		float32(common.GetFloat64ConfigWithDefault(clientQPS, 5)),
-		common.GetIntConfigWithDefault(clientBurst, 10))
+	c.argoClient = client.NewArgoClientOrFatal(common.GetDurationConfig(initConnectionTimeout), clientParams)
 
-	c.k8sCoreClient = client.CreateKubernetesCoreOrFatal(
-		common.GetDurationConfig(initConnectionTimeout),
-		float32(common.GetFloat64ConfigWithDefault(clientQPS, 5)),
-		common.GetIntConfigWithDefault(clientBurst, 10))
+	c.swfClient = client.NewScheduledWorkflowClientOrFatal(common.GetDurationConfig(initConnectionTimeout), clientParams)
+
+	c.k8sCoreClient = client.CreateKubernetesCoreOrFatal(common.GetDurationConfig(initConnectionTimeout), clientParams)
 
 	runStore := storage.NewRunStore(db, c.time)
 	c.runStore = runStore

--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -136,7 +136,7 @@ func (c *ClientManager) UUID() util.UUIDGeneratorInterface {
 	return c.uuid
 }
 
-func (c *ClientManager) init() {
+func (c *ClientManager) init(clientQPS float32, clientBurst int) {
 	glog.Info("Initializing client manager")
 	db := initDBClient(common.GetDurationConfig(initConnectionTimeout))
 
@@ -155,11 +155,11 @@ func (c *ClientManager) init() {
 	c.defaultExperimentStore = storage.NewDefaultExperimentStore(db)
 	c.objectStore = initMinioClient(common.GetDurationConfig(initConnectionTimeout))
 
-	c.argoClient = client.NewArgoClientOrFatal(common.GetDurationConfig(initConnectionTimeout))
+	c.argoClient = client.NewArgoClientOrFatal(common.GetDurationConfig(initConnectionTimeout), clientQPS, clientBurst)
 
-	c.swfClient = client.NewScheduledWorkflowClientOrFatal(common.GetDurationConfig(initConnectionTimeout))
+	c.swfClient = client.NewScheduledWorkflowClientOrFatal(common.GetDurationConfig(initConnectionTimeout), clientQPS, clientBurst)
 
-	c.k8sCoreClient = client.CreateKubernetesCoreOrFatal(common.GetDurationConfig(initConnectionTimeout))
+	c.k8sCoreClient = client.CreateKubernetesCoreOrFatal(common.GetDurationConfig(initConnectionTimeout), clientQPS, clientBurst)
 
 	runStore := storage.NewRunStore(db, c.time)
 	c.runStore = runStore
@@ -388,9 +388,9 @@ func initLogArchive() (logArchive archive.LogArchiveInterface) {
 }
 
 // newClientManager creates and Init a new instance of ClientManager
-func newClientManager() ClientManager {
+func newClientManager(clientQPS float32, clientBurst int) ClientManager {
 	clientManager := ClientManager{}
-	clientManager.init()
+	clientManager.init(clientQPS, clientBurst)
 
 	return clientManager
 }

--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -70,6 +70,20 @@ func GetBoolConfigWithDefault(configName string, value bool) bool {
 	return value
 }
 
+func GetFloat64ConfigWithDefault(configName string, value float64) float64 {
+	if !viper.IsSet(configName) {
+		return value
+	}
+	return viper.GetFloat64(configName)
+}
+
+func GetIntConfigWithDefault(configName string, value int) int {
+	if !viper.IsSet(configName) {
+		return value
+	}
+	return viper.GetInt(configName)
+}
+
 func GetDurationConfig(configName string) time.Duration {
 	if !viper.IsSet(configName) {
 		glog.Fatalf("Please specify flag %s", configName)

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -51,6 +51,8 @@ var (
 	sampleConfigPath = flag.String("sampleconfig", "", "Path to samples")
 
 	collectMetricsFlag = flag.Bool("collectMetricsFlag", true, "Whether to collect Prometheus metrics in API server.")
+	clientQPS          = flag.Float64("clientQPS", 5, "QPS of clientset.")
+	clientBurst        = flag.Int("clientBurst", 10, "Burst of clientset.")
 )
 
 type RegisterHttpHandlerFromEndpoint func(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error
@@ -59,7 +61,7 @@ func main() {
 	flag.Parse()
 
 	initConfig()
-	clientManager := newClientManager()
+	clientManager := newClientManager(float32(*clientQPS), *clientBurst)
 	resourceManager := resource.NewResourceManager(&clientManager)
 	err := loadSamples(resourceManager)
 	if err != nil {

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -51,8 +51,6 @@ var (
 	sampleConfigPath = flag.String("sampleconfig", "", "Path to samples")
 
 	collectMetricsFlag = flag.Bool("collectMetricsFlag", true, "Whether to collect Prometheus metrics in API server.")
-	clientQPS          = flag.Float64("clientQPS", 5, "QPS of clientset.")
-	clientBurst        = flag.Int("clientBurst", 10, "Burst of clientset.")
 )
 
 type RegisterHttpHandlerFromEndpoint func(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error
@@ -61,7 +59,7 @@ func main() {
 	flag.Parse()
 
 	initConfig()
-	clientManager := newClientManager(float32(*clientQPS), *clientBurst)
+	clientManager := newClientManager()
 	resourceManager := resource.NewResourceManager(&clientManager)
 	err := loadSamples(resourceManager)
 	if err != nil {

--- a/backend/src/cache/client/kubernetes_core.go
+++ b/backend/src/cache/client/kubernetes_core.go
@@ -23,11 +23,13 @@ func (c *KubernetesCore) PodClient(namespace string) v1.PodInterface {
 	return c.coreV1Client.Pods(namespace)
 }
 
-func createKubernetesCore() (KubernetesCoreInterface, error) {
+func createKubernetesCore(kubeClientQPS float32, kubeClientBurst int) (KubernetesCoreInterface, error) {
 	restConfig, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to initialize kubernetes client.")
 	}
+	restConfig.QPS = kubeClientQPS
+	restConfig.Burst = kubeClientBurst
 
 	clientSet, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
@@ -37,11 +39,11 @@ func createKubernetesCore() (KubernetesCoreInterface, error) {
 }
 
 // CreateKubernetesCoreOrFatal creates a new client for the Kubernetes pod.
-func CreateKubernetesCoreOrFatal(initConnectionTimeout time.Duration) KubernetesCoreInterface {
+func CreateKubernetesCoreOrFatal(initConnectionTimeout time.Duration, kubeClientQPS float32, kubeClientBurst int) KubernetesCoreInterface {
 	var client KubernetesCoreInterface
 	var err error
 	var operation = func() error {
-		client, err = createKubernetesCore()
+		client, err = createKubernetesCore(kubeClientQPS, kubeClientBurst)
 		if err != nil {
 			return err
 		}

--- a/backend/src/cache/client/kubernetes_core.go
+++ b/backend/src/cache/client/kubernetes_core.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cenkalti/backoff"
 	"github.com/golang/glog"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -23,13 +24,13 @@ func (c *KubernetesCore) PodClient(namespace string) v1.PodInterface {
 	return c.coreV1Client.Pods(namespace)
 }
 
-func createKubernetesCore(kubeClientQPS float32, kubeClientBurst int) (KubernetesCoreInterface, error) {
+func createKubernetesCore(clientParams util.ClientParameters) (KubernetesCoreInterface, error) {
 	restConfig, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to initialize kubernetes client.")
 	}
-	restConfig.QPS = kubeClientQPS
-	restConfig.Burst = kubeClientBurst
+	restConfig.QPS = float32(clientParams.QPS)
+	restConfig.Burst = clientParams.Burst
 
 	clientSet, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
@@ -39,11 +40,11 @@ func createKubernetesCore(kubeClientQPS float32, kubeClientBurst int) (Kubernete
 }
 
 // CreateKubernetesCoreOrFatal creates a new client for the Kubernetes pod.
-func CreateKubernetesCoreOrFatal(initConnectionTimeout time.Duration, kubeClientQPS float32, kubeClientBurst int) KubernetesCoreInterface {
+func CreateKubernetesCoreOrFatal(initConnectionTimeout time.Duration, clientParams util.ClientParameters) KubernetesCoreInterface {
 	var client KubernetesCoreInterface
 	var err error
 	var operation = func() error {
-		client, err = createKubernetesCore(kubeClientQPS, kubeClientBurst)
+		client, err = createKubernetesCore(clientParams)
 		if err != nil {
 			return err
 		}

--- a/backend/src/cache/client_manager.go
+++ b/backend/src/cache/client_manager.go
@@ -52,14 +52,14 @@ func (c *ClientManager) Close() {
 	c.db.Close()
 }
 
-func (c *ClientManager) init(params WhSvrDBParameters) {
+func (c *ClientManager) init(params WhSvrDBParameters, kubeClientQPS float32, kubeClientBurst int) {
 	timeoutDuration, _ := time.ParseDuration(DefaultConnectionTimeout)
 	db := initDBClient(params, timeoutDuration)
 
 	c.time = util.NewRealTime()
 	c.db = db
 	c.cacheStore = storage.NewExecutionCacheStore(db, c.time)
-	c.k8sCoreClient = client.CreateKubernetesCoreOrFatal(timeoutDuration)
+	c.k8sCoreClient = client.CreateKubernetesCoreOrFatal(timeoutDuration, kubeClientQPS, kubeClientBurst)
 }
 
 func initDBClient(params WhSvrDBParameters, initConnectionTimeout time.Duration) *storage.DB {
@@ -164,9 +164,9 @@ func initMysql(params WhSvrDBParameters, initConnectionTimeout time.Duration) st
 	return mysqlConfig.FormatDSN()
 }
 
-func NewClientManager(params WhSvrDBParameters) ClientManager {
+func NewClientManager(params WhSvrDBParameters, kubeClientQPS float32, kubeClientBurst int) ClientManager {
 	clientManager := ClientManager{}
-	clientManager.init(params)
+	clientManager.init(params, kubeClientQPS, kubeClientBurst)
 
 	return clientManager
 }

--- a/backend/src/cache/client_manager.go
+++ b/backend/src/cache/client_manager.go
@@ -52,14 +52,14 @@ func (c *ClientManager) Close() {
 	c.db.Close()
 }
 
-func (c *ClientManager) init(params WhSvrDBParameters, clientParams ClientParameters) {
+func (c *ClientManager) init(params WhSvrDBParameters, clientParams util.ClientParameters) {
 	timeoutDuration, _ := time.ParseDuration(DefaultConnectionTimeout)
 	db := initDBClient(params, timeoutDuration)
 
 	c.time = util.NewRealTime()
 	c.db = db
 	c.cacheStore = storage.NewExecutionCacheStore(db, c.time)
-	c.k8sCoreClient = client.CreateKubernetesCoreOrFatal(timeoutDuration, float32(clientParams.QPS), clientParams.burst)
+	c.k8sCoreClient = client.CreateKubernetesCoreOrFatal(timeoutDuration, clientParams)
 }
 
 func initDBClient(params WhSvrDBParameters, initConnectionTimeout time.Duration) *storage.DB {
@@ -164,7 +164,7 @@ func initMysql(params WhSvrDBParameters, initConnectionTimeout time.Duration) st
 	return mysqlConfig.FormatDSN()
 }
 
-func NewClientManager(params WhSvrDBParameters, clientParams ClientParameters) ClientManager {
+func NewClientManager(params WhSvrDBParameters, clientParams util.ClientParameters) ClientManager {
 	clientManager := ClientManager{}
 	clientManager.init(params, clientParams)
 

--- a/backend/src/cache/client_manager.go
+++ b/backend/src/cache/client_manager.go
@@ -52,14 +52,14 @@ func (c *ClientManager) Close() {
 	c.db.Close()
 }
 
-func (c *ClientManager) init(params WhSvrDBParameters, kubeClientQPS float32, kubeClientBurst int) {
+func (c *ClientManager) init(params WhSvrDBParameters, clientParams ClientParameters) {
 	timeoutDuration, _ := time.ParseDuration(DefaultConnectionTimeout)
 	db := initDBClient(params, timeoutDuration)
 
 	c.time = util.NewRealTime()
 	c.db = db
 	c.cacheStore = storage.NewExecutionCacheStore(db, c.time)
-	c.k8sCoreClient = client.CreateKubernetesCoreOrFatal(timeoutDuration, kubeClientQPS, kubeClientBurst)
+	c.k8sCoreClient = client.CreateKubernetesCoreOrFatal(timeoutDuration, float32(clientParams.QPS), clientParams.burst)
 }
 
 func initDBClient(params WhSvrDBParameters, initConnectionTimeout time.Duration) *storage.DB {
@@ -164,9 +164,9 @@ func initMysql(params WhSvrDBParameters, initConnectionTimeout time.Duration) st
 	return mysqlConfig.FormatDSN()
 }
 
-func NewClientManager(params WhSvrDBParameters, kubeClientQPS float32, kubeClientBurst int) ClientManager {
+func NewClientManager(params WhSvrDBParameters, clientParams ClientParameters) ClientManager {
 	clientManager := ClientManager{}
-	clientManager.init(params, kubeClientQPS, kubeClientBurst)
+	clientManager.init(params, clientParams)
 
 	return clientManager
 }

--- a/backend/src/cache/main.go
+++ b/backend/src/cache/main.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/kubeflow/pipelines/backend/src/cache/server"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
 )
 
 const (
@@ -54,14 +55,9 @@ type WhSvrDBParameters struct {
 	namespaceToWatch    string
 }
 
-type ClientParameters struct {
-	QPS   float64
-	burst int
-}
-
 func main() {
 	var params WhSvrDBParameters
-	var clientParams ClientParameters
+	var clientParams util.ClientParameters
 	flag.StringVar(&params.dbDriver, "db_driver", mysqlDBDriverDefault, "Database driver name, mysql is the default value")
 	flag.StringVar(&params.dbHost, "db_host", mysqlDBHostDefault, "Database host name.")
 	flag.StringVar(&params.dbPort, "db_port", mysqlDBPortDefault, "Database port number.")
@@ -70,8 +66,10 @@ func main() {
 	flag.StringVar(&params.dbPwd, "db_password", "", "Database password.")
 	flag.StringVar(&params.dbGroupConcatMaxLen, "db_group_concat_max_len", mysqlDBGroupConcatMaxLenDefault, "Database group concat max length.")
 	flag.StringVar(&params.namespaceToWatch, "namespace_to_watch", "kubeflow", "Namespace to watch.")
+	// Use default value of client QPS (5) & burst (10) defined in
+	// k8s.io/client-go/rest/config.go#RESTClientFor
 	flag.Float64Var(&clientParams.QPS, "kube_client_qps", 5, "The maximum QPS to the master from this client.")
-	flag.IntVar(&clientParams.burst, "kube_client_burst", 10, "Maximum burst for throttle from this client.")
+	flag.IntVar(&clientParams.Burst, "kube_client_burst", 10, "Maximum burst for throttle from this client.")
 
 	flag.Parse()
 

--- a/backend/src/cache/main.go
+++ b/backend/src/cache/main.go
@@ -54,10 +54,14 @@ type WhSvrDBParameters struct {
 	namespaceToWatch    string
 }
 
+type ClientParameters struct {
+	QPS   float64
+	burst int
+}
+
 func main() {
 	var params WhSvrDBParameters
-	var kubeClientQPS float64
-	var kubeClientBurst int
+	var clientParams ClientParameters
 	flag.StringVar(&params.dbDriver, "db_driver", mysqlDBDriverDefault, "Database driver name, mysql is the default value")
 	flag.StringVar(&params.dbHost, "db_host", mysqlDBHostDefault, "Database host name.")
 	flag.StringVar(&params.dbPort, "db_port", mysqlDBPortDefault, "Database port number.")
@@ -66,13 +70,13 @@ func main() {
 	flag.StringVar(&params.dbPwd, "db_password", "", "Database password.")
 	flag.StringVar(&params.dbGroupConcatMaxLen, "db_group_concat_max_len", mysqlDBGroupConcatMaxLenDefault, "Database group concat max length.")
 	flag.StringVar(&params.namespaceToWatch, "namespace_to_watch", "kubeflow", "Namespace to watch.")
-	flag.Float64Var(&kubeClientQPS, "kube_client_qps", 5, "QPS of kubeClient.")
-	flag.IntVar(&kubeClientBurst, "kube_client_burst", 10, "Burst of kubeClient.")
+	flag.Float64Var(&clientParams.QPS, "kube_client_qps", 5, "The maximum QPS to the master from this client.")
+	flag.IntVar(&clientParams.burst, "kube_client_burst", 10, "Maximum burst for throttle from this client.")
 
 	flag.Parse()
 
 	log.Println("Initing client manager....")
-	clientManager := NewClientManager(params, float32(kubeClientQPS), kubeClientBurst)
+	clientManager := NewClientManager(params, clientParams)
 
 	go server.WatchPods(params.namespaceToWatch, &clientManager)
 

--- a/backend/src/cache/main.go
+++ b/backend/src/cache/main.go
@@ -56,6 +56,8 @@ type WhSvrDBParameters struct {
 
 func main() {
 	var params WhSvrDBParameters
+	var kubeClientQPS float64
+	var kubeClientBurst int
 	flag.StringVar(&params.dbDriver, "db_driver", mysqlDBDriverDefault, "Database driver name, mysql is the default value")
 	flag.StringVar(&params.dbHost, "db_host", mysqlDBHostDefault, "Database host name.")
 	flag.StringVar(&params.dbPort, "db_port", mysqlDBPortDefault, "Database port number.")
@@ -64,11 +66,13 @@ func main() {
 	flag.StringVar(&params.dbPwd, "db_password", "", "Database password.")
 	flag.StringVar(&params.dbGroupConcatMaxLen, "db_group_concat_max_len", mysqlDBGroupConcatMaxLenDefault, "Database group concat max length.")
 	flag.StringVar(&params.namespaceToWatch, "namespace_to_watch", "kubeflow", "Namespace to watch.")
+	flag.Float64Var(&kubeClientQPS, "kube_client_qps", 5, "QPS of kubeClient.")
+	flag.IntVar(&kubeClientBurst, "kube_client_burst", 10, "Burst of kubeClient.")
 
 	flag.Parse()
 
 	log.Println("Initing client manager....")
-	clientManager := NewClientManager(params)
+	clientManager := NewClientManager(params, float32(kubeClientQPS), kubeClientBurst)
 
 	go server.WatchPods(params.namespaceToWatch, &clientManager)
 

--- a/backend/src/common/util/client_parameters.go
+++ b/backend/src/common/util/client_parameters.go
@@ -1,0 +1,8 @@
+package util
+
+// ClientParameters contains parameters needed when creating a client
+type ClientParameters struct {
+	// Use float64 instead of float32 here to use flag.Float64Var() directly
+	QPS   float64
+	Burst int
+}

--- a/backend/src/crd/controller/scheduledworkflow/main.go
+++ b/backend/src/crd/controller/scheduledworkflow/main.go
@@ -110,6 +110,8 @@ func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&namespace, "namespace", "", "The namespace name used for Kubernetes informers to obtain the listers.")
+	// Use default value of client QPS (5) & burst (10) defined in
+	// k8s.io/client-go/rest/config.go#RESTClientFor
 	flag.Float64Var(&clientQPS, "clientQPS", 5, "The maximum QPS to the master from this client.")
 	flag.IntVar(&clientBurst, "clientBurst", 10, "Maximum burst for throttle from this client.")
 	var err error

--- a/backend/src/crd/controller/scheduledworkflow/main.go
+++ b/backend/src/crd/controller/scheduledworkflow/main.go
@@ -110,8 +110,8 @@ func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&namespace, "namespace", "", "The namespace name used for Kubernetes informers to obtain the listers.")
-	flag.Float64Var(&clientQPS, "clientQPS", 5, "QPS of clientset.")
-	flag.IntVar(&clientBurst, "clientBurst", 10, "Burst of clientset.")
+	flag.Float64Var(&clientQPS, "clientQPS", 5, "The maximum QPS to the master from this client.")
+	flag.IntVar(&clientBurst, "clientBurst", 10, "Maximum burst for throttle from this client.")
 	var err error
 	location, err = util.GetLocation()
 	if err != nil {

--- a/backend/src/crd/controller/scheduledworkflow/main.go
+++ b/backend/src/crd/controller/scheduledworkflow/main.go
@@ -34,10 +34,12 @@ import (
 )
 
 var (
-	masterURL  string
-	kubeconfig string
-	namespace  string
-	location   *time.Location
+	masterURL   string
+	kubeconfig  string
+	namespace   string
+	location    *time.Location
+	clientQPS   float64
+	clientBurst int
 )
 
 func main() {
@@ -51,6 +53,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error building kubeconfig: %s", err.Error())
 	}
+	cfg.QPS = float32(clientQPS)
+	cfg.Burst = clientBurst
 
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
@@ -106,6 +110,8 @@ func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&namespace, "namespace", "", "The namespace name used for Kubernetes informers to obtain the listers.")
+	flag.Float64Var(&clientQPS, "clientQPS", 5, "QPS of clientset.")
+	flag.IntVar(&clientBurst, "clientBurst", 10, "Burst of clientset.")
 	var err error
 	location, err = util.GetLocation()
 	if err != nil {

--- a/backend/src/crd/controller/viewer/main.go
+++ b/backend/src/crd/controller/viewer/main.go
@@ -46,6 +46,8 @@ var (
 	namespace = flag.String("namespace", "kubeflow",
 		"Namespace within which CRD controller is running. Default is "+
 			"kubeflow.")
+	clientQPS   = flag.Float64("client_qps", 5, "QPS of clientset.")
+	clientBurst = flag.Int("client_burst", 10, "Burst of clientset.")
 )
 
 func main() {
@@ -55,6 +57,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to build valid config from supplied flags: %v", err)
 	}
+	cfg.QPS = float32(*clientQPS)
+	cfg.Burst = *clientBurst
 
 	cli, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	if err != nil {

--- a/backend/src/crd/controller/viewer/main.go
+++ b/backend/src/crd/controller/viewer/main.go
@@ -46,6 +46,8 @@ var (
 	namespace = flag.String("namespace", "kubeflow",
 		"Namespace within which CRD controller is running. Default is "+
 			"kubeflow.")
+	// Use default value of client QPS (5) & burst (10) defined in
+	// k8s.io/client-go/rest/config.go#RESTClientFor
 	clientQPS   = flag.Float64("client_qps", 5, "The maximum QPS to the master from this client.")
 	clientBurst = flag.Int("client_burst", 10, "Maximum burst for throttle from this client.")
 )

--- a/backend/src/crd/controller/viewer/main.go
+++ b/backend/src/crd/controller/viewer/main.go
@@ -46,8 +46,8 @@ var (
 	namespace = flag.String("namespace", "kubeflow",
 		"Namespace within which CRD controller is running. Default is "+
 			"kubeflow.")
-	clientQPS   = flag.Float64("client_qps", 5, "QPS of clientset.")
-	clientBurst = flag.Int("client_burst", 10, "Burst of clientset.")
+	clientQPS   = flag.Float64("client_qps", 5, "The maximum QPS to the master from this client.")
+	clientBurst = flag.Int("client_burst", 10, "Maximum burst for throttle from this client.")
 )
 
 func main() {

--- a/backend/test/integration/job_api_test.go
+++ b/backend/test/integration/job_api_test.go
@@ -88,7 +88,7 @@ func (s *JobApiTestSuite) SetupTest() {
 	if err != nil {
 		glog.Exitf("Failed to get job client. Error: %s", err.Error())
 	}
-	s.swfClient = client.NewScheduledWorkflowClientOrFatal(time.Second * 30)
+	s.swfClient = client.NewScheduledWorkflowClientOrFatal(time.Second*30, 5, 10)
 
 	s.cleanUp()
 }

--- a/backend/test/integration/job_api_test.go
+++ b/backend/test/integration/job_api_test.go
@@ -88,7 +88,7 @@ func (s *JobApiTestSuite) SetupTest() {
 	if err != nil {
 		glog.Exitf("Failed to get job client. Error: %s", err.Error())
 	}
-	s.swfClient = client.NewScheduledWorkflowClientOrFatal(time.Second*30, 5, 10)
+	s.swfClient = client.NewScheduledWorkflowClientOrFatal(time.Second*30, util.ClientParameters{QPS: 5, Burst: 10})
 
 	s.cleanUp()
 }


### PR DESCRIPTION
**Description of your changes:**
Fixes https://github.com/kubeflow/pipelines/issues/5095

Add flag options to specify QPS & burst of clients in multiple components including:
- API server
- cache server
- persistent agent
- scheduled workflow controller
- view controller

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
