### PR TITLE
chore(components/google-cloud): Create Release Branch for Google cloud pipeline components 0.1.7

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,9 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 version: 2
 sphinx:
-  configuration: docs/conf.py
+  configuration: components/google-cloud/docs/source/conf.py
 python:
-  version: 3.7
+  version: 3.8
   install:
-    - requirements: sdk/python/requirements.txt
+    - method: setuptools
+      path: components/google-cloud

--- a/components/google-cloud/RELEASE.md
+++ b/components/google-cloud/RELEASE.md
@@ -1,5 +1,11 @@
-# Current Version 0.1.7.dev (Still in Development)
-* Add notes for next release here.
+# Current Version 0.1.7
+* Add support for labels in custom_job wrapper. 
+* Add a component that connects the forecasting preprocessing and training components.
+* Write GCP_RESOURCE proto for the custom_job output.
+* Expose Custom Job parameters Service Account, Network and CMEK via Custom Job wrapper.
+* Increase KFP min version dependency.
+* AUpdate documentations for GCPC components.
+* Update typing checks to include Python3.6 deprecated types. 
 
 # Release 0.1.6
 * Experimental component for Model Forecast.

--- a/components/google-cloud/google_cloud_pipeline_components/aiplatform/utils.py
+++ b/components/google-cloud/google_cloud_pipeline_components/aiplatform/utils.py
@@ -32,7 +32,7 @@ METHOD_KEY = 'method'
 
 # Container image that is used for component containers
 # TODO tie the container version to sdk release version instead of latest
-DEFAULT_CONTAINER_IMAGE = 'gcr.io/ml-pipeline/google-cloud-pipeline-components:latest'
+DEFAULT_CONTAINER_IMAGE = 'gcr.io/ml-pipeline/google-cloud-pipeline-components:0.1.7'
 
 # map of MB SDK type to Metadata type
 RESOURCE_TO_METADATA_TYPE = {

--- a/components/google-cloud/google_cloud_pipeline_components/remote/aiplatform/Dockerfile
+++ b/components/google-cloud/google_cloud_pipeline_components/remote/aiplatform/Dockerfile
@@ -25,7 +25,7 @@ RUN pip3 install -U google-cloud-aiplatform
 RUN pip3 install -U google-cloud-storage
 
 # Install main package (switch to using pypi package for official release)
-RUN pip3 install "git+https://github.com/kubeflow/pipelines.git#egg=google-cloud-pipeline-components&subdirectory=components/google-cloud"
+RUN pip3 install "git+https://github.com/kubeflow/pipelines.git@google-cloud-pipeline-components-0.1.7#egg=google-cloud-pipeline-components&subdirectory=components/google-cloud"
 
 # Note that components can override the container entry ponint. 
 ENTRYPOINT ["python3","-m","google_cloud_pipeline_components.remote.aiplatform.remote_runner"]

--- a/components/google-cloud/google_cloud_pipeline_components/remote/aiplatform/cloudbuild.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/remote/aiplatform/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/kaniko-project/executor:latest'
   args: 
-  - --destination=gcr.io/$PROJECT_ID/google-cloud-pipeline-components:latest
+  - --destination=gcr.io/$PROJECT_ID/google-cloud-pipeline-components:0.1.7
   - --cache=true
   - --cache-ttl=12h

--- a/components/google-cloud/google_cloud_pipeline_components/version.py
+++ b/components/google-cloud/google_cloud_pipeline_components/version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """Contains the version string of Google Cloud Pipeline Components."""
 
-__version__ = "0.1.7.dev"
+__version__ = "0.1.7"


### PR DESCRIPTION
# Release Version 0.1.7
* Add support for labels in custom_job wrapper. 
* Add a component that connects the forecasting preprocessing and training components.
* Write GCP_RESOURCE proto for the custom_job output.
* Expose Custom Job parameters Service Account, Network and CMEK via Custom Job wrapper.
* Increase KFP min version dependency.
* AUpdate documentations for GCPC components.
* Update typing checks to include Python3.6 deprecated types. 