### PR TITLE
fix(sdk): fix cloud scheduler's job name

### DIFF
--- a/sdk/python/kfp/v2/google/client/schedule.py
+++ b/sdk/python/kfp/v2/google/client/schedule.py
@@ -136,7 +136,8 @@ def _create_from_pipeline_dict(
     pipeline_jobs_api_url = f'https://{region}-{_CAIPP_ENDPOINT_WITHOUT_REGION}/{_CAIPP_API_VERSION}/projects/{project_id}/locations/{region}/pipelineJobs'
 
     # Preparing the request body for the Cloud Function processing
-    full_pipeline_name = pipeline_dict.get('name')
+    pipeline_name = pipeline_dict['pipelineSpec']['pipelineInfo']['name']
+    full_pipeline_name = 'projects/{}/pipelineJobs/{}'.format(project_id, pipeline_name)
     pipeline_display_name = pipeline_dict.get('displayName')
     time_format_suffix = "-{{$.scheduledTime.strftime('%Y-%m-%d-%H-%M-%S')}}"
     if 'name' in pipeline_dict:


### PR DESCRIPTION
**Description of your changes:**
When scheduling a job with vertex pipelines, the name of the job is not reflected in the pipeline name.
e.g. `pipeline_pipeline_51f3dbec_-0-1-a-a-a` (I defined pipeline name as `test`)

This is because try to read a non-existent attribute from the compiled json.
https://github.com/kubeflow/pipelines/blob/ed2ba1a6b3efb9aa2623ce211e87982fa7b8be1c/sdk/python/kfp/v2/google/client/schedule.py#L123
The correct attribute path is `pipelineSpec/pipelineInfo/name` .

I think we should add the name or displayName attribute to compiled json at compile time, or add these attribute with schedule.py.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
