### PR TITLE
feat(sdk.v2): use consistent argument name in v2 compiler

### DIFF
--- a/sdk/python/kfp/v2/compiler/compiler.py
+++ b/sdk/python/kfp/v2/compiler/compiler.py
@@ -1082,7 +1082,7 @@ class Compiler(object):
 
   def compile(self,
               pipeline_func: Callable[..., Any],
-              output_path: str,
+              package_path: str,
               pipeline_root: Optional[str] = None,
               pipeline_name: Optional[str] = None,
               pipeline_parameters: Optional[Mapping[str, Any]] = None,
@@ -1091,7 +1091,7 @@ class Compiler(object):
 
     Args:
       pipeline_func: Pipeline function with @dsl.pipeline decorator.
-      output_path: The output pipeline job .json file path. for example,
+      package_path: The output pipeline job .json file path. for example,
         "~/pipeline_job.json"
       pipeline_root: The root of the pipeline outputs. Optional. The
         pipeline_root value can be specified either from this `compile()` method
@@ -1109,7 +1109,7 @@ class Compiler(object):
           pipeline_root=pipeline_root,
           pipeline_name=pipeline_name,
           pipeline_parameters_override=pipeline_parameters)
-      self._write_pipeline(pipeline_job, output_path)
+      self._write_pipeline(pipeline_job, package_path)
     finally:
       kfp.TYPE_CHECK = type_check_old_value
 

--- a/sdk/python/kfp/v2/compiler/compiler_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_test.py
@@ -69,7 +69,7 @@ class CompilerTest(unittest.TestCase):
       compiler.Compiler().compile(
           pipeline_func=simple_pipeline,
           pipeline_root='dummy_root',
-          output_path=target_json_file)
+          package_path=target_json_file)
 
       self.assertTrue(os.path.exists(target_json_file))
     finally:
@@ -118,7 +118,7 @@ class CompilerTest(unittest.TestCase):
       compiler.Compiler().compile(
           pipeline_func=download_and_print,
           pipeline_root='dummy_root',
-          output_path='output.json')
+          package_path='output.json')
 
   def test_compile_pipeline_with_dsl_graph_component_should_raise_error(self):
 
@@ -151,7 +151,7 @@ class CompilerTest(unittest.TestCase):
       compiler.Compiler().compile(
           pipeline_func=opsgroups_pipeline,
           pipeline_root='dummy_root',
-          output_path='output.json')
+          package_path='output.json')
 
   def test_compile_pipeline_with_misused_inputvalue_should_raise_error(self):
 
@@ -175,7 +175,7 @@ class CompilerTest(unittest.TestCase):
       compiler.Compiler().compile(
           pipeline_func=my_pipeline,
           pipeline_root='dummy',
-          output_path='output.json')
+          package_path='output.json')
 
   def test_compile_pipeline_with_misused_inputpath_should_raise_error(self):
 
@@ -199,7 +199,7 @@ class CompilerTest(unittest.TestCase):
       compiler.Compiler().compile(
           pipeline_func=my_pipeline,
           pipeline_root='dummy',
-          output_path='output.json')
+          package_path='output.json')
 
   def test_compile_pipeline_with_misused_inputuri_should_raise_error(self):
 
@@ -222,7 +222,7 @@ class CompilerTest(unittest.TestCase):
       compiler.Compiler().compile(
           pipeline_func=my_pipeline,
           pipeline_root='dummy',
-          output_path='output.json')
+          package_path='output.json')
 
   def test_compile_pipeline_with_misused_outputuri_should_raise_error(self):
 
@@ -246,7 +246,7 @@ class CompilerTest(unittest.TestCase):
       compiler.Compiler().compile(
           pipeline_func=my_pipeline,
           pipeline_root='dummy',
-          output_path='output.json')
+          package_path='output.json')
 
   def test_compile_pipeline_with_invalid_name_should_raise_error(self):
 
@@ -260,7 +260,7 @@ class CompilerTest(unittest.TestCase):
       compiler.Compiler().compile(
           pipeline_func=my_pipeline,
           pipeline_root='dummy',
-          output_path='output.json')
+          package_path='output.json')
 
   def test_compile_pipeline_with_importer_on_inputpath_should_raise_error(self):
 
@@ -287,7 +287,7 @@ class CompilerTest(unittest.TestCase):
       compiler.Compiler().compile(
           pipeline_func=my_pipeline,
           pipeline_root='dummy',
-          output_path='output.json')
+          package_path='output.json')
 
     # Python function based component authoring
     def my_component(datasets: components.InputPath('Datasets')):
@@ -306,7 +306,7 @@ class CompilerTest(unittest.TestCase):
       compiler.Compiler().compile(
           pipeline_func=my_pipeline,
           pipeline_root='dummy',
-          output_path='output.json')
+          package_path='output.json')
 
   def test_set_pipeline_root_through_pipeline_decorator(self):
 
@@ -319,7 +319,7 @@ class CompilerTest(unittest.TestCase):
 
       target_json_file = os.path.join(tmpdir, 'result.json')
       compiler.Compiler().compile(
-          pipeline_func=my_pipeline, output_path=target_json_file)
+          pipeline_func=my_pipeline, package_path=target_json_file)
 
       self.assertTrue(os.path.exists(target_json_file))
       with open(target_json_file) as f:
@@ -342,7 +342,7 @@ class CompilerTest(unittest.TestCase):
       compiler.Compiler().compile(
           pipeline_func=my_pipeline,
           pipeline_root='gs://path-override',
-          output_path=target_json_file)
+          package_path=target_json_file)
 
       self.assertTrue(os.path.exists(target_json_file))
       with open(target_json_file) as f:
@@ -364,7 +364,7 @@ class CompilerTest(unittest.TestCase):
       target_json_file = os.path.join(tmpdir, 'result.json')
       with self.assertWarnsRegex(UserWarning, 'pipeline_root is None or empty'):
         compiler.Compiler().compile(
-            pipeline_func=my_pipeline, output_path=target_json_file)
+            pipeline_func=my_pipeline, package_path=target_json_file)
 
       self.assertTrue(os.path.exists(target_json_file))
       with open(target_json_file) as f:

--- a/sdk/python/kfp/v2/compiler/main.py
+++ b/sdk/python/kfp/v2/compiler/main.py
@@ -60,7 +60,7 @@ def parse_arguments() -> argparse.Namespace:
 def _compile_pipeline_function(pipeline_funcs: List[Callable],
                                function_name: Optional[str], pipeline_root: str,
                                pipeline_parameters: Optional[Mapping[str, Any]],
-                               output_path: str, type_check: bool) -> None:
+                               package_path: str, type_check: bool) -> None:
   """Compiles a pipeline function.
 
   Args:
@@ -69,7 +69,7 @@ def _compile_pipeline_function(pipeline_funcs: List[Callable],
       multiple.
     pipeline_root: The root output directory for pipeline runtime.
     pipeline_parameters: The pipeline parameters as a dict of {name: value}.
-    output_path: The output path of the compiled result.
+    package_path: The output path of the compiled result.
     type_check: Whether to enable the type checking.
   """
   if len(pipeline_funcs) == 0:
@@ -96,7 +96,7 @@ def _compile_pipeline_function(pipeline_funcs: List[Callable],
       pipeline_func=pipeline_func,
       pipeline_root=pipeline_root,
       pipeline_parameters=pipeline_parameters,
-      output_path=output_path,
+      package_path=package_path,
       type_check=type_check)
 
 
@@ -120,7 +120,7 @@ class PipelineCollectorContext():
 def compile_pyfile(pyfile: str, function_name: Optional[str],
                    pipeline_root: str,
                    pipeline_parameters: Optional[Mapping[str, Any]],
-                   output_path: str, type_check: bool) -> None:
+                   package_path: str, type_check: bool) -> None:
   """Compiles a pipeline written in a .py file.
 
   Args:
@@ -128,7 +128,7 @@ def compile_pyfile(pyfile: str, function_name: Optional[str],
     function_name: The name of the pipeline function.
     pipeline_root: The root output directory for pipeline runtime.
     pipeline_parameters: The pipeline parameters as a dict of {name: value}.
-    output_path: The output path of the compiled result.
+    package_path: The output path of the compiled result.
     type_check: Whether to enable the type checking.
   """
   sys.path.insert(0, os.path.dirname(pyfile))
@@ -141,7 +141,7 @@ def compile_pyfile(pyfile: str, function_name: Optional[str],
         function_name=function_name,
         pipeline_root=pipeline_root,
         pipeline_parameters=pipeline_parameters,
-        output_path=output_path,
+        package_path=package_path,
         type_check=type_check)
   finally:
     del sys.path[0]
@@ -156,6 +156,6 @@ def main():
       function_name=args.function,
       pipeline_root=args.pipeline_root,
       pipeline_parameters=args.pipeline_parameters,
-      output_path=args.output,
+      package_path=args.output,
       type_check=not args.disable_type_check,
   )

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/lightweight_python_functions_v2_pipeline.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/lightweight_python_functions_v2_pipeline.py
@@ -98,4 +98,4 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=pipeline,
       pipeline_root='dummy_root',
-      output_path=__file__ + '.json')
+      package_path=__file__ + '.json')

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/lightweight_python_functions_v2_with_outputs.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/lightweight_python_functions_v2_with_outputs.py
@@ -79,4 +79,4 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=pipeline,
       pipeline_root='dummy_root',
-      output_path=__file__ + '.json')
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_after.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_after.py
@@ -44,4 +44,4 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=my_pipeline,
       pipeline_root='dummy_root',
-      output_path=__file__ + '.json')
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_concat_placeholder.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_concat_placeholder.py
@@ -32,4 +32,4 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=my_pipeline,
       pipeline_root='dummy_root',
-      output_path=__file__ + '.json')
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_condition.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_condition.py
@@ -47,5 +47,4 @@ def my_pipeline(text: str = 'condition test'):
 if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=my_pipeline,
-      pipeline_root='dummy_root',
-      output_path=__file__.replace('.py', '.json'))
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_if_placeholder.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_if_placeholder.py
@@ -33,4 +33,4 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=my_pipeline,
       pipeline_root='dummy_root',
-      output_path=__file__ + '.json')
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_loop_output.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_loop_output.py
@@ -39,4 +39,4 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=my_pipeline,
       pipeline_root='dummy_root',
-      output_path=__file__.replace('.py', '.json'))
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_loop_parameter.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_loop_parameter.py
@@ -34,4 +34,4 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=my_pipeline,
       pipeline_root='dummy_root',
-      output_path=__file__.replace('.py', '.json'))
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_loop_static.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_loop_static.py
@@ -35,4 +35,4 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=my_pipeline,
       pipeline_root='dummy_root',
-      output_path=__file__.replace('.py', '.json'))
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_nested_conditions.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_nested_conditions.py
@@ -53,4 +53,4 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=my_pipeline,
       pipeline_root='dummy_root',
-      output_path=__file__.replace('.py', '.json'))
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_nested_conditions_yaml.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_nested_conditions_yaml.py
@@ -89,4 +89,4 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=my_pipeline,
       pipeline_root='dummy_root',
-      output_path=__file__.replace('.py', '.json'))
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_ontology.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_ontology.py
@@ -43,4 +43,4 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=my_pipeline,
       pipeline_root='dummy_root',
-      output_path=__file__ + '.json')
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_params_containing_format.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_params_containing_format.py
@@ -33,4 +33,4 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=my_pipeline,
       pipeline_root='dummy_root',
-      output_path=__file__.replace('.py', '.json'))
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_resource_spec.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_resource_spec.py
@@ -46,5 +46,4 @@ def my_pipeline(input_location: str = 'gs://test-bucket/pipeline_root',
 if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=my_pipeline,
-      pipeline_root='dummy_root',
-      output_path=__file__ + '.json')
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_reused_component.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_reused_component.py
@@ -37,4 +37,4 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=my_pipeline,
       pipeline_root='dummy_root',
-      output_path=__file__ + '.json')
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_various_io_types.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_various_io_types.py
@@ -93,4 +93,4 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=my_pipeline,
       pipeline_root='dummy_root',
-      output_path=__file__ + '.json')
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/simple_pipeline_without_importer.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/simple_pipeline_without_importer.py
@@ -66,4 +66,4 @@ if __name__ == '__main__':
       pipeline_func=my_pipeline,
       pipeline_root='dummy_root',
       pipeline_parameters={'text': 'Hello KFP!'},
-      output_path=__file__.replace('.py' ,'.json'))
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/two_step_pipeline_with_importer.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/two_step_pipeline_with_importer.py
@@ -42,4 +42,4 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=my_pipeline,
       pipeline_root='dummy_root',
-      output_path=__file__ + '.json')
+      package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/xgboost_sample_pipeline.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/xgboost_sample_pipeline.py
@@ -93,4 +93,4 @@ if __name__ == '__main__':
   compiler.Compiler().compile(
       pipeline_func=xgboost_pipeline,
       pipeline_root='dummy_root',
-      output_path=__file__.replace('.py', '.json'))
+      package_path=__file__.replace('.py', '.json'))


### PR DESCRIPTION
**Description of your changes:**
Use `package_path` instead of `output_path` in v2 compiler interface for consistency with v1 compiler.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
