### PR TITLE
chore(components/google-cloud): Update google-cloud-aiplatform min version to 1.4.0

### DIFF
--- a/components/google-cloud/dependencies.py
+++ b/components/google-cloud/dependencies.py
@@ -20,7 +20,7 @@ def make_required_install_packages():
         # between kfp & aiplatform.
         "google-api-core<2dev,>=1.26.0",
         "kfp>=1.4.0,<2.0.0",
-        "google-cloud-aiplatform>=1.3.0",
+        "google-cloud-aiplatform>=1.4.0",
     ]
 
 


### PR DESCRIPTION
Increasing the min version for google-cloud-aiplatform to 1.4.0