### PR TITLE
fix(sdk): only apply importer node when compiling to IR

### DIFF
--- a/sdk/python/kfp/dsl/_component_bridge.py
+++ b/sdk/python/kfp/dsl/_component_bridge.py
@@ -311,9 +311,10 @@ def _attach_v2_specs(
           pipeline_task_spec.inputs.artifacts[
               input_name].task_output_artifact.output_artifact_key = (
                   argument_value.name)
-        else:
+        elif is_compiling_for_v2:
           # argument_value.op_name could be none, in which case an importer node
           # will be inserted later.
+          # Importer node is only applicable for v2 engine.
           pipeline_task_spec.inputs.artifacts[
               input_name].task_output_artifact.producer_task = ''
           type_schema = type_utils.get_input_artifact_type_schema(
@@ -337,8 +338,9 @@ def _attach_v2_specs(
         pipeline_task_spec.inputs.parameters[
             input_name].runtime_value.constant_value.string_value = (
                 argument_value)
-      else:
+      elif is_compiling_for_v2:
         # An importer node with constant value artifact_uri will be inserted.
+        # Importer node is only applicable for v2 engine.
         pipeline_task_spec.inputs.artifacts[
             input_name].task_output_artifact.producer_task = ''
         type_schema = type_utils.get_input_artifact_type_schema(

--- a/sdk/python/kfp/dsl/importer_node.py
+++ b/sdk/python/kfp/dsl/importer_node.py
@@ -40,7 +40,7 @@ def build_importer_spec(
   Returns:
     An importer spec.
   """
-  assert bool(pipeline_param_name) != bool(constant_value), (
+  assert bool(pipeline_param_name == None) != bool(constant_value == None), (
       'importer spec should be built using either pipeline_param_name or '
       'constant_value.')
   importer_spec = pipeline_spec_pb2.PipelineDeploymentConfig.ImporterSpec()

--- a/sdk/python/kfp/dsl/importer_node.py
+++ b/sdk/python/kfp/dsl/importer_node.py
@@ -40,7 +40,7 @@ def build_importer_spec(
   Returns:
     An importer spec.
   """
-  assert bool(pipeline_param_name == None) != bool(constant_value == None), (
+  assert bool(pipeline_param_name is None) != bool(constant_value is None), (
       'importer spec should be built using either pipeline_param_name or '
       'constant_value.')
   importer_spec = pipeline_spec_pb2.PipelineDeploymentConfig.ImporterSpec()


### PR DESCRIPTION
**Description of your changes:**
Fixes: #5263

The logic for inserting importer node heavily relies on inputs being properly type annotated -- importer node is for input artifact not connected to an upstream component while if an input is not type annotated or annotated using an arbitrary custom string, it's viewed as an artifact in v2. But such inputs in v1 could be parameters and importer logic shouldn't apply.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
