### PR TITLE
feat(components/google-cloud): Support input type union[str,list[str]]

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/aiplatform/remote_runner.py
+++ b/components/google-cloud/google_cloud_pipeline_components/aiplatform/remote_runner.py
@@ -205,7 +205,7 @@ def prepare_parameters(
             try:
                 # Attemp at converting string to list or dict:
                 # Some parameters accept union[str, sequence[str]]
-                # For these serialization with json is not possible as 
+                # For these serialization with json is not possible as
                 # component yaml conversion swaps double quote and single
                 # quotes in resulting in `JSON.Loads` loading such a list as
                 # a string. Using ast.literal_eval to attempt to convert the

--- a/components/google-cloud/google_cloud_pipeline_components/aiplatform/remote_runner.py
+++ b/components/google-cloud/google_cloud_pipeline_components/aiplatform/remote_runner.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """Module for remote execution of AI Platform pipeline component."""
 
-import ast
 import argparse
+import ast
 from distutils import util as distutil
 import inspect
 import json
@@ -211,7 +211,8 @@ def prepare_parameters(
                 # a string. Using ast.literal_eval to attempt to convert the
                 # str back to python literals.
                 value = ast.literal_eval(value)
-            except ValueError:
+                print(f"Conversion for value succeeded for value: {value}")
+            except:
                 # The input was actually a string and not a List,
                 #  no additional are required.
                 pass

--- a/components/google-cloud/google_cloud_pipeline_components/aiplatform/remote_runner.py
+++ b/components/google-cloud/google_cloud_pipeline_components/aiplatform/remote_runner.py
@@ -203,18 +203,18 @@ def prepare_parameters(
                 value = cast(value, param_type)
 
             try:
-                # Attemp at converting string to list or dict:
+                # Attempt at converting String to list:
                 # Some parameters accept union[str, sequence[str]]
                 # For these serialization with json is not possible as
-                # component yaml conversion swaps double quote and single
-                # quotes in resulting in `JSON.Loads` loading such a list as
-                # a string. Using ast.literal_eval to attempt to convert the
-                # str back to python literals.
+                # component yaml conversion swaps double and single
+                # quotes resulting in `JSON.Loads` loading such a list as
+                # a String. Using ast.literal_eval to attempt to convert the
+                # str back to a python List.
                 value = ast.literal_eval(value)
                 print(f"Conversion for value succeeded for value: {value}")
             except:
-                # The input was actually a string and not a List,
-                #  no additional are required.
+                # The input was actually a String and not a List,
+                # no additional transformations are required.
                 pass
 
             kwargs[key] = value

--- a/components/google-cloud/google_cloud_pipeline_components/aiplatform/remote_runner.py
+++ b/components/google-cloud/google_cloud_pipeline_components/aiplatform/remote_runner.py
@@ -199,18 +199,23 @@ def prepare_parameters(
             deserializer = utils.get_deserializer(param_type)
             if deserializer:
                 value = deserializer(value)
-
-                try:
-                    # Component yaml conversion swaps double quote and single
-                    # quote in dicts JSON.Loads loads such a dict as a string.
-                    # using ast.literal_eval to attempt to convert back to
-                    #  python literals.
-                    value = ast.literal_eval(value)
-                except:
-                    pass
-
             else:
                 value = cast(value, param_type)
+
+            try:
+                # Attemp at converting string to list or dict:
+                # Some parameters accept union[str, sequence[str]]
+                # For these serialization with json is not possible as 
+                # component yaml conversion swaps double quote and single
+                # quotes in resulting in `JSON.Loads` loading such a list as
+                # a string. Using ast.literal_eval to attempt to convert the
+                # str back to python literals.
+                value = ast.literal_eval(value)
+            except ValueError:
+                # The input was actually a string and not a List,
+                #  no additional are required.
+                pass
+
             kwargs[key] = value
 
 

--- a/components/google-cloud/google_cloud_pipeline_components/aiplatform/remote_runner.py
+++ b/components/google-cloud/google_cloud_pipeline_components/aiplatform/remote_runner.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Module for remote execution of AI Platform pipeline component."""
 
+import ast
 import argparse
 from distutils import util as distutil
 import inspect
@@ -198,6 +199,16 @@ def prepare_parameters(
             deserializer = utils.get_deserializer(param_type)
             if deserializer:
                 value = deserializer(value)
+
+                try:
+                    # Component yaml conversion swaps double quote and single
+                    # quote in dicts JSON.Loads loads such a dict as a string.
+                    # using ast.literal_eval to attempt to convert back to
+                    #  python literals.
+                    value = ast.literal_eval(value)
+                except:
+                    pass
+
             else:
                 value = cast(value, param_type)
             kwargs[key] = value

--- a/components/google-cloud/google_cloud_pipeline_components/aiplatform/utils.py
+++ b/components/google-cloud/google_cloud_pipeline_components/aiplatform/utils.py
@@ -116,7 +116,7 @@ def is_serializable_to_json(annotation: Any) -> bool:
     Returns:
         True if serializable to json.
     """
-    serializable_types = (Union, dict, list, collections.abc.Sequence)
+    serializable_types = (dict, list, collections.abc.Sequence)
     return getattr(annotation, '__origin__', None) in serializable_types
 
 

--- a/components/google-cloud/google_cloud_pipeline_components/aiplatform/utils.py
+++ b/components/google-cloud/google_cloud_pipeline_components/aiplatform/utils.py
@@ -116,7 +116,7 @@ def is_serializable_to_json(annotation: Any) -> bool:
     Returns:
         True if serializable to json.
     """
-    serializable_types = (str, dict, list, collections.abc.Sequence)
+    serializable_types = (Union, dict, list, collections.abc.Sequence)
     return getattr(annotation, '__origin__', None) in serializable_types
 
 

--- a/components/google-cloud/google_cloud_pipeline_components/aiplatform/utils.py
+++ b/components/google-cloud/google_cloud_pipeline_components/aiplatform/utils.py
@@ -116,7 +116,7 @@ def is_serializable_to_json(annotation: Any) -> bool:
     Returns:
         True if serializable to json.
     """
-    serializable_types = (dict, list, collections.abc.Sequence)
+    serializable_types = (str, dict, list, collections.abc.Sequence)
     return getattr(annotation, '__origin__', None) in serializable_types
 
 


### PR DESCRIPTION
Supporting input parameter types of union [ str, list[str] ], for example users can pass in 
```python 
  ds_op = gcc_aip.ImageDatasetCreateOp(
      project=PROJECT_ID,
      display_name='flowers',
      gcs_source='gs://...'
```
or
```python 
  ds_op = gcc_aip.ImageDatasetCreateOp(
      project=PROJECT_ID,
      display_name='flowers',
      gcs_source=['gs://sr1','gs://sr2'...],
```