### PR TITLE
chore(sdk.v2): fix runtime config wrong parameter type.

### DIFF
--- a/sdk/python/kfp/v2/compiler/compiler.py
+++ b/sdk/python/kfp/v2/compiler/compiler.py
@@ -1050,10 +1050,16 @@ class Compiler(object):
     )
 
     pipeline_parameters = {
-        arg.name: arg.value for arg in args_list_with_defaults
+        param.name: param for param in args_list_with_defaults
     }
     # Update pipeline parameters override if there were any.
-    pipeline_parameters.update(pipeline_parameters_override or {})
+    pipeline_parameters_override = pipeline_parameters_override or {}
+    for k, v in pipeline_parameters_override.items():
+      if k not in pipeline_parameters:
+        raise ValueError('Pipeline parameter {} does not match any known '
+                         'pipeline argument.'.format(k))
+      pipeline_parameters[k].value = v
+
     runtime_config = compiler_utils.build_runtime_config_spec(
         output_directory=pipeline_root, pipeline_parameters=pipeline_parameters)
     pipeline_job = pipeline_spec_pb2.PipelineJob(runtime_config=runtime_config)

--- a/sdk/python/kfp/v2/compiler/compiler_utils_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_utils_test.py
@@ -15,6 +15,7 @@
 
 import unittest
 
+from kfp.dsl import _pipeline_param
 from kfp.v2.compiler import compiler_utils
 from kfp.pipeline_spec import pipeline_spec_pb2
 from google.protobuf import json_format
@@ -26,9 +27,7 @@ class CompilerUtilsTest(unittest.TestCase):
   def assertProtoEquals(self, proto1: message.Message, proto2: message.Message):
     """Asserts the equality between two messages."""
     self.assertDictEqual(
-        json_format.MessageToDict(proto1),
-        json_format.MessageToDict(proto2))
-
+        json_format.MessageToDict(proto1), json_format.MessageToDict(proto2))
 
   def test_build_runtime_config_spec(self):
     expected_dict = {
@@ -36,6 +35,12 @@ class CompilerUtilsTest(unittest.TestCase):
         'parameters': {
             'input1': {
                 'stringValue': 'test'
+            },
+            'input2': {
+                'intValue': 2
+            },
+            'input3': {
+                'stringValue': '[1, 2, 3]'
             }
         }
     }
@@ -43,7 +48,20 @@ class CompilerUtilsTest(unittest.TestCase):
     json_format.ParseDict(expected_dict, expected_spec)
 
     runtime_config = compiler_utils.build_runtime_config_spec(
-        'gs://path', {'input1': 'test', 'input2': None})
+        'gs://path', {
+            'input1':
+                _pipeline_param.PipelineParam(
+                    name='input1', param_type='String', value='test'),
+            'input2':
+                _pipeline_param.PipelineParam(
+                    name='input2', param_type='Integer', value=2),
+            'input3':
+                _pipeline_param.PipelineParam(
+                    name='input3', param_type='List', value=[1,2,3]),
+            'input4':
+                _pipeline_param.PipelineParam(
+                    name='input4', param_type='Double', value=None)
+        })
     self.assertEqual(expected_spec, runtime_config)
 
   def test_validate_pipeline_name(self):
@@ -67,13 +85,11 @@ class CompilerUtilsTest(unittest.TestCase):
     test_v2_container_spec = compiler_utils.PipelineContainerSpec(
         image='my/dummy-image',
         command=['python', '-m', 'my_package.my_entrypoint'],
-        args=['arg1', 'arg2', '--function_name', 'test_func']
-    )
+        args=['arg1', 'arg2', '--function_name', 'test_func'])
     expected_container_spec = compiler_utils.PipelineContainerSpec(
         image='my/dummy-image',
         command=['python', '-m', 'kfp.container.entrypoint'],
-        args=['--executor_input_str','{{$}}', '--function_name', 'test_func']
-    )
+        args=['--executor_input_str', '{{$}}', '--function_name', 'test_func'])
     compiler_utils.refactor_v2_container_spec(test_v2_container_spec)
     self.assertProtoEquals(expected_container_spec, test_v2_container_spec)
 

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_ontology.json
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_ontology.json
@@ -158,7 +158,7 @@
         "stringValue": "gs://test-bucket/pipeline_root"
       },
       "n_epochs": {
-        "stringValue": "200"
+        "intValue": "200"
       }
     },
     "gcsOutputDirectory": "dummy_root"

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_resource_spec.json
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_resource_spec.json
@@ -166,7 +166,7 @@
         "stringValue": "sgd"
       },
       "n_epochs": {
-        "stringValue": "200"
+        "intValue": "200"
       }
     },
     "gcsOutputDirectory": "dummy_root"

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_reused_component.json
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_reused_component.json
@@ -138,10 +138,10 @@
   "runtimeConfig": {
     "parameters": {
       "b": {
-        "stringValue": "5"
+        "intValue": "5"
       },
       "a": {
-        "stringValue": "2"
+        "intValue": "2"
       }
     },
     "gcsOutputDirectory": "dummy_root"

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/two_step_pipeline_with_importer.json
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/two_step_pipeline_with_importer.json
@@ -209,7 +209,7 @@
   "runtimeConfig": {
     "parameters": {
       "epochs": {
-        "stringValue": "200"
+        "intValue": "200"
       },
       "optimizer": {
         "stringValue": "sgd"


### PR DESCRIPTION
**Description of your changes:**
Get runtime config value type from `PipelineParam.param_type` instead of from `type(PipelineParam.value)`. Because `PipelineParam.value` supports string type only.
https://github.com/kubeflow/pipelines/blob/2fc1016cd23a8ae607069478b6b48024bb1149bd/sdk/python/kfp/dsl/_pipeline_param.py#L153-L154

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
