### PR TITLE
manifests: Upgrade kpt to 1.0.0-beta.6. Fix #5368

### DIFF
--- a/manifests/kustomize/hack/test.sh
+++ b/manifests/kustomize/hack/test.sh
@@ -56,7 +56,4 @@ do
   kustomize build "${MANIFESTS_DIR}/${path}" >/dev/null
 done
 
-# TODO(Bobgy): fix this for kpt v1
-# verify these manifests work with kpt
-# to prevent issues like https://github.com/kubeflow/pipelines/issues/5368
-# kpt cfg tree "${MANIFESTS_DIR}" >/dev/null
+kpt pkg tree "${MANIFESTS_DIR}" >/dev/null

--- a/manifests/kustomize/third-party/argo/README.md
+++ b/manifests/kustomize/third-party/argo/README.md
@@ -20,6 +20,10 @@ Refer to [third_party/argo/README.md](../../../../third_party/argo/README.md).
 
 ### Upgrade argo manifests
 
+Requirement: 
+
+Use kpt version above 1.0.0-beta.6, refer to [kpt installation](https://kpt.dev/installation/) for downloading kpt.
+
 As one step of above, we need to upgrade argo manifests in this folder.
 
 1. Run:

--- a/manifests/kustomize/third-party/argo/upstream/manifests/Kptfile
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/Kptfile
@@ -1,11 +1,18 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: manifests
 upstream:
   type: git
   git:
-    commit: a245fe67db56d2808fb78c6079d08404cbee91aa
     repo: https://github.com/argoproj/argo-workflows
     directory: /manifests
-    ref: v3.1.1
+    ref: v3.1.6
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/argoproj/argo-workflows
+    directory: /manifests
+    ref: v3.1.6
+    commit: 14e1278572b28d8b1854858ce7de355ce60199c9

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/argo-server/argo-server-deployment.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/argo-server/argo-server-deployment.yaml
@@ -1,6 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
-metadata:
+metadata: # kpt-merge: /argo-server
   name: argo-server
 spec:
   selector:
@@ -19,7 +19,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          args: [ server ]
+          args: [server]
           ports:
             - name: web
               containerPort: 2746
@@ -35,7 +35,7 @@ spec:
               name: tmp
       volumes:
         - name: tmp
-          emptyDir: { }
+          emptyDir: {}
       securityContext:
         runAsNonRoot: true
       nodeSelector:

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/argo-server/argo-server-sa.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/argo-server/argo-server-sa.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
-metadata:
+metadata: # kpt-merge: /argo-server
   name: argo-server

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/argo-server/argo-server-service.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/argo-server/argo-server-service.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Service
-metadata:
+metadata: # kpt-merge: /argo-server
   name: argo-server
 spec:
   selector:

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/argo-server/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/argo-server/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
 - argo-server-deployment.yaml
 - argo-server-sa.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_clusterworkflowtemplates.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_clusterworkflowtemplates.yaml
@@ -1,7 +1,7 @@
 # This is an auto-generated file. DO NOT EDIT
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
-metadata:
+metadata: # kpt-merge: /clusterworkflowtemplates.argoproj.io
   name: clusterworkflowtemplates.argoproj.io
 spec:
   group: argoproj.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_cronworkflows.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_cronworkflows.yaml
@@ -1,7 +1,7 @@
 # This is an auto-generated file. DO NOT EDIT
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
-metadata:
+metadata: # kpt-merge: /cronworkflows.argoproj.io
   name: cronworkflows.argoproj.io
 spec:
   group: argoproj.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_workfloweventbindings.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_workfloweventbindings.yaml
@@ -1,7 +1,7 @@
 # This is an auto-generated file. DO NOT EDIT
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
-metadata:
+metadata: # kpt-merge: /workfloweventbindings.argoproj.io
   name: workfloweventbindings.argoproj.io
 spec:
   group: argoproj.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_workflows.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_workflows.yaml
@@ -1,7 +1,7 @@
 # This is an auto-generated file. DO NOT EDIT
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
-metadata:
+metadata: # kpt-merge: /workflows.argoproj.io
   name: workflows.argoproj.io
 spec:
   group: argoproj.io
@@ -14042,6 +14042,198 @@ spec:
             properties:
               artifactRepositoryRef:
                 properties:
+                  artifactRepository:
+                    properties:
+                      archiveLogs:
+                        type: boolean
+                      artifactory:
+                        properties:
+                          passwordSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          repoURL:
+                            type: string
+                          usernameSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      gcs:
+                        properties:
+                          bucket:
+                            type: string
+                          keyFormat:
+                            type: string
+                          serviceAccountKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      hdfs:
+                        properties:
+                          addresses:
+                            items:
+                              type: string
+                            type: array
+                          force:
+                            type: boolean
+                          hdfsUser:
+                            type: string
+                          krbCCacheSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          krbConfigConfigMap:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          krbKeytabSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          krbRealm:
+                            type: string
+                          krbServicePrincipalName:
+                            type: string
+                          krbUsername:
+                            type: string
+                          pathFormat:
+                            type: string
+                        type: object
+                      oss:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          bucket:
+                            type: string
+                          createBucketIfNotPresent:
+                            type: boolean
+                          endpoint:
+                            type: string
+                          keyFormat:
+                            type: string
+                          lifecycleRule:
+                            properties:
+                              markDeletionAfterDays:
+                                format: int32
+                                type: integer
+                              markInfrequentAccessAfterDays:
+                                format: int32
+                                type: integer
+                            type: object
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          securityToken:
+                            type: string
+                        type: object
+                      s3:
+                        properties:
+                          accessKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          bucket:
+                            type: string
+                          createBucketIfNotPresent:
+                            properties:
+                              objectLocking:
+                                type: boolean
+                            type: object
+                          endpoint:
+                            type: string
+                          insecure:
+                            type: boolean
+                          keyFormat:
+                            type: string
+                          keyPrefix:
+                            type: string
+                          region:
+                            type: string
+                          roleARN:
+                            type: string
+                          secretKeySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          useSDKCreds:
+                            type: boolean
+                        type: object
+                    type: object
                   configMap:
                     type: string
                   default:

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_workflowtemplates.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_workflowtemplates.yaml
@@ -1,7 +1,7 @@
 # This is an auto-generated file. DO NOT EDIT
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
-metadata:
+metadata: # kpt-merge: /workflowtemplates.argoproj.io
   name: workflowtemplates.argoproj.io
 spec:
   group: argoproj.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/full/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/full/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
 - argoproj.io_clusterworkflowtemplates.yaml
 - argoproj.io_cronworkflows.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
   - minimal

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_clusterworkflowtemplates.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_clusterworkflowtemplates.yaml
@@ -1,6 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
-metadata:
+metadata: # kpt-merge: /clusterworkflowtemplates.argoproj.io
   name: clusterworkflowtemplates.argoproj.io
 spec:
   group: argoproj.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_cronworkflows.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_cronworkflows.yaml
@@ -1,6 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
-metadata:
+metadata: # kpt-merge: /cronworkflows.argoproj.io
   name: cronworkflows.argoproj.io
 spec:
   group: argoproj.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_workfloweventbindings.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_workfloweventbindings.yaml
@@ -1,6 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
-metadata:
+metadata: # kpt-merge: /workfloweventbindings.argoproj.io
   name: workfloweventbindings.argoproj.io
 spec:
   group: argoproj.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_workflows.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_workflows.yaml
@@ -1,6 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
-metadata:
+metadata: # kpt-merge: /workflows.argoproj.io
   name: workflows.argoproj.io
 spec:
   group: argoproj.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_workflowtemplates.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_workflowtemplates.yaml
@@ -1,6 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
-metadata:
+metadata: # kpt-merge: /workflowtemplates.argoproj.io
   name: workflowtemplates.argoproj.io
 spec:
   group: argoproj.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/minimal/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/crds/minimal/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
 - argoproj.io_clusterworkflowtemplates.yaml
 - argoproj.io_cronworkflows.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
 - crds
 - workflow-controller

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/workflow-controller/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/workflow-controller/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
 - workflow-controller-configmap.yaml
 - workflow-controller-deployment.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-configmap.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-configmap.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ConfigMap
-metadata:
+metadata: # kpt-merge: /workflow-controller-configmap
   name: workflow-controller-configmap

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-deployment.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-deployment.yaml
@@ -1,6 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
-metadata:
+metadata: # kpt-merge: /workflow-controller
   name: workflow-controller
 spec:
   selector:

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-metrics-service.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-metrics-service.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Service
-metadata:
+metadata: # kpt-merge: /workflow-controller-metrics
   name: workflow-controller-metrics
   labels:
     app: workflow-controller

--- a/manifests/kustomize/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-sa.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-sa.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
-metadata:
+metadata: # kpt-merge: /argo
   name: argo

--- a/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/argo-server-rbac/argo-server-clusterole.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/argo-server-rbac/argo-server-clusterole.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-metadata:
+metadata: # kpt-merge: /argo-server-cluster-role
   name: argo-server-cluster-role
 rules:
   - apiGroups:

--- a/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/argo-server-rbac/argo-server-clusterolebinding.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/argo-server-rbac/argo-server-clusterolebinding.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
-metadata:
+metadata: # kpt-merge: /argo-server-binding
   name: argo-server-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/argo-server-rbac/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/argo-server-rbac/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
 - argo-server-clusterole.yaml
 - argo-server-clusterolebinding.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
 - ../base
 - ./workflow-controller-rbac

--- a/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
 - workflow-aggregate-roles.yaml
 - workflow-controller-clusterrole.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-metadata:
+metadata: # kpt-merge: /argo-aggregate-to-view
   name: argo-aggregate-to-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -22,11 +22,10 @@ rules:
   - get
   - list
   - watch
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-metadata:
+metadata: # kpt-merge: /argo-aggregate-to-edit
   name: argo-aggregate-to-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -53,11 +52,10 @@ rules:
   - patch
   - update
   - watch
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-metadata:
+metadata: # kpt-merge: /argo-aggregate-to-admin
   name: argo-aggregate-to-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"

--- a/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrole.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrole.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-metadata:
+metadata: # kpt-merge: /argo-cluster-role
   name: argo-cluster-role
 rules:
 - apiGroups:
@@ -83,10 +83,10 @@ rules:
   - create
   - patch
 - apiGroups:
-    - "policy"
+  - "policy"
   resources:
-    - poddisruptionbudgets
+  - poddisruptionbudgets
   verbs:
-    - create
-    - get
-    - delete
+  - create
+  - get
+  - delete

--- a/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrolebinding.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrolebinding.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
-metadata:
+metadata: # kpt-merge: /argo-binding
   name: argo-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-controller-role.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-controller-role.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
-metadata:
+metadata: # kpt-merge: /argo-role
   name: argo-role
 rules:
   - apiGroups:
@@ -17,4 +17,3 @@ rules:
       - secrets
     verbs:
       - get
-

--- a/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-controller-rolebinding.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-controller-rolebinding.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
-metadata:
+metadata: # kpt-merge: /argo-binding
   name: argo-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
-metadata:
+metadata: # kpt-merge: /argo-server-role
   name: argo-server-role
 rules:
   - apiGroups:

--- a/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/argo-server-rbac/argo-server-rolebinding.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/argo-server-rbac/argo-server-rolebinding.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
-metadata:
+metadata: # kpt-merge: /argo-server-binding
   name: argo-server-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/argo-server-rbac/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/argo-server-rbac/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
 - argo-server-role.yaml
 - argo-server-rolebinding.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/kustomization.yaml
@@ -1,21 +1,19 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
   - ../base
   - ./argo-server-rbac
   - ./workflow-controller-rbac
-
 patchesJson6902:
   - target:
       version: v1
       group: apps
       kind: Deployment
       name: workflow-controller
-    path: ./overlays/workflow-controller-deployment.json
+    path: ./overlays/workflow-controller-deployment.yaml
   - target:
       version: v1
       group: apps
       kind: Deployment
       name: argo-server
-    path: ./overlays/argo-server-deployment.json
+    path: ./overlays/argo-server-deployment.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/overlays/argo-server-deployment.json
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/overlays/argo-server-deployment.json
@@ -1,7 +1,0 @@
-[
-  {
-    "op": "add",
-    "path": "/spec/template/spec/containers/0/args/-",
-    "value": "--namespaced"
-  }
-]

--- a/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/overlays/argo-server-deployment.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/overlays/argo-server-deployment.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --namespaced

--- a/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/overlays/workflow-controller-deployment.json
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/overlays/workflow-controller-deployment.json
@@ -1,7 +1,0 @@
-[
-  {
-    "op": "add",
-    "path": "/spec/template/spec/containers/0/args/-",
-    "value": "--namespaced"
-  }
-]

--- a/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/overlays/workflow-controller-deployment.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/overlays/workflow-controller-deployment.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --namespaced

--- a/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/workflow-controller-rbac/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/workflow-controller-rbac/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
 - workflow-controller-role.yaml
 - workflow-controller-rolebinding.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/workflow-controller-rbac/workflow-controller-role.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/workflow-controller-rbac/workflow-controller-role.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
-metadata:
+metadata: # kpt-merge: /argo-role
   name: argo-role
 rules:
   - apiGroups:

--- a/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/workflow-controller-rbac/workflow-controller-rolebinding.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/namespace-install/workflow-controller-rbac/workflow-controller-rolebinding.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
-metadata:
+metadata: # kpt-merge: /argo-binding
   name: argo-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9,4 +9,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argo
-

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/argo-server-sso-secret.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/argo-server-sso-secret.yaml
@@ -1,6 +1,6 @@
 kind: Secret
 apiVersion: v1
-metadata:
+metadata: # kpt-merge: /argo-server-sso
   name: argo-server-sso
 stringData:
   clientID: argo-server

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/artifact-repositories-configmap.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/artifact-repositories-configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
-metadata:
+metadata: # kpt-merge: /artifact-repositories
   name: artifact-repositories
   annotations:
     # you'll want to change the default over time, e.g. when you move to new storage solution,

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/cluster-workflow-template-rbac.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/cluster-workflow-template-rbac.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-metadata:
+metadata: # kpt-merge: /argo-server-clusterworkflowtemplate-role
   name: argo-server-clusterworkflowtemplate-role
 rules:
   - apiGroups:
@@ -18,7 +18,7 @@ rules:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-metadata:
+metadata: # kpt-merge: /argo-clusterworkflowtemplate-role
   name: argo-clusterworkflowtemplate-role
 rules:
   - apiGroups:
@@ -33,7 +33,7 @@ rules:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
-metadata:
+metadata: # kpt-merge: /argo-clusterworkflowtemplate-role-binding
   name: argo-clusterworkflowtemplate-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -46,7 +46,7 @@ subjects:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
-metadata:
+metadata: # kpt-merge: /argo-server-clusterworkflowtemplate-role-binding
   name: argo-server-clusterworkflowtemplate-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -56,4 +56,3 @@ subjects:
   - kind: ServiceAccount
     name: argo-server
     namespace: argo
-

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/kubelet-executor-clusterrole.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/kubelet-executor-clusterrole.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-metadata:
+metadata: # kpt-merge: /kubelet-executor
   name: kubelet-executor
 rules:
   # This allows the kubelet executor.

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/kubelet-executor-default-clusterrolebinding.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/kubelet-executor-default-clusterrolebinding.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
-metadata:
+metadata: # kpt-merge: /kubelet-executor-default
   name: kubelet-executor-default
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
   - ../../namespace-install
   - minio
@@ -12,7 +11,6 @@ resources:
   - workflow-default-rolebinding.yaml
   - cluster-workflow-template-rbac.yaml
   - artifact-repositories-configmap.yaml
-
 patchesStrategicMerge:
   - overlays/workflow-controller-configmap.yaml
   - overlays/argo-server-deployment.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/minio/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/minio/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
   - minio-deploy.yaml
   - minio-service.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/minio/minio-deploy.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/minio/minio-deploy.yaml
@@ -1,6 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
-metadata:
+metadata: # kpt-merge: /minio
   name: minio
   labels:
     app: minio

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/minio/minio-pod.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/minio/minio-pod.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Pod
-metadata:
+metadata: # kpt-merge: /minio
   name: minio
   labels:
     app: minio

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/minio/minio-service.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/minio/minio-service.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Service
-metadata:
+metadata: # kpt-merge: /minio
   name: minio
   labels:
     app: minio
@@ -11,4 +11,3 @@ spec:
     - protocol: TCP
       port: 9000
       targetPort: 9000
-

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/minio/my-minio-cred-secret.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/minio/my-minio-cred-secret.yaml
@@ -3,7 +3,7 @@ stringData:
   accesskey: admin
   secretkey: password
 kind: Secret
-metadata:
+metadata: # kpt-merge: /my-minio-cred
   name: my-minio-cred
   labels:
     app: minio

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/overlays/argo-server-deployment.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/overlays/argo-server-deployment.yaml
@@ -1,6 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
-metadata:
+metadata: # kpt-merge: /argo-server
   name: argo-server
 spec:
   template:

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/overlays/workflow-controller-configmap.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/overlays/workflow-controller-configmap.yaml
@@ -57,5 +57,5 @@ data:
       scope: sensor-logs
       url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
 kind: ConfigMap
-metadata:
+metadata: # kpt-merge: /workflow-controller-configmap
   name: workflow-controller-configmap

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/prometheus/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/prometheus/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
   - prometheus-deployment.yaml
   - prometheus-config-cluster.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/prometheus/prometheus-config-cluster.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/prometheus/prometheus-config-cluster.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
-metadata:
+metadata: # kpt-merge: /prometheus-config
   name: prometheus-config
 data:
   prometheus.yaml: |

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/prometheus/prometheus-deployment.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/prometheus/prometheus-deployment.yaml
@@ -8,7 +8,7 @@
 # be modified if the default is overriden.
 apiVersion: apps/v1
 kind: Deployment
-metadata:
+metadata: # kpt-merge: /prometheus
   name: prometheus
 spec:
   replicas: 1
@@ -27,11 +27,9 @@ spec:
           args:
             - --config.file=/config/prometheus.yaml
           volumeMounts:
-          - name: config
-            mountPath: /config
+            - name: config
+              mountPath: /config
       volumes:
         - name: config
           configMap:
             name: prometheus-config
-
-

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/prometheus/prometheus-service.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/prometheus/prometheus-service.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Service
-metadata:
+metadata: # kpt-merge: /prometheus
   name: prometheus
 spec:
   selector:

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/webhooks/argo-workflows-webhook-clients-secret.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/webhooks/argo-workflows-webhook-clients-secret.yaml
@@ -1,6 +1,6 @@
 kind: Secret
 apiVersion: v1
-metadata:
+metadata: # kpt-merge: /argo-workflows-webhook-clients
   name: argo-workflows-webhook-clients
 # The data keys must be the name of a service account.
 stringData:
@@ -17,6 +17,6 @@ stringData:
     type: github
     secret: "shh!"
   # https://docs.gitlab.com/ee/user/project/integrations/webhooks.html
-  gitlab.com: |
+  gitlab.com: |-
     type: gitlab
     secret: "shh!"

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/webhooks/github.com-rolebinding.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/webhooks/github.com-rolebinding.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
-metadata:
+metadata: # kpt-merge: /github.com
   name: github.com
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/webhooks/github.com-sa.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/webhooks/github.com-sa.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
-metadata:
+metadata: # kpt-merge: /github.com
   name: github.com

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/webhooks/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/webhooks/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
   - submit-workflow-template-role.yaml
   - github.com-sa.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/webhooks/submit-workflow-template-role.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/webhooks/submit-workflow-template-role.yaml
@@ -2,7 +2,7 @@
 # You could tighten this further (but perhaps impractically) by using `resourceNames`
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
-metadata:
+metadata: # kpt-merge: /submit-workflow-template
   name: submit-workflow-template
 rules:
   - apiGroups:

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/workflow-default-rolebinding.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/workflow-default-rolebinding.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
-metadata:
+metadata: # kpt-merge: /workflow-default-binding
   name: workflow-default-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/workflow-role.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/base/workflow-role.yaml
@@ -1,7 +1,7 @@
 # https://argoproj.github.io/argo-workflows/workflow-rbac/
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
-metadata:
+metadata: # kpt-merge: /workflow-role
   name: workflow-role
 rules:
   # pod get/watch is used to identify the container IDs of the current pod

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/minimal/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/minimal/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
   - ../base

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/mysql/argo-mysql-config-secret.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/mysql/argo-mysql-config-secret.yaml
@@ -3,7 +3,7 @@ stringData:
   username: mysql
   password: password
 kind: Secret
-metadata:
+metadata: # kpt-merge: /argo-mysql-config
   name: argo-mysql-config
   labels:
     app: mysql

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/mysql/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/mysql/kustomization.yaml
@@ -1,11 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
   - ../base
   - argo-mysql-config-secret.yaml
   - mysql-deployment.yaml
   - mysql-service.yaml
-
 patchesStrategicMerge:
   - overlays/workflow-controller-configmap.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/mysql/mysql-deployment.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/mysql/mysql-deployment.yaml
@@ -1,6 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
-metadata:
+metadata: # kpt-merge: /mysql
   name: mysql
   labels:
     app: mysql

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/mysql/mysql-service.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/mysql/mysql-service.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Service
-metadata:
+metadata: # kpt-merge: /mysql
   name: mysql
   labels:
     app: mysql

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/mysql/overlays/workflow-controller-configmap.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/mysql/overlays/workflow-controller-configmap.yaml
@@ -20,5 +20,5 @@ data:
         name: argo-mysql-config
         key: password
 kind: ConfigMap
-metadata:
+metadata: # kpt-merge: /workflow-controller-configmap
   name: workflow-controller-configmap

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/postgres/argo-postgres-config-secret.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/postgres/argo-postgres-config-secret.yaml
@@ -3,7 +3,7 @@ stringData:
   username: postgres
   password: password
 kind: Secret
-metadata:
+metadata: # kpt-merge: /argo-postgres-config
   name: argo-postgres-config
   labels:
     app: postgres

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/postgres/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/postgres/kustomization.yaml
@@ -1,11 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
   - ../base
   - argo-postgres-config-secret.yaml
   - postgres-deployment.yaml
   - postgres-service.yaml
-
 patchesStrategicMerge:
   - overlays/workflow-controller-configmap.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/postgres/overlays/workflow-controller-configmap.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/postgres/overlays/workflow-controller-configmap.yaml
@@ -20,5 +20,5 @@ data:
         name: argo-postgres-config
         key: password
 kind: ConfigMap
-metadata:
+metadata: # kpt-merge: /workflow-controller-configmap
   name: workflow-controller-configmap

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/postgres/postgres-deployment.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/postgres/postgres-deployment.yaml
@@ -1,6 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
-metadata:
+metadata: # kpt-merge: /postgres
   name: postgres
   labels:
     app: postgres

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/postgres/postgres-service.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/postgres/postgres-service.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Service
-metadata:
+metadata: # kpt-merge: /postgres
   name: postgres
   labels:
     app: postgres

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/dex/dev-svc.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/dex/dev-svc.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Service
-metadata:
+metadata: # kpt-merge: /dex
   name: dex
 spec:
   ports:

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-cm.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-cm.yaml
@@ -29,5 +29,5 @@ data:
         username: admin
         userID: 08a8684b-db88-4b73-90a9-3cd1661f5466
 kind: ConfigMap
-metadata:
+metadata: # kpt-merge: /dex
   name: dex

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-deploy.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-deploy.yaml
@@ -1,6 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
-metadata:
+metadata: # kpt-merge: /dex
   labels:
     app: dex
   name: dex

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-rb.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-rb.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
-metadata:
+metadata: # kpt-merge: /dex
   name: dex
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-role.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-role.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
-metadata:
+metadata: # kpt-merge: /dex
   name: dex
 rules:
 - apiGroups:

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-sa.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-sa.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
-metadata:
+metadata: # kpt-merge: /dex
   name: dex

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/dex/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/dex/kustomization.yaml
@@ -1,9 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 commonLabels:
   "app.kubernetes.io/part-of": "dex"
-
 resources:
   - dex-cm.yaml
   - dex-role.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/kustomization.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/kustomization.yaml
@@ -1,10 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
   - ../base
   - dex
-
 patchesStrategicMerge:
   - overlays/workflow-controller-configmap.yaml
   - overlays/argo-server-sa.yaml

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/overlays/argo-server-sa.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/overlays/argo-server-sa.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
-metadata:
+metadata: # kpt-merge: /argo-server
   name: argo-server
   annotations:
     workflows.argoproj.io/rbac-rule: "'authors' in groups && email == 'kilgore@kilgore.trout'"

--- a/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/overlays/workflow-controller-configmap.yaml
+++ b/manifests/kustomize/third-party/argo/upstream/manifests/quick-start/sso/overlays/workflow-controller-configmap.yaml
@@ -15,5 +15,5 @@ data:
     rbac:
       enabled: true
 kind: ConfigMap
-metadata:
+metadata: # kpt-merge: /workflow-controller-configmap
   name: workflow-controller-configmap


### PR DESCRIPTION
**Description of your changes:**
Fix #5368
Partial #6100

- kpt is about to release this week 1.0.0-beta.6. For now we can download it via https://kpt.dev/installation/?id=source. gcloud release will be 2 versions behind.
- Update README about the kpt version requirement.
- Revert json format back to yaml format for non-KRM resources, because `kpt pkg get` shouldn't error out on non-KRM cases.
- Enable `kpt pkg tree` in manifests/kustomize/hack/test.sh



**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
