### PR TITLE
feat(sdk): set shell=False to run LocalClient both docker and local mode

### DIFF
--- a/sdk/python/kfp/_local_client.py
+++ b/sdk/python/kfp/_local_client.py
@@ -344,26 +344,7 @@ class LocalClient:
             "{pipeline_root}:{pipeline_root}".format(pipeline_root=self._pipeline_root),
             op.image,
         ] + cmd
-        cmd_line = []
-        is_arg = False
-        for sub_cmd in docker_cmd:
-            if is_arg:
-                if " " in sub_cmd:
-                    sub_cmd = f"'{sub_cmd}'"
-                cmd_line.append(sub_cmd)
-                is_arg = False
-            elif sub_cmd.startswith("--"):
-                cmd_line.append(sub_cmd)
-                is_arg = True
-            elif sub_cmd.startswith("program_path"):
-                cmd_line.append(f"'{sub_cmd}'")
-            elif sub_cmd.startswith("def"):
-                sub_cmd = sub_cmd.replace("\"", "'")
-                cmd_line.append(f"\"{sub_cmd}\"")
-            else:
-                cmd_line.append(sub_cmd)
-        cmd_line = " ".join(cmd_line)
-        return cmd_line
+        return docker_cmd
 
     def _run_group_dag(
         self,
@@ -414,10 +395,9 @@ class LocalClient:
                     cmd = self._generate_cmd_for_docker_execution(
                         run_name, pipeline, op, stack
                     )
-
                 process = subprocess.Popen(
                     cmd,
-                    shell="sh" != cmd[0],
+                    shell=False,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     universal_newlines=True,


### PR DESCRIPTION
**Description of your changes:**
I have found that `LocalClient` is not working in docker mode.
Main cause was docker run argument with wrong position of single quote and double quote.

Below is the example code that i used.
```python
import os
from pathlib import Path
from functools import partial

from kfp import LocalClient
from kfp.components import OutputPath, func_to_container_op
from kfp.dsl import pipeline


@partial(
    func_to_container_op,
    base_image="python:3.8-alpine",
)
def print_msg(msg_dir: OutputPath(), msg: str):
    print(msg)
    with open(msg_dir, "w") as f:
        f.write(msg)


@pipeline(
    name="example",
    description="example pipeline",
)
def simple_piepeline(msg):
    print_msg(msg=msg)


client = LocalClient(Path(os.getcwd()) / "local")
# local_run = client.create_run_from_pipeline_func(
#     simple_piepeline, {"msg": "'Hello, World!'"}, LocalClient.ExecutionMode(mode="local")
# )
docker_run = client.create_run_from_pipeline_func(simple_piepeline, {"msg": "Hello, World!"})
```
Running this code exits with below message.

```bash
ERROR:root:def _make_parent_dirs_and_return_path(file_path: str):
    import os
    os.makedirs(os.path.dirname(file_path), exist_ok=True)
    return file_path

def print_msg(msg_dir, msg):
    print(msg)
    with open(msg_dir, "w") as f:
        f.write(msg)

import argparse
_parser = argparse.ArgumentParser(prog='Print msg', description='')
_parser.add_argument("--msg", dest="msg", type=str, required=True, default=argparse.SUPPRESS)
_parser.add_argument("--msg-dir", dest="msg_dir", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
_parsed_args = vars(_parser.parse_args())

_outputs = print_msg(**_parsed_args)
: 2: def _make_parent_dirs_and_return_path(file_path: str):
    import os
    os.makedirs(os.path.dirname(file_path), exist_ok=True)
    return file_path

def print_msg(msg_dir, msg):
    print(msg)
    with open(msg_dir, "w") as f:
        f.write(msg)

import argparse
_parser = argparse.ArgumentParser(prog='Print msg', description='')
_parser.add_argument("--msg", dest="msg", type=str, required=True, default=argparse.SUPPRESS)
_parser.add_argument("--msg-dir", dest="msg_dir", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
_parsed_args = vars(_parser.parse_args())

_outputs = print_msg(**_parsed_args)
: cannot create : Directory nonexistent

ERROR:root:['docker', 'run', '-v', '/Users/aiden-mrx/Dropbox/workspace/mrxflow/examples/local:/Users/aiden-mrx/Dropbox/workspace/mrxflow/examples/local', 'test', 'sh', '-ec', 'program_path=$(mktemp)\nprintf "%s" "$0" > "$program_path"\npython3 -u "$program_path" "$@"\n', 'def _make_parent_dirs_and_return_path(file_path: str):\n    import os\n    os.makedirs(os.path.dirname(file_path), exist_ok=True)\n    return file_path\n\ndef print_msg(msg_dir, msg):\n    print(msg)\n    with open(msg_dir, "w") as f:\n        f.write(msg)\n\nimport argparse\n_parser = argparse.ArgumentParser(prog=\'Print msg\', description=\'\')\n_parser.add_argument("--msg", dest="msg", type=str, required=True, default=argparse.SUPPRESS)\n_parser.add_argument("--msg-dir", dest="msg_dir", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n\n_outputs = print_msg(**_parsed_args)\n', '--msg', 'Hello, World!', '--msg-dir', '/Users/aiden-mrx/Dropbox/workspace/mrxflow/examples/local/example_20210528141529/print-msg/outputs/msg_dir/data']
```

In `LocalClient._run_group_dag`, it converts `cmd` list to string with `subprocess.list2cmdline` function.
For example, above example code generated `cmd` is like this.
```python
cmd = ['docker', 'run', '-v', '/home/mrx/workspace/seldon-tutorial/mrxflow/examples/local:/home/mrx/workspace/seldon-tutorial/mrxflow/examples/local', 'python:3.8-alpine', 'sh', '-ec', '\'program_path=$(mktemp)\nprintf "%s" "$0" > "$program_path"\npython3 -u "$program_path" "$@"\n\'', '"def _make_parent_dirs_and_return_path(file_path: str):\n    import os\n    os.makedirs(os.path.dirname(file_path), exist_ok=True)\n    return file_path\n\ndef print_msg(msg_dir, msg):\n    print(msg)\n    with open(msg_dir, \'w\') as f:\n        f.write(msg)\n\nimport argparse\n_parser = argparse.ArgumentParser(prog=\'Print msg\', description=\'\')\n_parser.add_argument(\'--msg\', dest=\'msg\', type=str, required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\'--msg-dir\', dest=\'msg_dir\', type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n\n_outputs = print_msg(**_parsed_args)\n"', '--msg', 'Hello, World!', '--msg-dir', '/home/mrx/workspace/seldon-tutorial/mrxflow/examples/local/example_20210528060431/print-msg/outputs/msg_dir/data']
```

And converted result is like this.
```python
>>> import subprocess
>>> subprocess.list2cmdline(cmd)
'docker run -v /home/mrx/workspace/seldon-tutorial/mrxflow/examples/local:/home/mrx/workspace/seldon-tutorial/mrxflow/examples/local python:3.8-alpine sh -ec "\'program_path=$(mktemp)\nprintf \\"%s\\" \\"$0\\" > \\"$program_path\\"\npython3 -u \\"$program_path\\" \\"$@\\"\n\'" "\\"def _make_parent_dirs_and_return_path(file_path: str):\n    import os\n    os.makedirs(os.path.dirname(file_path), exist_ok=True)\n    return file_path\n\ndef print_msg(msg_dir, msg):\n    print(msg)\n    with open(msg_dir, \'w\') as f:\n        f.write(msg)\n\nimport argparse\n_parser = argparse.ArgumentParser(prog=\'Print msg\', description=\'\')\n_parser.add_argument(\'--msg\', dest=\'msg\', type=str, required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\'--msg-dir\', dest=\'msg_dir\', type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n\n_outputs = print_msg(**_parsed_args)\n\\"" --msg "Hello, World!" --msg-dir /home/mrx/workspace/seldon-tutorial/mrxflow/examples/local/example_20210528060431/print-msg/outputs/msg_dir/data'
```
As you can see, docker run command is wrapped with double quote, and it also generates `\"`.

To run this command properly, it shoule be generated like this.
```bash
docker run -v /home/mrx/workspace/seldon-tutorial/mrxflow/examples/local:/home/mrx/workspace/seldon-tutorial/mrxflow/examples/local python:3.8-alpine sh -ec 'program_path=$(mktemp)
printf "%s" "$0" > "$program_path"
python3 -u "$program_path" "$@"
' "def _make_parent_dirs_and_return_path(file_path: str):
    import os
    os.makedirs(os.path.dirname(file_path), exist_ok=True)
    return file_path

def print_msg(msg_dir, msg):
    print(msg)
    with open(msg_dir, 'w') as f:
        f.write(msg)

import argparse
_parser = argparse.ArgumentParser(prog='Print msg', description='')
_parser.add_argument('--msg', dest='msg', type=str, required=True, default=argparse.SUPPRESS)
_parser.add_argument('--msg-dir', dest='msg_dir', type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
_parsed_args = vars(_parser.parse_args())

_outputs = print_msg(**_parsed_args)
" --msg Hello, World! --msg-dir /home/mrx/workspace/seldon-tutorial/mrxflow/examples/local/example_20210528060431/print-msg/outputs/msg_dir/data
```

So i added  converting logic in `LocalClient._generate_cmd_for_docker_execution`.
```python
        cmd_line = []
        is_arg = False
        for sub_cmd in docker_cmd:
            if is_arg:
                if " " in sub_cmd:
                    sub_cmd = f"'{sub_cmd}'"
                cmd_line.append(sub_cmd)
                is_arg = False
            elif sub_cmd.startswith("--"):
                cmd_line.append(sub_cmd)
                is_arg = True
            elif sub_cmd.startswith("program_path"):
                cmd_line.append(f"'{sub_cmd}'")
            elif sub_cmd.startswith("def"):
                sub_cmd = sub_cmd.replace("\"", "'")
                cmd_line.append(f"\"{sub_cmd}\"")
            else:
                cmd_line.append(sub_cmd)
        cmd_line = " ".join(cmd_line)
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
