### PR TITLE
fix(components/google-cloud): Fix the default value of preprocessing_bigquery_dataset

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/experimental/forecasting/__init__.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/forecasting/__init__.py
@@ -27,7 +27,7 @@ __all__ = [
 def ForecastingPreprocessingOp(
     project_id: str,
     input_tables: str,
-    preprocessing_bigquery_dataset: Optional[str] = None):
+    preprocessing_bigquery_dataset: str = ''):
   """Preprocesses BigQuery tables for training or prediction.
 
   Creates a BigQuery table for training or prediction based on the input tables.
@@ -39,9 +39,9 @@ def ForecastingPreprocessingOp(
     project_id (str): The GCP project id that runs the pipeline.
     input_tables (str): Serialized Json array that specifies input BigQuery
     tables and specs.
-    preprocessing_bigquery_dataset (Optional[str]): Optional BigQuery dataset
-    to save the preprocessing result BigQuery table. Not not present, a new
-    dataset will be created by the component.
+    preprocessing_bigquery_dataset (str): Optional BigQuery dataset to save the
+    preprocessing result BigQuery table. If not present, a new dataset will be
+    created by the component.
 
   Returns:
     None


### PR DESCRIPTION
Update the default value of preprocessing_bigquery_dataset from None to empty string.
When the default value is set to None, the component compile function throws ValueError: No value provided for input preprocessing_bigquery_dataset

/assign @SinaChavoshi
/assign @IronPan