### PR TITLE
feat(components/google-cloud): Use Kaniko for image build

### DIFF
--- a/components/google-cloud/container/aiplatform/cloudbuild.yaml
+++ b/components/google-cloud/container/aiplatform/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/kaniko-project/executor:latest'
   args: 
-  - --destination=gcr.io/$PROJECT_ID/google-cloud-pipeline-components:latest
+  - --destination='gcr.io/$PROJECT_ID/google-cloud-pipeline-components:latest'
   - --cache=true
   - --cache-ttl=12h

--- a/components/google-cloud/container/aiplatform/cloudbuild.yaml
+++ b/components/google-cloud/container/aiplatform/cloudbuild.yaml
@@ -1,4 +1,6 @@
 steps:
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/sashaproject-1/aiplatform_component', '.']
-images: ['gcr.io/sashaproject-1/aiplatform_component']
+- name: 'gcr.io/kaniko-project/executor:latest'
+  args: 
+  - --destination=gcr.io/$PROJECT_ID/google-cloud-pipeline-components:latest
+  - --cache=true
+  - --cache-ttl=12h


### PR DESCRIPTION
Switching to use Kaniko for image build with caching enabled. This is both faster than plan docker, it also automatically overwrites / detect destination project making it easy to run in various tests environments. 