### PR TITLE
fix(sdk.v2): Fix the bug where string concat inside a loop may break compilation.

### DIFF
--- a/sdk/python/kfp/dsl/_component_bridge.py
+++ b/sdk/python/kfp/dsl/_component_bridge.py
@@ -459,11 +459,10 @@ def _attach_v2_specs(
   arguments = arguments.copy()
 
   # Preserve input params for ContainerOp.inputs
-  input_params = list(
-      set([
-          param for param in arguments.values()
-          if isinstance(param, _pipeline_param.PipelineParam)
-      ]))
+  input_params_set = set([
+      param for param in arguments.values()
+      if isinstance(param, _pipeline_param.PipelineParam)
+  ])
 
   for input_name, argument_value in arguments.items():
     input_type = component_spec._inputs_dict[input_name].type
@@ -523,6 +522,9 @@ def _attach_v2_specs(
                                '{} and compiler injected input name {}'.format(
                                    existing_input_name, additional_input_name))
 
+          # Add the additional param to the input params set. Otherwise, it will
+          # not be included when the params set is not empty.
+          input_params_set.add(param)
           additional_input_placeholder = (
               "{{{{$.inputs.parameters['{}']}}}}".format(additional_input_name))
           argument_value = argument_value.replace(param.pattern,
@@ -620,4 +622,4 @@ def _attach_v2_specs(
     task.arguments = resolved_cmd.args
 
     # limit this to v2 compiling only to avoid possible behavior change in v1.
-    task.inputs = input_params
+    task.inputs = list(input_params_set)

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_params_containing_format.json
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_params_containing_format.json
@@ -1,11 +1,52 @@
 {
   "pipelineSpec": {
     "components": {
+      "comp-for-loop-2": {
+        "dag": {
+          "tasks": {
+            "print-op2": {
+              "componentRef": {
+                "name": "comp-print-op2"
+              },
+              "inputs": {
+                "parameters": {
+                  "pipelineparam--name": {
+                    "componentInputParameter": "pipelineparam--name"
+                  },
+                  "text1": {
+                    "componentInputParameter": "pipelineparam--loop-item-param-1"
+                  },
+                  "text2": {
+                    "runtimeValue": {
+                      "constantValue": {
+                        "stringValue": " and {{$.inputs.parameters['pipelineparam--name']}}."
+                      }
+                    }
+                  }
+                }
+              },
+              "taskInfo": {
+                "name": "print-op2"
+              }
+            }
+          }
+        },
+        "inputDefinitions": {
+          "parameters": {
+            "pipelineparam--loop-item-param-1": {
+              "type": "STRING"
+            },
+            "pipelineparam--name": {
+              "type": "STRING"
+            }
+          }
+        }
+      },
       "comp-print-op": {
         "executorLabel": "exec-print-op",
         "inputDefinitions": {
           "parameters": {
-            "name": {
+            "text": {
               "type": "STRING"
             }
           }
@@ -22,7 +63,27 @@
         "executorLabel": "exec-print-op-2",
         "inputDefinitions": {
           "parameters": {
-            "name": {
+            "text": {
+              "type": "STRING"
+            }
+          }
+        },
+        "outputDefinitions": {
+          "parameters": {
+            "Output": {
+              "type": "STRING"
+            }
+          }
+        }
+      },
+      "comp-print-op2": {
+        "executorLabel": "exec-print-op2",
+        "inputDefinitions": {
+          "parameters": {
+            "text1": {
+              "type": "STRING"
+            },
+            "text2": {
               "type": "STRING"
             }
           }
@@ -41,8 +102,8 @@
         "exec-print-op": {
           "container": {
             "args": [
-              "--name",
-              "{{$.inputs.parameters['name']}}",
+              "--text",
+              "{{$.inputs.parameters['text']}}",
               "----output-paths",
               "{{$.outputs.parameters['Output'].output_file}}"
             ],
@@ -50,7 +111,7 @@
               "sh",
               "-ec",
               "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3 -u \"$program_path\" \"$@\"\n",
-              "def print_op(name):\n  print(name)\n  return name\n\ndef _serialize_str(str_value: str) -> str:\n    if not isinstance(str_value, str):\n        raise TypeError('Value \"{}\" has type \"{}\" instead of str.'.format(str(str_value), str(type(str_value))))\n    return str_value\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Print op', description='')\n_parser.add_argument(\"--name\", dest=\"name\", type=str, required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"----output-paths\", dest=\"_output_paths\", type=str, nargs=1)\n_parsed_args = vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_op(**_parsed_args)\n\n_outputs = [_outputs]\n\n_output_serializers = [\n    _serialize_str,\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+              "def print_op(text):\n  print(text)\n  return text\n\ndef _serialize_str(str_value: str) -> str:\n    if not isinstance(str_value, str):\n        raise TypeError('Value \"{}\" has type \"{}\" instead of str.'.format(str(str_value), str(type(str_value))))\n    return str_value\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Print op', description='')\n_parser.add_argument(\"--text\", dest=\"text\", type=str, required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"----output-paths\", dest=\"_output_paths\", type=str, nargs=1)\n_parsed_args = vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_op(**_parsed_args)\n\n_outputs = [_outputs]\n\n_output_serializers = [\n    _serialize_str,\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
             ],
             "image": "python:3.7"
           }
@@ -58,8 +119,8 @@
         "exec-print-op-2": {
           "container": {
             "args": [
-              "--name",
-              "{{$.inputs.parameters['name']}}",
+              "--text",
+              "{{$.inputs.parameters['text']}}",
               "----output-paths",
               "{{$.outputs.parameters['Output'].output_file}}"
             ],
@@ -67,7 +128,26 @@
               "sh",
               "-ec",
               "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3 -u \"$program_path\" \"$@\"\n",
-              "def print_op(name):\n  print(name)\n  return name\n\ndef _serialize_str(str_value: str) -> str:\n    if not isinstance(str_value, str):\n        raise TypeError('Value \"{}\" has type \"{}\" instead of str.'.format(str(str_value), str(type(str_value))))\n    return str_value\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Print op', description='')\n_parser.add_argument(\"--name\", dest=\"name\", type=str, required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"----output-paths\", dest=\"_output_paths\", type=str, nargs=1)\n_parsed_args = vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_op(**_parsed_args)\n\n_outputs = [_outputs]\n\n_output_serializers = [\n    _serialize_str,\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+              "def print_op(text):\n  print(text)\n  return text\n\ndef _serialize_str(str_value: str) -> str:\n    if not isinstance(str_value, str):\n        raise TypeError('Value \"{}\" has type \"{}\" instead of str.'.format(str(str_value), str(type(str_value))))\n    return str_value\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Print op', description='')\n_parser.add_argument(\"--text\", dest=\"text\", type=str, required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"----output-paths\", dest=\"_output_paths\", type=str, nargs=1)\n_parsed_args = vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_op(**_parsed_args)\n\n_outputs = [_outputs]\n\n_output_serializers = [\n    _serialize_str,\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
+            ],
+            "image": "python:3.7"
+          }
+        },
+        "exec-print-op2": {
+          "container": {
+            "args": [
+              "--text1",
+              "{{$.inputs.parameters['text1']}}",
+              "--text2",
+              "{{$.inputs.parameters['text2']}}",
+              "----output-paths",
+              "{{$.outputs.parameters['Output'].output_file}}"
+            ],
+            "command": [
+              "sh",
+              "-ec",
+              "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3 -u \"$program_path\" \"$@\"\n",
+              "def print_op2(text1, text2):\n  print(text1+text2)\n  return text1+text2\n\ndef _serialize_str(str_value: str) -> str:\n    if not isinstance(str_value, str):\n        raise TypeError('Value \"{}\" has type \"{}\" instead of str.'.format(str(str_value), str(type(str_value))))\n    return str_value\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Print op2', description='')\n_parser.add_argument(\"--text1\", dest=\"text1\", type=str, required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"--text2\", dest=\"text2\", type=str, required=True, default=argparse.SUPPRESS)\n_parser.add_argument(\"----output-paths\", dest=\"_output_paths\", type=str, nargs=1)\n_parsed_args = vars(_parser.parse_args())\n_output_files = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = print_op2(**_parsed_args)\n\n_outputs = [_outputs]\n\n_output_serializers = [\n    _serialize_str,\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n    try:\n        os.makedirs(os.path.dirname(output_file))\n    except OSError:\n        pass\n    with open(output_file, 'w') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"
             ],
             "image": "python:3.7"
           }
@@ -80,21 +160,42 @@
     "root": {
       "dag": {
         "tasks": {
+          "for-loop-2": {
+            "componentRef": {
+              "name": "comp-for-loop-2"
+            },
+            "inputs": {
+              "parameters": {
+                "pipelineparam--name": {
+                  "componentInputParameter": "name"
+                }
+              }
+            },
+            "parameterIterator": {
+              "itemInput": "pipelineparam--loop-item-param-1",
+              "items": {
+                "raw": "[1, 2]"
+              }
+            },
+            "taskInfo": {
+              "name": "for-loop-2"
+            }
+          },
           "print-op": {
             "componentRef": {
               "name": "comp-print-op"
             },
             "inputs": {
               "parameters": {
-                "name": {
+                "pipelineparam--name": {
+                  "componentInputParameter": "name"
+                },
+                "text": {
                   "runtimeValue": {
                     "constantValue": {
                       "stringValue": "Hello {{$.inputs.parameters['pipelineparam--name']}}"
                     }
                   }
-                },
-                "pipelineparam--name": {
-                  "componentInputParameter": "name"
                 }
               }
             },
@@ -111,17 +212,17 @@
             ],
             "inputs": {
               "parameters": {
-                "name": {
-                  "runtimeValue": {
-                    "constantValue": {
-                      "stringValue": "{{$.inputs.parameters['pipelineparam--print-op-Output']}}, again."
-                    }
-                  }
-                },
                 "pipelineparam--print-op-Output": {
                   "taskOutputParameter": {
                     "outputParameterKey": "Output",
                     "producerTask": "print-op"
+                  }
+                },
+                "text": {
+                  "runtimeValue": {
+                    "constantValue": {
+                      "stringValue": "{{$.inputs.parameters['pipelineparam--print-op-Output']}}, again."
+                    }
                   }
                 }
               }
@@ -141,7 +242,7 @@
       }
     },
     "schemaVersion": "2.0.0",
-    "sdkVersion": "kfp-1.6.0-rc.0"
+    "sdkVersion": "kfp-1.6.2"
   },
   "runtimeConfig": {
     "gcsOutputDirectory": "dummy_root",

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_params_containing_format.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_params_containing_format.py
@@ -18,16 +18,24 @@ from kfp.v2 import compiler
 
 
 @components.create_component_from_func
-def print_op(name: str) -> str:
-  print(name)
-  return name
+def print_op(text: str) -> str:
+  print(text)
+  return text
 
+@components.create_component_from_func
+def print_op2(text1: str, text2: str) -> str:
+  print(text1+text2)
+  return text1+text2
 
 @dsl.pipeline(name='pipeline-with-pipelineparam-containing-format',
               pipeline_root='dummy_root')
 def my_pipeline(name: str = 'KFP'):
   print_task = print_op('Hello {}'.format(name))
   print_op('{}, again.'.format(print_task.output))
+
+  new_value = f' and {name}.'
+  with dsl.ParallelFor([1,2]) as item:
+    print_op2(item, new_value)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of your changes:**
- Fixing a missing case from https://github.com/kubeflow/pipelines/pull/5183. Any additional input param resulted from string concatenation needs to be explicitly added to the op's inputs list. Otherwise, it will be missed out when it's not the only input.
- Updating the test sample to cover the scenario that was broken before the fix.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
