### PR TITLE
Fix the cache server in combination with kubeflow profile quotas

### DIFF
--- a/backend/src/cache/server/mutation.go
+++ b/backend/src/cache/server/mutation.go
@@ -152,6 +152,12 @@ func MutatePodIfCached(req *v1beta1.AdmissionRequest, clientMgr ClientManagerInt
 			Name:    "main",
 			Image:   image,
 			Command: []string{`echo`, `"This step output is taken from cache."`},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("0.01"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+			},
 		}
 		dummyContainers := []corev1.Container{
 			dummyContainer,


### PR DESCRIPTION
Caching is not compatible with profile quotas that specify CPU requests. https://github.com/kubeflow/pipelines/pull/5695 is overwritten by the mutatingwebhook at https://github.com/kubeflow/pipelines/blob/1db9db5be8c15518ce88935f786be09e5e163de6/backend/src/cache/server/mutation.go#L151-L155 

https://github.com/pantheon-systems/cassandra-operator/blob/735de0001e9d23ea0bf4a79c6b51f4ccbe95777d/pkg/resource/cassandra_pod.go#L90 as reference