### PR TITLE
chore: add missing places we need to upgrade mysql to 5.7

### DIFF
--- a/.cloudbuild.yaml
+++ b/.cloudbuild.yaml
@@ -186,7 +186,7 @@ steps:
   args: ['pull', 'gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance']
   id:   'pullMinio'
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['pull', 'gcr.io/ml-pipeline/mysql:5.6']
+  args: ['pull', 'gcr.io/ml-pipeline/mysql:5.7']
   id:   'pullMysql'
 - name: 'gcr.io/cloud-builders/docker'
   args: ['pull', 'gcr.io/cloudsql-docker/gce-proxy:1.14']

--- a/.release.cloudbuild.yaml
+++ b/.release.cloudbuild.yaml
@@ -433,14 +433,14 @@ steps:
     docker push gcr.io/ml-pipeline/google/pipelines-test/minio:$(cat /workspace/mm.ver)
 
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['pull', 'gcr.io/ml-pipeline/mysql:5.6']
+  args: ['pull', 'gcr.io/ml-pipeline/mysql:5.7']
   id:   'pullMysql'
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/ml-pipeline/mysql:5.6', 'gcr.io/ml-pipeline/google/pipelines/mysql:$TAG_NAME']
+  args: ['tag', 'gcr.io/ml-pipeline/mysql:5.7', 'gcr.io/ml-pipeline/google/pipelines/mysql:$TAG_NAME']
   id:   'tagMySqlForMarketplace'
   waitFor: ['pullMysql']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/ml-pipeline/mysql:5.6', 'gcr.io/ml-pipeline/google/pipelines-test/mysql:$TAG_NAME']
+  args: ['tag', 'gcr.io/ml-pipeline/mysql:5.7', 'gcr.io/ml-pipeline/google/pipelines-test/mysql:$TAG_NAME']
   id:   'tagMySqlForMarketplaceTest'
   waitFor: ['pullMysql']
 - id:   'tagMySqlForMarketplaceMajorMinor'
@@ -450,8 +450,8 @@ steps:
   args:
   - -ceux
   - |
-    docker tag gcr.io/ml-pipeline/mysql:5.6 gcr.io/ml-pipeline/google/pipelines/mysql:$(cat /workspace/mm.ver)
-    docker tag gcr.io/ml-pipeline/mysql:5.6 gcr.io/ml-pipeline/google/pipelines-test/mysql:$(cat /workspace/mm.ver)
+    docker tag gcr.io/ml-pipeline/mysql:5.7 gcr.io/ml-pipeline/google/pipelines/mysql:$(cat /workspace/mm.ver)
+    docker tag gcr.io/ml-pipeline/mysql:5.7 gcr.io/ml-pipeline/google/pipelines-test/mysql:$(cat /workspace/mm.ver)
     docker push gcr.io/ml-pipeline/google/pipelines/mysql:$(cat /workspace/mm.ver)
     docker push gcr.io/ml-pipeline/google/pipelines-test/mysql:$(cat /workspace/mm.ver)
 

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
@@ -1,4 +1,11 @@
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: mysql
@@ -35,6 +42,7 @@ spec:
         app: cloudsqlproxy
         app.kubernetes.io/name: {{ .Release.Name }}
     spec:
+      serviceAccountName: mysql
       containers:
         - image: {{ .Values.images.cloudsqlproxy}}
           name: cloudsqlproxy
@@ -108,12 +116,19 @@ spec:
         app: mysql
         app.kubernetes.io/name: {{ .Release.Name }}
     spec:
+      serviceAccountName: mysql
       containers:
-        - env:
+        - name: mysql
+          image: {{ .Values.images.mysql }}
+          args:
+          # https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_ignore-db-dir
+          # Ext4, Btrfs etc. volumes root directories have a lost+found directory that should not be treated as a database.
+          - --ignore-db-dir=lost+found
+          - --datadir
+          - /var/lib/mysql
+          env:
             - name: MYSQL_ALLOW_EMPTY_PASSWORD
               value: "true"
-          image: {{ .Values.images.mysql }}
-          name: mysql
           ports:
             - containerPort: 3306
               name: mysql

--- a/manifests/kustomize/env/platform-agnostic-multi-user/kustomization.yaml
+++ b/manifests/kustomize/env/platform-agnostic-multi-user/kustomization.yaml
@@ -16,9 +16,3 @@ commonLabels:
 # !!! If you want to customize the namespace,
 # please also update base/cache-deployer/cluster-scoped/cache-deployer-clusterrolebinding.yaml
 namespace: kubeflow
-
-images:
-  - name: mysql
-    newTag: "5.6"
-  - name: minio/minio
-    newTag: RELEASE.2018-02-09T22-40-05Z

--- a/manifests/kustomize/env/platform-agnostic/kustomization.yaml
+++ b/manifests/kustomize/env/platform-agnostic/kustomization.yaml
@@ -16,9 +16,3 @@ commonLabels:
 # !!! If you want to customize the namespace,
 # please also update base/cache-deployer/cluster-scoped/cache-deployer-clusterrolebinding.yaml
 namespace: kubeflow
-
-images:
-  - name: mysql
-    newTag: "5.6"
-  - name: minio/minio
-    newTag: RELEASE.2018-02-09T22-40-05Z

--- a/test/tag_for_hosted.sh
+++ b/test/tag_for_hosted.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -ex
+
 # It's called in ".cloudbuild.yaml" for each commits to master
 # It's used for Hosted deployment testing but also can be reused for other usages.
 #


### PR DESCRIPTION
**Description of your changes:**
Follow up fix of https://github.com/kubeflow/pipelines/pull/5278.
It broke gcp marketplace postsubmit test.
It's likely the lost+found argument that's the root cause, but I think it's nice keeping both manifests in sync anyway.
EDIT: that was wrong, root cause in https://github.com/kubeflow/pipelines/pull/5301#issuecomment-799358066

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
