### PR TITLE
chore: use a runtime parameter for pusher destination in the TFX example.

### DIFF
--- a/samples/core/parameterized_tfx_oss/taxi_pipeline_notebook.ipynb
+++ b/samples/core/parameterized_tfx_oss/taxi_pipeline_notebook.ipynb
@@ -78,6 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import json\n",
     "import os\n",
     "\n",
     "import kfp\n",
@@ -113,6 +114,14 @@
     "    name='module-file',\n",
     "    default='/opt/conda/lib/python3.7/site-packages/tfx/examples/chicago_taxi_pipeline/taxi_utils_native_keras.py',\n",
     "    ptype=str,\n",
+    ")\n",
+    "# Path that ML models are pushed, should be a GCS path.\n",
+    "# TODO: CHANGE the GCS bucket name to yours.\n",
+    "serving_model_dir = os.path.join('gs://your-bucket', 'serving_model', 'tfx_taxi_simple')\n",
+    "push_destination = tfx.dsl.experimental.RuntimeParameter(\n",
+    "     name='push_destination',\n",
+    "     default=json.dumps({'filesystem': {'base_directory': serving_model_dir}}),\n",
+    "     ptype=str,\n",
     ")"
    ]
   },
@@ -131,8 +140,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The input data location is parameterized by _data_root_param\n",
-    "\n",
     "example_gen = tfx.components.CsvExampleGen(input_base=data_root)\n",
     "\n",
     "statistics_gen = tfx.components.StatisticsGen(examples=example_gen.outputs['examples'])\n",
@@ -207,10 +214,7 @@
     "pusher = tfx.components.Pusher(\n",
     "  model=trainer.outputs['model'],\n",
     "  model_blessing=evaluator.outputs['blessing'],\n",
-    "  push_destination=tfx.proto.PushDestination(\n",
-    "      filesystem=tfx.proto.PushDestination.Filesystem(\n",
-    "          base_directory=os.path.join(\n",
-    "              pipeline_root, 'model_serving'))))"
+    "  push_destination=push_destination)"
    ]
   },
   {


### PR DESCRIPTION
**Description of your changes:**

{} Placeholder doesn't work well in component parameters and
it is better to have it as a runtime parameter for flexibility.

See also https://github.com/kubeflow/pipelines/issues/6311#issuecomment-900245391

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
