### PR TITLE
chore(components): Added canonical location for some components

### DIFF
--- a/components/CatBoost/Predict_class_probabilities/from_CSV/component.py
+++ b/components/CatBoost/Predict_class_probabilities/from_CSV/component.py
@@ -57,5 +57,6 @@ if __name__ == '__main__':
         packages_to_install=['catboost==0.23'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Predict_class_probabilities/from_CSV/component.py",
         },
     )

--- a/components/CatBoost/Predict_class_probabilities/from_CSV/component.py
+++ b/components/CatBoost/Predict_class_probabilities/from_CSV/component.py
@@ -57,6 +57,6 @@ if __name__ == '__main__':
         packages_to_install=['catboost==0.23'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Predict_class_probabilities/from_CSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Predict_class_probabilities/from_CSV/component.yaml",
         },
     )

--- a/components/CatBoost/Predict_class_probabilities/from_CSV/component.yaml
+++ b/components/CatBoost/Predict_class_probabilities/from_CSV/component.yaml
@@ -22,6 +22,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Predict_class_probabilities/from_CSV/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/CatBoost/Predict_classes/from_CSV/component.py
+++ b/components/CatBoost/Predict_classes/from_CSV/component.py
@@ -57,5 +57,6 @@ if __name__ == '__main__':
         packages_to_install=['catboost==0.22'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Predict_classes/from_CSV/component.py",
         },
     )

--- a/components/CatBoost/Predict_classes/from_CSV/component.py
+++ b/components/CatBoost/Predict_classes/from_CSV/component.py
@@ -57,6 +57,6 @@ if __name__ == '__main__':
         packages_to_install=['catboost==0.22'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Predict_classes/from_CSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Predict_classes/from_CSV/component.yaml",
         },
     )

--- a/components/CatBoost/Predict_classes/from_CSV/component.yaml
+++ b/components/CatBoost/Predict_classes/from_CSV/component.yaml
@@ -22,6 +22,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Predict_classes/from_CSV/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/CatBoost/Predict_values/from_CSV/component.py
+++ b/components/CatBoost/Predict_values/from_CSV/component.py
@@ -57,5 +57,6 @@ if __name__ == '__main__':
         packages_to_install=['catboost==0.23'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Predict_values/from_CSV/component.py",
         },
     )

--- a/components/CatBoost/Predict_values/from_CSV/component.py
+++ b/components/CatBoost/Predict_values/from_CSV/component.py
@@ -57,6 +57,6 @@ if __name__ == '__main__':
         packages_to_install=['catboost==0.23'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Predict_values/from_CSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Predict_values/from_CSV/component.yaml",
         },
     )

--- a/components/CatBoost/Predict_values/from_CSV/component.yaml
+++ b/components/CatBoost/Predict_values/from_CSV/component.yaml
@@ -22,6 +22,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Predict_values/from_CSV/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/CatBoost/Train_classifier/from_CSV/component.py
+++ b/components/CatBoost/Train_classifier/from_CSV/component.py
@@ -92,6 +92,6 @@ if __name__ == '__main__':
         packages_to_install=['catboost==0.23'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Train_classifier/from_CSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Train_classifier/from_CSV/component.yaml",
         },
     )

--- a/components/CatBoost/Train_classifier/from_CSV/component.py
+++ b/components/CatBoost/Train_classifier/from_CSV/component.py
@@ -92,5 +92,6 @@ if __name__ == '__main__':
         packages_to_install=['catboost==0.23'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Train_classifier/from_CSV/component.py",
         },
     )

--- a/components/CatBoost/Train_classifier/from_CSV/component.yaml
+++ b/components/CatBoost/Train_classifier/from_CSV/component.yaml
@@ -43,6 +43,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Train_classifier/from_CSV/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/CatBoost/Train_regression/from_CSV/component.py
+++ b/components/CatBoost/Train_regression/from_CSV/component.py
@@ -90,6 +90,6 @@ if __name__ == '__main__':
         packages_to_install=['catboost==0.23'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Train_regression/from_CSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Train_regression/from_CSV/component.yaml",
         },
     )

--- a/components/CatBoost/Train_regression/from_CSV/component.py
+++ b/components/CatBoost/Train_regression/from_CSV/component.py
@@ -90,5 +90,6 @@ if __name__ == '__main__':
         packages_to_install=['catboost==0.23'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Train_regression/from_CSV/component.py",
         },
     )

--- a/components/CatBoost/Train_regression/from_CSV/component.yaml
+++ b/components/CatBoost/Train_regression/from_CSV/component.yaml
@@ -42,6 +42,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/Train_regression/from_CSV/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/CatBoost/convert_CatBoostModel_to_AppleCoreMLModel/component.py
+++ b/components/CatBoost/convert_CatBoostModel_to_AppleCoreMLModel/component.py
@@ -36,5 +36,6 @@ if __name__ == '__main__':
         packages_to_install=['catboost==0.22'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/convert_CatBoostModel_to_AppleCoreMLModel/component.py",
         },
     )

--- a/components/CatBoost/convert_CatBoostModel_to_AppleCoreMLModel/component.py
+++ b/components/CatBoost/convert_CatBoostModel_to_AppleCoreMLModel/component.py
@@ -36,6 +36,6 @@ if __name__ == '__main__':
         packages_to_install=['catboost==0.22'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/convert_CatBoostModel_to_AppleCoreMLModel/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/convert_CatBoostModel_to_AppleCoreMLModel/component.yaml",
         },
     )

--- a/components/CatBoost/convert_CatBoostModel_to_AppleCoreMLModel/component.yaml
+++ b/components/CatBoost/convert_CatBoostModel_to_AppleCoreMLModel/component.yaml
@@ -18,6 +18,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/convert_CatBoostModel_to_AppleCoreMLModel/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/CatBoost/convert_CatBoostModel_to_ONNX/component.py
+++ b/components/CatBoost/convert_CatBoostModel_to_ONNX/component.py
@@ -31,5 +31,6 @@ if __name__ == '__main__':
         packages_to_install=['catboost==0.22'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/convert_CatBoostModel_to_ONNX/component.py",
         },
     )

--- a/components/CatBoost/convert_CatBoostModel_to_ONNX/component.py
+++ b/components/CatBoost/convert_CatBoostModel_to_ONNX/component.py
@@ -31,6 +31,6 @@ if __name__ == '__main__':
         packages_to_install=['catboost==0.22'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/convert_CatBoostModel_to_ONNX/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/convert_CatBoostModel_to_ONNX/component.yaml",
         },
     )

--- a/components/CatBoost/convert_CatBoostModel_to_ONNX/component.yaml
+++ b/components/CatBoost/convert_CatBoostModel_to_ONNX/component.yaml
@@ -18,6 +18,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/CatBoost/convert_CatBoostModel_to_ONNX/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/PyTorch/Convert_to_OnnxModel_from_PyTorchScriptModule/component.py
+++ b/components/PyTorch/Convert_to_OnnxModel_from_PyTorchScriptModule/component.py
@@ -32,5 +32,6 @@ if __name__ == '__main__':
         packages_to_install=[],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/PyTorch/Convert_to_OnnxModel_from_PyTorchScriptModule/component.py",
         },
     )

--- a/components/PyTorch/Convert_to_OnnxModel_from_PyTorchScriptModule/component.py
+++ b/components/PyTorch/Convert_to_OnnxModel_from_PyTorchScriptModule/component.py
@@ -32,6 +32,6 @@ if __name__ == '__main__':
         packages_to_install=[],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/PyTorch/Convert_to_OnnxModel_from_PyTorchScriptModule/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/PyTorch/Convert_to_OnnxModel_from_PyTorchScriptModule/component.yaml",
         },
     )

--- a/components/PyTorch/Convert_to_OnnxModel_from_PyTorchScriptModule/component.yaml
+++ b/components/PyTorch/Convert_to_OnnxModel_from_PyTorchScriptModule/component.yaml
@@ -3,6 +3,7 @@ description: Creates fully-connected network in PyTorch ScriptModule format
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/PyTorch/Convert_to_OnnxModel_from_PyTorchScriptModule/component.yaml'
 inputs:
 - {name: model, type: PyTorchScriptModule}
 - {name: list_of_input_shapes, type: JsonArray}

--- a/components/PyTorch/Create_PyTorch_Model_Archive/component.yaml
+++ b/components/PyTorch/Create_PyTorch_Model_Archive/component.yaml
@@ -9,6 +9,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/PyTorch/Create_PyTorch_Model_Archive/component.yaml'
 implementation:
   container:
     image: pytorch/torchserve:0.3.0-cpu

--- a/components/PyTorch/Create_fully_connected_network/component.py
+++ b/components/PyTorch/Create_fully_connected_network/component.py
@@ -39,5 +39,6 @@ if __name__ == '__main__':
         packages_to_install=[],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/PyTorch/Create_fully_connected_network/component.py",
         },
     )

--- a/components/PyTorch/Create_fully_connected_network/component.py
+++ b/components/PyTorch/Create_fully_connected_network/component.py
@@ -39,6 +39,6 @@ if __name__ == '__main__':
         packages_to_install=[],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/PyTorch/Create_fully_connected_network/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/PyTorch/Create_fully_connected_network/component.yaml",
         },
     )

--- a/components/PyTorch/Create_fully_connected_network/component.yaml
+++ b/components/PyTorch/Create_fully_connected_network/component.yaml
@@ -3,6 +3,7 @@ description: Creates fully-connected network in PyTorch ScriptModule format
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/PyTorch/Create_fully_connected_network/component.yaml'
 inputs:
 - {name: layer_sizes, type: JsonArray}
 - {name: activation_name, type: String, default: relu, optional: true}

--- a/components/PyTorch/Train_PyTorch_model/from_CSV/component.py
+++ b/components/PyTorch/Train_PyTorch_model/from_CSV/component.py
@@ -110,5 +110,6 @@ if __name__ == '__main__':
         packages_to_install=['pandas==1.1.5'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/PyTorch/Train_PyTorch_model/from_CSV/component.py",
         },
     )

--- a/components/PyTorch/Train_PyTorch_model/from_CSV/component.py
+++ b/components/PyTorch/Train_PyTorch_model/from_CSV/component.py
@@ -110,6 +110,6 @@ if __name__ == '__main__':
         packages_to_install=['pandas==1.1.5'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/PyTorch/Train_PyTorch_model/from_CSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/PyTorch/Train_PyTorch_model/from_CSV/component.yaml",
         },
     )

--- a/components/PyTorch/Train_PyTorch_model/from_CSV/component.yaml
+++ b/components/PyTorch/Train_PyTorch_model/from_CSV/component.yaml
@@ -3,6 +3,7 @@ description: Trains PyTorch model
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/PyTorch/Train_PyTorch_model/from_CSV/component.yaml'
 inputs:
 - {name: model, type: PyTorchScriptModule}
 - {name: training_data, type: CSV}

--- a/components/XGBoost/Cross_validation_for_regression/from_CSV/component.py
+++ b/components/XGBoost/Cross_validation_for_regression/from_CSV/component.py
@@ -66,6 +66,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Cross_validation_for_regression/from_CSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Cross_validation_for_regression/from_CSV/component.yaml",
         },
     )

--- a/components/XGBoost/Cross_validation_for_regression/from_CSV/component.py
+++ b/components/XGBoost/Cross_validation_for_regression/from_CSV/component.py
@@ -64,4 +64,8 @@ if __name__ == '__main__':
     xgboost_5_fold_cross_validation_for_regression_op = components.create_graph_component_from_pipeline_func(
         xgboost_5_fold_cross_validation_for_regression,
         output_component_file='component.yaml',
+        annotations={
+            "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Cross_validation_for_regression/from_CSV/component.py",
+        },
     )

--- a/components/XGBoost/Cross_validation_for_regression/from_CSV/component.yaml
+++ b/components/XGBoost/Cross_validation_for_regression/from_CSV/component.yaml
@@ -12,6 +12,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Cross_validation_for_regression/from_CSV/component.yaml'
 implementation:
   graph:
     tasks:

--- a/components/XGBoost/Predict/component.py
+++ b/components/XGBoost/Predict/component.py
@@ -53,5 +53,6 @@ if __name__ == '__main__':
         ],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Predict/component.py",
         },
     )

--- a/components/XGBoost/Predict/component.py
+++ b/components/XGBoost/Predict/component.py
@@ -53,6 +53,6 @@ if __name__ == '__main__':
         ],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Predict/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Predict/component.yaml",
         },
     )

--- a/components/XGBoost/Predict/component.yaml
+++ b/components/XGBoost/Predict/component.yaml
@@ -19,6 +19,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Predict/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/XGBoost/Predict/from_ApacheParquet/component.py
+++ b/components/XGBoost/Predict/from_ApacheParquet/component.py
@@ -53,6 +53,6 @@ if __name__ == '__main__':
         ],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Predict/from_ApacheParquet/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Predict/from_ApacheParquet/component.yaml",
         },
     )

--- a/components/XGBoost/Predict/from_ApacheParquet/component.py
+++ b/components/XGBoost/Predict/from_ApacheParquet/component.py
@@ -53,5 +53,6 @@ if __name__ == '__main__':
         ],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Predict/from_ApacheParquet/component.py",
         },
     )

--- a/components/XGBoost/Predict/from_ApacheParquet/component.yaml
+++ b/components/XGBoost/Predict/from_ApacheParquet/component.yaml
@@ -19,6 +19,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Predict/from_ApacheParquet/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/XGBoost/Train/component.py
+++ b/components/XGBoost/Train/component.py
@@ -89,5 +89,6 @@ if __name__ == '__main__':
         ],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Train/component.py",
         },
     )

--- a/components/XGBoost/Train/component.py
+++ b/components/XGBoost/Train/component.py
@@ -89,6 +89,6 @@ if __name__ == '__main__':
         ],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Train/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Train/component.yaml",
         },
     )

--- a/components/XGBoost/Train/component.yaml
+++ b/components/XGBoost/Train/component.yaml
@@ -39,6 +39,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Train/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/XGBoost/Train/from_ApacheParquet/component.py
+++ b/components/XGBoost/Train/from_ApacheParquet/component.py
@@ -89,6 +89,6 @@ if __name__ == '__main__':
         ],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Train/from_ApacheParquet/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Train/from_ApacheParquet/component.yaml",
         },
     )

--- a/components/XGBoost/Train/from_ApacheParquet/component.py
+++ b/components/XGBoost/Train/from_ApacheParquet/component.py
@@ -89,5 +89,6 @@ if __name__ == '__main__':
         ],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Train/from_ApacheParquet/component.py",
         },
     )

--- a/components/XGBoost/Train/from_ApacheParquet/component.yaml
+++ b/components/XGBoost/Train/from_ApacheParquet/component.yaml
@@ -39,6 +39,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Train/from_ApacheParquet/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/XGBoost/Train_and_cross-validate_regression/from_CSV/component.py
+++ b/components/XGBoost/Train_and_cross-validate_regression/from_CSV/component.py
@@ -48,6 +48,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Train_and_cross-validate_regression/from_CSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Train_and_cross-validate_regression/from_CSV/component.yaml",
         },
     )

--- a/components/XGBoost/Train_and_cross-validate_regression/from_CSV/component.py
+++ b/components/XGBoost/Train_and_cross-validate_regression/from_CSV/component.py
@@ -46,4 +46,8 @@ if __name__ == '__main__':
     xgboost_train_and_cv_regression_on_csv_op = components.create_graph_component_from_pipeline_func(
         xgboost_train_and_cv_regression_on_csv,
         output_component_file='component.yaml',
+        annotations={
+            "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Train_and_cross-validate_regression/from_CSV/component.py",
+        },
     )

--- a/components/XGBoost/Train_and_cross-validate_regression/from_CSV/component.yaml
+++ b/components/XGBoost/Train_and_cross-validate_regression/from_CSV/component.yaml
@@ -17,6 +17,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Train_and_cross-validate_regression/from_CSV/component.yaml'
 implementation:
   graph:
     tasks:

--- a/components/XGBoost/Train_regression_and_calculate_metrics/from_CSV/component.py
+++ b/components/XGBoost/Train_regression_and_calculate_metrics/from_CSV/component.py
@@ -53,4 +53,8 @@ if __name__ == '__main__':
     xgboost_train_regression_and_calculate_metrics_on_csv_op = components.create_graph_component_from_pipeline_func(
         xgboost_train_regression_and_calculate_metrics_on_csv,
         output_component_file='component.yaml',
+        annotations={
+            "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Train_regression_and_calculate_metrics/from_CSV/component.py",
+        },
     )

--- a/components/XGBoost/Train_regression_and_calculate_metrics/from_CSV/component.py
+++ b/components/XGBoost/Train_regression_and_calculate_metrics/from_CSV/component.py
@@ -55,6 +55,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Train_regression_and_calculate_metrics/from_CSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Train_regression_and_calculate_metrics/from_CSV/component.yaml",
         },
     )

--- a/components/XGBoost/Train_regression_and_calculate_metrics/from_CSV/component.yaml
+++ b/components/XGBoost/Train_regression_and_calculate_metrics/from_CSV/component.yaml
@@ -14,6 +14,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/XGBoost/Train_regression_and_calculate_metrics/from_CSV/component.yaml'
 implementation:
   graph:
     tasks:

--- a/components/_converters/ApacheParquet/from_ApacheArrowFeather/component.py
+++ b/components/_converters/ApacheParquet/from_ApacheArrowFeather/component.py
@@ -26,5 +26,6 @@ if __name__ == '__main__':
         packages_to_install=['pyarrow==0.17.1'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/from_ApacheArrowFeather/component.py",
         },
     )

--- a/components/_converters/ApacheParquet/from_ApacheArrowFeather/component.py
+++ b/components/_converters/ApacheParquet/from_ApacheArrowFeather/component.py
@@ -26,6 +26,6 @@ if __name__ == '__main__':
         packages_to_install=['pyarrow==0.17.1'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/from_ApacheArrowFeather/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/from_ApacheArrowFeather/component.yaml",
         },
     )

--- a/components/_converters/ApacheParquet/from_ApacheArrowFeather/component.yaml
+++ b/components/_converters/ApacheParquet/from_ApacheArrowFeather/component.yaml
@@ -14,6 +14,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/from_ApacheArrowFeather/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/_converters/ApacheParquet/from_CSV/component.py
+++ b/components/_converters/ApacheParquet/from_CSV/component.py
@@ -25,6 +25,6 @@ if __name__ == '__main__':
         packages_to_install=['pyarrow==0.17.1'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/from_CSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/from_CSV/component.yaml",
         },
     )

--- a/components/_converters/ApacheParquet/from_CSV/component.py
+++ b/components/_converters/ApacheParquet/from_CSV/component.py
@@ -25,5 +25,6 @@ if __name__ == '__main__':
         packages_to_install=['pyarrow==0.17.1'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/from_CSV/component.py",
         },
     )

--- a/components/_converters/ApacheParquet/from_CSV/component.yaml
+++ b/components/_converters/ApacheParquet/from_CSV/component.yaml
@@ -13,6 +13,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/from_CSV/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/_converters/ApacheParquet/from_TSV/component.py
+++ b/components/_converters/ApacheParquet/from_TSV/component.py
@@ -25,5 +25,6 @@ if __name__ == '__main__':
         packages_to_install=['pyarrow==0.17.1'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/from_TSV/component.py",
         },
     )

--- a/components/_converters/ApacheParquet/from_TSV/component.py
+++ b/components/_converters/ApacheParquet/from_TSV/component.py
@@ -25,6 +25,6 @@ if __name__ == '__main__':
         packages_to_install=['pyarrow==0.17.1'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/from_TSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/from_TSV/component.yaml",
         },
     )

--- a/components/_converters/ApacheParquet/from_TSV/component.yaml
+++ b/components/_converters/ApacheParquet/from_TSV/component.yaml
@@ -13,6 +13,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/from_TSV/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/_converters/ApacheParquet/to_ApacheArrowFeather/component.py
+++ b/components/_converters/ApacheParquet/to_ApacheArrowFeather/component.py
@@ -26,5 +26,6 @@ if __name__ == '__main__':
         packages_to_install=['pyarrow==0.17.1', 'pandas==1.0.3'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/to_ApacheArrowFeather/component.py",
         },
     )

--- a/components/_converters/ApacheParquet/to_ApacheArrowFeather/component.py
+++ b/components/_converters/ApacheParquet/to_ApacheArrowFeather/component.py
@@ -26,6 +26,6 @@ if __name__ == '__main__':
         packages_to_install=['pyarrow==0.17.1', 'pandas==1.0.3'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/to_ApacheArrowFeather/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/to_ApacheArrowFeather/component.yaml",
         },
     )

--- a/components/_converters/ApacheParquet/to_ApacheArrowFeather/component.yaml
+++ b/components/_converters/ApacheParquet/to_ApacheArrowFeather/component.yaml
@@ -14,6 +14,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/to_ApacheArrowFeather/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/_converters/ApacheParquet/to_CSV/component.py
+++ b/components/_converters/ApacheParquet/to_CSV/component.py
@@ -28,5 +28,6 @@ if __name__ == '__main__':
         packages_to_install=['pyarrow==0.17.1', 'pandas==1.0.3'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/to_CSV/component.py",
         },
     )

--- a/components/_converters/ApacheParquet/to_CSV/component.py
+++ b/components/_converters/ApacheParquet/to_CSV/component.py
@@ -28,6 +28,6 @@ if __name__ == '__main__':
         packages_to_install=['pyarrow==0.17.1', 'pandas==1.0.3'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/to_CSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/to_CSV/component.yaml",
         },
     )

--- a/components/_converters/ApacheParquet/to_CSV/component.yaml
+++ b/components/_converters/ApacheParquet/to_CSV/component.yaml
@@ -13,6 +13,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/to_CSV/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/_converters/ApacheParquet/to_TSV/component.py
+++ b/components/_converters/ApacheParquet/to_TSV/component.py
@@ -29,5 +29,6 @@ if __name__ == '__main__':
         packages_to_install=['pyarrow==0.17.1', 'pandas==1.0.3'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/to_TSV/component.py",
         },
     )

--- a/components/_converters/ApacheParquet/to_TSV/component.py
+++ b/components/_converters/ApacheParquet/to_TSV/component.py
@@ -29,6 +29,6 @@ if __name__ == '__main__':
         packages_to_install=['pyarrow==0.17.1', 'pandas==1.0.3'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/to_TSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/to_TSV/component.yaml",
         },
     )

--- a/components/_converters/ApacheParquet/to_TSV/component.yaml
+++ b/components/_converters/ApacheParquet/to_TSV/component.yaml
@@ -13,6 +13,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/ApacheParquet/to_TSV/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/_converters/KerasModelHdf5/to_TensorflowSavedModel/component.py
+++ b/components/_converters/KerasModelHdf5/to_TensorflowSavedModel/component.py
@@ -28,6 +28,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/KerasModelHdf5/to_TensorflowSavedModel/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/KerasModelHdf5/to_TensorflowSavedModel/component.yaml",
         },
     )

--- a/components/_converters/KerasModelHdf5/to_TensorflowSavedModel/component.py
+++ b/components/_converters/KerasModelHdf5/to_TensorflowSavedModel/component.py
@@ -28,5 +28,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/KerasModelHdf5/to_TensorflowSavedModel/component.py",
         },
     )

--- a/components/_converters/KerasModelHdf5/to_TensorflowSavedModel/component.yaml
+++ b/components/_converters/KerasModelHdf5/to_TensorflowSavedModel/component.yaml
@@ -7,6 +7,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/KerasModelHdf5/to_TensorflowSavedModel/component.yaml'
 implementation:
   container:
     image: tensorflow/tensorflow:2.3.0

--- a/components/_converters/OnnxModel/from_KerasModelHdf5/component.yaml
+++ b/components/_converters/OnnxModel/from_KerasModelHdf5/component.yaml
@@ -6,6 +6,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/OnnxModel/from_KerasModelHdf5/component.yaml'
 implementation:
   container:
     image: tensorflow/tensorflow:2.3.0

--- a/components/_converters/OnnxModel/from_TensorflowSavedModel/component.yaml
+++ b/components/_converters/OnnxModel/from_TensorflowSavedModel/component.yaml
@@ -6,6 +6,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/OnnxModel/from_TensorflowSavedModel/component.yaml'
 implementation:
   container:
     image: tensorflow/tensorflow:2.3.0

--- a/components/_converters/OnnxModel/to_TensorflowSavedModel/component.py
+++ b/components/_converters/OnnxModel/to_TensorflowSavedModel/component.py
@@ -21,5 +21,6 @@ if __name__ == '__main__':
         packages_to_install=['onnx-tf==1.7.0', 'onnx==1.8.0'],  # onnx-tf==1.7.0 is not compatible with onnx==1.8.1
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/OnnxModel/to_TensorflowSavedModel/component.py",
         },
     )

--- a/components/_converters/OnnxModel/to_TensorflowSavedModel/component.py
+++ b/components/_converters/OnnxModel/to_TensorflowSavedModel/component.py
@@ -21,6 +21,6 @@ if __name__ == '__main__':
         packages_to_install=['onnx-tf==1.7.0', 'onnx==1.8.0'],  # onnx-tf==1.7.0 is not compatible with onnx==1.8.1
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/OnnxModel/to_TensorflowSavedModel/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/OnnxModel/to_TensorflowSavedModel/component.yaml",
         },
     )

--- a/components/_converters/OnnxModel/to_TensorflowSavedModel/component.yaml
+++ b/components/_converters/OnnxModel/to_TensorflowSavedModel/component.yaml
@@ -1,6 +1,8 @@
 name: Convert to tensorflow saved model from onnx model
 metadata:
-  annotations: {author: Alexey Volkov <alexey.volkov@ark-kun.com>}
+  annotations: 
+    author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/OnnxModel/to_TensorflowSavedModel/component.yaml'
 inputs:
 - {name: model, type: OnnxModel}
 outputs:

--- a/components/_converters/TensorflowJSGraphModel/from_KerasModelHdf5/component.yaml
+++ b/components/_converters/TensorflowJSGraphModel/from_KerasModelHdf5/component.yaml
@@ -6,6 +6,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/TensorflowJSGraphModel/from_KerasModelHdf5/component.yaml'
 implementation:
   container:
     image: tensorflow/tensorflow:2.3.0

--- a/components/_converters/TensorflowJSGraphModel/from_TensorflowSavedModel/component.yaml
+++ b/components/_converters/TensorflowJSGraphModel/from_TensorflowSavedModel/component.yaml
@@ -6,6 +6,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/TensorflowJSGraphModel/from_TensorflowSavedModel/component.yaml'
 implementation:
   container:
     image: tensorflow/tensorflow:2.3.0

--- a/components/_converters/TensorflowJSLayersModel/from_KerasModelHdf5/component.yaml
+++ b/components/_converters/TensorflowJSLayersModel/from_KerasModelHdf5/component.yaml
@@ -6,6 +6,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/TensorflowJSLayersModel/from_KerasModelHdf5/component.yaml'
 implementation:
   container:
     image: tensorflow/tensorflow:2.3.0

--- a/components/_converters/TensorflowJSLayersModel/from_TensorflowSavedModel/component.yaml
+++ b/components/_converters/TensorflowJSLayersModel/from_TensorflowSavedModel/component.yaml
@@ -6,6 +6,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/TensorflowJSLayersModel/from_TensorflowSavedModel/component.yaml'
 implementation:
   container:
     image: tensorflow/tensorflow:2.3.0

--- a/components/_converters/TensorflowLiteModel/from_KerasModelHdf5/component.yaml
+++ b/components/_converters/TensorflowLiteModel/from_KerasModelHdf5/component.yaml
@@ -6,6 +6,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/TensorflowLiteModel/from_KerasModelHdf5/component.yaml'
 implementation:
   container:
     image: tensorflow/tensorflow:2.3.0

--- a/components/_converters/TensorflowLiteModel/from_TensorflowSavedModel/component.yaml
+++ b/components/_converters/TensorflowLiteModel/from_TensorflowSavedModel/component.yaml
@@ -6,6 +6,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/_converters/TensorflowLiteModel/from_TensorflowSavedModel/component.yaml'
 implementation:
   container:
     image: tensorflow/tensorflow:2.3.0

--- a/components/basics/Calculate_hash/component.yaml
+++ b/components/basics/Calculate_hash/component.yaml
@@ -7,6 +7,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/basics/Calculate_hash/component.yaml'
 implementation:
   container:
     image: alpine

--- a/components/dataset_manipulation/split_data_into_folds/in_CSV/component.py
+++ b/components/dataset_manipulation/split_data_into_folds/in_CSV/component.py
@@ -85,6 +85,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/dataset_manipulation/split_data_into_folds/in_CSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/dataset_manipulation/split_data_into_folds/in_CSV/component.yaml",
         },
     )

--- a/components/dataset_manipulation/split_data_into_folds/in_CSV/component.py
+++ b/components/dataset_manipulation/split_data_into_folds/in_CSV/component.py
@@ -85,5 +85,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/dataset_manipulation/split_data_into_folds/in_CSV/component.py",
         },
     )

--- a/components/dataset_manipulation/split_data_into_folds/in_CSV/component.yaml
+++ b/components/dataset_manipulation/split_data_into_folds/in_CSV/component.yaml
@@ -21,6 +21,7 @@ description: |-
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/dataset_manipulation/split_data_into_folds/in_CSV/component.yaml'
 inputs:
 - {name: table, type: CSV}
 - {name: number_of_folds, type: Integer, default: '5', optional: true}

--- a/components/datasets/Chicago_Taxi_Trips/component.yaml
+++ b/components/datasets/Chicago_Taxi_Trips/component.yaml
@@ -8,6 +8,7 @@ description: |
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/datasets/Chicago_Taxi_Trips/component.yaml'
 inputs:
 - {name: Where, type: String, default: 'trip_start_timestamp>="1900-01-01" AND trip_start_timestamp<"2100-01-01"'}
 - {name: Limit, type: Integer, default: '1000', description: 'Number of rows to return. The rows are randomly sampled.'}

--- a/components/datasets/HuggingFace/Load_dataset/component.py
+++ b/components/datasets/HuggingFace/Load_dataset/component.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
         packages_to_install=['datasets==1.6.2'],
         annotations={
             'author': 'Alexey Volkov <alexey.volkov@ark-kun.com>',
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/datasets/HuggingFace/Load_dataset/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/datasets/HuggingFace/Load_dataset/component.yaml",
         },
         output_component_file='component.yaml',
     )

--- a/components/datasets/HuggingFace/Load_dataset/component.py
+++ b/components/datasets/HuggingFace/Load_dataset/component.py
@@ -24,6 +24,7 @@ if __name__ == '__main__':
         packages_to_install=['datasets==1.6.2'],
         annotations={
             'author': 'Alexey Volkov <alexey.volkov@ark-kun.com>',
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/datasets/HuggingFace/Load_dataset/component.py",
         },
         output_component_file='component.yaml',
     )

--- a/components/datasets/HuggingFace/Load_dataset/component.yaml
+++ b/components/datasets/HuggingFace/Load_dataset/component.yaml
@@ -1,6 +1,8 @@
 name: Load dataset using huggingface
 metadata:
-  annotations: {author: Alexey Volkov <alexey.volkov@ark-kun.com>}
+  annotations: 
+    author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/datasets/HuggingFace/Load_dataset/component.yaml'
 inputs:
 - {name: dataset_name, type: String}
 outputs:

--- a/components/datasets/HuggingFace/Split_dataset/component.py
+++ b/components/datasets/HuggingFace/Split_dataset/component.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
         packages_to_install=['datasets==1.6.2'],
         annotations={
             'author': 'Alexey Volkov <alexey.volkov@ark-kun.com>',
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/datasets/HuggingFace/Split_dataset/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/datasets/HuggingFace/Split_dataset/component.yaml",
         },
         output_component_file='component.yaml',
     )

--- a/components/datasets/HuggingFace/Split_dataset/component.py
+++ b/components/datasets/HuggingFace/Split_dataset/component.py
@@ -30,6 +30,7 @@ if __name__ == '__main__':
         packages_to_install=['datasets==1.6.2'],
         annotations={
             'author': 'Alexey Volkov <alexey.volkov@ark-kun.com>',
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/datasets/HuggingFace/Split_dataset/component.py",
         },
         output_component_file='component.yaml',
     )

--- a/components/datasets/HuggingFace/Split_dataset/component.yaml
+++ b/components/datasets/HuggingFace/Split_dataset/component.yaml
@@ -1,6 +1,8 @@
 name: Split dataset huggingface
 metadata:
-  annotations: {author: Alexey Volkov <alexey.volkov@ark-kun.com>}
+  annotations: 
+    author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/datasets/HuggingFace/Split_dataset/component.yaml'
 inputs:
 - {name: dataset_dict, type: HuggingFaceDatasetDict}
 - {name: split_name, type: String, optional: true}

--- a/components/deprecated/tfx/Evaluator/component.yaml
+++ b/components/deprecated/tfx/Evaluator/component.yaml
@@ -22,6 +22,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/Evaluator/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/Evaluator/with_URI_IO/component.yaml
+++ b/components/deprecated/tfx/Evaluator/with_URI_IO/component.yaml
@@ -25,6 +25,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/Evaluator/with_URI_IO/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/ExampleGen/BigQueryExampleGen/component.yaml
+++ b/components/deprecated/tfx/ExampleGen/BigQueryExampleGen/component.yaml
@@ -11,6 +11,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/ExampleGen/BigQueryExampleGen/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/ExampleGen/BigQueryExampleGen/with_URI_IO/component.yaml
+++ b/components/deprecated/tfx/ExampleGen/BigQueryExampleGen/with_URI_IO/component.yaml
@@ -13,6 +13,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/ExampleGen/BigQueryExampleGen/with_URI_IO/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/ExampleGen/CsvExampleGen/component.yaml
+++ b/components/deprecated/tfx/ExampleGen/CsvExampleGen/component.yaml
@@ -16,6 +16,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/ExampleGen/CsvExampleGen/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/ExampleGen/CsvExampleGen/with_URI_IO/component.yaml
+++ b/components/deprecated/tfx/ExampleGen/CsvExampleGen/with_URI_IO/component.yaml
@@ -18,6 +18,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/ExampleGen/CsvExampleGen/with_URI_IO/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/ExampleGen/ImportExampleGen/component.yaml
+++ b/components/deprecated/tfx/ExampleGen/ImportExampleGen/component.yaml
@@ -16,6 +16,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/ExampleGen/ImportExampleGen/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/ExampleGen/ImportExampleGen/with_URI_IO/component.yaml
+++ b/components/deprecated/tfx/ExampleGen/ImportExampleGen/with_URI_IO/component.yaml
@@ -18,6 +18,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/ExampleGen/ImportExampleGen/with_URI_IO/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/ExampleValidator/component.yaml
+++ b/components/deprecated/tfx/ExampleValidator/component.yaml
@@ -8,6 +8,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/ExampleValidator/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/ExampleValidator/with_URI_IO/component.yaml
+++ b/components/deprecated/tfx/ExampleValidator/with_URI_IO/component.yaml
@@ -10,6 +10,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/ExampleValidator/with_URI_IO/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/SchemaGen/component.yaml
+++ b/components/deprecated/tfx/SchemaGen/component.yaml
@@ -8,6 +8,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/SchemaGen/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/SchemaGen/with_URI_IO/component.yaml
+++ b/components/deprecated/tfx/SchemaGen/with_URI_IO/component.yaml
@@ -10,6 +10,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/SchemaGen/with_URI_IO/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/StatisticsGen/component.yaml
+++ b/components/deprecated/tfx/StatisticsGen/component.yaml
@@ -8,6 +8,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/StatisticsGen/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/StatisticsGen/with_URI_IO/component.yaml
+++ b/components/deprecated/tfx/StatisticsGen/with_URI_IO/component.yaml
@@ -10,6 +10,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/StatisticsGen/with_URI_IO/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/Trainer/component.yaml
+++ b/components/deprecated/tfx/Trainer/component.yaml
@@ -21,6 +21,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/Trainer/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/Trainer/with_URI_IO/component.yaml
+++ b/components/deprecated/tfx/Trainer/with_URI_IO/component.yaml
@@ -24,6 +24,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/Trainer/with_URI_IO/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/Transform/component.yaml
+++ b/components/deprecated/tfx/Transform/component.yaml
@@ -18,6 +18,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/Transform/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/deprecated/tfx/Transform/with_URI_IO/component.yaml
+++ b/components/deprecated/tfx/Transform/with_URI_IO/component.yaml
@@ -22,6 +22,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/deprecated/tfx/Transform/with_URI_IO/component.yaml'
 implementation:
   container:
     image: tensorflow/tfx:0.29.0

--- a/components/filesystem/get_file/component.yaml
+++ b/components/filesystem/get_file/component.yaml
@@ -8,6 +8,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/filesystem/get_file/component.yaml'
 implementation:
   container:
     image: alpine

--- a/components/filesystem/get_subdirectory/component.yaml
+++ b/components/filesystem/get_subdirectory/component.yaml
@@ -8,6 +8,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/filesystem/get_subdirectory/component.yaml'
 implementation:
   container:
     image: alpine

--- a/components/filesystem/list_items/component.yaml
+++ b/components/filesystem/list_items/component.yaml
@@ -7,6 +7,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/filesystem/list_items/component.yaml'
 implementation:
   container:
     image: alpine

--- a/components/gcp/automl/create_dataset_for_tables/component.py
+++ b/components/gcp/automl/create_dataset_for_tables/component.py
@@ -64,5 +64,6 @@ if __name__ == '__main__':
         packages_to_install=['google-cloud-automl==0.4.0'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/create_dataset_for_tables/component.py",
         },
     )

--- a/components/gcp/automl/create_dataset_for_tables/component.py
+++ b/components/gcp/automl/create_dataset_for_tables/component.py
@@ -64,6 +64,6 @@ if __name__ == '__main__':
         packages_to_install=['google-cloud-automl==0.4.0'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/create_dataset_for_tables/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/create_dataset_for_tables/component.yaml",
         },
     )

--- a/components/gcp/automl/create_dataset_for_tables/component.yaml
+++ b/components/gcp/automl/create_dataset_for_tables/component.yaml
@@ -18,6 +18,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/create_dataset_for_tables/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/gcp/automl/create_model_for_tables/component.py
+++ b/components/gcp/automl/create_model_for_tables/component.py
@@ -66,6 +66,6 @@ if __name__ == '__main__':
         packages_to_install=['google-cloud-automl==0.4.0'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/create_model_for_tables/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/create_model_for_tables/component.yaml",
         },
     )

--- a/components/gcp/automl/create_model_for_tables/component.py
+++ b/components/gcp/automl/create_model_for_tables/component.py
@@ -66,5 +66,6 @@ if __name__ == '__main__':
         packages_to_install=['google-cloud-automl==0.4.0'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/create_model_for_tables/component.py",
         },
     )

--- a/components/gcp/automl/create_model_for_tables/component.yaml
+++ b/components/gcp/automl/create_model_for_tables/component.yaml
@@ -15,6 +15,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/create_model_for_tables/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/gcp/automl/deploy_model/component.py
+++ b/components/gcp/automl/deploy_model/component.py
@@ -39,6 +39,6 @@ if __name__ == '__main__':
         ],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/deploy_model/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/deploy_model/component.yaml",
         },
     )

--- a/components/gcp/automl/deploy_model/component.py
+++ b/components/gcp/automl/deploy_model/component.py
@@ -39,5 +39,6 @@ if __name__ == '__main__':
         ],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/deploy_model/component.py",
         },
     )

--- a/components/gcp/automl/deploy_model/component.yaml
+++ b/components/gcp/automl/deploy_model/component.yaml
@@ -14,6 +14,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/deploy_model/component.yaml'
 implementation:
   container:
     image: python:3.8

--- a/components/gcp/automl/export_data_to_gcs/component.py
+++ b/components/gcp/automl/export_data_to_gcs/component.py
@@ -56,6 +56,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',base_image='python:3.7',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/export_data_to_gcs/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/export_data_to_gcs/component.yaml",
         },
     )

--- a/components/gcp/automl/export_data_to_gcs/component.py
+++ b/components/gcp/automl/export_data_to_gcs/component.py
@@ -56,5 +56,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',base_image='python:3.7',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/export_data_to_gcs/component.py",
         },
     )

--- a/components/gcp/automl/export_data_to_gcs/component.yaml
+++ b/components/gcp/automl/export_data_to_gcs/component.yaml
@@ -20,6 +20,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/export_data_to_gcs/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/gcp/automl/export_model_to_gcs/component.py
+++ b/components/gcp/automl/export_model_to_gcs/component.py
@@ -51,5 +51,6 @@ if __name__ == '__main__':
         ],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/export_model_to_gcs/component.py",
         },
     )

--- a/components/gcp/automl/export_model_to_gcs/component.py
+++ b/components/gcp/automl/export_model_to_gcs/component.py
@@ -51,6 +51,6 @@ if __name__ == '__main__':
         ],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/export_model_to_gcs/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/export_model_to_gcs/component.yaml",
         },
     )

--- a/components/gcp/automl/export_model_to_gcs/component.yaml
+++ b/components/gcp/automl/export_model_to_gcs/component.yaml
@@ -18,6 +18,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/export_model_to_gcs/component.yaml'
 implementation:
   container:
     image: python:3.8

--- a/components/gcp/automl/import_data_from_bigquery/component.py
+++ b/components/gcp/automl/import_data_from_bigquery/component.py
@@ -56,6 +56,6 @@ if __name__ == '__main__':
         base_image='python:3.7',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/import_data_from_bigquery/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/import_data_from_bigquery/component.yaml",
         },
     )

--- a/components/gcp/automl/import_data_from_bigquery/component.py
+++ b/components/gcp/automl/import_data_from_bigquery/component.py
@@ -56,5 +56,6 @@ if __name__ == '__main__':
         base_image='python:3.7',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/import_data_from_bigquery/component.py",
         },
     )

--- a/components/gcp/automl/import_data_from_bigquery/component.yaml
+++ b/components/gcp/automl/import_data_from_bigquery/component.yaml
@@ -16,6 +16,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/import_data_from_bigquery/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/gcp/automl/import_data_from_gcs/component.py
+++ b/components/gcp/automl/import_data_from_gcs/component.py
@@ -57,6 +57,6 @@ if __name__ == '__main__':
         base_image='python:3.7',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/import_data_from_gcs/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/import_data_from_gcs/component.yaml",
         },
     )

--- a/components/gcp/automl/import_data_from_gcs/component.py
+++ b/components/gcp/automl/import_data_from_gcs/component.py
@@ -57,5 +57,6 @@ if __name__ == '__main__':
         base_image='python:3.7',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/import_data_from_gcs/component.py",
         },
     )

--- a/components/gcp/automl/import_data_from_gcs/component.yaml
+++ b/components/gcp/automl/import_data_from_gcs/component.yaml
@@ -17,6 +17,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/import_data_from_gcs/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/gcp/automl/prediction_service_batch_predict/component.py
+++ b/components/gcp/automl/prediction_service_batch_predict/component.py
@@ -73,5 +73,6 @@ if __name__ == '__main__':
         base_image='python:3.7',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/prediction_service_batch_predict/component.py",
         },
     )

--- a/components/gcp/automl/prediction_service_batch_predict/component.py
+++ b/components/gcp/automl/prediction_service_batch_predict/component.py
@@ -73,6 +73,6 @@ if __name__ == '__main__':
         base_image='python:3.7',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/prediction_service_batch_predict/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/prediction_service_batch_predict/component.yaml",
         },
     )

--- a/components/gcp/automl/prediction_service_batch_predict/component.yaml
+++ b/components/gcp/automl/prediction_service_batch_predict/component.yaml
@@ -30,6 +30,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/prediction_service_batch_predict/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/gcp/automl/split_dataset_table_column_names/component.py
+++ b/components/gcp/automl/split_dataset_table_column_names/component.py
@@ -54,5 +54,6 @@ if __name__ == '__main__':
         base_image='python:3.7',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/split_dataset_table_column_names/component.py",
         },
     )

--- a/components/gcp/automl/split_dataset_table_column_names/component.py
+++ b/components/gcp/automl/split_dataset_table_column_names/component.py
@@ -54,6 +54,6 @@ if __name__ == '__main__':
         base_image='python:3.7',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/split_dataset_table_column_names/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/split_dataset_table_column_names/component.yaml",
         },
     )

--- a/components/gcp/automl/split_dataset_table_column_names/component.yaml
+++ b/components/gcp/automl/split_dataset_table_column_names/component.yaml
@@ -16,6 +16,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/gcp/automl/split_dataset_table_column_names/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/git/clone/component.yaml
+++ b/components/git/clone/component.yaml
@@ -3,6 +3,7 @@ description: Creates a shallow clone of the specified repo branch
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/git/clone/component.yaml'
     volatile_component: "true"
 inputs:
 - {name: Repo URI, type: URI}

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/AutoML/Tables/Create_dataset/from_CSV/component.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/AutoML/Tables/Create_dataset/from_CSV/component.py
@@ -177,6 +177,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/AutoML/Tables/Create_dataset/from_CSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/AutoML/Tables/Create_dataset/from_CSV/component.yaml",
         },
     )

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/AutoML/Tables/Create_dataset/from_CSV/component.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/AutoML/Tables/Create_dataset/from_CSV/component.py
@@ -177,5 +177,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/AutoML/Tables/Create_dataset/from_CSV/component.py",
         },
     )

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/AutoML/Tables/Create_dataset/from_CSV/component.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/AutoML/Tables/Create_dataset/from_CSV/component.yaml
@@ -22,6 +22,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/AutoML/Tables/Create_dataset/from_CSV/component.yaml'
 implementation:
   container:
     image: python:3.8

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Add_measurement_for_trial/component.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Add_measurement_for_trial/component.py
@@ -117,5 +117,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/Optimizer/Add_measurement_for_trial/component.py",
         },
     )

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Add_measurement_for_trial/component.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Add_measurement_for_trial/component.py
@@ -117,6 +117,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/Optimizer/Add_measurement_for_trial/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/Optimizer/Add_measurement_for_trial/component.yaml",
         },
     )

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Add_measurement_for_trial/component.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Add_measurement_for_trial/component.yaml
@@ -20,6 +20,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/Optimizer/Add_measurement_for_trial/component.yaml'
 implementation:
   container:
     image: python:3.8

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Create_study/component.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Create_study/component.py
@@ -79,6 +79,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/Optimizer/Create_study/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/Optimizer/Create_study/component.yaml",
         },
     )

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Create_study/component.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Create_study/component.py
@@ -79,5 +79,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/Optimizer/Create_study/component.py",
         },
     )

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Create_study/component.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Create_study/component.yaml
@@ -16,6 +16,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/Optimizer/Create_study/component.yaml'
 implementation:
   container:
     image: python:3.8

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Suggest_parameter_sets_based_on_measurements/component.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Suggest_parameter_sets_based_on_measurements/component.py
@@ -183,6 +183,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/Optimizer/Suggest_parameter_sets_based_on_measurements/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/Optimizer/Suggest_parameter_sets_based_on_measurements/component.yaml",
         },
     )

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Suggest_parameter_sets_based_on_measurements/component.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Suggest_parameter_sets_based_on_measurements/component.py
@@ -183,5 +183,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/Optimizer/Suggest_parameter_sets_based_on_measurements/component.py",
         },
     )

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Suggest_parameter_sets_based_on_measurements/component.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Suggest_parameter_sets_based_on_measurements/component.yaml
@@ -23,6 +23,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/Optimizer/Suggest_parameter_sets_based_on_measurements/component.yaml'
 implementation:
   container:
     image: python:3.8

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Suggest_trials/component.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Suggest_trials/component.py
@@ -95,6 +95,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/Optimizer/Suggest_trials/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/Optimizer/Suggest_trials/component.yaml",
         },
     )

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Suggest_trials/component.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Suggest_trials/component.py
@@ -95,5 +95,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/Optimizer/Suggest_trials/component.py",
         },
     )

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Suggest_trials/component.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/Optimizer/Suggest_trials/component.yaml
@@ -10,6 +10,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/Optimizer/Suggest_trials/component.yaml'
 implementation:
   container:
     image: python:3.8

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/storage/download/component.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/storage/download/component.yaml
@@ -6,6 +6,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/storage/download/component.yaml'
 implementation:
     container:
         image: google/cloud-sdk

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/storage/download_blob/component.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/storage/download_blob/component.yaml
@@ -6,6 +6,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/storage/download_blob/component.yaml'
 implementation:
     container:
         image: google/cloud-sdk

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/storage/download_dir/component.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/storage/download_dir/component.yaml
@@ -6,6 +6,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/storage/download_dir/component.yaml'
 implementation:
     container:
         image: google/cloud-sdk

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/storage/list/component.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/storage/list/component.yaml
@@ -6,6 +6,7 @@ outputs:
 metadata:
     annotations:
         author: Alexey Volkov <alexey.volkov@ark-kun.com>
+        canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/storage/list/component.yaml'
         volatile_component: 'true'
 implementation:
     container:

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/storage/upload_to_explicit_uri/component.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/storage/upload_to_explicit_uri/component.yaml
@@ -7,6 +7,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/storage/upload_to_explicit_uri/component.yaml'
 implementation:
     container:
         image: google/cloud-sdk

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/storage/upload_to_unique_uri/component.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/storage/upload_to_unique_uri/component.yaml
@@ -8,6 +8,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/google-cloud/storage/upload_to_unique_uri/component.yaml'
 implementation:
     container:
         image: google/cloud-sdk

--- a/components/json/Build_dict/component.py
+++ b/components/json/Build_dict/component.py
@@ -37,6 +37,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/json/Build_dict/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/json/Build_dict/component.yaml",
         },
     )

--- a/components/json/Build_dict/component.py
+++ b/components/json/Build_dict/component.py
@@ -37,5 +37,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/json/Build_dict/component.py",
         },
     )

--- a/components/json/Build_dict/component.yaml
+++ b/components/json/Build_dict/component.yaml
@@ -16,6 +16,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/json/Build_dict/component.yaml'
 implementation:
   container:
     image: python:3.8

--- a/components/json/Build_list/component.py
+++ b/components/json/Build_list/component.py
@@ -27,5 +27,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/json/Build_list/component.py",
         },
     )

--- a/components/json/Build_list/component.py
+++ b/components/json/Build_list/component.py
@@ -27,6 +27,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/json/Build_list/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/json/Build_list/component.yaml",
         },
     )

--- a/components/json/Build_list/component.yaml
+++ b/components/json/Build_list/component.yaml
@@ -11,6 +11,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/json/Build_list/component.yaml'
 implementation:
   container:
     image: python:3.8

--- a/components/json/Combine_lists/component.py
+++ b/components/json/Combine_lists/component.py
@@ -27,6 +27,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/json/Combine_lists/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/json/Combine_lists/component.yaml",
         },
     )

--- a/components/json/Combine_lists/component.py
+++ b/components/json/Combine_lists/component.py
@@ -27,5 +27,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/json/Combine_lists/component.py",
         },
     )

--- a/components/json/Combine_lists/component.yaml
+++ b/components/json/Combine_lists/component.yaml
@@ -11,6 +11,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/json/Combine_lists/component.yaml'
 implementation:
   container:
     image: python:3.8

--- a/components/json/Get_element_by_index/component.yaml
+++ b/components/json/Get_element_by_index/component.yaml
@@ -7,6 +7,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/json/Get_element_by_index/component.yaml'
 implementation:
   container:
     image: stedolan/jq:latest

--- a/components/json/Get_element_by_key/component.yaml
+++ b/components/json/Get_element_by_key/component.yaml
@@ -7,6 +7,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/json/Get_element_by_key/component.yaml'
 implementation:
   container:
     image: stedolan/jq:latest

--- a/components/json/Query/component.yaml
+++ b/components/json/Query/component.yaml
@@ -8,6 +8,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/json/Query/component.yaml'
 implementation:
   container:
     image: stedolan/jq:latest

--- a/components/keras/Train_classifier/from_CSV/component.py
+++ b/components/keras/Train_classifier/from_CSV/component.py
@@ -89,5 +89,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/keras/Train_classifier/from_CSV/component.py",
         },
     )

--- a/components/keras/Train_classifier/from_CSV/component.py
+++ b/components/keras/Train_classifier/from_CSV/component.py
@@ -89,6 +89,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/keras/Train_classifier/from_CSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/keras/Train_classifier/from_CSV/component.yaml",
         },
     )

--- a/components/keras/Train_classifier/from_CSV/component.yaml
+++ b/components/keras/Train_classifier/from_CSV/component.yaml
@@ -25,6 +25,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/keras/Train_classifier/from_CSV/component.yaml'
 implementation:
   container:
     image: tensorflow/tensorflow:2.2.0

--- a/components/kfp/Run_component/component.py
+++ b/components/kfp/Run_component/component.py
@@ -45,6 +45,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/kfp/Run_component/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/kfp/Run_component/component.yaml",
         },
     )

--- a/components/kfp/Run_component/component.py
+++ b/components/kfp/Run_component/component.py
@@ -45,5 +45,6 @@ if __name__ == '__main__':
         output_component_file='component.yaml',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/kfp/Run_component/component.py",
         },
     )

--- a/components/kfp/Run_component/component.yaml
+++ b/components/kfp/Run_component/component.yaml
@@ -1,6 +1,8 @@
 name: Run component or pipeline
 metadata:
-  annotations: {author: Alexey Volkov <alexey.volkov@ark-kun.com>}
+  annotations: 
+    author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/kfp/Run_component/component.yaml'
 inputs:
 - {name: component_url, type: Url}
 - {name: arguments, type: JsonObject}

--- a/components/kubernetes/Apply_object/component.yaml
+++ b/components/kubernetes/Apply_object/component.yaml
@@ -8,6 +8,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/kubernetes/Apply_object/component.yaml'
 implementation:
   container:
     image: bitnami/kubectl:1.17.17

--- a/components/kubernetes/Create_PersistentVolumeClaim/component.yaml
+++ b/components/kubernetes/Create_PersistentVolumeClaim/component.yaml
@@ -7,6 +7,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/kubernetes/Create_PersistentVolumeClaim/component.yaml'
 implementation:
   container:
     image: bitnami/kubectl:1.17.17

--- a/components/kubernetes/Create_object/component.yaml
+++ b/components/kubernetes/Create_object/component.yaml
@@ -8,6 +8,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/kubernetes/Create_object/component.yaml'
 implementation:
   container:
     image: bitnami/kubectl:1.17.17

--- a/components/kubernetes/Delete_object/component.yaml
+++ b/components/kubernetes/Delete_object/component.yaml
@@ -8,6 +8,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/kubernetes/Delete_object/component.yaml'
 implementation:
   container:
     image: bitnami/kubectl:1.17.17

--- a/components/kubernetes/Get_object/component.yaml
+++ b/components/kubernetes/Get_object/component.yaml
@@ -7,6 +7,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/kubernetes/Get_object/component.yaml'
 implementation:
   container:
     image: bitnami/kubectl:1.17.17

--- a/components/ml_metrics/Aggregate_regression_metrics/component.py
+++ b/components/ml_metrics/Aggregate_regression_metrics/component.py
@@ -54,6 +54,6 @@ if __name__ == '__main__':
         base_image='python:3.7',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/ml_metrics/Aggregate_regression_metrics/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/ml_metrics/Aggregate_regression_metrics/component.yaml",
         },
     )

--- a/components/ml_metrics/Aggregate_regression_metrics/component.py
+++ b/components/ml_metrics/Aggregate_regression_metrics/component.py
@@ -54,5 +54,6 @@ if __name__ == '__main__':
         base_image='python:3.7',
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/ml_metrics/Aggregate_regression_metrics/component.py",
         },
     )

--- a/components/ml_metrics/Aggregate_regression_metrics/component.yaml
+++ b/components/ml_metrics/Aggregate_regression_metrics/component.yaml
@@ -20,6 +20,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/ml_metrics/Aggregate_regression_metrics/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/ml_metrics/Calculate_regression_metrics/from_CSV/component.py
+++ b/components/ml_metrics/Calculate_regression_metrics/from_CSV/component.py
@@ -65,5 +65,6 @@ if __name__ == '__main__':
         packages_to_install=['numpy==1.19.0'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/ml_metrics/Calculate_regression_metrics/from_CSV/component.py",
         },
     )

--- a/components/ml_metrics/Calculate_regression_metrics/from_CSV/component.py
+++ b/components/ml_metrics/Calculate_regression_metrics/from_CSV/component.py
@@ -65,6 +65,6 @@ if __name__ == '__main__':
         packages_to_install=['numpy==1.19.0'],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/ml_metrics/Calculate_regression_metrics/from_CSV/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/ml_metrics/Calculate_regression_metrics/from_CSV/component.yaml",
         },
     )

--- a/components/ml_metrics/Calculate_regression_metrics/from_CSV/component.yaml
+++ b/components/ml_metrics/Calculate_regression_metrics/from_CSV/component.yaml
@@ -4,6 +4,10 @@ description: |-
 
       Annotations:
           author: Alexey Volkov <alexey.volkov@ark-kun.com>
+metadata:
+  annotations: 
+    author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/ml_metrics/Calculate_regression_metrics/from_CSV/component.yaml'
 inputs:
 - {name: true_values}
 - {name: predicted_values}

--- a/components/notebooks/Run_notebook_using_papermill/component.yaml
+++ b/components/notebooks/Run_notebook_using_papermill/component.yaml
@@ -13,6 +13,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/notebooks/Run_notebook_using_papermill/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/pandas/Transform_DataFrame/in_ApacheParquet_format/component.py
+++ b/components/pandas/Transform_DataFrame/in_ApacheParquet_format/component.py
@@ -42,6 +42,6 @@ if __name__ == '__main__':
         ],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/pandas/Transform_DataFrame/in_ApacheParquet_format/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/pandas/Transform_DataFrame/in_ApacheParquet_format/component.yaml",
         },
     )

--- a/components/pandas/Transform_DataFrame/in_ApacheParquet_format/component.py
+++ b/components/pandas/Transform_DataFrame/in_ApacheParquet_format/component.py
@@ -42,5 +42,6 @@ if __name__ == '__main__':
         ],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/pandas/Transform_DataFrame/in_ApacheParquet_format/component.py",
         },
     )

--- a/components/pandas/Transform_DataFrame/in_ApacheParquet_format/component.yaml
+++ b/components/pandas/Transform_DataFrame/in_ApacheParquet_format/component.yaml
@@ -24,6 +24,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/pandas/Transform_DataFrame/in_ApacheParquet_format/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/pandas/Transform_DataFrame/in_CSV_format/component.py
+++ b/components/pandas/Transform_DataFrame/in_CSV_format/component.py
@@ -46,5 +46,6 @@ if __name__ == '__main__':
         ],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/pandas/Transform_DataFrame/in_CSV_format/component.py",
         },
     )

--- a/components/pandas/Transform_DataFrame/in_CSV_format/component.py
+++ b/components/pandas/Transform_DataFrame/in_CSV_format/component.py
@@ -46,6 +46,6 @@ if __name__ == '__main__':
         ],
         annotations={
             "author": "Alexey Volkov <alexey.volkov@ark-kun.com>",
-            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/pandas/Transform_DataFrame/in_CSV_format/component.py",
+            "canonical_location": "https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/pandas/Transform_DataFrame/in_CSV_format/component.yaml",
         },
     )

--- a/components/pandas/Transform_DataFrame/in_CSV_format/component.yaml
+++ b/components/pandas/Transform_DataFrame/in_CSV_format/component.yaml
@@ -24,6 +24,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/pandas/Transform_DataFrame/in_CSV_format/component.yaml'
 implementation:
   container:
     image: python:3.7

--- a/components/sample/C#_script/component.yaml
+++ b/components/sample/C#_script/component.yaml
@@ -7,6 +7,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/sample/C#_script/component.yaml'
 implementation:
   container:
     image: mcr.microsoft.com/dotnet/sdk:5.0

--- a/components/sample/Python_script/component.yaml
+++ b/components/sample/Python_script/component.yaml
@@ -7,6 +7,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/sample/Python_script/component.yaml'
 implementation:
   container:
     image: python:3.8

--- a/components/sample/R_script/component.yaml
+++ b/components/sample/R_script/component.yaml
@@ -7,6 +7,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/sample/R_script/component.yaml'
 implementation:
   container:
     image: r-base:4.0.2

--- a/components/sample/Shell_script/component.yaml
+++ b/components/sample/Shell_script/component.yaml
@@ -7,6 +7,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/sample/Shell_script/component.yaml'
 implementation:
   container:
     image: alpine

--- a/components/sample/keras/train_classifier/component.yaml
+++ b/components/sample/keras/train_classifier/component.yaml
@@ -13,6 +13,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/sample/keras/train_classifier/component.yaml'
 implementation:
   container:
     image: gcr.io/ml-pipeline/sample/keras/train_classifier

--- a/components/tables/Remove_header/component.yaml
+++ b/components/tables/Remove_header/component.yaml
@@ -3,6 +3,7 @@ description: Remove the header line from CSV and TSV data (unconditionally)
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/tables/Remove_header/component.yaml'
 inputs:
 - name: table
 outputs:

--- a/components/tensorflow/tensorboard/prepare_tensorboard/component.yaml
+++ b/components/tensorflow/tensorboard/prepare_tensorboard/component.yaml
@@ -12,6 +12,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/tensorflow/tensorboard/prepare_tensorboard/component.yaml'
 implementation:
   container:
     image: alpine

--- a/components/web/Download/component-sdk-v2.yaml
+++ b/components/web/Download/component-sdk-v2.yaml
@@ -8,6 +8,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/web/Download/component.yaml'
 implementation:
   container:
     image: byrnedo/alpine-curl@sha256:548379d0a4a0c08b9e55d9d87a592b7d35d9ab3037f4936f5ccd09d0b625a342

--- a/components/web/Download/component.yaml
+++ b/components/web/Download/component.yaml
@@ -7,6 +7,7 @@ outputs:
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/web/Download/component.yaml'
 implementation:
   container:
     # image: curlimages/curl  # Sets a non-root user which cannot write to mounted volumes. See https://github.com/curl/curl-docker/issues/22

--- a/sdk/my_component.py
+++ b/sdk/my_component.py
@@ -1,0 +1,20 @@
+from kfp.components.structures import *
+
+my_component_spec = ComponentSpec(
+    inputs=[
+        InputSpec(name="Input1", type="String", default="Hello"),
+        InputSpec(name="Input2", type="CSV"),
+    ],
+    outputs=[
+        OutputSpec(name="Output1", type="CSV"),
+    ],
+    implementation=ContainerImplementation(container=ContainerSpec(
+        image="busybox",
+        command=[
+            "my_program.sh",
+            "--input-1", InputValuePlaceholder(input_name="Input1"),
+            "--input-2-path", InputPathPlaceholder(input_name="Input2"),
+            "--output-1-path", OutputPathPlaceholder(output_name="Output1"),
+        ],
+    )),
+)


### PR DESCRIPTION
As discussed offline, the canonical locations help users find the original location of components even when people fork the KFP repo or copy the components to different places.