### PR TITLE
feat: add poddefault for automatic Jupyterlab authentication

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/composite-controller.yaml
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/composite-controller.yaml
@@ -38,6 +38,10 @@ spec:
     resource: authorizationpolicies
     updateStrategy:
       method: InPlace
+  - apiVersion: kubeflow.org/v1alpha1
+    resource: poddefaults
+    updateStrategy:
+      method: InPlace
   hooks:
     sync:
       webhook:


### PR DESCRIPTION
**Description of your changes:**
@Bobgy 
A poddefault is automatically created according to https://github.com/kubeflow/pipelines/issues/5138

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
