### PR TITLE
chore(v2/cache): cache mutation hook - skip v2 components

### DIFF
--- a/backend/src/cache/server/mutation.go
+++ b/backend/src/cache/server/mutation.go
@@ -285,5 +285,5 @@ func isTFXPod(pod *corev1.Pod) bool {
 }
 
 func isV2Pod(pod *corev1.Pod) bool {
-	return pod.Labels[V2ComponentAnnotationKey] == V2ComponentAnnotationValue
+	return pod.Annotations[V2ComponentAnnotationKey] == V2ComponentAnnotationValue
 }

--- a/backend/src/cache/server/mutation.go
+++ b/backend/src/cache/server/mutation.go
@@ -33,25 +33,25 @@ import (
 )
 
 const (
-	KFPCacheEnabledLabelKey   string = "pipelines.kubeflow.org/cache_enabled"
-	KFPCacheEnabledLabelValue string = "true"
-	KFPCachedLabelKey         string = "pipelines.kubeflow.org/reused_from_cache"
-	KFPCachedLabelValue       string = "true"
-	ArgoWorkflowNodeName      string = "workflows.argoproj.io/node-name"
-	ArgoWorkflowTemplate      string = "workflows.argoproj.io/template"
-	ExecutionKey              string = "pipelines.kubeflow.org/execution_cache_key"
-	CacheIDLabelKey           string = "pipelines.kubeflow.org/cache_id"
-	ArgoWorkflowOutputs       string = "workflows.argoproj.io/outputs"
-	MetadataWrittenKey        string = "pipelines.kubeflow.org/metadata_written"
-	AnnotationPath            string = "/metadata/annotations"
-	LabelPath                 string = "/metadata/labels"
-	SpecContainersPath        string = "/spec/containers"
-	SpecInitContainersPath    string = "/spec/initContainers"
-	TFXPodSuffix              string = "tfx/orchestration/kubeflow/container_entrypoint.py"
-	SdkTypeLabel              string = "pipelines.kubeflow.org/pipeline-sdk-type"
-	TfxSdkTypeLabel           string = "tfx"
-	V2ComponentLabelKey       string = "pipelines.kubeflow.org/v2_component"
-	V2ComponentLabelValue     string = "true"
+	KFPCacheEnabledLabelKey    string = "pipelines.kubeflow.org/cache_enabled"
+	KFPCacheEnabledLabelValue  string = "true"
+	KFPCachedLabelKey          string = "pipelines.kubeflow.org/reused_from_cache"
+	KFPCachedLabelValue        string = "true"
+	ArgoWorkflowNodeName       string = "workflows.argoproj.io/node-name"
+	ArgoWorkflowTemplate       string = "workflows.argoproj.io/template"
+	ExecutionKey               string = "pipelines.kubeflow.org/execution_cache_key"
+	CacheIDLabelKey            string = "pipelines.kubeflow.org/cache_id"
+	ArgoWorkflowOutputs        string = "workflows.argoproj.io/outputs"
+	MetadataWrittenKey         string = "pipelines.kubeflow.org/metadata_written"
+	AnnotationPath             string = "/metadata/annotations"
+	LabelPath                  string = "/metadata/labels"
+	SpecContainersPath         string = "/spec/containers"
+	SpecInitContainersPath     string = "/spec/initContainers"
+	TFXPodSuffix               string = "tfx/orchestration/kubeflow/container_entrypoint.py"
+	SdkTypeLabel               string = "pipelines.kubeflow.org/pipeline-sdk-type"
+	TfxSdkTypeLabel            string = "tfx"
+	V2ComponentAnnotationKey   string = "pipelines.kubeflow.org/v2_component"
+	V2ComponentAnnotationValue string = "true"
 )
 
 var (
@@ -285,5 +285,5 @@ func isTFXPod(pod *corev1.Pod) bool {
 }
 
 func isV2Pod(pod *corev1.Pod) bool {
-	return pod.Labels[V2ComponentLabelKey] == V2ComponentLabelValue
+	return pod.Labels[V2ComponentAnnotationKey] == V2ComponentAnnotationValue
 }

--- a/backend/src/cache/server/mutation.go
+++ b/backend/src/cache/server/mutation.go
@@ -50,6 +50,8 @@ const (
 	TFXPodSuffix              string = "tfx/orchestration/kubeflow/container_entrypoint.py"
 	SdkTypeLabel              string = "pipelines.kubeflow.org/pipeline-sdk-type"
 	TfxSdkTypeLabel           string = "tfx"
+	V2ComponentLabelKey       string = "pipelines.kubeflow.org/v2_component"
+	V2ComponentLabelValue     string = "true"
 )
 
 var (
@@ -89,6 +91,12 @@ func MutatePodIfCached(req *v1beta1.AdmissionRequest, clientMgr ClientManagerInt
 
 	if isTFXPod(&pod) {
 		log.Printf("This pod %s is created by tfx pipelines.", pod.ObjectMeta.Name)
+		return nil, nil
+	}
+
+	if isV2Pod(&pod) {
+		// KFP v2 handles caching by its driver.
+		log.Printf("This pod %s is created by KFP v2 pipelines.", pod.ObjectMeta.Name)
 		return nil, nil
 	}
 
@@ -274,4 +282,8 @@ func isTFXPod(pod *corev1.Pod) bool {
 	}
 	mainContainer := mainContainers[0]
 	return len(mainContainer.Command) != 0 && strings.HasSuffix(mainContainer.Command[len(mainContainer.Command)-1], TFXPodSuffix)
+}
+
+func isV2Pod(pod *corev1.Pod) bool {
+	return pod.Labels[V2ComponentLabelKey] == V2ComponentLabelValue
 }

--- a/backend/src/cache/server/mutation_test.go
+++ b/backend/src/cache/server/mutation_test.go
@@ -47,7 +47,7 @@ var (
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
-				corev1.Container{
+				{
 					Name:    "main",
 					Image:   "test_image",
 					Command: []string{"python"},
@@ -129,6 +129,14 @@ func TestMutatePodIfCachedWithTFXPod2(t *testing.T) {
 	tfxPod := *fakePod.DeepCopy()
 	tfxPod.Labels["pipelines.kubeflow.org/pipeline-sdk-type"] = "tfx"
 	patchOperation, err := MutatePodIfCached(GetFakeRequestFromPod(&tfxPod), fakeClientManager)
+	assert.Nil(t, patchOperation)
+	assert.Nil(t, err)
+}
+
+func TestMutatePodIfCachedWithKfpV2Pod(t *testing.T) {
+	v2Pod := *fakePod.DeepCopy()
+	v2Pod.Labels["pipelines.kubeflow.org/v2_component"] = "true"
+	patchOperation, err := MutatePodIfCached(GetFakeRequestFromPod(&v2Pod), fakeClientManager)
 	assert.Nil(t, patchOperation)
 	assert.Nil(t, err)
 }

--- a/backend/src/cache/server/mutation_test.go
+++ b/backend/src/cache/server/mutation_test.go
@@ -135,7 +135,7 @@ func TestMutatePodIfCachedWithTFXPod2(t *testing.T) {
 
 func TestMutatePodIfCachedWithKfpV2Pod(t *testing.T) {
 	v2Pod := *fakePod.DeepCopy()
-	v2Pod.Labels["pipelines.kubeflow.org/v2_component"] = "true"
+	v2Pod.Annotations["pipelines.kubeflow.org/v2_component"] = "true"
 	patchOperation, err := MutatePodIfCached(GetFakeRequestFromPod(&v2Pod), fakeClientManager)
 	assert.Nil(t, patchOperation)
 	assert.Nil(t, err)


### PR DESCRIPTION
**Description of your changes:**
V2 components handle caching using their own drivers, so we shouldn't run cache mutation webhook on it.

EDIT: you can try this cache-server image by gcr.io/ml-pipeline-test/4eb2828947a9d6a5566341e1001941369eee4225/cache-server@sha256:da9c38e339553bd98a512d6af4550ef56e789a53eecf16f8df2ce5daf5b66e5d

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
