### PR TITLE
fix(components): Update types for GCS components so it's compatible with v2.

### DIFF
--- a/components/google-cloud/storage/download/component.yaml
+++ b/components/google-cloud/storage/download/component.yaml
@@ -1,8 +1,8 @@
 name: Download from GCS
 inputs:
-- {name: GCS path, type: URI}
+- {name: GCS path, type: String}
 outputs:
-- {name: Data}
+- {name: Data, type: Artifact}
 implementation:
     container:
         image: google/cloud-sdk

--- a/components/google-cloud/storage/download/component.yaml
+++ b/components/google-cloud/storage/download/component.yaml
@@ -2,7 +2,7 @@ name: Download from GCS
 inputs:
 - {name: GCS path, type: String}
 outputs:
-- {name: Data, type: Artifact}
+- {name: Data}
 implementation:
     container:
         image: google/cloud-sdk

--- a/components/google-cloud/storage/download_blob/component.yaml
+++ b/components/google-cloud/storage/download_blob/component.yaml
@@ -1,8 +1,8 @@
 name: Download from GCS
 inputs:
-- {name: GCS path, type: URI}
+- {name: GCS path, type: String}
 outputs:
-- {name: Data}
+- {name: Data, type: Artifact}
 implementation:
     container:
         image: google/cloud-sdk

--- a/components/google-cloud/storage/download_blob/component.yaml
+++ b/components/google-cloud/storage/download_blob/component.yaml
@@ -2,7 +2,7 @@ name: Download from GCS
 inputs:
 - {name: GCS path, type: String}
 outputs:
-- {name: Data, type: Artifact}
+- {name: Data}
 implementation:
     container:
         image: google/cloud-sdk

--- a/components/google-cloud/storage/download_dir/component.yaml
+++ b/components/google-cloud/storage/download_dir/component.yaml
@@ -1,8 +1,8 @@
 name: Download from GCS
 inputs:
-- {name: GCS path, type: URI}
+- {name: GCS path, type: String}
 outputs:
-- {name: Data}
+- {name: Data, type: Artifact}
 implementation:
     container:
         image: google/cloud-sdk

--- a/components/google-cloud/storage/download_dir/component.yaml
+++ b/components/google-cloud/storage/download_dir/component.yaml
@@ -2,7 +2,7 @@ name: Download from GCS
 inputs:
 - {name: GCS path, type: String}
 outputs:
-- {name: Data, type: Artifact}
+- {name: Data}
 implementation:
     container:
         image: google/cloud-sdk

--- a/components/google-cloud/storage/list/component.yaml
+++ b/components/google-cloud/storage/list/component.yaml
@@ -1,6 +1,6 @@
 name: List blobs
 inputs:
-- {name: GCS path, type: URI, description: 'GCS path for listing. For recursive listing use the "gs://bucket/path/**" syntax".'}
+- {name: GCS path, type: String, description: 'GCS path for listing. For recursive listing use the "gs://bucket/path/**" syntax".'}
 outputs:
 - {name: Paths}
 metadata:

--- a/components/google-cloud/storage/upload_to_explicit_uri/component.yaml
+++ b/components/google-cloud/storage/upload_to_explicit_uri/component.yaml
@@ -1,6 +1,6 @@
 name: Upload to GCS
 inputs:
-- {name: Data, type: Artifact}
+- {name: Data}
 - {name: GCS path, type: String}
 outputs:
 - {name: GCS path, type: String}

--- a/components/google-cloud/storage/upload_to_explicit_uri/component.yaml
+++ b/components/google-cloud/storage/upload_to_explicit_uri/component.yaml
@@ -1,9 +1,9 @@
 name: Upload to GCS
 inputs:
-- {name: Data}
-- {name: GCS path, type: URI}
+- {name: Data, type: Artifact}
+- {name: GCS path, type: String}
 outputs:
-- {name: GCS path, type: URI}
+- {name: GCS path, type: String}
 implementation:
     container:
         image: google/cloud-sdk

--- a/components/google-cloud/storage/upload_to_unique_uri/component.yaml
+++ b/components/google-cloud/storage/upload_to_unique_uri/component.yaml
@@ -1,7 +1,7 @@
 name: Upload to GCS
 description: Upload to GCS with unique URI suffix
 inputs:
-- {name: Data, type: Artifact}
+- {name: Data}
 - {name: GCS path prefix, type: String}
 outputs:
 - {name: GCS path, type: String}

--- a/components/google-cloud/storage/upload_to_unique_uri/component.yaml
+++ b/components/google-cloud/storage/upload_to_unique_uri/component.yaml
@@ -1,10 +1,10 @@
 name: Upload to GCS
 description: Upload to GCS with unique URI suffix
 inputs:
-- {name: Data}
-- {name: GCS path prefix, type: URI}
+- {name: Data, type: Artifact}
+- {name: GCS path prefix, type: String}
 outputs:
-- {name: GCS path, type: URI}
+- {name: GCS path, type: String}
 implementation:
     container:
         image: google/cloud-sdk


### PR DESCRIPTION
Explicitly annotate URI types as String so they get treated
appropriately in v2.

**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
