### PR TITLE
test: Fixes wrong indentation in 'dsl_utils_test.py'.

### DIFF
--- a/sdk/python/kfp/dsl/dsl_utils_test.py
+++ b/sdk/python/kfp/dsl/dsl_utils_test.py
@@ -52,13 +52,12 @@ class DslUtilsTest(unittest.TestCase):
     with self.assertRaisesRegex(TypeError, 'Got unexpected type'):
       dsl_utils.get_value(_DummyClass())
 
+  def test_remove_task_name_prefix(self):
+    self.assertEqual('my-component',
+                     dsl_utils.remove_task_name_prefix('task-my-component'))
 
-def test_remove_task_name_prefix(self):
-  self.assertEqual('my-component',
-                   dsl_utils.remove_task_name_prefix('task-my-component'))
-
-  with self.assertRaises(AssertionError):
-    dsl_utils.remove_task_name_prefix('my-component')
+    with self.assertRaises(AssertionError):
+      dsl_utils.remove_task_name_prefix('my-component')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of your changes:**
It seems like a trivial indentation error and it should become part of the test class.

**Checklist:**
- [v] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
