### PR TITLE
feat(sdk/client): Add task in kfp.onprem to load k8s secrets as env vars

### DIFF
--- a/sdk/python/kfp/onprem.py
+++ b/sdk/python/kfp/onprem.py
@@ -1,3 +1,5 @@
+from typing import Dict, Text
+
 
 def mount_pvc(pvc_name='pipeline-claim', volume_name='pipeline', volume_mount_path='/mnt/pipeline'):
     """Modifier function to apply to a Container Op to simplify volume, volume mount addition and
@@ -26,3 +28,48 @@ def mount_pvc(pvc_name='pipeline-claim', volume_name='pipeline', volume_mount_pa
                 )
         )
     return _mount_pvc
+
+
+def use_k8s_secret(secret_name: Text = 'k8s-secret', k8s_secret_key_to_env: Dict = {}):
+    """An operator that configures the container to use k8s credentials.
+
+    k8s_secret_key_to_env specifies a mapping from the name of the keys in the k8s secret to the name of the environment
+    variables where the values will be added.
+
+    The secret needs to be deployed manually a priori.
+
+    Example:
+        ::
+
+            train = train_op(...)
+            train.apply(use_k8s_secret(secret_name='s3-secret',
+            k8s_secret_key_to_env={'secret_key': 'AWS_SECRET_ACCESS_KEY'}))
+
+        This will load the value in secret 's3-secret' at key 'secret_key' and source it as the environment variable
+        'AWS_SECRET_ACCESS_KEY'. I.e. it will produce the following section on the pod:
+        env:
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: s3-secret
+              key: secret_key
+    """
+
+    def _use_k8s_secret(task):
+        from kubernetes import client as k8s_client
+        for secret_key, env_var in k8s_secret_key_to_env.items():
+            task.container \
+                .add_env_variable(
+                k8s_client.V1EnvVar(
+                    name=env_var,
+                    value_from=k8s_client.V1EnvVarSource(
+                        secret_key_ref=k8s_client.V1SecretKeySelector(
+                            name=secret_name,
+                            key=secret_key
+                        )
+                    )
+                )
+            )
+        return task
+
+    return _use_k8s_secret


### PR DESCRIPTION
**Description of your changes:**
Add task in kfp.onprem to load k8s secrets as env vars.

This is a utility for on-prem users to be able to load k8s secrets as environment variables in a pipeline. Notably, it can be used for fetching passwords for any kind of backend storage that one wishes to use, e.g. Minio etc.

**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [X] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
