### PR TITLE
fix(backend): add brackets if metadata service host is ipv6.  Fixes (#5161)

### DIFF
--- a/backend/metadata_writer/src/metadata_helpers.py
+++ b/backend/metadata_writer/src/metadata_helpers.py
@@ -38,7 +38,7 @@ def connect_to_mlmd() -> metadata_store.MetadataStore:
         'METADATA_GRPC_SERVICE_SERVICE_PORT', 8080))
 
     mlmd_connection_config = metadata_store_pb2.MetadataStoreClientConfig(
-        host=[metadata_service_host] if isIPv6(metadata_service_host) else metadata_service_host,
+        host="[{}]".format(metadata_service_host) if isIPv6(metadata_service_host) else metadata_service_host,
         port=metadata_service_port,
     )
 


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/5161