### PR TITLE
chore: Avoid mutable default arguments

### DIFF
--- a/samples/test/util.py
+++ b/samples/test/util.py
@@ -163,8 +163,9 @@ def _run_test(callback):
             mode: kfp.dsl.PipelineExecutionMode = kfp.dsl.PipelineExecutionMode.
             V2_COMPATIBLE,
             enable_caching: bool = False,
-            arguments: dict = {},
+            arguments: Optional[dict] = None,
         ) -> kfp_server_api.ApiRunDetail:
+            arguments = arguments or {}
             extra_arguments = {}
             if mode != kfp.dsl.PipelineExecutionMode.V1_LEGACY:
                 extra_arguments = {


### PR DESCRIPTION
**Description of your changes:**
In general, we should avoid using mutable default arguments. It's a common mistake that may cause unexpected behavior at some point. See https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
