### PR TITLE
refactor(frontend) Set 1 Hour as a default value for recurring pipeline runs

### DIFF
--- a/frontend/src/components/Trigger.test.tsx
+++ b/frontend/src/components/Trigger.test.tsx
@@ -25,10 +25,10 @@ const PARAMS_DEFAULT = {
 };
 const PERIODIC_DEFAULT = {
   end_time: undefined,
-  interval_second: '60',
+  interval_second: (60 * 60).toString(),
   start_time: undefined,
 };
-const CRON_DEFAULT = { cron: '0 * * * * ?', end_time: undefined, start_time: undefined };
+const CRON_DEFAULT = { cron: '0 0 * * * ?', end_time: undefined, start_time: undefined };
 
 beforeAll(() => {
   process.env.TZ = 'UTC';
@@ -98,7 +98,7 @@ describe('Trigger', () => {
   });
 
   describe('interval trigger', () => {
-    it('builds an every-minute trigger by default', () => {
+    it('builds an every-hour trigger by default', () => {
       const spy = jest.fn();
       const tree = shallow(<Trigger onChange={spy} />);
       (tree.instance() as Trigger).handleChange('type')({
@@ -438,7 +438,7 @@ describe('Trigger', () => {
   });
 
   describe('cron', () => {
-    it('builds a 1-minute cron trigger by default', () => {
+    it('builds a 1-hour cron trigger by default', () => {
       const spy = jest.fn();
       const tree = shallow(<Trigger onChange={spy} />);
       (tree.instance() as Trigger).handleChange('type')({ target: { value: TriggerType.CRON } });
@@ -450,7 +450,7 @@ describe('Trigger', () => {
       });
     });
 
-    it('builds a 1-minute cron trigger with specified start date', () => {
+    it('builds a 1-hour cron trigger with specified start date', () => {
       const spy = jest.fn();
       const tree = shallow(<Trigger onChange={spy} />);
       (tree.instance() as Trigger).handleChange('type')({ target: { value: TriggerType.CRON } });
@@ -461,7 +461,11 @@ describe('Trigger', () => {
       expect(spy).toHaveBeenLastCalledWith({
         ...PARAMS_DEFAULT,
         trigger: {
-          cron_schedule: { ...CRON_DEFAULT, start_time: new Date('2018-03-23T07:53:00.000Z') },
+          cron_schedule: {
+            ...CRON_DEFAULT,
+            start_time: new Date('2018-03-23T07:53:00.000Z'),
+            cron: '0 53 * * * ?',
+          },
         },
       });
     });

--- a/frontend/src/components/Trigger.tsx
+++ b/frontend/src/components/Trigger.tsx
@@ -122,7 +122,7 @@ export default class Trigger extends React.Component<TriggerProps, TriggerState>
       editCron: parsedTrigger.type === TriggerType.CRON,
       cron: parsedTrigger.cron || '',
       // interval state
-      intervalCategory: parsedTrigger.intervalCategory ?? PeriodicInterval.MINUTE,
+      intervalCategory: parsedTrigger.intervalCategory ?? PeriodicInterval.HOUR,
       intervalValue: parsedTrigger.intervalValue ?? 1,
       startTimeMessage: '',
       endTimeMessage: '',

--- a/frontend/src/components/__snapshots__/Trigger.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Trigger.test.tsx.snap
@@ -935,7 +935,7 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
         onChange={[Function]}
         required={true}
         select={true}
-        value="Minute"
+        value="Hour"
         variant="outlined"
         width={95}
       >
@@ -1177,7 +1177,7 @@ exports[`Trigger renders periodic schedule controls if the trigger type is CRON 
         onChange={[Function]}
         required={true}
         select={true}
-        value="Minute"
+        value="Hour"
         variant="outlined"
         width={95}
       >
@@ -1244,7 +1244,7 @@ exports[`Trigger renders periodic schedule controls if the trigger type is CRON 
       disabled={true}
       label="cron expression"
       onChange={[Function]}
-      value="0 * * * * ?"
+      value="0 0 * * * ?"
       variant="outlined"
       width={300}
     />

--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -1772,7 +1772,7 @@ describe('NewRun', () => {
         trigger: {
           periodic_schedule: {
             end_time: undefined,
-            interval_second: '60',
+            interval_second: '3600',
             start_time: undefined,
           },
         },


### PR DESCRIPTION
Change the default value of recurring pipeline runs from 1 Minute to 1 Hour
Tests updated to reflect new default value. 
Fixes: #5748

Signed-off-by: Diana Atanasova <dianaa@vmware.com>

**Description of your changes:**


**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
