### PR TITLE
test: Remove upgrade command in project_cleaner

### DIFF
--- a/test/tools/project-cleaner/project_cleaner.sh
+++ b/test/tools/project-cleaner/project_cleaner.sh
@@ -19,10 +19,11 @@ set -ex
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
 pushd "${SCRIPT_DIR}"
 
+# It is not needed because we changed to use docker.io/library/golang:1.16.6 image.
 # Required as this script runs in Prow using kubekins-e2e image. That image uses go-1.12 version
 # as a result below packages specified in go.mod file are not discovered.
-go get -u "google.golang.org/api/container/v1"
-go get -u "gopkg.in/yaml.v2"
+# go get -u "google.golang.org/api/container/v1"
+# go get -u "gopkg.in/yaml.v2"
 
 echo "Building project cleaner tool"
 go build .

--- a/test/tools/project-cleaner/project_cleaner.sh
+++ b/test/tools/project-cleaner/project_cleaner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2018 The Kubeflow Authors
 #
@@ -16,8 +16,8 @@
 
 set -ex
 
-SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
-pushd "${SCRIPT_DIR}"
+SCRIPT_DIR=$(dirname "$0")
+cd "${SCRIPT_DIR}"
 
 # It is not needed because we changed to use docker.io/library/golang:1.16.6 image.
 # Required as this script runs in Prow using kubekins-e2e image. That image uses go-1.12 version
@@ -30,4 +30,3 @@ go build .
 
 echo "Executing project cleaner"
 ./project-cleaner --resource_spec resource_spec.yaml
-popd

--- a/test/tools/project-cleaner/project_cleaner.sh
+++ b/test/tools/project-cleaner/project_cleaner.sh
@@ -19,12 +19,6 @@ set -ex
 SCRIPT_DIR=$(dirname "$0")
 cd "${SCRIPT_DIR}"
 
-# It is not needed because we changed to use docker.io/library/golang:1.16.6 image.
-# Required as this script runs in Prow using kubekins-e2e image. That image uses go-1.12 version
-# as a result below packages specified in go.mod file are not discovered.
-# go get -u "google.golang.org/api/container/v1"
-# go get -u "gopkg.in/yaml.v2"
-
 echo "Building project cleaner tool"
 go build .
 


### PR DESCRIPTION
**Description of your changes:**

Fixing failing issue of project_cleaner.

There is an API change by gcloud compute package when upgrading from 0.89.0->0.90.0.

Check this new change using golang image:

```
docker run -it  -v $(pwd):$(pwd) -w $(pwd) docker.io/library/golang:1.16.6-alpine /bin/sh
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
