### PR TITLE
chore(v2): fix int/float parameter parsing with extra newline and fix reused_component sample

### DIFF
--- a/samples/test/reused_component_test.py
+++ b/samples/test/reused_component_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-from pprint import pprint
 
 import kfp
 from .reused_component import my_pipeline

--- a/samples/test/reused_component_test.py
+++ b/samples/test/reused_component_test.py
@@ -12,24 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+from pprint import pprint
+
 import kfp
 from .reused_component import my_pipeline
-from .util import run_pipeline_func, TestCase, NEEDS_A_FIX
+from .util import run_pipeline_func, TestCase, KfpMlmdClient
 
 
-def verify(run, run_id: str, **kwargs):
-    assert run.status == 'Succeeded'
-    # TODO(Bobgy): verify MLMD status
+def verify(run, argo_workflow_name: str, mlmd_connection_config, **kwargs):
+    t = unittest.TestCase()
+    t.maxDiff = None  # we always want to see full diff
+    t.assertEqual(run.status, 'Succeeded')
+
+    client = KfpMlmdClient(mlmd_connection_config=mlmd_connection_config)
+
+    tasks = client.get_tasks(argo_workflow_name=argo_workflow_name)
+    t.assertEqual(
+        tasks.get('add-3').outputs.parameters.get('sum'),
+        17, 'add result should be 17')
 
 
 run_pipeline_func([
+    TestCase(pipeline_func=my_pipeline, verify_func=verify),
     TestCase(
         pipeline_func=my_pipeline,
-        verify_func=verify,
         mode=kfp.dsl.PipelineExecutionMode.V1_LEGACY,
     ),
-    # TODO(v2-compatibility): fix this
-    # Current failure:
-    # main.go:56] Failed to successfuly execute component: %vstrconv.ParseInt: parsing "5\n": invalid syntax
-    TestCase(pipeline_func=my_pipeline, verify_func=NEEDS_A_FIX),
 ])

--- a/samples/test/util.py
+++ b/samples/test/util.py
@@ -235,7 +235,7 @@ class KfpTask:
     ):
         execution_type = execution_types_by_id[execution.type_id]
         params = _parse_parameters(execution)
-        events = events_by_execution_id[execution.id]
+        events = events_by_execution_id.get(execution.id, [])
         input_artifacts = []
         output_artifacts = []
         if events:

--- a/v2/cmd/launch/main.go
+++ b/v2/cmd/launch/main.go
@@ -49,10 +49,10 @@ func main() {
 	}
 	launcher, err := component.NewLauncher(*runtimeInfoJSON, opts)
 	if err != nil {
-		glog.Fatalf("Failed to create component launcher: %v", err)
+		glog.Exitf("Failed to create component launcher: %v", err)
 	}
 
 	if err := launcher.RunComponent(ctx, flag.Args()[0], flag.Args()[1:]...); err != nil {
-		glog.Fatalf("Failed to successfuly execute component: %v", err)
+		glog.Exitf("Failed to execute component: %v", err)
 	}
 }


### PR DESCRIPTION
**Description of your changes:**
Changes:
* when int/float parameter has an extra newline, we can ignore it when parsing its value
* this fixes reused_component sample


**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
