### PR TITLE
fix(sdk): fixes key name of parameter type

### DIFF
--- a/sdk/python/kfp/v2/google/client/runtime_config_builder.py
+++ b/sdk/python/kfp/v2/google/client/runtime_config_builder.py
@@ -58,7 +58,7 @@ class RuntimeConfigBuilder(object):
         parameter_input_definitions = job_spec['pipelineSpec']['root'].get(
             'inputDefinitions', {}).get('parameters', {})
         for k, v in parameter_input_definitions.items():
-            parameter_types[k] = v['type']
+            parameter_types[k] = v['parameterType']
 
         pipeline_root = runtime_config_spec.get('gcsOutputDirectory')
         parameter_values = _parse_runtime_parameters(runtime_config_spec)


### PR DESCRIPTION
**Description of your changes:**
The following change in the format of the compiled json.
https://github.com/kubeflow/pipelines/commit/0be57c38802b85d0b09b703e60b1b3131a1b9863
It causes an error when reading json, as it tries to read a key that doesn't exist.

```
   return self.client.create_run_from_job_spec(
  File "/Users/trs/Library/Caches/pypoetry/virtualenvs/env-1psWxIXB-py3.9/lib/python3.9/site-packages/kfp/v2/google/client/client.py", line 325, in create_run_from_job_spec
    builder = runtime_config_builder.RuntimeConfigBuilder.from_job_spec_json(
  File "/Users/trs/Library/Caches/pypoetry/virtualenvs/env-1psWxIXB-py3.9/lib/python3.9/site-packages/kfp/v2/google/client/runtime_config_builder.py", line 61, in from_job_spec_json
    parameter_types[k] = v['type']
KeyError: 'type'
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
