### PR TITLE
fix(backend): Fix connection lifetime default and variable names.

### DIFF
--- a/backend/src/apiserver/client_manager.go
+++ b/backend/src/apiserver/client_manager.go
@@ -50,7 +50,7 @@ const (
 	mysqlExtraParams       = "DBConfig.ExtraParams"
 	archiveLogFileName     = "ARCHIVE_CONFIG_LOG_FILE_NAME"
 	archiveLogPathPrefix   = "ARCHIVE_CONFIG_LOG_PATH_PREFIX"
-	dbConMaxLifeTimeSec    = "DBConfig.ConMaxLifeTimeSec"
+	dbConMaxLifeTime       = "DBConfig.ConMaxLifeTime"
 
 	visualizationServiceHost = "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST"
 	visualizationServicePort = "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT"
@@ -159,7 +159,7 @@ func (c *ClientManager) Authenticators() []auth.Authenticator {
 func (c *ClientManager) init() {
 	glog.Info("Initializing client manager")
 	db := initDBClient(common.GetDurationConfig(initConnectionTimeout))
-	db.SetConnMaxLifetime(common.GetDurationConfig(dbConMaxLifeTimeSec))
+	db.SetConnMaxLifetime(common.GetDurationConfig(dbConMaxLifeTime))
 
 	// time
 	c.time = util.NewRealTime()

--- a/backend/src/apiserver/config/config.json
+++ b/backend/src/apiserver/config/config.json
@@ -4,7 +4,7 @@
     "DataSourceName": "",
     "DBName": "mlpipeline",
     "GroupConcatMaxLen": "4194304",
-    "ConMaxLifeTimeSec": "120"
+    "ConMaxLifeTime": "120s"
   },
   "ObjectStoreConfig": {
     "AccessKey": "minio",

--- a/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
@@ -68,7 +68,10 @@ data:
   ## any node and avoid defaulting to specific nodes. Allowed values are:
   ## 'false' and 'true'.
   cacheNodeRestrictions: "false"
-  ## ConMaxLifeTimeSec will set the connection max lifetime for MySQL
+  ## ConMaxLifeTime will set the connection max lifetime for MySQL
   ## this is very important to setup when using external databases.
   ## See this issue for more details: https://github.com/kubeflow/pipelines/issues/5329
-  ConMaxLifeTimeSec: "120"
+  ## Note: this value should be a string that can be parsed by `time.ParseDuration`.
+  ## If this value doesn't include a unit abbreviation, the units will be assumed
+  ## to be nanoseconds.
+  ConMaxLifeTime: "120s"

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -58,11 +58,11 @@ spec:
             configMapKeyRef:
               name: pipeline-install-config
               key: dbPort
-        - name: DBCONFIG_CONMAXLIFETIMESEC
+        - name: DBCONFIG_CONMAXLIFETIME
           valueFrom:
             configMapKeyRef:
               name: pipeline-install-config
-              key: ConMaxLifeTimeSec
+              key: ConMaxLifeTime
         - name: OBJECTSTORECONFIG_ACCESSKEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
**Description of your changes:**

The apiserver config parser uses `viper.GetDuration` to parse the mysql
connection lifetime variable. The `viper.GetDuration` function uses
`cast.ToDuration`, which uses `cast.ToDurationE`, which assumes
durations to be in nanoseconds if they don't explictly include a unit.
Since the default lifetime in the kustomize manifest is `120`, we
expire connections after 120ns, which is probably unintended. To make
this more clear, this patch includes duration units in the default
values, and drops the `Secs` suffix from the configuration variables,
since the code doesn't assume that durations are in seconds.

See
https://github.com/spf13/cast/blob/22b2b540ce2e240dd3565d1238df82136be02051/caste.go#L68-L72.

Fixes #6492.

cc @Bobgy 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
