### PR TITLE
Fix the cache-deployer to run as non root

### DIFF
--- a/backend/src/cache/deployer/Dockerfile
+++ b/backend/src/cache/deployer/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --update \
 RUN gcloud components install kubectl
 
 ADD backend/src/cache/deployer/* /kfp/cache/deployer/
+RUN chmod -R 777 /kfp/cache/deployer
 
 WORKDIR /kfp/cache/deployer
 


### PR DESCRIPTION
Part of  https://github.com/kubeflow/manifests/pull/1756

The /kfp/cache/deployer directory is used to download stuff and must be fully accessible for any user.

```
+ echo 'Start deploying cache service to existing cluster:'
+ NAMESPACE=kubeflow
+ MUTATING_WEBHOOK_CONFIGURATION_NAME=cache-webhook-kubeflowStart deploying cache service to existing cluster:

+ WEBHOOK_SECRET_NAME=webhook-server-tls
+ mkdir -p //bin
+ export 'PATH=//bin:/google-cloud-sdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+ kubectl version --output json
+ jq --raw-output '(.serverVersion.major + "." + .serverVersion.minor)'
+ tr -d '"+'
+ server_version_major_minor=1.20
+ curl -s https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt
+ stable_build_version=v1.20.7
+ kubectl_url=https://storage.googleapis.com/kubernetes-release/release/v1.20.7/bin/linux/amd64/kubectl
+ curl -L -o //bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.20.7/bin/linux/amd64/kubectl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Failed to create the file //bin/kubectl: Permission denied
  0 38.3M    0  1367    0     0   7469      0  1:29:45 --:--:--  1:29:45  7469
curl: (23) Failure writing output to destination
+ chmod +x //bin/kubectl
chmod: //bin/kubectl: No such file or directory
+ true
/kfp/cache/deployer/deploy-cache-service.sh: line 47: can't create webhooks.txt: Permission denied
```

The image works and is available here https://mtr.external.otc.telekomcloud.com/repository/kubeflow/cache-deployer?tag=1.5.0

@bobgy @DavidSpek 
i think this is the last component that needed root rights, except for the bundled istio.

I also encountered another bug  on the way: https://github.com/kubeflow/pipelines/pull/5743