### PR TITLE
fix(cli): update client to allow equal signs('=') in parameters. Fixes #5577

### DIFF
--- a/sdk/python/kfp/cli/run.py
+++ b/sdk/python/kfp/cli/run.py
@@ -76,7 +76,8 @@ def submit(ctx, experiment_name, run_name, package_file, pipeline_id, pipeline_n
         click.echo('You must provide one of [package_file, pipeline_id, version].', err=True)
         sys.exit(1)
 
-    arg_dict = dict(arg.split('=') for arg in args)
+    arg_dict = dict(arg.split('=', maxsplit=1) for arg in args)
+
     experiment = client.create_experiment(experiment_name)
     run = client.run_pipeline(experiment.id, run_name, package_file, arg_dict, pipeline_id,
                               version_id=version)


### PR DESCRIPTION
**Description of your changes:**
Update to allow equal signs in parameters fixes: https://github.com/kubeflow/pipelines/issues/5577

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
