### PR TITLE
fix(viewer): viewer crd controller panics using tensorboard image without tag. Part of #5471

### DIFF
--- a/backend/src/crd/controller/viewer/reconciler/reconciler.go
+++ b/backend/src/crd/controller/viewer/reconciler/reconciler.go
@@ -178,15 +178,23 @@ func setPodSpecForTensorboard(view *viewerV1beta1.Viewer, s *corev1.PodSpec) {
 		fmt.Sprintf("--logdir=%s", view.Spec.TensorboardSpec.LogDir),
 		fmt.Sprintf("--path_prefix=/tensorboard/%s/", view.Name),
 	}
-
-	tfImageVersion := strings.Split(view.Spec.TensorboardSpec.TensorflowImage, ":")[1]
-	// This is needed for tf 2.0
-	if !strings.HasPrefix(tfImageVersion, `1.`) {
+	isTensorflowV1 := false
+	parts := strings.Split(view.Spec.TensorboardSpec.TensorflowImage, ":")
+	// an image might not contain a tag
+	if len(parts) == 2 {
+		tfImageVersion := parts[1]
+		if strings.HasPrefix(tfImageVersion, `1.`) {
+			isTensorflowV1 = true
+		}
+	}
+	if !isTensorflowV1 {
+		// This is needed for tf 2.0.
+		// https://github.com/kubeflow/pipelines/issues/2440
 		c.Args = append(c.Args, "--bind_all")
 	}
 
 	c.Ports = []corev1.ContainerPort{
-		corev1.ContainerPort{ContainerPort: viewerTargetPort},
+		{ContainerPort: viewerTargetPort},
 	}
 
 }
@@ -259,7 +267,7 @@ func serviceFrom(v *viewerV1beta1.Viewer, deploymentName string) *corev1.Service
 				"viewer":     v.Name,
 			},
 			Ports: []corev1.ServicePort{
-				corev1.ServicePort{
+				{
 					Name:       "http",
 					Protocol:   corev1.ProtocolTCP,
 					Port:       80,

--- a/backend/src/crd/controller/viewer/reconciler/reconciler_test.go
+++ b/backend/src/crd/controller/viewer/reconciler/reconciler_test.go
@@ -196,6 +196,48 @@ func TestReconcile_EachViewerCreatesADeployment(t *testing.T) {
 	}
 }
 
+func TestReconcile_ImageWithoutTagCountAsTFv2(t *testing.T) {
+	customImageWithoutTag := "potentially_custom_tensorflow_without_tag"
+	viewer := &viewerV1beta1.Viewer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "viewer-123",
+			Namespace: "kubeflow",
+		},
+		Spec: viewerV1beta1.ViewerSpec{
+			Type: viewerV1beta1.ViewerTypeTensorboard,
+			TensorboardSpec: viewerV1beta1.TensorboardSpec{
+				LogDir:          "gs://tensorboard/logdir",
+				TensorflowImage: customImageWithoutTag,
+			},
+		},
+	}
+
+	cli := fake.NewFakeClient(viewer)
+	reconciler, _ := New(cli, scheme.Scheme, &Options{MaxNumViewers: 10})
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "viewer-123", Namespace: "kubeflow"},
+	}
+	_, err := reconciler.Reconcile(req)
+
+	if err != nil {
+		t.Fatalf("Reconcile(%+v) = %v; Want nil error", req, err)
+	}
+
+	gotDpls := getDeployments(t, cli)
+	actualArgs := gotDpls[0].Spec.Template.Spec.Containers[0].Args
+	hasBindAllArg := false
+	for _, arg := range actualArgs {
+		if arg == "--bind_all" {
+			hasBindAllArg = true
+		}
+	}
+	if !hasBindAllArg {
+		t.Errorf("Created viewer CRD %+v\nWant --bind_all arg\nGot args: %+v",
+			viewer, actualArgs)
+	}
+}
+
 func TestReconcile_ViewerUsesSpecifiedVolumeMountsForDeployment(t *testing.T) {
 	viewer := &viewerV1beta1.Viewer{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**Description of your changes:**
Part of #5471 

When testing https://github.com/kubeflow/pipelines/issues/5471, I found viewer crd controller crashes with tensorboard image without tag. We should treat them as tensorflow v2.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
- [ ] Do you want this pull request (PR) cherry-picked into the current release branch?

    [Learn more about cherry-picking updates into the release branch](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#cherry-picking-pull-requests-to-release-branch).
<!--
    **(Recommended.)** Ask the PR approver to add the `cherrypick-approved` label to this PR. The release manager adds this PR to the release branch in a batch update before release.
-->
