### PR TITLE
fix(Profile Controller): Disable indent when json dumps

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/sync.py
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/sync.py
@@ -93,7 +93,7 @@ def get_settings_from_env(controller_port=None,
 def server_factory(visualization_server_image,
                    visualization_server_tag, frontend_image, frontend_tag,
                    disable_istio_sidecar, minio_access_key,
-                   minio_secret_key, kfp_default_pipeline_root=None, 
+                   minio_secret_key, kfp_default_pipeline_root=None,
                    url="", controller_port=8080):
     """
     Returns an HTTPServer populated with Handler with customized settings
@@ -360,8 +360,8 @@ def server_factory(visualization_server_image,
                     }
                 },
             ]
-            print('Received request:\n', json.dumps(parent, indent=2, sort_keys=True))
-            print('Desired resources except secrets:\n', json.dumps(desired_resources, indent=2, sort_keys=True))
+            print('Received request:\n', json.dumps(parent, sort_keys=True))
+            print('Desired resources except secrets:\n', json.dumps(desired_resources, sort_keys=True))
             # Moved after the print argument because this is sensitive data.
             desired_resources.append({
                 "apiVersion": "v1",

--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/test_sync.py
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/test_sync.py
@@ -202,7 +202,7 @@ def test_sync_server_with_pipeline_enabled(sync_server, data, expected_status,
     url = f"http://{server.server_address[0]}:{str(server.server_address[1])}"
     print("url: ", url)
     print("data")
-    print(json.dumps(data, indent=2))
+    print(json.dumps(data))
     x = requests.post(url, data=json.dumps(data))
     results = json.loads(x.text)
 
@@ -245,7 +245,7 @@ def test_sync_server_with_direct_passing_of_settings(
     url = f"http://{server.server_address[0]}:{str(server.server_address[1])}"
     print("url: ", url)
     print("data")
-    print(json.dumps(data, indent=2))
+    print(json.dumps(data))
     x = requests.post(url, data=json.dumps(data))
     results = json.loads(x.text)
 
@@ -271,7 +271,7 @@ def test_sync_server_without_pipeline_enabled(sync_server, data, expected_status
     """
     Nearly end-to-end test of how Controller serves .sync as a POST
 
-    Tests case where metadata.labels.pipelines.kubeflow.org/enabled does not 
+    Tests case where metadata.labels.pipelines.kubeflow.org/enabled does not
     exist and thus server returns an empty reply
     """
     server, environ = sync_server


### PR DESCRIPTION
**Description of your changes:**

It's not a good idea to print the logs with indent, we should remove the indent.
It's better to keep the msg as single line.

```
Received request:
 {
  "apiVersion": "v1",
  "kind": "Namespace",
  "metadata": {
    "annotations": {
      "owner": "mask@example.com"
    },
...
```

1. When we debug with `kubectl logs`, this is not developer friendly
2. This is not friendly for log tools also.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
