### PR TITLE
Add configurable connection max lifetime for MySQL

### DIFF
--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -154,7 +154,7 @@ func (c *ClientManager) Authenticators() []auth.Authenticator {
 func (c *ClientManager) init() {
 	glog.Info("Initializing client manager")
 	db := initDBClient(common.GetDurationConfig(initConnectionTimeout))
-	db.SetConnMaxLifetime(time.Second * time.Duration(common.GetIntConfigWithDefault(dbConMaxLifeTimeSec, 120)))
+	db.SetConnMaxLifetime(common.GetDurationConfig(dbConMaxLifeTimeSec))
 
 	// time
 	c.time = util.NewRealTime()

--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -50,7 +50,7 @@ const (
 	mysqlExtraParams       = "DBConfig.ExtraParams"
 	archiveLogFileName     = "ARCHIVE_CONFIG_LOG_FILE_NAME"
 	archiveLogPathPrefix   = "ARCHIVE_CONFIG_LOG_PATH_PREFIX"
-	dbConMaxLifetimeSec    = "DBConfig.DBMaxLifetimeSec"
+	dbConMaxLifeTimeSec    = "DBConfig.ConMaxLifeTimeSec"
 
 	visualizationServiceHost = "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST"
 	visualizationServicePort = "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT"
@@ -154,7 +154,7 @@ func (c *ClientManager) Authenticators() []auth.Authenticator {
 func (c *ClientManager) init() {
 	glog.Info("Initializing client manager")
 	db := initDBClient(common.GetDurationConfig(initConnectionTimeout))
-	db.SetConnMaxLifetime(time.Second * time.Duration(common.GetIntConfigWithDefault(dbConMaxLifetimeSec, 120)))
+	db.SetConnMaxLifetime(time.Second * time.Duration(common.GetIntConfigWithDefault(dbConMaxLifeTimeSec, 120)))
 
 	// time
 	c.time = util.NewRealTime()

--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -50,6 +50,7 @@ const (
 	mysqlExtraParams       = "DBConfig.ExtraParams"
 	archiveLogFileName     = "ARCHIVE_CONFIG_LOG_FILE_NAME"
 	archiveLogPathPrefix   = "ARCHIVE_CONFIG_LOG_PATH_PREFIX"
+	dbConMaxLifetimeSec    = "DBConfig.DBMaxLifetimeSec"
 
 	visualizationServiceHost = "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST"
 	visualizationServicePort = "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT"
@@ -153,6 +154,7 @@ func (c *ClientManager) Authenticators() []auth.Authenticator {
 func (c *ClientManager) init() {
 	glog.Info("Initializing client manager")
 	db := initDBClient(common.GetDurationConfig(initConnectionTimeout))
+	db.SetConnMaxLifetime(time.Second * time.Duration(common.GetIntConfigWithDefault(dbConMaxLifetimeSec, 120)))
 
 	// time
 	c.time = util.NewRealTime()

--- a/backend/src/apiserver/config/config.json
+++ b/backend/src/apiserver/config/config.json
@@ -3,7 +3,8 @@
     "DriverName": "mysql",
     "DataSourceName": "",
     "DBName": "mlpipeline",
-    "GroupConcatMaxLen": "4194304"
+    "GroupConcatMaxLen": "4194304",
+    "ConMaxLifeTimeSec": "120"
   },
   "ObjectStoreConfig": {
     "AccessKey": "minio",

--- a/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
@@ -33,3 +33,7 @@ data:
   ## any node and avoid defaulting to specific nodes. Allowed values are:
   ## 'false' and 'true'.
   cacheNodeRestrictions: "false"
+  ## ConMaxLifeTimeSec will set the connection max lifetime for MySQL
+  ## this is very important to setup when using external databases.
+  ## See this issue for more details: https://github.com/kubeflow/pipelines/issues/5329
+  ConMaxLifeTimeSec: "120"

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -58,6 +58,11 @@ spec:
             configMapKeyRef:
               name: pipeline-install-config
               key: dbPort
+        - name: DBCONFIG_CONMAXLIFETIMESEC
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: ConMaxLifeTimeSec
         - name: OBJECTSTORECONFIG_ACCESSKEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
**Description of your changes:**

This allows users to set an env variable DBCONFIG_DBMAXLIFETIME. It solves https://github.com/kubeflow/pipelines/issues/5329 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
