### PR TITLE
chore(v2): unify pipeline name between MLMD and KFP DB. Fixes #5978

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -261,7 +261,14 @@ func (r *ResourceManager) UpdatePipelineDefaultVersion(pipelineId string, versio
 
 func (r *ResourceManager) CreatePipeline(name string, description string, namespace string, pipelineFile []byte) (*model.Pipeline, error) {
 	// Extract the parameter from the pipeline
-	params, err := util.GetParameters(pipelineFile)
+	wf, err := util.ValidateWorkflow(pipelineFile)
+	if err != nil {
+		return nil, util.Wrap(err, "Create pipeline failed")
+	}
+	if wf.IsV2() {
+		overrideV2PipelineName(wf, name, namespace)
+	}
+	paramsJson, err := util.MarshalParameters(wf.Spec.Arguments.Parameters)
 	if err != nil {
 		return nil, util.Wrap(err, "Create pipeline failed")
 	}
@@ -270,12 +277,12 @@ func (r *ResourceManager) CreatePipeline(name string, description string, namesp
 	pipeline := &model.Pipeline{
 		Name:        name,
 		Description: description,
-		Parameters:  params,
+		Parameters:  paramsJson,
 		Status:      model.PipelineCreating,
 		Namespace:   namespace,
 		DefaultVersion: &model.PipelineVersion{
 			Name:       name,
-			Parameters: params,
+			Parameters: paramsJson,
 			Status:     model.PipelineVersionCreating}}
 	newPipeline, err := r.pipelineStore.CreatePipeline(pipeline)
 	if err != nil {
@@ -508,7 +515,6 @@ func (r *ResourceManager) ListTasks(filterContext *common.FilterContext,
 	opts *list.Options) (tasks []*model.Task, total_size int, nextPageToken string, err error) {
 	return r.taskStore.ListTasks(filterContext, opts)
 }
-
 
 func (r *ResourceManager) ListJobs(filterContext *common.FilterContext,
 	opts *list.Options) (jobs []*model.Job, total_size int, nextPageToken string, err error) {
@@ -1178,12 +1184,6 @@ func (r *ResourceManager) getDefaultSA() string {
 }
 
 func (r *ResourceManager) CreatePipelineVersion(apiVersion *api.PipelineVersion, pipelineFile []byte, updateDefaultVersion bool) (*model.PipelineVersion, error) {
-	// Extract the parameters from the pipeline
-	params, err := util.GetParameters(pipelineFile)
-	if err != nil {
-		return nil, util.Wrap(err, "Create pipeline version failed")
-	}
-
 	// Extract pipeline id
 	var pipelineId = ""
 	for _, resourceReference := range apiVersion.ResourceReferences {
@@ -1192,7 +1192,24 @@ func (r *ResourceManager) CreatePipelineVersion(apiVersion *api.PipelineVersion,
 		}
 	}
 	if len(pipelineId) == 0 {
-		return nil, util.Wrap(err, "Create pipeline version failed due to missing pipeline id")
+		return nil, util.NewInvalidInputError("Create pipeline version failed due to missing pipeline id")
+	}
+
+	// Extract the parameters from the pipeline
+	wf, err := util.ValidateWorkflow(pipelineFile)
+	if err != nil {
+		return nil, util.Wrap(err, "Create pipeline version failed")
+	}
+	if wf.IsV2() {
+		pipeline, err := r.GetPipeline(pipelineId)
+		if err != nil {
+			return nil, util.Wrap(err, "Create pipeline version failed")
+		}
+		overrideV2PipelineName(wf, pipeline.Name, pipeline.Namespace)
+	}
+	paramsJson, err := util.MarshalParameters(wf.Spec.Arguments.Parameters)
+	if err != nil {
+		return nil, util.Wrap(err, "Create pipeline version failed")
 	}
 
 	// Construct model.PipelineVersion
@@ -1200,7 +1217,7 @@ func (r *ResourceManager) CreatePipelineVersion(apiVersion *api.PipelineVersion,
 		Name:          apiVersion.Name,
 		PipelineId:    pipelineId,
 		Status:        model.PipelineVersionCreating,
-		Parameters:    params,
+		Parameters:    paramsJson,
 		CodeSourceUrl: apiVersion.CodeSourceUrl,
 	}
 	version, err = r.pipelineStore.CreatePipelineVersion(version, updateDefaultVersion)

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1195,7 +1195,7 @@ func (r *ResourceManager) CreatePipelineVersion(apiVersion *api.PipelineVersion,
 		return nil, util.NewInvalidInputError("Create pipeline version failed due to missing pipeline id")
 	}
 
-	// Extract the parameters from the pipeline
+	// Extract the parameters from the pipeline & override pipeline name parameter.
 	wf, err := util.ValidateWorkflow(pipelineFile)
 	if err != nil {
 		return nil, util.Wrap(err, "Create pipeline version failed")

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -332,13 +332,13 @@ func TestCreatePipeline_ComplexPipeline(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestCreatePipeline_GetParametersError(t *testing.T) {
+func TestCreatePipeline_ParseWorkflowError(t *testing.T) {
 	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
 	defer store.Close()
 	manager := NewResourceManager(store)
 	_, err := manager.CreatePipeline("pipeline1", "", "", []byte("I am invalid yaml"))
 	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
-	assert.Contains(t, err.Error(), "Failed to parse the parameter")
+	assert.Contains(t, err.Error(), "Failed to parse the workflow template")
 }
 
 func TestCreatePipeline_StorePipelineMetadataError(t *testing.T) {
@@ -2914,7 +2914,7 @@ func TestCreatePipelineVersion_CreatePipelineVersionFileError(t *testing.T) {
 	assert.NotNil(t, version)
 }
 
-func TestCreatePipelineVersion_GetParametersError(t *testing.T) {
+func TestCreatePipelineVersion_ParseWorkflowError(t *testing.T) {
 	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
 	defer store.Close()
 	manager := NewResourceManager(store)
@@ -2942,7 +2942,7 @@ func TestCreatePipelineVersion_GetParametersError(t *testing.T) {
 		},
 		[]byte("I am invalid yaml"), true)
 	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
-	assert.Contains(t, err.Error(), "Failed to parse the parameter")
+	assert.Contains(t, err.Error(), "Failed to parse the workflow")
 }
 
 func TestCreatePipelineVersion_StorePipelineVersionMetadataError(t *testing.T) {

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -286,6 +286,38 @@ func TestCreatePipeline(t *testing.T) {
 	assert.Equal(t, pipelineExpected, pipeline)
 }
 
+func TestCreatePipeline_V2PipelineName(t *testing.T) {
+	tests := []struct {
+		name         string
+		namespace    string
+		pipelineName string
+	}{
+		{"v2-compat", "", "pipeline/v2-compat"},
+		{"pipe3", "", "pipeline/pipe3"},
+		{"pipeline2", "kubeflow", "namespace/kubeflow/pipeline/pipeline2"},
+		{"abcd", "user", "namespace/user/pipeline/abcd"},
+	}
+	for _, test := range tests {
+		store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+		defer store.Close()
+		manager := NewResourceManager(store)
+
+		createdPipeline, err := manager.CreatePipeline(test.name, "", test.namespace, []byte(strings.TrimSpace(
+			v2compatPipeline)))
+		require.Nil(t, err)
+		params, err := util.UnmarshalParameters(createdPipeline.Parameters)
+		require.Nil(t, err)
+		var nameParam *v1alpha1.Parameter
+		for _, param := range params {
+			if param.Name == "pipeline-name" {
+				nameParam = &param
+			}
+		}
+		require.NotNil(t, nameParam)
+		require.Equal(t, test.pipelineName, nameParam.Value.String())
+	}
+}
+
 func TestCreatePipeline_ComplexPipeline(t *testing.T) {
 	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
 	defer store.Close()
@@ -2111,6 +2143,255 @@ func TestReadArtifact_NoRun_NotFound(t *testing.T) {
 }
 
 const (
+	v2compatPipeline = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: two-step-pipeline-
+  annotations:
+    pipelines.kubeflow.org/kfp_sdk_version: 1.6.4
+    pipelines.kubeflow.org/pipeline_compilation_time: '2021-07-14T06:59:20.208189'
+    pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "", "name": "pipeline-output-directory"},
+      {"default": "pipeline/two_step_pipeline", "name": "pipeline-name"}], "name":
+      "two_step_pipeline"}'
+    pipelines.kubeflow.org/v2_pipeline: "true"
+  labels:
+    pipelines.kubeflow.org/v2_pipeline: "true"
+    pipelines.kubeflow.org/kfp_sdk_version: 1.6.4
+spec:
+  entrypoint: two-step-pipeline
+  templates:
+  - name: preprocess
+    container:
+      args:
+      - sh
+      - -ec
+      - |
+        program_path=$(mktemp)
+        printf "%s" "$0" > "$program_path"
+        python3 -u "$program_path" "$@"
+      - |
+        def _make_parent_dirs_and_return_path(file_path: str):
+            import os
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+            return file_path
+
+        def preprocess(
+            uri, some_int, output_parameter_one,
+            output_dataset_one
+        ):
+            '''Dummy Preprocess Step.'''
+            with open(output_dataset_one, 'w') as f:
+                f.write('Output dataset')
+            with open(output_parameter_one, 'w') as f:
+                f.write("{}".format(1234))
+
+        import argparse
+        _parser = argparse.ArgumentParser(prog='Preprocess', description='Dummy Preprocess Step.')
+        _parser.add_argument("--uri", dest="uri", type=str, required=True, default=argparse.SUPPRESS)
+        _parser.add_argument("--some-int", dest="some_int", type=int, required=True, default=argparse.SUPPRESS)
+        _parser.add_argument("--output-parameter-one", dest="output_parameter_one", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
+        _parser.add_argument("--output-dataset-one", dest="output_dataset_one", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
+        _parsed_args = vars(_parser.parse_args())
+
+        _outputs = preprocess(**_parsed_args)
+      - --uri
+      - '{{$.inputs.parameters[''uri'']}}'
+      - --some-int
+      - '{{$.inputs.parameters[''some_int'']}}'
+      - --output-parameter-one
+      - '{{$.outputs.parameters[''output_parameter_one''].output_file}}'
+      - --output-dataset-one
+      - '{{$.outputs.artifacts[''output_dataset_one''].path}}'
+      command: [/kfp-launcher/launch, --mlmd_server_address, $(METADATA_GRPC_SERVICE_HOST),
+        --mlmd_server_port, $(METADATA_GRPC_SERVICE_PORT), --runtime_info_json, $(KFP_V2_RUNTIME_INFO),
+        --container_image, $(KFP_V2_IMAGE), --task_name, preprocess, --pipeline_name,
+        '{{inputs.parameters.pipeline-name}}', --pipeline_run_id, $(WORKFLOW_ID),
+        --pipeline_task_id, $(KFP_POD_NAME), --pipeline_root, '{{inputs.parameters.pipeline-output-directory}}',
+        --, some_int=12, uri=uri-to-import, --]
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef: {fieldPath: metadata.name}
+      - name: KFP_NAMESPACE
+        valueFrom:
+          fieldRef: {fieldPath: metadata.namespace}
+      - name: WORKFLOW_ID
+        valueFrom:
+          fieldRef: {fieldPath: 'metadata.labels[''workflows.argoproj.io/workflow'']'}
+      - name: ENABLE_CACHING
+        valueFrom:
+          fieldRef: {fieldPath: 'metadata.labels[''pipelines.kubeflow.org/enable_caching'']'}
+      - {name: KFP_V2_IMAGE, value: 'python:3.9'}
+      - {name: KFP_V2_RUNTIME_INFO, value: '{"inputParameters": {"some_int": {"type":
+          "INT"}, "uri": {"type": "STRING"}}, "inputArtifacts": {}, "outputParameters":
+          {"output_parameter_one": {"type": "INT", "path": "/tmp/outputs/output_parameter_one/data"}},
+          "outputArtifacts": {"output_dataset_one": {"schemaTitle": "system.Dataset",
+          "instanceSchema": "", "metadataPath": "/tmp/outputs/output_dataset_one/data"}}}'}
+      envFrom:
+      - configMapRef: {name: metadata-grpc-configmap, optional: true}
+      image: python:3.9
+      volumeMounts:
+      - {mountPath: /kfp-launcher, name: kfp-launcher}
+    inputs:
+      parameters:
+      - {name: pipeline-name}
+      - {name: pipeline-output-directory}
+    outputs:
+      parameters:
+      - name: preprocess-output_parameter_one
+        valueFrom: {path: /tmp/outputs/output_parameter_one/data}
+      artifacts:
+      - {name: preprocess-output_dataset_one, path: /tmp/outputs/output_dataset_one/data}
+      - {name: preprocess-output_parameter_one, path: /tmp/outputs/output_parameter_one/data}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/v2_component: "true"
+        pipelines.kubeflow.org/component_ref: '{}'
+        pipelines.kubeflow.org/arguments.parameters: '{"some_int": "12", "uri": "uri-to-import"}'
+      labels:
+        pipelines.kubeflow.org/kfp_sdk_version: 1.6.4
+        pipelines.kubeflow.org/pipeline-sdk-type: kfp
+        pipelines.kubeflow.org/v2_component: "true"
+        pipelines.kubeflow.org/enable_caching: "true"
+    initContainers:
+    - command: [/bin/mount_launcher.sh]
+      image: gcr.io/ml-pipeline/kfp-launcher:1.6.4
+      name: kfp-launcher
+      mirrorVolumeMounts: true
+    volumes:
+    - {name: kfp-launcher}
+  - name: train-op
+    container:
+      args:
+      - sh
+      - -ec
+      - |
+        program_path=$(mktemp)
+        printf "%s" "$0" > "$program_path"
+        python3 -u "$program_path" "$@"
+      - |
+        def _make_parent_dirs_and_return_path(file_path: str):
+            import os
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+            return file_path
+
+        def train_op(
+            dataset,
+            model,
+            num_steps = 100
+        ):
+            '''Dummy Training Step.'''
+
+            with open(dataset, 'r') as input_file:
+                input_string = input_file.read()
+                with open(model, 'w') as output_file:
+                    for i in range(num_steps):
+                        output_file.write(
+                            "Step {}\n{}\n=====\n".format(i, input_string)
+                        )
+
+        import argparse
+        _parser = argparse.ArgumentParser(prog='Train op', description='Dummy Training Step.')
+        _parser.add_argument("--dataset", dest="dataset", type=str, required=True, default=argparse.SUPPRESS)
+        _parser.add_argument("--num-steps", dest="num_steps", type=int, required=False, default=argparse.SUPPRESS)
+        _parser.add_argument("--model", dest="model", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
+        _parsed_args = vars(_parser.parse_args())
+
+        _outputs = train_op(**_parsed_args)
+      - --dataset
+      - '{{$.inputs.artifacts[''dataset''].path}}'
+      - --num-steps
+      - '{{$.inputs.parameters[''num_steps'']}}'
+      - --model
+      - '{{$.outputs.artifacts[''model''].path}}'
+      command: [/kfp-launcher/launch, --mlmd_server_address, $(METADATA_GRPC_SERVICE_HOST),
+        --mlmd_server_port, $(METADATA_GRPC_SERVICE_PORT), --runtime_info_json, $(KFP_V2_RUNTIME_INFO),
+        --container_image, $(KFP_V2_IMAGE), --task_name, train-op, --pipeline_name,
+        '{{inputs.parameters.pipeline-name}}', --pipeline_run_id, $(WORKFLOW_ID),
+        --pipeline_task_id, $(KFP_POD_NAME), --pipeline_root, '{{inputs.parameters.pipeline-output-directory}}',
+        --, 'num_steps={{inputs.parameters.preprocess-output_parameter_one}}', --]
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef: {fieldPath: metadata.name}
+      - name: KFP_NAMESPACE
+        valueFrom:
+          fieldRef: {fieldPath: metadata.namespace}
+      - name: WORKFLOW_ID
+        valueFrom:
+          fieldRef: {fieldPath: 'metadata.labels[''workflows.argoproj.io/workflow'']'}
+      - name: ENABLE_CACHING
+        valueFrom:
+          fieldRef: {fieldPath: 'metadata.labels[''pipelines.kubeflow.org/enable_caching'']'}
+      - {name: KFP_V2_IMAGE, value: 'python:3.7'}
+      - {name: KFP_V2_RUNTIME_INFO, value: '{"inputParameters": {"num_steps": {"type":
+          "INT"}}, "inputArtifacts": {"dataset": {"metadataPath": "/tmp/inputs/dataset/data",
+          "schemaTitle": "system.Dataset", "instanceSchema": ""}}, "outputParameters":
+          {}, "outputArtifacts": {"model": {"schemaTitle": "system.Model", "instanceSchema":
+          "", "metadataPath": "/tmp/outputs/model/data"}}}'}
+      envFrom:
+      - configMapRef: {name: metadata-grpc-configmap, optional: true}
+      image: python:3.7
+      volumeMounts:
+      - {mountPath: /kfp-launcher, name: kfp-launcher}
+    inputs:
+      parameters:
+      - {name: pipeline-name}
+      - {name: pipeline-output-directory}
+      - {name: preprocess-output_parameter_one}
+      artifacts:
+      - {name: preprocess-output_dataset_one, path: /tmp/inputs/dataset/data}
+    outputs:
+      artifacts:
+      - {name: train-op-model, path: /tmp/outputs/model/data}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/v2_component: "true"
+        pipelines.kubeflow.org/component_ref: '{}'
+        pipelines.kubeflow.org/arguments.parameters: '{"num_steps": "{{inputs.parameters.preprocess-output_parameter_one}}"}'
+      labels:
+        pipelines.kubeflow.org/kfp_sdk_version: 1.6.4
+        pipelines.kubeflow.org/pipeline-sdk-type: kfp
+        pipelines.kubeflow.org/v2_component: "true"
+        pipelines.kubeflow.org/enable_caching: "true"
+    initContainers:
+    - command: [/bin/mount_launcher.sh]
+      image: gcr.io/ml-pipeline/kfp-launcher:1.6.4
+      name: kfp-launcher
+      mirrorVolumeMounts: true
+    volumes:
+    - {name: kfp-launcher}
+  - name: two-step-pipeline
+    inputs:
+      parameters:
+      - {name: pipeline-name}
+      - {name: pipeline-output-directory}
+    dag:
+      tasks:
+      - name: preprocess
+        template: preprocess
+        arguments:
+          parameters:
+          - {name: pipeline-name, value: '{{inputs.parameters.pipeline-name}}'}
+          - {name: pipeline-output-directory, value: '{{inputs.parameters.pipeline-output-directory}}'}
+      - name: train-op
+        template: train-op
+        dependencies: [preprocess]
+        arguments:
+          parameters:
+          - {name: pipeline-name, value: '{{inputs.parameters.pipeline-name}}'}
+          - {name: pipeline-output-directory, value: '{{inputs.parameters.pipeline-output-directory}}'}
+          - {name: preprocess-output_parameter_one, value: '{{tasks.preprocess.outputs.parameters.preprocess-output_parameter_one}}'}
+          artifacts:
+          - {name: preprocess-output_dataset_one, from: '{{tasks.preprocess.outputs.artifacts.preprocess-output_dataset_one}}'}
+  arguments:
+    parameters:
+    - {name: pipeline-output-directory, value: ''}
+    - {name: pipeline-name, value: pipeline/two_step_pipeline}
+  serviceAccountName: pipeline-runner
+`
+
 	complexPipeline = `
 # Copyright 2018 The Kubeflow Authors
 #

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -292,10 +292,10 @@ func TestCreatePipeline_V2PipelineName(t *testing.T) {
 		namespace    string
 		pipelineName string
 	}{
-		{"v2-compat", "", "pipeline/v2-compat"},
-		{"pipe3", "", "pipeline/pipe3"},
-		{"pipeline2", "kubeflow", "namespace/kubeflow/pipeline/pipeline2"},
-		{"abcd", "user", "namespace/user/pipeline/abcd"},
+		{name: "v2-compat", namespace: "", pipelineName: "pipeline/v2-compat"},
+		{name: "pipe3", namespace: "", pipelineName: "pipeline/pipe3"},
+		{name: "pipeline2", namespace: "kubeflow", pipelineName: "namespace/kubeflow/pipeline/pipeline2"},
+		{name: "abcd", namespace: "user", pipelineName: "namespace/user/pipeline/abcd"},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
@@ -2831,10 +2831,10 @@ func TestCreatePipelineVersion_V2PipelineName(t *testing.T) {
 		namespace    string
 		pipelineName string
 	}{
-		{"v2-compat", "", "pipeline/v2-compat"},
-		{"pipe3", "", "pipeline/pipe3"},
-		{"pipeline2", "kubeflow", "namespace/kubeflow/pipeline/pipeline2"},
-		{"abcd", "user", "namespace/user/pipeline/abcd"},
+		{name: "v2-compat", namespace: "", pipelineName: "pipeline/v2-compat"},
+		{name: "pipe3", namespace: "", pipelineName: "pipeline/pipe3"},
+		{name: "pipeline2", namespace: "kubeflow", pipelineName: "namespace/kubeflow/pipeline/pipeline2"},
+		{name: "abcd", namespace: "user", pipelineName: "namespace/user/pipeline/abcd"},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {

--- a/backend/src/apiserver/resource/resource_manager_util.go
+++ b/backend/src/apiserver/resource/resource_manager_util.go
@@ -266,3 +266,16 @@ func convertPipelineIdToDefaultPipelineVersion(pipelineSpec *api.PipelineSpec, r
 	})
 	return nil
 }
+
+// Override pipeline name parameter if this is a v2 compatible pipeline.
+func overrideV2PipelineName(wf *util.Workflow, name string, namespace string) {
+	var pipelineRef string
+	if namespace != "" {
+		pipelineRef = fmt.Sprintf("namespace/%s/pipeline/%s", namespace, name)
+	} else {
+		pipelineRef = fmt.Sprintf("pipeline/%s", name)
+	}
+	overrides := make(map[string]string)
+	overrides["pipeline-name"] = pipelineRef
+	wf.OverrideParameters(overrides)
+}

--- a/backend/src/apiserver/server/api_converter.go
+++ b/backend/src/apiserver/server/api_converter.go
@@ -15,9 +15,6 @@
 package server
 
 import (
-	"encoding/json"
-
-	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	api "github.com/kubeflow/pipelines/backend/api/go_client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
@@ -131,12 +128,11 @@ func toApiParameters(paramsString string) ([]*api.Parameter, error) {
 	if paramsString == "" {
 		return nil, nil
 	}
-	apiParams := make([]*api.Parameter, 0)
-	var params []v1alpha1.Parameter
-	err := json.Unmarshal([]byte(paramsString), &params)
+	params, err := util.UnmarshalParameters(paramsString)
 	if err != nil {
 		return nil, util.NewInternalServerError(err, "Parameter with wrong format is stored")
 	}
+	apiParams := make([]*api.Parameter, 0)
 	for _, param := range params {
 		var value string
 		if param.Value != nil {
@@ -207,14 +203,14 @@ func ToApiRunDetail(run *model.RunDetail) *api.RunDetail {
 
 func ToApiTask(task *model.Task) *api.Task {
 	return &api.Task{
-		Id:                   task.UUID,
-		Namespace:            task.Namespace,
-		PipelineName:         task.PipelineName,
-		RunId:                task.RunUUID,
-		MlmdExecutionID:      task.MLMDExecutionID,
-		CreatedAt:            &timestamp.Timestamp{Seconds: task.CreatedTimestamp},
-		FinishedAt:           &timestamp.Timestamp{Seconds: task.FinishedTimestamp},
-		Fingerprint:          task.Fingerprint,
+		Id:              task.UUID,
+		Namespace:       task.Namespace,
+		PipelineName:    task.PipelineName,
+		RunId:           task.RunUUID,
+		MlmdExecutionID: task.MLMDExecutionID,
+		CreatedAt:       &timestamp.Timestamp{Seconds: task.CreatedTimestamp},
+		FinishedAt:      &timestamp.Timestamp{Seconds: task.FinishedTimestamp},
+		Fingerprint:     task.Fingerprint,
 	}
 }
 

--- a/backend/src/apiserver/server/api_converter_test.go
+++ b/backend/src/apiserver/server/api_converter_test.go
@@ -15,8 +15,9 @@
 package server
 
 import (
-	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
 	"testing"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
 	api "github.com/kubeflow/pipelines/backend/api/go_client"
@@ -71,11 +72,8 @@ func TestToApiPipeline_ErrorParsingField(t *testing.T) {
 		DefaultVersion: &model.PipelineVersion{},
 	}
 	apiPipeline := ToApiPipeline(modelPipeline)
-	expectedApiPipeline := &api.Pipeline{
-		Id:    "pipeline1",
-		Error: "InternalServerError: Parameter with wrong format is stored: invalid character 'i' looking for beginning of value",
-	}
-	assert.Equal(t, expectedApiPipeline, apiPipeline)
+	assert.Equal(t, "pipeline1", apiPipeline.Id)
+	assert.Contains(t, apiPipeline.Error, "Parameter with wrong format is stored")
 }
 
 func TestToApiRunDetail(t *testing.T) {
@@ -444,11 +442,8 @@ func TestToApiJob_ErrorParsingField(t *testing.T) {
 	}
 
 	apiJob := ToApiJob(modelJob)
-	expectedApiJob := &api.Job{
-		Id:    "job1",
-		Error: "InternalServerError: Parameter with wrong format is stored: invalid character 'i' looking for beginning of value",
-	}
-	assert.Equal(t, expectedApiJob, apiJob)
+	assert.Equal(t, "job1", apiJob.Id)
+	assert.Contains(t, apiJob.Error, "InternalServerError: Parameter with wrong format is stored")
 }
 
 func TestToApiJobs(t *testing.T) {

--- a/backend/src/common/util/template_util.go
+++ b/backend/src/common/util/template_util.go
@@ -43,6 +43,9 @@ func UnmarshalParameters(paramsString string) ([]v1alpha1.Parameter, error) {
 // Marshal parameters to JSON encoded string.
 // This also checks result is not longer than a limit.
 func MarshalParameters(params []v1alpha1.Parameter) (string, error) {
+	if params == nil {
+		return "[]", nil
+	}
 	paramBytes, err := json.Marshal(params)
 	if err != nil {
 		return "", NewInvalidInputErrorWithDetails(err, "Failed to marshal the parameter.")

--- a/backend/src/common/util/template_util_test.go
+++ b/backend/src/common/util/template_util_test.go
@@ -23,26 +23,17 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-func TestGetParameters(t *testing.T) {
-	wf := unmarshalWf(template)
-	wf.Spec.Arguments.Parameters = []v1alpha1.Parameter{{Name: "dup", Value: v1alpha1.AnyStringPtr("value1")}}
-	templateBytes, _ := yaml.Marshal(wf)
-	paramString, err := GetParameters([]byte(templateBytes))
-	assert.Nil(t, err)
-	assert.Equal(t, `[{"name":"dup","value":"value1"}]`, paramString)
-}
-
 func TestFailValidation(t *testing.T) {
 	wf := unmarshalWf(emptyName)
 	wf.Spec.Arguments.Parameters = []v1alpha1.Parameter{{Name: "dup", Value: v1alpha1.AnyStringPtr("value1")}}
 	templateBytes, _ := yaml.Marshal(wf)
-	_, err := GetParameters([]byte(templateBytes))
+	_, err := ValidateWorkflow([]byte(templateBytes))
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "name is required")
 	}
 }
 
-func TestGetParameters_ParametersTooLong(t *testing.T) {
+func TestValidateWorkflow_ParametersTooLong(t *testing.T) {
 	var params []v1alpha1.Parameter
 	// Create a long enough parameter string so it exceed the length limit of parameter.
 	for i := 0; i < 10000; i++ {
@@ -51,7 +42,7 @@ func TestGetParameters_ParametersTooLong(t *testing.T) {
 	template := v1alpha1.Workflow{Spec: v1alpha1.WorkflowSpec{Arguments: v1alpha1.Arguments{
 		Parameters: params}}}
 	templateBytes, _ := yaml.Marshal(template)
-	_, err := GetParameters(templateBytes)
+	_, err := ValidateWorkflow(templateBytes)
 	assert.Equal(t, codes.InvalidArgument, err.(*UserError).ExternalStatusCode())
 }
 

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -324,3 +324,9 @@ func (w *Workflow) PersistedFinalState() bool {
 	}
 	return false
 }
+
+// IsV2 whether the workflow is a v2 compatible pipeline.
+func (w *Workflow) IsV2() bool {
+	value := w.GetObjectMeta().GetAnnotations()["pipelines.kubeflow.org/v2_pipeline"]
+	return value == "true"
+}

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -1037,8 +1037,13 @@ class Compiler(object):
 
     if self._mode == dsl.PipelineExecutionMode.V2_COMPATIBLE:
       pipeline_name = getattr(pipeline_func, '_component_human_name', '')
+      # pipeline names have one of the following formats:
+      # * pipeline/<name>
+      # * namespace/<ns>/pipeline/<name>
+      # when compiling, we will only have pipeline/<name>, but it will be overriden
+      # when uploading the pipeline to KFP API server.
       self._pipeline_name_param = dsl.PipelineParam(name='pipeline-name',
-                                                    value=pipeline_name)
+                                                    value=f'pipeline/{pipeline_name}')
 
     import kfp
     type_check_old_value = kfp.TYPE_CHECK

--- a/sdk/python/kfp/compiler/testdata/v2_compatible_two_step_pipeline.yaml
+++ b/sdk/python/kfp/compiler/testdata/v2_compatible_two_step_pipeline.yaml
@@ -4,10 +4,10 @@ metadata:
   generateName: my-test-pipeline-
   annotations:
     pipelines.kubeflow.org/kfp_sdk_version: 1.6.4
-    pipelines.kubeflow.org/pipeline_compilation_time: '2021-07-13T00:27:44.352978'
+    pipelines.kubeflow.org/pipeline_compilation_time: '2021-07-14T10:07:48.903495'
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "gs://output-directory/v2-artifacts",
-      "name": "pipeline-output-directory"}, {"default": "my-test-pipeline", "name":
-      "pipeline-name"}], "name": "my-test-pipeline"}'
+      "name": "pipeline-output-directory"}, {"default": "pipeline/my-test-pipeline",
+      "name": "pipeline-name"}], "name": "my-test-pipeline"}'
     pipelines.kubeflow.org/v2_pipeline: "true"
   labels:
     pipelines.kubeflow.org/v2_pipeline: "true"
@@ -53,13 +53,15 @@ spec:
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             return file_path
 
-        def preprocess(uri, some_int, output_parameter_one,
-                       output_dataset_one):
-          '''Dummy Preprocess Step.'''
-          with open(output_dataset_one, 'w') as f:
-            f.write('Output dataset')
-          with open(output_parameter_one, 'w') as f:
-            f.write("{}".format(1234))
+        def preprocess(
+            uri, some_int, output_parameter_one,
+            output_dataset_one
+        ):
+            '''Dummy Preprocess Step.'''
+            with open(output_dataset_one, 'w') as f:
+                f.write('Output dataset')
+            with open(output_parameter_one, 'w') as f:
+                f.write("{}".format(1234))
 
         import argparse
         _parser = argparse.ArgumentParser(prog='Preprocess', description='Dummy Preprocess Step.')
@@ -151,16 +153,20 @@ spec:
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             return file_path
 
-        def train(dataset,
-                  model,
-                  num_steps = 100):
-          '''Dummy Training Step.'''
+        def train(
+            dataset,
+            model,
+            num_steps = 100
+        ):
+            '''Dummy Training Step.'''
 
-          with open(dataset, 'r') as input_file:
-            input_string = input_file.read()
-            with open(model, 'w') as output_file:
-              for i in range(num_steps):
-                output_file.write("Step {}\n{}\n=====\n".format(i, input_string))
+            with open(dataset, 'r') as input_file:
+                input_string = input_file.read()
+                with open(model, 'w') as output_file:
+                    for i in range(num_steps):
+                        output_file.write(
+                            "Step {}\n{}\n=====\n".format(i, input_string)
+                        )
 
         import argparse
         _parser = argparse.ArgumentParser(prog='Train', description='Dummy Training Step.')
@@ -236,5 +242,5 @@ spec:
   arguments:
     parameters:
     - {name: pipeline-output-directory, value: 'gs://output-directory/v2-artifacts'}
-    - {name: pipeline-name, value: my-test-pipeline}
+    - {name: pipeline-name, value: pipeline/my-test-pipeline}
   serviceAccountName: pipeline-runner

--- a/sdk/python/kfp/compiler/testdata/v2_compatible_two_step_pipeline.yaml
+++ b/sdk/python/kfp/compiler/testdata/v2_compatible_two_step_pipeline.yaml
@@ -4,7 +4,7 @@ metadata:
   generateName: my-test-pipeline-
   annotations:
     pipelines.kubeflow.org/kfp_sdk_version: 1.6.4
-    pipelines.kubeflow.org/pipeline_compilation_time: '2021-07-14T10:07:48.903495'
+    pipelines.kubeflow.org/pipeline_compilation_time: '2021-07-14T10:49:23.340805'
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "gs://output-directory/v2-artifacts",
       "name": "pipeline-output-directory"}, {"default": "pipeline/my-test-pipeline",
       "name": "pipeline-name"}], "name": "my-test-pipeline"}'
@@ -53,15 +53,13 @@ spec:
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             return file_path
 
-        def preprocess(
-            uri, some_int, output_parameter_one,
-            output_dataset_one
-        ):
-            '''Dummy Preprocess Step.'''
-            with open(output_dataset_one, 'w') as f:
-                f.write('Output dataset')
-            with open(output_parameter_one, 'w') as f:
-                f.write("{}".format(1234))
+        def preprocess(uri, some_int, output_parameter_one,
+                       output_dataset_one):
+          '''Dummy Preprocess Step.'''
+          with open(output_dataset_one, 'w') as f:
+            f.write('Output dataset')
+          with open(output_parameter_one, 'w') as f:
+            f.write("{}".format(1234))
 
         import argparse
         _parser = argparse.ArgumentParser(prog='Preprocess', description='Dummy Preprocess Step.')
@@ -153,20 +151,16 @@ spec:
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             return file_path
 
-        def train(
-            dataset,
-            model,
-            num_steps = 100
-        ):
-            '''Dummy Training Step.'''
+        def train(dataset,
+                  model,
+                  num_steps = 100):
+          '''Dummy Training Step.'''
 
-            with open(dataset, 'r') as input_file:
-                input_string = input_file.read()
-                with open(model, 'w') as output_file:
-                    for i in range(num_steps):
-                        output_file.write(
-                            "Step {}\n{}\n=====\n".format(i, input_string)
-                        )
+          with open(dataset, 'r') as input_file:
+            input_string = input_file.read()
+            with open(model, 'w') as output_file:
+              for i in range(num_steps):
+                output_file.write("Step {}\n{}\n=====\n".format(i, input_string))
 
         import argparse
         _parser = argparse.ArgumentParser(prog='Train', description='Dummy Training Step.')

--- a/sdk/python/kfp/compiler/testdata/v2_compatible_two_step_pipeline_with_custom_launcher.yaml
+++ b/sdk/python/kfp/compiler/testdata/v2_compatible_two_step_pipeline_with_custom_launcher.yaml
@@ -4,7 +4,7 @@ metadata:
   generateName: my-test-pipeline-with-custom-launcher-
   annotations:
     pipelines.kubeflow.org/kfp_sdk_version: 1.6.4
-    pipelines.kubeflow.org/pipeline_compilation_time: '2021-07-14T10:07:48.596530'
+    pipelines.kubeflow.org/pipeline_compilation_time: '2021-07-14T10:49:23.033713'
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "gs://output-directory/v2-artifacts",
       "name": "pipeline-output-directory"}, {"default": "pipeline/my-test-pipeline-with-custom-launcher",
       "name": "pipeline-name"}], "name": "my-test-pipeline-with-custom-launcher"}'
@@ -53,15 +53,13 @@ spec:
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             return file_path
 
-        def preprocess(
-            uri, some_int, output_parameter_one,
-            output_dataset_one
-        ):
-            '''Dummy Preprocess Step.'''
-            with open(output_dataset_one, 'w') as f:
-                f.write('Output dataset')
-            with open(output_parameter_one, 'w') as f:
-                f.write("{}".format(1234))
+        def preprocess(uri, some_int, output_parameter_one,
+                       output_dataset_one):
+          '''Dummy Preprocess Step.'''
+          with open(output_dataset_one, 'w') as f:
+            f.write('Output dataset')
+          with open(output_parameter_one, 'w') as f:
+            f.write("{}".format(1234))
 
         import argparse
         _parser = argparse.ArgumentParser(prog='Preprocess', description='Dummy Preprocess Step.')
@@ -153,20 +151,16 @@ spec:
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             return file_path
 
-        def train(
-            dataset,
-            model,
-            num_steps = 100
-        ):
-            '''Dummy Training Step.'''
+        def train(dataset,
+                  model,
+                  num_steps = 100):
+          '''Dummy Training Step.'''
 
-            with open(dataset, 'r') as input_file:
-                input_string = input_file.read()
-                with open(model, 'w') as output_file:
-                    for i in range(num_steps):
-                        output_file.write(
-                            "Step {}\n{}\n=====\n".format(i, input_string)
-                        )
+          with open(dataset, 'r') as input_file:
+            input_string = input_file.read()
+            with open(model, 'w') as output_file:
+              for i in range(num_steps):
+                output_file.write("Step {}\n{}\n=====\n".format(i, input_string))
 
         import argparse
         _parser = argparse.ArgumentParser(prog='Train', description='Dummy Training Step.')

--- a/sdk/python/kfp/compiler/testdata/v2_compatible_two_step_pipeline_with_custom_launcher.yaml
+++ b/sdk/python/kfp/compiler/testdata/v2_compatible_two_step_pipeline_with_custom_launcher.yaml
@@ -4,9 +4,9 @@ metadata:
   generateName: my-test-pipeline-with-custom-launcher-
   annotations:
     pipelines.kubeflow.org/kfp_sdk_version: 1.6.4
-    pipelines.kubeflow.org/pipeline_compilation_time: '2021-07-13T00:27:44.204633'
+    pipelines.kubeflow.org/pipeline_compilation_time: '2021-07-14T10:07:48.596530'
     pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "gs://output-directory/v2-artifacts",
-      "name": "pipeline-output-directory"}, {"default": "my-test-pipeline-with-custom-launcher",
+      "name": "pipeline-output-directory"}, {"default": "pipeline/my-test-pipeline-with-custom-launcher",
       "name": "pipeline-name"}], "name": "my-test-pipeline-with-custom-launcher"}'
     pipelines.kubeflow.org/v2_pipeline: "true"
   labels:
@@ -53,13 +53,15 @@ spec:
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             return file_path
 
-        def preprocess(uri, some_int, output_parameter_one,
-                       output_dataset_one):
-          '''Dummy Preprocess Step.'''
-          with open(output_dataset_one, 'w') as f:
-            f.write('Output dataset')
-          with open(output_parameter_one, 'w') as f:
-            f.write("{}".format(1234))
+        def preprocess(
+            uri, some_int, output_parameter_one,
+            output_dataset_one
+        ):
+            '''Dummy Preprocess Step.'''
+            with open(output_dataset_one, 'w') as f:
+                f.write('Output dataset')
+            with open(output_parameter_one, 'w') as f:
+                f.write("{}".format(1234))
 
         import argparse
         _parser = argparse.ArgumentParser(prog='Preprocess', description='Dummy Preprocess Step.')
@@ -151,16 +153,20 @@ spec:
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             return file_path
 
-        def train(dataset,
-                  model,
-                  num_steps = 100):
-          '''Dummy Training Step.'''
+        def train(
+            dataset,
+            model,
+            num_steps = 100
+        ):
+            '''Dummy Training Step.'''
 
-          with open(dataset, 'r') as input_file:
-            input_string = input_file.read()
-            with open(model, 'w') as output_file:
-              for i in range(num_steps):
-                output_file.write("Step {}\n{}\n=====\n".format(i, input_string))
+            with open(dataset, 'r') as input_file:
+                input_string = input_file.read()
+                with open(model, 'w') as output_file:
+                    for i in range(num_steps):
+                        output_file.write(
+                            "Step {}\n{}\n=====\n".format(i, input_string)
+                        )
 
         import argparse
         _parser = argparse.ArgumentParser(prog='Train', description='Dummy Training Step.')
@@ -236,5 +242,5 @@ spec:
   arguments:
     parameters:
     - {name: pipeline-output-directory, value: 'gs://output-directory/v2-artifacts'}
-    - {name: pipeline-name, value: my-test-pipeline-with-custom-launcher}
+    - {name: pipeline-name, value: pipeline/my-test-pipeline-with-custom-launcher}
   serviceAccountName: pipeline-runner

--- a/v2/component/launcher.go
+++ b/v2/component/launcher.go
@@ -469,7 +469,7 @@ func (l *Launcher) executeWithoutCacheHit(ctx context.Context, executorInput *pi
 	}
 	pipelineRunUUID := pod.GetObjectMeta().GetLabels()["pipeline/runid"]
 	task := &api.Task{
-		PipelineName:    fmt.Sprintf("pipeline/%s", l.options.PipelineName),
+		PipelineName:    l.options.PipelineName,
 		RunId:           pipelineRunUUID,
 		MlmdExecutionID: strconv.FormatInt(*id, 10),
 		CreatedAt:       &timestamp.Timestamp{Seconds: executedStartedTime},


### PR DESCRIPTION
**Description of your changes:**
Fixes #5978 

The change unifies pipeline name and pipeline MLMD context name for v2 compatible mode.

Behavior:
* when v2 compatible pipelines are compiled, their pipeline names will be `pipeline/<name>` (name is taken from `@pipeline(name='xxxx')` annotation)
* when compiled pipelines are uploaded to KFP API server, their pipeline names will be renamed to the KFP pipeline resource name. Depending on whether the pipeline is shared or namespaced, pipeline name will be `namespace/<ns>/pipeline/<name>` or `pipeline/<name>`.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
