### PR TITLE
fix(sdk): Allow other nvidia gpu resource types. Fixes #5026

### DIFF
--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -315,8 +315,8 @@ def _op_to_template(op: BaseOp):
     if isinstance(op, dsl.ContainerOp) and ('resources' in op.container.keys()):
         for setting, val in op.container['resources'].items():
             for resource, param in val.items():
-                if (resource in ['cpu', 'memory', 'amd.com/gpu'] \
-                    resource.startswith('nvidia.com/') or \
+                if (resource in ['cpu', 'memory', 'amd.com/gpu'] or\
+                    resource.startswith('nvidia.com/') or\
                     or re.match('^{{inputs.parameters.*}}$', resource))\
                     and re.match('^{{inputs.parameters.*}}$', str(param)):
                     if not 'containers' in podSpecPatch:

--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -315,7 +315,7 @@ def _op_to_template(op: BaseOp):
     if isinstance(op, dsl.ContainerOp) and ('resources' in op.container.keys()):
         for setting, val in op.container['resources'].items():
             for resource, param in val.items():
-                if (resource in ['cpu', 'memory', 'amd.com/gpu', 'nvidia.com/gpu'] \
+                if (resource in ['cpu', 'memory', 'amd.com/gpu'] \
                     resource.startswith('nvidia.com/') or \
                     or re.match('^{{inputs.parameters.*}}$', resource))\
                     and re.match('^{{inputs.parameters.*}}$', str(param)):

--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -315,7 +315,9 @@ def _op_to_template(op: BaseOp):
     if isinstance(op, dsl.ContainerOp) and ('resources' in op.container.keys()):
         for setting, val in op.container['resources'].items():
             for resource, param in val.items():
-                if (resource in ['cpu', 'memory', 'amd.com/gpu', 'nvidia.com/gpu'] or re.match('^{{inputs.parameters.*}}$', resource))\
+                if (resource in ['cpu', 'memory', 'amd.com/gpu', 'nvidia.com/gpu'] \
+                    resource.startswith('nvidia.com/') or \
+                    or re.match('^{{inputs.parameters.*}}$', resource))\
                     and re.match('^{{inputs.parameters.*}}$', str(param)):
                     if not 'containers' in podSpecPatch:
                         podSpecPatch['containers'] = [{


### PR DESCRIPTION
**Description of your changes:**

- Allows more general NVIDIA GPU setups by permitting resources to take on a wider set of values
- Compatible with the new A100 servers, which use the resource names `nvidia.com/mig-1g.10gb`, `nvidia.com/mig-2g.20gb`, `nvidia.com/mig-4g.40gb` and `nvidia.com/mig-7g.80gb`.
- I also note in #5026 that @kd303's A100 GPU has the resource name `nvidia.com/mig-3g.20gb`. This change would work for his setup also.

I could have fixed it to specifically those resource names, but I imagine there may be other setups out there I am not aware of and opted to accept any resource name starting with `nvidia.com/`

I have tested this change on my A100 server setup and it works fine.

