### PR TITLE
fix(sdk): Fix serialization of ExecutorInput.

### DIFF
--- a/sdk/python/kfp/components/_yaml_utils.py
+++ b/sdk/python/kfp/components/_yaml_utils.py
@@ -37,16 +37,6 @@ def dump_yaml(data):
         class OrderedDumper(Dumper):
             pass
         def _dict_representer(dumper, data):
-            # Special-case executorInput and outputMetadata to make the output
-            # YAML prettier.
-            if data == {'executorInput': None}:
-                return dumper.represent_scalar(
-                    value='{executorInput}',
-                    tag=yaml.resolver.BaseResolver.DEFAULT_SCALAR_TAG)
-            if data == {'outputMetadata': None}:
-                return dumper.represent_scalar(
-                    value='{outputMetadata}',
-                    tag=yaml.resolver.BaseResolver.DEFAULT_SCALAR_TAG)
             return dumper.represent_mapping(
                 yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
                 data.items())

--- a/sdk/python/kfp/containers_tests/testdata/expected_component.yaml
+++ b/sdk/python/kfp/containers_tests/testdata/expected_component.yaml
@@ -11,5 +11,10 @@ implementation:
   container:
     image: gcr.io/my-project/my-image:123456
     command: [python, -m, kfp.containers.entrypoint]
-    args: [--executor_input_str, '{executorInput}', --function_name, test_function,
-      --output_metadata_path, '{outputMetadata}']
+    args:
+    - --executor_input_str
+    - {executorInput: null}
+    - --function_name
+    - test_function
+    - --output_metadata_path
+    - {outputMetadata: null}


### PR DESCRIPTION
The special-casing resulted in component.yaml not being able to load
correctly. Now, both `{executorInput}` and `{executorInput: null}` work.
The latter is what is generated when saving components that have this
placeholder.

**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?
