### PR TITLE
chore(components/google-cloud): Create Release Branch for Google cloud pipeline components 0.1.2

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,9 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 version: 2
 sphinx:
-  configuration: docs/conf.py
+  configuration: components/google-cloud/docs/source/conf.py
 python:
-  version: 3.7
+  version: 3.8
   install:
-    - requirements: sdk/python/requirements.txt
+    - method: setuptools
+      path: components/google-cloud

--- a/components/google-cloud/RELEASE.md
+++ b/components/google-cloud/RELEASE.md
@@ -1,6 +1,7 @@
-# Current Version 0.1.2.dev (Still in Development)
+# Release 0.1.2
 
-*   Add notes for next release here.
+*   Add components for AutoMLForecasting.
+*   Update API documentation. 
 
 # Release 0.1.1
 

--- a/components/google-cloud/container/aiplatform/Dockerfile
+++ b/components/google-cloud/container/aiplatform/Dockerfile
@@ -21,6 +21,6 @@ WORKDIR /root
 RUN pip3 install --upgrade pip
 
 # TODO() change from using PR commit id to release 
-RUN pip3 install "git+https://github.com/kubeflow/pipelines.git#egg=google-cloud-pipeline-components&subdirectory=components/google-cloud"
+RUN pip3 install "git+https://github.com/kubeflow/pipelines.git@google-cloud-pipeline-components-0.1.2#egg=google-cloud-pipeline-components&subdirectory=components/google-cloud"
 
 ENTRYPOINT ["python3","-m","google_cloud_pipeline_components.aiplatform.remote_runner"]

--- a/components/google-cloud/container/aiplatform/cloudbuild.yaml
+++ b/components/google-cloud/container/aiplatform/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/kaniko-project/executor:latest'
   args: 
-  - --destination='gcr.io/$PROJECT_ID/google-cloud-pipeline-components:latest'
+  - --destination='gcr.io/$PROJECT_ID/google-cloud-pipeline-components:0.1.2'
   - --cache=true
   - --cache-ttl=12h

--- a/components/google-cloud/google_cloud_pipeline_components/aiplatform/utils.py
+++ b/components/google-cloud/google_cloud_pipeline_components/aiplatform/utils.py
@@ -31,7 +31,7 @@ METHOD_KEY = 'method'
 
 # Container image that is used for component containers
 # TODO tie the container version to sdk release version instead of latest
-DEFAULT_CONTAINER_IMAGE = 'gcr.io/sashaproject-1/aiplatform_component:latest'
+DEFAULT_CONTAINER_IMAGE = 'gcr.io/ml-pipeline/google-cloud-pipeline-components:0.1.2'
 
 # map of MB SDK type to Metadata type
 RESOURCE_TO_METADATA_TYPE = {

--- a/components/google-cloud/google_cloud_pipeline_components/version.py
+++ b/components/google-cloud/google_cloud_pipeline_components/version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """Contains the version string of Google Cloud Pipeline Components."""
 
-__version__ = "0.1.2.dev"
+__version__ = "0.1.2"


### PR DESCRIPTION
Releasing Google cloud pipeline components 0.1.2 which Includes:
*   Add components for AutoMLForecasting.
*   Update API documentation. 