### PR TITLE
feat(components/google-cloud): Support Proto Plus serialization

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/aiplatform/utils.py
+++ b/components/google-cloud/google_cloud_pipeline_components/aiplatform/utils.py
@@ -21,6 +21,7 @@ import tempfile
 import docstring_parser
 
 from google.cloud import aiplatform
+from google.cloud import aiplatform_v1beta1
 import kfp
 from kfp import components
 from kfp.components.structures import ComponentSpec, ContainerImplementation, ContainerSpec, InputPathPlaceholder, InputSpec, InputValuePlaceholder, OutputPathPlaceholder, OutputSpec, OutputUriPlaceholder, InputUriPlaceholder
@@ -39,6 +40,13 @@ RESOURCE_TO_METADATA_TYPE = {
     aiplatform.Model: "Model",
     aiplatform.Endpoint: "Artifact",
     aiplatform.BatchPredictionJob: "Artifact"
+}
+
+PROTO_PLUS_CLASS_TYPES = {
+    aiplatform_v1beta1.types.explanation_metadata.ExplanationMetadata:
+        "ExplanationMetadata",
+    aiplatform_v1beta1.types.explanation.ExplanationParameters:
+        "ExplanationParameters",
 }
 
 
@@ -72,7 +80,9 @@ def get_forward_reference(
 # This is the Union of all typed datasets.
 # Relying on the annotation defined in the SDK
 # as additional typed Datasets may be added in the future.
-dataset_annotation = inspect.signature(aiplatform.CustomTrainingJob.run).parameters['dataset'].annotation
+dataset_annotation = inspect.signature(aiplatform.CustomTrainingJob.run
+                                      ).parameters['dataset'].annotation
+
 
 def resolve_annotation(annotation: Any) -> Any:
     """Resolves annotation type against a MB SDK type.
@@ -143,17 +153,34 @@ def is_mb_sdk_resource_noun_type(mb_sdk_type: Any) -> bool:
     return False
 
 
+def get_proto_plus_class(annotation: Any) -> Optional[Callable]:
+    """Get Proto Plus Class for this annotation.
+
+    Args:
+        annotation: parameter annotation
+    Returns:
+        Proto Plus Class for annotation type
+    """
+    if annotation in PROTO_PLUS_CLASS_TYPES:
+        return annotation
+
+
 def get_serializer(annotation: Any) -> Optional[Callable]:
     """Get a serializer for objects to pass them as strings.
 
     Remote runner will deserialize.
-    # TODO handle proto.Message
 
     Args:
         annotation: Parameter annotation
     Returns:
         serializer for that annotation type
     """
+    # proto_plus fields need to be serialized using
+    # the Proto Plus Class for the object.
+    proto_plus_class = get_proto_plus_class(annotation)
+    if proto_plus_class:
+        return proto_plus_class.to_json
+
     if is_serializable_to_json(annotation):
         return json.dumps
 
@@ -168,6 +195,12 @@ def get_deserializer(annotation: Any) -> Optional[Callable[..., str]]:
     Returns:
         deserializer for annotation type
     """
+    # proto_plus fields need to be serialized / deserialized using
+    # the Proto Plus Class for the object.
+    proto_plus_class = get_proto_plus_class(annotation)
+    if proto_plus_class:
+        return proto_plus_class.from_json
+
     if is_serializable_to_json(annotation):
         return json.loads
 

--- a/components/google-cloud/google_cloud_pipeline_components/aiplatform/utils.py
+++ b/components/google-cloud/google_cloud_pipeline_components/aiplatform/utils.py
@@ -168,15 +168,11 @@ def get_proto_plus_class(annotation: Any) -> Optional[Callable]:
 def get_serializer(annotation: Any) -> Optional[Callable]:
     """Get a serializer for objects to pass them as strings.
 
-    Remote runner will deserialize.
-
     Args:
         annotation: Parameter annotation
     Returns:
         serializer for that annotation type
     """
-    # proto_plus fields need to be serialized using
-    # the Proto Plus Class for the object.
     proto_plus_class = get_proto_plus_class(annotation)
     if proto_plus_class:
         return proto_plus_class.to_json
@@ -189,14 +185,12 @@ def get_deserializer(annotation: Any) -> Optional[Callable[..., str]]:
     """Get deserializer for objects to pass them as strings.
 
     Remote runner will deserialize.
-    # TODO handle proto.Message
+
     Args:
         annotation: parameter annotation
     Returns:
         deserializer for annotation type
     """
-    # proto_plus fields need to be serialized / deserialized using
-    # the Proto Plus Class for the object.
     proto_plus_class = get_proto_plus_class(annotation)
     if proto_plus_class:
         return proto_plus_class.from_json


### PR DESCRIPTION
Add support for Proto Plus serialization / deserialization. This is specifically used in `ModelUploadOp` for model explainability parameters. 