### PR TITLE
chore(sdk): Argo lint requires '--kinds=workflows' argument for offline linting. 

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -1160,7 +1160,7 @@ def _run_argo_lint(yaml_text: str):
   import subprocess
   argo_path = shutil.which('argo')
   if argo_path:
-    result = subprocess.run([argo_path, '--offline=true', 'lint', '/dev/stdin'], input=yaml_text.encode('utf-8'), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result = subprocess.run([argo_path, '--offline=true', '--kinds=workflows', 'lint', '/dev/stdin'], input=yaml_text.encode('utf-8'), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if result.returncode:
       if re.match(
           pattern=r'.+failed to resolve {{tasks\..+\.outputs\.artifacts\..+}}.+',


### PR DESCRIPTION
**Description of your changes:**
From the docs of argo lint: 

```
--kinds strings   Which kinds will be linted. Can be: workflows|workflowtemplates|cronworkflows|clusterworkflowtemplates (default [all])
```

To validate:
```
cd pipelines/samples/core/resource_spec
python runtime_resource_request.py
argo --offline=true --kinds=workflows lint runtime_resource_request.py.yaml
```

expected output:

```
no linting errors found!
```

Sorry that i missed it forgot, and looked at the integration test that passed only. Will see if I can make a test to check the validation as part of the test suite. . 

The offline linting is only able to handled `workflows`(which is the only argo resource type used in kubeflow of `workflows|workflowtemplates|cronworkflows|clusterworkflowtemplates` ), I missed this in the PR #5981 as commented by here: https://github.com/kubeflow/pipelines/pull/5981#issuecomment-886387502

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
