### PR TITLE
feat(sdk): Surface kubernetes configuration in container builder

### DIFF
--- a/sdk/python/kfp/containers/_container_builder.py
+++ b/sdk/python/kfp/containers/_container_builder.py
@@ -56,7 +56,7 @@ class ContainerBuilder(object):
   ContainerBuilder helps build a container image
   """
   def __init__(self, gcs_staging=None, default_image_name=None, namespace=None,
-               service_account='kubeflow-pipelines-container-builder', kaniko_executor_image=KANIKO_EXECUTOR_IMAGE_DEFAULT):
+               service_account='kubeflow-pipelines-container-builder', kaniko_executor_image=KANIKO_EXECUTOR_IMAGE_DEFAULT, kubernetes_configuration=None):
     """
     Args:
       gcs_staging (str): GCS bucket/blob that can store temporary build files,
@@ -71,6 +71,8 @@ class ContainerBuilder(object):
           The default value is "kubeflow-pipelines-container-builder". It works with Kubeflow Pipelines clusters installed using Google Cloud Marketplace or Standalone with version > 0.4.0.
           The service account should have permission to read and write from staging gcs path and upload built images to gcr.io.
       kaniko_executor_image (str): Docker image used to run kaniko executor. Defaults to gcr.io/kaniko-project/executor:v0.10.0.
+      kubernetes_configuration (kubernetes.Configuration): Kubernetes client configuration object to be used when talking with Kubernetes API.
+        This is optional. If not specified, it will use the default configuration. This can be used to personalize the client used to talk to the Kubernetes server and change authentication parameters.
     """
     self._gcs_staging = gcs_staging
     self._gcs_staging_checked = False
@@ -78,6 +80,7 @@ class ContainerBuilder(object):
     self._namespace = namespace
     self._service_account = service_account
     self._kaniko_image = kaniko_executor_image
+    self._kubernetes_configuration = kubernetes_configuration
 
   def _get_namespace(self):
     if self._namespace is None:
@@ -183,7 +186,7 @@ class ContainerBuilder(object):
                                                target_image=target_image)
       logging.info('Start a kaniko job for build.')
       from ._k8s_job_helper import K8sJobHelper
-      k8s_helper = K8sJobHelper()
+      k8s_helper = K8sJobHelper(self._kubernetes_configuration)
       result_pod_obj = k8s_helper.run_job(kaniko_spec, timeout)
       logging.info('Kaniko job complete.')
 

--- a/sdk/python/kfp/containers/_container_builder.py
+++ b/sdk/python/kfp/containers/_container_builder.py
@@ -56,7 +56,7 @@ class ContainerBuilder(object):
   ContainerBuilder helps build a container image
   """
   def __init__(self, gcs_staging=None, default_image_name=None, namespace=None,
-               service_account='kubeflow-pipelines-container-builder', kaniko_executor_image=KANIKO_EXECUTOR_IMAGE_DEFAULT, kubernetes_configuration=None):
+               service_account='kubeflow-pipelines-container-builder', kaniko_executor_image=KANIKO_EXECUTOR_IMAGE_DEFAULT, k8s_client_configuration=None):
     """
     Args:
       gcs_staging (str): GCS bucket/blob that can store temporary build files,
@@ -71,7 +71,7 @@ class ContainerBuilder(object):
           The default value is "kubeflow-pipelines-container-builder". It works with Kubeflow Pipelines clusters installed using Google Cloud Marketplace or Standalone with version > 0.4.0.
           The service account should have permission to read and write from staging gcs path and upload built images to gcr.io.
       kaniko_executor_image (str): Docker image used to run kaniko executor. Defaults to gcr.io/kaniko-project/executor:v0.10.0.
-      kubernetes_configuration (kubernetes.Configuration): Kubernetes client configuration object to be used when talking with Kubernetes API.
+      k8s_client_configuration (kubernetes.Configuration): Kubernetes client configuration object to be used when talking with Kubernetes API.
         This is optional. If not specified, it will use the default configuration. This can be used to personalize the client used to talk to the Kubernetes server and change authentication parameters.
     """
     self._gcs_staging = gcs_staging
@@ -80,7 +80,7 @@ class ContainerBuilder(object):
     self._namespace = namespace
     self._service_account = service_account
     self._kaniko_image = kaniko_executor_image
-    self._kubernetes_configuration = kubernetes_configuration
+    self._k8s_client_configuration = k8s_client_configuration
 
   def _get_namespace(self):
     if self._namespace is None:
@@ -186,7 +186,7 @@ class ContainerBuilder(object):
                                                target_image=target_image)
       logging.info('Start a kaniko job for build.')
       from ._k8s_job_helper import K8sJobHelper
-      k8s_helper = K8sJobHelper(self._kubernetes_configuration)
+      k8s_helper = K8sJobHelper(self._k8s_client_configuration)
       result_pod_obj = k8s_helper.run_job(kaniko_spec, timeout)
       logging.info('Kaniko job complete.')
 

--- a/sdk/python/kfp/containers/_k8s_job_helper.py
+++ b/sdk/python/kfp/containers/_k8s_job_helper.py
@@ -23,16 +23,16 @@ import os
 class K8sJobHelper(object):
   """ Kubernetes Helper """
 
-  def __init__(self):
-    if not self._configure_k8s():
+  def __init__(self, kubernetes_configuration=None):
+    if not self._configure_k8s(kubernetes_configuration):
       raise Exception('K8sHelper __init__ failure')
 
-  def _configure_k8s(self):
+  def _configure_k8s(self, kubernetes_configuration=None):
     k8s_config_file = os.environ.get('KUBECONFIG')
     if k8s_config_file:
       try:
         logging.info('Loading kubernetes config from the file %s', k8s_config_file)
-        config.load_kube_config(config_file=k8s_config_file)
+        config.load_kube_config(config_file=k8s_config_file, client_configuration=kubernetes_configuration)
       except Exception as e:
         raise RuntimeError('Can not load kube config from the file %s, error: %s', k8s_config_file, e)
     else:
@@ -42,7 +42,7 @@ class K8sJobHelper(object):
       except:
         logging.info('Cannot find in-cluster config, trying the local kubernetes config. ')
         try:
-          config.load_kube_config()
+          config.load_kube_config(client_configuration=kubernetes_configuration)
           logging.info('Found local kubernetes config. Initialized with kube_config.')
         except:
           raise RuntimeError('Forgot to run the gcloud command? Check out the link: \

--- a/sdk/python/kfp/containers/_k8s_job_helper.py
+++ b/sdk/python/kfp/containers/_k8s_job_helper.py
@@ -23,16 +23,16 @@ import os
 class K8sJobHelper(object):
   """ Kubernetes Helper """
 
-  def __init__(self, kubernetes_configuration=None):
-    if not self._configure_k8s(kubernetes_configuration):
+  def __init__(self, k8s_client_configuration=None):
+    if not self._configure_k8s(k8s_client_configuration):
       raise Exception('K8sHelper __init__ failure')
 
-  def _configure_k8s(self, kubernetes_configuration=None):
+  def _configure_k8s(self, k8s_client_configuration=None):
     k8s_config_file = os.environ.get('KUBECONFIG')
     if k8s_config_file:
       try:
         logging.info('Loading kubernetes config from the file %s', k8s_config_file)
-        config.load_kube_config(config_file=k8s_config_file, client_configuration=kubernetes_configuration)
+        config.load_kube_config(config_file=k8s_config_file, client_configuration=k8s_client_configuration)
       except Exception as e:
         raise RuntimeError('Can not load kube config from the file %s, error: %s', k8s_config_file, e)
     else:
@@ -42,7 +42,7 @@ class K8sJobHelper(object):
       except:
         logging.info('Cannot find in-cluster config, trying the local kubernetes config. ')
         try:
-          config.load_kube_config(client_configuration=kubernetes_configuration)
+          config.load_kube_config(client_configuration=k8s_client_configuration)
           logging.info('Found local kubernetes config. Initialized with kube_config.')
         except:
           raise RuntimeError('Forgot to run the gcloud command? Check out the link: \


### PR DESCRIPTION
**Description of your changes:**

Python Kubernetes SDK doesn't handle well tokens that expire. [GCP default authentication](https://github.com/kubernetes-client/python-base/blob/b4d3aad42dc23e7a6c0e5c032691f8dc385a786c/config/kube_config.py#L577) has set its own custom refresh token, but for other kubernetes API authentication mechanisms it's not trivial to implement.

In order to customize authentication, users of the python sdk can customize the [client configuration object](https://github.com/kubernetes-client/python/blob/master/kubernetes/client/configuration.py) to set a custom `refresh_api_key_hook` and provide it to `load_kube_config`.

With this change, in ContainerBuilder, we can inject a custom client configuration that will be used by the client to check the kaniko execution.


I avoided setting it for `load_incluster_config` as usually that uses the internal token provider in the cluster and therefore has less need to be customized. To avoid confusion, I can name it `kubernetes_outcluster_configuration`?

Related issues: https://github.com/kubernetes-client/python/issues/741
