### PR TITLE
feat(sdk): Better error message when compiling for v2. Fixes #5688, Fixes #5727

### DIFF
--- a/samples/core/exit_handler/exit_handler.py
+++ b/samples/core/exit_handler/exit_handler.py
@@ -39,7 +39,7 @@ def echo_msg(msg: str):
     description=
     'Downloads a message and prints it. The exit handler will run after the pipeline finishes (successfully or not).'
 )
-def pipeline_exit_handler(url='gs://ml-pipeline/shakespeare1.txt'):
+def pipeline_exit_handler(url: str = 'gs://ml-pipeline/shakespeare1.txt'):
     """A sample pipeline showing exit handler."""
 
     exit_task = echo_msg('exit!')

--- a/samples/core/loop_parameter/loop_parameter.py
+++ b/samples/core/loop_parameter/loop_parameter.py
@@ -29,4 +29,4 @@ def my_pipeline(greeting:str='this is a test for looping through parameters'):
     with dsl.ParallelFor(generate_task.output) as item:
         concat_task = concat_op(a=item.a, b=item.b)
         concat_task.after(print_task)
-        print_task_2 = print_op(concat_task.output.ignore_type())
+        print_task_2 = print_op(concat_task.output)

--- a/samples/core/loop_static/loop_static.py
+++ b/samples/core/loop_static/loop_static.py
@@ -10,22 +10,22 @@ def print_op(text: str) -> str:
 
 
 @components.create_component_from_func
-def sum_op(a: float, b: float) -> float:
+def concat_op(a: str, b: str) -> str:
     print(a + b)
     return a + b
 
 
-_DEFAULT_LOOP_ARGUMENTS = [{'a': 1, 'b': 2}, {'a': 10, 'b': 20}]
+_DEFAULT_LOOP_ARGUMENTS = [{'a': '1', 'b': '2'}, {'a': '10', 'b': '20'}]
 
 
 @dsl.pipeline(name='pipeline-with-loop-static')
 def my_pipeline(
     static_loop_arguments: List[dict] = _DEFAULT_LOOP_ARGUMENTS,
-    greeting='this is a test for looping through parameters'
+    greeting: str = 'this is a test for looping through parameters',
 ):
     print_task = print_op(text=greeting)
 
     with dsl.ParallelFor(static_loop_arguments) as item:
-        sum_task = sum_op(a=item.a, b=item.b)
-        sum_task.after(print_task)
-        print_task_2 = print_op(sum_task.output.ignore_type())
+        concat_task = concat_op(a=item.a, b=item.b)
+        concat_task.after(print_task)
+        print_task_2 = print_op(concat_task.output)

--- a/sdk/python/kfp/_config.py
+++ b/sdk/python/kfp/_config.py
@@ -13,3 +13,6 @@
 # limitations under the License.
 #TODO: wrap the DSL level configuration into one Config
 TYPE_CHECK = True
+# COMPILING_FOR_V2 is True when using kfp.v2.compiler or use (v1) kfp.compiler
+# with V2_COMPATIBLE or V2_ENGINE mode
+COMPILING_FOR_V2 = False

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -1042,6 +1042,12 @@ class Compiler(object):
 
     import kfp
     type_check_old_value = kfp.TYPE_CHECK
+    compiling_for_v2_old_value = kfp.COMPILING_FOR_V2
+    kfp.COMPILING_FOR_V2 = self._mode in [
+        dsl.PipelineExecutionMode.V2_COMPATIBLE,
+        dsl.PipelineExecutionMode.V2_ENGINE,
+    ]
+
     try:
       kfp.TYPE_CHECK = type_check
       self._create_and_write_workflow(
@@ -1050,6 +1056,7 @@ class Compiler(object):
           package_path=package_path)
     finally:
       kfp.TYPE_CHECK = type_check_old_value
+      kfp.COMPILING_FOR_V2 = compiling_for_v2_old_value
 
   @staticmethod
   def _write_workflow(workflow: Dict[Text, Any], package_path: Text = None):

--- a/sdk/python/kfp/compiler/v2_compatible_compiler_test.py
+++ b/sdk/python/kfp/compiler/v2_compatible_compiler_test.py
@@ -117,6 +117,24 @@ class TestV2CompatibleModeCompiler(unittest.TestCase):
         kfp_compiler, v2_compatible_two_step_pipeline,
         'v2_compatible_two_step_pipeline_with_custom_launcher.yaml')
 
+  def test_constructing_container_op_directly_should_error(
+      self):
+
+    @dsl.pipeline(name='test-pipeline')
+    def my_pipeline():
+      dsl.ContainerOp(
+          name='comp1',
+          image='gcr.io/dummy',
+          command=['python', 'main.py']
+      )
+
+    with self.assertRaisesRegex(
+        RuntimeError,
+        'Constructing ContainerOp instances directly is deprecated and not '
+        'supported when compiling to v2 \(using v2 compiler or v1 compiler '
+        'with V2_COMPATIBLE or V2_ENGINE mode\).'):
+      compiler.Compiler(mode=dsl.PipelineExecutionMode.V2_COMPATIBLE).compile(
+          pipeline_func=my_pipeline, package_path='result.json')
 
 if __name__ == '__main__':
   unittest.main()

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -25,6 +25,7 @@ from kubernetes.client.models import (V1Container, V1EnvVar, V1EnvFromSource,
                                       V1VolumeMount, V1ContainerPort,
                                       V1Lifecycle, V1Volume)
 
+import kfp
 from kfp.components import _structures
 from kfp.dsl import _pipeline_param
 from kfp.dsl import dsl_utils
@@ -1155,6 +1156,11 @@ class ContainerOp(BaseOp):
           'https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.components.html#kfp.components.load_component_from_file',
           category=FutureWarning,
       )
+      if kfp.COMPILING_FOR_V2:
+        raise RuntimeError(
+            'Constructing ContainerOp instances directly is deprecated and not '
+            'supported when compiling to v2 (using v2 compiler or v1 compiler '
+            'with V2_COMPATIBLE or V2_ENGINE mode).')
 
     # `container` prop in `io.argoproj.workflow.v1alpha1.Template`
     container_kwargs = container_kwargs or {}

--- a/sdk/python/kfp/v2/compiler/compiler.py
+++ b/sdk/python/kfp/v2/compiler/compiler.py
@@ -952,8 +952,6 @@ class Compiler(object):
       sanitized_ops[sanitized_name] = op
     pipeline.ops = sanitized_ops
 
-  # The name of this method is used to check if compiling for v2.
-  # See `is_compiling_for_v2` in `kfp/dsl/_component_bridge.py`
   def _create_pipeline_v2(
       self,
       pipeline_func: Callable[..., Any],
@@ -1058,8 +1056,10 @@ class Compiler(object):
       type_check: Whether to enable the type check or not, default: True.
     """
     type_check_old_value = kfp.TYPE_CHECK
+    compiling_for_v2_old_value = kfp.COMPILING_FOR_V2
     try:
       kfp.TYPE_CHECK = type_check
+      kfp.COMPILING_FOR_V2 = True
       pipeline_job = self._create_pipeline_v2(
           pipeline_func=pipeline_func,
           pipeline_name=pipeline_name,
@@ -1067,6 +1067,7 @@ class Compiler(object):
       self._write_pipeline(pipeline_job, package_path)
     finally:
       kfp.TYPE_CHECK = type_check_old_value
+      kfp.COMPILING_FOR_V2 = compiling_for_v2_old_value
 
   def _write_pipeline(self, pipeline_job: pipeline_spec_pb2.PipelineJob,
                       output_path: str) -> None:

--- a/sdk/python/kfp/v2/compiler/compiler_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_test.py
@@ -124,31 +124,24 @@ class CompilerTest(unittest.TestCase):
         NotImplementedError,
         'dsl.graph_component is not yet supported in KFP v2 compiler.'):
 
-      @dsl.graph_component
-      def echo1_graph_component(text1):
-        dsl.ContainerOp(
-            name='echo1-task1',
-            image='library/bash:4.4.23',
-            command=['sh', '-c'],
-            arguments=['echo "$0"', text1])
+      @dsl.component
+      def flip_coin_op() -> str:
+        import random
+        result = 'heads' if random.randint(0, 1) == 0 else 'tails'
+        return result
 
       @dsl.graph_component
-      def echo2_graph_component(text2):
-        dsl.ContainerOp(
-            name='echo2-task1',
-            image='library/bash:4.4.23',
-            command=['sh', '-c'],
-            arguments=['echo "$0"', text2])
+      def flip_coin_graph_component():
+        flip = flip_coin_op()
+        with dsl.Condition(flip.output == 'heads'):
+          flip_coin_graph_component()
 
       @dsl.pipeline(name='test-pipeline', pipeline_root='dummy_root')
-      def opsgroups_pipeline(text1: str = 'message 1',
-                             text2: str = 'message 2'):
-        step1_graph_component = echo1_graph_component(text1)
-        step2_graph_component = echo2_graph_component(text2)
-        step2_graph_component.after(step1_graph_component)
+      def my_pipeline():
+        flip_coin_graph_component()
 
       compiler.Compiler().compile(
-          pipeline_func=opsgroups_pipeline, package_path='output.json')
+          pipeline_func=my_pipeline, package_path='output.json')
 
   def test_compile_pipeline_with_misused_inputvalue_should_raise_error(self):
 
@@ -405,6 +398,24 @@ class CompilerTest(unittest.TestCase):
       compiler.Compiler().compile(
           pipeline_func=my_pipeline, package_path='result.json')
 
+  def test_constructing_container_op_directly_should_error(
+      self):
+
+    @dsl.pipeline(name='test-pipeline')
+    def my_pipeline():
+      dsl.ContainerOp(
+          name='comp1',
+          image='gcr.io/dummy',
+          command=['python', 'main.py']
+      )
+
+    with self.assertRaisesRegex(
+        RuntimeError,
+        'Constructing ContainerOp instances directly is deprecated and not '
+        'supported when compiling to v2 \(using v2 compiler or v1 compiler '
+        'with V2_COMPATIBLE or V2_ENGINE mode\).'):
+      compiler.Compiler().compile(
+          pipeline_func=my_pipeline, package_path='result.json')
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
**Description of your changes:**
- Turn `is_compiling_for_v2` (previously apply to v2 compiler only) into a global config, and make it cover v2 compatible mode as well. 
- Also raise error when users construct `ContainerOp` instances directly from user code.

Fixes: #5688, #5727

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
