### PR TITLE
feat(v2): enable v2 compatible mode in full Kubeflow with zero config. Fixes #5680

### DIFF
--- a/v2/cmd/launch/main.go
+++ b/v2/cmd/launch/main.go
@@ -30,7 +30,7 @@ var (
 	pipelineName      = flag.String("pipeline_name", "", "The current pipeline name.")
 	pipelineRunID     = flag.String("pipeline_run_id", "", "The current pipeline run ID.")
 	pipelineTaskID    = flag.String("pipeline_task_id", "", "The current pipeline task ID.")
-	pipelineRoot      = flag.String("pipeline_root", "minio://mlpipeline/v2/artifacts", "The root output directory in which to store output artifacts.")
+	pipelineRoot      = flag.String("pipeline_root", "", "The root output directory in which to store output artifacts.")
 )
 
 func main() {

--- a/v2/component/launcher.go
+++ b/v2/component/launcher.go
@@ -192,6 +192,7 @@ func NewLauncher(runtimeInfo string, options *LauncherOptions) (*Launcher, error
 		if err != nil {
 			return nil, err
 		}
+		// LauncherConfig is optional, so it can be nil when err == nil.
 		if config != nil && config.Data != nil {
 			defaultRootFromConfig := config.Data["defaultPipelineRoot"]
 			if defaultRootFromConfig != "" {
@@ -808,7 +809,7 @@ func getLauncherConfig(clientSet *kubernetes.Clientset, namespace string) (*v1.C
 	config, err := clientSet.CoreV1().ConfigMaps(namespace).Get(context.Background(), "kfp-launcher", metav1.GetOptions{})
 	if err != nil {
 		if k8errors.IsNotFound(err) {
-			// LancherConfig is optional, so ignore not found error.
+			// LauncherConfig is optional, so ignore not found error.
 			return nil, nil
 		}
 		return nil, err

--- a/v2/objectstore/object_store.go
+++ b/v2/objectstore/object_store.go
@@ -1,0 +1,78 @@
+// Copyright 2021 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This package contains helper methods for using object stores.
+// TODO: move other object store related methods here.
+package objectstore
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/golang/glog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// The endpoint uses Kubernetes service DNS name with namespace:
+// https://kubernetes.io/docs/concepts/services-networking/service/#dns
+const defaultMinioEndpointInMultiUserMode = "minio-service.kubeflow:9000"
+const minioArtifactSecretName = "mlpipeline-minio-artifact"
+
+func MinioDefaultEndpoint() string {
+	// Discover minio-service in the same namespace by env var.
+	// https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables
+	minioHost := os.Getenv("MINIO_SERVICE_SERVICE_HOST")
+	minioPort := os.Getenv("MINIO_SERVICE_SERVICE_PORT")
+	if minioHost != "" && minioPort != "" {
+		// If there is a minio-service Kubernetes service in the same namespace,
+		// MINIO_SERVICE_SERVICE_HOST and MINIO_SERVICE_SERVICE_PORT env vars should
+		// exist by default, so we use it as default.
+		return minioHost + ":" + minioPort
+	}
+	// If the env vars do not exist, we guess that we are running in KFP multi user mode, so default minio service should be `minio-service.kubeflow:9000`.
+	glog.Infof("Cannot detect minio-service in the same namespace, default to %s as MinIO endpoint.", defaultMinioEndpointInMultiUserMode)
+	return defaultMinioEndpointInMultiUserMode
+}
+
+type MinioCredential struct {
+	AccessKey string
+	SecretKey string
+}
+
+func GetMinioCredential(clientSet *kubernetes.Clientset, namespace string) (cred MinioCredential, err error) {
+	defer func() {
+		if err != nil {
+			// wrap error before returning
+			err = fmt.Errorf("Failed to get MinIO credential from secret name=%q namespace=%q: %w", minioArtifactSecretName, namespace, err)
+		}
+	}()
+	secret, err := clientSet.CoreV1().Secrets(namespace).Get(
+		context.Background(),
+		minioArtifactSecretName,
+		metav1.GetOptions{})
+	if err != nil {
+		return cred, err
+	}
+	cred.AccessKey = string(secret.Data["accesskey"])
+	cred.SecretKey = string(secret.Data["secretkey"])
+	if cred.AccessKey == "" {
+		return cred, fmt.Errorf("does not have 'accesskey' key")
+	}
+	if cred.SecretKey == "" {
+		return cred, fmt.Errorf("does not have 'secretkey' key")
+	}
+	return cred, nil
+}

--- a/v2/objectstore/object_store_test.go
+++ b/v2/objectstore/object_store_test.go
@@ -1,0 +1,70 @@
+// Copyright 2021 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstore_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kubeflow/pipelines/v2/objectstore"
+)
+
+func Test_GetMinioDefaultEndpoint(t *testing.T) {
+
+	defer func() {
+		os.Unsetenv("MINIO_SERVICE_SERVICE_HOST")
+		os.Unsetenv("MINIO_SERVICE_SERVICE_PORT")
+	}()
+	tests := []struct {
+		name                string
+		minioServiceHostEnv string
+		minioServicePortEnv string
+		want                string
+	}{
+		{
+			name:                "In full Kubeflow, KFP multi-user mode on",
+			minioServiceHostEnv: "",
+			minioServicePortEnv: "",
+			want:                "minio-service.kubeflow:9000",
+		},
+		{
+			name:                "In KFP standalone without multi-user mode",
+			minioServiceHostEnv: "1.2.3.4",
+			minioServicePortEnv: "4321",
+			want:                "1.2.3.4:4321",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.minioServiceHostEnv != "" {
+				os.Setenv("MINIO_SERVICE_SERVICE_HOST", tt.minioServiceHostEnv)
+			} else {
+				os.Unsetenv("MINIO_SERVICE_SERVICE_HOST")
+			}
+			if tt.minioServicePortEnv != "" {
+				os.Setenv("MINIO_SERVICE_SERVICE_PORT", tt.minioServicePortEnv)
+			} else {
+				os.Unsetenv("MINIO_SERVICE_SERVICE_PORT")
+			}
+			got := objectstore.MinioDefaultEndpoint()
+			if got != tt.want {
+				t.Errorf(
+					"MinioDefaultEndpoint() = %q, want %q\nwhen MINIO_SERVICE_SERVICE_HOST=%q MINIO_SERVICE_SERVICE_PORT=%q",
+					got, tt.want, tt.minioServiceHostEnv, tt.minioServicePortEnv,
+				)
+			}
+		})
+	}
+}

--- a/v2/objectstore/object_store_test.go
+++ b/v2/objectstore/object_store_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func Test_GetMinioDefaultEndpoint(t *testing.T) {
-
 	defer func() {
 		os.Unsetenv("MINIO_SERVICE_SERVICE_HOST")
 		os.Unsetenv("MINIO_SERVICE_SERVICE_PORT")


### PR DESCRIPTION
**Description of your changes:**
Fixes #5680
Investigation and rationale are logged in #5680.

Changes:
* Makes default pipeline root configurable via key `defaultPipelineRoot` in a configmap named `kfp-launcher` in the same namespace as the pipeline run.
* Defaults minio service to the same namespace via `MINIO_SERVICE_SERVICE_HOST` env var. When not found, fallbacks to `minio-service.kubeflow:9000` (default service name of MinIO in full Kubeflow).

How this PR makes kfp v2 compatible run on Kubeflow:
1. For distributions using MinIO, now we can auto discover the minio service in kubeflow namespace.
2. For distributions not using MinIO, they can configure default pipeline root to other storage URL, e.g. for Kubeflow on GCP, we can default pipeline root to a GCS path during deployment via key `defaultPipelineRoot` in a configmap named `kfp-launcher` in the same namespace as the pipeline run

As a follow up, https://github.com/kubeflow/pipelines/pull/5750 makes defaultPipelineRoot configurable as `defaultPipelineRoot` field in `pipeline-install-config` for both KFP standalone and multi-user mode.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
