### PR TITLE
feat(frontend): Introduce pipeline detail v2 page. Fix #6179

### DIFF
--- a/frontend/src/Css.tsx
+++ b/frontend/src/Css.tsx
@@ -31,7 +31,7 @@ export const color = {
   graphBg: '#f2f2f2',
   grey: '#5f6368', // Google grey 500
   inactive: '#5f6368',
-  lightGrey: '#eee', // Google grey 200
+  lightGrey: '#eeeeee', // Google grey 200
   lowContrast: '#80868b', // Google grey 600
   secondaryText: 'rgba(0, 0, 0, .88)',
   separator: '#e8e8e8',

--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -48,6 +48,7 @@ import { commonCss } from '../Css';
 import NewPipelineVersion from '../pages/NewPipelineVersion';
 import { GettingStarted } from '../pages/GettingStarted';
 import { KFP_FLAGS, Deployments } from '../lib/Flags';
+import PipelineDetailsV2 from 'src/pages/PipelineDetailsV2';
 
 export type RouteConfig = {
   path: string;
@@ -108,6 +109,7 @@ export const RoutePage = {
   PIPELINES: '/pipelines',
   PIPELINE_DETAILS: `/pipelines/details/:${RouteParams.pipelineId}/version/:${RouteParams.pipelineVersionId}?`,
   PIPELINE_DETAILS_NO_VERSION: `/pipelines/details/:${RouteParams.pipelineId}?`, // pipelineId is optional
+  PIPELINE_DETAILS_NO_VERSION_V2: `/v2/pipelines/details`, // pipelineId is optional
   RUNS: '/runs',
   RUN_DETAILS: `/runs/details/:${RouteParams.runId}`,
   RECURRING_RUNS: '/recurringruns',
@@ -191,6 +193,7 @@ const Router: React.FC<RouterProps> = ({ configs }) => {
     { path: RoutePage.RECURRING_RUN_DETAILS, Component: RecurringRunDetails },
     { path: RoutePage.RUN_DETAILS, Component: RunDetails },
     { path: RoutePage.COMPARE, Component: Compare },
+    { path: RoutePage.PIPELINE_DETAILS_NO_VERSION_V2, Component: PipelineDetailsV2 },
   ];
 
   return (

--- a/frontend/src/components/__snapshots__/Router.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Router.test.tsx.snap
@@ -128,6 +128,12 @@ exports[`Router initial render 1`] = `
       path="/compare"
       render={[Function]}
     />
+    <Route
+      exact={true}
+      key="20"
+      path="/v2/pipelines/details"
+      render={[Function]}
+    />
     <Route>
       <RoutedPage />
     </Route>

--- a/frontend/src/lib/Buttons.ts
+++ b/frontend/src/lib/Buttons.ts
@@ -371,7 +371,7 @@ export default class Buttons {
 
   public visualizeIRPipeline(): Buttons {
     this._map[ButtonKeys.VISUALIZE_IR_PIPELINE] = {
-      action: () => null,
+      action: () => this._pipelineDetailV2(),
       icon: ExtensionIcon,
       id: 'visIRPipelineBtn',
       outlined: true,
@@ -905,5 +905,9 @@ export default class Buttons {
       'Archive',
       'experiment',
     );
+  }
+
+  private _pipelineDetailV2(): void {
+    this._props.history.push(RoutePage.PIPELINE_DETAILS_NO_VERSION_V2);
   }
 }

--- a/frontend/src/pages/PipelineDetailsV2.test.tsx
+++ b/frontend/src/pages/PipelineDetailsV2.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import * as React from 'react';
 import { CommonTestWrapper } from 'src/TestWrapper';
 import { testBestPractices } from '../TestUtils';
@@ -34,11 +34,11 @@ describe('PipelineDetailsV2', () => {
   });
 
   it('Render detail page with reactflow', async () => {
-    const { container } = render(
+    render(
       <CommonTestWrapper>
         <PipelineDetailsV2></PipelineDetailsV2>
       </CommonTestWrapper>,
     );
-    expect(container.querySelector('.react-flow__pane')).not.toBeNull();
+    expect(screen.getByTestId('StaticCanvas')).not.toBeNull();
   });
 });

--- a/frontend/src/pages/PipelineDetailsV2.test.tsx
+++ b/frontend/src/pages/PipelineDetailsV2.test.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { CommonTestWrapper } from 'src/TestWrapper';
+import { testBestPractices } from '../TestUtils';
+import PipelineDetailsV2 from './PipelineDetailsV2';
+
+testBestPractices();
+describe('PipelineDetailsV2', () => {
+  beforeEach(() => {
+    // Required by reactflow render.
+    window.ResizeObserver =
+      window.ResizeObserver ||
+      jest.fn().mockImplementation(() => ({
+        disconnect: jest.fn(),
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+      }));
+  });
+
+  it('Render detail page with reactflow', async () => {
+    const { container } = render(
+      <CommonTestWrapper>
+        <PipelineDetailsV2></PipelineDetailsV2>
+      </CommonTestWrapper>,
+    );
+    expect(container.querySelector('.react-flow__pane')).not.toBeNull();
+  });
+});

--- a/frontend/src/pages/PipelineDetailsV2.tsx
+++ b/frontend/src/pages/PipelineDetailsV2.tsx
@@ -14,25 +14,20 @@
  * limitations under the License.
  */
 import React from 'react';
+import { commonCss } from '../Css';
+import StaticCanvas from './v2/StaticCanvas';
 
 interface PipelineDetailsV2Props {}
 
-export const PipelineDetailsV2: React.FC<PipelineDetailsV2Props> = props => {
-  const samples = ['1', '2'];
-
-  const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {};
+const PipelineDetailsV2: React.FC<PipelineDetailsV2Props> = () => {
   return (
-    <div style={{ display: 'flex', flexFlow: 'row wrap', justifyContent: 'flex-start' }}>
-      <div style={{ margin: 'auto' }}>
-        <select onChange={handleSelectChange}>
-          {samples.map(sample => {
-            return <option value={sample}>{sample}</option>;
-          })}
-        </select>
-      </div>
-      <div style={{ margin: 'auto' }}>
-        <PipelineIRDialog onSubmit={onSubmit}></PipelineIRDialog>
+    <div className={commonCss.page}>
+      <div className={commonCss.page} style={{ position: 'relative', overflow: 'hidden' }}>
+        <StaticCanvas elements={[]}></StaticCanvas>
+        {/* <div>{pipelineIR}</div> */}
       </div>
     </div>
   );
 };
+
+export default PipelineDetailsV2;

--- a/frontend/src/pages/PipelineDetailsV2.tsx
+++ b/frontend/src/pages/PipelineDetailsV2.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+
+interface PipelineDetailsV2Props {}
+
+export const PipelineDetailsV2: React.FC<PipelineDetailsV2Props> = props => {
+  const samples = ['1', '2'];
+
+  const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {};
+  return (
+    <div style={{ display: 'flex', flexFlow: 'row wrap', justifyContent: 'flex-start' }}>
+      <div style={{ margin: 'auto' }}>
+        <select onChange={handleSelectChange}>
+          {samples.map(sample => {
+            return <option value={sample}>{sample}</option>;
+          })}
+        </select>
+      </div>
+      <div style={{ margin: 'auto' }}>
+        <PipelineIRDialog onSubmit={onSubmit}></PipelineIRDialog>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/v2/StaticCanvas.tsx
+++ b/frontend/src/pages/v2/StaticCanvas.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface StaticCanvas {
+  elements: Elements;
+  namespaces: string[];
+  doubleClickNode: (node: Node) => void;
+  setNamespaces: (namespaces: string[]) => void;
+}
+
+const StaticCanvas = ({ elements, namespaces, doubleClickNode, setNamespaces }: StaticCanvas) => {
+  return (
+    <>
+      <SubDagNamespace namespaces={namespaces} setNamespaces={setNamespaces}></SubDagNamespace>
+      <ReactFlowProvider>
+        <ReactFlow
+          style={{ background: '#f2f2f2' }}
+          elements={elements}
+          snapToGrid={true}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          key='edges'
+          onElementClick={(event, element) => {
+            console.log(event);
+            console.log(element);
+          }}
+          onNodeDoubleClick={(event, element) => {
+            doubleClickNode(element as Node);
+          }}
+        >
+          <MiniMap />
+          <Controls />
+          <Background variant={BackgroundVariant.Dots} />
+        </ReactFlow>
+      </ReactFlowProvider>
+    </>
+  );
+};
+export default StaticCanvas;

--- a/frontend/src/pages/v2/StaticCanvas.tsx
+++ b/frontend/src/pages/v2/StaticCanvas.tsx
@@ -30,19 +30,21 @@ export interface StaticCanvasProps {
 
 const StaticCanvas = ({ elements }: StaticCanvasProps) => {
   return (
-    <ReactFlowProvider>
-      <ReactFlow
-        style={{ background: color.lightGrey }}
-        elements={elements}
-        snapToGrid={true}
-        nodeTypes={{}}
-        edgeTypes={{}}
-      >
-        <MiniMap />
-        <Controls />
-        <Background />
-      </ReactFlow>
-    </ReactFlowProvider>
+    <div data-testid='StaticCanvas'>
+      <ReactFlowProvider>
+        <ReactFlow
+          style={{ background: color.lightGrey }}
+          elements={elements}
+          snapToGrid={true}
+          nodeTypes={{}}
+          edgeTypes={{}}
+        >
+          <MiniMap />
+          <Controls />
+          <Background />
+        </ReactFlow>
+      </ReactFlowProvider>
+    </div>
   );
 };
 export default StaticCanvas;

--- a/frontend/src/pages/v2/StaticCanvas.tsx
+++ b/frontend/src/pages/v2/StaticCanvas.tsx
@@ -14,39 +14,35 @@
  * limitations under the License.
  */
 
-export interface StaticCanvas {
+import React from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  Elements,
+  MiniMap,
+  ReactFlowProvider,
+} from 'react-flow-renderer';
+import { color } from 'src/Css';
+
+export interface StaticCanvasProps {
   elements: Elements;
-  namespaces: string[];
-  doubleClickNode: (node: Node) => void;
-  setNamespaces: (namespaces: string[]) => void;
 }
 
-const StaticCanvas = ({ elements, namespaces, doubleClickNode, setNamespaces }: StaticCanvas) => {
+const StaticCanvas = ({ elements }: StaticCanvasProps) => {
   return (
-    <>
-      <SubDagNamespace namespaces={namespaces} setNamespaces={setNamespaces}></SubDagNamespace>
-      <ReactFlowProvider>
-        <ReactFlow
-          style={{ background: '#f2f2f2' }}
-          elements={elements}
-          snapToGrid={true}
-          nodeTypes={nodeTypes}
-          edgeTypes={edgeTypes}
-          key='edges'
-          onElementClick={(event, element) => {
-            console.log(event);
-            console.log(element);
-          }}
-          onNodeDoubleClick={(event, element) => {
-            doubleClickNode(element as Node);
-          }}
-        >
-          <MiniMap />
-          <Controls />
-          <Background variant={BackgroundVariant.Dots} />
-        </ReactFlow>
-      </ReactFlowProvider>
-    </>
+    <ReactFlowProvider>
+      <ReactFlow
+        style={{ background: color.lightGrey }}
+        elements={elements}
+        snapToGrid={true}
+        nodeTypes={{}}
+        edgeTypes={{}}
+      >
+        <MiniMap />
+        <Controls />
+        <Background />
+      </ReactFlow>
+    </ReactFlowProvider>
   );
 };
 export default StaticCanvas;


### PR DESCRIPTION
**Description of your changes:**

Fix https://github.com/kubeflow/pipelines/issues/6179

1. Page url: `https://kfp_domain/v2/pipeline/details`
2. Render reactflow canvas by default
3. Doesn't take pipeline ID yet, because we are blocked on backend API implementation.

Keeping the change simple in this PR, the main goal is to introduce the basic layout of V2 pipeline detail page. You can visit using `IR Pipeline` button after you enabled the V2 feature.

![emptysimplepipelinepagev2](https://user-images.githubusercontent.com/37026441/127240617-e366b225-1104-4ee4-b696-cc76c57bbf63.png)


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
