### PR TITLE
feat(sample): Add markdown visualization example for v1 and v2 compatible

### DIFF
--- a/samples/core/visualization/markdown.py
+++ b/samples/core/visualization/markdown.py
@@ -29,11 +29,10 @@ def markdown_visualization() -> NamedTuple('VisualizationOutput', [('mlpipeline_
             {
                 # Markdown that is hardcoded inline
                 'storage': 'inline',
-                'source': '''
-                    # Inline Markdown
+                'source': '''# Inline Markdown
 
-                    * [Kubeflow official doc](https://www.kubeflow.org/),
-                    ''',
+* [Kubeflow official doc](https://www.kubeflow.org/).
+''',
                 'type': 'markdown',
             },
             {

--- a/samples/core/visualization/markdown.py
+++ b/samples/core/visualization/markdown.py
@@ -29,7 +29,11 @@ def markdown_visualization() -> NamedTuple('VisualizationOutput', [('mlpipeline_
             {
                 # Markdown that is hardcoded inline
                 'storage': 'inline',
-                'source': '# Inline Markdown\n[A link](https://www.kubeflow.org/)',
+                'source': '''
+                    # Inline Markdown
+
+                    * [Kubeflow official doc](https://www.kubeflow.org/),
+                    ''',
                 'type': 'markdown',
             },
             {
@@ -52,8 +56,8 @@ markdown_visualization_op = comp.func_to_container_op(
 
 
 @dsl.pipeline(
-    name='calculation-pipeline',
-    description='A toy pipeline that performs arithmetic calculations.'
+    name='markdown-pipeline',
+    description='A sample pipeline to generate markdown for UI visualization.'
 )
 def markdown_pipeline():
     # Passing a task output reference as operation arguments

--- a/samples/core/visualization/markdown.py
+++ b/samples/core/visualization/markdown.py
@@ -19,7 +19,7 @@ import kfp.components as comp
 # Demonstrates imports, helper functions and multiple outputs
 from typing import NamedTuple
 
-
+@comp.create_component_from_func
 def markdown_visualization() -> NamedTuple('VisualizationOutput', [('mlpipeline_ui_metadata', 'UI_metadata')]):
     import json
 
@@ -50,10 +50,6 @@ def markdown_visualization() -> NamedTuple('VisualizationOutput', [('mlpipeline_
     return divmod_output(json.dumps(metadata))
 
 
-markdown_visualization_op = comp.func_to_container_op(
-    markdown_visualization, base_image='tensorflow/tensorflow:1.11.0-py3')
-
-
 @dsl.pipeline(
     name='markdown-pipeline',
     description='A sample pipeline to generate markdown for UI visualization.'
@@ -61,4 +57,4 @@ markdown_visualization_op = comp.func_to_container_op(
 def markdown_pipeline():
     # Passing a task output reference as operation arguments
     # For an operation with a single return value, the output reference can be accessed using `task.output` or `task.outputs['output_name']` syntax
-    markdown_visualization_task = markdown_visualization_op()
+    markdown_visualization_task = markdown_visualization()

--- a/samples/core/visualization/markdown.py
+++ b/samples/core/visualization/markdown.py
@@ -1,0 +1,61 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import kfp.dsl as dsl
+import kfp.components as comp
+
+# Advanced function
+# Demonstrates imports, helper functions and multiple outputs
+from typing import NamedTuple
+
+
+def markdown_visualization() -> NamedTuple('VisualizationOutput', [('mlpipeline_ui_metadata', 'UI_metadata')]):
+    import json
+
+    # Exports a sample tensorboard:
+    metadata = {
+        'outputs': [
+            {
+                # Markdown that is hardcoded inline
+                'storage': 'inline',
+                'source': '# Inline Markdown\n[A link](https://www.kubeflow.org/)',
+                'type': 'markdown',
+            },
+            {
+                # Markdown that is read from a file
+                'source': 'https://raw.githubusercontent.com/kubeflow/pipelines/master/README.md',
+                # Alternatively, use Google Cloud Storage for sample.
+                # 'source': 'gs://jamxl-kfp-bucket/v2-compatible/markdown/markdown_example.md',
+                'type': 'markdown',
+            }]
+    }
+
+    from collections import namedtuple
+    divmod_output = namedtuple('VisualizationOutput', [
+                               'mlpipeline_ui_metadata'])
+    return divmod_output(json.dumps(metadata))
+
+
+markdown_visualization_op = comp.func_to_container_op(
+    markdown_visualization, base_image='tensorflow/tensorflow:1.11.0-py3')
+
+
+@dsl.pipeline(
+    name='calculation-pipeline',
+    description='A toy pipeline that performs arithmetic calculations.'
+)
+def markdown_pipeline():
+    # Passing a task output reference as operation arguments
+    # For an operation with a single return value, the output reference can be accessed using `task.output` or `task.outputs['output_name']` syntax
+    markdown_visualization_task = markdown_visualization_op()

--- a/samples/core/visualization/markdown_test.py
+++ b/samples/core/visualization/markdown_test.py
@@ -1,0 +1,29 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from .markdown import markdown_pipeline
+from ...test.util import run_pipeline_func, TestCase
+
+import kfp
+
+run_pipeline_func([TestCase(pipeline_func=markdown_pipeline,
+                            mode=kfp.dsl.PipelineExecutionMode.V2_COMPATIBLE,
+                            arguments={
+                                kfp.dsl.ROOT_PARAMETER_NAME:
+                                'minio://mlpipeline/override/artifacts'
+                            }),
+                   TestCase(pipeline_func=markdown_pipeline,
+                            mode=kfp.dsl.PipelineExecutionMode.V1_LEGACY
+                            )])


### PR DESCRIPTION
**Description of your changes:**
Partial https://github.com/kubeflow/pipelines/issues/5932

Ability to run same pipeline for v1 and v2 compatible, it will generate Markdown for UI visualization.

Command to initialize test:

```
python3 -m samples.core.visualization.markdown_test
```

![mdviewer](https://user-images.githubusercontent.com/37026441/123735181-95150500-d853-11eb-8df8-87e13417102f.png)


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
