### PR TITLE
fix(sdk): Update upper bound on kubernetes constraint in Python SDK

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -17,6 +17,7 @@
 * Remove dead code on importer check in v1. [\#6508](https://github.com/kubeflow/pipelines/pull/6508)
 * Fix issue where dict, list, bool typed input parameters don't accept constant values or pipeline inputs. [\#6523](https://github.com/kubeflow/pipelines/pull/6523)
 * Depends on `kfp-pipeline-spec>=0.1.10,<0.2.0` [\#6515](https://github.com/kubeflow/pipelines/pull/6515)
+* Depends on kubernetes>=8.0.0,<19. [\#6532](https://github.com/kubeflow/pipelines/pull/6532)
 
 ## Documentation Updates
 

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -13,7 +13,7 @@ docstring-parser>=0.7.3,<1
 # kfp.dsl
 PyYAML>=5.3,<6
 jsonschema>=3.0.1,<4
-kubernetes>=8.0.0,<13
+kubernetes>=8.0.0,<19
 
 # kfp.Client
 kfp-server-api>=1.1.2,<2.0.0

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile requirements.in
 #
+
 absl-py==0.11.0
     # via -r requirements.in
 attrs==20.3.0
@@ -68,7 +69,7 @@ kfp-pipeline-spec==0.1.9
     # via -r requirements.in
 kfp-server-api==1.3.0
     # via -r requirements.in
-kubernetes==12.0.1
+kubernetes==18.20.0
     # via -r requirements.in
 oauthlib==3.1.0
     # via requests-oauthlib

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -28,7 +28,7 @@ REQUIRES = [
     # `Blob.from_string` was introduced in google-cloud-storage 1.20.0
     # https://github.com/googleapis/python-storage/blob/master/CHANGELOG.md#1200
     'google-cloud-storage>=1.20.0,<2',
-    'kubernetes>=8.0.0,<13',
+    'kubernetes>=8.0.0,<19',
     # google-api-python-client v2 doesn't work for private dicovery by default:
     # https://github.com/googleapis/google-api-python-client/issues/1225#issuecomment-791058235
     'google-api-python-client>=1.7.8,<2',


### PR DESCRIPTION
**Description of your changes:**

Attempt to align with `kfserving` and support versions of `kubernetes` Python SDK `> 13`, we're (Zillow that is) now running KFP on Kubernetes `v1.18` (likely soon `v1.19+` as EKS is deprecating things quickly!) so trying to upgrade the SDK client. Figured I'd also just update all the requirements pinned in the `requirements.txt`.

This would also align with the strategy from `kfserving`, see [here](https://github.com/kubeflow/kfserving/blob/master/python/kfserving/requirements.txt#L6). This also conforms to the policy that seems to have been set where an upper bound is desired, introduced in [this PR](https://github.com/kubeflow/pipelines/pull/5258/files). This should update the tests to cover the latest releases of the `kubernetes` package ([PyPI link](https://pypi.org/project/kubernetes/)).