### PR TITLE
feat(sample): Add HTML sample for v1/v2 visualization

### DIFF
--- a/samples/core/visualization/hello-world.html
+++ b/samples/core/visualization/hello-world.html
@@ -1,0 +1,52 @@
+<!--
+  Copyright 2021 The Kubeflow Authors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<html>
+  <head>
+    <style>
+      .message {
+        color: #666;
+        font-family: monospace;
+        line-height: 22px;
+        padding: 10px;
+        text-align: center;
+      }
+      .error.message {
+        color: red;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="error message">Hello World!</div>
+    <script>
+      const message = document.querySelector(".message");
+      message.innerText += "\nI can run Javascript.";
+      document.addEventListener("DOMContentLoaded", () => {
+        try {
+          const parentCookie = window.parent.document.cookie;
+          message.innerText += "\nWARNING! I can see parent's cookies!";
+        } catch (_) {
+          message.innerText += "\nI can't see parent's cookies!";
+          message.classList.remove("error");
+        }
+      });
+    </script>
+    <noscript>
+      <div class="error message">WARNING: I can't run Javascript.</div>
+    </noscript>
+  </body>
+</html>

--- a/samples/core/visualization/html.py
+++ b/samples/core/visualization/html.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 import kfp.dsl as dsl
-import kfp.components as comp
+from kfp.components import create_component_from_func
 
 # Advanced function
 # Demonstrates imports, helper functions and multiple outputs
 from typing import NamedTuple
 
+@create_component_from_func
 def html_visualization(gcsPath: str) -> NamedTuple('VisualizationOutput', [('mlpipeline_ui_metadata', 'UI_metadata')]):
     import json
 
@@ -31,7 +32,7 @@ def html_visualization(gcsPath: str) -> NamedTuple('VisualizationOutput', [('mlp
     }
 
     # Temporarily hack for empty string scenario: https://github.com/kubeflow/pipelines/issues/5830
-    if gcsPath and gcsPath != "" and gcsPath != "BEGIN-KFP-PARAM[]END-KFP-PARAM":
+    if gcsPath and gcsPath != 'BEGIN-KFP-PARAM[]END-KFP-PARAM':
         metadata.get('outputs').append({
             'type': 'web-app',
             'storage': 'gcs',
@@ -43,15 +44,12 @@ def html_visualization(gcsPath: str) -> NamedTuple('VisualizationOutput', [('mlp
         'mlpipeline_ui_metadata'])
     return visualization_output(json.dumps(metadata))
 
-html_visualization_op = comp.func_to_container_op(
-    html_visualization, base_image='tensorflow/tensorflow:1.11.0-py3')
-
 @dsl.pipeline(
     name='html-pipeline',
     description='A sample pipeline to generate HTML for UI visualization.'
 )
 def html_pipeline():
-    html_visualization_task = html_visualization_op("")
+    html_visualization_task = html_visualization("")
     # html_visualization_task = html_visualization_op("gs://jamxl-kfp-bucket/v2-compatible/html/hello-world.html")
     # Replace the parameter gcsPath with actual google cloud storage path with html file.
     # For example: Upload hello-world.html in the same folder to gs://bucket-name/hello-world.html.

--- a/samples/core/visualization/html.py
+++ b/samples/core/visualization/html.py
@@ -1,0 +1,59 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import kfp.dsl as dsl
+import kfp.components as comp
+
+# Advanced function
+# Demonstrates imports, helper functions and multiple outputs
+from typing import NamedTuple
+
+def html_visualization(gcsPath: str) -> NamedTuple('VisualizationOutput', [('mlpipeline_ui_metadata', 'UI_metadata')]):
+    import json
+
+    metadata = {
+        'outputs': [{
+            'type': 'web-app',
+            'storage': 'inline',
+            'source': '<h1>Hello, World!</h1>',
+        }]
+    }
+
+    # Temporarily hack for empty string scenario: https://github.com/kubeflow/pipelines/issues/5830
+    if gcsPath and gcsPath != "" and gcsPath != "BEGIN-KFP-PARAM[]END-KFP-PARAM":
+        metadata.get('outputs').append({
+            'type': 'web-app',
+            'storage': 'gcs',
+            'source': gcsPath,
+        })
+
+    from collections import namedtuple
+    visualization_output = namedtuple('VisualizationOutput', [
+        'mlpipeline_ui_metadata'])
+    return visualization_output(json.dumps(metadata))
+
+html_visualization_op = comp.func_to_container_op(
+    html_visualization, base_image='tensorflow/tensorflow:1.11.0-py3')
+
+@dsl.pipeline(
+    name='html-pipeline',
+    description='A sample pipeline to generate HTML for UI visualization.'
+)
+def html_pipeline():
+    html_visualization_task = html_visualization_op("")
+    # html_visualization_task = html_visualization_op("gs://jamxl-kfp-bucket/v2-compatible/html/hello-world.html")
+    # Replace the parameter gcsPath with actual google cloud storage path with html file.
+    # For example: Upload hello-world.html in the same folder to gs://bucket-name/hello-world.html.
+    # Then uncomment the following line.
+    # html_visualization_task = html_visualization_op("gs://bucket-name/hello-world.html")

--- a/samples/core/visualization/html_test.py
+++ b/samples/core/visualization/html_test.py
@@ -1,0 +1,27 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import kfp
+from .html import html_pipeline
+from ...test.util import run_pipeline_func, TestCase
+
+run_pipeline_func([TestCase(pipeline_func=html_pipeline,
+                            mode=kfp.dsl.PipelineExecutionMode.V2_COMPATIBLE,
+                            arguments={
+                                kfp.dsl.ROOT_PARAMETER_NAME:
+                                'minio://mlpipeline/override/artifacts'
+                            }),
+                   TestCase(pipeline_func=html_pipeline,
+                            mode=kfp.dsl.PipelineExecutionMode.V1_LEGACY
+                            )])


### PR DESCRIPTION
**Description of your changes:**
Partial https://github.com/kubeflow/pipelines/issues/5932

Ability to run same pipeline for v1 and v2 compatible, it will generate HTML for UI visualization.

Command to initialize test:

```
python3 -m samples.core.visualization.html_test
```

User needs to upload sample HTML file to gcs location and update html.py to provide gcs path, if they want to see example other than static inline string.

![htmlviewer](https://user-images.githubusercontent.com/37026441/123746646-c3501000-d866-11eb-8438-2b9155131f08.png)




**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
