### PR TITLE
build(google_cloud_components sdk): switch to installing aiplatfrom from head

### DIFF
--- a/components/google-cloud/dependencies.py
+++ b/components/google-cloud/dependencies.py
@@ -30,4 +30,4 @@ def make_required_test_packages():
 
 def make_dependency_links():
   # TODO: change to google-cloud-aiplatform
-  return ["https://github.com/googleapis/python-aiplatform.git"]
+  return ["https://github.com/googleapis/python-aiplatform.git#egg=google-cloud-aiplatform"]

--- a/components/google-cloud/dependencies.py
+++ b/components/google-cloud/dependencies.py
@@ -16,7 +16,7 @@
 def make_required_install_packages():
   return [
       "kfp>=1.4.0,<2.0.0",
-      "google-cloud-aiplatform>=0.7.1,<1.0.0",
+      # "google-cloud-aiplatform>=0.7.1,<1.0.0",
   ]
 
 
@@ -30,4 +30,4 @@ def make_required_test_packages():
 
 def make_dependency_links():
   # TODO: change to google-cloud-aiplatform
-  return []
+  return ["https://github.com/googleapis/python-aiplatform.git"]

--- a/components/google-cloud/tests/presubmit.sh
+++ b/components/google-cloud/tests/presubmit.sh
@@ -19,9 +19,6 @@ cd "$source_root/components/google-cloud"
 # Verify package build correctly
 python setup.py bdist_wheel clean
 
-# Temporary work around for installing google.cloud.aiplatfrom from dev branch
-pip3 install git+https://github.com/googleapis/python-aiplatform@dev
-
 # Verify package can be installed and loaded correctly
 WHEEL_FILE=$(find "$source_root/components/google-cloud/dist/" -name "google_cloud_pipeline_components*.whl")
 pip3 install --upgrade $WHEEL_FILE

--- a/components/google-cloud/tests/presubmit.sh
+++ b/components/google-cloud/tests/presubmit.sh
@@ -19,6 +19,9 @@ cd "$source_root/components/google-cloud"
 # Verify package build correctly
 python setup.py bdist_wheel clean
 
+# Temporary work around for installing google.cloud.aiplatfrom from dev branch
+pip3 install git+https://github.com/googleapis/python-aiplatform
+
 # Verify package can be installed and loaded correctly
 WHEEL_FILE=$(find "$source_root/components/google-cloud/dist/" -name "google_cloud_pipeline_components*.whl")
 pip3 install --upgrade $WHEEL_FILE


### PR DESCRIPTION
Switching to install AI Platform dependency from head during preview as some of the features needed will not be released to PyPI in time.