### PR TITLE
Fix(sdk): Enable FutureWarning with PipelineParam. Fix #5280

### DIFF
--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -1104,37 +1104,6 @@ class ContainerOp(BaseOp):
                      sidecars=sidecars,
                      is_exit_handler=is_exit_handler)
 
-    def _contains_argument_from_tfx_sdk(
-        arguments: Optional[ArgumentOrArguments]
-    ) -> bool:
-      if isinstance(arguments, str):
-        return arguments == '--component_launcher_class_path'
-      if not arguments or not isinstance(arguments, Iterable):
-        return False
-
-      def _is_argument_from_tfx_sdk(arg: ContainerOpArgument):
-        if isinstance(arg, str):
-          return arg == '--component_launcher_class_path'
-        else:
-          return False
-
-      return any([
-          _is_argument_from_tfx_sdk(arg) for arg in arguments
-      ])
-
-    if (not ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING) and (
-        not _contains_argument_from_tfx_sdk(arguments)):
-      # The warning is suppressed for pipelines created using the TFX SDK.
-      warnings.warn(
-          'Please create reusable components instead of constructing ContainerOp instances directly.'
-          ' Reusable components are shareable, portable and have compatibility and support guarantees.'
-          ' Please see the documentation: https://www.kubeflow.org/docs/pipelines/sdk/component-development/#writing-your-component-definition-file'
-          ' The components can be created manually (or, in case of python, using kfp.components.create_component_from_func or func_to_container_op)'
-          ' and then loaded using kfp.components.load_component_from_file, load_component_from_uri or load_component_from_text: '
-          'https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.components.html#kfp.components.load_component_from_file',
-          category=FutureWarning,
-      )
-
     self.attrs_with_pipelineparams = BaseOp.attrs_with_pipelineparams + [
         '_container', 'artifact_arguments', '_parameter_arguments'
     ]  #Copying the BaseOp class variable!
@@ -1167,6 +1136,19 @@ class ContainerOp(BaseOp):
     # convert to list if not a list
     command = as_string_list(command)
     arguments = as_string_list(arguments)
+
+    if (not ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING) and (
+        '--component_launcher_class_path' not in (arguments or [])):
+      # The warning is suppressed for pipelines created using the TFX SDK.
+      warnings.warn(
+          'Please create reusable components instead of constructing ContainerOp instances directly.'
+          ' Reusable components are shareable, portable and have compatibility and support guarantees.'
+          ' Please see the documentation: https://www.kubeflow.org/docs/pipelines/sdk/component-development/#writing-your-component-definition-file'
+          ' The components can be created manually (or, in case of python, using kfp.components.create_component_from_func or func_to_container_op)'
+          ' and then loaded using kfp.components.load_component_from_file, load_component_from_uri or load_component_from_text: '
+          'https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.components.html#kfp.components.load_component_from_file',
+          category=FutureWarning,
+      )
 
     # `container` prop in `io.argoproj.workflow.v1alpha1.Template`
     container_kwargs = container_kwargs or {}

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -15,7 +15,7 @@
 import inspect
 import re
 import warnings
-from typing import Any, Dict, List, TypeVar, Union, Callable, Optional, Sequence
+from typing import Any, Dict, List, TypeVar, Union, Callable, Optional, Sequence, Iterable
 
 from kubernetes.client import V1Toleration, V1Affinity
 from kubernetes.client.models import (V1Container, V1EnvVar, V1EnvFromSource,
@@ -32,6 +32,9 @@ from kfp.pipeline_spec import pipeline_spec_pb2
 T = TypeVar('T')
 # type alias: either a string or a list of string
 StringOrStringList = Union[str, List[str]]
+ContainerOpArgument = Union[str, int, float, bool,
+                            _pipeline_param.PipelineParam]
+ArgumentOrArguments = Union[ContainerOpArgument, Iterable[ContainerOpArgument]]
 
 ALLOWED_RETRY_POLICIES = (
     'Always',
@@ -1086,7 +1089,7 @@ class ContainerOp(BaseOp):
       name: str,
       image: str,
       command: Optional[StringOrStringList] = None,
-      arguments: Optional[StringOrStringList] = None,
+      arguments: Optional[ArgumentOrArguments] = None,
       init_containers: Optional[List[UserContainer]] = None,
       sidecars: Optional[List[Sidecar]] = None,
       container_kwargs: Optional[Dict] = None,

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -15,7 +15,7 @@
 import inspect
 import re
 import warnings
-from typing import Any, Dict, List, TypeVar, Union, Callable, Optional, Sequence, Iterable
+from typing import Any, Dict, List, TypeVar, Union, Callable, Optional, Sequence
 
 from kubernetes.client import V1Toleration, V1Affinity
 from kubernetes.client.models import (V1Container, V1EnvVar, V1EnvFromSource,
@@ -34,7 +34,7 @@ T = TypeVar('T')
 StringOrStringList = Union[str, List[str]]
 ContainerOpArgument = Union[str, int, float, bool,
                             _pipeline_param.PipelineParam]
-ArgumentOrArguments = Union[ContainerOpArgument, Iterable[ContainerOpArgument]]
+ArgumentOrArguments = Union[ContainerOpArgument, List]
 
 ALLOWED_RETRY_POLICIES = (
     'Always',

--- a/sdk/python/tests/dsl/component_bridge_tests.py
+++ b/sdk/python/tests/dsl/component_bridge_tests.py
@@ -20,7 +20,7 @@ import kfp
 from pathlib import Path
 from kfp.components import load_component_from_text, create_component_from_func
 from kfp.dsl.types import InconsistentTypeException
-
+from kfp.dsl import PipelineParam
 
 class TestComponentBridge(unittest.TestCase):
     # Alternatively, we could use kfp.dsl.Pipleine().__enter__ and __exit__
@@ -243,6 +243,10 @@ class TestComponentBridge(unittest.TestCase):
 
         with self.assertWarnsRegex(FutureWarning, expected_regex='reusable'):
             kfp.dsl.ContainerOp(name='name', image='image')
+
+        with self.assertWarnsRegex(FutureWarning, expected_regex='reusable'):
+            kfp.dsl.ContainerOp(name='name', image='image', arguments=['dammy', PipelineParam('param')])
+
 
     def test_prevent_passing_container_op_as_argument(self):
         component_text = textwrap.dedent('''\

--- a/sdk/python/tests/dsl/component_bridge_tests.py
+++ b/sdk/python/tests/dsl/component_bridge_tests.py
@@ -245,7 +245,7 @@ class TestComponentBridge(unittest.TestCase):
             kfp.dsl.ContainerOp(name='name', image='image')
 
         with self.assertWarnsRegex(FutureWarning, expected_regex='reusable'):
-            kfp.dsl.ContainerOp(name='name', image='image', arguments=['dammy', PipelineParam('param')])
+            kfp.dsl.ContainerOp(name='name', image='image', arguments=[PipelineParam('param1'), PipelineParam('param2')])
 
 
     def test_prevent_passing_container_op_as_argument(self):


### PR DESCRIPTION
Enable raising `FutureWarning` when `dsl.ContainerOp` is used directly.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

I guess it is better to fix this issue and release fixed version of SDK. However, since master branch has made breaking change,   we need more work to update the KFP SDK.