### PR TITLE
chore: Add platform-agnostic-multi-user-pns manifest

### DIFF
--- a/manifests/kustomize/env/platform-agnostic-multi-user-pns/kustomization.yaml
+++ b/manifests/kustomize/env/platform-agnostic-multi-user-pns/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../platform-agnostic-multi-user
+
+patchesStrategicMerge:
+- workflow-controller-configmap-patch.yaml

--- a/manifests/kustomize/env/platform-agnostic-multi-user-pns/workflow-controller-configmap-patch.yaml
+++ b/manifests/kustomize/env/platform-agnostic-multi-user-pns/workflow-controller-configmap-patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workflow-controller-configmap
+data:
+  # References:
+  # * https://github.com/argoproj/argo-workflows/blob/v2.12.9/config/config.go
+  # * https://github.com/argoproj/argo-workflows/blob/v2.12.9/docs/workflow-controller-configmap.md
+  # * https://github.com/argoproj/argo-workflows/blob/v2.12.9/docs/workflow-controller-configmap.yaml
+
+  # pns executor is a more portable default, see https://github.com/kubeflow/pipelines/issues/1654.
+  # However, it is flaky for containers that run really fast, see https://github.com/kubeflow/pipelines/issues/5285.
+  # So we still default to docker for now.
+  containerRuntimeExecutor: pns


### PR DESCRIPTION
**Description of your changes:**
Due to https://github.com/kubeflow/pipelines/pull/5312 reverting back to the docker executor, this PR adds manifests for a multi-user installation using the PNS executor. This will probably be needed for many Kubeflow deployments with the upcoming 1.3 release. 

- [x] Do you want this pull request (PR) cherry-picked into the current release branch?

/cc @Bobgy 