### PR TITLE
fix(sdk compiler):Fix v2 compile for exit handler  Fixes #5854

### DIFF
--- a/sdk/python/kfp/v2/compiler/compiler.py
+++ b/sdk/python/kfp/v2/compiler/compiler.py
@@ -790,6 +790,21 @@ class Compiler(object):
             pipeline_spec_pb2.PipelineTaskSpec.TriggerPolicy(
                 condition=condition_string))
 
+      if isinstance(subgroup, dsl.OpsGroup) and subgroup.type == 'exit_handler':
+
+        # "punch the hole", adding inputs needed by its subgroup or tasks.
+        dsl_component_spec.build_component_inputs_spec(
+            component_spec=subgroup_component_spec,
+            pipeline_params=subgroup_params,
+            is_root_component=False,
+        )
+        dsl_component_spec.build_task_inputs_spec(
+            subgroup_task_spec,
+            subgroup_params,
+            tasks_in_current_dag,
+            is_parent_component_root,
+        )
+
       # Generate dependencies section for this task.
       if dependencies.get(subgroup.name, None):
         group_dependencies = list(dependencies[subgroup.name])

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_exit_handler.json
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_exit_handler.json
@@ -30,17 +30,20 @@
               "inputs": {
                 "parameters": {
                   "message": {
-                    "runtimeValue": {
-                      "constantValue": {
-                        "stringValue": "Hello World!"
-                      }
-                    }
+                    "componentInputParameter": "pipelineparam--message"
                   }
                 }
               },
               "taskInfo": {
                 "name": "print-op-2"
               }
+            }
+          }
+        },
+        "inputDefinitions": {
+          "parameters": {
+            "pipelineparam--message": {
+              "type": "STRING"
             }
           }
         }
@@ -147,6 +150,13 @@
             "componentRef": {
               "name": "comp-exit-handler-1"
             },
+            "inputs": {
+              "parameters": {
+                "pipelineparam--message": {
+                  "componentInputParameter": "message"
+                }
+              }
+            },
             "taskInfo": {
               "name": "exit-handler-1"
             }
@@ -177,12 +187,24 @@
             }
           }
         }
+      },
+      "inputDefinitions": {
+        "parameters": {
+          "message": {
+            "type": "STRING"
+          }
+        }
       }
     },
     "schemaVersion": "2.0.0",
-    "sdkVersion": "kfp-1.6.2"
+    "sdkVersion": "kfp-1.6.3"
   },
   "runtimeConfig": {
-    "gcsOutputDirectory": "dummy_root"
+    "gcsOutputDirectory": "dummy_root",
+    "parameters": {
+      "message": {
+        "stringValue": "Hello World!"
+      }
+    }
   }
 }

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_exit_handler.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_exit_handler.py
@@ -33,12 +33,12 @@ def fail_op(message: str):
 
 
 @dsl.pipeline(name='pipeline-with-exit-handler', pipeline_root='dummy_root')
-def my_pipeline():
+def my_pipeline(message: str = 'Hello World!'):
 
   exit_task = print_op('Exit handler has worked!')
 
   with dsl.ExitHandler(exit_task):
-    print_op('Hello World!')
+    print_op(message)
     fail_op('Task failed.')
 
 


### PR DESCRIPTION
**Description of your changes:**
If `exit_handler` is used, an error will occur at compile time because inputs are not set for tasks in that group(https://github.com/kubeflow/pipelines/issues/5854)
So, set input as well as `condition` subgroup.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
