### PR TITLE
fix(sdk, v2): Fix error when replica_count isn't set

### DIFF
--- a/sdk/python/kfp/v2/google/experimental/custom_job.py
+++ b/sdk/python/kfp/v2/google/experimental/custom_job.py
@@ -133,7 +133,7 @@ def run_as_aiplatform_custom_job(
       worker_pool_spec['diskSpec']['bootDiskSizeGb'] = boot_disk_size_gb
 
     job_spec['workerPoolSpecs'] = [worker_pool_spec]
-    if replica_count > 1:
+    if replica_count is not None and replica_count > 1:
       additional_worker_pool_spec = copy.deepcopy(worker_pool_spec)
       additional_worker_pool_spec['replicaCount'] = str(replica_count-1)
       job_spec['workerPoolSpecs'].append(additional_worker_pool_spec)


### PR DESCRIPTION
**Description of your changes:**
`replica_count` is an optional arg of run_as_aiplatform_custom_job and the default value is `None`.
However, if it not set, it raises `TypeError: '>' not supported between instances of 'NoneType' and 'int'`.

I added the check if replica_count is not None.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
