### PR TITLE
feat(frontend): Disable delete button if no pipeline version is not selected

### DIFF
--- a/frontend/src/pages/PipelineDetails.test.tsx
+++ b/frontend/src/pages/PipelineDetails.test.tsx
@@ -464,13 +464,29 @@ describe('PipelineDetails', () => {
     );
   });
 
-  it('has a delete button', async () => {
+  it('has a delete button and it is enabled for pipeline version deletion', async () => {
     tree = shallow(<PipelineDetails {...generateProps()} />);
     await getPipelineVersionTemplateSpy;
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
     const deleteBtn = instance.getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
     expect(deleteBtn).toBeDefined();
+    expect(deleteBtn.disabled).toBeFalsy();
+  });
+
+  it('has a delete button, and it is disabled because no version is selected', async () => {
+    let pageProps = generateProps();
+    pageProps.match.params = {
+      [RouteParams.pipelineId]: testPipeline.id,
+    };
+    tree = shallow(<PipelineDetails {...pageProps} />);
+
+    await getPipelineVersionTemplateSpy;
+    await TestUtils.flushPromises();
+    const instance = tree.instance() as PipelineDetails;
+    const deleteBtn = instance.getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
+    expect(deleteBtn).toBeDefined();
+    expect(deleteBtn.disabled).toBeTruthy();
   });
 
   it('shows delete confirmation dialog when delete button is clicked', async () => {

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -116,7 +116,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
           () => (pipelineVersionIdFromParams ? [pipelineVersionIdFromParams] : []),
           'pipeline version',
           this._deleteCallback.bind(this),
-          true /* useCurrentResource */,
+          pipelineVersionIdFromParams ? true : false /* useCurrentResource */,
         );
       return {
         actions: buttons.getToolbarActionMap(),


### PR DESCRIPTION

**Description of your changes:**

Partial https://github.com/kubeflow/pipelines/issues/6779

Currently KFP Pipeline Detail page has a Delete button which is always enabled. But actually if you don't select a pipeline version, the button does nothing and redirect you to the Pipeline List page. So we should disable the Delete button if this button does nothing.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
