### PR TITLE
fix(v2): Escape strings in RuntimeInfo.

### DIFF
--- a/samples/core/exit_handler/exit_handler.py
+++ b/samples/core/exit_handler/exit_handler.py
@@ -17,14 +17,14 @@ import kfp
 from kfp import dsl, components
 
 gcs_download_op = kfp.components.load_component_from_url(
-    'https://raw.githubusercontent.com/kubeflow/pipelines/1.5.0-rc.3/components/google-cloud/storage/download_blob/component.yaml'
+    'https://raw.githubusercontent.com/kubeflow/pipelines/master/components/google-cloud/storage/download_blob/component.yaml'
 )
 
 
 @components.create_component_from_func
 def echo_op(msg: str):
-    """Print a message."""
-    print(msg)
+  """Print a message."""
+  print(msg)
 
 
 @dsl.pipeline(
@@ -33,14 +33,14 @@ def echo_op(msg: str):
     'Downloads a message and prints it. The exit handler will run after the pipeline finishes (successfully or not).'
 )
 def pipeline_exit_handler(url='gs://ml-pipeline/shakespeare1.txt'):
-    """A sample pipeline showing exit handler."""
+  """A sample pipeline showing exit handler."""
 
-    exit_task = echo_op('exit!')
+  exit_task = echo_op('exit!')
 
-    with dsl.ExitHandler(exit_task):
-        download_task = gcs_download_op(url)
-        echo_task = echo_op(download_task.output)
+  with dsl.ExitHandler(exit_task):
+    download_task = gcs_download_op(url)
+    echo_task = echo_op(download_task.output)
 
 
 if __name__ == '__main__':
-    kfp.compiler.Compiler().compile(pipeline_exit_handler, __file__ + '.yaml')
+  kfp.compiler.Compiler().compile(pipeline_exit_handler, __file__ + '.yaml')

--- a/samples/core/exit_handler/exit_handler_test.py
+++ b/samples/core/exit_handler/exit_handler_test.py
@@ -21,15 +21,8 @@ run_pipeline_func([
         pipeline_func=pipeline_exit_handler,
         mode=kfp.dsl.PipelineExecutionMode.V1_LEGACY,
     ),
-    # TODO(v2-compatible): The following test case fails with:
-    #   File "/Users/gongyuan/kfp/pipelines/sdk/python/kfp/compiler/compiler.py", line 678, in _create_dag_templates
-    #     launcher_image=self._launcher_image)
-    #   File "/Users/gongyuan/kfp/pipelines/sdk/python/kfp/compiler/v2_compat.py", line 108, in update_op
-    #     artifact_info = {"fileInputPath": op.input_artifact_paths[artifact_name]}
-    # KeyError: 'GCS path'
-    #
-    # TestCase(
-    #     pipeline_func=pipeline_exit_handler,
-    #     mode=kfp.dsl.PipelineExecutionMode.V2_COMPATIBLE,
-    # ),
+    TestCase(
+        pipeline_func=pipeline_exit_handler,
+        mode=kfp.dsl.PipelineExecutionMode.V2_COMPATIBLE,
+    ),
 ])

--- a/samples/core/loop_parallelism/loop_parallelism_test.py
+++ b/samples/core/loop_parallelism/loop_parallelism_test.py
@@ -21,28 +21,8 @@ run_pipeline_func([
         pipeline_func=pipeline,
         mode=kfp.dsl.PipelineExecutionMode.V1_LEGACY,
     ),
-
-    # TODO(v2-compatible): one pod fails randomly with this error
-    # F0414 13:49:21.024015       1 main.go:56] Failed to successfuly execute component: %vrpc error: code = AlreadyExists desc = Given node already exists: type_id: 57
-    # name: "my-pipeline"
-    # Internal: mysql_query failed: errno: 1062, error: Duplicate entry '57-my-pipeline' for key 'type_id'
-    # goroutine 1 [running]:
-
-    # TODO(v2-compatible): two pods fail stably at the following op:
-    # print_op(item)
-    #
-    # Error message:
-    # F0414 13:52:28.364169       1 main.go:52] Failed to create component launcher: %vinvalid character 'A' after object key:value pair
-    # goroutine 1 [running]:
-    #
-    # The following was the runtime info, the problem was that one parameter
-    # value contains a JSON string, but we didn't escape it.
-    #
-    # {"inputParameters": {"s": {"parameterType": "STRING",
-    # "parameterValue": "{"A_a":1,"B_b":2}"}}, "inputArtifacts": {},
-    # "outputParameters": {}, "outputArtifacts": {}}
-    # TestCase(
-    #     pipeline_func=pipeline,
-    #     mode=kfp.dsl.PipelineExecutionMode.V2_COMPATIBLE,
-    # ),
+    TestCase(
+        pipeline_func=pipeline,
+        mode=kfp.dsl.PipelineExecutionMode.V2_COMPATIBLE,
+    ),
 ])

--- a/sdk/python/kfp/compiler/v2_compat.py
+++ b/sdk/python/kfp/compiler/v2_compat.py
@@ -100,7 +100,8 @@ def update_op(op: dsl.ContainerOp,
         "type":
             pipeline_spec_pb2.PrimitiveType.PrimitiveTypeEnum.Name(spec.type),
         "value":
-            op._parameter_arguments[parameter],
+            "BEGIN-KFP-PARAM[{}]END-KFP-PARAM".format(
+                op._parameter_arguments[parameter])
     }
     runtime_info["inputParameters"][parameter] = parameter_info
 

--- a/v2/component/runtime_info.go
+++ b/v2/component/runtime_info.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -71,6 +72,27 @@ type runtimeInfo struct {
 	OutputArtifacts  map[string]*outputArtifact
 }
 
+var paramDelimiterRE = regexp.MustCompile(`"BEGIN-KFP-PARAM[[].+?[]]END-KFP-PARAM"`)
+
+func escapeParameters(unescaped string) (string, error) {
+	var jsonEncodeErr error
+	escapeFunc := func(value string) string {
+		value = strings.TrimPrefix(value, `"BEGIN-KFP-PARAM[`)
+		value = strings.TrimSuffix(value, `]END-KFP-PARAM"`)
+		var b []byte
+		b, jsonEncodeErr = json.Marshal(value)
+		return string(b)
+	}
+
+	escaped := paramDelimiterRE.ReplaceAllStringFunc(unescaped, escapeFunc)
+
+	if jsonEncodeErr != nil {
+		return "", fmt.Errorf("failed to JSON-encode parameter %q: %w", unescaped, jsonEncodeErr)
+	}
+
+	return escaped, nil
+}
+
 func parseRuntimeInfo(jsonEncoded string) (*runtimeInfo, error) {
 	r := &runtimeInfo{
 		InputParameters:  make(map[string]*inputParameter),
@@ -79,9 +101,14 @@ func parseRuntimeInfo(jsonEncoded string) (*runtimeInfo, error) {
 		OutputArtifacts:  make(map[string]*outputArtifact),
 	}
 
-	if err := json.Unmarshal([]byte(jsonEncoded), r); err != nil {
+	escaped, err := escapeParameters(jsonEncoded)
+	if err != nil {
+		return nil, fmt.Errorf("failed to escape parameters from RuntimeInfo: %w", err)
+	}
+
+	if err := json.Unmarshal([]byte(escaped), r); err != nil {
 		// Do not quote jsonEncoded, because JSON format is hard to read if quoted.
-		return nil, fmt.Errorf("Invalid runtime info: %w.\n===RuntimeInfo===\n%s\n======", err, jsonEncoded)
+		return nil, fmt.Errorf("Invalid runtime info: %w.\n===RuntimeInfo===\n%s\n======", err, escaped)
 	}
 
 	return r, nil

--- a/v2/component/runtime_info_test.go
+++ b/v2/component/runtime_info_test.go
@@ -36,12 +36,12 @@ func Test_parseRuntimeInfo(t *testing.T) {
 		wantErr     bool
 	}{
 		{
-			name: "Parses InputParameters Correctly",
+			name: "Parse input ints",
 			jsonEncoded: `{
 				"inputParameters": {
 					"my_param": {
 						"type": "INT",
-						"value": "123"
+						"value": "BEGIN-KFP-PARAM[123]END-KFP-PARAM"
 					}
 				}
 			}`,
@@ -50,6 +50,46 @@ func Test_parseRuntimeInfo(t *testing.T) {
 					"my_param": {
 						Type:  "INT",
 						Value: "123",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Parse input strings with quotes",
+			jsonEncoded: `{
+				"inputParameters": {
+					"my_param": {
+						"type": "STRING",
+						"value": "BEGIN-KFP-PARAM[some random "value" 'with' "quotes"]END-KFP-PARAM"
+					}
+				}
+			}`,
+			want: &runtimeInfo{
+				InputParameters: map[string]*inputParameter{
+					"my_param": {
+						Type:  "STRING",
+						Value: "some random \"value\" 'with' \"quotes\"",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Parse serialized dictionaries",
+			jsonEncoded: `{
+				"inputParameters": {
+					"my_param": {
+						"type": "STRING",
+						"value": "BEGIN-KFP-PARAM[{"A": "a-value", "B": 123}]END-KFP-PARAM"
+					}
+				}
+			}`,
+			want: &runtimeInfo{
+				InputParameters: map[string]*inputParameter{
+					"my_param": {
+						Type:  "STRING",
+						Value: "{\"A\": \"a-value\", \"B\": 123}",
 					},
 				},
 			},


### PR DESCRIPTION
This allows strings to be serialized dictionaries etc.

Also, re-enable a couple of v2 tests.

**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
