### PR TITLE
feat(sdk): Type checking to treat "explicit" generic artifact as any artifact type.

### DIFF
--- a/sdk/python/kfp/v2/compiler/compiler_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_test.py
@@ -342,14 +342,27 @@ class CompilerTest(unittest.TestCase):
     def producer_op2(output: dsl.Output[dsl.Artifact]):
       pass
 
+    consumer_op1 = components.load_component_from_text("""
+      name: consumer compoent
+      inputs:
+      - {name: input, type: MyDataset}
+      implementation:
+        container:
+          image: dummy
+          args:
+          - {inputPath: input}
+      """)
+
     @dsl.component
-    def consumer_op(input: dsl.Input[dsl.Dataset]):
+    def consumer_op2(input: dsl.Input[dsl.Dataset]):
       pass
 
     @dsl.pipeline(name='test-pipeline')
     def my_pipeline():
-      consumer_op(producer_op1().output)
-      consumer_op(producer_op2().output)
+      consumer_op1(producer_op1().output)
+      consumer_op1(producer_op2().output)
+      consumer_op2(producer_op1().output)
+      consumer_op2(producer_op2().output)
 
     try:
       tmpdir = tempfile.mkdtemp()

--- a/sdk/python/kfp/v2/compiler/compiler_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_test.py
@@ -21,6 +21,7 @@ import unittest
 from kfp.v2 import components
 from kfp.v2 import compiler
 from kfp.v2 import dsl
+from kfp.dsl import types
 
 
 class CompilerTest(unittest.TestCase):
@@ -322,6 +323,74 @@ class CompilerTest(unittest.TestCase):
         ' type, such as \"str\", \"int\", and \"float\".'):
       compiler.Compiler().compile(
           pipeline_func=my_pipeline, package_path='output.json')
+
+  def test_passing_generic_artifact_to_input_expecting_concrete_artifact(
+      self):
+
+    producer_op1 = components.load_component_from_text("""
+      name: producer compoent
+      outputs:
+      - {name: output, type: Artifact}
+      implementation:
+        container:
+          image: dummy
+          args:
+          - {outputPath: output}
+      """)
+
+    @dsl.component
+    def producer_op2(output: dsl.Output[dsl.Artifact]):
+      pass
+
+    @dsl.component
+    def consumer_op(input: dsl.Input[dsl.Dataset]):
+      pass
+
+    @dsl.pipeline(name='test-pipeline')
+    def my_pipeline():
+      consumer_op(producer_op1().output)
+      consumer_op(producer_op2().output)
+
+    try:
+      tmpdir = tempfile.mkdtemp()
+      target_json_file = os.path.join(tmpdir, 'result.json')
+      compiler.Compiler().compile(
+          pipeline_func=my_pipeline, package_path=target_json_file)
+
+      self.assertTrue(os.path.exists(target_json_file))
+    finally:
+      shutil.rmtree(tmpdir)
+
+  def test_passing_arbitrary_artifact_to_input_expecting_concrete_artifact(
+      self):
+
+    producer_op1 = components.load_component_from_text("""
+      name: producer compoent
+      outputs:
+      - {name: output, type: SomeArbitraryType}
+      implementation:
+        container:
+          image: dummy
+          args:
+          - {outputPath: output}
+      """)
+
+    @dsl.component
+    def consumer_op(input: dsl.Input[dsl.Dataset]):
+      pass
+
+    @dsl.pipeline(name='test-pipeline')
+    def my_pipeline():
+      consumer_op(producer_op1().output)
+      consumer_op(producer_op2().output)
+
+    with self.assertRaisesRegex(
+        types.InconsistentTypeException,
+        'Incompatible argument passed to the input "input" of component '
+        '"Consumer op": Argument type "SomeArbitraryType" is incompatible with '
+        'the input type "Dataset"'):
+      compiler.Compiler().compile(
+          pipeline_func=my_pipeline, package_path='result.json')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of your changes:**
- Outputs without type or typed as "Artifact" can be passed to inputs typed as any artifact type.
   For example, output with type `Artifact` can be passed to input with type `Dataset`.
- Outputs typed as arbitrary name cannot be used in the same way.
   For example, output with type `SomeArbitraryType` **cannot** be passed to input with type `Dataset`.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
