### PR TITLE
fix(sdk): Fix default value of component input not picked up. Fixes #5880.

### DIFF
--- a/samples/test/lightweight_python_functions_v2_pipeline.py
+++ b/samples/test/lightweight_python_functions_v2_pipeline.py
@@ -87,8 +87,6 @@ def train(
     input_list: List[str],
     # An input parameter of type int with a default value.
     num_steps: int = 100,
-    # An input parameter of type string with default value.
-    message_with_default: str = 'hello world',
 ):
   """Dummy Training step"""
   with open(dataset_one_path, 'r') as input_file:
@@ -104,8 +102,6 @@ def train(
           f'input_dict: {input_dict}, type {type(input_dict)} || '
           f'input_list: {input_list}, type {type(input_list)} \n')
   
-  print(f'message_with_default="{message_with_default}"')
-
   with open(model.path, 'w') as output_file:
     for i in range(num_steps):
       output_file.write('Step {}\n{}\n=====\n'.format(i, line))
@@ -125,7 +121,7 @@ def pipeline(message: str = 'message'):
       input_bool=preprocess_task.outputs['output_bool_parameter'],
       input_dict=preprocess_task.outputs['output_dict_parameter'],
       input_list=preprocess_task.outputs['output_list_parameter'],
-      num_steps=5)
+  )
 
 
 if __name__ == '__main__':

--- a/samples/test/lightweight_python_functions_v2_pipeline_test.py
+++ b/samples/test/lightweight_python_functions_v2_pipeline_test.py
@@ -85,9 +85,7 @@ def verify(
                     'input_dict': '{"A": 1, "B": 2}',
                     'input_list': '["a", "b", "c"]',
                     'message': 'message',
-                    'num_steps': 5,
-                    # TODO: uncomment this, should be "hello world"
-                    # 'message_with_default': "hello world",
+                    'num_steps': 100,
                 }
             },
             'name': 'train',

--- a/sdk/python/kfp/dsl/_component_bridge.py
+++ b/sdk/python/kfp/dsl/_component_bridge.py
@@ -451,7 +451,6 @@ def _attach_v2_specs(
   pipeline_task_spec = pipeline_spec_pb2.PipelineTaskSpec()
 
   # Check types of the reference arguments and serialize PipelineParams
-  original_arguments = arguments
   arguments = arguments.copy()
 
   # Preserve input params for ContainerOp.inputs
@@ -459,6 +458,18 @@ def _attach_v2_specs(
       param for param in arguments.values()
       if isinstance(param, _pipeline_param.PipelineParam)
   ])
+
+  # Add component inputs with default value to the arguments dict if they are not
+  # in the arguments dict already.
+  for input_spec in component_spec.inputs or []:
+    if input_spec.name not in arguments and input_spec.default is not None:
+      default_value = input_spec.default
+      if input_spec.type == 'Integer':
+        default_value = int(default_value)
+      elif input_spec.type == 'Float':
+        default_value = float(default_value)
+      arguments[input_spec.name] = default_value
+
 
   for input_name, argument_value in arguments.items():
     input_type = component_spec._inputs_dict[input_name].type
@@ -594,7 +605,7 @@ def _attach_v2_specs(
   pipeline_task_spec.task_info.name = (dsl_utils.sanitize_task_name(task.name))
 
   resolved_cmd = _resolve_commands_and_args_v2(
-      component_spec=component_spec, arguments=original_arguments)
+      component_spec=component_spec, arguments=arguments)
 
   task.container_spec = (
       pipeline_spec_pb2.PipelineDeploymentConfig.PipelineContainerSpec(

--- a/sdk/python/kfp/dsl/_component_bridge.py
+++ b/sdk/python/kfp/dsl/_component_bridge.py
@@ -202,6 +202,19 @@ def _create_container_op_from_component_and_arguments(
   Returns:
     A ContainerOp instance.
   """
+
+  # Add component inputs with default value to the arguments dict if they are not
+  # in the arguments dict already.
+  arguments = arguments.copy()
+  for input_spec in component_spec.inputs or []:
+    if input_spec.name not in arguments and input_spec.default is not None:
+      default_value = input_spec.default
+      if input_spec.type == 'Integer':
+        default_value = int(default_value)
+      elif input_spec.type == 'Float':
+        default_value = float(default_value)
+      arguments[input_spec.name] = default_value
+
   # Check types of the reference arguments and serialize PipelineParams
   original_arguments = arguments
   arguments = arguments.copy()
@@ -458,18 +471,6 @@ def _attach_v2_specs(
       param for param in arguments.values()
       if isinstance(param, _pipeline_param.PipelineParam)
   ])
-
-  # Add component inputs with default value to the arguments dict if they are not
-  # in the arguments dict already.
-  for input_spec in component_spec.inputs or []:
-    if input_spec.name not in arguments and input_spec.default is not None:
-      default_value = input_spec.default
-      if input_spec.type == 'Integer':
-        default_value = int(default_value)
-      elif input_spec.type == 'Float':
-        default_value = float(default_value)
-      arguments[input_spec.name] = default_value
-
 
   for input_name, argument_value in arguments.items():
     input_type = component_spec._inputs_dict[input_name].type

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/lightweight_python_functions_v2_pipeline.json
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/lightweight_python_functions_v2_pipeline.json
@@ -222,7 +222,7 @@
                 "num_steps": {
                   "runtimeValue": {
                     "constantValue": {
-                      "intValue": "5"
+                      "intValue": "100"
                     }
                   }
                 }
@@ -243,7 +243,7 @@
       }
     },
     "schemaVersion": "2.0.0",
-    "sdkVersion": "kfp-1.6.0-rc.0"
+    "sdkVersion": "kfp-1.6.3"
   },
   "runtimeConfig": {
     "gcsOutputDirectory": "dummy_root"

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/lightweight_python_functions_v2_pipeline.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/lightweight_python_functions_v2_pipeline.py
@@ -121,7 +121,7 @@ def pipeline(message: str):
       input_bool=preprocess_task.outputs['output_bool_parameter'],
       input_dict=preprocess_task.outputs['output_dict_parameter'],
       input_list=preprocess_task.outputs['output_list_parameter'],
-      num_steps=5)
+  )
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/xgboost_sample_pipeline.json
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/xgboost_sample_pipeline.json
@@ -185,8 +185,20 @@
             }
           },
           "parameters": {
+            "booster": {
+              "type": "STRING"
+            },
             "label_column": {
               "type": "INT"
+            },
+            "learning_rate": {
+              "type": "DOUBLE"
+            },
+            "max_depth": {
+              "type": "INT"
+            },
+            "min_split_loss": {
+              "type": "DOUBLE"
             },
             "num_iterations": {
               "type": "INT"
@@ -222,8 +234,20 @@
             }
           },
           "parameters": {
+            "booster": {
+              "type": "STRING"
+            },
             "label_column_name": {
               "type": "STRING"
+            },
+            "learning_rate": {
+              "type": "DOUBLE"
+            },
+            "max_depth": {
+              "type": "INT"
+            },
+            "min_split_loss": {
+              "type": "DOUBLE"
             },
             "num_iterations": {
               "type": "INT"
@@ -393,6 +417,14 @@
               "{{$.inputs.parameters['num_iterations']}}",
               "--objective",
               "{{$.inputs.parameters['objective']}}",
+              "--booster",
+              "{{$.inputs.parameters['booster']}}",
+              "--learning-rate",
+              "{{$.inputs.parameters['learning_rate']}}",
+              "--min-split-loss",
+              "{{$.inputs.parameters['min_split_loss']}}",
+              "--max-depth",
+              "{{$.inputs.parameters['max_depth']}}",
               "--model",
               "{{$.outputs.artifacts['model'].path}}",
               "--model-config",
@@ -421,6 +453,14 @@
               "{{$.inputs.parameters['num_iterations']}}",
               "--objective",
               "{{$.inputs.parameters['objective']}}",
+              "--booster",
+              "{{$.inputs.parameters['booster']}}",
+              "--learning-rate",
+              "{{$.inputs.parameters['learning_rate']}}",
+              "--min-split-loss",
+              "{{$.inputs.parameters['min_split_loss']}}",
+              "--max-depth",
+              "{{$.inputs.parameters['max_depth']}}",
               "--model",
               "{{$.outputs.artifacts['model'].path}}",
               "--model-config",
@@ -672,10 +712,38 @@
                 }
               },
               "parameters": {
+                "booster": {
+                  "runtimeValue": {
+                    "constantValue": {
+                      "stringValue": "gbtree"
+                    }
+                  }
+                },
                 "label_column": {
                   "runtimeValue": {
                     "constantValue": {
                       "intValue": "0"
+                    }
+                  }
+                },
+                "learning_rate": {
+                  "runtimeValue": {
+                    "constantValue": {
+                      "doubleValue": 0.3
+                    }
+                  }
+                },
+                "max_depth": {
+                  "runtimeValue": {
+                    "constantValue": {
+                      "intValue": "6"
+                    }
+                  }
+                },
+                "min_split_loss": {
+                  "runtimeValue": {
+                    "constantValue": {
+                      "doubleValue": 0.0
                     }
                   }
                 },
@@ -716,10 +784,38 @@
                 }
               },
               "parameters": {
+                "booster": {
+                  "runtimeValue": {
+                    "constantValue": {
+                      "stringValue": "gbtree"
+                    }
+                  }
+                },
                 "label_column_name": {
                   "runtimeValue": {
                     "constantValue": {
                       "stringValue": "tips"
+                    }
+                  }
+                },
+                "learning_rate": {
+                  "runtimeValue": {
+                    "constantValue": {
+                      "doubleValue": 0.3
+                    }
+                  }
+                },
+                "max_depth": {
+                  "runtimeValue": {
+                    "constantValue": {
+                      "intValue": "6"
+                    }
+                  }
+                },
+                "min_split_loss": {
+                  "runtimeValue": {
+                    "constantValue": {
+                      "doubleValue": 0.0
                     }
                   }
                 },
@@ -747,7 +843,7 @@
       }
     },
     "schemaVersion": "2.0.0",
-    "sdkVersion": "kfp-1.6.0-rc.0"
+    "sdkVersion": "kfp-1.6.3"
   },
   "runtimeConfig": {
     "gcsOutputDirectory": "dummy_root"


### PR DESCRIPTION
**Description of your changes:**
- Fix default value of component input not picked up in v2 and v2 compatible mode.
- This PR also introduce a behavior change for v1. Current in v1, the default value from component input spec, e.g: https://github.com/kubeflow/pipelines/blob/e7c281bd65ca79c20c2ae52a4dc4798241333b53/components/XGBoost/Train/component.yaml#L33
appears to be informational only. While the source of truth is inside the container, e.g.:
https://github.com/kubeflow/pipelines/blob/e7c281bd65ca79c20c2ae52a4dc4798241333b53/components/XGBoost/Train/component.yaml#L71
Normally, the two would be in sync if the component.yaml is generated by the SDK. However, they could be different if user hand-write the yaml. 
If user doesn't provide a value or param reference for such optional input, the input gets its default value from within the container -- instead of being passed through as an argument to container interface. This makes the input a hidden execution property, it will not be recorded in MLMD either in v1 or in v2. With this change, we make the default value from input spec the SOT. It will be explicitly passed to the container via command line arguments, and it will be recorded in MLMD just like a user input.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
