### PR TITLE
feat: allow the default-editor to edit argo workflows and fix bug #6649

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/view-edit-cluster-roles.yaml
+++ b/manifests/kustomize/base/installs/multi-user/view-edit-cluster-roles.yaml
@@ -90,7 +90,9 @@ rules:
   - '*'
   resources:
   - cronworkflows
+  - cronworkflows/finalizers
   - workflows
+  - workflows/finalizers
   - workfloweventbindings
   - workflowtemplates
 

--- a/manifests/kustomize/base/installs/multi-user/view-edit-cluster-roles.yaml
+++ b/manifests/kustomize/base/installs/multi-user/view-edit-cluster-roles.yaml
@@ -78,6 +78,21 @@ rules:
   - delete
   - disable
   - enable
+- apiGroups:
+  - kubeflow.org
+  verbs:
+  - '*'
+  resources:
+  - scheduledworkflows
+- apiGroups:
+  - argoproj.io
+  verbs:
+  - '*'
+  resources:
+  - cronworkflows
+  - workflows
+  - workfloweventbindings
+  - workflowtemplates
 
 ---
 


### PR DESCRIPTION
**Description of your changes:**

@elikatsis  @zijianjoy 
This also fixes  bug https://github.com/kubeflow/pipelines/issues/6649

@Bobgy Currently the jupyterlab user has no way to cleanup his workspace

With this change e.g. 
```
kubectl -n $NAMESPACE delete workflows -l 'workflows.argoproj.io/completed=true' # for argo
```
works

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
