### PR TITLE
fix(backend): argo uri in dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,7 +16,7 @@ RUN python3 -m pip install -r requirements.txt --no-cache-dir
 
 # Downloading Argo CLI so that the samples are validated
 ENV ARGO_VERSION v2.12.9
-RUN curl -sLO https://github.com/argoproj/argo/releases/download/${ARGO_VERSION}/argo-linux-amd64.gz && \
+RUN curl -sLO https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-amd64.gz && \
   gunzip argo-linux-amd64.gz && \
   chmod +x argo-linux-amd64 && \
   mv ./argo-linux-amd64 /usr/local/bin/argo


### PR DESCRIPTION
argo repo download uri had changed to 'argo-workflows',and previous version would run into 'not found'.
