### PR TITLE
chore(components/google-cloud): Add uni tests for Custom_job_remote_runner

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/experimental/remote/gcp_launcher/custom_job_remote_runner.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/remote/gcp_launcher/custom_job_remote_runner.py
@@ -12,6 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import logging
+import os
+import time
+from os import path
+from google.cloud import aiplatform
+from google.cloud.aiplatform.compat.types import job_state as gca_job_state
+
+_POLLING_INTERVAL_IN_SECONDS = 20
+_CONNECTION_ERROR_RETRY_LIMIT = 5
+
+_JOB_COMPLETE_STATES = (
+    gca_job_state.JobState.JOB_STATE_SUCCEEDED,
+    gca_job_state.JobState.JOB_STATE_FAILED,
+    gca_job_state.JobState.JOB_STATE_CANCELLED,
+    gca_job_state.JobState.JOB_STATE_PAUSED,
+)
+
+_JOB_ERROR_STATES = (
+    gca_job_state.JobState.JOB_STATE_FAILED,
+    gca_job_state.JobState.JOB_STATE_CANCELLED,
+    gca_job_state.JobState.JOB_STATE_PAUSED,
+)
 
 def create_custom_job(
     type,
@@ -34,32 +57,6 @@ def create_custom_job(
 
   Also retry on ConnectionError up to _CONNECTION_ERROR_RETRY_LIMIT times during the poll.
   """
-
-    import json
-    import logging
-    import os
-    import time
-    from os import path
-    from google.cloud import aiplatform
-    from google.protobuf import json_format
-    from google.cloud.aiplatform.compat.types import job_state as gca_job_state
-
-    _POLLING_INTERVAL_IN_SECONDS = 20
-    _CONNECTION_ERROR_RETRY_LIMIT = 5
-
-    _JOB_COMPLETE_STATES = (
-        gca_job_state.JobState.JOB_STATE_SUCCEEDED,
-        gca_job_state.JobState.JOB_STATE_FAILED,
-        gca_job_state.JobState.JOB_STATE_CANCELLED,
-        gca_job_state.JobState.JOB_STATE_PAUSED,
-    )
-
-    _JOB_ERROR_STATES = (
-        gca_job_state.JobState.JOB_STATE_FAILED,
-        gca_job_state.JobState.JOB_STATE_CANCELLED,
-        gca_job_state.JobState.JOB_STATE_PAUSED,
-    )
-
     client_options = {"api_endpoint": gcp_region + '-aiplatform.googleapis.com'}
     # Initialize client that will be used to create and send requests.
     job_client = aiplatform.gapic.JobServiceClient(

--- a/components/google-cloud/tests/experimental/custom_job/test_custom_job.py
+++ b/components/google-cloud/tests/experimental/custom_job/test_custom_job.py
@@ -22,11 +22,10 @@ from kfp.v2 import dsl
 import textwrap
 
 
-class VertexAIUtilsTests(unittest.TestCase):
+class VertexAICustomJobUtilsTests(unittest.TestCase):
 
     def setUp(self):
-        super(VertexAIUtilsTests, self).setUp()
-        self.maxDiff = None
+        super(VertexAICustomJobUtilsTests, self).setUp()
         custom_job._DEFAULT_CUSTOM_JOB_CONTAINER_IMAGE = 'test_launcher_image'
 
     def _create_a_container_based_component(self) -> callable:

--- a/components/google-cloud/tests/experimental/remote/gcp_launcher/test_custom_job_remote_runner.py
+++ b/components/google-cloud/tests/experimental/remote/gcp_launcher/test_custom_job_remote_runner.py
@@ -1,0 +1,151 @@
+# Copyright 2021 The Kubeflow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test Vertex AI Custom Job Remote Runner Client module."""
+
+import json
+from logging import raiseExceptions
+from os import path
+import time
+import unittest
+from unittest import mock
+from google_cloud_pipeline_components.experimental.remote.gcp_launcher import custom_job_remote_runner
+from google.cloud import aiplatform
+from google.cloud.aiplatform.compat.types import job_state as gca_job_state
+
+
+class CustomJobRemoteRunnerUtilsTests(unittest.TestCase):
+
+    def setUp(self):
+        super(CustomJobRemoteRunnerUtilsTests, self).setUp()
+        self._payload = '{"display_name": "ContainerComponent", "job_spec": {"worker_pool_specs": [{"machine_spec": {"machine_type": "n1-standard-4"}, "replica_count": 1, "container_spec": {"image_uri": "google/cloud-sdk:latest", "command": ["sh", "-c", "set -e -x\\necho \\"$0, this is an output parameter\\"\\n", "{{$.inputs.parameters[\'input_text\']}}", "{{$.outputs.parameters[\'output_value\'].output_file}}"]}}]}}'
+        self._gcp_project = 'test_gcp_project'
+        self._gcp_region = 'test_region'
+        self._gcp_resouces_path = 'gcp_resouces'
+        self._type = 'CustomJob'
+
+    @mock.patch.object(aiplatform.gapic, 'JobServiceClient', autospec=True)
+    def test_custom_job_remote_runner_on_region_is_set_correctly_in_client_options(
+        self, mock_job_service_client
+    ):
+
+        job_client = mock.Mock()
+        mock_job_service_client.return_value = job_client
+
+        create_custom_job_response = mock.Mock()
+        job_client.create_custom_job.return_value = create_custom_job_response
+        create_custom_job_response.name = 'test_custom_job'
+
+        get_custom_job_response = mock.Mock()
+        job_client.get_custom_job.return_value = get_custom_job_response
+        get_custom_job_response.state = gca_job_state.JobState.JOB_STATE_SUCCEEDED
+
+        custom_job_remote_runner.create_custom_job(
+            self._type, self._gcp_project, self._gcp_region, self._payload,
+            self._gcp_resouces_path
+        )
+        mock_job_service_client.assert_called_once_with(
+            client_options={
+                'api_endpoint': 'test_region-aiplatform.googleapis.com'
+            }
+        )
+
+    @mock.patch.object(aiplatform.gapic, 'JobServiceClient', autospec=True)
+    @mock.patch.object(path, "exists", autospec=True)
+    def test_custom_job_remote_runner_on_payload_deserializes_correctly(
+        self, mock_path_exists, mock_job_service_client
+    ):
+
+        job_client = mock.Mock()
+        mock_job_service_client.return_value = job_client
+
+        create_custom_job_response = mock.Mock()
+        job_client.create_custom_job.return_value = create_custom_job_response
+        create_custom_job_response.name = 'test_custom_job'
+
+        get_custom_job_response = mock.Mock()
+        job_client.get_custom_job.return_value = get_custom_job_response
+        get_custom_job_response.state = gca_job_state.JobState.JOB_STATE_SUCCEEDED
+
+        mock_path_exists.return_value = False
+
+        custom_job_remote_runner.create_custom_job(
+            self._type, self._gcp_project, self._gcp_region, self._payload,
+            self._gcp_resouces_path
+        )
+
+        expected_parent = f"projects/{self._gcp_project}/locations/{self._gcp_region}"
+        expected_job_spec = json.loads(self._payload, strict=False)
+
+        job_client.create_custom_job.assert_called_once_with(
+            parent=expected_parent, custom_job=expected_job_spec
+        )
+
+    @mock.patch.object(aiplatform.gapic, 'JobServiceClient', autospec=True)
+    @mock.patch.object(path, "exists", autospec=True)
+    def test_custom_job_remote_runner_raises_exception_on_error(
+        self, mock_path_exists, mock_job_service_client
+    ):
+
+        job_client = mock.Mock()
+        mock_job_service_client.return_value = job_client
+
+        create_custom_job_response = mock.Mock()
+        job_client.create_custom_job.return_value = create_custom_job_response
+        create_custom_job_response.name = 'test_custom_job'
+
+        get_custom_job_response = mock.Mock()
+        job_client.get_custom_job.return_value = get_custom_job_response
+        get_custom_job_response.state = gca_job_state.JobState.JOB_STATE_FAILED
+
+        mock_path_exists.return_value = False
+
+        with self.assertRaises(RuntimeError):
+            custom_job_remote_runner.create_custom_job(
+                self._type, self._gcp_project, self._gcp_region, self._payload,
+                self._gcp_resouces_path
+            )
+
+    @mock.patch.object(aiplatform.gapic, 'JobServiceClient', autospec=True)
+    @mock.patch.object(path, "exists", autospec=True)
+    @mock.patch.object(time, "sleep", autospec=True)
+    def test_custom_job_remote_runner_retries_to_get_status_on_non_completed_job(
+        self, mock_time_sleep, mock_path_exists, mock_job_service_client
+    ):
+        job_client = mock.Mock()
+        mock_job_service_client.return_value = job_client
+
+        create_custom_job_response = mock.Mock()
+        job_client.create_custom_job.return_value = create_custom_job_response
+        create_custom_job_response.name = 'test_custom_job'
+
+        get_custom_job_response_success = mock.Mock()
+        get_custom_job_response_success.state = gca_job_state.JobState.JOB_STATE_SUCCEEDED
+
+        get_custom_job_response_running = mock.Mock()
+        get_custom_job_response_running.state = gca_job_state.JobState.JOB_STATE_RUNNING
+
+        job_client.get_custom_job.side_effect = [
+            get_custom_job_response_running, get_custom_job_response_success
+        ]
+
+        mock_path_exists.return_value = False
+
+        custom_job_remote_runner.create_custom_job(
+            self._type, self._gcp_project, self._gcp_region, self._payload,
+            self._gcp_resouces_path
+        )
+        mock_time_sleep.assert_called_once_with(
+            custom_job_remote_runner._POLLING_INTERVAL_IN_SECONDS
+        )
+        self.assertEqual(job_client.get_custom_job.call_count, 2)


### PR DESCRIPTION
Add 83% code coverage for `custom_job_remote_runner.py`

```
----------- coverage: platform linux, python 3.8.8-final-0 -----------
Name                                                                                                              Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------------------------------------------------------------------------
google_cloud_pipeline_components/__init__.py                                                                          2      0   100%
google_cloud_pipeline_components/aiplatform/__init__.py                                                              29      0   100%
google_cloud_pipeline_components/aiplatform/utils.py                                                                214     11    95%   68-69, 111, 116, 209-211, 316-317, 351-354
google_cloud_pipeline_components/experimental/__init__.py                                                             3      0   100%
google_cloud_pipeline_components/experimental/custom_job/__init__.py                                                  1      0   100%
google_cloud_pipeline_components/experimental/custom_job/custom_job.py                                               76      5    93%   88, 127, 150-154, 169
google_cloud_pipeline_components/experimental/remote/__init__.py                                                      1      0   100%
google_cloud_pipeline_components/experimental/remote/gcp_launcher/__init__.py                                         1      0   100%
google_cloud_pipeline_components/experimental/remote/gcp_launcher/custom_job_remote_runner.py                        42      7    83%   102-118
google_cloud_pipeline_components/experimental/remote/gcp_launcher/launcher.py                                        15     15     0%   15-32
google_cloud_pipeline_components/experimental/tensorflow_probability/anomaly_detection/tfp_anomaly_detection.py      66     59    11%   48-218, 222-226
google_cloud_pipeline_components/remote/aiplatform/remote_runner.py                                                 124     43    65%   84-95, 123-124, 141-142, 216, 226-245, 249-280, 284
google_cloud_pipeline_components/version.py                                                                           2      0   100%
```