### PR TITLE
chore: Fix error building component

### DIFF
--- a/components/gcp/container/Dockerfile
+++ b/components/gcp/container/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.7-slim
+FROM python:3.7
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	wget patch \


### PR DESCRIPTION
I saw the error otherwise
```
 unable to execute 'gcc': No such file or directory
  error: command 'gcc' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for google-cloud-profiler
    ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python3 -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-i1on4ezh/google-cloud-profiler_b49199e7f8bd42c685afdffc8a4294bc/setup.py'"'"'; __file__='"'"'/tmp/pip-install-
```

**Description of your changes:**


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
