### PR TITLE
fix(sdk.v2): fix `Optional` type hint causing executor to ignore user inputs for parameters.

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -17,9 +17,10 @@
 * Remove dead code on importer check in v1. [\#6508](https://github.com/kubeflow/pipelines/pull/6508)
 * Fix issue where dict, list, bool typed input parameters don't accept constant values or pipeline inputs. [\#6523](https://github.com/kubeflow/pipelines/pull/6523)
 * Fix passing in "" to a str parameter causes the parameter to receive it as None instead. [\#6533](https://github.com/kubeflow/pipelines/pull/6533)
-* Depends on `kfp-pipeline-spec>=0.1.10,<0.2.0` [\#6515](https://github.com/kubeflow/pipelines/pull/6515)
-* Depends on kubernetes>=8.0.0,<19. [\#6532](https://github.com/kubeflow/pipelines/pull/6532)
 * Get short name of complex input/output types to ensure we can map to appropriate de|serializer. [\#6504](https://github.com/kubeflow/pipelines/pull/6504)
+* Fix Optional type hint causing executor to ignore user inputs for parameters. [\#6541](https://github.com/kubeflow/pipelines/pull/6541)
+* Depends on `kfp-pipeline-spec>=0.1.10,<0.2.0` [\#6515](https://github.com/kubeflow/pipelines/pull/6515)
+* Depends on `kubernetes>=8.0.0,<19`. [\#6532](https://github.com/kubeflow/pipelines/pull/6532)
 
 ## Documentation Updates
 

--- a/sdk/python/kfp/v2/compiler_cli_tests/compiler_cli_tests.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/compiler_cli_tests.py
@@ -155,6 +155,9 @@ class CompilerCliTests(unittest.TestCase):
     def test_pipeline_with_env(self):
         self._test_compile_py_to_json('pipeline_with_env')
 
+    def test_v2_component_with_optional_inputs(self):
+        self._test_compile_py_to_json('v2_component_with_optional_inputs')
+
     def test_experimental_v2_component(self):
         self._test_compile_py_to_json('experimental_v2_component')
 

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/v2_component_with_optional_inputs.json
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/v2_component_with_optional_inputs.json
@@ -1,0 +1,86 @@
+{
+  "pipelineSpec": {
+    "components": {
+      "comp-component-op": {
+        "executorLabel": "exec-component-op",
+        "inputDefinitions": {
+          "parameters": {
+            "input1": {
+              "type": "STRING"
+            },
+            "input2": {
+              "type": "STRING"
+            }
+          }
+        }
+      }
+    },
+    "deploymentSpec": {
+      "executors": {
+        "exec-component-op": {
+          "container": {
+            "args": [
+              "--executor_input",
+              "{{$}}",
+              "--function_to_execute",
+              "component_op"
+            ],
+            "command": [
+              "sh",
+              "-c",
+              "(python3 -m ensurepip || python3 -m ensurepip --user) && (PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet                 --no-warn-script-location 'kfp==1.8.1' || PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet                 --no-warn-script-location 'kfp==1.8.1' --user) && \"$0\" \"$@\"",
+              "sh",
+              "-ec",
+              "program_path=$(mktemp -d)\nprintf \"%s\" \"$0\" > \"$program_path/ephemeral_component.py\"\npython3 -m kfp.v2.components.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n",
+              "\nfrom kfp.v2.dsl import *\nfrom typing import *\n\ndef component_op(\n    input1: str = 'default value',\n    input2: Optional[str] = None,\n    input3: Optional[str] = None,\n):\n    print(f'input1: {input1}, type: {type(input1)}')\n    print(f'input2: {input2}, type: {type(input2)}')\n    print(f'input3: {input3}, type: {type(input3)}')\n\n"
+            ],
+            "image": "python:3.7"
+          }
+        }
+      }
+    },
+    "pipelineInfo": {
+      "name": "v2-component-optional-input"
+    },
+    "root": {
+      "dag": {
+        "tasks": {
+          "component-op": {
+            "cachingOptions": {
+              "enableCache": true
+            },
+            "componentRef": {
+              "name": "comp-component-op"
+            },
+            "inputs": {
+              "parameters": {
+                "input1": {
+                  "runtimeValue": {
+                    "constantValue": {
+                      "stringValue": "Hello"
+                    }
+                  }
+                },
+                "input2": {
+                  "runtimeValue": {
+                    "constantValue": {
+                      "stringValue": "World"
+                    }
+                  }
+                }
+              }
+            },
+            "taskInfo": {
+              "name": "component-op"
+            }
+          }
+        }
+      }
+    },
+    "schemaVersion": "2.0.0",
+    "sdkVersion": "kfp-1.8.1"
+  },
+  "runtimeConfig": {
+    "gcsOutputDirectory": "dummy_root"
+  }
+}

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/v2_component_with_optional_inputs.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/v2_component_with_optional_inputs.py
@@ -1,0 +1,41 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Optional
+
+from kfp.v2 import compiler, dsl
+from kfp.v2.dsl import component
+
+
+@component
+def component_op(
+    input1: str = 'default value',
+    input2: Optional[str] = None,
+    input3: Optional[str] = None,
+):
+    print(f'input1: {input1}, type: {type(input1)}')
+    print(f'input2: {input2}, type: {type(input2)}')
+    print(f'input3: {input3}, type: {type(input3)}')
+
+
+@dsl.pipeline(pipeline_root='dummy_root', name='v2-component-optional-input')
+def pipeline():
+    component_op(
+        input1='Hello',
+        input2='World',
+    )
+
+
+if __name__ == '__main__':
+    compiler.Compiler().compile(
+        pipeline_func=pipeline, package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/kfp/v2/components/executor.py
+++ b/sdk/python/kfp/v2/components/executor.py
@@ -262,6 +262,11 @@ class Executor():
             if k == 'return':
                 continue
 
+            # Annotations for parameter types could be written as, for example,
+            # `Optional[str]`. In this case, we need to strip off the part
+            # `Optional[]` to get the actual parameter type.
+            v = type_annotations.maybe_strip_optional_from_annotation(v)
+
             if self._is_parameter(v):
                 func_kwargs[k] = self._get_input_parameter_value(k, v)
 

--- a/sdk/python/kfp/v2/components/types/type_annotations_test.py
+++ b/sdk/python/kfp/v2/components/types/type_annotations_test.py
@@ -14,14 +14,18 @@
 """Tests for kfp.v2.components.types.type_annotations."""
 
 import unittest
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
+from absl.testing import parameterized
 from kfp.v2.components.types import type_annotations
 from kfp.v2.components.types.artifact_types import Model
-from kfp.v2.components.types.type_annotations import Input, InputAnnotation, Output, OutputAnnotation
+from kfp.v2.components.types.type_annotations import (Input, InputAnnotation,
+                                                      InputPath, Output,
+                                                      OutputAnnotation,
+                                                      OutputPath)
 
 
-class AnnotationsTest(unittest.TestCase):
+class AnnotationsTest(parameterized.TestCase):
 
     def test_is_artifact_annotation(self):
         self.assertTrue(type_annotations.is_artifact_annotation(Input[Model]))
@@ -74,6 +78,78 @@ class AnnotationsTest(unittest.TestCase):
         self.assertEqual(
             type_annotations.get_io_artifact_annotation(Model), None)
         self.assertEqual(type_annotations.get_io_artifact_annotation(str), None)
+
+    @parameterized.parameters(
+        {
+            'original_annotation': str,
+            'expected_annotation': str,
+        },
+        {
+            'original_annotation': 'MyCustomType',
+            'expected_annotation': 'MyCustomType',
+        },
+        {
+            'original_annotation': List[int],
+            'expected_annotation': List[int],
+        },
+        {
+            'original_annotation': Optional[str],
+            'expected_annotation': str,
+        },
+        {
+            'original_annotation': Optional[Dict[str, float]],
+            'expected_annotation': Dict[str, float],
+        },
+        {
+            'original_annotation': Optional[List[Dict[str, Any]]],
+            'expected_annotation': List[Dict[str, Any]],
+        },
+        {
+            'original_annotation': Input[Model],
+            'expected_annotation': Input[Model],
+        },
+        {
+            'original_annotation': InputPath('Model'),
+            'expected_annotation': InputPath('Model'),
+        },
+        {
+            'original_annotation': OutputPath(Model),
+            'expected_annotation': OutputPath(Model),
+        },
+    )
+    def test_maybe_strip_optional_from_annotation(self, original_annotation,
+                                                  expected_annotation):
+        self.assertEqual(
+            expected_annotation,
+            type_annotations.maybe_strip_optional_from_annotation(
+                original_annotation))
+
+    @parameterized.parameters(
+        {
+            'original_type_name': 'str',
+            'expected_type_name': 'str',
+        },
+        {
+            'original_type_name': 'typing.List[int]',
+            'expected_type_name': 'List',
+        },
+        {
+            'original_type_name': 'List[int]',
+            'expected_type_name': 'List',
+        },
+        {
+            'original_type_name': 'Dict[str, str]',
+            'expected_type_name': 'Dict',
+        },
+        {
+            'original_type_name': 'List[Dict[str, str]]',
+            'expected_type_name': 'List',
+        },
+    )
+    def test_get_short_type_name(self, original_type_name, expected_type_name):
+        self.assertEqual(
+            expected_type_name,
+            type_annotations.get_short_type_name(original_type_name))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of your changes:**
The issue is `_is_parameter` would return `False` on annotation `Optional[str]`:
https://github.com/kubeflow/pipelines/blob/a0b18eb9e8da25c7b81b0b75cf0f39297c809d20/sdk/python/kfp/v2/components/executor.py#L167-L173
As a result, we would not set the value in `func_kwargs`: 
https://github.com/kubeflow/pipelines/blob/a0b18eb9e8da25c7b81b0b75cf0f39297c809d20/sdk/python/kfp/v2/components/executor.py#L265-L266

The fix is to strip off `Optional[]` before passing the annotation to `_is_parameter` and `_get_input_parameter_value`.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
