### PR TITLE
feat(api): Add PipelineTaskFinalStatus to pipeline_spec.proto

### DIFF
--- a/api/v2alpha1/google/rpc/status.proto
+++ b/api/v2alpha1/google/rpc/status.proto
@@ -1,0 +1,47 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.rpc;
+
+import "google/protobuf/any.proto";
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/genproto/googleapis/rpc/status;status";
+option java_multiple_files = true;
+option java_outer_classname = "StatusProto";
+option java_package = "com.google.rpc";
+option objc_class_prefix = "RPC";
+
+// The `Status` type defines a logical error model that is suitable for
+// different programming environments, including REST APIs and RPC APIs. It is
+// used by [gRPC](https://github.com/grpc). Each `Status` message contains
+// three pieces of data: error code, error message, and error details.
+//
+// You can find out more about this error model and how to work with it in the
+// [API Design Guide](https://cloud.google.com/apis/design/errors).
+message Status {
+  // The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+  int32 code = 1;
+
+  // A developer-facing error message, which should be in English. Any
+  // user-facing error message should be localized and sent in the
+  // [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+  string message = 2;
+
+  // A list of messages that carry the error details.  There is a common set of
+  // message types for APIs to use.
+  repeated google.protobuf.Any details = 3;
+}

--- a/api/v2alpha1/pipeline_spec.proto
+++ b/api/v2alpha1/pipeline_spec.proto
@@ -4,6 +4,7 @@ package ml_pipelines;
 
 import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
+import "google/rpc/status.proto";
 
 option go_package = "github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec";
 
@@ -786,4 +787,49 @@ message ExecutorOutput {
 
   // The updated metadata for output artifact.
   map<string, ArtifactList> artifacts = 2;
+}
+
+// The final status of a task. The structure will be passed to input parameter
+// of kind `task_final_status`.
+message PipelineTaskFinalStatus {
+  // The final state of the task.
+  // The value is the string version of [PipelineStateEnum.PipelineTaskState][]
+  string state = 1;
+
+  // The error of the task.
+  google.rpc.Status error = 2;
+}
+
+message PipelineStateEnum {
+  enum PipelineTaskState {
+    TASK_STATE_UNSPECIFIED = 0;
+    PENDING = 1;
+    RUNNING_DRIVER = 2;
+    DRIVER_SUCCEEDED = 3;
+    RUNNING_EXECUTOR = 4;
+    SUCCEEDED = 5;
+    CANCEL_PENDING = 6;
+    CANCELLING = 7;
+    CANCELLED = 8;
+    FAILED = 9;
+    // Indicates that the task is skipped to run due to a cache hit.
+    SKIPPED = 10;
+    // Indicates that the task was just populated to the DB but not ready to
+    // be scheduled.  Once job handler determined the task being ready to
+    // be scheduled, the task state will change to PENDING.  The state
+    // transition is depicted below:
+    //  * QUEUED(not ready to run) --> PENDING(ready to run) --> RUNNING
+    QUEUED = 11;
+    // Indicates that the task is not triggered based on the
+    // [PipelineTaskSpec.TriggerPolicy.condition][] config.
+    NOT_TRIGGERED = 12;
+    // Indicates that the tasks will no longer be schedulable.  Usually a task
+    // was set to this state because its all upstream tasks are in final state
+    // but the [PipelineTaskSpec.TriggerPolicy.strategy][] disallows the task to
+    // be triggered.
+    // The difference between `NOT_TRIGGERED` is that `UNSCHEDULABLE` must met
+    // [PipelineTaskSpec.TriggerPolicy.strategy][], but must not met the
+    // [PipelineTaskSpec.TriggerPolicy.condition][].
+    UNSCHEDULABLE = 13;
+  }
 }


### PR DESCRIPTION
**Description of your changes:**
`PipelineTaskFinalStatus` is the value format for `TaskFinalStatus`, which is used by Exit handler.
https://github.com/kubeflow/pipelines/blob/97b9bdb530adaf824ff9aee14ff1a8ac70eb063e/api/v2alpha1/pipeline_spec.proto#L260


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
