### PR TITLE
fix(manifests): replace argo ClusterRoleBinding namespace

### DIFF
--- a/manifests/kustomize/third-party/argo/installs/cluster/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/installs/cluster/kustomization.yaml
@@ -8,3 +8,11 @@ bases:
 - ../../upstream/manifests/base/crds
 - ../../upstream/manifests/cluster-install/workflow-controller-rbac
 - ../../base
+
+patchesJson6902:
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRoleBinding
+    name: argo-binding
+  path: workflow-controller-clusterrolebinding-patch.json

--- a/manifests/kustomize/third-party/argo/installs/cluster/workflow-controller-clusterrolebinding-patch.json
+++ b/manifests/kustomize/third-party/argo/installs/cluster/workflow-controller-clusterrolebinding-patch.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/subjects/0/namespace",
+    "value": "kubeflow"
+  }
+]


### PR DESCRIPTION
**Description of your changes:**
In default situation on deploying with kustomize, the ClusterRoleBinding of "service account" argo is bound to namespace `argo`, the workflow-controller can not access the configmap `workflow-controller-configmap` in namespace `kubeflow`, we should modify it to  namespace `kubeflow`.

The error log of workflow-controller
```
time="2021-08-17T08:54:24Z" level=info msg="index config" indexWorkflowSemaphoreKeys=true
time="2021-08-17T08:54:24Z" level=info msg="cron config" cronSyncPeriod=10s
time="2021-08-17T08:54:24.143Z" level=info msg="config map" name=workflow-controller-configmap
time="2021-08-17T08:54:24.156Z" level=info msg="Get configmaps 403"
time="2021-08-17T08:54:24.156Z" level=fatal msg="Failed to register watch for controller config map: configmaps \"workflow-controller-configmap\" is forbidden: User \"system:serviceaccount:kubeflow:argo\" cannot get resource \"configmaps\" in API group \"\" in the namespace \"kubeflow\""
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
