### PR TITLE
fix(components): Fixes `default-editor` unable to create PVC in `default` namespace

### DIFF
--- a/components/contrib/kubernetes/Create_PersistentVolumeClaim/component.yaml
+++ b/components/contrib/kubernetes/Create_PersistentVolumeClaim/component.yaml
@@ -1,6 +1,7 @@
 name: Create PersistentVolumeClaim in Kubernetes
 inputs:
 - {name: Name,         type: String}
+- {name: Namespace,    type: String, default: default}
 - {name: Storage size, type: String, default: 1Gi}
 outputs:
 - {name: Name,         type: String}
@@ -16,8 +17,9 @@ implementation:
     - -exc
     - |
       name=$0
-      storage_size=$1
-      output_name_path=$2
+      namespace=$1
+      storage_size=$2
+      output_name_path=$3
       mkdir -p "$(dirname "$output_name_path")"
       object_path=$(mktemp)
 
@@ -26,6 +28,7 @@ implementation:
       kind: PersistentVolumeClaim
       metadata:
         name: $name
+        namespace: $namespace
       spec:
         #storageClassName: standard
         accessModes:
@@ -34,10 +37,11 @@ implementation:
           requests:
             storage: $storage_size
       EOF
-      object_name=$(kubectl apply -f "$object_path" --namespace default --output=name)
+      object_name=$(kubectl apply -f "$object_path" --output=name)
       object_name=${object_name##persistentvolumeclaim/}
       echo "$object_name" >"$output_name_path"
 
     - {inputValue: Name}
+    - {inputValue: Namespace}
     - {inputValue: Storage size}
     - {outputPath: Name}


### PR DESCRIPTION
**Description of your changes:**
The component fails when the pipeline is run in namespaces other than `default` as `default-editor` service account wouldn't have access to the default namespace. Adding an extra arg called `namespace` which should give users the flexibility to run it in their namespace instead.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
