### PR TITLE
feat(sdk.v2): Support container environment variable in v2.

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -2,6 +2,8 @@
 
 ## Major Features and Improvements
 
+* Support container environment variable in v2. [\#6515](https://github.com/kubeflow/pipelines/pull/6515)
+
 ## Breaking Changes
 
 ### For Pipeline Authors
@@ -11,6 +13,8 @@
 ## Deprecations
 
 ## Bug Fixes and Other Changes
+
+* Depends on `kfp-pipeline-spec>=0.1.10,<0.2.0` [\#6515](https://github.com/kubeflow/pipelines/pull/6515)
 
 ## Documentation Updates
 

--- a/sdk/python/kfp/dsl/_component_bridge.py
+++ b/sdk/python/kfp/dsl/_component_bridge.py
@@ -629,7 +629,13 @@ def _attach_v2_specs(
         pipeline_spec_pb2.PipelineDeploymentConfig.PipelineContainerSpec(
             image=component_spec.implementation.container.image,
             command=resolved_cmd.command,
-            args=resolved_cmd.args))
+            args=resolved_cmd.args,
+            env=[
+                pipeline_spec_pb2.PipelineDeploymentConfig.PipelineContainerSpec
+                .EnvVar(name=name, value=value)
+                for name, value in task.container.env_dict.items()
+            ],
+        ))
 
     # TODO(chensun): dedupe IR component_spec and contaienr_spec
     pipeline_task_spec.component_ref.name = (

--- a/sdk/python/kfp/v2/compiler_cli_tests/compiler_cli_tests.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/compiler_cli_tests.py
@@ -14,11 +14,11 @@
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
 import unittest
-import re
 
 
 def _ignore_kfp_version_helper(file):
@@ -151,6 +151,9 @@ class CompilerCliTests(unittest.TestCase):
 
     def test_pipeline_with_exit_handler(self):
         self._test_compile_py_to_json('pipeline_with_exit_handler')
+
+    def test_pipeline_with_env(self):
+        self._test_compile_py_to_json('pipeline_with_env')
 
     def test_experimental_v2_component(self):
         self._test_compile_py_to_json('experimental_v2_component')

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_env.json
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_env.json
@@ -1,0 +1,98 @@
+{
+  "pipelineSpec": {
+    "components": {
+      "comp-print-env": {
+        "executorLabel": "exec-print-env"
+      },
+      "comp-print-env-op": {
+        "executorLabel": "exec-print-env-op"
+      }
+    },
+    "deploymentSpec": {
+      "executors": {
+        "exec-print-env": {
+          "container": {
+            "command": [
+              "sh",
+              "-c",
+              "set -e -x\necho \"$ENV2\"\necho \"$ENV3\"\n"
+            ],
+            "env": [
+              {
+                "name": "ENV2",
+                "value": "val2"
+              },
+              {
+                "name": "ENV3",
+                "value": "val3"
+              }
+            ],
+            "image": "alpine"
+          }
+        },
+        "exec-print-env-op": {
+          "container": {
+            "args": [
+              "--executor_input",
+              "{{$}}",
+              "--function_to_execute",
+              "print_env_op"
+            ],
+            "command": [
+              "sh",
+              "-c",
+              "(python3 -m ensurepip || python3 -m ensurepip --user) && (PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet                 --no-warn-script-location 'kfp==1.8.0' || PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet                 --no-warn-script-location 'kfp==1.8.0' --user) && \"$0\" \"$@\"",
+              "sh",
+              "-ec",
+              "program_path=$(mktemp -d)\nprintf \"%s\" \"$0\" > \"$program_path/ephemeral_component.py\"\npython3 -m kfp.v2.components.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n",
+              "\nfrom kfp.v2.dsl import *\nfrom typing import *\n\ndef print_env_op():\n    import os\n    print(os.environ['ENV1'])\n\n"
+            ],
+            "env": [
+              {
+                "name": "ENV1",
+                "value": "val1"
+              }
+            ],
+            "image": "python:3.7"
+          }
+        }
+      }
+    },
+    "pipelineInfo": {
+      "name": "pipeline-with-env"
+    },
+    "root": {
+      "dag": {
+        "tasks": {
+          "print-env": {
+            "cachingOptions": {
+              "enableCache": true
+            },
+            "componentRef": {
+              "name": "comp-print-env"
+            },
+            "taskInfo": {
+              "name": "print-env"
+            }
+          },
+          "print-env-op": {
+            "cachingOptions": {
+              "enableCache": true
+            },
+            "componentRef": {
+              "name": "comp-print-env-op"
+            },
+            "taskInfo": {
+              "name": "print-env-op"
+            }
+          }
+        }
+      }
+    },
+    "schemaVersion": "2.0.0",
+    "sdkVersion": "kfp-1.8.0"
+  },
+  "runtimeConfig": {
+    "gcsOutputDirectory": "dummy_root"
+  }
+}

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_env.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_env.py
@@ -1,0 +1,55 @@
+# Copyright 2020 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import kfp.v2.compiler as compiler
+from kfp import components
+from kfp.v2 import dsl
+from kfp.v2.dsl import component
+
+
+@component
+def print_env_op():
+    import os
+    print(os.environ['ENV1'])
+
+
+print_env_2_op = components.load_component_from_text("""
+name: Print env
+implementation:
+  container:
+    image: alpine
+    command:
+    - sh
+    - -c
+    - |
+      set -e -x
+      echo "$ENV2"
+      echo "$ENV3"
+    env:
+      ENV2: val0
+""")
+
+
+@dsl.pipeline(name='pipeline-with-env', pipeline_root='dummy_root')
+def my_pipeline():
+    print_env_op().set_env_variable(name='ENV1', value='val1')
+    print_env_2_op().set_env_variable(
+        name='ENV2', value='val2').set_env_variable(
+            name='ENV3', value='val3')
+
+
+if __name__ == '__main__':
+    compiler.Compiler().compile(
+        pipeline_func=my_pipeline,
+        package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -14,6 +14,7 @@
 
 import os
 import re
+
 from setuptools import setup
 
 NAME = 'kfp'
@@ -46,7 +47,7 @@ REQUIRES = [
     'Deprecated>=1.2.7,<2',
     'strip-hints>=0.1.8,<1',
     'docstring-parser>=0.7.3,<1',
-    'kfp-pipeline-spec>=0.1.9,<0.2.0',
+    'kfp-pipeline-spec>=0.1.10,<0.2.0',
     'fire>=0.3.1,<1',
     'protobuf>=3.13.0,<4',
     # Standard library backports


### PR DESCRIPTION
**Description of your changes:**
In v1, the `add_env_variable()` method takes an input of type `kubernetes.client.models.V1EnvVar`, which does not fit for Vertex Pipelines. So we add a new method `set_env_variable()` for v2.
The new method accepts a pair of `name` and `value` from constant values, but not from `PipelineParam`. The same limitation also exists in v1 `add_env_variable()`.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
