### PR TITLE
fix(deployment): reduce artifact name collision rate under heavy load

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/argo.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/argo.yaml
@@ -259,7 +259,18 @@ data:
     s3:
       endpoint: 'minio-service.{{ .Release.Namespace }}:9000'
       bucket: '{{ if .Values.managedstorage.enabled }}{{ .Values.managedstorage.gcsBucketName }}{{ else }}mlpipeline{{ end }}'
-      keyFormat: "{{ `artifacts/{{workflow.name}}/{{pod.name}}` }}"
+      # keyFormat is a format pattern to define how artifacts will be organized in a bucket.
+      # It can reference workflow metadata variables such as workflow.namespace, workflow.name,
+      # pod.name. Can also use strftime formating of workflow.creationTimestamp so that workflow
+      # artifacts can be organized by date. If omitted, will use `{{workflow.name}}/{{pod.name}}`,
+      # which has potential for have collisions, because names do not guarantee they are unique
+      # over the lifetime of the cluster.
+      # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/.
+      #
+      # The following format looks like:
+      # artifacts/my-workflow-abc123/2018/08/23/my-workflow-abc123-1234567890
+      # Adding date into the path greatly reduces the chance of {{pod.name}} collision.
+      keyFormat: "{{ `artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}` }}"
       # insecure will disable TLS. Primarily used for minio installs not configured with TLS
       insecure: true
       accessKeySecret:
@@ -268,19 +279,6 @@ data:
       secretKeySecret:
         name: mlpipeline-minio-artifact
         key: secretkey
-
-  # keyFormat is a format pattern to define how artifacts will be organized in a bucket.
-  # It can reference workflow metadata variables such as workflow.namespace, workflow.name,
-  # pod.name. Can also use strftime formating of workflow.creationTimestamp so that workflow
-  # artifacts can be organized by date. If omitted, will use `{{workflow.name}}/{{pod.name}}`,
-  # which has potential for have collisions, because names do not guarantee they are unique
-  # over the lifetime of the cluster.
-  # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/.
-  #
-  # The following format looks like:
-  # artifacts/my-workflow-abc123/2018/08/23/my-workflow-abc123-1234567890
-  # Adding date into the path greatly reduces the chance of {{pod.name}} collision.
-  keyFormat: "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}"
 kind: ConfigMap
 metadata:
   name: workflow-controller-configmap

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/argo.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/argo.yaml
@@ -268,6 +268,19 @@ data:
       secretKeySecret:
         name: mlpipeline-minio-artifact
         key: secretkey
+
+  # keyFormat is a format pattern to define how artifacts will be organized in a bucket.
+  # It can reference workflow metadata variables such as workflow.namespace, workflow.name,
+  # pod.name. Can also use strftime formating of workflow.creationTimestamp so that workflow
+  # artifacts can be organized by date. If omitted, will use `{{workflow.name}}/{{pod.name}}`,
+  # which has potential for have collisions, because names do not guarantee they are unique
+  # over the lifetime of the cluster.
+  # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/.
+  #
+  # The following format looks like:
+  # artifacts/my-workflow-abc123/2018/08/23/my-workflow-abc123-1234567890
+  # Adding date into the path greatly reduces the chance of {{pod.name}} collision.
+  keyFormat: "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}"
 kind: ConfigMap
 metadata:
   name: workflow-controller-configmap

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/argo.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/argo.yaml
@@ -262,14 +262,14 @@ data:
       # keyFormat is a format pattern to define how artifacts will be organized in a bucket.
       # It can reference workflow metadata variables such as workflow.namespace, workflow.name,
       # pod.name. Can also use strftime formating of workflow.creationTimestamp so that workflow
-      # artifacts can be organized by date. If omitted, will use `{{workflow.name}}/{{pod.name}}`,
+      # artifacts can be organized by date. If omitted, will use workflow.name/pod.name,
       # which has potential for have collisions, because names do not guarantee they are unique
       # over the lifetime of the cluster.
       # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/.
       #
       # The following format looks like:
       # artifacts/my-workflow-abc123/2018/08/23/my-workflow-abc123-1234567890
-      # Adding date into the path greatly reduces the chance of {{pod.name}} collision.
+      # Adding date into the path greatly reduces the chance of pod.name collision.
       keyFormat: "{{ `artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}` }}"
       # insecure will disable TLS. Primarily used for minio installs not configured with TLS
       insecure: true

--- a/manifests/gcp_marketplace/test/snapshot-base.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-base.yaml
@@ -252,6 +252,7 @@ spec:
             value: 'root'
           - name: DBCONFIG_PASSWORD
             value: ''
+          
           - name: CACHE_IMAGE
             valueFrom:
               configMapKeyRef:
@@ -320,6 +321,92 @@ spec:
   ports:
     - port: 443
       targetPort: webhook-api
+
+---
+# Source: kubeflow-pipelines/templates/mysql.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql
+  labels:
+    app.kubernetes.io/name: my-release
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    app.kubernetes.io/name: my-release
+spec:
+  ports:
+    - port: 3306
+  selector:
+    
+    app: mysql
+    
+    app.kubernetes.io/name: my-release
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pv-claim
+  labels:
+    app.kubernetes.io/name: my-release
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  labels:
+    app.kubernetes.io/name: my-release
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+      app.kubernetes.io/name: my-release
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: mysql
+        app.kubernetes.io/name: my-release
+    spec:
+      serviceAccountName: mysql
+      containers:
+        - name: mysql
+          image: gcr.io/ml-pipeline/google/pipelines/mysql:dummy
+          args:
+          # https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_ignore-db-dir
+          # Ext4, Btrfs etc. volumes root directories have a lost+found directory that should not be treated as a database.
+          - --ignore-db-dir=lost+found
+          - --datadir
+          - /var/lib/mysql
+          env:
+            - name: MYSQL_ALLOW_EMPTY_PASSWORD
+              value: "true"
+          ports:
+            - containerPort: 3306
+              name: mysql
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: mysql-persistent-storage
+          resources:
+            requests:
+              cpu: 100m
+              memory: 800Mi
+      volumes:
+        - name: mysql-persistent-storage
+          persistentVolumeClaim:
+            claimName: mysql-pv-claim
+
 
 ---
 # Source: kubeflow-pipelines/templates/proxy.yaml
@@ -649,14 +736,25 @@ data:
   # pns executor is a more portable default, see https://github.com/kubeflow/pipelines/issues/1654.
   containerRuntimeExecutor: pns
 
-  # Note, some-string-without-template-interpretation is a way to avoid some brackets interpreted as template.
+  # Note, some-string-{{without}}-template-interpretation is a way to avoid some brackets interpreted as template.
   # Reference: https://github.com/helm/helm/issues/2798#issuecomment-467319526
   artifactRepository: |
     archiveLogs: true
     s3:
-      endpoint: 'minio-service.kubeflow:9000',
-      bucket: 'mlpipeline',
-      keyFormat: "artifacts/{{workflow.name}}/{{pod.name}}"
+      endpoint: 'minio-service.kubeflow:9000'
+      bucket: 'mlpipeline'
+      # keyFormat is a format pattern to define how artifacts will be organized in a bucket.
+      # It can reference workflow metadata variables such as workflow.namespace, workflow.name,
+      # pod.name. Can also use strftime formating of workflow.creationTimestamp so that workflow
+      # artifacts can be organized by date. If omitted, will use workflow.name/pod.name,
+      # which has potential for have collisions, because names do not guarantee they are unique
+      # over the lifetime of the cluster.
+      # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/.
+      #
+      # The following format looks like:
+      # artifacts/my-workflow-abc123/2018/08/23/my-workflow-abc123-1234567890
+      # Adding date into the path greatly reduces the chance of pod.name collision.
+      keyFormat: "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}"
       # insecure will disable TLS. Primarily used for minio installs not configured with TLS
       insecure: true
       accessKeySecret:
@@ -1841,78 +1939,6 @@ spec:
 
 
 ---
-# Source: kubeflow-pipelines/templates/mysql.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: mysql
-  labels:
-    app.kubernetes.io/name: my-release
-spec:
-  ports:
-    - port: 3306
-  selector:
-    
-    app: mysql
-    
-    app.kubernetes.io/name: my-release
----
-
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: mysql-pv-claim
-  labels:
-    app.kubernetes.io/name: my-release
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 20Gi
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: mysql
-  labels:
-    app.kubernetes.io/name: my-release
-spec:
-  selector:
-    matchLabels:
-      app: mysql
-      app.kubernetes.io/name: my-release
-  strategy:
-    type: Recreate
-  template:
-    metadata:
-      labels:
-        app: mysql
-        app.kubernetes.io/name: my-release
-    spec:
-      containers:
-        - env:
-            - name: MYSQL_ALLOW_EMPTY_PASSWORD
-              value: "true"
-          image: gcr.io/ml-pipeline/google/pipelines/mysql:dummy
-          name: mysql
-          ports:
-            - containerPort: 3306
-              name: mysql
-          volumeMounts:
-            - mountPath: /var/lib/mysql
-              name: mysql-persistent-storage
-          resources:
-            requests:
-              cpu: 100m
-              memory: 800Mi
-      volumes:
-        - name: mysql-persistent-storage
-          persistentVolumeClaim:
-            claimName: mysql-pv-claim
-
-
----
 # Source: kubeflow-pipelines/templates/application.yaml
 apiVersion: app.k8s.io/v1beta1
 kind: Application
@@ -1928,7 +1954,7 @@ metadata:
 spec:
   descriptor:
     type: Kubeflow Pipelines
-    version: 1.4.1
+    version: 1.6.0
     description: |-
       Reusable end-to-end ML workflow
     maintainers:

--- a/manifests/gcp_marketplace/test/snapshot-managed-storage-with-db-prefix.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-managed-storage-with-db-prefix.yaml
@@ -265,13 +265,14 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: mysql-credential
-                key: password        
+                key: password
+          
           - name: CACHE_IMAGE
             valueFrom:
               configMapKeyRef:
                 name: cache-configmap
                 key: cache_image
-          - name: REMOVE_NODE_RESTRICTIONS
+          - name: CACHE_NODE_RESTRICTIONS
             valueFrom:
               configMapKeyRef:
                 name: cache-configmap
@@ -334,6 +335,93 @@ spec:
   ports:
     - port: 443
       targetPort: webhook-api
+
+---
+# Source: kubeflow-pipelines/templates/mysql.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql
+  labels:
+    app.kubernetes.io/name: my-release
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    app.kubernetes.io/name: my-release
+spec:
+  ports:
+    - port: 3306
+  selector:
+    
+    app: cloudsqlproxy
+    
+    app.kubernetes.io/name: my-release
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudsqlproxy
+  labels:
+    app: cloudsqlproxy
+    app.kubernetes.io/name: my-release
+spec:
+  selector:
+    matchLabels:
+      app: cloudsqlproxy
+      app.kubernetes.io/name: my-release
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cloudsqlproxy
+        app.kubernetes.io/name: my-release
+    spec:
+      serviceAccountName: mysql
+      containers:
+        - image: gcr.io/ml-pipeline/google/pipelines/cloudsqlproxy:dummy
+          name: cloudsqlproxy
+          env:
+          command: ["/cloud_sql_proxy",
+                    "-dir=/cloudsql",
+            # Replace with your own CloudSQL instance ID
+                    "-instances=myproject:us-central1:myinstance=tcp:0.0.0.0:3306",
+            # System workload uses GCE default service account or Workload Identity's service account
+            #       "-credential_file=/credentials/application_default_credentials.json",
+                    "term_timeout=10s"]
+          # set term_timeout if require graceful handling of shutdown
+          # NOTE: proxy will stop accepting new connections; only wait on existing connections
+          lifecycle:
+            preStop:
+              exec:
+                # (optional) add a preStop hook so that termination is delayed
+                # this is required if your server still require new connections (e.g., connection pools)
+                command: ['sleep', '10']
+          ports:
+            - name: mysql
+              containerPort: 3306
+          volumeMounts:
+            - mountPath: /cloudsql
+              name: cloudsql
+      volumes:
+        - name: cloudsql
+          emptyDir:
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-credential
+  labels:
+    app: mysql-credential
+    app.kubernetes.io/name: my-release
+type: Opaque
+data:
+  username: "cm9vdA=="
+  password: "MTIzNA=="
+
 
 ---
 # Source: kubeflow-pipelines/templates/proxy.yaml
@@ -663,14 +751,25 @@ data:
   # pns executor is a more portable default, see https://github.com/kubeflow/pipelines/issues/1654.
   containerRuntimeExecutor: pns
 
-  # Note, some-string-without-template-interpretation is a way to avoid some brackets interpreted as template.
+  # Note, some-string-{{without}}-template-interpretation is a way to avoid some brackets interpreted as template.
   # Reference: https://github.com/helm/helm/issues/2798#issuecomment-467319526
   artifactRepository: |
     archiveLogs: true
     s3:
-      endpoint: 'minio-service.kubeflow:9000',
-      bucket: 'mybucket',
-      keyFormat: "artifacts/{{workflow.name}}/{{pod.name}}"
+      endpoint: 'minio-service.kubeflow:9000'
+      bucket: 'mybucket'
+      # keyFormat is a format pattern to define how artifacts will be organized in a bucket.
+      # It can reference workflow metadata variables such as workflow.namespace, workflow.name,
+      # pod.name. Can also use strftime formating of workflow.creationTimestamp so that workflow
+      # artifacts can be organized by date. If omitted, will use workflow.name/pod.name,
+      # which has potential for have collisions, because names do not guarantee they are unique
+      # over the lifetime of the cluster.
+      # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/.
+      #
+      # The following format looks like:
+      # artifacts/my-workflow-abc123/2018/08/23/my-workflow-abc123-1234567890
+      # Adding date into the path greatly reduces the chance of pod.name collision.
+      keyFormat: "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}"
       # insecure will disable TLS. Primarily used for minio installs not configured with TLS
       insecure: true
       accessKeySecret:
@@ -1864,85 +1963,6 @@ spec:
 
 
 ---
-# Source: kubeflow-pipelines/templates/mysql.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: mysql
-  labels:
-    app.kubernetes.io/name: my-release
-spec:
-  ports:
-    - port: 3306
-  selector:
-    
-    app: cloudsqlproxy
-    
-    app.kubernetes.io/name: my-release
----
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: cloudsqlproxy
-  labels:
-    app: cloudsqlproxy
-    app.kubernetes.io/name: my-release
-spec:
-  selector:
-    matchLabels:
-      app: cloudsqlproxy
-      app.kubernetes.io/name: my-release
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: cloudsqlproxy
-        app.kubernetes.io/name: my-release
-    spec:
-      containers:
-        - image: gcr.io/ml-pipeline/google/pipelines/cloudsqlproxy:dummy
-          name: cloudsqlproxy
-          env:
-          command: ["/cloud_sql_proxy",
-                    "-dir=/cloudsql",
-            # Replace with your own CloudSQL instance ID
-                    "-instances=myproject:us-central1:myinstance=tcp:0.0.0.0:3306",
-            # System workload uses GCE default service account or Workload Identity's service account
-            #       "-credential_file=/credentials/application_default_credentials.json",
-                    "term_timeout=10s"]
-          # set term_timeout if require graceful handling of shutdown
-          # NOTE: proxy will stop accepting new connections; only wait on existing connections
-          lifecycle:
-            preStop:
-              exec:
-                # (optional) add a preStop hook so that termination is delayed
-                # this is required if your server still require new connections (e.g., connection pools)
-                command: ['sleep', '10']
-          ports:
-            - name: mysql
-              containerPort: 3306
-          volumeMounts:
-            - mountPath: /cloudsql
-              name: cloudsql
-      volumes:
-        - name: cloudsql
-          emptyDir:
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: mysql-credential
-  labels:
-    app: mysql-credential
-    app.kubernetes.io/name: my-release
-type: Opaque
-data:
-  username: "cm9vdA=="
-  password: "MTIzNA=="
-
-
----
 # Source: kubeflow-pipelines/templates/application.yaml
 apiVersion: app.k8s.io/v1beta1
 kind: Application
@@ -1958,7 +1978,7 @@ metadata:
 spec:
   descriptor:
     type: Kubeflow Pipelines
-    version: 1.4.1
+    version: 1.6.0
     description: |-
       Reusable end-to-end ML workflow
     maintainers:

--- a/manifests/gcp_marketplace/test/snapshot-managed-storage.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-managed-storage.yaml
@@ -229,6 +229,8 @@ data:
   mysql_driver: "mysql"
   mysql_host: "mysql"
   mysql_port: "3306"
+  cache_image: "gcr.io/google-containers/busybox"
+  cache_node_restrictions: "false"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -265,6 +267,16 @@ spec:
                 name: mysql-credential
                 key: password
           
+          - name: CACHE_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                name: cache-configmap
+                key: cache_image
+          - name: CACHE_NODE_RESTRICTIONS
+            valueFrom:
+              configMapKeyRef:
+                name: cache-configmap
+                key: cache_node_restrictions
           - name: DBCONFIG_DRIVER
             valueFrom:
               configMapKeyRef:
@@ -323,6 +335,93 @@ spec:
   ports:
     - port: 443
       targetPort: webhook-api
+
+---
+# Source: kubeflow-pipelines/templates/mysql.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql
+  labels:
+    app.kubernetes.io/name: my-release
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    app.kubernetes.io/name: my-release
+spec:
+  ports:
+    - port: 3306
+  selector:
+    
+    app: cloudsqlproxy
+    
+    app.kubernetes.io/name: my-release
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudsqlproxy
+  labels:
+    app: cloudsqlproxy
+    app.kubernetes.io/name: my-release
+spec:
+  selector:
+    matchLabels:
+      app: cloudsqlproxy
+      app.kubernetes.io/name: my-release
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cloudsqlproxy
+        app.kubernetes.io/name: my-release
+    spec:
+      serviceAccountName: mysql
+      containers:
+        - image: gcr.io/ml-pipeline/google/pipelines/cloudsqlproxy:dummy
+          name: cloudsqlproxy
+          env:
+          command: ["/cloud_sql_proxy",
+                    "-dir=/cloudsql",
+            # Replace with your own CloudSQL instance ID
+                    "-instances=myproject:us-central1:myinstance=tcp:0.0.0.0:3306",
+            # System workload uses GCE default service account or Workload Identity's service account
+            #       "-credential_file=/credentials/application_default_credentials.json",
+                    "term_timeout=10s"]
+          # set term_timeout if require graceful handling of shutdown
+          # NOTE: proxy will stop accepting new connections; only wait on existing connections
+          lifecycle:
+            preStop:
+              exec:
+                # (optional) add a preStop hook so that termination is delayed
+                # this is required if your server still require new connections (e.g., connection pools)
+                command: ['sleep', '10']
+          ports:
+            - name: mysql
+              containerPort: 3306
+          volumeMounts:
+            - mountPath: /cloudsql
+              name: cloudsql
+      volumes:
+        - name: cloudsql
+          emptyDir:
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-credential
+  labels:
+    app: mysql-credential
+    app.kubernetes.io/name: my-release
+type: Opaque
+data:
+  username: "cm9vdA=="
+  password: "MTIzNA=="
+
 
 ---
 # Source: kubeflow-pipelines/templates/proxy.yaml
@@ -652,14 +751,25 @@ data:
   # pns executor is a more portable default, see https://github.com/kubeflow/pipelines/issues/1654.
   containerRuntimeExecutor: pns
 
-  # Note, some-string-without-template-interpretation is a way to avoid some brackets interpreted as template.
+  # Note, some-string-{{without}}-template-interpretation is a way to avoid some brackets interpreted as template.
   # Reference: https://github.com/helm/helm/issues/2798#issuecomment-467319526
   artifactRepository: |
     archiveLogs: true
     s3:
-      endpoint: 'minio-service.kubeflow:9000',
-      bucket: 'mybucket',
-      keyFormat: "artifacts/{{workflow.name}}/{{pod.name}}"
+      endpoint: 'minio-service.kubeflow:9000'
+      bucket: 'mybucket'
+      # keyFormat is a format pattern to define how artifacts will be organized in a bucket.
+      # It can reference workflow metadata variables such as workflow.namespace, workflow.name,
+      # pod.name. Can also use strftime formating of workflow.creationTimestamp so that workflow
+      # artifacts can be organized by date. If omitted, will use workflow.name/pod.name,
+      # which has potential for have collisions, because names do not guarantee they are unique
+      # over the lifetime of the cluster.
+      # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/.
+      #
+      # The following format looks like:
+      # artifacts/my-workflow-abc123/2018/08/23/my-workflow-abc123-1234567890
+      # Adding date into the path greatly reduces the chance of pod.name collision.
+      keyFormat: "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}"
       # insecure will disable TLS. Primarily used for minio installs not configured with TLS
       insecure: true
       accessKeySecret:
@@ -1853,85 +1963,6 @@ spec:
 
 
 ---
-# Source: kubeflow-pipelines/templates/mysql.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: mysql
-  labels:
-    app.kubernetes.io/name: my-release
-spec:
-  ports:
-    - port: 3306
-  selector:
-    
-    app: cloudsqlproxy
-    
-    app.kubernetes.io/name: my-release
----
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: cloudsqlproxy
-  labels:
-    app: cloudsqlproxy
-    app.kubernetes.io/name: my-release
-spec:
-  selector:
-    matchLabels:
-      app: cloudsqlproxy
-      app.kubernetes.io/name: my-release
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: cloudsqlproxy
-        app.kubernetes.io/name: my-release
-    spec:
-      containers:
-        - image: gcr.io/ml-pipeline/google/pipelines/cloudsqlproxy:dummy
-          name: cloudsqlproxy
-          env:
-          command: ["/cloud_sql_proxy",
-                    "-dir=/cloudsql",
-            # Replace with your own CloudSQL instance ID
-                    "-instances=myproject:us-central1:myinstance=tcp:0.0.0.0:3306",
-            # System workload uses GCE default service account or Workload Identity's service account
-            #       "-credential_file=/credentials/application_default_credentials.json",
-                    "term_timeout=10s"]
-          # set term_timeout if require graceful handling of shutdown
-          # NOTE: proxy will stop accepting new connections; only wait on existing connections
-          lifecycle:
-            preStop:
-              exec:
-                # (optional) add a preStop hook so that termination is delayed
-                # this is required if your server still require new connections (e.g., connection pools)
-                command: ['sleep', '10']
-          ports:
-            - name: mysql
-              containerPort: 3306
-          volumeMounts:
-            - mountPath: /cloudsql
-              name: cloudsql
-      volumes:
-        - name: cloudsql
-          emptyDir:
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: mysql-credential
-  labels:
-    app: mysql-credential
-    app.kubernetes.io/name: my-release
-type: Opaque
-data:
-  username: "cm9vdA=="
-  password: "MTIzNA=="
-
-
----
 # Source: kubeflow-pipelines/templates/application.yaml
 apiVersion: app.k8s.io/v1beta1
 kind: Application
@@ -1947,7 +1978,7 @@ metadata:
 spec:
   descriptor:
     type: Kubeflow Pipelines
-    version: 1.4.1
+    version: 1.6.0
     description: |-
       Reusable end-to-end ML workflow
     maintainers:

--- a/manifests/kustomize/third-party/argo/base/workflow-controller-configmap-patch.yaml
+++ b/manifests/kustomize/third-party/argo/base/workflow-controller-configmap-patch.yaml
@@ -19,7 +19,18 @@ data:
     s3:
       endpoint: "minio-service.$(kfp-namespace):9000"
       bucket: "$(kfp-artifact-bucket-name)"
-      keyFormat: "artifacts/{{workflow.name}}/{{pod.name}}"
+      # keyFormat is a format pattern to define how artifacts will be organized in a bucket.
+      # It can reference workflow metadata variables such as workflow.namespace, workflow.name,
+      # pod.name. Can also use strftime formating of workflow.creationTimestamp so that workflow
+      # artifacts can be organized by date. If omitted, will use `{{workflow.name}}/{{pod.name}}`,
+      # which has potential for have collisions, because names do not guarantee they are unique
+      # over the lifetime of the cluster.
+      # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/.
+      #
+      # The following format looks like:
+      # artifacts/my-workflow-abc123/2018/08/23/my-workflow-abc123-1234567890
+      # Adding date into the path greatly reduces the chance of {{pod.name}} collision.
+      keyFormat: "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}"
       # insecure will disable TLS. Primarily used for minio installs not configured with TLS
       insecure: true
       accessKeySecret:
@@ -37,15 +48,3 @@ data:
       limits:
         cpu: 0.5
         memory: 512Mi
-  # keyFormat is a format pattern to define how artifacts will be organized in a bucket.
-  # It can reference workflow metadata variables such as workflow.namespace, workflow.name,
-  # pod.name. Can also use strftime formating of workflow.creationTimestamp so that workflow
-  # artifacts can be organized by date. If omitted, will use `{{workflow.name}}/{{pod.name}}`,
-  # which has potential for have collisions, because names do not guarantee they are unique
-  # over the lifetime of the cluster.
-  # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/.
-  #
-  # The following format looks like:
-  # artifacts/my-workflow-abc123/2018/08/23/my-workflow-abc123-1234567890
-  # Adding date into the path greatly reduces the chance of {{pod.name}} collision.
-  keyFormat: "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}"

--- a/manifests/kustomize/third-party/argo/base/workflow-controller-configmap-patch.yaml
+++ b/manifests/kustomize/third-party/argo/base/workflow-controller-configmap-patch.yaml
@@ -37,3 +37,15 @@ data:
       limits:
         cpu: 0.5
         memory: 512Mi
+  # keyFormat is a format pattern to define how artifacts will be organized in a bucket.
+  # It can reference workflow metadata variables such as workflow.namespace, workflow.name,
+  # pod.name. Can also use strftime formating of workflow.creationTimestamp so that workflow
+  # artifacts can be organized by date. If omitted, will use `{{workflow.name}}/{{pod.name}}`,
+  # which has potential for have collisions, because names do not guarantee they are unique
+  # over the lifetime of the cluster.
+  # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/.
+  #
+  # The following format looks like:
+  # artifacts/my-workflow-abc123/2018/08/23/my-workflow-abc123-1234567890
+  # Adding date into the path greatly reduces the chance of {{pod.name}} collision.
+  keyFormat: "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}"


### PR DESCRIPTION
**Description of your changes:**
reduce artifact name collision rate under heavy load by including date into artifact key format.

The problem this fixes:

when load is heavy, there's a higher chance of getting two different pods with the same name.
In such a case, the pod will be getting the same output artifact names, because {{workflow.name}}/{{pod.name}} is the same. Then this pod will be overwriting existing artifacts, which is bad. What's worse, GCS
buckets typically have a retention period when overwriting is forbidden, so the new Pod will fail
instead. This causes intermittent workflow execution failures.

The new fix reduces the rate of artifact name collision by including the date in artifact key format.

Backwards compatibility concern: the config change only affects new pipeline runs. Also KFP doesn't provide any interface to access artifacts from outside of the system, so I think this won't be causing breaking changes.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
