### PR TITLE
feat(sdk.v2): Raise error on artifacts vs. parameters mismatch in v2.

### DIFF
--- a/sdk/python/kfp/dsl/_component_bridge.py
+++ b/sdk/python/kfp/dsl/_component_bridge.py
@@ -22,11 +22,12 @@ from kfp.components import _structures
 from kfp.components import _components
 from kfp.components import _naming
 from kfp import dsl
-from kfp.dsl import _pipeline_param
-from kfp.dsl import types
-from kfp.dsl import component_spec as dsl_component_spec
 from kfp.dsl import _container_op
+from kfp.dsl import _for_loop
+from kfp.dsl import _pipeline_param
+from kfp.dsl import component_spec as dsl_component_spec
 from kfp.dsl import dsl_utils
+from kfp.dsl import types
 from kfp.dsl import type_utils
 from kfp.pipeline_spec import pipeline_spec_pb2
 
@@ -206,9 +207,9 @@ def _create_container_op_from_component_and_arguments(
   for input_name, argument_value in arguments.items():
     if isinstance(argument_value, _pipeline_param.PipelineParam):
       input_type = component_spec._inputs_dict[input_name].type
-      reference_type = argument_value.param_type
+      argument_type = argument_value.param_type
       types.verify_type_compatibility(
-          reference_type, input_type,
+          argument_type, input_type,
           'Incompatible argument passed to the input "{}" of component "{}": '
           .format(input_name, component_spec.name))
 
@@ -457,7 +458,7 @@ def _attach_v2_specs(
   original_arguments = arguments
   arguments = arguments.copy()
 
-  # Preserver input params for ContainerOp.inputs
+  # Preserve input params for ContainerOp.inputs
   input_params = list(
       set([
           param for param in arguments.values()
@@ -465,11 +466,19 @@ def _attach_v2_specs(
       ]))
 
   for input_name, argument_value in arguments.items():
+    input_type = component_spec._inputs_dict[input_name].type
+
     if isinstance(argument_value, _pipeline_param.PipelineParam):
-      input_type = component_spec._inputs_dict[input_name].type
-      reference_type = argument_value.param_type
+      argument_type = argument_value.param_type
+
+      # Loop arguments defaults to 'String' type if type is unknown.
+      if argument_type is None and isinstance(
+          argument_value, (_for_loop.LoopArguments,
+                           _for_loop.LoopArgumentVariable)):
+        argument_type = 'String'
+
       types.verify_type_compatibility(
-          reference_type, input_type,
+          argument_type, input_type,
           'Incompatible argument passed to the input "{}" of component "{}": '
           .format(input_name, component_spec.name))
 
@@ -495,6 +504,7 @@ def _attach_v2_specs(
               input_name].task_output_artifact.output_artifact_key = (
                   argument_value.name)
     elif isinstance(argument_value, str):
+      argument_type = 'String'
       pipeline_params = _pipeline_param.extract_pipelineparams_from_any(
           argument_value)
       if pipeline_params and is_compiling_for_v2:
@@ -534,9 +544,11 @@ def _attach_v2_specs(
             input_name].runtime_value.constant_value.string_value = (
                 argument_value)
     elif isinstance(argument_value, int):
+      argument_type = 'Integer'
       pipeline_task_spec.inputs.parameters[
           input_name].runtime_value.constant_value.int_value = argument_value
     elif isinstance(argument_value, float):
+      argument_type = 'Float'
       pipeline_task_spec.inputs.parameters[
           input_name].runtime_value.constant_value.double_value = argument_value
     elif isinstance(argument_value, _container_op.ContainerOp):
@@ -548,6 +560,32 @@ def _attach_v2_specs(
         raise NotImplementedError(
             'Input argument supports only the following types: PipelineParam'
             ', str, int, float. Got: "{}".'.format(argument_value))
+
+    argument_is_parameter_type = type_utils.is_parameter_type(argument_type)
+    input_is_parameter_type = type_utils.is_parameter_type(input_type)
+    if is_compiling_for_v2 and (argument_is_parameter_type !=
+                                input_is_parameter_type):
+      if isinstance(argument_value, dsl.PipelineParam):
+        param_or_value_msg = 'PipelineParam "{}"'.format(
+            argument_value.full_name)
+      else:
+        param_or_value_msg = 'value "{}"'.format(argument_value)
+
+      raise TypeError(
+          'Passing '
+          '{param_or_value} with type "{arg_type}" (as "{arg_category}") to '
+          'component input '
+          '"{input_name}" with type "{input_type}" (as "{input_category}") is '
+          'incompatible. Please fix the type of the component input.'.format(
+              param_or_value=param_or_value_msg,
+              arg_type=argument_type,
+              arg_category='Parameter'
+              if argument_is_parameter_type else 'Artifact',
+              input_name=input_name,
+              input_type=input_type,
+              input_category='Paramter'
+              if input_is_parameter_type else 'Artifact',
+          ))
 
   if not component_spec.name:
     component_spec.name = _components._default_component_name

--- a/sdk/python/kfp/dsl/_component_bridge.py
+++ b/sdk/python/kfp/dsl/_component_bridge.py
@@ -472,16 +472,17 @@ def _attach_v2_specs(
     if isinstance(argument_value, _pipeline_param.PipelineParam):
       argument_type = argument_value.param_type
 
-      # Loop arguments defaults to 'String' type if type is unknown.
-      if argument_type is None and isinstance(
-          argument_value, (_for_loop.LoopArguments,
-                           _for_loop.LoopArgumentVariable)):
-        argument_type = 'String'
-
       types.verify_type_compatibility(
           argument_type, input_type,
           'Incompatible argument passed to the input "{}" of component "{}": '
           .format(input_name, component_spec.name))
+
+      # Loop arguments defaults to 'String' type if type is unknown.
+      # This has to be done after the type compatiblity check.
+      if argument_type is None and isinstance(
+          argument_value, (_for_loop.LoopArguments,
+                           _for_loop.LoopArgumentVariable)):
+        argument_type = 'String'
 
       arguments[input_name] = str(argument_value)
 

--- a/sdk/python/kfp/dsl/_component_bridge.py
+++ b/sdk/python/kfp/dsl/_component_bridge.py
@@ -467,6 +467,7 @@ def _attach_v2_specs(
 
   for input_name, argument_value in arguments.items():
     input_type = component_spec._inputs_dict[input_name].type
+    argument_type = None
 
     if isinstance(argument_value, _pipeline_param.PipelineParam):
       argument_type = argument_value.param_type

--- a/sdk/python/kfp/v2/compiler/compiler.py
+++ b/sdk/python/kfp/v2/compiler/compiler.py
@@ -988,6 +988,13 @@ class Compiler(object):
         if arg_name == pipeline_input.name:
           arg_type = pipeline_input.type
           break
+      if not type_utils.is_parameter_type(arg_type):
+        raise TypeError(
+            'The pipeline argument "{arg_name}" is viewed as an artifact due to '
+            'its type "{arg_type}". And we currently do not support passing '
+            'artifacts as pipeline inputs. Consider type annotating the argument'
+            ' with a primitive type, such as "str", "int", and "float".'.format(
+                arg_name=arg_name, arg_type=arg_type))
       args_list.append(
           dsl.PipelineParam(
               sanitize_k8s_name(arg_name, True), param_type=arg_type))

--- a/sdk/python/kfp/v2/compiler/compiler_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_test.py
@@ -140,7 +140,8 @@ class CompilerTest(unittest.TestCase):
             arguments=['echo "$0"', text2])
 
       @dsl.pipeline(name='test-pipeline', pipeline_root='dummy_root')
-      def opsgroups_pipeline(text1='message 1', text2='message 2'):
+      def opsgroups_pipeline(text1: str = 'message 1',
+                             text2: str = 'message 2'):
         step1_graph_component = echo1_graph_component(text1)
         step2_graph_component = echo2_graph_component(text2)
         step2_graph_component.after(step1_graph_component)
@@ -304,6 +305,21 @@ class CompilerTest(unittest.TestCase):
         'Passing PipelineParam "input1" with type "String" \(as "Parameter"\) '
         'to component input "some_input" with type "None" \(as "Artifact"\) is '
         'incompatible. Please fix the type of the component input.'):
+      compiler.Compiler().compile(
+          pipeline_func=my_pipeline, package_path='output.json')
+
+  def test_passing_missing_type_annotation_on_pipeline_input_should_error(self):
+
+    @dsl.pipeline(name='test-pipeline', pipeline_root='gs://path')
+    def my_pipeline(input1):
+      pass
+
+    with self.assertRaisesRegex(
+        TypeError,
+        'The pipeline argument \"input1\" is viewed as an artifact due to its '
+        'type \"None\". And we currently do not support passing artifacts as '
+        'pipeline inputs. Consider type annotating the argument with a primitive'
+        ' type, such as \"str\", \"int\", and \"float\".'):
       compiler.Compiler().compile(
           pipeline_func=my_pipeline, package_path='output.json')
 

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_various_io_types.json
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_various_io_types.json
@@ -46,24 +46,18 @@
       "comp-upstream": {
         "executorLabel": "exec-upstream",
         "inputDefinitions": {
-          "artifacts": {
-            "input_3": {
-              "artifactType": {
-                "schemaTitle": "system.Artifact"
-              }
-            },
-            "input_4": {
-              "artifactType": {
-                "schemaTitle": "system.Artifact"
-              }
-            }
-          },
           "parameters": {
             "input_1": {
               "type": "STRING"
             },
             "input_2": {
               "type": "DOUBLE"
+            },
+            "input_3": {
+              "type": "STRING"
+            },
+            "input_4": {
+              "type": "STRING"
             }
           }
         },
@@ -129,8 +123,8 @@
             "args": [
               "{{$.inputs.parameters['input_1']}}",
               "{{$.inputs.parameters['input_2']}}",
-              "{{$.inputs.artifacts['input_3'].uri}}",
-              "{{$.inputs.artifacts['input_4'].uri}}",
+              "{{$.inputs.parameters['input_3']}}",
+              "{{$.inputs.parameters['input_4']}}",
               "{{$.outputs.parameters['output_1'].output_file}}",
               "{{$.outputs.artifacts['output_2'].uri}}",
               "{{$.outputs.artifacts['output_3'].path}}",
@@ -224,6 +218,12 @@
                       "doubleValue": 3.1415926
                     }
                   }
+                },
+                "input_3": {
+                  "componentInputParameter": "input3"
+                },
+                "input_4": {
+                  "componentInputParameter": "input4"
                 }
               }
             },
@@ -234,20 +234,14 @@
         }
       },
       "inputDefinitions": {
-        "artifacts": {
-          "input3": {
-            "artifactType": {
-              "schemaTitle": "system.Artifact"
-            }
-          },
-          "input4": {
-            "artifactType": {
-              "schemaTitle": "system.Artifact"
-            }
-          }
-        },
         "parameters": {
           "input1": {
+            "type": "STRING"
+          },
+          "input3": {
+            "type": "STRING"
+          },
+          "input4": {
             "type": "STRING"
           }
         }

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_various_io_types.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_various_io_types.py
@@ -23,8 +23,8 @@ name: upstream
 inputs:
 - {name: input_1, type: String}
 - {name: input_2, type: Float}
-- {name: input_3, type: }
-- {name: input_4}
+- {name: input_3, type: String}
+- {name: input_4, type: String}
 outputs:
 - {name: output_1, type: Integer}
 - {name: output_2, type: Model}
@@ -39,8 +39,8 @@ implementation:
     args:
     - {inputValue: input_1}
     - {inputValue: input_2}
-    - {inputUri: input_3}
-    - {inputUri: input_4}
+    - {inputValue: input_3}
+    - {inputValue: input_4}
     - {outputPath: output_1}
     - {outputUri: output_2}
     - {outputPath: output_3}
@@ -76,8 +76,8 @@ implementation:
 
 @dsl.pipeline(name='pipeline-with-various-types', pipeline_root='dummy_root')
 def my_pipeline(input1: str,
-                input3,
-                input4=''):
+                input3: str,
+                input4: str=''):
   component_1 = component_op_1(
       input_1=input1,
       input_2=3.1415926,


### PR DESCRIPTION
**Description of your changes:**
- Raises error when pipeline arguments are categorized as artifacts - the most common cause is missing type annotation.
- Raises error on passing an artifact to a parameter or vice versa. 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
