### PR TITLE
fix:(ModelBatchPredictOp): Fixed missing double-quotes around gcs_source_uris.

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/aiplatform/batch_predict_job/component.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/aiplatform/batch_predict_job/component.yaml
@@ -236,7 +236,7 @@ implementation:
           ', "input_config": {',
           '"instances_format": "', {inputValue: instances_format}, '"',
           ', "gcs_source": {',
-          '"uris":',  {inputValue: gcs_source_uris},
+          '"uris": "',  {inputValue: gcs_source_uris}, '"',
           '}',
           ', "bigquery_source": {',
           '"input_uri": "', {inputValue: bigquery_source_input_uri}, '"',


### PR DESCRIPTION
**Description of your changes:**
gcs_source_uris were not being properly escaped due to missing quotes in component definition causing BatchPredictionJobs to fail when using the ModelBatchPredictOp in Vertex AI.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
