### PR TITLE
chore(components/google-cloud): Increase KFP min version

### DIFF
--- a/components/google-cloud/dependencies.py
+++ b/components/google-cloud/dependencies.py
@@ -19,7 +19,7 @@ def make_required_install_packages():
         # Explicity add google-api-core as a dependancy to avoid conflict
         # between kfp & aiplatform.
         "google-api-core<2dev,>=1.26.0",
-        "kfp>=1.4.0,<2.0.0",
+        "kfp>=1.7.2,<2.0.0",
         "google-cloud-aiplatform>=1.4.0",
     ]
 


### PR DESCRIPTION
After KFP v2 refactoring and the corresponding GCPC change only KFP versions post refactoring (ie. kfp>= 1.7.2) are compatible with GCPC >= 0.1.6.