### PR TITLE
feat(deployment): update mysql to 5.7 and support running as nonroot

### DIFF
--- a/manifests/kustomize/third-party/mysql/kustomization.yaml
+++ b/manifests/kustomize/third-party/mysql/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - mysql-deployment.yaml
 - mysql-pv-claim.yaml
 - mysql-service.yaml
+- mysql-serviceaccount.yaml

--- a/manifests/kustomize/third-party/mysql/mysql-deployment.yaml
+++ b/manifests/kustomize/third-party/mysql/mysql-deployment.yaml
@@ -17,6 +17,8 @@ spec:
     spec:
       serviceAccountName: mysql
       containers:
+      # https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_ignore-db-dir
+      # Ext4, Btrfs etc. volumes root directories have a lost+found directory that should not be treated as a database.
       - args:
         - --ignore-db-dir=lost+found
         - --datadir

--- a/manifests/kustomize/third-party/mysql/mysql-deployment.yaml
+++ b/manifests/kustomize/third-party/mysql/mysql-deployment.yaml
@@ -15,11 +15,15 @@ spec:
       labels:
         app: mysql
     spec:
+      serviceAccountName: mysql
       containers:
-      - env:
+      - args:
+        - --datadir
+        - /var/lib/mysql
+        env:
         - name: MYSQL_ALLOW_EMPTY_PASSWORD
           value: "true"
-        image: gcr.io/ml-pipeline/mysql:5.6
+        image: docker.io/mysql:5.7
         name: mysql
         ports:
         - containerPort: 3306

--- a/manifests/kustomize/third-party/mysql/mysql-deployment.yaml
+++ b/manifests/kustomize/third-party/mysql/mysql-deployment.yaml
@@ -18,6 +18,7 @@ spec:
       serviceAccountName: mysql
       containers:
       - args:
+        - --ignore-db-dir=lost+found
         - --datadir
         - /var/lib/mysql
         env:

--- a/manifests/kustomize/third-party/mysql/mysql-deployment.yaml
+++ b/manifests/kustomize/third-party/mysql/mysql-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         env:
         - name: MYSQL_ALLOW_EMPTY_PASSWORD
           value: "true"
-        image: docker.io/mysql:5.7
+        image: gcr.io/ml-pipeline/mysql:5.7
         name: mysql
         ports:
         - containerPort: 3306

--- a/manifests/kustomize/third-party/mysql/mysql-serviceaccount.yaml
+++ b/manifests/kustomize/third-party/mysql/mysql-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql
+  

--- a/test/tag_for_hosted.sh
+++ b/test/tag_for_hosted.sh
@@ -108,8 +108,8 @@ docker tag gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z-license-complia
 docker push gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/minio:$SEM_VER
 docker push gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/minio:$MM_VER
 
-docker tag gcr.io/ml-pipeline/mysql:5.6 gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$SEM_VER
-docker tag gcr.io/ml-pipeline/mysql:5.6 gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$MM_VER
+docker tag gcr.io/ml-pipeline/mysql:5.7 gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$SEM_VER
+docker tag gcr.io/ml-pipeline/mysql:5.7 gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$MM_VER
 docker push gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$SEM_VER
 docker push gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$MM_VER
 


### PR DESCRIPTION
@Bobgy sorry, but the heavy restructuring made it quite pointless to do a manual rebase of #5228 

docker.io/mysql:5.7 is an official dockerhub image. So there should not be rate limits AFAIK. But you can of course create gcr.io/ml-pipeline/mysql:5.7 . 

metadata-db that you want to merge with this mysql database currently uses mysql:8.0. But ml-pipeline does not work with 8.0
```
[julius@localhost ~]$ kubectl -n kubeflow logs ml-pipeline-7c56db5db9-ts547 -c ml-pipeline-api-server 
I0310 18:49:55.490470       8 client_manager.go:134] Initializing client manager
I0310 18:49:55.490564       8 config.go:50] Config DBConfig.ExtraParams not specified, skipping

(Error 1046: No database selected) 
[2021-03-10 18:49:55]  

(Error 1046: No database selected) 
[2021-03-10 18:49:55]  

(Error 1046: No database selected) 
[2021-03-10 18:49:55]  

(Error 1046: No database selected) 
[2021-03-10 18:49:55]  

(Error 1046: No database selected) 
[2021-03-10 18:49:55]  

(Error 1046: No database selected) 
[2021-03-10 18:49:55]  

(Error 1046: No database selected) 
[2021-03-10 18:49:55]  
F0310 18:49:55.518981       8 client_manager.go:212] Failed to initialize the databases.
```

So you should make sure that the metadata stuff works with 5.7 or fix ml-pipeline to work with 8.0 and create gcr.io/ml-pipeline/mysql:8.0 from docker.io/mysql:8.0.

I tested that metadata-db works with mysql:5.7 and all pods are running, but i could not really test the functionallity because https://github.com/kubeflow/metadata/blob/master/sdk/python/sample/demo.ipynb seems to be broken.


Related to https://github.com/kubeflow/manifests/pull/1756/