### PR TITLE
chore(components): Update README and reduce output size of KFServing component

### DIFF
--- a/components/kubeflow/kfserving/README.md
+++ b/components/kubeflow/kfserving/README.md
@@ -3,7 +3,7 @@
 This is the Kubeflow Pipelines component for KFServing. This uses the [V1beta1 API](https://github.com/kubeflow/kfserving/blob/master/docs/apis/v1beta1/README.md),
 so your cluster must have a KFServing version >= v0.5.0 in order to use this.
 
-For those still using an older version of KFServing less than v0.5.0, an older version of the KFServing Pipelines component must be used
+If you are using KFServing version prior to v0.5.0, an older deprecated version of the KFServing Pipelines component must be used
 and can be found at [this commit](https://github.com/kubeflow/pipelines/tree/65bed9b6d1d676ef2d541a970d3edc0aee12400d/components/kubeflow/kfserving).
 Sample usage of this component can be found [here](https://github.com/kubeflow/kfserving/blob/master/docs/samples/pipelines/kfs-pipeline-v1alpha2.ipynb).
 
@@ -182,5 +182,4 @@ kfserving_op(
     inferenceservice_yaml=isvc_yaml
 )
 ```
-
 

--- a/components/kubeflow/kfserving/README.md
+++ b/components/kubeflow/kfserving/README.md
@@ -1,6 +1,11 @@
 # KFServing Component
 
-This is the Kubeflow Pipelines component for KFServing. This uses the [V1beta1 API](https://github.com/kubeflow/kfserving/blob/master/docs/apis/v1beta1/README.md).
+This is the Kubeflow Pipelines component for KFServing. This uses the [V1beta1 API](https://github.com/kubeflow/kfserving/blob/master/docs/apis/v1beta1/README.md),
+so your cluster must have a KFServing version >= v0.5.0 in order to use this.
+
+For those still using an older version of KFServing less than v0.5.0, an older version of the KFServing Pipelines component must be used
+and can be found at [this commit](https://github.com/kubeflow/pipelines/tree/65bed9b6d1d676ef2d541a970d3edc0aee12400d/components/kubeflow/kfserving).
+Sample usage of this component can be found [here](https://github.com/kubeflow/kfserving/blob/master/docs/samples/pipelines/kfs-pipeline-v1alpha2.ipynb).
 
 ## Usage
 

--- a/components/kubeflow/kfserving/src/kfservingdeployer.py
+++ b/components/kubeflow/kfserving/src/kfservingdeployer.py
@@ -404,6 +404,13 @@ def main():
             sys.exit(1)
 
     if output_path:
+        try:
+            # Remove some less needed fields to reduce output size.
+            del model_status['metadata']['managedFields']
+            del model_status['status']['conditions']
+        except KeyError:
+            pass
+
         if not os.path.exists(os.path.dirname(output_path)):
             os.makedirs(os.path.dirname(output_path))
         with open(output_path, "w") as report:


### PR DESCRIPTION
The output content should not exceed 4096 bytes, so this removes some unneeded fields from the output JSON.

Container termination messages are limited to 4096 bytes. Messages longer than that are truncated, or in the case of Tekton pipelines, one would get a `Error while handling results: Termination message is above max allowed size 4096, caused by large task result` error message.

The README was also updated to better inform about the needed KFServing version to use the component.

Closes: #5353