### PR TITLE
chore: restore KFP SDK version to 1.6.2, decouple SDK release from KFP main release.

### DIFF
--- a/sdk/python/kfp/__init__.py
+++ b/sdk/python/kfp/__init__.py
@@ -16,7 +16,7 @@
 # https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
-__version__ = '1.6.0'
+__version__ = '1.6.2'
 
 from . import components
 from . import containers

--- a/test/release/bump-version-in-place.sh
+++ b/test/release/bump-version-in-place.sh
@@ -42,6 +42,7 @@ sed -i.bak -e 's|\([ (]\)#\([0-9]\+\)|\1[\\#\2](https://github.com/kubeflow/pipe
 "$REPO_ROOT/components/release-in-place.sh" $TAG_NAME
 "$REPO_ROOT/manifests/gcp_marketplace/hack/release.sh" $TAG_NAME
 "$REPO_ROOT/manifests/kustomize/hack/release.sh" $TAG_NAME
-"$REPO_ROOT/sdk/hack/release.sh" $TAG_NAME
+# De-couple SDK release for now.
+# "$REPO_ROOT/sdk/hack/release.sh" $TAG_NAME
 "$REPO_ROOT/backend/api/hack/generator.sh"
 "$REPO_ROOT/backend/api/build_kfp_server_api_python_package.sh"


### PR DESCRIPTION
**Description of your changes:**
It was accidentally overwritten by https://github.com/kubeflow/pipelines/commit/1c66f93f5149a8d5ed7f33895d3ebc01e662d837

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
