### PR TITLE
chore(sdk): Fix a warning message

### DIFF
--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -983,7 +983,7 @@ def create_component_from_func_v2(func: Callable,
     warnings.warn(
         'create_component_from_func_v2() has been deprecated and will be'
         ' removed in KFP v1.9. Please use'
-        ' kfp.v2.components.create_component_from_func() instead.',
+        ' @kfp.v2.dsl.component() instead.',
         category=FutureWarning,
     )
     from kfp.v2.components import component_factory

--- a/sdk/python/kfp/v2/components/__init__.py
+++ b/sdk/python/kfp/v2/components/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from kfp.v2.components.component_factory import create_component_from_func
+
 from kfp.v2.components.yaml_component import load_component_from_text
 from kfp.v2.components.yaml_component import load_component_from_file
 from kfp.v2.components.yaml_component import load_component_from_url

--- a/sdk/python/kfp/v2/components/__init__.py
+++ b/sdk/python/kfp/v2/components/__init__.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kfp.v2.components.component_factory import create_component_from_func
-
 from kfp.v2.components.yaml_component import load_component_from_text
 from kfp.v2.components.yaml_component import load_component_from_file
 from kfp.v2.components.yaml_component import load_component_from_url


### PR DESCRIPTION
**Description of your changes:**

This PR fixes the problem that importing `kfp.v2.components.create_component_from_func` fails although `kfp.components.create_component_from_func_v2()` shows a warning saying "Please use `kfp.v2.components.create_component_from_func()` instead.".
https://github.com/kubeflow/pipelines/blob/1.7.1/sdk/python/kfp/components/_python_op.py#L875-L880

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
