### PR TITLE
test: v2 sample test supports multiple test cases & internal endpoint

### DIFF
--- a/samples/test/fail_test.py
+++ b/samples/test/fail_test.py
@@ -14,7 +14,7 @@
 """Fail pipeline."""
 
 from .fail import fail_pipeline
-from .util import run_pipeline_func
+from .util import run_pipeline_func, TestCase
 
 
 def verify(run, run_id: str):
@@ -22,4 +22,4 @@ def verify(run, run_id: str):
     # TODO(Bobgy): verify MLMD status
 
 
-run_pipeline_func(pipeline_func=fail_pipeline, verify_func=verify)
+run_pipeline_func([TestCase(pipeline_func=fail_pipeline, verify_func=verify)])

--- a/samples/test/two_step_test.py
+++ b/samples/test/two_step_test.py
@@ -14,7 +14,7 @@
 """Two step v2-compatible pipeline."""
 
 from .two_step import two_step_pipeline
-from .util import run_pipeline_func
+from .util import run_pipeline_func, TestCase
 
 
 def verify(run, run_id: str):
@@ -22,4 +22,4 @@ def verify(run, run_id: str):
     # TODO(Bobgy): verify MLMD status
 
 
-run_pipeline_func(pipeline_func=two_step_pipeline, verify_func=verify)
+run_pipeline_func([TestCase(pipeline_func=pipeline, verify_func=verify)])

--- a/samples/test/two_step_test.py
+++ b/samples/test/two_step_test.py
@@ -22,4 +22,6 @@ def verify(run, run_id: str):
     # TODO(Bobgy): verify MLMD status
 
 
-run_pipeline_func([TestCase(pipeline_func=pipeline, verify_func=verify)])
+run_pipeline_func([
+    TestCase(pipeline_func=two_step_pipeline, verify_func=verify)
+])

--- a/samples/test/util.py
+++ b/samples/test/util.py
@@ -1,55 +1,106 @@
 import kfp
+import os
+from typing import Dict, List, Callable
+from dataclasses import dataclass
 
 MINUTE = 60
 
 
-def default_verify_func(run_id, run):
+def _default_verify_func(run_id, run):
     assert run.status == 'Succeeded'
 
 
-def run_pipeline_func(
-    pipeline_func,
-    verify_func=default_verify_func,
-    mode=kfp.dsl.PipelineExecutionMode.V2_COMPATIBLE
-):
+@dataclass
+class TestCase:
+    '''Test case for running a KFP sample'''
+    pipeline_func: Callable
+    mode: kfp.dsl.PipelineExecutionMode = kfp.dsl.PipelineExecutionMode.V2_COMPATIBLE
+    arguments: Dict[str, str] = None
+    verify_func: Callable = _default_verify_func
+
+
+def run_pipeline_func(test_cases: List[TestCase]):
     """Run a pipeline function and wait for its result.
 
     :param pipeline_func: pipeline function to run
     :type pipeline_func: function
     """
 
+    def test_wrapper(run_pipeline):
+        for case in test_cases:
+            result = run_pipeline(
+                pipeline_func=case.pipeline_func,
+                mode=case.mode,
+                arguments=case.arguments or {}
+            )
+            case.verify_func(run=result, run_id=result.id)
+
+    _run_test(test_wrapper)
+
+
+def _run_test(callback):
+
     def main(
-        output_directory: str,  # example gs://your-bucket/path/to/workdir
-        host: str = 'http://ml-pipeline:8888',
+        output_directory: str = None,  # example
+        host: str = None,
+        external_host: str = None,
         launcher_image: 'URI' = None,
         experiment: str = 'v2_sample_test_samples',
     ):
         """Test file CLI entrypoint used by Fire.
 
-        :param output_directory: pipeline output directory that holds intermediate artifacts.
-        :type output_directory: str
+        :param host: Hostname pipelines can access, defaults to 'http://ml-pipeline:8888'.
+        :type host: str, optional
+        :param external_host: External hostname users can access from their browsers.
+        :type external_host: str, optional
+        :param output_directory: pipeline output directory that holds intermediate
+        artifacts, example gs://your-bucket/path/to/workdir.
+        :type output_directory: str, optional
         :param launcher_image: override launcher image, only used in V2_COMPATIBLE mode
         :type launcher_image: URI, optional
         :param experiment: experiment the run is added to, defaults to 'v2_sample_test_samples'
         :type experiment: str, optional
         """
+
+        # Default to env values, so people can set up their env and run these
+        # tests without specifying any commands.
+        if host is None:
+            host = os.getenv('KFP_HOST', 'http://ml-pipeline:8888')
+        if external_host is None:
+            external_host = host
+        if output_directory is None:
+            output_directory = os.getenv('KFP_OUTPUT_DIRECTORY')
+
         client = kfp.Client(host=host)
-        run_result = client.create_run_from_pipeline_func(
+
+        def run_pipeline(
             pipeline_func,
-            mode=mode,
-            arguments={kfp.dsl.ROOT_PARAMETER_NAME: output_directory},
-            launcher_image=launcher_image,
-            experiment_name=experiment,
-        )
-        print("Run details page URL:")
-        print(f"{host}/#/runs/details/{run_result.run_id}")
-        run_response = run_result.wait_for_run_completion(10 * MINUTE)
-        run = run_response.run
-        from pprint import pprint
-        pprint(run_response.run)
-        print("Run details page URL:")
-        print(f"{host}/#/runs/details/{run_result.run_id}")
-        verify_func(run_id=run_result.run_id, run=run)
+            mode: str = kfp.dsl.PipelineExecutionMode.V2_COMPATIBLE,
+            arguments: dict = {},
+        ):
+            run_result = client.create_run_from_pipeline_func(
+                pipeline_func,
+                mode=mode,
+                arguments={
+                    kfp.dsl.ROOT_PARAMETER_NAME: output_directory,
+                    **arguments
+                },
+                launcher_image=launcher_image,
+                experiment_name=experiment,
+            )
+            print("Run details page URL:")
+            print(f"{external_host}/#/runs/details/{run_result.run_id}")
+            run_response = run_result.wait_for_run_completion(10 * MINUTE)
+            run = run_response.run
+            from pprint import pprint
+            # Hide detailed information
+            run.pipeline_spec.workflow_manifest = None
+            pprint(run)
+            print("Run details page URL:")
+            print(f"{external_host}/#/runs/details/{run_result.run_id}")
+            return run
+
+        callback(run_pipeline=run_pipeline)
 
     import fire
     fire.Fire(main)

--- a/samples/test/util.py
+++ b/samples/test/util.py
@@ -96,8 +96,6 @@ def _run_test(callback):
             # Hide detailed information
             run.pipeline_spec.workflow_manifest = None
             pprint(run)
-            print("Run details page URL:")
-            print(f"{external_host}/#/runs/details/{run_result.run_id}")
             return run
 
         callback(run_pipeline=run_pipeline)

--- a/samples/test/util.py
+++ b/samples/test/util.py
@@ -1,6 +1,6 @@
 import kfp
 import os
-from typing import Dict, List, Callable
+from typing import Dict, List, Callable, Optional
 from dataclasses import dataclass
 
 MINUTE = 60
@@ -15,7 +15,7 @@ class TestCase:
     '''Test case for running a KFP sample'''
     pipeline_func: Callable
     mode: kfp.dsl.PipelineExecutionMode = kfp.dsl.PipelineExecutionMode.V2_COMPATIBLE
-    arguments: Dict[str, str] = None
+    arguments: Optional[Dict[str, str]] = None
     verify_func: Callable = _default_verify_func
 
 
@@ -41,10 +41,10 @@ def run_pipeline_func(test_cases: List[TestCase]):
 def _run_test(callback):
 
     def main(
-        output_directory: str = None,  # example
-        host: str = None,
-        external_host: str = None,
-        launcher_image: 'URI' = None,
+        output_directory: Optional[str] = None,  # example
+        host: Optional[str] = None,
+        external_host: Optional[str] = None,
+        launcher_image: Optional['URI'] = None,
         experiment: str = 'v2_sample_test_samples',
     ):
         """Test file CLI entrypoint used by Fire.
@@ -74,8 +74,9 @@ def _run_test(callback):
         client = kfp.Client(host=host)
 
         def run_pipeline(
-            pipeline_func,
-            mode: str = kfp.dsl.PipelineExecutionMode.V2_COMPATIBLE,
+            pipeline_func: Callable,
+            mode: kfp.dsl.PipelineExecutionMode = kfp.dsl.PipelineExecutionMode.
+            V2_COMPATIBLE,
             arguments: dict = {},
         ):
             run_result = client.create_run_from_pipeline_func(

--- a/v2/test/Dockerfile
+++ b/v2/test/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.7-alpine
+FROM python:3.7-slim
 
 WORKDIR /workdir
 COPY . /workdir

--- a/v2/test/components/run_sample.yaml
+++ b/v2/test/components/run_sample.yaml
@@ -12,33 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Run KFP Sample
+name: Run KFP Test Sample
 inputs:
 - {name: Name, type: String}
 - {name: Sample Path, type: Path}
 - {name: GCS Root, type: URI}
 - {name: Host, type: URI, default: "http://ml-pipeline:8888"}
+- {name: External Host, type: URI}
 - {name: Launcher Image, type: URI, default: "gcr.io/ml-pipeline/kfp-launcher:latest"}
 implementation:
   container:
     image: python:3.7-alpine
     command:
-    - sh
-    - -exc
-    - |
-        sample_path="$0"
-        name="$1"
-        root="$2"
-        host="$3"
-        launcher_image="$4"
-
-        python3 -m "$sample_path" \
-          --output_directory "$root/$name" \
-          --host "$host" \
-          --launcher_image "$launcher_image"
-
+    - python3
+    - -m
     - inputValue: Sample Path
-    - inputValue: Name
-    - inputValue: GCS Root
+    - --output_directory
+    - concat: [{inputValue: GCS Root}, '/', {inputValue: Name}]
+    - --host
     - inputValue: Host
+    - --external_host
+    - inputValue: External Host
+    - --launcher_image
     - inputValue: Launcher Image

--- a/v2/test/sample_test.py
+++ b/v2/test/sample_test.py
@@ -69,7 +69,7 @@ def v2_sample_test(
             name=sample.name,
             sample_path=sample.path,
             gcs_root=gcs_root,
-            host=kfp_host,
+            external_host=kfp_host,
             launcher_image=build_kfp_launcher_op.outputs['digest']
         )
         run_sample_op.container.image = build_samples_image_op.outputs['digest']


### PR DESCRIPTION
**Description of your changes:**
Changes:
* v2 sample test supports multiple test cases -- many samples need more than one set of tests, either testing both v1 and v2 compatible versions, or testing multiple set of arguments, as shown in https://github.com/kubeflow/pipelines/pull/5431
* use internal endpoint for accessing KFP API server -- so that when errors happen, we can see the detailed error log (we preserve URLs as external links by passing in an extra parameter called external_host)

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
