### PR TITLE
fix(sdk): Fix hard-coded AI Platform endpoint

### DIFF
--- a/sdk/python/kfp/v2/google/client/schedule.py
+++ b/sdk/python/kfp/v2/google/client/schedule.py
@@ -32,7 +32,7 @@ from kfp.v2.google.client import runtime_config_builder
 _PROXY_FUNCTION_NAME = 'templated_http_request-v1'
 _PROXY_FUNCTION_FILENAME = '_cloud_function_templated_http_request.py'
 
-_CAIPP_DEFAULT_ENDPOINT = 'us-central1-aiplatform.googleapis.com'
+_CAIPP_DEFAULT_ENDPOINT = '{region}-aiplatform.googleapis.com'
 _CAIPP_SERVICE_NAME = 'aiplatform'
 _CAIPP_API_VERSION = 'v1beta1'
 
@@ -94,7 +94,8 @@ def create_from_pipeline_file(
     pipeline_dict['runtimeConfig'] = updated_runtime_config
 
   # Creating job creation request to get the final request URL
-  pipeline_jobs_api_url = f'https://{_CAIPP_DEFAULT_ENDPOINT}/{_CAIPP_API_VERSION}/projects/{project_id}/locations/{region}/pipelineJobs'
+  ciapp_endpoint = _CAIPP_DEFAULT_ENDPOINT.format(region=region)
+  pipeline_jobs_api_url = f'https://{ciapp_endpoint}/{_CAIPP_API_VERSION}/projects/{project_id}/locations/{region}/pipelineJobs'
 
   # Preparing the request body for the Cloud Function processing
   full_pipeline_name = pipeline_dict.get('name')


### PR DESCRIPTION
**Description of your changes:**
The region of the endpoint of the ai platform is hard-coded, so if the region you want to run is different from the hard-coded one, it will fail to kick the job from the cloud function.
![スクリーンショット 2021-08-02 19 07 56](https://user-images.githubusercontent.com/11388424/127844767-075271c6-4deb-4c14-9376-e2f7e772426d.png)


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
