### PR TITLE
metadata-writer: Fix multi-user mode

### DIFF
--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -137,13 +137,21 @@ pods_with_written_metadata = set()
 
 while True:
     print("Start watching Kubernetes Pods created by Argo")
-    for event in k8s_watch.stream(
+    pod_stream = k8s_watch.stream(
         k8s_api.list_namespaced_pod,
         namespace=namespace_to_watch,
         label_selector=ARGO_WORKFLOW_LABEL_KEY,
         timeout_seconds=1800,  # Sometimes watch gets stuck
         _request_timeout=2000,  # Sometimes HTTP GET gets stuck
-    ):
+    )
+    if not namespace_to_watch:
+        pod_stream = k8s_watch.stream(
+            k8s_api.list_pod_for_all_namespaces,
+            label_selector=ARGO_WORKFLOW_LABEL_KEY,
+            timeout_seconds=1800,  # Sometimes watch gets stuck
+            _request_timeout=2000,  # Sometimes HTTP GET gets stuck
+        )
+    for event in pod_stream:
         try:
             obj = event['object']
             print('Kubernetes Pod event: ', event['type'], obj.metadata.name, obj.metadata.resource_version)
@@ -313,7 +321,7 @@ while True:
                         if art_name.startswith(output_prefix):
                             art_name = art_name[len(output_prefix):]
                         argo_output_artifacts[art_name] = artifact
-                    
+
                     output_artifacts = []
                     for name, art in argo_output_artifacts.items():
                         artifact_uri = argo_artifact_to_uri(art)
@@ -354,7 +362,7 @@ while True:
                         METADATA_OUTPUT_ARTIFACT_IDS_ANNOTATION_KEY: json.dumps(artifact_ids),
                     },
                 }
-                
+
                 patch_pod_metadata(
                     namespace=obj.metadata.namespace,
                     pod_name=obj.metadata.name,

--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -137,14 +137,15 @@ pods_with_written_metadata = set()
 
 while True:
     print("Start watching Kubernetes Pods created by Argo")
-    pod_stream = k8s_watch.stream(
-        k8s_api.list_namespaced_pod,
-        namespace=namespace_to_watch,
-        label_selector=ARGO_WORKFLOW_LABEL_KEY,
-        timeout_seconds=1800,  # Sometimes watch gets stuck
-        _request_timeout=2000,  # Sometimes HTTP GET gets stuck
-    )
-    if not namespace_to_watch:
+    if namespace_to_watch:
+        pod_stream = k8s_watch.stream(
+            k8s_api.list_namespaced_pod,
+            namespace=namespace_to_watch,
+            label_selector=ARGO_WORKFLOW_LABEL_KEY,
+            timeout_seconds=1800,  # Sometimes watch gets stuck
+            _request_timeout=2000,  # Sometimes HTTP GET gets stuck
+        )
+    else:
         pod_stream = k8s_watch.stream(
             k8s_api.list_pod_for_all_namespaces,
             label_selector=ARGO_WORKFLOW_LABEL_KEY,


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/5413

The metadata-writer should use a different function to watch Pods, if
the namespace is empty, i.e, if it wants to watch Pods in all
namespaces.

/cc @Bobgy 