### PR TITLE
feat(deployment): multi-user mode manifests for subject access review integration. Fixes #3513

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/api-service/cluster-role.yaml
+++ b/manifests/kustomize/base/installs/multi-user/api-service/cluster-role.yaml
@@ -4,6 +4,15 @@ metadata:
   name: ml-pipeline
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+  - delete
+- apiGroups:
   - argoproj.io
   resources:
   - workflows
@@ -27,8 +36,8 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - ""
+  - authorization.k8s.io
   resources:
-  - pods
+  - subjectaccessreviews
   verbs:
-  - delete
+  - create

--- a/manifests/kustomize/base/installs/multi-user/kustomization.yaml
+++ b/manifests/kustomize/base/installs/multi-user/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - ../../pipeline/cluster-scoped
 - ../../cache-deployer/cluster-scoped
 - ../generic
+- view-edit-cluster-roles.yaml
 - api-service
 - pipelines-ui
 - pipelines-profile-controller

--- a/manifests/kustomize/base/installs/multi-user/view-edit-cluster-roles.yaml
+++ b/manifests/kustomize/base/installs/multi-user/view-edit-cluster-roles.yaml
@@ -9,11 +9,11 @@ kind: ClusterRole
 metadata:
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
-  name: kubeflow-pipeline-edit
+  name: kubeflow-pipelines-edit
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
-      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipeline-edit: "true"
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipelines-edit: "true"
 rules: []
 
 ---
@@ -22,13 +22,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipeline-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipelines-edit: "true"
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
-  name: kubeflow-pipeline-view
+  name: kubeflow-pipelines-view
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
-      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipeline-view: "true"
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipelines-view: "true"
 rules: []
 
 ---
@@ -37,8 +37,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipeline-edit: "true"
-  name: aggregate-to-pipeline-edit
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipelines-edit: "true"
+  name: aggregate-to-kubeflow-pipelines-edit
 rules:
 - apiGroups:
   - pipelines.kubeflow.org
@@ -85,8 +85,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipeline-view: "true"
-  name: aggregate-to-pipeline-view
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipelines-view: "true"
+  name: aggregate-to-kubeflow-pipelines-view
 rules:
 - apiGroups:
   - pipelines.kubeflow.org

--- a/manifests/kustomize/base/pipeline/multi-user/kustomization.yaml
+++ b/manifests/kustomize/base/pipeline/multi-user/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- view-edit-roles.yaml


### PR DESCRIPTION
Fixes #3513

**Description of your changes:**
Changes:
* rename `kubeflow-pipeline-edit` cluster role to `kubeflow-pipelines-edit` (Kubeflow Pipelines is the official brand)
* move subjectaccessreview related manifests to multi-user install folder, so it's builtin for KFP multi-user mode
* sync ml-pipeline cluster role with permissions needed in ml-pipeline role

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
