### PR TITLE
fix(deployment): GCP AI Platform Pipelines -- correct default values when some fields left empty. Fixes #5717

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/values.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/values.yaml
@@ -17,13 +17,12 @@ images:
   cacheserver: gcr.io/ml-pipeline/google/pipelines/cacheserver:dummy
   cachedeployer: gcr.io/ml-pipeline/google/pipelines/cachedeployer:dummy
 
-serviceAccountCredential: ""
 gcpDefaultConfigName: "gcp-default-config"
 
 managedstorage:
   enabled: false
-  cloudsqlInstanceConnectionName: null
-  gcsBucketName: null
+  cloudsqlInstanceConnectionName: ""
+  gcsBucketName: ""
   databaseNamePrefix: '{{ .Release.Name | replace "-" "_" | replace "." "_" }}'
   dbUsername: 'root'
   dbPassword: ''

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/values.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/values.yaml
@@ -23,6 +23,6 @@ managedstorage:
   enabled: false
   cloudsqlInstanceConnectionName: ""
   gcsBucketName: ""
-  databaseNamePrefix: '{{ .Release.Name | replace "-" "_" | replace "." "_" }}'
+  databaseNamePrefix: ""
   dbUsername: 'root'
   dbPassword: ''

--- a/manifests/gcp_marketplace/schema.yaml
+++ b/manifests/gcp_marketplace/schema.yaml
@@ -244,9 +244,8 @@ properties:
       During the deployment process, Kubeflow Pipelines creates two databases,
       "<prefix>_pipeline" and "<prefix>_metadata". If the prefix specified
       matches a previous deployment, this deployment will reuse the existing
-      databases. If this value is not specified, the application instance name
-      is used.
-    default: '{{ .Release.Name | replace "-" "_" | replace "." "_" }}'
+      databases.
+    default: ""
 required:
   - name
   - namespace

--- a/manifests/gcp_marketplace/schema.yaml
+++ b/manifests/gcp_marketplace/schema.yaml
@@ -219,7 +219,7 @@ properties:
       database username for Kubeflow Pipelines to use when connecting to your
       MySQL instance on Cloud SQL. If you leave this field empty, this value
       defaults to 'root'. Learn more about MySQL users, see https://cloud.google.com/sql/docs/mysql/users.
-    default: ""
+    default: root
   managedstorage.dbPassword:
     type: string
     title: Database password (Managed storage only)
@@ -246,7 +246,7 @@ properties:
       matches a previous deployment, this deployment will reuse the existing
       databases. If this value is not specified, the application instance name
       is used.
-    default: ""
+    default: '{{ .Release.Name | replace "-" "_" | replace "." "_" }}'
 required:
   - name
   - namespace


### PR DESCRIPTION
**Description of your changes:**
Fixes #5717
According to the issue, schema.yaml default values should match values.yaml, because schema.yaml's default values are what actually take effect when users do not specify some fields.

Note, this PR is hard to verify, so we need to verify before next release.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
