### PR TITLE
feat(components): Add a KServe component

### DIFF
--- a/components/kserve/Dockerfile
+++ b/components/kserve/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.6-slim
+
+COPY requirements.txt .
+RUN python3 -m pip install -r \
+    requirements.txt --quiet --no-cache-dir \
+    && rm -f requirements.txt
+
+ENV APP_HOME /app
+COPY src $APP_HOME
+WORKDIR $APP_HOME
+
+ENTRYPOINT ["python"]
+CMD ["kservedeployer.py"]

--- a/components/kserve/OWNERS
+++ b/components/kserve/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+  - animeshsingh
+reviewers:
+  - animeshsingh
+  - Tomcli

--- a/components/kserve/README.md
+++ b/components/kserve/README.md
@@ -1,0 +1,174 @@
+# KServe Component
+
+This is the Kubeflow Pipelines component for KServe. This component uses the KServe [V1beta1 API](https://github.com/kserve/kserve/blob/master/docs/apis/v1beta1/README.md),
+and KServe v0.7.0, so you cluster must also support this.
+
+## Usage
+
+Load the component with:
+
+```python
+import kfp.dsl as dsl
+import kfp
+from kfp import components
+
+kserve_op = components.load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/master/components/kserve/component.yaml')
+```
+
+### Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| action   | `create` | Action to execute on KServe. Available options are `create`, `update`, `apply`, and `delete`. Note: `apply` is equivalent to `update` if the resource exists and `create` if not. |
+| model_name |  | Name to give to the deployed model/InferenceService |
+| model_uri  |  | Path of the S3 or GCS compatible directory containing the  model. |
+| canary_traffic_percent | `100` | The traffic split percentage between the candidate model and the last ready model |
+| namespace |  | Kubernetes namespace where the KServe service is deployed. If no namespace is provided, `anonymous` will be used unless a namespace is provided in the `inferenceservice_yaml` argument. |
+| framework |  | Machine learning framework for model serving. Currently the supported frameworks are  `tensorflow`, `pytorch`, `sklearn`, `xgboost`, `onnx`, `triton`, `pmml`, and `lightgbm`. |
+| custom_model_spec | `{}` | Custom model runtime container spec in JSON. Sample spec: `{"image": "codait/max-object-detector", "port":5000, "name": "test-container"}` |
+| inferenceservice_yaml | `{}` | Raw InferenceService serialized YAML for deployment. Use this if you need additional configurations for your InferenceService. |
+| autoscaling_target | `0` | Autoscaling Target Number. If not 0, sets the following annotation on the InferenceService: `autoscaling.knative.dev/target` |
+| service_account | | ServiceAccount to use to run the InferenceService pod. |
+| enable_istio_sidecar | `True` | Whether to enable istio sidecar injection. |
+| watch_timeouot | `300` | Timeout in seconds for watching until the InferenceService becomes ready. |
+| min_replicas | `-1` | Minimum number of InferenceService replicas. Default of -1 just delegates to pod default of 1. |
+| max_replicas | `-1` | Maximum number of InferenceService replicas. |
+
+
+### Basic InferenceService Creation
+
+The following will use the KServe component to deploy a TensorFlow model.
+
+```python
+@dsl.pipeline(
+  name='KServe Pipeline',
+  description='A pipeline for KServe.'
+)
+def kserve_pipeline():
+    kserve_op(
+        action='apply',
+        model_name='tf-sample',
+        model_uri='gs://kfserving-samples/models/tensorflow/flowers',
+        framework='tensorflow',
+    )
+kfp.Client().create_run_from_pipeline_func(kserve_pipeline, arguments={})
+```
+
+Sample op for deploying a PyTorch model:
+
+```python
+kserve_op(
+    action='apply',
+    model_name='pytorch-test',
+    model_uri='gs://kfserving-examples/models/torchserve/image_classifier',
+    framework='pytorch'
+)
+```
+
+### Canary Rollout
+
+Ensure you have an initial model deployed with 100 percent traffic with something like:
+
+```python
+kserve_op(
+    action = 'apply',
+    model_name='tf-sample',
+    model_uri='gs://kfserving-samples/models/tensorflow/flowers',
+    framework='tensorflow',
+)
+```
+
+Deploy the candidate model which will only get a portion of traffic:
+
+```python
+kserve_op(
+    action='apply',
+    model_name='tf-sample',
+    model_uri='gs://kfserving-samples/models/tensorflow/flowers-2',
+    framework='tensorflow',
+    canary_traffic_percent='10'
+)
+```
+
+To promote the candidate model, you can either set `canary_traffic_percent` to `100` or simply remove it, then re-run the pipeline:
+
+```python
+kserve_op(
+    action='apply',
+    model_name='tf-sample',
+    model_uri='gs://kfserving-samples/models/tensorflow/flowers-2',
+    framework='tensorflow'
+)
+```
+
+If you instead want to rollback the candidate model, then set `canary_traffic_percent` to `0`, then re-run the pipeline:
+
+```python
+kserve_op(
+    action='apply',
+    model_name='tf-sample',
+    model_uri='gs://kfserving-samples/models/tensorflow/flowers-2',
+    framework='tensorflow',
+    canary_traffic_percent='0'
+)
+```
+
+### Deletion
+
+To delete a model, simply set the `action` to `'delete'` and pass in the InferenceService name:
+
+```python
+kserve_op(
+    action='delete',
+    model_name='tf-sample'
+)
+```
+
+### Custom Runtime
+
+To pass in a custom model serving runtime, you can use the `custom_model_spec` argument. Currently,
+the expected format for `custom_model_spec` coincides with:
+
+```json
+{
+    "image": "some_image",
+    "port": "port_number",
+    "name": "custom-container",
+    "env" : [{ "name": "some_name", "value": "some_value"}],
+    "resources": { "requests": {},  "limits": {}}
+}
+```
+
+Sample deployment:
+
+```python
+container_spec = '{ "image": "codait/max-object-detector", "port":5000, "name": "custom-container"}'
+kserve_op(
+    action='apply',
+    model_name='custom-simple',
+    custom_model_spec=container_spec
+)
+```
+
+### Deploy using InferenceService YAML
+
+If you need more fine-grained configuration, there is the option to deploy using an InferenceService YAML file:
+
+```python
+isvc_yaml = '''
+apiVersion: "serving.kserve.io/v1beta1"
+kind: "InferenceService"
+metadata:
+  name: "sklearn-iris"
+  namespace: "anonymous"
+spec:
+  predictor:
+    sklearn:
+      storageUri: "gs://kfserving-samples/models/sklearn/iris"
+'''
+kserve_op(
+    action='apply',
+    inferenceservice_yaml=isvc_yaml
+)
+```
+

--- a/components/kserve/README.md
+++ b/components/kserve/README.md
@@ -1,7 +1,15 @@
 # KServe Component
 
-This is the Kubeflow Pipelines component for KServe. This component uses the KServe [V1beta1 API](https://github.com/kserve/kserve/blob/master/docs/apis/v1beta1/README.md),
-and KServe v0.7.0, so you cluster must also support this.
+Organization: KServe
+
+Organization Description: KServe is a highly scalable and standards based Model Inference Platform on Kubernetes for Trusted AI
+
+Version information: 0.7.0
+
+Test status: Currently manual tests
+
+Owners information:
+ - Animesh Singh (animeshsingh) - IBM, singhan@us.ibm.com
 
 ## Usage
 

--- a/components/kserve/component.yaml
+++ b/components/kserve/component.yaml
@@ -21,7 +21,7 @@ outputs:
   - {name: InferenceService Status,   type: String,                        description: 'Status JSON output of InferenceService'}
 implementation:
   container:
-    image: quay.io/aipipeline/kfserving-component:v0.5.1  # TODO: Update this
+    image: quay.io/aipipeline/kserve-component:v0.7.0
     command: ['python']
     args: [
       -u, kservedeployer.py,

--- a/components/kserve/component.yaml
+++ b/components/kserve/component.yaml
@@ -1,0 +1,44 @@
+name: Serve a model with KServe 
+description: Serve Models using KServe 
+inputs:
+  - {name: Action,                    type: String, default: 'create',     description: 'Action to execute on KServe'}
+  - {name: Model Name,                type: String, default: '',           description: 'Name to give to the deployed model'}
+  - {name: Model URI,                 type: String, default: '',           description: 'Path of the S3 or GCS compatible directory containing the model.'}
+  - {name: Canary Traffic Percent,    type: String, default: '100',        description: 'The traffic split percentage between the candidate model and the last ready model'}
+  - {name: Namespace,                 type: String, default: '',           description: 'Kubernetes namespace where the KServe service is deployed.'}
+  - {name: Framework,                 type: String, default: '',           description: 'Machine Learning Framework for Model Serving.'}
+  - {name: Custom Model Spec,         type: String, default: '{}',         description: 'Custom model runtime container spec in JSON'}
+  - {name: Autoscaling Target,        type: String, default: '0',          description: 'Autoscaling Target Number'}
+  - {name: Service Account,           type: String, default: '',           description: 'ServiceAccount to use to run the InferenceService pod'}
+  - {name: Enable Istio Sidecar,      type: Bool,   default: 'True',       description: 'Whether to enable istio sidecar injection'}
+  - {name: InferenceService YAML,     type: String, default: '{}',         description: 'Raw InferenceService serialized YAML for deployment'}
+  - {name: Watch Timeout,             type: String, default: '300',        description: "Timeout seconds for watching until InferenceService becomes ready."}
+  - {name: Min Replicas,              type: String, default: '-1',         description: 'Minimum number of InferenceService replicas'}
+  - {name: Max Replicas,              type: String, default: '-1',         description: 'Maximum number of InferenceService replicas'}
+  - {name: Request Timeout,           type: String, default: '60',         description: "Specifies the number of seconds to wait before timing out a request to the component."}
+
+outputs:
+  - {name: InferenceService Status,   type: String,                        description: 'Status JSON output of InferenceService'}
+implementation:
+  container:
+    image: quay.io/aipipeline/kfserving-component:v0.5.1  # TODO: Update this
+    command: ['python']
+    args: [
+      -u, kservedeployer.py,
+      --action,                 {inputValue: Action},
+      --model-name,             {inputValue: Model Name},
+      --model-uri,              {inputValue: Model URI},
+      --canary-traffic-percent, {inputValue: Canary Traffic Percent},
+      --namespace,              {inputValue: Namespace},
+      --framework,              {inputValue: Framework},
+      --custom-model-spec,      {inputValue: Custom Model Spec},
+      --autoscaling-target,     {inputValue: Autoscaling Target},
+      --service-account,        {inputValue: Service Account},
+      --enable-istio-sidecar,   {inputValue: Enable Istio Sidecar},
+      --output-path,            {outputPath: InferenceService Status},
+      --inferenceservice-yaml,  {inputValue: InferenceService YAML},
+      --watch-timeout,          {inputValue: Watch Timeout},
+      --min-replicas,           {inputValue: Min Replicas},
+      --max-replicas,           {inputValue: Max Replicas},
+      --request-timeout,        {inputValue: Request Timeout}
+    ]

--- a/components/kserve/requirements.txt
+++ b/components/kserve/requirements.txt
@@ -1,0 +1,2 @@
+kubernetes==19.15.0
+kserve==0.7.0

--- a/components/kserve/src/kservedeployer.py
+++ b/components/kserve/src/kservedeployer.py
@@ -1,0 +1,434 @@
+# Copyright 2019 kubeflow.org.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from distutils.util import strtobool
+import json
+import os
+import sys
+import time
+import yaml
+
+from kubernetes import client
+
+from kserve import constants
+from kserve import KServeClient
+from kserve import V1beta1InferenceService
+from kserve import V1beta1InferenceServiceSpec
+from kserve import V1beta1LightGBMSpec
+from kserve import V1beta1ONNXRuntimeSpec
+from kserve import V1beta1PMMLSpec
+from kserve import V1beta1PredictorSpec
+from kserve import V1beta1SKLearnSpec
+from kserve import V1beta1TFServingSpec
+from kserve import V1beta1TorchServeSpec
+from kserve import V1beta1TritonSpec
+from kserve import V1beta1XGBoostSpec
+from kserve.api.kf_serving_watch import isvc_watch
+
+
+AVAILABLE_FRAMEWORKS = {
+    'tensorflow': V1beta1TFServingSpec,
+    'pytorch': V1beta1TorchServeSpec,
+    'sklearn': V1beta1SKLearnSpec,
+    'xgboost': V1beta1XGBoostSpec,
+    'onnx': V1beta1ONNXRuntimeSpec,
+    'triton': V1beta1TritonSpec,
+    'pmml': V1beta1PMMLSpec,
+    'lightgbm': V1beta1LightGBMSpec
+}
+
+
+def create_predictor_spec(framework, storage_uri, canary_traffic_percent,
+                          service_account, min_replicas, max_replicas, containers, request_timeout):
+    """
+    Create and return V1beta1PredictorSpec to be used in a V1beta1InferenceServiceSpec
+    object.
+    """
+
+    predictor_spec = V1beta1PredictorSpec(
+        service_account_name=service_account,
+        min_replicas=(min_replicas
+                      if min_replicas >= 0
+                      else None
+                     ),
+        max_replicas=(max_replicas
+                      if max_replicas > 0 and max_replicas >= min_replicas
+                      else None
+                     ),
+        containers=(containers or None),
+        canary_traffic_percent=canary_traffic_percent,
+        timeout=request_timeout
+    )
+    # If the containers field was set, then this is custom model serving.
+    if containers:
+        return predictor_spec
+
+    if framework not in AVAILABLE_FRAMEWORKS:
+        raise ValueError("Error: No matching framework: " + framework)
+
+    setattr(
+        predictor_spec,
+        framework,
+        AVAILABLE_FRAMEWORKS[framework](storage_uri=storage_uri)
+    )
+    return predictor_spec
+
+
+def create_custom_container_spec(custom_model_spec):
+    """
+    Given a JSON container spec, return a V1Container object
+    representing the container. This is used for passing in
+    custom server images. The expected format for the input is:
+
+    { "image": "test/containerimage",
+      "port":5000,
+      "name": "custom-container" }
+    """
+
+    env = (
+        [
+            client.V1EnvVar(name=i["name"], value=i["value"])
+            for i in custom_model_spec["env"]
+        ]
+        if custom_model_spec.get("env", "")
+        else None
+    )
+    ports = (
+        [client.V1ContainerPort(container_port=int(custom_model_spec.get("port", "")), protocol="TCP")]
+        if custom_model_spec.get("port", "")
+        else None
+    )
+    resources = (
+        client.V1ResourceRequirements(
+            requests=(custom_model_spec["resources"]["requests"]
+                      if custom_model_spec.get('resources', {}).get('requests')
+                      else None
+                      ),
+            limits=(custom_model_spec["resources"]["limits"]
+                    if custom_model_spec.get('resources', {}).get('limits')
+                    else None
+                    ),
+        )
+        if custom_model_spec.get("resources", {})
+        else None
+    )
+    return client.V1Container(
+        name=custom_model_spec.get("name", "custom-container"),
+        image=custom_model_spec["image"],
+        env=env,
+        ports=ports,
+        command=custom_model_spec.get("command", None),
+        args=custom_model_spec.get("args", None),
+        image_pull_policy=custom_model_spec.get("image_pull_policy", None),
+        working_dir=custom_model_spec.get("working_dir", None),
+        resources=resources
+    )
+
+
+def create_inference_service(metadata, predictor_spec):
+    """
+    Build and return V1beta1InferenceService object.
+    """
+    return V1beta1InferenceService(
+        api_version=constants.KSERVE_V1BETA1,
+        kind=constants.KSERVE_KIND,
+        metadata=metadata,
+        spec=V1beta1InferenceServiceSpec(
+            predictor=predictor_spec
+        ),
+    )
+
+
+def submit_api_request(kserve_client, action, name, isvc, namespace=None,
+                       watch=False, timeout_seconds=300):
+    """
+    Creates or updates a Kubernetes custom object. This code is borrowed from the
+    KServeClient.create/patch methods as using those directly doesn't allow for
+    sending in dicts as the InferenceService object which is needed for supporting passing
+    in raw InferenceService serialized YAML.
+    """
+    custom_obj_api = kserve_client.api_instance
+    args = [constants.KSERVE_GROUP,constants.KSERVE_V1BETA1_VERSION,
+            namespace, constants.KSERVE_PLURAL]
+    if action == 'update':
+        outputs = custom_obj_api.patch_namespaced_custom_object(*args, name, isvc)
+    else:
+        outputs = custom_obj_api.create_namespaced_custom_object(*args, isvc)
+
+    if watch:
+        # Sleep 3 to avoid status still be True within a very short time.
+        time.sleep(3)
+        isvc_watch(
+            name=outputs['metadata']['name'],
+            namespace=namespace,
+            timeout_seconds=timeout_seconds)
+    else:
+        return outputs
+
+
+def perform_action(action, model_name, model_uri, canary_traffic_percent, namespace,
+                   framework, custom_model_spec, service_account, inferenceservice_yaml,
+                   request_timeout, autoscaling_target=0, enable_istio_sidecar=True, 
+                   watch_timeout=300, min_replicas=0, max_replicas=0):
+    """
+    Perform the specified action. If the action is not 'delete' and `inferenceService_yaml`
+    was provided, the dict representation of the YAML will be sent directly to the
+    Kubernetes API. Otherwise, a V1beta1InferenceService object will be built using the
+    provided input and then sent for creation/update.
+    :return InferenceService JSON output
+    """
+    kserve_client = KServeClient()
+
+    if inferenceservice_yaml:
+        # Overwrite name and namespace if exists
+        if namespace:
+            inferenceservice_yaml['metadata']['namespace'] = namespace
+
+        if model_name:
+            inferenceservice_yaml['metadata']['name'] = model_name
+        else:
+            model_name = inferenceservice_yaml['metadata']['name']
+
+        isvc = inferenceservice_yaml
+
+    elif action != 'delete':
+        # Create annotations
+        annotations = {}
+        if int(autoscaling_target) != 0:
+            annotations["autoscaling.knative.dev/target"] = str(autoscaling_target)
+        if not enable_istio_sidecar:
+            annotations["sidecar.istio.io/inject"] = 'false'
+        if not annotations:
+            annotations = None
+        metadata = client.V1ObjectMeta(
+            name=model_name, namespace=namespace, annotations=annotations
+        )
+
+        # If a custom model container spec was provided, build the V1Container
+        # object using it.
+        containers = []
+        if custom_model_spec:
+            containers = [create_custom_container_spec(custom_model_spec)]
+
+        # Build the V1beta1PredictorSpec.
+        predictor_spec = create_predictor_spec(
+            framework, model_uri, canary_traffic_percent, service_account,
+            min_replicas, max_replicas, containers, request_timeout
+        )
+
+        isvc = create_inference_service(metadata, predictor_spec)
+
+    if action == "create":
+        submit_api_request(kserve_client, 'create', model_name, isvc, namespace,
+                           watch=True, timeout_seconds=watch_timeout)
+    elif action == "update":
+        submit_api_request(kserve_client, 'update', model_name, isvc, namespace,
+                           watch=True, timeout_seconds=watch_timeout)
+    elif action == "apply":
+        try:
+            submit_api_request(kserve_client, 'create', model_name, isvc, namespace,
+                               watch=True, timeout_seconds=watch_timeout)
+        except Exception:
+            submit_api_request(kserve_client, 'update', model_name, isvc, namespace,
+                               watch=True, timeout_seconds=watch_timeout)
+    elif action == "delete":
+        kserve_client.delete(model_name, namespace=namespace)
+    else:
+        raise ("Error: No matching action: " + action)
+
+    model_status = kserve_client.get(model_name, namespace=namespace)
+    return model_status
+
+
+def main():
+    """
+    This parses arguments passed in from the CLI and performs the corresponding action.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--action", type=str, help="Action to execute on KServe", default="create"
+    )
+    parser.add_argument(
+        "--model-name", type=str, help="Name to give to the deployed model"
+    )
+    parser.add_argument(
+        "--model-uri",
+        type=str,
+        help="Path of the S3, GCS or PVC directory containing the model",
+    )
+    parser.add_argument(
+        "--canary-traffic-percent",
+        type=str,
+        help="The traffic split percentage between the candidate model and the last ready model",
+        default="100",
+    )
+    parser.add_argument(
+        "--namespace",
+        type=str,
+        help="Kubernetes namespace where the KServe service is deployed",
+        default="",
+    )
+    parser.add_argument(
+        "--framework",
+        type=str,
+        help="Model serving framework to use. Available frameworks: " +
+             str(list(AVAILABLE_FRAMEWORKS.keys())),
+        default=""
+    )
+    parser.add_argument(
+        "--custom-model-spec",
+        type=json.loads,
+        help="The container spec for a custom model runtime",
+        default="{}",
+    )
+    parser.add_argument(
+        "--autoscaling-target", type=str, help="Autoscaling target number", default="0"
+    )
+    parser.add_argument(
+        "--service-account",
+        type=str,
+        help="Service account containing s3 credentials",
+        default="",
+    )
+    parser.add_argument(
+        "--enable-istio-sidecar",
+        type=strtobool,
+        help="Whether to inject istio sidecar",
+        default="True"
+    )
+    parser.add_argument(
+        "--inferenceservice-yaml",
+        type=yaml.safe_load,
+        help="Raw InferenceService serialized YAML for deployment",
+        default="{}"
+    )
+    parser.add_argument("--output-path", type=str, help="Path to store URI output")
+    parser.add_argument("--watch-timeout",
+                        type=str,
+                        help="Timeout seconds for watching until InferenceService becomes ready.",
+                        default="300")
+    parser.add_argument(
+        "--min-replicas", type=str, help="Minimum number of replicas", default="-1"
+    )
+    parser.add_argument(
+        "--max-replicas", type=str, help="Maximum number of replicas", default="-1"
+    )
+    parser.add_argument("--request-timeout",
+                        type=str,
+                        help="Specifies the number of seconds to wait before timing out a request to the component.",
+                        default="60")
+
+    args = parser.parse_args()
+
+    action = args.action.lower()
+    model_name = args.model_name
+    model_uri = args.model_uri
+    canary_traffic_percent = int(args.canary_traffic_percent)
+    namespace = args.namespace
+    framework = args.framework.lower()
+    output_path = args.output_path
+    custom_model_spec = args.custom_model_spec
+    autoscaling_target = int(args.autoscaling_target)
+    service_account = args.service_account
+    enable_istio_sidecar = args.enable_istio_sidecar
+    inferenceservice_yaml = args.inferenceservice_yaml
+    watch_timeout = int(args.watch_timeout)
+    min_replicas = int(args.min_replicas)
+    max_replicas = int(args.max_replicas)
+    request_timeout = int(args.request_timeout)
+
+    # Default the namespace.
+    if not namespace:
+        namespace = 'anonymous'
+        # If no namespace was provided, but one is listed in the YAML, use that.
+        if inferenceservice_yaml and inferenceservice_yaml.get('metadata', {}).get('namespace'):
+            namespace = inferenceservice_yaml['metadata']['namespace']
+
+    # Only require model name when an Isvc YAML was not provided.
+    if not inferenceservice_yaml and not model_name:
+        parser.error('{} argument is required when performing "{}" action'.format(
+            'model_name', action
+    ))
+    # If the action isn't a delete, require 'model-uri' and 'framework' only if an Isvc YAML
+    # or custom model container spec are not provided.
+    if action != 'delete':
+        if not inferenceservice_yaml and not custom_model_spec and not (model_uri and framework):
+            parser.error('Arguments for {} and {} are required when performing "{}" action'.format(
+                'model_uri', 'framework', action
+        ))
+
+    model_status = perform_action(
+        action=action,
+        model_name=model_name,
+        model_uri=model_uri,
+        canary_traffic_percent=canary_traffic_percent,
+        namespace=namespace,
+        framework=framework,
+        custom_model_spec=custom_model_spec,
+        autoscaling_target=autoscaling_target,
+        service_account=service_account,
+        enable_istio_sidecar=enable_istio_sidecar,
+        inferenceservice_yaml=inferenceservice_yaml,
+        request_timeout=request_timeout,
+        watch_timeout=watch_timeout,
+        min_replicas=min_replicas,
+        max_replicas=max_replicas
+    )
+
+    print(model_status)
+
+    if action != 'delete':
+        # Check whether the model is ready
+        for condition in model_status["status"]["conditions"]:
+            if condition['type'] == 'Ready':
+                if condition['status'] == 'True':
+                    print('Model is ready\n')
+                    break
+                print('Model is timed out, please check the InferenceService events for more details.')
+                sys.exit(1)
+        try:
+            print( model_status["status"]["url"] + " is the Knative domain.")
+            print("Sample test commands: \n")
+            # model_status['status']['url'] is like http://flowers-sample.kubeflow.example.com/v1/models/flowers-sample
+            print("curl -v -X GET %s" % model_status["status"]["url"])
+            print("\nIf the above URL is not accessible, it's recommended to setup Knative with a configured DNS.\n"\
+                "https://knative.dev/docs/install/installing-istio/#configuring-dns")
+        except Exception:
+            print("Model is not ready, check the logs for the Knative URL status.")
+            sys.exit(1)
+
+    if output_path:
+        try:
+            # Remove some less needed fields to reduce output size.
+            del model_status['metadata']['managedFields']
+            del model_status['status']['conditions']
+            if sys.getsizeof(model_status) > 3000:
+                del model_status['components']['predictor']['address']['url']
+                del model_status['components']['predictor']['latestCreatedRevision']
+                del model_status['components']['predictor']['latestReadyRevision']
+                del model_status['components']['predictor']['latestRolledoutRevision']
+                del model_status['components']['predictor']['url']
+                del model_status['spec']
+        except KeyError:
+            pass
+
+        if not os.path.exists(os.path.dirname(output_path)):
+            os.makedirs(os.path.dirname(output_path))
+        with open(output_path, "w") as report:
+            report.write(json.dumps(model_status, indent=4))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Description of your changes:**
I have added a KServe component for KServe 0.7.0

I have added it in a separate directory so the existing KFServing component can be accessed easily still because it is still used in the current Kubeflow releases.

Two questions:
- This component was made by  copying the KFServing component and updating it for KServe. I didn't copy the `OWNERS` file because I don't know what the etiquette is here. Should I just keep the same `OWNERS` file?
- Currently the `component.yaml` still points to the old image `quay.io/aipipeline/kfserving-component:v0.5.1`. This should be updated somehow but this should be done by a Kubeflow member with access to the right docker repo right?

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
