### PR TITLE
fix(sdk): support argo workflow variables while sanitizing k8s names. Fixes #6559

### DIFF
--- a/sdk/python/kfp/dsl/_pipeline_param.py
+++ b/sdk/python/kfp/dsl/_pipeline_param.py
@@ -34,7 +34,7 @@ def sanitize_k8s_name(name, allow_capital_underscore=False):
       A sanitized name.
     """
     # Argo Workflow Variables are captured in Odd-indexed Arrays
-    groups = re.split("({{.+}})", name)
+    groups = re.split("({{.+?}})", name)
 
     for i in range(0, len(groups), 2):
         if allow_capital_underscore:

--- a/sdk/python/kfp/dsl/_pipeline_param.py
+++ b/sdk/python/kfp/dsl/_pipeline_param.py
@@ -33,12 +33,19 @@ def sanitize_k8s_name(name, allow_capital_underscore=False):
     Returns:
       A sanitized name.
     """
-    if allow_capital_underscore:
-        return re.sub('-+', '-', re.sub('[^-_0-9A-Za-z]+', '-',
-                                        name)).lstrip('-').rstrip('-')
-    else:
-        return re.sub('-+', '-', re.sub('[^-0-9a-z]+', '-',
-                                        name.lower())).lstrip('-').rstrip('-')
+    # Argo Workflow Variables are captured in Odd-indexed Arrays
+    groups = re.split("({{.+}})", name)
+
+    for i in range(0, len(groups), 2):
+        if allow_capital_underscore:
+            group = re.sub('[^-_0-9A-Za-z]+', '-', groups[i])
+        else:
+            group = re.sub('[^-0-9a-z]+', '-', groups[i])
+
+        groups[i] = re.sub('-+', '-', group)
+
+    sanitized_name = ''.join(groups).lstrip('-').rstrip('-')
+    return sanitized_name
 
 
 def match_serialized_pipelineparam(payload: str) -> List[PipelineParamTuple]:

--- a/sdk/python/tests/dsl/pipeline_param_tests.py
+++ b/sdk/python/tests/dsl/pipeline_param_tests.py
@@ -118,6 +118,3 @@ class TestSanitizeK8sName(unittest.TestCase):
         got = list(map(sanitize_k8s_name,cases))
         expected = ["abc-def", "abc-bc"]
         self.assertListEqual(got, expected)
-
-
-

--- a/sdk/python/tests/dsl/pipeline_param_tests.py
+++ b/sdk/python/tests/dsl/pipeline_param_tests.py
@@ -108,9 +108,9 @@ class TestPipelineParam(unittest.TestCase):
 class TestSanitizeK8sName(unittest.TestCase):
 
     def test_argo_variables(self):
-        cases = ["{{workflow.name}}", "abc-{{workflow.name}}-def.."]
-        got = list(map(sanitize_k8s_name,cases))
-        expected = ["{{workflow.name}}", "abc-{{workflow.name}}-def"]
+        cases = ["{{workflow.name}}", "abc-{{workflow.name}}-def..", "{{workflow.name}}-?{{workflow.uid}}"]
+        got = list(map(sanitize_k8s_name, cases))
+        expected = ["{{workflow.name}}", "abc-{{workflow.name}}-def", "{{workflow.name}}-{{workflow.uid}}"]
         self.assertListEqual(got, expected)
 
     def test_sanitize_names(self):

--- a/sdk/python/tests/dsl/pipeline_param_tests.py
+++ b/sdk/python/tests/dsl/pipeline_param_tests.py
@@ -14,7 +14,7 @@
 
 from kubernetes.client.models import V1ConfigMap, V1Container, V1EnvVar
 from kfp.dsl import PipelineParam
-from kfp.dsl._pipeline_param import _extract_pipelineparams, extract_pipelineparams_from_any
+from kfp.dsl._pipeline_param import _extract_pipelineparams, extract_pipelineparams_from_any, sanitize_k8s_name
 import unittest
 
 
@@ -104,3 +104,20 @@ class TestPipelineParam(unittest.TestCase):
         ]
         params = _extract_pipelineparams(payload)
         self.assertListEqual([p1, p2, p3], params)
+
+class TestSanitizeK8sName(unittest.TestCase):
+
+    def test_argo_variables(self):
+        cases = ["{{workflow.name}}", "abc-{{workflow.name}}-def.."]
+        got = list(map(sanitize_k8s_name,cases))
+        expected = ["{{workflow.name}}", "abc-{{workflow.name}}-def"]
+        self.assertListEqual(got, expected)
+
+    def test_sanitize_names(self):
+        cases = ["abc*def*", "abcAbc-_-"]
+        got = list(map(sanitize_k8s_name,cases))
+        expected = ["abc-def", "abc-bc"]
+        self.assertListEqual(got, expected)
+
+
+


### PR DESCRIPTION
**Description of your changes:**

- Changes for sanitize_k8s_name in dsl to support argo workflow variables like to support resource names like:
  - pvc-{{workflow.name}}
  - crd-{{workflow.uid}} etc.
- Added tests for sanitize_k8s_name

Fix #6559 



**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
