### PR TITLE
feat(samples): Confusion Matrix sample for v1/v2 visualization

### DIFF
--- a/samples/core/visualization/confusion_matrix.csv
+++ b/samples/core/visualization/confusion_matrix.csv
@@ -1,0 +1,9 @@
+rose,rose,100
+rose,lily,20
+rose,iris,5
+lily,rose,40
+lily,lily,200
+lily,iris,33
+iris,rose,0
+iris,lily,10
+iris,iris,200

--- a/samples/core/visualization/confusion_matrix.py
+++ b/samples/core/visualization/confusion_matrix.py
@@ -1,0 +1,55 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import kfp.dsl as dsl
+from kfp.components import create_component_from_func
+
+# Advanced function
+# Demonstrates imports, helper functions and multiple outputs
+from typing import NamedTuple
+
+
+@create_component_from_func
+def confusion_visualization(matrix_uri: str = 'https://raw.githubusercontent.com/kubeflow/pipelines/master/samples/core/visualization/confusion_matrix.csv') -> NamedTuple('VisualizationOutput', [('mlpipeline_ui_metadata', 'UI_metadata')]):
+    """Provide confusion matrix csv file to visualize as metrics."""
+    import json
+    
+    metadata = {
+        'outputs' : [{
+          'type': 'confusion_matrix',
+          'format': 'csv',
+          'schema': [
+            {'name': 'target', 'type': 'CATEGORY'},
+            {'name': 'predicted', 'type': 'CATEGORY'},
+            {'name': 'count', 'type': 'NUMBER'},
+          ],
+          'source': matrix_uri,
+          'labels': ['rose', 'lily', 'iris'],
+        }]
+    }
+    
+    from collections import namedtuple
+    visualization_output = namedtuple('VisualizationOutput', [
+        'mlpipeline_ui_metadata'])
+    return visualization_output(json.dumps(metadata))
+        
+@dsl.pipeline(
+    name='confusion-matrix-pipeline',
+    description='A sample pipeline to generate Confusion Matrix for UI visualization.'
+)
+def confusion_matrix_pipeline():
+    confusion_visualization_task = confusion_visualization()
+    # You can also upload samples/core/visualization/confusion_matrix.csv to Google Cloud Storage.
+    # And call the component function with gcs path parameter like below:
+    # confusion_visualization_task2 = confusion_visualization('gs://<bucket-name>/<path>/confusion_matrix.csv')

--- a/samples/core/visualization/confusion_matrix_test.py
+++ b/samples/core/visualization/confusion_matrix_test.py
@@ -1,0 +1,28 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .confusion_matrix import confusion_matrix_pipeline
+from ...test.util import run_pipeline_func, TestCase
+
+import kfp
+
+run_pipeline_func([TestCase(pipeline_func=confusion_matrix_pipeline,
+                            mode=kfp.dsl.PipelineExecutionMode.V2_COMPATIBLE,
+                            arguments={
+                                kfp.dsl.ROOT_PARAMETER_NAME:
+                                'minio://mlpipeline/override/artifacts'
+                            }),
+                   TestCase(pipeline_func=confusion_matrix_pipeline,
+                            mode=kfp.dsl.PipelineExecutionMode.V1_LEGACY
+                            )])


### PR DESCRIPTION
**Description of your changes:**
Partial https://github.com/kubeflow/pipelines/issues/5932

Ability to run same pipeline for v1 and v2 compatible, it will generate confusion matrix for UI visualization.

Command to initialize test:

```
python3 -m samples.core.visualization.confusion_matrix_test
```

User needs to upload sample confusion_matrix.csv file to gcs location and uncomment the bottom line of confusion_matrix.py to provide gcs path, if they want to see example other than public content like GitHub raw URL.

![confusionviewer](https://user-images.githubusercontent.com/37026441/123873122-dd333680-d8ea-11eb-8c64-763b72a076f2.png)


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
