### PR TITLE
chore: remove unused fields in the persistence client

### DIFF
--- a/backend/src/agent/persistence/client/pipeline_client.go
+++ b/backend/src/agent/persistence/client/pipeline_client.go
@@ -38,13 +38,10 @@ type PipelineClientInterface interface {
 }
 
 type PipelineClient struct {
-	initializeTimeout     time.Duration
-	timeout               time.Duration
-	basePath              string
-	mlPipelineServiceName string
-	mlPipelineServicePort string
-	reportServiceClient   api.ReportServiceClient
-	runServiceClient      api.RunServiceClient
+	initializeTimeout   time.Duration
+	timeout             time.Duration
+	reportServiceClient api.ReportServiceClient
+	runServiceClient    api.RunServiceClient
 }
 
 func NewPipelineClient(


### PR DESCRIPTION
**Description of your changes:**

The following fields are unexported: 

```
basePath              string
mlPipelineServiceName string
mlPipelineServicePort string
```

but not set, https://github.com/kubeflow/pipelines/blob/ed3453f7940b7f95e6c0ef02f44626f8eb55cdbf/backend/src/agent/persistence/client/pipeline_client.go#L70-L75



**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
