### PR TITLE
fix(cli): handle when pipeline.paramters is None

### DIFF
--- a/sdk/python/kfp/cli/pipeline.py
+++ b/sdk/python/kfp/cli/pipeline.py
@@ -194,7 +194,9 @@ def _display_pipeline(pipeline, output_format):
 
     # Pipeline parameter details
     headers = ["Parameter Name", "Default Value"]
-    data = [[param.name, param.value] for param in pipeline.parameters]
+    data = []
+    if pipeline.parameters is not None:
+        data = [[param.name, param.value] for param in pipeline.parameters]
 
     if output_format == OutputFormat.table.name:
         print_output([], ["Pipeline Details"], output_format)


### PR DESCRIPTION
**Description of your changes:**

When you upload pipeline which doesn't have parameter using kfp command line tool, you can see this message.
```bash
❯ kfp pipeline upload -p iris-pipeline-ci-test examples/iris_pipeline_example.yaml
'NoneType' object is not iterable
```

After this pr merged, you can see this message.
```bash
❯ kfp pipeline upload -p iris-pipeline-ci-test examples/iris_pipeline_example.yaml
Pipeline Details
------------------
ID           ebb77e3f-5959-442e-aab1-4469b8ff7995
Name         iris-pipeline-ci-test
Description
Uploaded at  2021-05-24T07:08:03+00:00
+------------------+-----------------+
| Parameter Name   | Default Value   |
+==================+=================+
+------------------+-----------------+
```


Signed-off-by: ByungchanKim <kbc8894@gmail.com>