### PR TITLE
fix: runasnonroot for kubeflow-pipelines-controller

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/deployment.yaml
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - name: hooks
           mountPath: /hooks
         ports:
-        - containerPort: 80
+        - containerPort: 8080
       volumes:
       - name: hooks
         configMap:

--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/service.yaml
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/service.yaml
@@ -7,4 +7,4 @@ spec:
   - name: http
     port: 80
     protocol: TCP
-    targetPort: 80
+    targetPort: 8080

--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/sync.py
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/sync.py
@@ -266,4 +266,4 @@ class Controller(BaseHTTPRequestHandler):
         self.wfile.write(bytes(json.dumps(desired), 'utf-8'))
 
 
-HTTPServer(("", 80), Controller).serve_forever()
+HTTPServer(("", 8080), Controller).serve_forever()


### PR DESCRIPTION
@DavidSpek  @Bobgy  Please include it into Kubeflow 1.3. it is a trivial change like https://github.com/kubeflow/kubeflow/pull/5668 and strictly needed for https://github.com/kubeflow/manifests/pull/1756

ports below 1024 prevent runasnonroot, so we switch from 80 to 8080.
