### PR TITLE
chore: add offline linting

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -1146,7 +1146,7 @@ Please create a new issue at https://github.com/kubeflow/pipelines/issues attach
             container:
               image: docker/whalesay:latest""")
     except:
-      warnings.warn("Cannot validate the compiled workflow. Found the argo program in PATH, but it's not usable. argo v2.4.3 should work.")
+      warnings.warn("Cannot validate the compiled workflow. Found the argo program in PATH, but it's not usable. argo v3.1.1 should work.")
 
     if has_working_argo_lint:
       _run_argo_lint(yaml_text)
@@ -1158,7 +1158,7 @@ def _run_argo_lint(yaml_text: str):
   import subprocess
   argo_path = shutil.which('argo')
   if argo_path:
-    result = subprocess.run([argo_path, 'lint', '/dev/stdin'], input=yaml_text.encode('utf-8'), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result = subprocess.run([argo_path, '--offline=true', 'lint', '/dev/stdin'], input=yaml_text.encode('utf-8'), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if result.returncode:
       if re.match(
           pattern=r'.+failed to resolve {{tasks\..+\.outputs\.artifacts\..+}}.+',

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -1146,7 +1146,7 @@ Please create a new issue at https://github.com/kubeflow/pipelines/issues attach
             container:
               image: docker/whalesay:latest""")
     except:
-      warnings.warn("Cannot validate the compiled workflow. Found the argo program in PATH, but it's not usable. argo v3.1.1 should work.")
+      warnings.warn("Cannot validate the compiled workflow. Found the argo program in PATH, but it's not usable. argo CLI v3.1.1+ should work.")
 
     if has_working_argo_lint:
       _run_argo_lint(yaml_text)


### PR DESCRIPTION
**Description of your changes:**
Argo now have linting in offline mode: https://github.com/argoproj/argo-workflows/pull/5569, we now use:

https://github.com/kubeflow/pipelines/blob/df1ab4db5e72e2ddb6f098343a3faf51599087d1/backend/Dockerfile#L36

in the `Dockerfile` and since Argo 3.1.1 supports offline linting i suggest we updated the error message and set it to `offline`

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
