### PR TITLE
fix(compilerV2): Fixed pipeline parameter types and constant arguments

### DIFF
--- a/sdk/python/kfp/dsl/_component_bridge.py
+++ b/sdk/python/kfp/dsl/_component_bridge.py
@@ -330,6 +330,9 @@ def _attach_v2_specs(
       is_compiling_for_v2 = True
       break
 
+  # Make a copy of the spec, since some hacks change it
+  component_spec = copy.deepcopy(component_spec)
+
   def _resolve_commands_and_args_v2(
       component_spec: _structures.ComponentSpec,
       arguments: Mapping[str, Any],
@@ -343,7 +346,6 @@ def _attach_v2_specs(
     Returns:
       A named tuple: _components._ResolvedCommandLineAndPaths.
     """
-    component_spec = copy.deepcopy(component_spec)
     inputs_dict = {
         input_spec.name: input_spec
         for input_spec in component_spec.inputs or []

--- a/sdk/python/kfp/dsl/_component_bridge.py
+++ b/sdk/python/kfp/dsl/_component_bridge.py
@@ -541,10 +541,9 @@ def _attach_v2_specs(
       # Converting inputs that have constant arguments to parameter inputs.
       if not type_utils.is_parameter_type(input_type):
         component_spec._inputs_dict[input_name].type = 'String'
-      if type_utils.is_parameter_type(input_type):
-        pipeline_task_spec.inputs.parameters[
-            input_name].runtime_value.constant_value.string_value = (
-                argument_value)
+      pipeline_task_spec.inputs.parameters[
+          input_name].runtime_value.constant_value.string_value = (
+              argument_value)
     elif isinstance(argument_value, int):
       # In IR, constant arguments can only be passed to parameter inputs.
       # Converting inputs that have constant arguments to parameter inputs.

--- a/sdk/python/kfp/dsl/_component_bridge.py
+++ b/sdk/python/kfp/dsl/_component_bridge.py
@@ -465,8 +465,8 @@ def _attach_v2_specs(
           if isinstance(param, _pipeline_param.PipelineParam)
       ]))
   for input_name, argument_value in arguments.items():
+    input_type = component_spec._inputs_dict[input_name].type
     if isinstance(argument_value, _pipeline_param.PipelineParam):
-      input_type = component_spec._inputs_dict[input_name].type
       reference_type = argument_value.param_type
       types.verify_type_compatibility(
           reference_type, input_type,
@@ -535,7 +535,6 @@ def _attach_v2_specs(
             pipeline_task_spec.inputs.parameters[
                 additional_input_name].component_input_parameter = param.full_name
 
-      input_type = component_spec._inputs_dict[input_name].type
       # In IR, constant arguments can only be passed to parameter inputs.
       # Converting inputs that have constant arguments to parameter inputs.
       if not type_utils.is_parameter_type(input_type):

--- a/sdk/python/kfp/dsl/_component_bridge.py
+++ b/sdk/python/kfp/dsl/_component_bridge.py
@@ -498,7 +498,7 @@ def _attach_v2_specs(
                   argument_value.name)
         else:
           # Argument is a reference to a pipeline input.
-          # Pipleine inputs can only be parameters. Fixing accordingly.
+          # Pipeline inputs can only be parameters. Fixing accordingly.
           if not type_utils.is_parameter_type(input_type):
             component_spec._inputs_dict[input_name].type = 'String'
           pipeline_task_spec.inputs.parameters[

--- a/sdk/python/kfp/dsl/component_spec.py
+++ b/sdk/python/kfp/dsl/component_spec.py
@@ -140,14 +140,18 @@ def build_component_inputs_spec(
         param_name if is_root_component else
         additional_input_name_for_pipelineparam(param_name))
 
-    if type_utils.is_parameter_type(param.param_type):
+    input_type = param.param_type
+    if is_root_component and not type_utils.is_parameter_type(input_type):
+      input_type = 'String'
+
+    if type_utils.is_parameter_type(input_type):
       component_spec.input_definitions.parameters[
-          input_name].type = type_utils.get_parameter_type(param.param_type)
+          input_name].type = type_utils.get_parameter_type(input_type)
     elif input_name not in getattr(component_spec.input_definitions,
                                    'parameters', []):
       component_spec.input_definitions.artifacts[
           input_name].artifact_type.CopyFrom(
-              type_utils.get_artifact_type_schema(param.param_type))
+              type_utils.get_artifact_type_schema(input_type))
 
 
 def build_component_outputs_spec(

--- a/sdk/python/kfp/dsl/component_spec_test.py
+++ b/sdk/python/kfp/dsl/component_spec_test.py
@@ -105,14 +105,10 @@ class ComponentSpecTest(parameterized.TestCase):
           'is_root_component': True,
           'expected_result': {
               'inputDefinitions': {
-                  'artifacts': {
-                      'input1': {
-                          'artifactType': {
-                              'schemaTitle': 'system.Dataset'
-                          }
-                      }
-                  },
                   'parameters': {
+                      'input1': {
+                          'type': 'STRING'
+                      },
                       'input2': {
                           'type': 'INT'
                       },

--- a/sdk/python/kfp/v2/compiler/compiler_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_test.py
@@ -152,8 +152,19 @@ class CompilerTest(unittest.TestCase):
 
   def test_compile_pipeline_with_misused_inputvalue_should_raise_error(self):
 
-    component_op = components.load_component_from_text("""
-        name: compoent with misused placeholder
+    produce_op = components.load_component_from_text("""
+        name: Produce model
+        outputs:
+        - {name: model, type: Model}
+        implementation:
+          container:
+            image: dummy
+            args:
+            - {outputPath: model}
+        """)
+
+    consume_op = components.load_component_from_text("""
+        name: Consume model as value
         inputs:
         - {name: model, type: Model}
         implementation:
@@ -164,8 +175,9 @@ class CompilerTest(unittest.TestCase):
         """)
 
     @dsl.pipeline(name='test-pipeline', pipeline_root='dummy_root')
-    def my_pipeline(model):
-      component_op(model=model)
+    def my_pipeline():
+      model = produce_op().output
+      consume_op(model=model)
 
     with self.assertRaisesRegex(
         TypeError,

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_various_io_types.json
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_various_io_types.json
@@ -52,18 +52,12 @@
             },
             "input_1": {
               "type": "STRING"
-            }
-          },
-          "artifacts": {
-            "input_4": {
-              "artifactType": {
-                "schemaTitle": "system.Artifact"
-              }
             },
             "input_3": {
-              "artifactType": {
-                "schemaTitle": "system.Artifact"
-              }
+              "type": "STRING"
+            },
+            "input_4": {
+              "type": "STRING"
             }
           }
         }
@@ -132,8 +126,8 @@
             "args": [
               "{{$.inputs.parameters['input_1']}}",
               "{{$.inputs.parameters['input_2']}}",
-              "{{$.inputs.artifacts['input_3'].uri}}",
-              "{{$.inputs.artifacts['input_4'].uri}}",
+              "{{$.inputs.parameters['input_3']}}",
+              "{{$.inputs.parameters['input_4']}}",
               "{{$.inputs.parameters['input_date']}}",
               "{{$.outputs.parameters['output_1'].output_file}}",
               "{{$.outputs.artifacts['output_2'].uri}}",
@@ -149,24 +143,18 @@
       }
     },
     "schemaVersion": "2.0.0",
-    "sdkVersion": "kfp-1.5.0-rc.3",
+    "sdkVersion": "kfp-1.5.0",
     "root": {
       "inputDefinitions": {
         "parameters": {
           "input1": {
             "type": "STRING"
-          }
-        },
-        "artifacts": {
-          "input4": {
-            "artifactType": {
-              "schemaTitle": "system.Artifact"
-            }
           },
           "input3": {
-            "artifactType": {
-              "schemaTitle": "system.Artifact"
-            }
+            "type": "STRING"
+          },
+          "input4": {
+            "type": "STRING"
           }
         }
       },
@@ -191,6 +179,12 @@
                 },
                 "input_1": {
                   "componentInputParameter": "input1"
+                },
+                "input_3": {
+                  "componentInputParameter": "input3"
+                },
+                "input_4": {
+                  "componentInputParameter": "input4"
                 }
               }
             },

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_various_io_types.json
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_various_io_types.json
@@ -47,6 +47,9 @@
             "input_2": {
               "type": "DOUBLE"
             },
+            "input_date": {
+              "type": "STRING"
+            },
             "input_1": {
               "type": "STRING"
             }
@@ -131,6 +134,7 @@
               "{{$.inputs.parameters['input_2']}}",
               "{{$.inputs.artifacts['input_3'].uri}}",
               "{{$.inputs.artifacts['input_4'].uri}}",
+              "{{$.inputs.parameters['input_date']}}",
               "{{$.outputs.parameters['output_1'].output_file}}",
               "{{$.outputs.artifacts['output_2'].uri}}",
               "{{$.outputs.artifacts['output_3'].path}}",
@@ -175,6 +179,13 @@
                   "runtimeValue": {
                     "constantValue": {
                       "doubleValue": 3.1415926
+                    }
+                  }
+                },
+                "input_date": {
+                  "runtimeValue": {
+                    "constantValue": {
+                      "stringValue": "2021-04-12"
                     }
                   }
                 },

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_various_io_types.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_various_io_types.py
@@ -25,6 +25,7 @@ inputs:
 - {name: input_2, type: Float}
 - {name: input_3, type: }
 - {name: input_4}
+- {name: input_date, type: Date}
 outputs:
 - {name: output_1, type: Integer}
 - {name: output_2, type: Model}
@@ -41,6 +42,7 @@ implementation:
     - {inputValue: input_2}
     - {inputUri: input_3}
     - {inputUri: input_4}
+    - {inputValue: input_date}
     - {outputPath: output_1}
     - {outputUri: output_2}
     - {outputPath: output_3}
@@ -83,6 +85,7 @@ def my_pipeline(input1: str,
       input_2=3.1415926,
       input_3=input3,
       input_4=input4,
+      input_date='2021-04-12',
   )
   component_2 = component_op_2(
       input_a=component_1.outputs['output_1'],

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_various_io_types.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_various_io_types.py
@@ -40,8 +40,8 @@ implementation:
     args:
     - {inputValue: input_1}
     - {inputValue: input_2}
-    - {inputUri: input_3}
-    - {inputUri: input_4}
+    - {inputValue: input_3}
+    - {inputValue: input_4}
     - {inputValue: input_date}
     - {outputPath: output_1}
     - {outputUri: output_2}


### PR DESCRIPTION
Fixes the following scenarios in v2 compiler:

* Constant value passed to a component that consumes the input by value (`inputValue`) when the type of the input is not recognized as a parameter
* Pipeline input has a type that is not recognized as a parameter
* Pipeline input reference is passed to a component that consumes the input by value (`inputValue`) when the type of the input is not recognized as a parameter

Fixes #5711 
