### PR TITLE
chore(components/google-cloud): Clean up unit tests

### DIFF
--- a/components/google-cloud/tests/aiplatform/test_componets_compile.py
+++ b/components/google-cloud/tests/aiplatform/test_componets_compile.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Test google-cloud-pipeline-componets to ensure the compile without error."""
 
+import os
 import unittest
 import kfp
 from kfp.v2 import compiler
@@ -53,6 +54,11 @@ class ComponetsCompileTest(unittest.TestCase):
         self._gcs_destination_prefix = "gs://test_gcs_output_dir/batch_prediction"
         self._serving_container_image_uri = "gcr.io/test_project/test_image:test_tag"
         self._artifact_uri = "project/test_artifact_uri"
+        self._package_path="pipeline.json"
+
+    def tearDown(self):
+        if os.path.exists(self._package_path):
+            os.remove(self._package_path)
 
     def test_image_data_pipeline_component_ops_compile(self):
 
@@ -108,7 +114,7 @@ class ComponetsCompileTest(unittest.TestCase):
 
         compiler.Compiler().compile(
             pipeline_func=pipeline,
-            package_path="pipeline.json"
+            package_path=self._package_path
         )
 
     def test_tabular_data_pipeline_component_ops_compile(self):
@@ -158,7 +164,7 @@ class ComponetsCompileTest(unittest.TestCase):
 
         compiler.Compiler().compile(
             pipeline_func=pipeline,
-            package_path="pipeline.json"
+            package_path=self._package_path
         )
 
     def test_text_data_pipeline_component_ops_compile(self):
@@ -213,7 +219,7 @@ class ComponetsCompileTest(unittest.TestCase):
 
         compiler.Compiler().compile(
             pipeline_func=pipeline,
-            package_path="pipeline.json"
+            package_path=self._package_path
         )
 
     def test_video_data_pipeline_component_ops_compile(self):
@@ -267,7 +273,7 @@ class ComponetsCompileTest(unittest.TestCase):
 
         compiler.Compiler().compile(
             pipeline_func=pipeline,
-            package_path="pipeline.json"
+            package_path=self._package_path
         )
 
     def test_model_pipeline_component_ops_compile(self):
@@ -300,5 +306,5 @@ class ComponetsCompileTest(unittest.TestCase):
 
         compiler.Compiler().compile(
             pipeline_func=pipeline,
-            package_path="pipeline.json"
+            package_path=self._package_path
         )

--- a/components/google-cloud/tests/experimental/remote/gcp_launcher/test_custom_job_remote_runner.py
+++ b/components/google-cloud/tests/experimental/remote/gcp_launcher/test_custom_job_remote_runner.py
@@ -15,7 +15,7 @@
 
 import json
 from logging import raiseExceptions
-from os import path
+import os
 import time
 import unittest
 from unittest import mock
@@ -33,6 +33,10 @@ class CustomJobRemoteRunnerUtilsTests(unittest.TestCase):
         self._gcp_region = 'test_region'
         self._gcp_resouces_path = 'gcp_resouces'
         self._type = 'CustomJob'
+
+    def tearDown(self):
+        if os.path.exists(self._gcp_resouces_path):
+            os.remove(self._gcp_resouces_path)
 
     @mock.patch.object(aiplatform.gapic, 'JobServiceClient', autospec=True)
     def test_custom_job_remote_runner_on_region_is_set_correctly_in_client_options(
@@ -61,7 +65,7 @@ class CustomJobRemoteRunnerUtilsTests(unittest.TestCase):
         )
 
     @mock.patch.object(aiplatform.gapic, 'JobServiceClient', autospec=True)
-    @mock.patch.object(path, "exists", autospec=True)
+    @mock.patch.object(os.path, "exists", autospec=True)
     def test_custom_job_remote_runner_on_payload_deserializes_correctly(
         self, mock_path_exists, mock_job_service_client
     ):
@@ -92,7 +96,7 @@ class CustomJobRemoteRunnerUtilsTests(unittest.TestCase):
         )
 
     @mock.patch.object(aiplatform.gapic, 'JobServiceClient', autospec=True)
-    @mock.patch.object(path, "exists", autospec=True)
+    @mock.patch.object(os.path, "exists", autospec=True)
     def test_custom_job_remote_runner_raises_exception_on_error(
         self, mock_path_exists, mock_job_service_client
     ):
@@ -117,7 +121,7 @@ class CustomJobRemoteRunnerUtilsTests(unittest.TestCase):
             )
 
     @mock.patch.object(aiplatform.gapic, 'JobServiceClient', autospec=True)
-    @mock.patch.object(path, "exists", autospec=True)
+    @mock.patch.object(os.path, "exists", autospec=True)
     @mock.patch.object(time, "sleep", autospec=True)
     def test_custom_job_remote_runner_retries_to_get_status_on_non_completed_job(
         self, mock_time_sleep, mock_path_exists, mock_job_service_client

--- a/components/google-cloud/tests/presubmit.sh
+++ b/components/google-cloud/tests/presubmit.sh
@@ -20,7 +20,7 @@ cd "$source_root/components/google-cloud"
 python setup.py bdist_wheel clean
 
 # Temporary work around for installing google.cloud.aiplatfrom from dev branch
-pip3 install git+https://github.com/googleapis/python-aiplatform@dev
+pip3 install google-cloud-aiplatform
 
 # Verify package can be installed and loaded correctly
 WHEEL_FILE=$(find "$source_root/components/google-cloud/dist/" -name "google_cloud_pipeline_components*.whl")


### PR DESCRIPTION
Adding teardown / clean up step to a few unit tests that where leaving a residue after execution. 
Also changing the test install script to install `google-cloud-aiplatform` sdk from master instead of dev branch.