### PR TITLE
feat(deployment): Allow traffic to the API-Server if the identity header is not set

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/istio-authorization-config.yaml
+++ b/manifests/kustomize/base/installs/multi-user/istio-authorization-config.yaml
@@ -32,6 +32,10 @@ spec:
         - cluster.local/ns/kubeflow/sa/ml-pipeline-scheduledworkflow
         - cluster.local/ns/kubeflow/sa/ml-pipeline-viewer-crd-service-account
         - cluster.local/ns/kubeflow/sa/kubeflow-pipelines-cache
+  # For user workloads, which cannot user http headers for authentication
+  - when:
+    - key: request.headers[kubeflow-userid]
+      notValues: ['*']
 ---
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy


### PR DESCRIPTION
Add a rule that allows traffic to the Pipelines API-Server, when the `kubeflow-userid` header is not set.
This way, users can utilize ServiceAccountToken authentication to authenticate from their Notebooks / Pipelines, or other workloads.

