### PR TITLE
test: Revert "fix: Add workaround init container to fix test infra"

### DIFF
--- a/test/component_test.yaml
+++ b/test/component_test.yaml
@@ -95,20 +95,7 @@ spec:
         - name: strict-image-name
           valueFrom:
             path: /outputs/strict-image-name/file
-      # TODO work around networking issues,remove initContainers once networking issues gets resolved
-      initContainers:
-        - name: workaround
-          image: k8s.gcr.io/build-image/debian-iptables-amd64:buster-v1.6.7
-          command:
-            - sh
-            - -c
-            - "iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu"
-          securityContext:
-            capabilities:
-              add:
-                - NET_ADMIN
-            privileged: true
-      container:
+    container:
       image: "{{workflow.parameters.image-builder-image}}"
       imagePullPolicy: 'Always'
       command:

--- a/test/e2e_test_gke_v2.yaml
+++ b/test/e2e_test_gke_v2.yaml
@@ -195,19 +195,6 @@ spec:
         - name: strict-image-name
           valueFrom:
             path: /outputs/strict-image-name/file
-    # TODO work around networking issues,remove initContainers once networking issues gets resolved
-    initContainers:
-    - name: workaround
-      image: k8s.gcr.io/build-image/debian-iptables-amd64:buster-v1.6.7
-      command:
-        - sh
-        - -c
-        - "iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu"
-      securityContext:
-        capabilities:
-          add:
-            - NET_ADMIN
-        privileged: true
     container:
       image: "{{workflow.parameters.image-builder-image}}"
       imagePullPolicy: 'Always'

--- a/test/sample_test.yaml
+++ b/test/sample_test.yaml
@@ -127,19 +127,6 @@ spec:
           - name: strict-image-name
             valueFrom:
               path: /outputs/strict-image-name/file
-      # TODO work around networking issues,remove initContainers once networking issues gets resolved
-      initContainers:
-        - name: workaround
-          image: k8s.gcr.io/build-image/debian-iptables-amd64:buster-v1.6.7
-          command:
-            - sh
-            - -c
-            - "iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu"
-          securityContext:
-            capabilities:
-              add:
-                - NET_ADMIN
-            privileged: true
       container:
         image: "{{workflow.parameters.image-builder-image}}"
         imagePullPolicy: 'Always'


### PR DESCRIPTION
Reverts kubeflow/pipelines#6618
The networking of Test infra should get fixed. We don't need this workaround anymore.