### PR TITLE
chore(components/google-cloud): Add model forecast documentation to Sphinx docs

### DIFF
--- a/components/google-cloud/docs/source/google_cloud_pipeline_components.experimental.forecasting.rst
+++ b/components/google-cloud/docs/source/google_cloud_pipeline_components.experimental.forecasting.rst
@@ -1,0 +1,7 @@
+google\_cloud\_pipeline\_components.experimental.forecasting package
+====================================================================
+
+.. automodule:: google_cloud_pipeline_components.experimental.forecasting
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/components/google-cloud/docs/source/google_cloud_pipeline_components.experimental.rst
+++ b/components/google-cloud/docs/source/google_cloud_pipeline_components.experimental.rst
@@ -8,6 +8,6 @@ Components
    :maxdepth: 1
 
    google_cloud_pipeline_components.experimental.custom_job
-   google_cloud_pipeline_components.experimental.tensorflow_probability
    google_cloud_pipeline_components.experimental.forecasting
+   google_cloud_pipeline_components.experimental.tensorflow_probability
 

--- a/components/google-cloud/docs/source/google_cloud_pipeline_components.experimental.rst
+++ b/components/google-cloud/docs/source/google_cloud_pipeline_components.experimental.rst
@@ -9,4 +9,5 @@ Components
 
    google_cloud_pipeline_components.experimental.custom_job
    google_cloud_pipeline_components.experimental.tensorflow_probability
+   google_cloud_pipeline_components.experimental.forecasting
 


### PR DESCRIPTION
This is to add the new experimental forecast feature to Sphinx API docs