### PR TITLE
docs(backend): fix incorrect maxNumViewers help text

### DIFF
--- a/backend/src/crd/controller/viewer/main.go
+++ b/backend/src/crd/controller/viewer/main.go
@@ -42,7 +42,7 @@ var (
 	kubecfg       = flag.String("kubecfg", "", "Path to a valid kubeconfig.")
 	maxNumViewers = flag.Int("max_num_viewers", 50,
 		"Maximum number of viewer instances allowed within "+
-			"the cluster before the controller starts deleting the oldest one.")
+			"each namespace before the controller starts deleting the oldest one in that namespace.")
 	namespace = flag.String("namespace", "kubeflow",
 		"Namespace within which CRD controller is running. Default is "+
 			"kubeflow.")


### PR DESCRIPTION
maxNumViewers is per namespace not entire cluster.
[This PR](https://github.com/kubeflow/pipelines/pull/1623/files#diff-36da225a16f9c6742cee006c2554b6ef6836c9ab2b509a5169b5d3a4acc36977)
changed the scope from cluster to namespace.
