### PR TITLE
fix(sdk.v2): Avoid pydantic union bug

### DIFF
--- a/samples/test/lightweight_python_functions_v2_with_outputs_test.py
+++ b/samples/test/lightweight_python_functions_v2_with_outputs_test.py
@@ -52,9 +52,8 @@ def verify(run: kfp_server_api.ApiRun, mlmd_connection_config, **kwargs):
 
 
 run_pipeline_func([
-    # TODO(chensun): debug and fix v2 compiler bug on optional input
-    # TestCase(
-    #     pipeline_func=pipeline,
-    #     mode=kfp.dsl.PipelineExecutionMode.V2_ENGINE,
-    # ),
+    TestCase(
+        pipeline_func=pipeline,
+        mode=kfp.dsl.PipelineExecutionMode.V2_ENGINE,
+    ),
 ])

--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -28,6 +28,7 @@
 * Fix regression on optional inputs [\#6905](https://github.com/kubeflow/pipelines/pull/6905) [\#6937](https://github.com/kubeflow/pipelines/pull/6937)
 * Depends on `google-auth>=1.6.1,<3` [\#6939](https://github.com/kubeflow/pipelines/pull/6939)
 * Change otherwise to else in yaml [\#6952](https://github.com/kubeflow/pipelines/pull/6952)
+* Avoid pydantic bug on Union type [\#6957](https://github.com/kubeflow/pipelines/pull/6957)
 
 ## Documentation Updates
 

--- a/sdk/python/kfp/v2/components/structures.py
+++ b/sdk/python/kfp/v2/components/structures.py
@@ -41,9 +41,8 @@ class InputSpec(BaseModel):
         optional: Wether the input is optional. An input is optional when it has
             an explicit default value.
     """
-    # TODO(ji-yaqi): Add logic to cast default value into the specified type.
     type: str
-    default: Optional[Union[str, int, float, bool, dict, list]] = None
+    default: Optional[Any] = None
     description: Optional[str] = None
     _optional: bool = pydantic.PrivateAttr()
 


### PR DESCRIPTION
**Description of your changes:**
Too much hassle to use Union types in pydantic. Likely not worth using it to specify parameter types for input default.

pydantic will attempt to 'match' any of the types defined under Union and will use the first one that matches.
https://pydantic-docs.helpmanual.io/usage/types/#unions


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
