### PR TITLE
fix(backend): fixes proxy race. Fixes #4494

### DIFF
--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -288,6 +288,8 @@ def _op_to_template(op: BaseOp):
         template['volumes'] = [convert_k8s_obj_to_json(volume) for volume in processed_op.volumes]
         template['volumes'].sort(key=lambda x: x['name'])
 
+    template.setdefault('metadata', {}).setdefault('annotations', {})['proxy.istio.io/config'] = '{ "holdApplicationUntilProxyStarts": true }'
+
     if isinstance(op, dsl.ContainerOp) and op._metadata and not op.is_v2:
         template.setdefault('metadata', {}).setdefault('annotations', {})['pipelines.kubeflow.org/component_spec'] = json.dumps(op._metadata.to_dict(), sort_keys=True)
 


### PR DESCRIPTION
**Description of your changes:**
On a fresh install of kubeflow 1.3 with minikf or minikube using the argo backend; if an operation in the pipeline needs network connectivity it will race with the istio proxy coming online. Adding the istio annotation to each op container fixes the problem.

Fixes https://github.com/kubeflow/pipelines/issues/4494 