### PR TITLE
chore(v2): support pipeline parameter defaults + running specs directly

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -67,14 +67,15 @@ image-launcher-dev:
 # Build images, push them to dev image registry, build backend compiler, compile pipelines and run them.
 .PHONY: dev
 dev: image-dev build/compiler \
-	pipeline/v2/hello_world \
-	pipeline/v2/producer_consumer_param \
-	pipeline/test/two_step \
-	pipeline/test/lightweight_python_functions_v2_pipeline
+	pipeline/v2/hello_world
+# TODO(v2): migrate v1 samples to v2.
+# pipeline/test/two_step \
+# pipeline/test/lightweight_python_functions_v2_pipeline
+# pipeline/v2/producer_consumer_param \
 
 .PHONY: build image-dev
 build: build/launcher build/compiler build/driver
-image-dev: image-launcher-v2-dev image-driver-dev image-launcher-dev
+image-dev: image-launcher-v2-dev image-driver-dev
 
 # Install v2 backend compiler to ~/bin.
 # Please add ~/bin to your $PATH first.

--- a/v2/cmd/compiler/main.go
+++ b/v2/cmd/compiler/main.go
@@ -21,13 +21,18 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
-	"github.com/golang/protobuf/jsonpb"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/v2/compiler"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 var (
-	spec         = flag.String("spec", "", "path to pipeline spec file")
+	// The spec flag is added to make running a pipeline with default parameters easier.
+	// Backend compiler should only accept PipelineJob.
+	specPath     = flag.String("spec", "", "path to pipeline spec file")
+	jobPath      = flag.String("job", "", "path to pipeline job file")
 	launcher     = flag.String("launcher", "", "v2 launcher image")
 	driver       = flag.String("driver", "", "v2 driver image")
 	pipelineRoot = flag.String("pipeline_root", "", "pipeline root")
@@ -35,20 +40,31 @@ var (
 
 func main() {
 	flag.Parse()
-	if spec == nil || *spec == "" {
-		glog.Exitf("spec must be specified")
+	noSpec := specPath == nil || *specPath == ""
+	noJob := jobPath == nil || *jobPath == ""
+	if noSpec && noJob {
+		glog.Exitf("spec or job must be specified")
 	}
-	err := compile(*spec)
+	if !noSpec && !noJob {
+		glog.Exitf("spec and job cannot be specified at the same time")
+	}
+	var job *pipelinespec.PipelineJob
+	var err error
+	if !noSpec {
+		job, err = loadSpec(*specPath)
+	} else {
+		// !noJob
+		job, err = loadJob(*jobPath)
+	}
 	if err != nil {
+		glog.Exitf("Failed to load: %v", err)
+	}
+	if err := compile(job); err != nil {
 		glog.Exitf("Failed to compile: %v", err)
 	}
 }
 
-func compile(specPath string) error {
-	job, err := load(specPath)
-	if err != nil {
-		return err
-	}
+func compile(job *pipelinespec.PipelineJob) error {
 	wf, err := compiler.Compile(job, &compiler.Options{
 		DriverImage:   *driver,
 		LauncherImage: *launcher,
@@ -75,15 +91,50 @@ func init() {
 	flag.Set("stderrthreshold", "WARNING")
 }
 
-func load(path string) (*pipelinespec.PipelineJob, error) {
-	content, err := ioutil.ReadFile(path)
+func loadJob(path string) (*pipelinespec.PipelineJob, error) {
+	bytes, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	json := string(content)
 	job := &pipelinespec.PipelineJob{}
-	if err := jsonpb.UnmarshalString(json, job); err != nil {
-		return nil, fmt.Errorf("Failed to parse pipeline job, error: %s, job: %v", err, json)
+	if err := protojson.Unmarshal(bytes, job); err != nil {
+		return nil, fmt.Errorf("Failed to parse pipeline job, error: %s, job: %v", err, string(bytes))
 	}
 	return job, nil
+}
+
+func loadSpec(path string) (*pipelinespec.PipelineJob, error) {
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	spec := &pipelinespec.PipelineSpec{}
+	if err := protojson.Unmarshal(bytes, spec); err != nil {
+		return nil, fmt.Errorf("Failed to parse pipeline spec, error: %s, spec: %v", err, string(bytes))
+	}
+	return jobFromSpec(spec)
+}
+
+func jobFromSpec(spec *pipelinespec.PipelineSpec) (*pipelinespec.PipelineJob, error) {
+	specStruct, err := toStruct(spec)
+	if err != nil {
+		return nil, err
+	}
+	job := &pipelinespec.PipelineJob{}
+	job.Name = spec.GetPipelineInfo().GetName()
+	job.PipelineSpec = specStruct
+	job.RuntimeConfig = &pipelinespec.PipelineJob_RuntimeConfig{
+		ParameterValues: map[string]*structpb.Value{},
+	}
+	return job, nil
+}
+
+func toStruct(msg proto.Message) (*structpb.Struct, error) {
+	specStr, err := protojson.Marshal(msg)
+	if err != nil {
+		return nil, err
+	}
+	res := &structpb.Struct{}
+	err = protojson.Unmarshal(specStr, res)
+	return res, err
 }

--- a/v2/component/launcher_v2.go
+++ b/v2/component/launcher_v2.go
@@ -267,7 +267,7 @@ func collectOutputParameters(executorInput *pipelinespec.ExecutorInput, executor
 			return fmt.Errorf("failed to find output parameter name=%q in component spec", name)
 		}
 		msg := func(err error) error {
-			return fmt.Errorf("failed to read output parameter name=%q type=%q path=%q: %w", name, paramSpec.GetType(), param.GetOutputFile(), err)
+			return fmt.Errorf("failed to read output parameter name=%q type=%q path=%q: %w", name, paramSpec.GetParameterType(), param.GetOutputFile(), err)
 		}
 		b, err := ioutil.ReadFile(param.GetOutputFile())
 		if err != nil {


### PR DESCRIPTION
**Description of your changes:**
Changes
* v2 backend compiler now accepts PipelineSpec with the `--spec` flag. This makes it easier to run compiled specs. When submitting a PipelineJob, use the `--job` flag instead.

Future Plan (outside of this PR):
* Other tests are pending migration in https://github.com/kubeflow/pipelines/issues/6928

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
