### PR TITLE
feat(components/google-cloud): Add description for prep data for train component.

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/experimental/forecasting/README.md
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/forecasting/README.md
@@ -145,7 +145,6 @@ input_tables = json.dumps(input_table_specs)
 
 @dsl.pipeline(name='forecasting-pipeline-training')
 def pipeline(input_tables: str):
-def pipeline():
   # A workflow consists of training validation and preprocessing:
   validation = forecasting.ForecastingValidationOp(input_tables=input_tables, validation_theme='FORECASTING_TRAINING')
   preprocess = forecasting.ForecastingPreprocessingOp(project_id='endless-forms-most-beautiful', input_tables=input_tables)

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/forecasting/README.md
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/forecasting/README.md
@@ -144,11 +144,8 @@ input_tables = json.dumps(input_table_specs)
 
 
 @dsl.pipeline(name='forecasting-pipeline-training')
-<<<<<<< HEAD
 def pipeline(input_tables: str):
-=======
 def pipeline():
->>>>>>> 6b9f80d375d2d919d2e42bad2f70c1521c16dfb9
   # A workflow consists of training validation and preprocessing:
   validation = forecasting.ForecastingValidationOp(input_tables=input_tables, validation_theme='FORECASTING_TRAINING')
   preprocess = forecasting.ForecastingPreprocessingOp(project_id='endless-forms-most-beautiful', input_tables=input_tables)

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/forecasting/prepare_data_for_train/component.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/forecasting/prepare_data_for_train/component.yaml
@@ -1,5 +1,48 @@
 name: Prepare data for train
-description: Prepares the parameters for the training step.
+description: |
+    Prepares the parameters for the training step.
+
+    Args:
+      input_tables (str):
+        Required. Serialized Json array that specifies input BigQuery tables and
+        specs.
+      preprocess_metadata (str):
+        Required. The output of ForecastingPreprocessingOp that is a serialized
+        dictionary with 2 fields: processed_bigquery_table_uri and
+        column_metadata.
+      model_feature_columns (str):
+        Optional. Serialized list of column names that will be used as input
+        feature in the training step. If None, all columns will be used in
+        training.
+
+    Returns:
+      NamedTuple:
+        time_series_identifier_column (str):
+          Name of the column that identifies the time series.
+        time_series_attribute_columns (str):
+          Serialized column names that should be used as attribute columns.
+        available_at_forecast_columns (str):
+          Serialized column names of columns that are available at forecast.
+        unavailable_at_forecast_columns (str):
+          Serialized column names of columns that are unavailable at forecast.
+        column_transformations (str):
+          Serialized transformations to apply to the input columns.
+        preprocess_bq_uri (str):
+          The BigQuery table that saves the preprocessing result and will be used
+          as training input.
+        target_column (str):
+          The name of the column values of which the Model is to predict.
+        time_column (str):
+          Name of the column that identifies time order in the time series.
+        predefined_split_column (str):
+          Name of the column that specifies an ML use of the row.
+        weight_column (str):
+          Name of the column that should be used as the weight column.
+        data_granularity_unit (str):
+          The data granularity unit.
+        data_granularity_count (str):
+          The number of data granularity units between data points in the
+          training data.
 inputs:
 - name: input_tables
   type: String


### PR DESCRIPTION
The python-based component has docstring in the original python method. But when converted to yaml by create_component_from_func method, the docstring didn't show up in the description field. This pr manually copies the docstring to the description field.

/assign @SinaChavoshi
/assign @IronPan