### PR TITLE
chore(components): fix default return value and correct grammar

### DIFF
--- a/components/gcp/ml_engine/deploy/component.yaml
+++ b/components/gcp/ml_engine/deploy/component.yaml
@@ -70,7 +70,7 @@ inputs:
   - name: replace_existing_version
     description: >-
       A Boolean flag that indicates whether to replace existing version in case of conflict.
-    default: 'Fasle'
+    default: 'False'
     type: Bool
   - name: set_default
     description: >-

--- a/components/gcp/ml_engine/train/component.yaml
+++ b/components/gcp/ml_engine/train/component.yaml
@@ -102,7 +102,7 @@ outputs:
     type: String
   - name: job_dir
     description: >-
-      The output path in Cloud Storage of the trainning job, which contains 
+      The output path in Cloud Storage of the training job, which contains
       the trained model files.
     type: GCSPath
   - name: MLPipeline UI metadata


### PR DESCRIPTION
I noticed a typo in default bool return type - small PR that fixes it.
 
**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [x] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
