### PR TITLE
chore(sdk): allow google-auth < 3

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -25,6 +25,7 @@
 * Fix display name support for groups [\#6832](https://github.com/kubeflow/pipelines/pull/6832)
 * Remove redundant check in set_gpu_limit [\#6866](https://github.com/kubeflow/pipelines/pull/6866)
 * Fix regression on optional inputs [\#6905](https://github.com/kubeflow/pipelines/pull/6905)
+* Depends on `google-auth>=1.6.1,<3` [\#6939](https://github.com/kubeflow/pipelines/pull/6939)
 
 ## Documentation Updates
 

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -21,7 +21,7 @@ kfp-server-api>=1.1.2,<2.0.0
 
 # kfp.Client GCP auth
 google-cloud-storage>=1.20.0,<2
-google-auth>=1.6.1,<2
+google-auth>=1.6.1,<3
 requests-toolbelt>=0.8.0,<1
 
 # CLI

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -29,7 +29,10 @@ REQUIRES = [
     # https://github.com/googleapis/python-storage/blob/master/CHANGELOG.md#1200
     'google-cloud-storage>=1.20.0,<2',
     'kubernetes>=8.0.0,<19',
-    'google-auth>=1.6.1,<2',
+    # NOTE: Maintainers, please do not require google-auth>=2.x.x
+    # Until this issue is closed
+    # https://github.com/googleapis/google-cloud-python/issues/10566
+    'google-auth>=1.6.1,<3',
     'requests-toolbelt>=0.8.0,<1',
     'cloudpickle>=2.0.0,<3',
     # Update the upper version whenever a new major version of the


### PR DESCRIPTION
**Description of your changes:**
google-auth recently published a 2.0.0 release which removed support for Python 2.7. google-auth now requires Python >=3.6. No other breaking changes were made. You can see the full list of changes [here](https://github.com/googleapis/google-auth-library-python/commit/560cf1e).

I'm opening this as @kweinmeister mentioned the `google-auth<2` pin is making it difficult to resolve dependencies with some Google AI libraries.

**Motivation:**
google-auth is a dependency of many different libraries that interact with Google APIs. Increasing the time and number of packages with compatible pins on google-auth lowers the chance end developers who use multiple libraries will see dependency conflicts. 

If possible, please also retain compatibility with 1.x.x versions of google-auth until this issue is resolved
googleapis/google-cloud-python#10566, as that will further reduce the likelihood of diamond dependency conflicts.

Googlers, see [this doc](https://docs.google.com/document/d/1euAvUsia_4zf98lNvpwA3K0o2b4y5Xr9xAkyzCnIMzQ/edit) for more information.

**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
