### PR TITLE
feat(frontend): Support new artifact name retrival and hide MLMD tab in v2 pipeline. Fix #5675

### DIFF
--- a/frontend/src/lib/MlmdUtils.ts
+++ b/frontend/src/lib/MlmdUtils.ts
@@ -201,7 +201,7 @@ export interface LinkedArtifact {
   artifact: Artifact;
 }
 
-async function getLinkedArtifactsByEvents(events: Event[]): Promise<LinkedArtifact[]> {
+export async function getLinkedArtifactsByEvents(events: Event[]): Promise<LinkedArtifact[]> {
   const artifactIds = events
     .filter(event => event.getArtifactId())
     .map(event => event.getArtifactId());
@@ -272,4 +272,11 @@ export function filterArtifactsByType(
     .filter(artifactType => artifactType.getName() === artifactTypeName)
     .map(artifactType => artifactType.getId());
   return artifacts.filter(artifact => artifactTypeIds.includes(artifact.getTypeId()));
+}
+
+export function getArtifactName(linkedArtifact: LinkedArtifact): string | undefined {
+  return linkedArtifact.event
+    .getPath()
+    ?.getStepsList()[0]
+    .getKey();
 }

--- a/frontend/src/pages/ExecutionDetails.tsx
+++ b/frontend/src/pages/ExecutionDetails.tsx
@@ -16,40 +16,36 @@
 
 import {
   Api,
-  ArtifactCustomProperties,
-  ArtifactProperties,
   ArtifactType,
   Event,
   Execution,
   ExecutionCustomProperties,
   ExecutionProperties,
-  GetArtifactsByIDRequest,
-  GetExecutionsByIDRequest,
+  ExecutionType,
+  getArtifactTypes,
   GetEventsByExecutionIDsRequest,
   GetEventsByExecutionIDsResponse,
-  getArtifactTypes,
+  GetExecutionsByIDRequest,
   getResourceProperty,
   logger,
-  ExecutionType,
 } from '@kubeflow/frontend';
+import { GetExecutionTypesByIDRequest } from '@kubeflow/frontend/src/mlmd/generated/ml_metadata/proto/metadata_store_service_pb';
 import { CircularProgress } from '@material-ui/core';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
+import { getArtifactName, getLinkedArtifactsByEvents } from 'src/lib/MlmdUtils';
 import { classes, stylesheet } from 'typestyle';
-import { Page, PageErrorHandler } from './Page';
-import { ToolbarProps } from '../components/Toolbar';
-import { RoutePage, RouteParams, RoutePageFactory } from '../components/Router';
-import { commonCss, padding } from '../Css';
 import { ResourceInfo, ResourceType } from '../components/ResourceInfo';
+import { RoutePage, RoutePageFactory, RouteParams } from '../components/Router';
+import { ToolbarProps } from '../components/Toolbar';
+import { commonCss, padding } from '../Css';
 import { serviceErrorToString } from '../lib/Utils';
-import { GetExecutionTypesByIDRequest } from '@kubeflow/frontend/src/mlmd/generated/ml_metadata/proto/metadata_store_service_pb';
-
-type ArtifactIdList = number[];
+import { Page, PageErrorHandler } from './Page';
 
 interface ExecutionDetailsState {
   execution?: Execution;
   executionType?: ExecutionType;
-  events?: Record<Event.Type, ArtifactIdList>;
+  events?: Record<Event.Type, Event[]>;
   artifactTypeMap?: Map<number, ArtifactType>;
 }
 
@@ -125,22 +121,22 @@ export class ExecutionDetailsContent extends Component<
         }
         <SectionIO
           title={'Declared Inputs'}
-          artifactIds={this.state.events[Event.Type.DECLARED_INPUT]}
+          events={this.state.events[Event.Type.DECLARED_INPUT]}
           artifactTypeMap={this.state.artifactTypeMap}
         />
         <SectionIO
           title={'Inputs'}
-          artifactIds={this.state.events[Event.Type.INPUT]}
+          events={this.state.events[Event.Type.INPUT]}
           artifactTypeMap={this.state.artifactTypeMap}
         />
         <SectionIO
           title={'Declared Outputs'}
-          artifactIds={this.state.events[Event.Type.DECLARED_OUTPUT]}
+          events={this.state.events[Event.Type.DECLARED_OUTPUT]}
           artifactTypeMap={this.state.artifactTypeMap}
         />
         <SectionIO
           title={'Outputs'}
-          artifactIds={this.state.events[Event.Type.OUTPUT]}
+          events={this.state.events[Event.Type.OUTPUT]}
           artifactTypeMap={this.state.artifactTypeMap}
         />
       </div>
@@ -257,8 +253,8 @@ export class ExecutionDetailsContent extends Component<
 
 function parseEventsByType(
   response: GetEventsByExecutionIDsResponse | null,
-): Record<Event.Type, ArtifactIdList> {
-  const events: Record<Event.Type, ArtifactIdList> = {
+): Record<Event.Type, Event[]> {
+  const events: Record<Event.Type, Event[]> = {
     [Event.Type.UNKNOWN]: [],
     [Event.Type.DECLARED_INPUT]: [],
     [Event.Type.INPUT]: [],
@@ -276,7 +272,7 @@ function parseEventsByType(
     const type = event.getType();
     const id = event.getArtifactId();
     if (type != null && id != null) {
-      events[type].push(id);
+      events[type].push(event);
     }
   });
 
@@ -292,7 +288,7 @@ interface ArtifactInfo {
 
 interface SectionIOProps {
   title: string;
-  artifactIds: number[];
+  events: Event[];
   artifactTypeMap?: Map<number, ArtifactType>;
 }
 class SectionIO extends Component<
@@ -308,27 +304,21 @@ class SectionIO extends Component<
   }
 
   public async componentDidMount(): Promise<void> {
-    // loads extra metadata about artifacts
-    const request = new GetArtifactsByIDRequest();
-    request.setArtifactIdsList(this.props.artifactIds);
-
     try {
-      const response = await Api.getInstance().metadataStoreService.getArtifactsByID(request);
+      const linkedArtifacts = await getLinkedArtifactsByEvents(this.props.events);
 
       const artifactDataMap = {};
-      response.getArtifactsList().forEach(artifact => {
-        const id = artifact.getId();
+      linkedArtifacts.forEach(linkedArtifact => {
+        const id = linkedArtifact.event.getArtifactId();
         if (!id) {
-          logger.error('Artifact has empty id', artifact.toObject());
+          logger.error('Artifact has empty id', linkedArtifact.artifact.toObject());
           return;
         }
         artifactDataMap[id] = {
           id,
-          name: (getResourceProperty(artifact, ArtifactProperties.NAME) ||
-            getResourceProperty(artifact, ArtifactCustomProperties.NAME, true) ||
-            '') as string, // TODO: assert name is string
-          typeId: artifact.getTypeId(),
-          uri: artifact.getUri() || '',
+          name: getArtifactName(linkedArtifact),
+          typeId: linkedArtifact.artifact.getTypeId(),
+          uri: linkedArtifact.artifact.getUri() || '',
         };
       });
       this.setState({
@@ -340,8 +330,8 @@ class SectionIO extends Component<
   }
 
   public render(): JSX.Element | null {
-    const { title, artifactIds } = this.props;
-    if (artifactIds.length === 0) {
+    const { title, events } = this.props;
+    if (events.length === 0) {
       return null;
     }
 
@@ -358,7 +348,8 @@ class SectionIO extends Component<
             </tr>
           </thead>
           <tbody>
-            {artifactIds.map(id => {
+            {events.map(event => {
+              const id = event.getArtifactId();
               const data = this.state.artifactDataMap[id] || {};
               const type =
                 this.props.artifactTypeMap && data.typeId

--- a/frontend/src/pages/RunDetails.test.tsx
+++ b/frontend/src/pages/RunDetails.test.tsx
@@ -34,7 +34,7 @@ import * as Utils from '../lib/Utils';
 import WorkflowParser from '../lib/WorkflowParser';
 import TestUtils from '../TestUtils';
 import { PageProps } from './Page';
-import EnhancedRunDetails, { RunDetailsInternalProps, TEST_ONLY } from './RunDetails';
+import EnhancedRunDetails, { RunDetailsInternalProps, SidePanelTab, TEST_ONLY } from './RunDetails';
 
 const RunDetails = TEST_ONLY.RunDetails;
 
@@ -56,15 +56,15 @@ jest.mock('../components/Graph', () => {
 });
 
 const STEP_TABS = {
-  INPUT_OUTPUT: 0,
-  VISUALIZATIONS: 1,
-  ML_METADATA: 2,
-  TASK_DETAILS: 3,
-  VOLUMES: 4,
-  LOGS: 5,
-  POD: 6,
-  EVENTS: 7,
-  MANIFEST: 8,
+  INPUT_OUTPUT: SidePanelTab.INPUT_OUTPUT,
+  VISUALIZATIONS: SidePanelTab.VISUALIZATIONS,
+  TASK_DETAILS: SidePanelTab.TASK_DETAILS,
+  VOLUMES: SidePanelTab.VOLUMES,
+  LOGS: SidePanelTab.LOGS,
+  POD: SidePanelTab.POD,
+  EVENTS: SidePanelTab.EVENTS,
+  ML_METADATA: SidePanelTab.ML_METADATA,
+  MANIFEST: SidePanelTab.MANIFEST,
 };
 
 const WORKFLOW_TEMPLATE = {

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -79,28 +79,17 @@ import { ExecutionDetailsContent } from './ExecutionDetails';
 import { Page, PageProps } from './Page';
 import { statusToIcon } from './Status';
 
-enum SidePaneTab {
+export enum SidePanelTab {
   INPUT_OUTPUT,
   VISUALIZATIONS,
-  ML_METADATA,
   TASK_DETAILS,
   VOLUMES,
   LOGS,
   POD,
   EVENTS,
+  ML_METADATA,
   MANIFEST,
 }
-
-const tabsNames = [
-  'Input/Output',
-  'Visualizations',
-  'ML Metadata',
-  'Details',
-  'Volumes',
-  'Logs',
-  'Pod',
-  'Events',
-];
 
 interface SelectedNodeDetails {
   id: string;
@@ -144,7 +133,7 @@ interface RunDetailsState {
   selectedNodeDetails: SelectedNodeDetails | null;
   sidepanelBannerMode: Mode;
   sidepanelBusy: boolean;
-  sidepanelSelectedTab: SidePaneTab;
+  sidepanelSelectedTab: SidePanelTab;
   workflow?: Workflow;
   mlmdRunContext?: Context;
   mlmdExecutions?: Execution[];
@@ -196,7 +185,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
     selectedTab: 0,
     sidepanelBannerMode: 'warning',
     sidepanelBusy: false,
-    sidepanelSelectedTab: SidePaneTab.INPUT_OUTPUT,
+    sidepanelSelectedTab: SidePanelTab.INPUT_OUTPUT,
     mlmdRunContext: undefined,
     mlmdExecutions: undefined,
     showReducedGraph: false,
@@ -344,14 +333,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                             )}
                             <div className={commonCss.page}>
                               <MD2Tabs
-                                tabs={[
-                                  ...tabsNames,
-                                  // NOTE: it's only possible to conditionally add a tab at the end
-                                  ...(WorkflowParser.getNodeManifest(workflow, selectedNodeId)
-                                    .length > 0
-                                    ? ['Manifest']
-                                    : []),
-                                ]}
+                                tabs={this.getTabNames(workflow, selectedNodeId)}
                                 selectedTab={sidepanelSelectedTab}
                                 onSwitch={this._loadSidePaneTab.bind(this)}
                               />
@@ -360,7 +342,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                 data-testid='run-details-node-details'
                                 className={commonCss.page}
                               >
-                                {sidepanelSelectedTab === SidePaneTab.VISUALIZATIONS &&
+                                {sidepanelSelectedTab === SidePanelTab.VISUALIZATIONS &&
                                   this.state.selectedNodeDetails &&
                                   this.state.workflow &&
                                   !isV2Pipeline(workflow) && (
@@ -383,13 +365,13 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                       onError={this.handleError}
                                     />
                                   )}
-                                {sidepanelSelectedTab === SidePaneTab.VISUALIZATIONS &&
+                                {sidepanelSelectedTab === SidePanelTab.VISUALIZATIONS &&
                                   this.state.selectedNodeDetails &&
                                   this.state.workflow &&
                                   isV2Pipeline(workflow) &&
                                   selectedExecution && <MetricsTab execution={selectedExecution} />}
 
-                                {sidepanelSelectedTab === SidePaneTab.INPUT_OUTPUT &&
+                                {sidepanelSelectedTab === SidePanelTab.INPUT_OUTPUT &&
                                   !isV2Pipeline(workflow) && (
                                     <div className={padding(20)}>
                                       <DetailsTable
@@ -425,7 +407,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                       />
                                     </div>
                                   )}
-                                {sidepanelSelectedTab === SidePaneTab.INPUT_OUTPUT &&
+                                {sidepanelSelectedTab === SidePanelTab.INPUT_OUTPUT &&
                                   isV2Pipeline(workflow) &&
                                   selectedExecution && (
                                     <InputOutputTab
@@ -434,7 +416,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                     />
                                   )}
 
-                                {sidepanelSelectedTab === SidePaneTab.TASK_DETAILS && (
+                                {sidepanelSelectedTab === SidePanelTab.TASK_DETAILS && (
                                   <div className={padding(20)}>
                                     <DetailsTable
                                       title='Task Details'
@@ -443,42 +425,43 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                   </div>
                                 )}
 
-                                {sidepanelSelectedTab === SidePaneTab.ML_METADATA && (
-                                  <div className={padding(20)}>
-                                    {selectedExecution && (
-                                      <>
-                                        <div>
-                                          This step corresponds to execution{' '}
-                                          <Link
-                                            className={commonCss.link}
-                                            to={RoutePageFactory.executionDetails(
-                                              selectedExecution.getId(),
-                                            )}
-                                          >
-                                            "{ExecutionHelpers.getName(selectedExecution)}".
-                                          </Link>
-                                        </div>
-                                        <ExecutionDetailsContent
-                                          key={selectedExecution.getId()}
-                                          id={selectedExecution.getId()}
-                                          onError={
-                                            ((msg: string, ...args: any[]) => {
-                                              // TODO: show a proper error banner and retry button
-                                              console.warn(msg);
-                                            }) as any
-                                          }
-                                          // No title here
-                                          onTitleUpdate={() => null}
-                                        />
-                                      </>
-                                    )}
-                                    {!selectedExecution && (
-                                      <div>Corresponding ML Metadata not found.</div>
-                                    )}
-                                  </div>
-                                )}
+                                {sidepanelSelectedTab === SidePanelTab.ML_METADATA &&
+                                  !isV2Pipeline(workflow) && (
+                                    <div className={padding(20)}>
+                                      {selectedExecution && (
+                                        <>
+                                          <div>
+                                            This step corresponds to execution{' '}
+                                            <Link
+                                              className={commonCss.link}
+                                              to={RoutePageFactory.executionDetails(
+                                                selectedExecution.getId(),
+                                              )}
+                                            >
+                                              "{ExecutionHelpers.getName(selectedExecution)}".
+                                            </Link>
+                                          </div>
+                                          <ExecutionDetailsContent
+                                            key={selectedExecution.getId()}
+                                            id={selectedExecution.getId()}
+                                            onError={
+                                              ((msg: string, ...args: any[]) => {
+                                                // TODO: show a proper error banner and retry button
+                                                console.warn(msg);
+                                              }) as any
+                                            }
+                                            // No title here
+                                            onTitleUpdate={() => null}
+                                          />
+                                        </>
+                                      )}
+                                      {!selectedExecution && (
+                                        <div>Corresponding ML Metadata not found.</div>
+                                      )}
+                                    </div>
+                                  )}
 
-                                {sidepanelSelectedTab === SidePaneTab.VOLUMES && (
+                                {sidepanelSelectedTab === SidePanelTab.VOLUMES && (
                                   <div className={padding(20)}>
                                     <DetailsTable
                                       title='Volume Mounts'
@@ -490,7 +473,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                   </div>
                                 )}
 
-                                {sidepanelSelectedTab === SidePaneTab.MANIFEST && (
+                                {sidepanelSelectedTab === SidePanelTab.MANIFEST && (
                                   <div className={padding(20)}>
                                     <DetailsTable
                                       title='Resource Manifest'
@@ -502,7 +485,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                   </div>
                                 )}
 
-                                {sidepanelSelectedTab === SidePaneTab.POD &&
+                                {sidepanelSelectedTab === SidePanelTab.POD &&
                                   selectedNodeDetails.phase !== NodePhase.SKIPPED && (
                                     <div className={commonCss.page}>
                                       {selectedNodeId && namespace && (
@@ -511,7 +494,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                     </div>
                                   )}
 
-                                {sidepanelSelectedTab === SidePaneTab.EVENTS &&
+                                {sidepanelSelectedTab === SidePanelTab.EVENTS &&
                                   selectedNodeDetails.phase !== NodePhase.SKIPPED && (
                                     <div className={commonCss.page}>
                                       {selectedNodeId && namespace && (
@@ -520,7 +503,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
                                     </div>
                                   )}
 
-                                {sidepanelSelectedTab === SidePaneTab.LOGS &&
+                                {sidepanelSelectedTab === SidePanelTab.LOGS &&
                                   selectedNodeDetails.phase !== NodePhase.SKIPPED && (
                                     <div className={commonCss.page}>
                                       {this.state.logsBannerMessage && (
@@ -649,6 +632,62 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
         )}
       </div>
     );
+  }
+  getTabNames(workflow: Workflow, selectedNodeId: string): string[] {
+    // NOTE: it's only possible to conditionally add a tab at the end
+    const tabNameList = [];
+    for (let tab in SidePanelTab) {
+      // plus symbol changes enum to number.
+      switch (+tab) {
+        case SidePanelTab.INPUT_OUTPUT: {
+          tabNameList.push('Input/Output');
+          break;
+        }
+        case SidePanelTab.VISUALIZATIONS: {
+          tabNameList.push('Visualizations');
+          break;
+        }
+        case SidePanelTab.ML_METADATA: {
+          if (isV2Pipeline(workflow)) {
+            break;
+          }
+          tabNameList.push('ML Metadata');
+          break;
+        }
+        case SidePanelTab.TASK_DETAILS: {
+          tabNameList.push('Details');
+          break;
+        }
+        case SidePanelTab.VOLUMES: {
+          tabNameList.push('Volumes');
+          break;
+        }
+        case SidePanelTab.LOGS: {
+          tabNameList.push('Logs');
+          break;
+        }
+        case SidePanelTab.POD: {
+          tabNameList.push('Pod');
+          break;
+        }
+        case SidePanelTab.EVENTS: {
+          tabNameList.push('Events');
+          break;
+        }
+        case SidePanelTab.MANIFEST: {
+          if (WorkflowParser.getNodeManifest(workflow, selectedNodeId).length === 0) {
+            break;
+          }
+          tabNameList.push('Manifest');
+          break;
+        }
+        default: {
+          console.error(`Unable to find corresponding tab name for ${tab}`);
+          break;
+        }
+      }
+    }
+    return tabNameList;
   }
 
   public async componentDidMount(): Promise<void> {
@@ -940,7 +979,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
     );
   }
 
-  private async _loadSidePaneTab(tab: SidePaneTab): Promise<void> {
+  private async _loadSidePaneTab(tab: SidePanelTab): Promise<void> {
     const workflow = this.state.workflow;
     const selectedNodeDetails = this.state.selectedNodeDetails;
 
@@ -970,7 +1009,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
       this.setStateSafe({ selectedNodeDetails, sidepanelSelectedTab: tab, sidepanelBannerMode });
 
       switch (tab) {
-        case SidePaneTab.LOGS:
+        case SidePanelTab.LOGS:
           if (node.phase !== NodePhase.PENDING && node.phase !== NodePhase.SKIPPED) {
             await this._loadSelectedNodeLogs();
           } else {

--- a/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunDetails.test.tsx.snap
@@ -574,17 +574,17 @@ exports[`RunDetails logs tab does not load logs if clicked node status is skippe
             >
               <MD2Tabs
                 onSwitch={[Function]}
-                selectedTab={5}
+                selectedTab={4}
                 tabs={
                   Array [
                     "Input/Output",
                     "Visualizations",
-                    "ML Metadata",
                     "Details",
                     "Volumes",
                     "Logs",
                     "Pod",
                     "Events",
+                    "ML Metadata",
                   ]
                 }
               />
@@ -682,17 +682,17 @@ exports[`RunDetails logs tab keeps side pane open and on same tab when logs chan
             >
               <MD2Tabs
                 onSwitch={[Function]}
-                selectedTab={5}
+                selectedTab={4}
                 tabs={
                   Array [
                     "Input/Output",
                     "Visualizations",
-                    "ML Metadata",
                     "Details",
                     "Volumes",
                     "Logs",
                     "Pod",
                     "Events",
+                    "ML Metadata",
                   ]
                 }
               />
@@ -806,17 +806,17 @@ exports[`RunDetails logs tab loads and shows logs in side pane 1`] = `
             >
               <MD2Tabs
                 onSwitch={[Function]}
-                selectedTab={5}
+                selectedTab={4}
                 tabs={
                   Array [
                     "Input/Output",
                     "Visualizations",
-                    "ML Metadata",
                     "Details",
                     "Volumes",
                     "Logs",
                     "Pod",
                     "Events",
+                    "ML Metadata",
                   ]
                 }
               />
@@ -930,17 +930,17 @@ exports[`RunDetails logs tab switches to logs tab in side pane 1`] = `
             >
               <MD2Tabs
                 onSwitch={[Function]}
-                selectedTab={5}
+                selectedTab={4}
                 tabs={
                   Array [
                     "Input/Output",
                     "Visualizations",
-                    "ML Metadata",
                     "Details",
                     "Volumes",
                     "Logs",
                     "Pod",
                     "Events",
+                    "ML Metadata",
                   ]
                 }
               />
@@ -1059,12 +1059,12 @@ exports[`RunDetails opens side panel when graph node is clicked 1`] = `
                   Array [
                     "Input/Output",
                     "Visualizations",
-                    "ML Metadata",
                     "Details",
                     "Volumes",
                     "Logs",
                     "Pod",
                     "Events",
+                    "ML Metadata",
                   ]
                 }
               />
@@ -1599,12 +1599,12 @@ exports[`RunDetails switches to inputs/outputs tab in side pane 1`] = `
                   Array [
                     "Input/Output",
                     "Visualizations",
-                    "ML Metadata",
                     "Details",
                     "Volumes",
                     "Logs",
                     "Pod",
                     "Events",
+                    "ML Metadata",
                   ]
                 }
               />
@@ -1762,12 +1762,12 @@ exports[`RunDetails switches to manifest tab in side pane 1`] = `
                   Array [
                     "Input/Output",
                     "Visualizations",
-                    "ML Metadata",
                     "Details",
                     "Volumes",
                     "Logs",
                     "Pod",
                     "Events",
+                    "ML Metadata",
                   ]
                 }
               />
@@ -1914,17 +1914,17 @@ exports[`RunDetails switches to volumes tab in side pane 1`] = `
             >
               <MD2Tabs
                 onSwitch={[Function]}
-                selectedTab={4}
+                selectedTab={3}
                 tabs={
                   Array [
                     "Input/Output",
                     "Visualizations",
-                    "ML Metadata",
                     "Details",
                     "Volumes",
                     "Logs",
                     "Pod",
                     "Events",
+                    "ML Metadata",
                   ]
                 }
               />


### PR DESCRIPTION

**Description of your changes:**

Fix #5675

In V1 pipeline, we show artifact names by reading from event.
![v1pipelineartifactname](https://user-images.githubusercontent.com/37026441/124013914-bed74480-d997-11eb-9a93-47f7287a1717.png)

In V2 pipeline, we hide ML Metadata tab because Input/Output tab has already shown the same information.
![v2pipelinehide](https://user-images.githubusercontent.com/37026441/124013993-d31b4180-d997-11eb-8b1e-0a864273b614.png)



**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
