### PR TITLE
fix(sdk.v2): fixes broken output parameter type checking in `_handle_single_return_value`

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -13,6 +13,7 @@
 ## Bug Fixes and Other Changes
 
 * v2 compiler to throw no task defined error. [\#6545](https://github.com/kubeflow/pipelines/pull/6545)
+* Improve output parameter type checking in V2 SDK. [\#6566](https://github.com/kubeflow/pipelines/pull/6566)
 
 ## Documentation Updates
 

--- a/sdk/python/kfp/v2/components/executor.py
+++ b/sdk/python/kfp/v2/components/executor.py
@@ -189,11 +189,12 @@ class Executor():
     def _handle_single_return_value(self, output_name: str,
                                     annotation_type: Any, return_value: Any):
         if self._is_parameter(annotation_type):
-            if type(return_value) != annotation_type:
+            origin_type = getattr(annotation_type, '__origin__', None) or annotation_type
+            if not isinstance(return_value, origin_type):
                 raise ValueError(
                     'Function `{}` returned value of type {}; want type {}'
                     .format(self._func.__name__, type(return_value),
-                            annotation_type))
+                            origin_type))
             self._write_output_parameter_value(output_name, return_value)
         elif self._is_artifact(annotation_type):
             self._write_output_artifact_payload(output_name, return_value)

--- a/sdk/python/kfp/v2/components/executor_test.py
+++ b/sdk/python/kfp/v2/components/executor_test.py
@@ -17,7 +17,7 @@ import json
 import os
 import tempfile
 import unittest
-from typing import Callable, NamedTuple, Optional
+from typing import Callable, Dict, List, NamedTuple, Optional
 
 from kfp.v2.components import executor
 from kfp.v2.components.types import artifact_types
@@ -294,6 +294,162 @@ class ExecutorTest(unittest.TestCase):
             "parameters": {
                 "Output": {
                     "intValue": 42
+                }
+            },
+        })
+
+    def test_function_with_list_output(self):
+        executor_input = """\
+    {
+      "inputs": {
+        "parameters": {
+          "first": {
+            "intValue": 40
+          },
+          "second": {
+            "intValue": 2
+          }
+        }
+      },
+      "outputs": {
+        "parameters": {
+          "output": {
+            "outputFile": "gs://some-bucket/output"
+          }
+        },
+        "outputFile": "%s/output_metadata.json"
+      }
+    }
+    """
+
+        def test_func(first: int, second: int) -> List:
+            return [first, second]
+
+        self._get_executor(test_func, executor_input).execute()
+        with open(os.path.join(self._test_dir, 'output_metadata.json'),
+                  'r') as f:
+            output_metadata = json.loads(f.read())
+        self.assertDictEqual(output_metadata, {
+            "parameters": {
+                "Output": {
+                    "stringValue": "[40, 2]"
+                }
+            },
+        })
+
+    def test_function_with_dict_output(self):
+        executor_input = """\
+    {
+      "inputs": {
+        "parameters": {
+          "first": {
+            "intValue": 40
+          },
+          "second": {
+            "intValue": 2
+          }
+        }
+      },
+      "outputs": {
+        "parameters": {
+          "output": {
+            "outputFile": "gs://some-bucket/output"
+          }
+        },
+        "outputFile": "%s/output_metadata.json"
+      }
+    }
+    """
+
+        def test_func(first: int, second: int) -> Dict:
+            return {"first": first, "second": second}
+
+        self._get_executor(test_func, executor_input).execute()
+        with open(os.path.join(self._test_dir, 'output_metadata.json'),
+                  'r') as f:
+            output_metadata = json.loads(f.read())
+        self.assertDictEqual(output_metadata, {
+            "parameters": {
+                "Output": {
+                    "stringValue": "{\"first\": 40, \"second\": 2}"
+                }
+            },
+        })
+
+    def test_function_with_typed_list_output(self):
+        executor_input = """\
+    {
+      "inputs": {
+        "parameters": {
+          "first": {
+            "intValue": 40
+          },
+          "second": {
+            "intValue": 2
+          }
+        }
+      },
+      "outputs": {
+        "parameters": {
+          "output": {
+            "outputFile": "gs://some-bucket/output"
+          }
+        },
+        "outputFile": "%s/output_metadata.json"
+      }
+    }
+    """
+
+        def test_func(first: int, second: int) -> List[int]:
+            return [first, second]
+
+        self._get_executor(test_func, executor_input).execute()
+        with open(os.path.join(self._test_dir, 'output_metadata.json'),
+                  'r') as f:
+            output_metadata = json.loads(f.read())
+        self.assertDictEqual(output_metadata, {
+            "parameters": {
+                "Output": {
+                    "stringValue": "[40, 2]"
+                }
+            },
+        })
+
+    def test_function_with_typed_dict_output(self):
+        executor_input = """\
+    {
+      "inputs": {
+        "parameters": {
+          "first": {
+            "intValue": 40
+          },
+          "second": {
+            "intValue": 2
+          }
+        }
+      },
+      "outputs": {
+        "parameters": {
+          "output": {
+            "outputFile": "gs://some-bucket/output"
+          }
+        },
+        "outputFile": "%s/output_metadata.json"
+      }
+    }
+    """
+
+        def test_func(first: int, second: int) -> Dict[str, int]:
+            return {"first": first, "second": second}
+
+        self._get_executor(test_func, executor_input).execute()
+        with open(os.path.join(self._test_dir, 'output_metadata.json'),
+                  'r') as f:
+            output_metadata = json.loads(f.read())
+        self.assertDictEqual(output_metadata, {
+            "parameters": {
+                "Output": {
+                    "stringValue": "{\"first\": 40, \"second\": 2}"
                 }
             },
         })


### PR DESCRIPTION
**Description of your changes:**
This function would fail under two scenarios:
- typed `list` or `dict` output parameters (ie. `Dict[str, str]`) raised an incorrect `ValueError`
- using `list` or `dict` rather than `List` or `Dict` raised an incorrect `ValueError` ([PEP 585](https://www.python.org/dev/peps/pep-0585/#terminology))

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
