### PR TITLE
fix(scheduledworkflow): Set location to make CRON timezone work, Fixes #2653

### DIFF
--- a/backend/Dockerfile.scheduledworkflow
+++ b/backend/Dockerfile.scheduledworkflow
@@ -15,6 +15,7 @@ WORKDIR /bin
 COPY --from=builder /bin/controller /bin/controller
 COPY --from=builder /go/src/github.com/kubeflow/pipelines/third_party/license.txt /bin/license.txt
 RUN chmod +x /bin/controller
+RUN apk --no-cache add tzdata
 
 ENV NAMESPACE ""
 

--- a/backend/src/crd/controller/scheduledworkflow/main.go
+++ b/backend/src/crd/controller/scheduledworkflow/main.go
@@ -43,7 +43,6 @@ var (
 )
 
 func main() {
-	initEnv()
 	flag.Parse()
 
 	// set up signals so we handle the first shutdown signal gracefully
@@ -107,6 +106,8 @@ func initEnv() {
 }
 
 func init() {
+	initEnv()
+
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&namespace, "namespace", "", "The namespace name used for Kubernetes informers to obtain the listers.")
@@ -116,6 +117,7 @@ func init() {
 	flag.IntVar(&clientBurst, "clientBurst", 10, "Maximum burst for throttle from this client.")
 	var err error
 	location, err = util.GetLocation()
+	log.Info("Location: %s", location.String())
 	if err != nil {
 		log.Fatalf("Error running controller: %s", err.Error())
 	}

--- a/backend/src/crd/controller/scheduledworkflow/main.go
+++ b/backend/src/crd/controller/scheduledworkflow/main.go
@@ -117,7 +117,7 @@ func init() {
 	flag.IntVar(&clientBurst, "clientBurst", 10, "Maximum burst for throttle from this client.")
 	var err error
 	location, err = util.GetLocation()
-	log.Info("Location: %s", location.String())
+	log.Infof("Location: %s", location.String())
 	if err != nil {
 		log.Fatalf("Error running controller: %s", err.Error())
 	}

--- a/backend/src/crd/controller/scheduledworkflow/main.go
+++ b/backend/src/crd/controller/scheduledworkflow/main.go
@@ -117,8 +117,8 @@ func init() {
 	flag.IntVar(&clientBurst, "clientBurst", 10, "Maximum burst for throttle from this client.")
 	var err error
 	location, err = util.GetLocation()
-	log.Infof("Location: %s", location.String())
 	if err != nil {
 		log.Fatalf("Error running controller: %s", err.Error())
 	}
+	log.Infof("Location: %s", location.String())
 }


### PR DESCRIPTION
I've tried to log the Location, it shows the default location is `Local` no matter what the CRON_SCHEDULE_TIMEZONE is.  Here's maybe a bug, the `util.GetLocation()` in `init()` depends on the viper's config, but the viper config will be initialized from environment variables in `initEnv()`. But the `initEnv()` is invoked in `main()` in current code. 
The Go execution order is `init()` goes first and then the `main()`, so the `util.GetLocation()` will be execute BEFORE the `initEnv()`, the viper does not load the config from environment variables in that moment.

This PR moves `initEnv()` into `init()` to make sure the `util.GetLocation()` to be executed after `initEnv()`, so that the location can be loaded properly.

fixes https://github.com/kubeflow/pipelines/issues/2653#issuecomment-854387762

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
