### PR TITLE
fix(sdk): allow "name" and "value" to sub-vars of LoopArguments. Fixes #6020

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -903,6 +903,7 @@ class Compiler(object):
       pipeline_conf,
     )
 
+  @_for_loop.with_loop_arguments_decomposing_deactivated
   def _create_workflow_from_spec(
       self,
       dsl_pipeline: dsl.Pipeline,

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -32,11 +32,12 @@ from kfp.compiler._k8s_helper import convert_k8s_obj_to_json, sanitize_k8s_name
 from kfp.compiler._op_to_template import _op_to_template, _process_obj
 from kfp.compiler._default_transformers import add_pod_env, add_pod_labels
 
-from kfp.components.structures import InputSpec
+from kfp.components.structures import InputSpec, ComponentSpec
 from kfp.components._yaml_utils import dump_yaml
 from kfp.dsl._metadata import _extract_pipeline_metadata
 from kfp.dsl._ops_group import OpsGroup
 from kfp.dsl._pipeline_param import extract_pipelineparams_from_any, PipelineParam
+
 
 _SDK_VERSION_LABEL = 'pipelines.kubeflow.org/kfp_sdk_version'
 _SDK_ENV_LABEL = 'pipelines.kubeflow.org/pipeline-sdk-type'
@@ -895,6 +896,21 @@ class Compiler(object):
     with dsl.Pipeline(pipeline_name) as dsl_pipeline:
       pipeline_func(*args_list, **kwargs_dict)
 
+    return self._create_workflow_from_spec(
+      dsl_pipeline,
+      pipeline_meta,
+      params_list, default_param_values,
+      pipeline_conf,
+    )
+
+  def _create_workflow_from_spec(
+      self,
+      dsl_pipeline: dsl.Pipeline,
+      pipeline_meta: ComponentSpec,
+      params_list: List[dsl.PipelineParam],
+      default_param_values: Dict[str, Any],
+      pipeline_conf: Optional[dsl.PipelineConf] = None,
+  ) -> Dict[Text, Any]:
     pipeline_conf = pipeline_conf or dsl_pipeline.conf # Configuration passed to the compiler is overriding. Unfortunately, it's not trivial to detect whether the dsl_pipeline.conf was ever modified.
 
     self._validate_exit_handler(dsl_pipeline)

--- a/sdk/python/kfp/dsl/_for_loop.py
+++ b/sdk/python/kfp/dsl/_for_loop.py
@@ -64,17 +64,6 @@ class LoopArguments(dsl.PipelineParam):
               'If you input a list of dicts then all dicts should have the same keys. '
               'Got: {}.'.format(items))
 
-      # then this block creates loop_args.variable_a and loop_args.variable_b
-      for subvar_name in subvar_names:
-        if not self._subvar_name_is_legal(subvar_name):
-          raise ValueError(
-              "Tried to create subvariable named {} but that's not a legal Python variable "
-              'name.'.format(subvar_name))
-        setattr(
-            self, subvar_name,
-            LoopArgumentVariable(
-                self.name, subvar_name, loop_args_op_name=self.op_name))
-
     self.items_or_pipeline_param = items
     self.referenced_subvar_names = []
 

--- a/sdk/python/kfp/dsl/_pipeline_param.py
+++ b/sdk/python/kfp/dsl/_pipeline_param.py
@@ -208,8 +208,11 @@ class PipelineParam(object):
     #if self.value:
     #  return str(self.value)
 
-    op_name = self.op_name if self.op_name else ''
-    return '{{pipelineparam:op=%s;name=%s}}' % (op_name, self.name)
+    op_name = object.__getattribute__(self, 'op_name')
+    name = object.__getattribute__(self, 'name')
+
+    op_name = op_name if op_name else ''
+    return '{{pipelineparam:op=%s;name=%s}}' % (op_name, name)
 
   def __repr__(self):
     # return str({self.__class__.__name__: self.__dict__})
@@ -243,7 +246,9 @@ class PipelineParam(object):
     return ConditionOperator('>=', self, other)
 
   def __hash__(self):
-    return hash((self.op_name, self.name))
+    op_name = object.__getattribute__(self, 'op_name')
+    name = object.__getattribute__(self, 'name')
+    return hash((op_name, name))
 
   def ignore_type(self):
     """ignore_type ignores the type information such that type checking would also pass"""

--- a/sdk/python/kfp/v2/compiler/compiler.py
+++ b/sdk/python/kfp/v2/compiler/compiler.py
@@ -1077,6 +1077,7 @@ class Compiler(object):
       pipeline_parameters_override,
     )
 
+  @_for_loop.with_loop_arguments_decomposing_deactivated
   def _create_pipeline_v2_from_spec(
         self,
         dsl_pipeline: dsl.Pipeline,

--- a/sdk/python/kfp/v2/compiler/compiler.py
+++ b/sdk/python/kfp/v2/compiler/compiler.py
@@ -28,6 +28,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Uni
 import kfp
 from kfp.compiler._k8s_helper import sanitize_k8s_name
 from kfp.components import _python_op
+from kfp.components.structures import ComponentSpec
 from kfp import dsl
 from kfp.dsl import _for_loop
 from kfp.dsl import _pipeline_param
@@ -1068,6 +1069,21 @@ class Compiler(object):
 
     with dsl.Pipeline(pipeline_name) as dsl_pipeline:
       pipeline_func(*args_list)
+
+    return self._create_pipeline_v2_from_spec(
+      dsl_pipeline,
+      pipeline_meta,
+      pipeline_root,
+      pipeline_parameters_override,
+    )
+
+  def _create_pipeline_v2_from_spec(
+        self,
+        dsl_pipeline: dsl.Pipeline,
+        pipeline_meta: ComponentSpec,
+        pipeline_root: str,
+        pipeline_parameters_override: Optional[Mapping[str, Any]] = None,
+  ) -> pipeline_spec_pb2.PipelineJob:
 
     self._validate_exit_handler(dsl_pipeline)
     self._sanitize_and_inject_artifact(dsl_pipeline)


### PR DESCRIPTION
**Description of your changes:**
As describe in issue #6020. Introducing context-switching in behaviour of `LoopArguments` which fixes problems with json keys named just like field of the `PipelineParam` class, including very common (name-type-value format) keys "name" and "value".

**Suggested follow-up:**
* Introduce `__getitem__` to `LoopArguments`. That is consistent with most of python libraries manipulating json, i.e. treating the json as a `Mapping[str, Any], not a class with fields. It also avoids all problems with keys not being proper python names, e.g. "sub-type".
  * Deprecate the dot-accessing of fields in v2 and remove it in the next comparably major release?
* Create a context-manager, decorator and possibly other utils that are more general than `loop_arguments_decomposing_deactivated`, e.g. marking the stages with at least two values: in-pipeline-building and in-pipeline-compiling. That way, other classes may change their behaviour too, e.g. some methods can be unusable at DSL-building-time or vice-versa.

<!--
**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->

**Notes:**
It seems it could be cherry-picked in the current release branch.