### PR TITLE
feat!: use argo emissary executor by default. Fixes #5718

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/argo.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/argo.yaml
@@ -345,7 +345,7 @@ data:
   # * https://github.com/argoproj/argo-workflows/blob/v3.1.1/docs/workflow-controller-configmap.md
   # * https://github.com/argoproj/argo-workflows/blob/v3.1.1/docs/workflow-controller-configmap.yaml
 
-  containerRuntimeExecutor: docker
+  containerRuntimeExecutor: emissary
 
   # Note, {{ `some-string-{{without}}-template-interpretation` }} is a way to avoid some brackets interpreted as template.
   # Reference: https://github.com/helm/helm/issues/2798#issuecomment-467319526

--- a/manifests/kustomize/third-party/argo/base/workflow-controller-configmap-patch.yaml
+++ b/manifests/kustomize/third-party/argo/base/workflow-controller-configmap-patch.yaml
@@ -9,7 +9,7 @@ data:
   # * https://github.com/argoproj/argo-workflows/blob/v3.1.1/docs/workflow-controller-configmap.yaml
 
   # emissary executor is a more portable default, see https://github.com/kubeflow/pipelines/issues/1654.
-  containerRuntimeExecutor: docker
+  containerRuntimeExecutor: emissary
 
   # In artifactRepository.s3.endpoint, $(kfp-namespace) is needed, because in multi-user mode, pipelines may run in other namespaces.
   artifactRepository: |


### PR DESCRIPTION
**Description of your changes:**
Fixes #5718 

### Breaking change
Argo emissary executor requires that each container has explicit command and args defined, refer to https://argoproj.github.io/argo-workflows/workflow-executors/#emissary-emissary.

Why we decide to adopt the breaking change? We'd have the same breaking change in bit.ly/kfp-v2-compatible and bit.ly/kfp-v2. So I think it aligns with KFP's long term goal, and it's OK to introduce the breaking change now.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
