### PR TITLE
feat(sdk): Add sorted function to definitions to make constant result

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -593,7 +593,7 @@ def _func_to_component_spec(func, extra_code='', base_image : str = None, packag
 
     pre_func_code = '\n'.join(list(pre_func_definitions))
 
-    arg_parse_code_lines = list(definitions) + arg_parse_code_lines
+    arg_parse_code_lines = sorted(list(definitions)) + arg_parse_code_lines
 
     arg_parse_code_lines.append(
         '_parsed_args = vars(_parser.parse_args())',


### PR DESCRIPTION
**Description of your changes:**
Hi, guys.
I had an issue with change component.yaml file was changing even there was no code change.
I found that below lines were changed every time when i try to compile.
```yaml
      def _deserialize_bool(s) -> bool:
          from distutils.util import strtobool
          return strtobool(s) == 1

      def _serialize_json(obj) -> str:
          if isinstance(obj, str):
              return obj
          import json
          def default_serializer(obj):
              if hasattr(obj, 'to_struct'):
                  return obj.to_struct()
              else:
                  raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
          return json.dumps(obj, default=default_serializer, sort_keys=True)
```

I made an example code to reproduce this issue.
```python
from typing import NamedTuple
from pathlib import Path

from kfp.components import create_component_from_func


def print_funtion(
    print_msg: str = "",
    print_bool: bool = True,
) -> NamedTuple("Outputs", [("example_outputs", dict)]):
    if print_bool:
        print(print_msg)


if __name__ == "__main__":
    print_funtion = create_component_from_func(
        print_funtion,
        output_component_file="component.yaml",
    )
```
Trying to compile this code several times, below two case were continuously appeared.
- Case 1

```python
      def _deserialize_bool(s) -> bool:
          from distutils.util import strtobool
          return strtobool(s) == 1

      def _serialize_json(obj) -> str:
          if isinstance(obj, str):
              return obj
          import json
          def default_serializer(obj):
              if hasattr(obj, 'to_struct'):
                  return obj.to_struct()
              else:
                  raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
          return json.dumps(obj, default=default_serializer, sort_keys=True)
```
- Case 2
```python
      def _serialize_json(obj) -> str:
          if isinstance(obj, str):
              return obj
          import json
          def default_serializer(obj):
              if hasattr(obj, 'to_struct'):
                  return obj.to_struct()
              else:
                  raise TypeError("Object of type '%s' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)
          return json.dumps(obj, default=default_serializer, sort_keys=True)

      def _deserialize_bool(s) -> bool:
          from distutils.util import strtobool
          return strtobool(s) == 1

```

I printed `arg_parse_code_lines` in `_func_to_component_spec` to see how it works.
```bash
> python component.py
['def _deserialize_bool(s) -> bool:\n    from distutils.util import strtobool\n    return strtobool(s) == 1\n', 'def _serialize_json(obj) -> str:\n    if isinstance(obj, str):\n        return obj\n    import json\n    def default_serializer(obj):\n        if hasattr(obj, \'to_struct\'):\n            return obj.to_struct()\n        else:\n            raise TypeError("Object of type \'%s\' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)\n    return json.dumps(obj, default=default_serializer, sort_keys=True)\n', 'import argparse', "_parser = argparse.ArgumentParser(prog='Print funtion', description='')", '_parser.add_argument("--print-msg", dest="print_msg", type=str, required=False, default=argparse.SUPPRESS)', '_parser.add_argument("--print-float", dest="print_float", type=float, required=False, default=argparse.SUPPRESS)', '_parser.add_argument("--print-bool", dest="print_bool", type=_deserialize_bool, required=False, default=argparse.SUPPRESS)', '_parser.add_argument("--bool-arg", dest="bool_arg", type=_deserialize_bool, required=False, default=argparse.SUPPRESS)', '_parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)']
> python component.py
['def _serialize_json(obj) -> str:\n    if isinstance(obj, str):\n        return obj\n    import json\n    def default_serializer(obj):\n        if hasattr(obj, \'to_struct\'):\n            return obj.to_struct()\n        else:\n            raise TypeError("Object of type \'%s\' is not JSON serializable and does not have .to_struct() method." % obj.__class__.__name__)\n    return json.dumps(obj, default=default_serializer, sort_keys=True)\n', 'def _deserialize_bool(s) -> bool:\n    from distutils.util import strtobool\n    return strtobool(s) == 1\n', 'import argparse', "_parser = argparse.ArgumentParser(prog='Print funtion', description='')", '_parser.add_argument("--print-msg", dest="print_msg", type=str, required=False, default=argparse.SUPPRESS)', '_parser.add_argument("--print-float", dest="print_float", type=float, required=False, default=argparse.SUPPRESS)', '_parser.add_argument("--print-bool", dest="print_bool", type=_deserialize_bool, required=False, default=argparse.SUPPRESS)', '_parser.add_argument("--bool-arg", dest="bool_arg", type=_deserialize_bool, required=False, default=argparse.SUPPRESS)', '_parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)']
```

And i found that order of `definitions` was not constant.

So i added `sorted` function to `definitions` before appending to `arg_parse_code_lines`.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
