### PR TITLE
chore(sdk): Import mock from stdlib and drop dependency.

### DIFF
--- a/sdk/python/kfp/components_tests/test_components.py
+++ b/sdk/python/kfp/components_tests/test_components.py
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
-import os
 import requests
-import sys
 import textwrap
 import unittest
-from contextlib import contextmanager
 from pathlib import Path
+from unittest import mock
 
 
 from .. import components as comp

--- a/sdk/python/kfp/containers_tests/component_builder_test.py
+++ b/sdk/python/kfp/containers_tests/component_builder_test.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for kfp.containers._component_builder module."""
-import mock
 import os
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
 from kfp.containers import _component_builder
 from kfp.containers import _container_builder

--- a/sdk/python/kfp/containers_tests/test_build_image_api.py
+++ b/sdk/python/kfp/containers_tests/test_build_image_api.py
@@ -12,14 +12,10 @@
 # See the License for the speci
 
 import os
-import re
-import sys
 import tempfile
 import unittest
 from pathlib import Path
 from typing import Callable
-
-import mock
 
 from kfp.containers import build_image_from_working_dir
 

--- a/sdk/python/kfp/v2/google/client/schedule_test.py
+++ b/sdk/python/kfp/v2/google/client/schedule_test.py
@@ -17,8 +17,8 @@ import base64
 import hashlib
 import json
 import os
-import mock
 import unittest
+from unittest import mock
 
 from kfp.v2.google.client import schedule
 

--- a/sdk/python/requirements-test.txt
+++ b/sdk/python/requirements-test.txt
@@ -1,3 +1,2 @@
 -r requirements.txt
-mock==3.0.5
 frozendict==2.0.2

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -56,7 +56,6 @@ REQUIRES = [
 
 TESTS_REQUIRE = [
     'frozendict',
-    'mock',
 ]
 
 

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -25,8 +25,8 @@ import sys
 import zipfile
 import tarfile
 import tempfile
-import mock
 import yaml
+from unittest import mock
 
 from absl.testing import parameterized
 from kfp.compiler import Compiler

--- a/sdk/python/tests/compiler/component_builder_test.py
+++ b/sdk/python/tests/compiler/component_builder_test.py
@@ -16,12 +16,6 @@ from kfp.containers._component_builder import _generate_dockerfile, _dependency_
 
 import os
 import unittest
-import yaml
-import tarfile
-from pathlib import Path
-import inspect
-from collections import OrderedDict
-from typing import NamedTuple
 
 class TestVersionedDependency(unittest.TestCase):
 

--- a/sdk/python/tests/compiler/container_builder_test.py
+++ b/sdk/python/tests/compiler/container_builder_test.py
@@ -17,7 +17,7 @@ import tarfile
 import unittest
 import yaml
 import tempfile
-import mock
+from unittest import mock
 from kfp.containers._component_builder import ContainerBuilder
 
 GCS_BASE = 'gs://kfp-testing/'


### PR DESCRIPTION
**Description of your changes:**

I noticed that we're installing `mock`, which is now available in the stdlib. This patch drops the `mock` dependency and imports it from `unittest`.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
