### PR TITLE
test: clarify a caveat when running v2 sample test locally

### DIFF
--- a/v2/test/Makefile
+++ b/v2/test/Makefile
@@ -35,6 +35,11 @@ context:
 # matter your working dir is dirty or not. It always packages current content
 # into the tarball.
 # Reference: https://stackoverflow.com/a/23486703/8745218
+#
+# Note, there's one caveat, for any files not tracked by git, they will not be uploaded.
+# So recommend doing a `git add -A` before running this if you added new files. However,
+# it's OK to have dirty files, the dirty version in your workdir will be uploaded
+# as expected.
 	cd $(REPO_ROOT); \
 	stash=$$(git stash create); \
 	git archive --format=tar "$${stash:-HEAD}" | gzip >v2/test/tmp/context.tar.gz

--- a/v2/test/README.md
+++ b/v2/test/README.md
@@ -19,7 +19,7 @@ Currently, it's not possible to grant KFP UI only permission, but we can grant
 such access to [Kubeflow ci-viewer google group](https://github.com/kubeflow/internal-acls/blob/master/google_groups/groups/ci-viewer.yaml).
 Contact @Bobgy if you have such a need.
 
-## How to run sample test in your own KFP?
+## How to run the entire sample test suite in your own KFP?
 
 You need to create an `.env` file in this folder and add the following config to
 it:
@@ -42,6 +42,22 @@ Run sample test by:
 
 ```bash
 make sample-test
+```
+
+Note, there's one caveat, for any files not tracked by git, they will not be uploaded.
+So recommend doing a `git add -A` before running this if you added new files. However,
+it's OK to have dirty files, the dirty version in your workdir will be uploaded
+as expected.
+
+For why the caveat exists, refer to context rule in [Makefile](./Makefile).
+
+## How to develop one single sample?
+
+```bash
+cd ${REPO_ROOT}
+python -m v2.test.samples.<your_test_name> --host <your-KFP-host> --output_directory gs://your-bucket/path/to/output/dir
+# or to see all available command line arguments
+python -m v2.test.samples.<your_test_name> --help
 ```
 
 ## How to add a sample to this test infra?


### PR DESCRIPTION
**Description of your changes:**
Document a caveat I found when experimenting

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
