### PR TITLE
chore: add labels and error to the gcp_resources.proto

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/experimental/proto/gcp_resources.proto
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/proto/gcp_resources.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package gcp_launcher;
 
+import "google/rpc/status.proto";
+
 // The schema of the GCP resource. It will be used to parse the output parameter
 // "GCP_RESOURCES"
 message GcpResources {
@@ -12,6 +14,10 @@ message GcpResources {
     // The unique resource uri. E.g.
     // https://dataflow.googleapis.com/v1b3/projects/project_1/locations/us-central1/jobs/123
     optional string resource_uri = 2;
+    // The error from the resource.
+    google.rpc.Status error = 3;
+    // The labels of the resource, can be used to save custom metadata.
+    repeated string labels = 4;
   }
 
   // A list of resources.

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/proto/gcp_resources.proto
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/proto/gcp_resources.proto
@@ -16,7 +16,7 @@ message GcpResources {
     optional string resource_uri = 2;
     // The error from the resource.
     google.rpc.Status error = 3;
-    // The labels of the resource, can be used to save custom metadata.
+    // Optional. Used by component to save extra custom metadata for the resource.
     repeated string labels = 4;
   }
 


### PR DESCRIPTION
- added the error field, which is present in the backend proto definition
- added the labels field, user can use it to save custom metadata

**Description of your changes:**


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
