### PR TITLE
feat(sdk): Enable re-use of PVC with VolumeOp

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -12,7 +12,7 @@
 
 ## Bug Fixes and Other Changes
 * Fix duplicate function for `list_pipeline_versions()`. [\#6594](https://github.com/kubeflow/pipelines/pull/6594)
-
+* Support re-use of PVC with VolumeOp. [\#6582](https://github.com/kubeflow/pipelines/pull/6582)
 ## Documentation Updates
 
 # 1.8.2

--- a/sdk/python/kfp/dsl/_volume_op.py
+++ b/sdk/python/kfp/dsl/_volume_op.py
@@ -48,6 +48,7 @@ class VolumeOp(ResourceOp):
         VolumeSnapshot name (Alpha feature)
       volume_name: VolumeName is the binding reference to the PersistentVolume
         backing this claim.
+      generate_unique_name: Generate unique name for the PVC
       kwargs: See :py:class:`kfp.dsl.ResourceOp`
 
     Raises:
@@ -68,6 +69,7 @@ class VolumeOp(ResourceOp):
                  annotations: Dict[str, str] = None,
                  data_source=None,
                  volume_name=None,
+                 generate_unique_name: bool = True,
                  **kwargs):
         # Add size to attribute outputs
         self.attribute_outputs = {"size": "{.status.capacity.storage}"}
@@ -103,7 +105,7 @@ class VolumeOp(ResourceOp):
         if not match_serialized_pipelineparam(str(resource_name)):
             resource_name = sanitize_k8s_name(resource_name)
         pvc_metadata = V1ObjectMeta(
-            name="{{workflow.name}}-%s" % resource_name,
+            name="{{workflow.name}}-%s" % resource_name if generate_unique_name else resource_name,
             annotations=annotations)
         requested_resources = V1ResourceRequirements(requests={"storage": size})
         pvc_spec = V1PersistentVolumeClaimSpec(


### PR DESCRIPTION
**Description of your changes:**
Ideally, `VolumeOp` should create a unique PVC for each run. But in the case where the same PVC has to be re-used for recurring runs `generate_name` argument can be set to `False`.

Fixes: https://github.com/kubeflow/pipelines/issues/6562

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
