### PR TITLE
chore(components/pytorch): Updating pytorch-kfp-component dependency list

### DIFF
--- a/components/PyTorch/pytorch-kfp-components/setup.py
+++ b/components/PyTorch/pytorch-kfp-components/setup.py
@@ -25,6 +25,7 @@ from setuptools import setup, find_packages
 def make_required_install_packages():
     return [
       "kfp>=1.6.1",
+      "pytorch-lightning>=1.4.0",
       "torch>=1.7.1",
       "torchserve>=0.3.0",
       "torch-model-archiver",
@@ -44,7 +45,7 @@ def make_required_test_packages():
 
 
 def make_dependency_links():
-    return ["https://github.com/PyTorchLightning/pytorch-lightning.git"]
+    return []
 
 
 def detect_version(base_path):


### PR DESCRIPTION
Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

Due to the dependency on pytorch job operator with PTL master, the pytorch-kfp-components pip package was referenced to the master branch of pytorch-lightning.

The changes are released as part of pytorch-lighthing 1.4.0 release. Updating the plugin with pytorch-lightning 1.4.0 and above as dependency.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
