### PR TITLE
fix(backend): recognize "sidecar.istio.io/inject" annotation to use Istio service mesh optionally. Fixes #6200

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -381,8 +381,8 @@ func (r *ResourceManager) CreateRun(ctx context.Context, apiRun *api.Run) (*mode
 
 	r.setDefaultServiceAccount(&workflow, apiRun.GetServiceAccount())
 
-	// Disable istio sidecar injection
-	workflow.SetAnnotationsToAllTemplates(util.AnnotationKeyIstioSidecarInject, util.AnnotationValueIstioSidecarInjectDisabled)
+	// Disable istio sidecar injection if not specified
+	workflow.SetAnnotationsToAllTemplatesIfKeyNotExist(util.AnnotationKeyIstioSidecarInject, util.AnnotationValueIstioSidecarInjectDisabled)
 	// Add a KFP specific label for cache service filtering. The cache_enabled flag here is a global control for whether cache server will
 	// receive targeting pods. Since cache server only receives pods in step level, the resource manager here will set this global label flag
 	// on every single step/pod so the cache server can understand.
@@ -729,8 +729,8 @@ func (r *ResourceManager) CreateJob(ctx context.Context, apiJob *api.Job) (*mode
 
 	r.setDefaultServiceAccount(&workflow, apiJob.GetServiceAccount())
 
-	// Disable istio sidecar injection
-	workflow.SetAnnotationsToAllTemplates(util.AnnotationKeyIstioSidecarInject, util.AnnotationValueIstioSidecarInjectDisabled)
+	// Disable istio sidecar injection if not specified
+	workflow.SetAnnotationsToAllTemplatesIfKeyNotExist(util.AnnotationKeyIstioSidecarInject, util.AnnotationValueIstioSidecarInjectDisabled)
 
 	swfGeneratedName, err := toSWFCRDResourceGeneratedName(apiJob.Name)
 	if err != nil {

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -202,14 +202,18 @@ func (w *Workflow) OverrideName(name string) {
 	w.Name = name
 }
 
-// SetAnnotations sets annotations on all templates in a Workflow
-func (w *Workflow) SetAnnotationsToAllTemplates(key string, value string) {
+// SetAnnotationsToAllTemplatesIfKeyNotExist sets annotations on all templates in a Workflow
+// if the annotation key does not exist
+func (w *Workflow) SetAnnotationsToAllTemplatesIfKeyNotExist(key string, value string) {
 	if len(w.Spec.Templates) == 0 {
 		return
 	}
 	for index := range w.Spec.Templates {
 		if w.Spec.Templates[index].Metadata.Annotations == nil {
 			w.Spec.Templates[index].Metadata.Annotations = make(map[string]string)
+		}
+		if _, isSet := w.Spec.Templates[index].Metadata.Annotations[key]; isSet {
+			return
 		}
 		w.Spec.Templates[index].Metadata.Annotations[key] = value
 	}

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -213,7 +213,7 @@ func (w *Workflow) SetAnnotationsToAllTemplatesIfKeyNotExist(key string, value s
 			w.Spec.Templates[index].Metadata.Annotations = make(map[string]string)
 		}
 		if _, isSet := w.Spec.Templates[index].Metadata.Annotations[key]; isSet {
-			return
+			continue
 		}
 		w.Spec.Templates[index].Metadata.Annotations[key] = value
 	}


### PR DESCRIPTION
**Description of your changes:**

Fixes #6067, #6200

Instead of always overwriting `"sidecar.istio.io/inject"` annotation in runtime, set the annotation if the key does not exist.

By this change, users can use Istio service mesh optionally to enable communication between pipelines and another micro services. Without this change, the communication can cause errors like `RBAC: access denied` even with appropriate routing.

In pipeline SDK, enabling Istio service mesh is as easy as

```python
@kfp.dsl.pipeline(name=PIPELINE_NAME)
def dpf_pipeline():
    debug_task = debug_op()
    # Inject Istio proxy
    debug_task.add_pod_annotation("sidecar.istio.io/inject", "true")
    # Wait Istio proxy setup
    debug_task.add_pod_annotation("proxy.istio.io/config", '{ "holdApplicationUntilProxyStarts": true }')
```

As written in [doc on Argo Repository](https://github.com/argoproj/argo-workflows/blob/master/docs/sidecar-injection.md), Istio sidecar injection can be problematic for controlling entire workflow, however, users can optionally set container lifecycle like below to terminate Istio sidecar proxy.

```yaml
spec:
  containers:
  - name: lifecycle-example
    image: pipeline-conatiner-image
    lifecycle:
      preStop:
        exec:
          command: ["/bin/sh","-c","curl -XPOST localhost:15000/quitquitquit"]
```

In addition, in our product, we do not experience such an endless sidecar containers. Istio proxies exits by themselves when other containers finish and will be `COMPLETED` state.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
