### PR TITLE
refactor(v2): save pipeline root to pipeline run context. Part of #6152

### DIFF
--- a/v2/cmd/driver/main.go
+++ b/v2/cmd/driver/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
+	"github.com/kubeflow/pipelines/v2/config"
 	"github.com/kubeflow/pipelines/v2/driver"
 	"github.com/kubeflow/pipelines/v2/metadata"
 )
@@ -37,6 +38,7 @@ var (
 	driverType        = flag.String(driverTypeArg, "", "task driver type, one of ROOT_DAG, CONTAINER")
 	pipelineName      = flag.String("pipeline_name", "", "pipeline context name")
 	runID             = flag.String("run_id", "", "pipeline run uid")
+	pipelineRoot      = flag.String("pipeline_root", "", "pipeline object storage root")
 	componentSpecJson = flag.String("component", "{}", "component spec")
 	taskSpecJson      = flag.String("task", "{}", "task spec")
 	runtimeConfigJson = flag.String("runtime_config", "{}", "jobruntime config")
@@ -102,6 +104,10 @@ func drive() (err error) {
 	if err := jsonpb.UnmarshalString(*runtimeConfigJson, runtimeConfig); err != nil {
 		return fmt.Errorf("failed to unmarshal runtime config, error: %w\nruntimeConfig: %v", err, runtimeConfigJson)
 	}
+	namespace, err := config.InPodNamespace()
+	if err != nil {
+		return err
+	}
 	client, err := newMlmdClient()
 	if err != nil {
 		return err
@@ -109,6 +115,8 @@ func drive() (err error) {
 	options := driver.Options{
 		PipelineName:   *pipelineName,
 		RunID:          *runID,
+		PipelineRoot:   *pipelineRoot,
+		Namespace:      namespace,
 		Component:      componentSpec,
 		Task:           taskSpec,
 		DAGExecutionID: *dagExecutionID,

--- a/v2/cmd/driver/main.go
+++ b/v2/cmd/driver/main.go
@@ -38,7 +38,6 @@ var (
 	driverType        = flag.String(driverTypeArg, "", "task driver type, one of ROOT_DAG, CONTAINER")
 	pipelineName      = flag.String("pipeline_name", "", "pipeline context name")
 	runID             = flag.String("run_id", "", "pipeline run uid")
-	pipelineRoot      = flag.String("pipeline_root", "", "pipeline object storage root")
 	componentSpecJson = flag.String("component", "{}", "component spec")
 	taskSpecJson      = flag.String("task", "{}", "task spec")
 	runtimeConfigJson = flag.String("runtime_config", "{}", "jobruntime config")
@@ -115,7 +114,6 @@ func drive() (err error) {
 	options := driver.Options{
 		PipelineName:   *pipelineName,
 		RunID:          *runID,
-		PipelineRoot:   *pipelineRoot,
 		Namespace:      namespace,
 		Component:      componentSpec,
 		Task:           taskSpec,

--- a/v2/cmd/launcher/main.go
+++ b/v2/cmd/launcher/main.go
@@ -81,7 +81,7 @@ func run() error {
 		MLMDServerPort:    *mlmdServerPort,
 		EnableCaching:     enableCachingBool,
 	}
-	launcher, err := component.NewLauncher(*runtimeInfoJSON, opts)
+	launcher, err := component.NewLauncher(ctx, *runtimeInfoJSON, opts)
 	if err != nil {
 		return fmt.Errorf("Failed to create component launcher: %w", err)
 	}

--- a/v2/compiler/argo_test.go
+++ b/v2/compiler/argo_test.go
@@ -105,8 +105,6 @@ func Test_argo_compiler(t *testing.T) {
         - '{{inputs.parameters.executor-input}}'
         - --component_spec
         - '{{inputs.parameters.component}}'
-        - --namespace
-        - $(KFP_NAMESPACE)
         - --pod_name
         - $(KFP_POD_NAME)
         - --pod_uid
@@ -117,10 +115,6 @@ func Test_argo_compiler(t *testing.T) {
         - $(METADATA_GRPC_SERVICE_PORT)
         - --
         env:
-        - name: KFP_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: KFP_POD_NAME
           valueFrom:
             fieldRef:

--- a/v2/compiler/container.go
+++ b/v2/compiler/container.go
@@ -148,8 +148,6 @@ func containerExecutorTemplate(container *pipelinespec.PipelineDeploymentConfig_
 		"--execution_id", inputValue(paramExecutionID),
 		"--executor_input", inputValue(paramExecutorInput),
 		"--component_spec", inputValue(paramComponent),
-		"--namespace",
-		"$(KFP_NAMESPACE)",
 		"--pod_name",
 		"$(KFP_POD_NAME)",
 		"--pod_uid",
@@ -204,13 +202,6 @@ func containerExecutorTemplate(container *pipelinespec.PipelineDeploymentConfig_
 				},
 			}},
 			Env: []k8score.EnvVar{{
-				Name: "KFP_NAMESPACE",
-				ValueFrom: &k8score.EnvVarSource{
-					FieldRef: &k8score.ObjectFieldSelector{
-						FieldPath: "metadata.namespace",
-					},
-				},
-			}, {
 				Name: "KFP_POD_NAME",
 				ValueFrom: &k8score.EnvVarSource{
 					FieldRef: &k8score.ObjectFieldSelector{

--- a/v2/component/launcher.go
+++ b/v2/component/launcher.go
@@ -34,6 +34,7 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/v2/cacheutils"
+	"github.com/kubeflow/pipelines/v2/config"
 	api "github.com/kubeflow/pipelines/v2/kfp-api"
 	"github.com/kubeflow/pipelines/v2/metadata"
 	"github.com/kubeflow/pipelines/v2/objectstore"
@@ -41,8 +42,6 @@ import (
 	"gocloud.dev/blob"
 	_ "gocloud.dev/blob/gcsblob"
 	"google.golang.org/protobuf/encoding/protojson"
-	k8errors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -111,13 +110,10 @@ func (o *LauncherOptions) validate() error {
 }
 
 const outputMetadataFilepath = "/tmp/kfp_outputs/output_metadata.json"
-const defaultPipelineRoot = "minio://mlpipeline/v2/artifacts"
-const launcherConfigName = "kfp-launcher"
-const configKeyDefaultPipelineRoot = "defaultPipelineRoot"
 
 // NewLauncher creates a new launcher object using the JSON-encoded runtimeInfo
 // and specified options.
-func NewLauncher(runtimeInfo string, options *LauncherOptions) (*Launcher, error) {
+func NewLauncher(ctx context.Context, runtimeInfo string, options *LauncherOptions) (*Launcher, error) {
 	restConfig, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to initialize kubernetes client: %w", err)
@@ -131,17 +127,12 @@ func NewLauncher(runtimeInfo string, options *LauncherOptions) (*Launcher, error
 	}
 
 	if len(options.PipelineRoot) == 0 {
-		config, err := getLauncherConfig(k8sClient, options.Namespace)
+		cfg, err := config.FromConfigMap(ctx, k8sClient, options.Namespace)
 		if err != nil {
 			return nil, err
 		}
-		options.PipelineRoot = getDefaultPipelineRoot(config)
+		options.PipelineRoot = cfg.DefaultPipelineRoot()
 		glog.Infof("PipelineRoot defaults to %q.", options.PipelineRoot)
-	}
-
-	bc, err := objectstore.ParseBucketConfig(options.PipelineRoot)
-	if err != nil {
-		return nil, err
 	}
 
 	rt, err := parseRuntimeInfo(runtimeInfo)
@@ -168,7 +159,6 @@ func NewLauncher(runtimeInfo string, options *LauncherOptions) (*Launcher, error
 		runtimeInfo:    rt,
 		metadataClient: metadataClient,
 		cacheClient:    cacheClient,
-		bucketConfig:   bc,
 		k8sClient:      k8sClient,
 		cmdArgs:        cmdArgs,
 	}, nil
@@ -193,11 +183,14 @@ func (l *Launcher) executeWithoutCacheEnabled(ctx context.Context, executorInput
 	cmd := l.cmdArgs[0]
 	args := make([]string, len(l.cmdArgs)-1)
 	_ = copy(args, l.cmdArgs[1:])
-	pipeline, err := l.metadataClient.GetPipeline(ctx, l.options.PipelineName, l.options.RunID, l.options.Namespace, l.options.RunResource)
+	pipeline, err := l.metadataClient.GetPipeline(ctx, l.options.PipelineName, l.options.RunID, l.options.Namespace, l.options.RunResource, l.options.PipelineRoot)
 	if err != nil {
 		return fmt.Errorf("unable to get pipeline with PipelineName %q PipelineRunID %q: %w", l.options.PipelineName, l.options.RunID, err)
 	}
-
+	l.bucketConfig, err = objectstore.ParseBucketConfig(pipeline.GetPipelineRoot())
+	if err != nil {
+		return err
+	}
 	ecfg, err := metadata.GenerateExecutionConfig(executorInput)
 	if err != nil {
 		return fmt.Errorf("failed to generate execution config: %w", err)
@@ -241,9 +234,13 @@ func (l *Launcher) executeWithCacheEnabled(ctx context.Context, executorInput *p
 		return fmt.Errorf("failure while getting executionCache: %w", err)
 	}
 
-	pipeline, err := l.metadataClient.GetPipeline(ctx, l.options.PipelineName, l.options.RunID, l.options.Namespace, l.options.RunResource)
+	pipeline, err := l.metadataClient.GetPipeline(ctx, l.options.PipelineName, l.options.RunID, l.options.Namespace, l.options.RunResource, l.options.PipelineRoot)
 	if err != nil {
 		return fmt.Errorf("unable to get pipeline with PipelineName %q PipelineRunID %q: %w", l.options.PipelineName, l.options.RunID, err)
+	}
+	l.bucketConfig, err = objectstore.ParseBucketConfig(pipeline.GetPipelineRoot())
+	if err != nil {
+		return err
 	}
 
 	ecfg, err := metadata.GenerateExecutionConfig(executorInput)
@@ -829,26 +826,4 @@ func getExecutorOutputFile() (*pipelinespec.ExecutorOutput, error) {
 	}
 
 	return executorOutput, nil
-}
-
-func getLauncherConfig(clientSet *kubernetes.Clientset, namespace string) (map[string]string, error) {
-	config, err := clientSet.CoreV1().ConfigMaps(namespace).Get(context.Background(), launcherConfigName, metav1.GetOptions{})
-	if err != nil {
-		if k8errors.IsNotFound(err) {
-			glog.Infof("cannot find launcher configmap: name=%q namespace=%q", launcherConfigName, namespace)
-			// LauncherConfig is optional, so ignore not found error.
-			return nil, nil
-		}
-		return nil, err
-	}
-	return config.Data, nil
-}
-
-func getDefaultPipelineRoot(launcherConfig map[string]string) string {
-	root := defaultPipelineRoot
-	// The key defaultPipelineRoot is optional in launcher config.
-	if launcherConfig[configKeyDefaultPipelineRoot] != "" {
-		root = launcherConfig[configKeyDefaultPipelineRoot]
-	}
-	return root
 }

--- a/v2/component/launcher_v2.go
+++ b/v2/component/launcher_v2.go
@@ -7,9 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
-	"github.com/kubeflow/pipelines/v2/config"
 	"github.com/kubeflow/pipelines/v2/metadata"
 	"github.com/kubeflow/pipelines/v2/objectstore"
 	pb "github.com/kubeflow/pipelines/v2/third_party/ml_metadata"
@@ -75,14 +73,6 @@ func NewLauncherV2(ctx context.Context, executionID int64, executorInputJSON, co
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize kubernetes client set: %w", err)
 	}
-	if len(opts.PipelineRoot) == 0 {
-		config, err := config.FromConfigMap(ctx, k8sClient, opts.Namespace)
-		if err != nil {
-			return nil, err
-		}
-		opts.PipelineRoot = config.DefaultPipelineRoot()
-		glog.Infof("PipelineRoot defaults to %q.", opts.PipelineRoot)
-	}
 	metadataClient, err := metadata.NewClient(opts.MLMDServerAddress, opts.MLMDServerPort)
 	if err != nil {
 		return nil, err
@@ -112,15 +102,16 @@ func (l *LauncherV2) Execute(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	bucketConfig, err := objectstore.ParseBucketConfig(l.options.PipelineRoot)
-	if err != nil {
-		return err
-	}
-	bucket, err := objectstore.OpenBucket(ctx, l.k8sClient, l.options.Namespace, bucketConfig)
-	if err != nil {
-		return err
-	}
-	executorOutput, err := executeV2(ctx, l.executorInput, l.component, l.command, l.args, bucket, bucketConfig)
+	// TODO(Bobgy): provide bucket and bucketConfig
+	// bucketConfig, err := objectstore.ParseBucketConfig(l.options.PipelineRoot)
+	// if err != nil {
+	// 	return err
+	// }
+	// bucket, err := objectstore.OpenBucket(ctx, l.k8sClient, l.options.Namespace, bucketConfig)
+	// if err != nil {
+	// 	return err
+	// }
+	executorOutput, err := executeV2(ctx, l.executorInput, l.component, l.command, l.args, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/v2/config/env.go
+++ b/v2/config/env.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/golang/glog"
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	configMapName                = "kfp-launcher"
+	defaultPipelineRoot          = "minio://mlpipeline/v2/artifacts"
+	configKeyDefaultPipelineRoot = "defaultPipelineRoot"
+)
+
+// Config is the KFP runtime configuration.
+type Config struct {
+	data map[string]string
+}
+
+// FromConfigMap loads config from a kfp-launcher Kubernetes config map.
+func FromConfigMap(ctx context.Context, clientSet kubernetes.Interface, namespace string) (*Config, error) {
+	config, err := clientSet.CoreV1().ConfigMaps(namespace).Get(ctx, configMapName, metav1.GetOptions{})
+	if err != nil {
+		if k8errors.IsNotFound(err) {
+			glog.Infof("cannot find launcher configmap: name=%q namespace=%q", configMapName, namespace)
+			// LauncherConfig is optional, so ignore not found error.
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &Config{data: config.Data}, nil
+}
+
+// Config.DefaultPipelineRoot gets the configured default pipeline root.
+func (c *Config) DefaultPipelineRoot() string {
+	// The key defaultPipelineRoot is optional in launcher config.
+	if c == nil || c.data[configKeyDefaultPipelineRoot] == "" {
+		return defaultPipelineRoot
+	}
+	return c.data[configKeyDefaultPipelineRoot]
+}
+
+// InPodNamespace gets current namespace from inside a Kubernetes Pod.
+func InPodNamespace() (string, error) {
+	// The path is available in Pods.
+	// https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/#directly-accessing-the-rest-api
+	ns, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return "", fmt.Errorf("failed to get namespace in Pod: %w", err)
+	}
+	return string(ns), nil
+}


### PR DESCRIPTION
Part of #6152 

**Description of your changes:**
Reasoning: pipeline root should be read from config only once (config may be modified), and then preserved in pipeline run context. All the tasks in one pipeline should use the same pipeline root.
The refactoring also makes pipeline root easier to access, so that when building KFP v2, I can get pipeline root from both the driver and the launcher, because both places need it.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
