### PR TITLE
fix(sdk): Fix bug where empty string was not preserved as pipeline param default value.

### DIFF
--- a/sdk/python/kfp/dsl/_pipeline_param.py
+++ b/sdk/python/kfp/dsl/_pipeline_param.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import re
 from collections import namedtuple
-from typing import List, Dict, Union
+from typing import Dict, List, Optional, Union
 
 # TODO: Move this to a separate class
 # For now, this identifies a condition with only "==" operator supported.
@@ -162,10 +162,10 @@ class PipelineParam(object):
 
   def __init__(self,
                name: str,
-               op_name: str = None,
-               value: str = None,
-               param_type: Union[str, Dict] = None,
-               pattern: str = None):
+               op_name: Optional[str] = None,
+               value: Optional[str] = None,
+               param_type: Optional[Union[str, Dict]] = None,
+               pattern: Optional[str] = None):
     valid_name_regex = r'^[A-Za-z][A-Za-z0-9\s_-]*$'
     if not re.match(valid_name_regex, name):
       raise ValueError(
@@ -180,7 +180,7 @@ class PipelineParam(object):
     # so that serialization and unserialization remain consistent
     # (i.e. None => '' => None)
     self.op_name = op_name if op_name else None
-    self.value = value if value else None
+    self.value = value
     self.param_type = param_type
     self.pattern = pattern or str(self)
 

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_various_io_types.json
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_various_io_types.json
@@ -257,6 +257,11 @@
     "sdkVersion": "kfp-1.5.0"
   },
   "runtimeConfig": {
-    "gcsOutputDirectory": "dummy_root"
+    "gcsOutputDirectory": "dummy_root",
+    "parameters": {
+      "input4": {
+        "stringValue": ""
+      }
+    }
   }
 }


### PR DESCRIPTION
**Description of your changes:**
It's mentioned in the comment that 
https://github.com/kubeflow/pipelines/blob/f80f4785c7166de41182487b1c2fcf4563d5186c/sdk/python/kfp/dsl/_pipeline_param.py#L179-L183

However, this shouldn't apply to `value`, which is not even included in the serialization/deserialization process.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
