### PR TITLE
fix(components/google-cloud): Google cloud pipeline components 0.1.4

### DIFF
--- a/components/google-cloud/dependencies.py
+++ b/components/google-cloud/dependencies.py
@@ -16,8 +16,8 @@
 
 def make_required_install_packages():
     return [
-        "kfp>=1.4.0,<2.0.0",
         "google-cloud-aiplatform>=1.1.1",
+        "kfp>=1.4.0,<2.0.0",
     ]
 
 

--- a/components/google-cloud/dependencies.py
+++ b/components/google-cloud/dependencies.py
@@ -16,8 +16,8 @@
 
 def make_required_install_packages():
     return [
-        "google-api-core<2dev,>=1.21.0",
-        "google-cloud-aiplatform>=1.1.1",
+        "google-api-core<2dev,>=1.26.0",
+        "google-cloud-aiplatform>=1.3",
         "kfp>=1.4.0,<2.0.0",
     ]
 

--- a/components/google-cloud/dependencies.py
+++ b/components/google-cloud/dependencies.py
@@ -16,6 +16,7 @@
 
 def make_required_install_packages():
     return [
+        "google-api-core<2dev,>=1.21.0",
         "google-cloud-aiplatform>=1.1.1",
         "kfp>=1.4.0,<2.0.0",
     ]

--- a/components/google-cloud/dependencies.py
+++ b/components/google-cloud/dependencies.py
@@ -17,7 +17,7 @@
 def make_required_install_packages():
     return [
         "google-api-core<2dev,>=1.26.0",
-        "google-cloud-aiplatform>=1.3",
+        "google-cloud-aiplatform>=1.3.0",
         "kfp>=1.4.0,<2.0.0",
     ]
 

--- a/components/google-cloud/docs/requirements.txt
+++ b/components/google-cloud/docs/requirements.txt
@@ -1,1 +1,2 @@
+google-api-core<2dev,>=1.21.0
 components/google-cloud/

--- a/components/google-cloud/docs/requirements.txt
+++ b/components/google-cloud/docs/requirements.txt
@@ -1,2 +1,2 @@
-google-api-core<2dev,>=1.21.0
+google-api-core==1.21.0
 components/google-cloud/

--- a/components/google-cloud/docs/requirements.txt
+++ b/components/google-cloud/docs/requirements.txt
@@ -1,2 +1,1 @@
-google-api-core==1.21.0
 components/google-cloud/


### PR DESCRIPTION
Fix read the docs issue by explicitly adding `google-api-core<2dev,>=1.21.0`, as a requirement for `google-cloud-pipeline-components`. 