### PR TITLE
fix(sdk/tests) fix parallelfor_item_argument_resolving compiler test, Fixes #5270 

### DIFF
--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.py
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.py
@@ -24,17 +24,17 @@ def produce_str() -> str:
 
 @func_to_container_op
 def produce_list_of_dicts() -> list:
-    return ({"aaa": "aaa1", "bbb": "bbb1"}, {"aaa": "aaa2", "bbb": "bbb2"})
+    return [{"aaa": "aaa1", "bbb": "bbb1"}, {"aaa": "aaa2", "bbb": "bbb2"}]
 
 
 @func_to_container_op
 def produce_list_of_strings() -> list:
-    return ("a", "z")
+    return ["a", "z"]
 
 
 @func_to_container_op
 def produce_list_of_ints() -> list:
-    return (1234567890, 987654321)
+    return [1234567890, 987654321]
 
 
 @func_to_container_op

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.py
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.py
@@ -24,17 +24,17 @@ def produce_str() -> str:
 
 @func_to_container_op
 def produce_list_of_dicts() -> list:
-    return ([{"aaa": "aaa1", "bbb": "bbb1"}, {"aaa": "aaa2", "bbb": "bbb2"}],)
+    return ({"aaa": "aaa1", "bbb": "bbb1"}, {"aaa": "aaa2", "bbb": "bbb2"})
 
 
 @func_to_container_op
 def produce_list_of_strings() -> list:
-    return (["a", "z"],)
+    return ("a", "z")
 
 
 @func_to_container_op
 def produce_list_of_ints() -> list:
-    return ([1234567890, 987654321],)
+    return (1234567890, 987654321)
 
 
 @func_to_container_op

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: parallelfor-item-argument-resolving-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.4.0, pipelines.kubeflow.org/pipeline_compilation_time: '2021-03-09T13:24:31.319648',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.4.0, pipelines.kubeflow.org/pipeline_compilation_time: '2021-03-11T10:42:45.755332',
     pipelines.kubeflow.org/pipeline_spec: '{"name": "Parallelfor item argument resolving"}'}
   labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.4.0}
 spec:
@@ -441,7 +441,7 @@ spec:
         python3 -u "$program_path" "$@"
       - |
         def produce_list_of_dicts():
-            return ({"aaa": "aaa1", "bbb": "bbb1"}, {"aaa": "aaa2", "bbb": "bbb2"})
+            return [{"aaa": "aaa1", "bbb": "bbb1"}, {"aaa": "aaa2", "bbb": "bbb2"}]
 
         def _serialize_json(obj) -> str:
             if isinstance(obj, str):
@@ -489,7 +489,7 @@ spec:
           {"args": ["----output-paths", {"outputPath": "Output"}], "command": ["sh",
           "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
           -u \"$program_path\" \"$@\"\n", "def produce_list_of_dicts():\n    return
-          ({\"aaa\": \"aaa1\", \"bbb\": \"bbb1\"}, {\"aaa\": \"aaa2\", \"bbb\": \"bbb2\"})\n\ndef
+          [{\"aaa\": \"aaa1\", \"bbb\": \"bbb1\"}, {\"aaa\": \"aaa2\", \"bbb\": \"bbb2\"}]\n\ndef
           _serialize_json(obj) -> str:\n    if isinstance(obj, str):\n        return
           obj\n    import json\n    def default_serializer(obj):\n        if hasattr(obj,
           ''to_struct''):\n            return obj.to_struct()\n        else:\n            raise
@@ -516,7 +516,7 @@ spec:
         python3 -u "$program_path" "$@"
       - |
         def produce_list_of_ints():
-            return (1234567890, 987654321)
+            return [1234567890, 987654321]
 
         def _serialize_json(obj) -> str:
             if isinstance(obj, str):
@@ -564,7 +564,7 @@ spec:
           {"args": ["----output-paths", {"outputPath": "Output"}], "command": ["sh",
           "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
           -u \"$program_path\" \"$@\"\n", "def produce_list_of_ints():\n    return
-          (1234567890, 987654321)\n\ndef _serialize_json(obj) -> str:\n    if isinstance(obj,
+          [1234567890, 987654321]\n\ndef _serialize_json(obj) -> str:\n    if isinstance(obj,
           str):\n        return obj\n    import json\n    def default_serializer(obj):\n        if
           hasattr(obj, ''to_struct''):\n            return obj.to_struct()\n        else:\n            raise
           TypeError(\"Object of type ''%s'' is not JSON serializable and does not
@@ -590,7 +590,7 @@ spec:
         python3 -u "$program_path" "$@"
       - |
         def produce_list_of_strings():
-            return ("a", "z")
+            return ["a", "z"]
 
         def _serialize_json(obj) -> str:
             if isinstance(obj, str):
@@ -638,7 +638,7 @@ spec:
           {"args": ["----output-paths", {"outputPath": "Output"}], "command": ["sh",
           "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
           -u \"$program_path\" \"$@\"\n", "def produce_list_of_strings():\n    return
-          (\"a\", \"z\")\n\ndef _serialize_json(obj) -> str:\n    if isinstance(obj,
+          [\"a\", \"z\"]\n\ndef _serialize_json(obj) -> str:\n    if isinstance(obj,
           str):\n        return obj\n    import json\n    def default_serializer(obj):\n        if
           hasattr(obj, ''to_struct''):\n            return obj.to_struct()\n        else:\n            raise
           TypeError(\"Object of type ''%s'' is not JSON serializable and does not

--- a/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
+++ b/sdk/python/tests/compiler/testdata/parallelfor_item_argument_resolving.yaml
@@ -2,9 +2,9 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: parallelfor-item-argument-resolving-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.3.0, pipelines.kubeflow.org/pipeline_compilation_time: '2021-01-20T11:30:05.340345',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.4.0, pipelines.kubeflow.org/pipeline_compilation_time: '2021-03-09T13:24:31.319648',
     pipelines.kubeflow.org/pipeline_spec: '{"name": "Parallelfor item argument resolving"}'}
-  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.3.0}
+  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.4.0}
 spec:
   entrypoint: parallelfor-item-argument-resolving
   templates:
@@ -441,7 +441,7 @@ spec:
         python3 -u "$program_path" "$@"
       - |
         def produce_list_of_dicts():
-            return ([{"aaa": "aaa1", "bbb": "bbb1"}, {"aaa": "aaa2", "bbb": "bbb2"}],)
+            return ({"aaa": "aaa1", "bbb": "bbb1"}, {"aaa": "aaa2", "bbb": "bbb2"})
 
         def _serialize_json(obj) -> str:
             if isinstance(obj, str):
@@ -489,7 +489,7 @@ spec:
           {"args": ["----output-paths", {"outputPath": "Output"}], "command": ["sh",
           "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
           -u \"$program_path\" \"$@\"\n", "def produce_list_of_dicts():\n    return
-          ([{\"aaa\": \"aaa1\", \"bbb\": \"bbb1\"}, {\"aaa\": \"aaa2\", \"bbb\": \"bbb2\"}],)\n\ndef
+          ({\"aaa\": \"aaa1\", \"bbb\": \"bbb1\"}, {\"aaa\": \"aaa2\", \"bbb\": \"bbb2\"})\n\ndef
           _serialize_json(obj) -> str:\n    if isinstance(obj, str):\n        return
           obj\n    import json\n    def default_serializer(obj):\n        if hasattr(obj,
           ''to_struct''):\n            return obj.to_struct()\n        else:\n            raise
@@ -516,7 +516,7 @@ spec:
         python3 -u "$program_path" "$@"
       - |
         def produce_list_of_ints():
-            return ([1234567890, 987654321],)
+            return (1234567890, 987654321)
 
         def _serialize_json(obj) -> str:
             if isinstance(obj, str):
@@ -564,7 +564,7 @@ spec:
           {"args": ["----output-paths", {"outputPath": "Output"}], "command": ["sh",
           "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
           -u \"$program_path\" \"$@\"\n", "def produce_list_of_ints():\n    return
-          ([1234567890, 987654321],)\n\ndef _serialize_json(obj) -> str:\n    if isinstance(obj,
+          (1234567890, 987654321)\n\ndef _serialize_json(obj) -> str:\n    if isinstance(obj,
           str):\n        return obj\n    import json\n    def default_serializer(obj):\n        if
           hasattr(obj, ''to_struct''):\n            return obj.to_struct()\n        else:\n            raise
           TypeError(\"Object of type ''%s'' is not JSON serializable and does not
@@ -590,7 +590,7 @@ spec:
         python3 -u "$program_path" "$@"
       - |
         def produce_list_of_strings():
-            return (["a", "z"],)
+            return ("a", "z")
 
         def _serialize_json(obj) -> str:
             if isinstance(obj, str):
@@ -638,7 +638,7 @@ spec:
           {"args": ["----output-paths", {"outputPath": "Output"}], "command": ["sh",
           "-ec", "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3
           -u \"$program_path\" \"$@\"\n", "def produce_list_of_strings():\n    return
-          ([\"a\", \"z\"],)\n\ndef _serialize_json(obj) -> str:\n    if isinstance(obj,
+          (\"a\", \"z\")\n\ndef _serialize_json(obj) -> str:\n    if isinstance(obj,
           str):\n        return obj\n    import json\n    def default_serializer(obj):\n        if
           hasattr(obj, ''to_struct''):\n            return obj.to_struct()\n        else:\n            raise
           TypeError(\"Object of type ''%s'' is not JSON serializable and does not


### PR DESCRIPTION
**Description of your changes:**
Fixes #5270 

The sdk compiler testdata `parallelfor_item_argument_resolving.py` does not need to put the brackets `[ ]` around the return statement. Having the extra brackets will cause the issue #5270.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
