### PR TITLE
feat(sdk): special handling for type annotation using `typing.Optional`

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -44,6 +44,7 @@ import warnings
 
 import docstring_parser
 
+from kfp.components import type_annotation_utils
 from kfp.dsl import io_types
 
 T = TypeVar('T')
@@ -325,20 +326,22 @@ def _extract_component_interface(func: Callable) -> ComponentSpec:
             return type_struct
         return type_name
 
+
     input_names = set()
     output_names = set()
     for parameter in parameters:
-        parameter_type = parameter.annotation
+        parameter_type = type_annotation_utils.extract_type_with_optional(
+            parameter.annotation)
         passing_style = None
         io_name = parameter.name
 
-        if io_types.is_artifact_annotation(parameter.annotation):
+        if io_types.is_artifact_annotation(parameter_type):
             # passing_style is either io_types.InputAnnotation or
             # io_types.OutputAnnotation.
-            passing_style = io_types.get_io_artifact_annotation(parameter.annotation)
+            passing_style = io_types.get_io_artifact_annotation(parameter_type)
 
             # parameter_type is io_types.Artifact or one of its subclasses.
-            parameter_type = io_types.get_io_artifact_class(parameter.annotation)
+            parameter_type = io_types.get_io_artifact_class(parameter_type)
             if not issubclass(parameter_type, io_types.Artifact):
                 raise ValueError(
                     'Input[T] and Output[T] are only supported when T is a '
@@ -348,11 +351,11 @@ def _extract_component_interface(func: Callable) -> ComponentSpec:
             if parameter.default is not inspect.Parameter.empty:
                 raise ValueError('Default values for Input/Output artifacts are not supported.')
         elif isinstance(
-            parameter.annotation,
+            parameter_type,
             (InputArtifact, InputPath, InputTextFile, InputBinaryFile,
              OutputArtifact, OutputPath, OutputTextFile, OutputBinaryFile)):
-            passing_style = type(parameter.annotation)
-            parameter_type = parameter.annotation.type
+            passing_style = type(parameter_type)
+            parameter_type = parameter_type.type
             if parameter.default is not inspect.Parameter.empty and not (passing_style == InputPath and parameter.default is None):
                 raise ValueError('Path inputs only support default values of None. Default values for outputs are not supported.')
             # Removing the "_path" and "_file" suffixes from the input/output names as the argument passed to the component needs to be the data itself, not local file path.
@@ -360,7 +363,7 @@ def _extract_component_interface(func: Callable) -> ComponentSpec:
             # But from the outside perspective, there are no files or paths - the actual data objects (or references to them) are passed in.
             # It looks very strange when argument passing code looks like this: `component(number_file_path=42)`. This looks like an error since 42 is not a path. It's not even a string.
             # It's much more natural to strip the names of file inputs and outputs of "_file" or "_path" suffixes. Then the argument passing code will look natural: "component(number=42)".
-            if isinstance(parameter.annotation, (InputPath, OutputPath)) and io_name.endswith('_path'):
+            if isinstance(parameter_type, (InputPath, OutputPath)) and io_name.endswith('_path'):
                 io_name = io_name[0:-len('_path')]
             if io_name.endswith('_file'):
                 io_name = io_name[0:-len('_file')]

--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -354,6 +354,11 @@ def _extract_component_interface(func: Callable) -> ComponentSpec:
             parameter_type,
             (InputArtifact, InputPath, InputTextFile, InputBinaryFile,
              OutputArtifact, OutputPath, OutputTextFile, OutputBinaryFile)):
+            if isinstance(parameter_type, (InputPath, OutputPath)) and io_name.endswith('_path'):
+                io_name = io_name[0:-len('_path')]
+            if io_name.endswith('_file'):
+                io_name = io_name[0:-len('_file')]
+
             passing_style = type(parameter_type)
             parameter_type = parameter_type.type
             if parameter.default is not inspect.Parameter.empty and not (passing_style == InputPath and parameter.default is None):
@@ -363,10 +368,6 @@ def _extract_component_interface(func: Callable) -> ComponentSpec:
             # But from the outside perspective, there are no files or paths - the actual data objects (or references to them) are passed in.
             # It looks very strange when argument passing code looks like this: `component(number_file_path=42)`. This looks like an error since 42 is not a path. It's not even a string.
             # It's much more natural to strip the names of file inputs and outputs of "_file" or "_path" suffixes. Then the argument passing code will look natural: "component(number=42)".
-            if isinstance(parameter_type, (InputPath, OutputPath)) and io_name.endswith('_path'):
-                io_name = io_name[0:-len('_path')]
-            if io_name.endswith('_file'):
-                io_name = io_name[0:-len('_file')]
 
         type_struct = annotation_to_type_struct(parameter_type)
 

--- a/sdk/python/kfp/components/type_annotation_utils.py
+++ b/sdk/python/kfp/components/type_annotation_utils.py
@@ -14,9 +14,9 @@
 """Utilities for handling Python type annotation."""
 
 import re
-from typing import _GenericAlias, TypeVar, Union
+from typing import TypeVar, Union
 
-T = TypeVar('T', str, type, _GenericAlias)
+T = TypeVar('T')
 
 
 def extract_type_with_optional(annotation: T) -> T:

--- a/sdk/python/kfp/components/type_annotation_utils.py
+++ b/sdk/python/kfp/components/type_annotation_utils.py
@@ -19,8 +19,8 @@ from typing import TypeVar, Union
 T = TypeVar('T')
 
 
-def extract_type_with_optional(annotation: T) -> T:
-  """Extracts the type from Optional[<type>] if applicable.
+def maybe_strip_optional_from_annotation(annotation: T) -> T:
+  """Strips 'Optional' from 'Optional[<type>]' if applicable.
 
   For example::
     Optional[str] -> str

--- a/sdk/python/kfp/components/type_annotation_utils.py
+++ b/sdk/python/kfp/components/type_annotation_utils.py
@@ -1,0 +1,65 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for handling Python type annotation."""
+
+import re
+from typing import _GenericAlias, TypeVar, Union
+
+T = TypeVar('T', str, type, _GenericAlias)
+
+
+def extract_type_with_optional(annotation: T) -> T:
+  """Extracts the type from Optional[<type>] if applicable.
+
+  For example::
+    Optional[str] -> str
+    str -> str
+    List[int] -> List[int]
+
+  Args:
+    annotation: The original type annotation which may or may not has
+      `Optional`.
+
+  Returns:
+    The type inside Optional[] if Optional exists, otherwise the original type.
+  """
+  if getattr(annotation, '__origin__',
+             None) is Union and annotation.__args__[1] is type(None):
+    return annotation.__args__[0]
+  return annotation
+
+
+def get_short_type_name(type_name: str) -> str:
+  """Extracts the short form type name.
+
+  This method is used for looking up serializer for a given type.
+
+  For example::
+    typing.List -> List
+    typing.List[int] -> List
+    typing.Dict[str, str] -> Dict
+    List -> List
+    str -> str
+
+  Args:
+    type_name: The original type name.
+
+  Returns:
+    The short form type name or the original name if pattern doesn't match.
+  """
+  match = re.match('(typing\.)?(?P<type>\w+)(?:\[.+\])?', type_name)
+  if match:
+    return match.group('type')
+  else:
+    return type_name

--- a/sdk/python/kfp/components/type_annotation_utils_test.py
+++ b/sdk/python/kfp/components/type_annotation_utils_test.py
@@ -1,0 +1,86 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for kfp.components.type_annoation_utils."""
+
+import unittest
+from absl.testing import parameterized
+from typing import Any, Dict, List, Optional
+
+from kfp.components import type_annotation_utils
+
+
+class TypeAnnotationUtilsTest(parameterized.TestCase):
+
+  @parameterized.parameters(
+      {
+          'original_annotation': str,
+          'expected_annotation': str,
+      },
+      {
+          'original_annotation': 'MyCustomType',
+          'expected_annotation': 'MyCustomType',
+      },
+      {
+          'original_annotation': List[int],
+          'expected_annotation': List[int],
+      },
+      {
+          'original_annotation': Optional[str],
+          'expected_annotation': str,
+      },
+      {
+          'original_annotation': Optional[Dict[str, float]],
+          'expected_annotation': Dict[str, float],
+      },
+      {
+          'original_annotation': Optional[List[Dict[str, Any]]],
+          'expected_annotation': List[Dict[str, Any]],
+      },
+  )
+  def test_extract_type_with_optional(self, original_annotation,
+                                      expected_annotation):
+    self.assertEqual(
+        expected_annotation,
+        type_annotation_utils.extract_type_with_optional(original_annotation))
+
+  @parameterized.parameters(
+      {
+          'original_type_name': 'str',
+          'expected_type_name': 'str',
+      },
+      {
+          'original_type_name': 'typing.List[int]',
+          'expected_type_name': 'List',
+      },
+      {
+          'original_type_name': 'List[int]',
+          'expected_type_name': 'List',
+      },
+      {
+          'original_type_name': 'Dict[str, str]',
+          'expected_type_name': 'Dict',
+      },
+      {
+          'original_type_name': 'List[Dict[str, str]]',
+          'expected_type_name': 'List',
+      },
+  )
+  def test_get_short_type_name(self, original_type_name, expected_type_name):
+    self.assertEqual(
+        expected_type_name,
+        type_annotation_utils.get_short_type_name(original_type_name))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdk/python/kfp/components/type_annotation_utils_test.py
+++ b/sdk/python/kfp/components/type_annotation_utils_test.py
@@ -48,11 +48,12 @@ class TypeAnnotationUtilsTest(parameterized.TestCase):
           'expected_annotation': List[Dict[str, Any]],
       },
   )
-  def test_extract_type_with_optional(self, original_annotation,
-                                      expected_annotation):
+  def test_maybe_strip_optional_from_annotation(self, original_annotation,
+                                                expected_annotation):
     self.assertEqual(
         expected_annotation,
-        type_annotation_utils.extract_type_with_optional(original_annotation))
+        type_annotation_utils.maybe_strip_optional_from_annotation(
+            original_annotation))
 
   @parameterized.parameters(
       {

--- a/sdk/python/kfp/components_tests/test_data_passing.py
+++ b/sdk/python/kfp/components_tests/test_data_passing.py
@@ -19,18 +19,6 @@ from ..components import _data_passing
 
 class DataPassingTest(unittest.TestCase):
 
-  def test_get_short_type_name(self):
-    self.assertEqual('str', _data_passing._get_short_type_name('str'))
-
-    self.assertEqual('List',
-                     _data_passing._get_short_type_name('typing.List[int]'))
-
-    self.assertEqual('List', _data_passing._get_short_type_name('typing.List'))
-
-    self.assertEqual('List', _data_passing._get_short_type_name('List[int]'))
-
-    self.assertEqual(
-        'Dict', _data_passing._get_short_type_name('typing.Dict[str, str]'))
 
   def test_serialize_value(self):
     self.assertEqual(

--- a/sdk/python/kfp/dsl/type_utils.py
+++ b/sdk/python/kfp/dsl/type_utils.py
@@ -15,7 +15,7 @@
 import inspect
 from typing import Dict, List, Optional, Type, Union
 from kfp.components import structures
-from kfp.components import _data_passing
+from kfp.components import type_annotation_utils
 from kfp.pipeline_spec import pipeline_spec_pb2
 from kfp.dsl import artifact_utils
 from kfp.dsl import io_types
@@ -67,7 +67,7 @@ def is_parameter_type(type_name: Optional[Union[str, dict]]) -> bool:
     True if the type name maps to a parameter type else False.
   """
   if isinstance(type_name, str):
-    type_name = _data_passing._get_short_type_name(type_name)
+    type_name = type_annotation_utils.get_short_type_name(type_name)
   elif isinstance(type_name, dict):
     type_name = list(type_name.keys())[0]
   else:
@@ -112,7 +112,7 @@ def get_parameter_type(
   elif isinstance(param_type, dict):
     type_name = list(param_type.keys())[0]
   else:
-    type_name = _data_passing._get_short_type_name(str(param_type))
+    type_name = type_annotation_utils.get_short_type_name(str(param_type))
   return _PARAMETER_TYPES_MAPPING.get(type_name.lower())
 
 

--- a/sdk/python/tests/dsl/component_tests.py
+++ b/sdk/python/tests/dsl/component_tests.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List, Optional
+import unittest
+
 import kfp
 import kfp.dsl as dsl
 from kfp.dsl import component, graph_component
 from kfp.dsl.types import Integer, GCSPath, InconsistentTypeException
 from kfp.dsl import ContainerOp, Pipeline, PipelineParam
 from kfp.components.structures import ComponentSpec, InputSpec, OutputSpec
-import unittest
+
 
 class TestPythonComponent(unittest.TestCase):
 
@@ -40,6 +43,26 @@ class TestPythonComponent(unittest.TestCase):
     golden_meta.inputs.append(InputSpec(name='b', type={'Integer': {'openapi_schema_validator': {"type": "integer"}}}, default="12", optional=True))
     golden_meta.inputs.append(InputSpec(name='c', type={'ArtifactB': {'path_type':'file', 'file_type': 'tsv'}}, default='gs://hello/world', optional=True))
     golden_meta.outputs.append(OutputSpec(name='model', type={'Integer': {'openapi_schema_validator': {"type": "integer"}}}))
+
+    self.assertEqual(containerOp._metadata, golden_meta)
+
+  def test_component_metadata_standard_type_annotation(self):
+    """Test component decorator metadata."""
+
+    class MockContainerOp:
+      def _set_metadata(self, component_meta):
+        self._metadata = component_meta
+
+    @component
+    def componentA(a: float, b: List[int], c: Optional[str] = None) -> None:
+      return MockContainerOp()
+
+    containerOp = componentA('str_value', '[1,2,3]')
+
+    golden_meta = ComponentSpec(name='ComponentA', inputs=[], outputs=None)
+    golden_meta.inputs.append(InputSpec(name='a', type='Float'))
+    golden_meta.inputs.append(InputSpec(name='b', type='typing.List[int]'))
+    golden_meta.inputs.append(InputSpec(name='c', type='String', default=None, optional=True))
 
     self.assertEqual(containerOp._metadata, golden_meta)
 

--- a/sdk/python/tests/dsl/component_tests.py
+++ b/sdk/python/tests/dsl/component_tests.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from typing import List, Optional
 import unittest
 
@@ -61,8 +62,11 @@ class TestPythonComponent(unittest.TestCase):
 
     golden_meta = ComponentSpec(name='ComponentA', inputs=[], outputs=None)
     golden_meta.inputs.append(InputSpec(name='a', type='Float'))
-    golden_meta.inputs.append(InputSpec(name='b', type='typing.List[int]'))
-    golden_meta.inputs.append(InputSpec(name='c', type='String', default=None, optional=True))
+    golden_meta.inputs.append(
+        InputSpec(name='b', type='typing.List[int]' if sys.version_info >=
+                  (3,7) else 'List'))
+    golden_meta.inputs.append(
+        InputSpec(name='c', type='String', default=None, optional=True))
 
     self.assertEqual(containerOp._metadata, golden_meta)
 


### PR DESCRIPTION
**Description of your changes:**
-  Extract the real type from `typing.Optional[<type>]`.
    Before this change, a function-based component, like shown below,
    ```
    @component
    def some_op(a: Optional[str] = None):
        ...
    ```
    when saved to a component YAML, will generate the YAML spec as follows: 
    ```
    name: Some op
    inputs:
    - {name: a, type: typing.Optional[str], optional: true}
    ...
    ```
    There're two issues with this YAML spec.
     1. `typing.Optional[str]` contains redundant info, given the input spec also has `optional: true`. 
     2. `typing.Optional[str]` would be recognized as an artifact in v2. Although we could fix this issue separately, but I think a better fix is to get rid of `Optional` from the beginning. 
    
   After this change, the same function-based component will generate the YAML as follows:
    ```
    name: Some op
    inputs:
    - {name: a, type: String, optional: true}
    ...
    ```
-  Also refactor and move `_data_passing._get_short_type_name()` to `type_annotation_utils.get_short_type_name()`.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
