### PR TITLE
feat(sdk): Add ability to load secrets to volume in onprem

### DIFF
--- a/sdk/python/kfp/onprem.py
+++ b/sdk/python/kfp/onprem.py
@@ -6,8 +6,9 @@ def mount_pvc(
     volume_name='pipeline',
     volume_mount_path='/mnt/pipeline'
 ):
-    """Modifier function to apply to a Container Op to simplify volume, volume mount addition and
-    enable better reuse of volumes, volume claims across container ops.
+    """Modifier function to apply to a Container Op to simplify volume, volume
+    mount addition and enable better reuse of volumes, volume claims across
+    container ops.
 
     Example:
         ::

--- a/sdk/python/kfp/onprem.py
+++ b/sdk/python/kfp/onprem.py
@@ -21,8 +21,7 @@ def mount_pvc(
         from kubernetes import client as k8s_client
         # there can be other ops in a pipeline (e.g. ResourceOp, VolumeOp)
         # refer to #3906
-        if not hasattr(task, "add_volume") or not hasattr(task,
-                                                          "add_volume_mount"):
+        if not hasattr(task, "add_volume") or not hasattr(task, "add_volume_mount"):
             return task
         local_pvc = k8s_client.V1PersistentVolumeClaimVolumeSource(
             claim_name=pvc_name

--- a/sdk/python/kfp/onprem.py
+++ b/sdk/python/kfp/onprem.py
@@ -46,7 +46,7 @@ def use_k8s_secret(
     secret_name: str = 'k8s-secret',
     k8s_secret_key_to_env: Dict = {},
     k8s_secret_key_to_volume: Dict = {},
-    mount_path="/mnt"
+    mount_path: str = "/mnt"
 ):
     """An operator that configures the container to use k8s credentials.
 


### PR DESCRIPTION
**Description of your changes:**
Currently `kfp.onprem.use_k8s_secret` only allows loading secrets to ENV variables.

This PR adds the ability to load them as a volume

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
