### PR TITLE
fix(components/google-cloud): Move the input param details out of the pipeline definition.

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/experimental/forecasting/README.md
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/forecasting/README.md
@@ -144,7 +144,7 @@ input_tables = json.dumps(input_table_specs)
 
 
 @dsl.pipeline(name='forecasting-pipeline-training')
-def pipeline():
+def pipeline(input_tables: str):
   # A workflow consists of training validation and preprocessing:
   validation = forecasting.ForecastingValidationOp(input_tables=input_tables, validation_theme='FORECASTING_TRAINING')
   preprocess = forecasting.ForecastingPreprocessingOp(project_id='endless-forms-most-beautiful', input_tables=input_tables)


### PR DESCRIPTION
Address @SinaChavoshi's comment in https://github.com/kubeflow/pipelines/pull/6452
In README.md, move the details of constructing the input outside the pipeline definition.

/assign @SinaChavoshi
/assign @IronPan