### PR TITLE
feat(sdk): proper json serialization of dict/list items in run args fixes #5896

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -465,19 +465,19 @@ class Client(object):
       raise ValueError('Either experiment_id or experiment_name is required')
     if experiment_id is not None:
       return self._experiment_api.get_experiment(id=experiment_id)
-    experiment_filter = json.dumps({ 
-        "predicates": [ 
-          { 
-            "op":  _FILTER_OPERATIONS["EQUALS"], 
-            "key": "name", 
-            "stringValue": experiment_name, 
+    experiment_filter = json.dumps({
+        "predicates": [
+          {
+            "op":  _FILTER_OPERATIONS["EQUALS"],
+            "key": "name",
+            "stringValue": experiment_name,
           }
-        ] 
+        ]
       })
     if namespace:
       result = self._experiment_api.list_experiment(
         filter=experiment_filter,
-        resource_reference_key_type=kfp_server_api.models.api_resource_type.ApiResourceType.NAMESPACE, 
+        resource_reference_key_type=kfp_server_api.models.api_resource_type.ApiResourceType.NAMESPACE,
         resource_reference_key_id=namespace)
     else:
       result = self._experiment_api.list_experiment(filter=experiment_filter)
@@ -707,7 +707,7 @@ class Client(object):
       pipeline_json_string = json.dumps(pipeline_obj)
     api_params = [kfp_server_api.ApiParameter(
         name=sanitize_k8s_name(name=k, allow_capital_underscore=True),
-        value=str(v)) for k,v in params.items()]
+        value=str(v) if type(v) not in (list, dict) else json.dumps(v)) for k,v in params.items()]
     resource_references = []
     key = kfp_server_api.models.ApiResourceKey(id=experiment_id,
                                         type=kfp_server_api.models.ApiResourceType.EXPERIMENT)


### PR DESCRIPTION
**Description of your changes:**
When giving list/dict inputs as part of your pipeline arguments, these values are json serialied instead of casted to string.

This change was done in method `_create_job_config` of the `Client` class. 
