### PR TITLE
fix(components/google-cloud): Add temporary work around for key not found during compile

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/experimental/custom_job/custom_job.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/custom_job/custom_job.py
@@ -81,7 +81,7 @@ def run_as_vertex_ai_custom_job(
     """
     job_spec = {}
 
-    # As a temporary work aruond for issue with kfp v1 based compiler where
+    # As a temporary work aruond for issue with kfp v2 based compiler where
     # compiler expects place holders in origional form in args, instead of
     # using fields from outputs, we add back the args from the origional
     # component to the custom job component. These args will be ignored

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/custom_job/custom_job.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/custom_job/custom_job.py
@@ -81,6 +81,13 @@ def run_as_vertex_ai_custom_job(
     """
     job_spec = {}
 
+    # As a temporary work aruond for issue with kfp v1 based compiler where
+    # compiler expects place holders in origional form in args, instead of
+    # using fields from outputs, we add back the args from the origional
+    # component to the custom job component. These args will be ignored
+    # by the remote launcher.
+    copy_of_origional_args = []
+
     if worker_pool_specs is not None:
         worker_pool_specs = copy.deepcopy(worker_pool_specs)
 
@@ -98,6 +105,7 @@ def run_as_vertex_ai_custom_job(
                         container_spec['command'], _is_output_parameter
                     )
                 if 'args' in container_spec:
+                    copy_of_origional_args = container_spec['args'].copy()
                     dsl_utils.resolve_cmd_lines(
                         container_spec['args'], _is_output_parameter
                     )
@@ -138,22 +146,23 @@ def run_as_vertex_ai_custom_job(
             }
         }
         if component_spec.component_spec.implementation.container.command:
-            dsl_utils.resolve_cmd_lines(
-                component_spec.component_spec.implementation.container.command,
-                _is_output_parameter
+            container_command_copy = component_spec.component_spec.implementation.container.command.copy(
             )
-            worker_pool_spec['container_spec'][
-                'command'
-            ] = component_spec.component_spec.implementation.container.command
+            dsl_utils.resolve_cmd_lines(
+                container_command_copy, _is_output_parameter
+            )
+            worker_pool_spec['container_spec']['command'
+                                              ] = container_command_copy
 
         if component_spec.component_spec.implementation.container.args:
-            dsl_utils.resolve_cmd_lines(
-                component_spec.component_spec.implementation.container.args,
-                _is_output_parameter
+            container_args_copy = component_spec.component_spec.implementation.container.args.copy(
             )
-            worker_pool_spec['container_spec'][
-                'args'
-            ] = component_spec.component_spec.implementation.container.args
+            copy_of_origional_args = component_spec.component_spec.implementation.container.args.copy(
+            )
+            dsl_utils.resolve_cmd_lines(
+                container_args_copy, _is_output_parameter
+            )
+            worker_pool_spec['container_spec']['args'] = container_args_copy
         if accelerator_type is not None:
             worker_pool_spec['machine_spec']['accelerator_type'
                                             ] = accelerator_type
@@ -222,7 +231,7 @@ def run_as_vertex_ai_custom_job(
                     structures.OutputPathPlaceholder(
                         output_name='GCP_RESOURCES'
                     ),
-                ],
+                ] + copy_of_origional_args ,
             )
         )
     )

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/remote/gcp_launcher/launcher.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/remote/gcp_launcher/launcher.py
@@ -70,7 +70,8 @@ def _parse_args(args):
         required=True,
         default=argparse.SUPPRESS
     )
-    return vars(parser.parse_args(args))
+    parsed_args, _ = parser.parse_known_args(args)
+    return vars(parsed_args)
 
 
 def main(argv):
@@ -90,8 +91,6 @@ def main(argv):
     """
 
     parsed_args = _parse_args(argv)
-    import pprint
-    pprint.pprint(parsed_args)
 
     if parsed_args['type'] == 'CustomJob':
         custom_job_remote_runner.create_custom_job(**parsed_args)

--- a/components/google-cloud/tests/experimental/custom_job/test_custom_job.py
+++ b/components/google-cloud/tests/experimental/custom_job/test_custom_job.py
@@ -197,7 +197,7 @@ implementation:
                         '{"display_name": "ContainerComponent", "job_spec": {"worker_pool_specs": [{"machine_spec": {"machine_type": "test_machine_type"}, "replica_count": 2, "container_spec": {"image_uri": "test_image_uri", "command": ["test_command"], "args": ["test_args"]}}]}}',
                         '--gcp_resources', {
                             'outputPath': 'GCP_RESOURCES'
-                        }
+                        }, 'test_args'
                     ]
                 }
             }

--- a/components/google-cloud/tests/experimental/remote/gcp_launcher/test_launcher.py
+++ b/components/google-cloud/tests/experimental/remote/gcp_launcher/test_launcher.py
@@ -26,7 +26,8 @@ class LauncherUtilsTests(unittest.TestCase):
         self._input_args = [
             "--type", "CustomJob", "--gcp_project", "test_project",
             "--gcp_region", "us_central1", "--payload", "test_payload",
-            "--gcp_resources", "test_file_path/test_file.txt"
+            "--gcp_resources", "test_file_path/test_file.txt", "--extra_arg",
+            "extra_arg_value"
         ]
         self._payload = '{"display_name": "ContainerComponent", "job_spec": {"worker_pool_specs": [{"machine_spec": {"machine_type": "n1-standard-4"}, "replica_count": 1, "container_spec": {"image_uri": "google/cloud-sdk:latest", "command": ["sh", "-c", "set -e -x\\necho \\"$0, this is an output parameter\\"\\n", "{{$.inputs.parameters[\'input_text\']}}", "{{$.outputs.parameters[\'output_value\'].output_file}}"]}}]}}'
         self._gcp_project = 'test_gcp_project'


### PR DESCRIPTION
This is to add a temporary fix ( until KFP v2.0) work around in custom job to avoid the error key not found when output is not part of the args.