### PR TITLE
chore(manifests): Add commonLabels to cache kustomizations

### DIFF
--- a/manifests/kustomize/base/cache-deployer/kustomization.yaml
+++ b/manifests/kustomize/base/cache-deployer/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
   - cache-deployer-role.yaml
   - cache-deployer-rolebinding.yaml
   - cache-deployer-deployment.yaml
+commonLabels:
+  app: cache-deployer
 images:
   - name: gcr.io/ml-pipeline/cache-deployer
     newTag: 1.5.0-rc.0

--- a/manifests/kustomize/base/cache/kustomization.yaml
+++ b/manifests/kustomize/base/cache/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - cache-role.yaml
   - cache-rolebinding.yaml
   - cache-sa.yaml
+commonLabels:
+  app: cache-server
 images:
   - name: gcr.io/ml-pipeline/cache-server
     newTag: 1.5.0-rc.0

--- a/manifests/kustomize/base/installs/multi-user/cache/kustomization.yaml
+++ b/manifests/kustomize/base/installs/multi-user/cache/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  app: cache-server
 resources:
 - cluster-role.yaml
 - cluster-role-binding.yaml


### PR DESCRIPTION
**Description of your changes:**

Add commonLabels to cache kustomizations. This is helpful for consumers who want to quickly get all objects related to the cache components, in order to remove them.

This change does not break backwards compatibility and follows the best practice of labelling all components of an app. @Bobgy what do you think?