### PR TITLE
fix(components/google-cloud): Fix custom job wrapper error on empty input spec.

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/experimental/custom_job/custom_job.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/custom_job/custom_job.py
@@ -96,8 +96,11 @@ def custom_training_job_op(
     """
     job_spec = {}
     input_specs = []
+    output_specs = []
     if component_spec.component_spec.inputs:
         input_specs = component_spec.component_spec.inputs
+    if component_spec.component_spec.outputs:
+        output_specs = component_spec.component_spec.outputs
 
     if worker_pool_specs is not None:
         worker_pool_specs = copy.deepcopy(worker_pool_specs)
@@ -214,7 +217,7 @@ def custom_training_job_op(
     input_specs[:] = [
         input_spec for input_spec in input_specs
         if input_spec.name not in ('service_account', 'network', 'tensorboard',
-                                'base_output_directory')
+                                   'base_output_directory')
     ]
     job_spec['service_account'] = "{{$.inputs.parameters['service_account']}}"
     job_spec['network'] = "{{$.inputs.parameters['network']}}"
@@ -251,7 +254,7 @@ def custom_training_job_op(
             structures.InputSpec(name='project', type='String'),
             structures.InputSpec(name='location', type='String')
         ],
-        outputs=component_spec.component_spec.outputs +
+        outputs=output_specs +
         [structures.OutputSpec(name='gcp_resources', type='String')],
         implementation=structures.ContainerImplementation(
             container=structures.ContainerSpec(

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/custom_job/custom_job.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/custom_job/custom_job.py
@@ -95,7 +95,9 @@ def custom_training_job_op(
       A Custom Job component OP correspoinding to the input component OP.
     """
     job_spec = {}
-    input_specs = component_spec.component_spec.inputs
+    input_specs = []
+    if component_spec.component_spec.inputs:
+        input_specs = component_spec.component_spec.inputs
 
     if worker_pool_specs is not None:
         worker_pool_specs = copy.deepcopy(worker_pool_specs)
@@ -209,12 +211,11 @@ def custom_training_job_op(
                 default=encryption_spec_key_name),)
 
     # Remove any existing service_account from component input list.
-    if input_specs:
-        input_specs[:] = [
-            input_spec for input_spec in input_specs
-            if input_spec.name not in ('service_account', 'network', 'tensorboard',
-                                    'base_output_directory')
-        ]
+    input_specs[:] = [
+        input_spec for input_spec in input_specs
+        if input_spec.name not in ('service_account', 'network', 'tensorboard',
+                                'base_output_directory')
+    ]
     job_spec['service_account'] = "{{$.inputs.parameters['service_account']}}"
     job_spec['network'] = "{{$.inputs.parameters['network']}}"
 

--- a/components/google-cloud/google_cloud_pipeline_components/experimental/custom_job/custom_job.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/custom_job/custom_job.py
@@ -209,11 +209,12 @@ def custom_training_job_op(
                 default=encryption_spec_key_name),)
 
     # Remove any existing service_account from component input list.
-    input_specs[:] = [
-        input_spec for input_spec in input_specs
-        if input_spec.name not in ('service_account', 'network', 'tensorboard',
-                                   'base_output_directory')
-    ]
+    if input_specs:
+        input_specs[:] = [
+            input_spec for input_spec in input_specs
+            if input_spec.name not in ('service_account', 'network', 'tensorboard',
+                                    'base_output_directory')
+        ]
     job_spec['service_account'] = "{{$.inputs.parameters['service_account']}}"
     job_spec['network'] = "{{$.inputs.parameters['network']}}"
 


### PR DESCRIPTION
This is to address the issue when component has not input the custom job errors out with 
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-12-daac6e47c769> in <module>
----> 1 custom_job_distributed_training_op= gcpc.experimental.custom_job.custom_training_job_op(distributed_train_mnist)

/opt/conda/lib/python3.7/site-packages/google_cloud_pipeline_components/experimental/custom_job/custom_job.py in custom_training_job_op(component_spec, display_name, replica_count, machine_type, accelerator_type, accelerator_count, boot_disk_type, boot_disk_size_gb, timeout, restart_job_on_worker_restart, service_account, network, worker_pool_specs, encryption_spec_key_name, tensorboard, base_output_directory, labels)
    211     # Remove any existing service_account from component input list.
    212     input_specs[:] = [
--> 213         input_spec for input_spec in input_specs
    214         if input_spec.name not in ('service_account', 'network', 'tensorboard',
    215                                    'base_output_directory')

TypeError: 'NoneType' object is not iterable
```