### PR TITLE
chore: update deprecated download_as_string to download_as_bytes

### DIFF
--- a/components/gcp/container/component_sdk/python/kfp_component/google/dataflow/_common_ops.py
+++ b/components/gcp/container/component_sdk/python/kfp_component/google/dataflow/_common_ops.py
@@ -47,14 +47,14 @@ def wait_for_job_done(df_client, project_id, job_id, location=None, wait_interva
                 ))
             time.sleep(wait_interval)
 
-def wait_and_dump_job(df_client, project_id, location, job, 
+def wait_and_dump_job(df_client, project_id, location, job,
     wait_interval,
     job_id_output_path,
     job_object_output_path,
 ):
     display_job_link(project_id, job)
     job_id = job.get('id')
-    job = wait_for_job_done(df_client, project_id, job_id, 
+    job = wait_for_job_done(df_client, project_id, job_id,
         location, wait_interval)
     gcp_common.dump_file(job_object_output_path, json.dumps(job))
     gcp_common.dump_file(job_id_output_path, job.get('id'))
@@ -97,7 +97,7 @@ def read_job_id_and_location(storage_client, staging_location):
     if staging_location:
         job_blob = _get_job_blob(storage_client, staging_location)
         if job_blob.exists():
-            job_data = job_blob.download_as_string().decode().split(',')
+            job_data = job_blob.download_as_bytes().decode().split(',')
             # Returns (job_id, location)
             logging.info('Found existing job {}.'.format(job_data))
             return (job_data[0], job_data[1])

--- a/components/gcp/container/component_sdk/python/tests/google/dataflow/test__launch_python.py
+++ b/components/gcp/container/component_sdk/python/tests/google/dataflow/test__launch_python.py
@@ -53,7 +53,7 @@ class LaunchPythonTest(unittest.TestCase):
         mock_client, mock_context, mock_stage_file, mock_display, mock_storage):
         mock_context().__enter__().context_id.return_value = 'ctx-1'
         mock_storage.Client().bucket().blob().exists.return_value = True
-        mock_storage.Client().bucket().blob().download_as_string.return_value = b'job-1,us-central1'
+        mock_storage.Client().bucket().blob().download_as_bytes.return_value = b'job-1,us-central1'
         expected_job = {
             'id': 'job-1',
             'currentState': 'JOB_STATE_DONE'

--- a/components/gcp/container/component_sdk/python/tests/google/dataflow/test__launch_template.py
+++ b/components/gcp/container/component_sdk/python/tests/google/dataflow/test__launch_template.py
@@ -26,7 +26,7 @@ MODULE = 'kfp_component.google.dataflow._launch_template'
 @mock.patch(MODULE + '.DataflowClient')
 class LaunchTemplateTest(unittest.TestCase):
 
-    def test_launch_template_succeed(self, mock_client, mock_context, mock_display, 
+    def test_launch_template_succeed(self, mock_client, mock_context, mock_display,
         mock_storage):
         mock_context().__enter__().context_id.return_value = 'context-1'
         mock_storage.Client().bucket().blob().exists.return_value = False
@@ -54,11 +54,11 @@ class LaunchTemplateTest(unittest.TestCase):
             'job-1,'
         )
 
-    def test_launch_template_retry_succeed(self, 
+    def test_launch_template_retry_succeed(self,
         mock_client, mock_context, mock_display, mock_storage):
         mock_context().__enter__().context_id.return_value = 'ctx-1'
         mock_storage.Client().bucket().blob().exists.return_value = True
-        mock_storage.Client().bucket().blob().download_as_string.return_value = b'job-1,'
+        mock_storage.Client().bucket().blob().download_as_bytes.return_value = b'job-1,'
         pending_job = {
             'currentState': 'JOB_STATE_PENDING'
         }
@@ -79,8 +79,8 @@ class LaunchTemplateTest(unittest.TestCase):
 
         self.assertEqual(expected_job, result)
         mock_client().launch_template.assert_not_called()
-    
-    def test_launch_template_fail(self, mock_client, mock_context, mock_display, 
+
+    def test_launch_template_fail(self, mock_client, mock_context, mock_display,
         mock_storage):
         mock_context().__enter__().context_id.return_value = 'context-1'
         mock_storage.Client().bucket().blob().exists.return_value = False
@@ -93,7 +93,7 @@ class LaunchTemplateTest(unittest.TestCase):
         }
         mock_client().get_job.return_value = failed_job
 
-        self.assertRaises(RuntimeError, 
+        self.assertRaises(RuntimeError,
             lambda: launch_template('project-1', 'gs://foo/bar', {
                 "parameters": {
                     "foo": "bar"
@@ -103,4 +103,3 @@ class LaunchTemplateTest(unittest.TestCase):
                 }
             }))
 
-    

--- a/components/google-cloud/Optimizer/Add_measurement_for_trial/component.py
+++ b/components/google-cloud/Optimizer/Add_measurement_for_trial/component.py
@@ -53,7 +53,7 @@ def add_measurement_for_trial_in_gcp_ai_platform_optimizer(
         client = storage.Client(project_id)
         bucket = client.get_bucket(_OPTIMIZER_API_DOCUMENT_BUCKET)
         blob = bucket.get_blob(_OPTIMIZER_API_DOCUMENT_FILE)
-        discovery_document = blob.download_as_string()
+        discovery_document = blob.download_as_bytes()
         return discovery.build_from_document(service=discovery_document)
 
     # Workaround for the Optimizer bug: Optimizer returns resource names that use project number, but only supports resource names with project IDs when making requests
@@ -84,7 +84,7 @@ def add_measurement_for_trial_in_gcp_ai_platform_optimizer(
         name=fix_resource_name(trial_name),
         body=measurement,
     ).execute()
-    
+
     if complete_trial:
         should_stop_trial = True
         complete_response = trials_api.complete(

--- a/components/google-cloud/Optimizer/Add_measurement_for_trial/component.yaml
+++ b/components/google-cloud/Optimizer/Add_measurement_for_trial/component.yaml
@@ -79,7 +79,7 @@ implementation:
               client = storage.Client(project_id)
               bucket = client.get_bucket(_OPTIMIZER_API_DOCUMENT_BUCKET)
               blob = bucket.get_blob(_OPTIMIZER_API_DOCUMENT_FILE)
-              discovery_document = blob.download_as_string()
+              discovery_document = blob.download_as_bytes()
               return discovery.build_from_document(service=discovery_document)
 
           # Workaround for the Optimizer bug: Optimizer returns resource names that use project number, but only supports resource names with project IDs when making requests

--- a/components/google-cloud/Optimizer/Create_study/component.py
+++ b/components/google-cloud/Optimizer/Create_study/component.py
@@ -44,7 +44,7 @@ def create_study_in_gcp_ai_platform_optimizer(
         client = storage.Client(project_id)
         bucket = client.get_bucket(_OPTIMIZER_API_DOCUMENT_BUCKET)
         blob = bucket.get_blob(_OPTIMIZER_API_DOCUMENT_FILE)
-        discovery_document = blob.download_as_string()
+        discovery_document = blob.download_as_bytes()
         return discovery.build_from_document(service=discovery_document)
 
     ml_api = create_caip_optimizer_client(gcp_project_id)

--- a/components/google-cloud/Optimizer/Create_study/component.yaml
+++ b/components/google-cloud/Optimizer/Create_study/component.yaml
@@ -68,7 +68,7 @@ implementation:
               client = storage.Client(project_id)
               bucket = client.get_bucket(_OPTIMIZER_API_DOCUMENT_BUCKET)
               blob = bucket.get_blob(_OPTIMIZER_API_DOCUMENT_FILE)
-              discovery_document = blob.download_as_string()
+              discovery_document = blob.download_as_bytes()
               return discovery.build_from_document(service=discovery_document)
 
           ml_api = create_caip_optimizer_client(gcp_project_id)

--- a/components/google-cloud/Optimizer/Suggest_parameter_sets_based_on_measurements/component.py
+++ b/components/google-cloud/Optimizer/Suggest_parameter_sets_based_on_measurements/component.py
@@ -55,7 +55,7 @@ def suggest_parameter_sets_from_measurements_using_gcp_ai_platform_optimizer(
         client = storage.Client(project_id)
         bucket = client.get_bucket(_OPTIMIZER_API_DOCUMENT_BUCKET)
         blob = bucket.get_blob(_OPTIMIZER_API_DOCUMENT_FILE)
-        discovery_document = blob.download_as_string()
+        discovery_document = blob.download_as_bytes()
         return discovery.build_from_document(service=discovery_document)
 
     # Workaround for the Optimizer bug: Optimizer returns resource names that use project number, but only supports resource names with project IDs when making requests
@@ -111,7 +111,7 @@ def suggest_parameter_sets_from_measurements_using_gcp_ai_platform_optimizer(
         else:
             raise TypeError(f'Unsupported parameter type "{paremeter_type_name}"')
         return result
-        
+
     try:
         logging.info(f'Adding {len(metrics_for_parameter_sets)} measurements to the study.')
         for parameters_and_metrics in metrics_for_parameter_sets:

--- a/components/google-cloud/Optimizer/Suggest_parameter_sets_based_on_measurements/component.yaml
+++ b/components/google-cloud/Optimizer/Suggest_parameter_sets_based_on_measurements/component.yaml
@@ -86,7 +86,7 @@ implementation:
               client = storage.Client(project_id)
               bucket = client.get_bucket(_OPTIMIZER_API_DOCUMENT_BUCKET)
               blob = bucket.get_blob(_OPTIMIZER_API_DOCUMENT_FILE)
-              discovery_document = blob.download_as_string()
+              discovery_document = blob.download_as_bytes()
               return discovery.build_from_document(service=discovery_document)
 
           # Workaround for the Optimizer bug: Optimizer returns resource names that use project number, but only supports resource names with project IDs when making requests

--- a/components/google-cloud/Optimizer/Suggest_trials/component.py
+++ b/components/google-cloud/Optimizer/Suggest_trials/component.py
@@ -46,7 +46,7 @@ def suggest_trials_in_gcp_ai_platform_optimizer(
         client = storage.Client(project_id)
         bucket = client.get_bucket(_OPTIMIZER_API_DOCUMENT_BUCKET)
         blob = bucket.get_blob(_OPTIMIZER_API_DOCUMENT_FILE)
-        discovery_document = blob.download_as_string()
+        discovery_document = blob.download_as_bytes()
         return discovery.build_from_document(service=discovery_document)
 
     # Workaround for the Optimizer bug: Optimizer returns resource names that use project number, but only supports resource names with project IDs when making requests

--- a/components/google-cloud/Optimizer/Suggest_trials/component.yaml
+++ b/components/google-cloud/Optimizer/Suggest_trials/component.yaml
@@ -64,7 +64,7 @@ implementation:
               client = storage.Client(project_id)
               bucket = client.get_bucket(_OPTIMIZER_API_DOCUMENT_BUCKET)
               blob = bucket.get_blob(_OPTIMIZER_API_DOCUMENT_FILE)
-              discovery_document = blob.download_as_string()
+              discovery_document = blob.download_as_bytes()
               return discovery.build_from_document(service=discovery_document)
 
           # Workaround for the Optimizer bug: Optimizer returns resource names that use project number, but only supports resource names with project IDs when making requests

--- a/sdk/python/kfp/v2/google/client/client_utils.py
+++ b/sdk/python/kfp/v2/google/client/client_utils.py
@@ -51,7 +51,7 @@ def _load_json_from_gs_uri(uri: str) -> Dict[str, Any]:
   """
   storage_client = storage.Client()
   blob = storage.Blob.from_string(uri, storage_client)
-  return json.loads(blob.download_as_string())
+  return json.loads(blob.download_as_bytes())
 
 
 def _load_json_from_local_file(file_path: str) -> Dict[str, Any]:

--- a/sdk/python/kfp/v2/google/client/client_utils_test.py
+++ b/sdk/python/kfp/v2/google/client/client_utils_test.py
@@ -25,10 +25,10 @@ from kfp.v2.google.client import client_utils
 class ClientUtilsTest(unittest.TestCase):
 
   @mock.patch.object(storage, 'Client', autospec=True)
-  @mock.patch.object(storage.Blob, 'download_as_string', autospec=True)
-  def test_load_json_from_gs_uri(self, mock_download_as_string,
+  @mock.patch.object(storage.Blob, 'download_as_bytes', autospec=True)
+  def test_load_json_from_gs_uri(self, mock_download_as_bytes,
                                  unused_storage_client):
-    mock_download_as_string.return_value = b'{"key":"value"}'
+    mock_download_as_bytes.return_value = b'{"key":"value"}'
     self.assertEqual({'key': 'value'},
                      client_utils.load_json('gs://bucket/path/to/blob'))
 
@@ -44,10 +44,10 @@ class ClientUtilsTest(unittest.TestCase):
           'https://storage.google.com/bucket/blob')
 
   @mock.patch.object(storage, 'Client', autospec=True)
-  @mock.patch.object(storage.Blob, 'download_as_string', autospec=True)
+  @mock.patch.object(storage.Blob, 'download_as_bytes', autospec=True)
   def test_load_json_from_gs_uri_with_invalid_json_should_fail(
-      self, mock_download_as_string, unused_storage_client):
-    mock_download_as_string.return_value = b'invalid-json'
+      self, mock_download_as_bytes, unused_storage_client):
+    mock_download_as_bytes.return_value = b'invalid-json'
     with self.assertRaises(json.decoder.JSONDecodeError):
       client_utils._load_json_from_gs_uri('gs://bucket/path/to/blob')
 


### PR DESCRIPTION
Update deprecated `download_as_string` to `download_as_bytes`, since `download_as_string` is deprecated. 

https://googleapis.dev/python/storage/latest/blobs.html#google.cloud.storage.blob.Blob.download_as_string 