### PR TITLE
fix(sorting): use array index as key for TableRow

### DIFF
--- a/frontend/src/components/viewers/PagedTable.tsx
+++ b/frontend/src/components/viewers/PagedTable.tsx
@@ -126,12 +126,11 @@ class PagedTable extends Viewer<PagedTableProps, PagedTableState> {
           </TableHead>
 
           <TableBody>
-            {/* TODO: bug: sorting keeps appending items */}
             {this._stableSort(data)
               .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-              .map(row => {
+              .map((row, index) => {
                 return (
-                  <TableRow hover={true} tabIndex={-1} key={row[0]} className={this._css.row}>
+                  <TableRow hover={true} tabIndex={-1} key={index} className={this._css.row}>
                     {row.map((cell, i) => (
                       <TableCell key={i} className={this._css.cell}>
                         {cell}

--- a/frontend/src/components/viewers/__snapshots__/PagedTable.test.tsx.snap
+++ b/frontend/src/components/viewers/__snapshots__/PagedTable.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`PagedTable renders simple data 1`] = `
       <WithStyles(TableRow)
         className="row"
         hover={true}
-        key="col1"
+        key="0"
         tabIndex={-1}
       >
         <WithStyles(TableCell)
@@ -151,7 +151,7 @@ exports[`PagedTable renders simple data 1`] = `
       <WithStyles(TableRow)
         className="row"
         hover={true}
-        key="col4"
+        key="1"
         tabIndex={-1}
       >
         <WithStyles(TableCell)
@@ -221,7 +221,7 @@ exports[`PagedTable renders simple data without labels 1`] = `
       <WithStyles(TableRow)
         className="row"
         hover={true}
-        key="col1"
+        key="0"
         tabIndex={-1}
       >
         <WithStyles(TableCell)
@@ -246,7 +246,7 @@ exports[`PagedTable renders simple data without labels 1`] = `
       <WithStyles(TableRow)
         className="row"
         hover={true}
-        key="col4"
+        key="1"
         tabIndex={-1}
       >
         <WithStyles(TableCell)
@@ -371,7 +371,7 @@ exports[`PagedTable sorts on first column ascending 1`] = `
       <WithStyles(TableRow)
         className="row"
         hover={true}
-        key="col1"
+        key="0"
         tabIndex={-1}
       >
         <WithStyles(TableCell)
@@ -396,7 +396,7 @@ exports[`PagedTable sorts on first column ascending 1`] = `
       <WithStyles(TableRow)
         className="row"
         hover={true}
-        key="col4"
+        key="1"
         tabIndex={-1}
       >
         <WithStyles(TableCell)
@@ -521,7 +521,7 @@ exports[`PagedTable sorts on first column descending 1`] = `
       <WithStyles(TableRow)
         className="row"
         hover={true}
-        key="col4"
+        key="0"
         tabIndex={-1}
       >
         <WithStyles(TableCell)
@@ -546,7 +546,7 @@ exports[`PagedTable sorts on first column descending 1`] = `
       <WithStyles(TableRow)
         className="row"
         hover={true}
-        key="col1"
+        key="1"
         tabIndex={-1}
       >
         <WithStyles(TableCell)


### PR DESCRIPTION
**Description of your changes:**

We noticed that the PagedTable component was rendering "duplicated values".
Basically it was not rendering the new data, it was comparing the changes with the new ones and creating the update patch.
The `key` for each row of the `TableRow` from material-ui should be unique, which was not being respected if we use the value from the data that should be rendered.

Basically this just uses the index from the sorted data as `key` for the `TableRow` component and that's it.

You can check this working here: https://codesandbox.io/s/zen-fermi-b2k6b?file=/demo.tsx
This is a small port from this repository with static data and labels, just for test purpose.

Please let us know if you do not agree, we are more than pleased to change accordingly your needs.

Thanks 🙇 


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 