### PR TITLE
feat(deployment): update and secure metacontroller

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/composite-controller.yaml
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/composite-controller.yaml
@@ -1,13 +1,18 @@
+# Change resyncPeriodSeconds to 1 hour from insane 20 seconds  
+# Only  sync namespaces with pipelines.kubeflow.org/enabled = "true"
 apiVersion: metacontroller.k8s.io/v1alpha1
 kind: CompositeController
 metadata:
   name: kubeflow-pipelines-profile-controller
 spec:
   generateSelector: true
-  resyncPeriodSeconds: 10
+  resyncPeriodSeconds: 3600
   parentResource:
     apiVersion: v1
     resource: namespaces
+    labelSelector:
+      matchLabels:
+        pipelines.kubeflow.org/enabled = "true"
   childResources:
   - apiVersion: v1
     resource: secrets

--- a/manifests/kustomize/third-party/metacontroller/base/kustomization.yaml
+++ b/manifests/kustomize/third-party/metacontroller/base/kustomization.yaml
@@ -8,7 +8,3 @@ resources:
 - stateful-set.yaml
 commonLabels:
   kustomize.component: metacontroller
-images:
-- name: metacontroller/metacontroller
-  newName: metacontroller/metacontroller
-  newTag: v0.3.0

--- a/manifests/kustomize/third-party/metacontroller/base/stateful-set.yaml
+++ b/manifests/kustomize/third-party/metacontroller/base/stateful-set.yaml
@@ -18,26 +18,28 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       containers:
-      - command:
-        - /usr/bin/metacontroller
-        - --logtostderr
-        - -v=4
-        - --discovery-interval=20s
-        image: metacontroller/metacontroller:v0.3.0
-        imagePullPolicy: Always
-        name: metacontroller
-        ports:
-        - containerPort: 2345
-        resources:
-          limits:
-            cpu: "4"
-            memory: 4Gi
-          requests:
-            cpu: 500m
-            memory: 1Gi
-        securityContext:
-          allowPrivilegeEscalation: true
-          privileged: true
+        - resources:
+            limits:
+              cpu: '1'
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          command:
+            - /usr/bin/metacontroller
+            - --zap-log-level=4
+            - '--discovery-interval=3600s' # less insane than 10 seconds
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            privileged: false
+            allowPrivilegeEscalation: false
+          name: metacontroller
+          image: 'docker.io/metacontrollerio/metacontroller:v2.0.4'
       serviceAccountName: meta-controller-service
   # Workaround for https://github.com/kubernetes-sigs/kustomize/issues/677
   volumeClaimTemplates: []


### PR DESCRIPTION
@Bobgy @zijianjoy @orugantichetan
 Fixes #5578

I
*  upgraded to 2.0.4
*  removed insane permissions (e.g. privileged root container)
*  removed insane cpu and memory ressources (4 cores 4 GB)
*  restricted the namespaces to kubeflow profile namespaces
*  Reduced to a sane amount of logging
*  Omitted networkattachmentdefinitions for rootless istio-cni on Openshift and i did not update the profile-controller accordingly. I can still add them if someone is interested. This would also add something to pipelines-profile-controller sync.py https://istio.io/latest/docs/setup/platform-setup/openshift/#additional-requirements-for-the-application-namespace. I can also create a second pull request for that. In the same pull request i could also add the poddefault for authentication with serviceaccounts https://github.com/kubeflow/pipelines/issues/5138#issuecomment-911399642 @bartgras

Sadly it still needs cluster-admin rights, but maybe someone has an idea on how to restrict it even further.
