### PR TITLE
chore (sdk) typo err in cli/pipeline suppy -> supply

### DIFF
--- a/sdk/python/kfp/cli/pipeline.py
+++ b/sdk/python/kfp/cli/pipeline.py
@@ -74,7 +74,7 @@ def upload_version(ctx, package_file, pipeline_version, pipeline_id=None, pipeli
     client = ctx.obj["client"]
     output_format = ctx.obj["output"]
     if bool(pipeline_id) == bool(pipeline_name):
-        raise ValueError("Need to suppy 'pipeline-name' or 'pipeline-id'")
+        raise ValueError("Need to supply 'pipeline-name' or 'pipeline-id'")
     if pipeline_name is not None:
         pipeline_id = client.get_pipeline_id(name=pipeline_name)
         if pipeline_id is None:


### PR DESCRIPTION
**Description of your changes:**
There was an typo error in cli/pipeline.py
```python
    if bool(pipeline_id) == bool(pipeline_name):
        raise ValueError("Need to suppy 'pipeline-name' or 'pipeline-id'")
```

Changed suppy to supply

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
