### PR TITLE
refactor(v2): executions use parent_dag_id custom property for DAG - task relationship

### DIFF
--- a/samples/test/util.py
+++ b/samples/test/util.py
@@ -28,9 +28,13 @@ from kfp.onprem import add_default_resource_spec
 import kfp.v2.compiler
 import kfp_server_api
 from ml_metadata import metadata_store
+from ml_metadata.metadata_store.metadata_store import ListOptions
 from ml_metadata.proto import metadata_store_pb2
 
 MINUTE = 60
+
+logger = logging.getLogger('samples.test.util')
+logger.setLevel('INFO')
 
 
 # Add **kwargs, so that when new arguments are added, this doesn't fail for
@@ -47,6 +51,12 @@ def NEEDS_A_FIX(run_id, run, **kwargs):
     assert run.status == 'Failed'
 
 
+Verifier = Callable[[
+    int, kfp_server_api.ApiRun, kfp_server_api.ApiRunDetail, metadata_store_pb2
+    .MetadataStoreClientConfig
+], None]
+
+
 @dataclass
 class TestCase:
     """Test case for running a KFP sample."""
@@ -54,10 +64,7 @@ class TestCase:
     mode: kfp.dsl.PipelineExecutionMode = kfp.dsl.PipelineExecutionMode.V2_COMPATIBLE
     enable_caching: bool = False
     arguments: Optional[Dict[str, str]] = None
-    verify_func: Callable[[
-        int, kfp_server_api.ApiRun, kfp_server_api
-        .ApiRunDetail, metadata_store_pb2.MetadataStoreClientConfig
-    ], None] = _default_verify_func
+    verify_func: Verifier = _default_verify_func
 
 
 def run_pipeline_func(test_cases: List[TestCase]):
@@ -121,6 +128,23 @@ def run_pipeline_func(test_cases: List[TestCase]):
     _run_test(test_wrapper)
 
 
+def debug_verify(run_id: str, verify_func: Verifier):
+    '''Debug a verify function quickly using MLMD data from an existing KFP run ID.'''
+    t = unittest.TestCase()
+    t.maxDiff = None  # we always want to see full diff
+    client = KfpMlmdClient()
+    tasks = client.get_tasks(run_id=run_id)
+    pprint(tasks)
+
+    verify_func(
+        run=kfp_server_api.ApiRun(id=run_id, status='Succeeded'),
+        run_id=run_id,
+        t=t,
+        tasks=tasks,
+        client=client,
+    )
+
+
 def _retry_with_backoff(fn: Callable, retries=3, backoff_in_seconds=1):
     i = 0
     while True:
@@ -141,7 +165,7 @@ def _retry_with_backoff(fn: Callable, retries=3, backoff_in_seconds=1):
 def _run_test(callback):
 
     def main(
-        output_directory: Optional[str] = None,  # example
+        pipeline_root: Optional[str] = None,  # example
         host: Optional[str] = None,
         external_host: Optional[str] = None,
         launcher_image: Optional[str] = None,
@@ -157,9 +181,9 @@ def _run_test(callback):
         :type host: str, optional
         :param external_host: External hostname users can access from their browsers.
         :type external_host: str, optional
-        :param output_directory: pipeline output directory that holds intermediate
+        :param pipeline_root: pipeline root that holds intermediate
         artifacts, example gs://your-bucket/path/to/workdir.
-        :type output_directory: str, optional
+        :type pipeline_root: str, optional
         :param launcher_image: override launcher image, only used in V2_COMPATIBLE mode
         :type launcher_image: URI, optional
         :param launcher_v2_image: override launcher v2 image, only used in V2_ENGINE mode
@@ -180,8 +204,14 @@ def _run_test(callback):
             host = os.getenv('KFP_HOST', 'http://ml-pipeline:8888')
         if external_host is None:
             external_host = host
-        if output_directory is None:
-            output_directory = os.getenv('KFP_OUTPUT_DIRECTORY')
+        if pipeline_root is None:
+            pipeline_root = os.getenv('KFP_PIPELINE_ROOT')
+            if not pipeline_root:
+                pipeline_root = os.getenv('KFP_OUTPUT_DIRECTORY')
+                if pipeline_root:
+                    logger.warning(
+                        f'KFP_OUTPUT_DIRECTORY env var is left for backward compatibility, please use KFP_PIPELINE_ROOT instead.'
+                    )
         if metadata_service_host is None:
             metadata_service_host = os.getenv('METADATA_GRPC_SERVICE_HOST',
                                               'metadata-grpc-service')
@@ -214,7 +244,7 @@ def _run_test(callback):
                         fn=pipeline_func,
                         driver_image=driver_image,
                         launcher_v2_image=launcher_v2_image,
-                        pipeline_root=output_directory,
+                        pipeline_root=pipeline_root,
                         enable_caching=enable_caching,
                         arguments={
                             **arguments,
@@ -283,9 +313,9 @@ def _run_test(callback):
 def run_v2_pipeline(
     client: kfp.Client,
     fn: Callable,
-    driver_image: str,
-    launcher_v2_image: str,
-    pipeline_root: str,
+    driver_image: Optional[str],
+    launcher_v2_image: Optional[str],
+    pipeline_root: Optional[str],
     enable_caching: bool,
     arguments: Mapping[str, str],
 ):
@@ -325,13 +355,13 @@ def run_v2_pipeline(
             'kfp-v2-compiler',
             '--job',
             pipeline_job,
-            '--driver',
-            driver_image,
-            '--launcher',
-            launcher_v2_image,
-            '--pipeline_root',
-            pipeline_root,
         ]
+        if driver_image:
+            args += ['--driver', driver_image]
+        if launcher_v2_image:
+            args += ['--launcher', launcher_v2_image]
+        if pipeline_root:
+            args += ['--pipeline_root', pipeline_root]
         # call v2 backend compiler CLI to compile pipeline spec to argo workflow
         subprocess.check_call(args, stdout=f)
     return client.create_run_from_pipeline_package(
@@ -490,10 +520,23 @@ class KfpMlmdClient:
         if not run_context:
             raise Exception(
                 f'Cannot find system.PipelineRun context "{run_id}"')
-        logging.info(
-            f'run_context: name={run_context.name} id={run_context.id}')
-        executions = self.mlmd_store.get_executions_by_context(
-            context_id=run_context.id)
+        logger.info(f'run_context: name={run_context.name} id={run_context.id}')
+
+        root = self.mlmd_store.get_execution_by_type_and_name(
+            type_name='system.DAGExecution',
+            execution_name=f'run/{run_id}',
+        )
+        if not root:
+            raise Exception(
+                f'Cannot find system.DAGExecution execution "run/{run_id}"')
+        logger.info(f'root_dag: name={root.name} id={root.id}')
+
+        # Note, we only need to query by parent_id. However, there is no index
+        # on parent_id. To speed up the query, we also limit the query to the
+        # run context (contexts have index).
+        filter_query = f'contexts_run.id = {run_context.id} AND custom_properties.parent_id.int_value = {root.id}'
+        executions = self.mlmd_store.get_executions(
+            list_options=ListOptions(filter_query=filter_query))
         execution_types = self.mlmd_store.get_execution_types_by_id(
             list(set([e.type_id for e in executions])))
         execution_types_by_id = {et.id: et for et in execution_types}

--- a/samples/test/util.py
+++ b/samples/test/util.py
@@ -531,10 +531,10 @@ class KfpMlmdClient:
                 f'Cannot find system.DAGExecution execution "run/{run_id}"')
         logger.info(f'root_dag: name={root.name} id={root.id}')
 
-        # Note, we only need to query by parent_id. However, there is no index
-        # on parent_id. To speed up the query, we also limit the query to the
+        # Note, we only need to query by parent_dag_id. However, there is no index
+        # on parent_dag_id. To speed up the query, we also limit the query to the
         # run context (contexts have index).
-        filter_query = f'contexts_run.id = {run_context.id} AND custom_properties.parent_id.int_value = {root.id}'
+        filter_query = f'contexts_run.id = {run_context.id} AND custom_properties.parent_dag_id.int_value = {root.id}'
         executions = self.mlmd_store.get_executions(
             list_options=ListOptions(filter_query=filter_query))
         execution_types = self.mlmd_store.get_execution_types_by_id(

--- a/v2/cmd/driver/main.go
+++ b/v2/cmd/driver/main.go
@@ -19,11 +19,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/kubeflow/pipelines/v2/cacheutils"
-	"github.com/kubeflow/pipelines/v2/driver"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/kubeflow/pipelines/v2/cacheutils"
+	"github.com/kubeflow/pipelines/v2/driver"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/jsonpb"
@@ -46,7 +47,6 @@ var (
 	runtimeConfigJson = flag.String("runtime_config", "{}", "jobruntime config")
 
 	// container inputs
-	dagContextID      = flag.Int64("dag_context_id", 0, "DAG context ID")
 	dagExecutionID    = flag.Int64("dag_execution_id", 0, "DAG execution ID")
 	containerSpecJson = flag.String("container", "{}", "container spec")
 
@@ -56,7 +56,6 @@ var (
 
 	// output paths
 	executionIDPath   = flag.String("execution_id_path", "", "Exeucution ID output path")
-	contextIDPath     = flag.String("context_id_path", "", "Context ID output path")
 	executorInputPath = flag.String("executor_input_path", "", "Executor Input output path")
 	// output paths, the value stored in the paths will be either 'true' or 'false'
 	cachedDecisionPath = flag.String("cached_decision_path", "", "Cached Decision output path")
@@ -136,7 +135,6 @@ func drive() (err error) {
 		Component:      componentSpec,
 		Task:           taskSpec,
 		DAGExecutionID: *dagExecutionID,
-		DAGContextID:   *dagContextID,
 	}
 	var execution *driver.Execution
 	switch *driverType {
@@ -156,12 +154,6 @@ func drive() (err error) {
 		glog.Infof("output execution.ID=%v", execution.ID)
 		if err = writeFile(*executionIDPath, []byte(fmt.Sprint(execution.ID))); err != nil {
 			return fmt.Errorf("failed to write execution ID to file: %w", err)
-		}
-	}
-	if execution.Context != 0 {
-		glog.Infof("output execution.Context=%v", execution.Context)
-		if err = writeFile(*contextIDPath, []byte(fmt.Sprint(execution.Context))); err != nil {
-			return fmt.Errorf("failed to write context ID to file: %w", err)
 		}
 	}
 	if execution.ExecutorInput != nil {

--- a/v2/compiler/argo.go
+++ b/v2/compiler/argo.go
@@ -144,10 +144,8 @@ const (
 	paramContainer      = "container"      // container spec
 	paramImporter       = "importer"       // importer spec
 	paramRuntimeConfig  = "runtime-config" // job runtime config, pipeline level inputs
-	paramDAGContextID   = "dag-context-id"
 	paramDAGExecutionID = "dag-execution-id"
 	paramExecutionID    = "execution-id"
-	paramContextID      = "context-id"
 	paramExecutorInput  = "executor-input"
 	paramCachedDecision = "cached-decision" // indicate hit cache or not
 )

--- a/v2/compiler/argo_test.go
+++ b/v2/compiler/argo_test.go
@@ -42,8 +42,6 @@ func Test_argo_compiler(t *testing.T) {
               - hello-world
               - --run_id
               - '{{workflow.uid}}'
-              - --dag_context_id
-              - '{{inputs.parameters.dag-context-id}}'
               - --dag_execution_id
               - '{{inputs.parameters.dag-execution-id}}'
               - --component
@@ -68,7 +66,6 @@ func Test_argo_compiler(t *testing.T) {
               - name: component
               - name: task
               - name: container
-              - name: dag-context-id
               - name: dag-execution-id
             metadata: {}
             name: system-container-driver
@@ -97,12 +94,12 @@ func Test_argo_compiler(t *testing.T) {
                 def hello_world(text):
                     print(text)
                     return text
-        
+
                 import argparse
                 _parser = argparse.ArgumentParser(prog='Hello world', description='')
                 _parser.add_argument("--text", dest="text", type=str, required=True, default=argparse.SUPPRESS)
                 _parsed_args = vars(_parser.parse_args())
-        
+
                 _outputs = hello_world(**_parsed_args)
               - --text
               - '{{$.inputs.parameters[''text'']}}'
@@ -184,8 +181,6 @@ func Test_argo_compiler(t *testing.T) {
                       argparse\n_parser = argparse.ArgumentParser(prog=''Hello world'', description='''')\n_parser.add_argument(\"--text\",
                       dest=\"text\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
                       = vars(_parser.parse_args())\n\n_outputs = hello_world(**_parsed_args)\n"],"args":["--text","{{$.inputs.parameters[''text'']}}"]}'
-                  - name: dag-context-id
-                    value: '{{inputs.parameters.dag-context-id}}'
                   - name: dag-execution-id
                     value: '{{inputs.parameters.dag-execution-id}}'
                 name: driver
@@ -206,7 +201,6 @@ func Test_argo_compiler(t *testing.T) {
             inputs:
               parameters:
               - name: task
-              - name: dag-context-id
               - name: dag-execution-id
               - default: '{"inputDefinitions":{"parameters":{"text":{"type":"STRING"}}},"executorLabel":"exec-hello-world"}'
                 name: component
@@ -217,8 +211,6 @@ func Test_argo_compiler(t *testing.T) {
               tasks:
               - arguments:
                   parameters:
-                  - name: dag-context-id
-                    value: '{{inputs.parameters.dag-context-id}}'
                   - name: dag-execution-id
                     value: '{{inputs.parameters.dag-execution-id}}'
                   - name: task
@@ -227,7 +219,6 @@ func Test_argo_compiler(t *testing.T) {
                 template: comp-hello-world
             inputs:
               parameters:
-              - name: dag-context-id
               - name: dag-execution-id
             metadata: {}
             name: root-dag
@@ -246,8 +237,6 @@ func Test_argo_compiler(t *testing.T) {
               - '{{inputs.parameters.runtime-config}}'
               - --execution_id_path
               - '{{outputs.parameters.execution-id.path}}'
-              - --context_id_path
-              - '{{outputs.parameters.context-id.path}}'
               command:
               - driver
               image: gcr.io/ml-pipeline/kfp-driver:latest
@@ -264,9 +253,6 @@ func Test_argo_compiler(t *testing.T) {
               - name: execution-id
                 valueFrom:
                   path: /tmp/outputs/execution-id
-              - name: context-id
-                valueFrom:
-                  path: /tmp/outputs/context-id
           - dag:
               tasks:
               - arguments:
@@ -283,8 +269,6 @@ func Test_argo_compiler(t *testing.T) {
                   parameters:
                   - name: dag-execution-id
                     value: '{{tasks.driver.outputs.parameters.execution-id}}'
-                  - name: dag-context-id
-                    value: '{{tasks.driver.outputs.parameters.context-id}}'
                 dependencies:
                 - driver
                 name: dag
@@ -300,7 +284,7 @@ func Test_argo_compiler(t *testing.T) {
 		},
 		{
 			jobPath: "testdata/importer.json",
-			expectedText: `        
+			expectedText: `
         apiVersion: argoproj.io/v1alpha1
         kind: Workflow
         metadata:
@@ -372,8 +356,6 @@ func Test_argo_compiler(t *testing.T) {
               tasks:
               - arguments:
                   parameters:
-                  - name: dag-context-id
-                    value: '{{inputs.parameters.dag-context-id}}'
                   - name: dag-execution-id
                     value: '{{inputs.parameters.dag-execution-id}}'
                   - name: task
@@ -382,7 +364,6 @@ func Test_argo_compiler(t *testing.T) {
                 template: comp-importer
             inputs:
               parameters:
-              - name: dag-context-id
               - name: dag-execution-id
             metadata: {}
             name: root-dag
@@ -401,8 +382,6 @@ func Test_argo_compiler(t *testing.T) {
               - '{{inputs.parameters.runtime-config}}'
               - --execution_id_path
               - '{{outputs.parameters.execution-id.path}}'
-              - --context_id_path
-              - '{{outputs.parameters.context-id.path}}'
               command:
               - driver
               image: gcr.io/ml-pipeline/kfp-driver:latest
@@ -419,9 +398,6 @@ func Test_argo_compiler(t *testing.T) {
               - name: execution-id
                 valueFrom:
                   path: /tmp/outputs/execution-id
-              - name: context-id
-                valueFrom:
-                  path: /tmp/outputs/context-id
           - dag:
               tasks:
               - arguments:
@@ -438,8 +414,6 @@ func Test_argo_compiler(t *testing.T) {
                   parameters:
                   - name: dag-execution-id
                     value: '{{tasks.driver.outputs.parameters.execution-id}}'
-                  - name: dag-context-id
-                    value: '{{tasks.driver.outputs.parameters.context-id}}'
                 dependencies:
                 - driver
                 name: dag

--- a/v2/compiler/container.go
+++ b/v2/compiler/container.go
@@ -27,7 +27,6 @@ func (c *workflowCompiler) Container(name string, component *pipelinespec.Compon
 		inputParameter(paramComponent),
 		inputParameter(paramTask),
 		containerJson,
-		inputParameter(paramDAGContextID),
 		inputParameter(paramDAGExecutionID),
 	)
 	t := containerExecutorTemplate(container, c.launcherImage, c.spec.PipelineInfo.GetName())
@@ -40,7 +39,6 @@ func (c *workflowCompiler) Container(name string, component *pipelinespec.Compon
 		Inputs: wfapi.Inputs{
 			Parameters: []wfapi.Parameter{
 				{Name: paramTask},
-				{Name: paramDAGContextID},
 				{Name: paramDAGExecutionID},
 				// TODO(Bobgy): reuse the entire 2-step container template
 				{Name: paramComponent, Default: wfapi.AnyStringPtr(componentJson)},
@@ -74,7 +72,7 @@ type containerDriverOutputs struct {
 	cached        string
 }
 
-func (c *workflowCompiler) containerDriverTask(name, component, task, container, dagContextID, dagExecutionID string) (*wfapi.DAGTask, *containerDriverOutputs) {
+func (c *workflowCompiler) containerDriverTask(name, component, task, container, dagExecutionID string) (*wfapi.DAGTask, *containerDriverOutputs) {
 	dagTask := &wfapi.DAGTask{
 		Name:     name,
 		Template: c.addContainerDriverTemplate(),
@@ -83,7 +81,6 @@ func (c *workflowCompiler) containerDriverTask(name, component, task, container,
 				{Name: paramComponent, Value: wfapi.AnyStringPtr(component)},
 				{Name: paramTask, Value: wfapi.AnyStringPtr(task)},
 				{Name: paramContainer, Value: wfapi.AnyStringPtr(container)},
-				{Name: paramDAGContextID, Value: wfapi.AnyStringPtr(dagContextID)},
 				{Name: paramDAGExecutionID, Value: wfapi.AnyStringPtr(dagExecutionID)},
 			},
 		},
@@ -92,7 +89,6 @@ func (c *workflowCompiler) containerDriverTask(name, component, task, container,
 		executorInput: taskOutputParameter(name, paramExecutorInput),
 		executionID:   taskOutputParameter(name, paramExecutionID),
 		cached:        taskOutputParameter(name, paramCachedDecision),
-
 	}
 	return dagTask, outputs
 }
@@ -110,7 +106,6 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 				{Name: paramComponent},
 				{Name: paramTask},
 				{Name: paramContainer},
-				{Name: paramDAGContextID},
 				{Name: paramDAGExecutionID},
 			},
 		},
@@ -128,7 +123,6 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 				"--type", "CONTAINER",
 				"--pipeline_name", c.spec.GetPipelineInfo().GetName(),
 				"--run_id", runID(),
-				"--dag_context_id", inputValue(paramDAGContextID),
 				"--dag_execution_id", inputValue(paramDAGExecutionID),
 				"--component", inputValue(paramComponent),
 				"--task", inputValue(paramTask),

--- a/v2/compiler/dag.go
+++ b/v2/compiler/dag.go
@@ -194,7 +194,6 @@ func addImplicitDependencies(dagSpec *pipelinespec.DagSpec) error {
 			}
 			return nil
 		}
-		// TODO(Bobgy): add implicit dependencies introduced by artifacts
 		for _, input := range task.GetInputs().GetParameters() {
 			switch input.GetKind().(type) {
 			case *pipelinespec.TaskInputsSpec_InputParameterSpec_TaskOutputParameter:

--- a/v2/compiler/dag.go
+++ b/v2/compiler/dag.go
@@ -20,7 +20,6 @@ func (c *workflowCompiler) DAG(name string, componentSpec *pipelinespec.Componen
 	dag := &wfapi.Template{
 		Inputs: wfapi.Inputs{
 			Parameters: []wfapi.Parameter{
-				{Name: paramDAGContextID},
 				{Name: paramDAGExecutionID},
 			},
 		},
@@ -38,10 +37,6 @@ func (c *workflowCompiler) DAG(name string, componentSpec *pipelinespec.Componen
 			Dependencies: kfpTask.GetDependentTasks(),
 			Arguments: wfapi.Arguments{
 				Parameters: []wfapi.Parameter{
-					{
-						Name:  paramDAGContextID,
-						Value: wfapi.AnyStringPtr(inputParameter(paramDAGContextID)),
-					},
 					{
 						Name:  paramDAGExecutionID,
 						Value: wfapi.AnyStringPtr(inputParameter(paramDAGExecutionID)),
@@ -75,7 +70,6 @@ func (c *workflowCompiler) DAG(name string, componentSpec *pipelinespec.Componen
 				Arguments: wfapi.Arguments{
 					Parameters: []wfapi.Parameter{
 						{Name: paramDAGExecutionID, Value: wfapi.AnyStringPtr(outputs.executionID)},
-						{Name: paramDAGContextID, Value: wfapi.AnyStringPtr(outputs.contextID)},
 					},
 				},
 			},
@@ -86,7 +80,7 @@ func (c *workflowCompiler) DAG(name string, componentSpec *pipelinespec.Componen
 }
 
 type dagDriverOutputs struct {
-	contextID, executionID string
+	executionID string
 }
 
 func (c *workflowCompiler) dagDriverTask(name string, component *pipelinespec.ComponentSpec, task *pipelinespec.PipelineTaskSpec, runtimeConfig *pipelinespec.PipelineJob_RuntimeConfig) (*wfapi.DAGTask, *dagDriverOutputs, error) {
@@ -134,7 +128,6 @@ func (c *workflowCompiler) dagDriverTask(name string, component *pipelinespec.Co
 		},
 	}
 	return t, &dagDriverOutputs{
-		contextID:   taskOutputParameter(name, paramContextID),
 		executionID: taskOutputParameter(name, paramExecutionID),
 	}, nil
 }
@@ -156,7 +149,6 @@ func (c *workflowCompiler) addDAGDriverTemplate() string {
 		Outputs: wfapi.Outputs{
 			Parameters: []wfapi.Parameter{
 				{Name: paramExecutionID, ValueFrom: &wfapi.ValueFrom{Path: "/tmp/outputs/execution-id"}},
-				{Name: paramContextID, ValueFrom: &wfapi.ValueFrom{Path: "/tmp/outputs/context-id"}},
 			},
 		},
 		Container: &k8score.Container{
@@ -169,7 +161,6 @@ func (c *workflowCompiler) addDAGDriverTemplate() string {
 				"--component", inputValue(paramComponent),
 				"--runtime_config", inputValue(paramRuntimeConfig),
 				"--execution_id_path", outputPath(paramExecutionID),
-				"--context_id_path", outputPath(paramContextID),
 			},
 		},
 	}

--- a/v2/driver/driver.go
+++ b/v2/driver/driver.go
@@ -192,7 +192,7 @@ func Container(ctx context.Context, opts Options, mlmd *metadata.Client, cacheCl
 	}
 	ecfg.TaskName = opts.Task.GetTaskInfo().GetName()
 	ecfg.ExecutionType = metadata.ContainerExecutionTypeName
-	ecfg.ParentID = dag.Execution.GetID()
+	ecfg.ParentDagID = dag.Execution.GetID()
 
 	if opts.Task.GetCachingOptions() != nil && opts.Task.GetCachingOptions().GetEnableCache() {
 		glog.Infof("Task {%s} enables cache", opts.Task.GetTaskInfo().GetName())

--- a/v2/driver/driver.go
+++ b/v2/driver/driver.go
@@ -112,7 +112,6 @@ func RootDAG(ctx context.Context, opts Options, mlmd *metadata.Client) (executio
 		return nil, err
 	}
 	ecfg.ExecutionType = metadata.DagExecutionTypeName
-	ecfg.PipelineRoot = pipeline.GetPipelineRoot()
 	ecfg.Name = fmt.Sprintf("run/%s", opts.RunID)
 	exec, err := mlmd.CreateExecution(ctx, pipeline, ecfg)
 	if err != nil {
@@ -185,7 +184,7 @@ func Container(ctx context.Context, opts Options, mlmd *metadata.Client, cacheCl
 	}
 	executorInput := &pipelinespec.ExecutorInput{
 		Inputs:  inputs,
-		Outputs: provisionOutputs(dag.GetPipelineRoot(), opts.Task.GetTaskInfo().GetName(), opts.Component.GetOutputDefinitions()),
+		Outputs: provisionOutputs(pipeline.GetPipelineRoot(), opts.Task.GetTaskInfo().GetName(), opts.Component.GetOutputDefinitions()),
 	}
 	ecfg, err := metadata.GenerateExecutionConfig(executorInput)
 	if err != nil {

--- a/v2/driver/driver.go
+++ b/v2/driver/driver.go
@@ -34,7 +34,6 @@ type Options struct {
 	Task *pipelinespec.PipelineTaskSpec
 	// required only by container driver
 	DAGExecutionID int64
-	DAGContextID   int64
 	Container      *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec
 	// required only by root DAG driver
 	Namespace string
@@ -52,9 +51,6 @@ func (o Options) info() string {
 	if o.DAGExecutionID != 0 {
 		msg = msg + fmt.Sprintf(", dagExecutionID=%v", o.DAGExecutionID)
 	}
-	if o.DAGContextID != 0 {
-		msg = msg + fmt.Sprintf(", dagContextID=%v", o.DAGContextID)
-	}
 	if o.RuntimeConfig != nil {
 		msg = msg + ", runtimeConfig" // this only means runtimeConfig is not empty
 	}
@@ -66,7 +62,6 @@ func (o Options) info() string {
 
 type Execution struct {
 	ID            int64
-	Context       int64 // only specified when this is a DAG execution
 	ExecutorInput *pipelinespec.ExecutorInput
 	Cached        bool // only specified when this is a Container execution
 }
@@ -116,8 +111,9 @@ func RootDAG(ctx context.Context, opts Options, mlmd *metadata.Client) (executio
 	if err != nil {
 		return nil, err
 	}
-	ecfg.IsRootDAG = true
 	ecfg.ExecutionType = metadata.DagExecutionTypeName
+	ecfg.PipelineRoot = pipeline.GetPipelineRoot()
+	ecfg.Name = fmt.Sprintf("run/%s", opts.RunID)
 	exec, err := mlmd.CreateExecution(ctx, pipeline, ecfg)
 	if err != nil {
 		return nil, err
@@ -125,7 +121,7 @@ func RootDAG(ctx context.Context, opts Options, mlmd *metadata.Client) (executio
 	glog.Infof("Created execution: %s", exec)
 	// No need to return ExecutorInput, because tasks in the DAG will resolve
 	// needed info from MLMD.
-	return &Execution{ID: exec.GetID(), Context: pipeline.GetRunCtxID()}, nil
+	return &Execution{ID: exec.GetID()}, nil
 }
 
 func validateRootDAG(opts Options) (err error) {
@@ -155,9 +151,6 @@ func validateRootDAG(opts Options) (err error) {
 	if opts.DAGExecutionID != 0 {
 		return fmt.Errorf("DAG execution ID is unnecessary")
 	}
-	if opts.DAGContextID != 0 {
-		return fmt.Errorf("DAG context ID is unncessary")
-	}
 	if opts.Container != nil {
 		return fmt.Errorf("container spec is unncessary")
 	}
@@ -181,12 +174,12 @@ func Container(ctx context.Context, opts Options, mlmd *metadata.Client, cacheCl
 	if err != nil {
 		return nil, err
 	}
-	dag, err := mlmd.GetDAG(ctx, opts.DAGExecutionID, opts.DAGContextID)
+	dag, err := mlmd.GetDAG(ctx, opts.DAGExecutionID)
 	if err != nil {
 		return nil, err
 	}
 	glog.Infof("parent DAG: %+v", dag.Execution)
-	inputs, err := resolveInputs(ctx, dag, opts.Task, mlmd)
+	inputs, err := resolveInputs(ctx, dag, pipeline, opts.Task, mlmd)
 	if err != nil {
 		return nil, err
 	}
@@ -200,6 +193,7 @@ func Container(ctx context.Context, opts Options, mlmd *metadata.Client, cacheCl
 	}
 	ecfg.TaskName = opts.Task.GetTaskInfo().GetName()
 	ecfg.ExecutionType = metadata.ContainerExecutionTypeName
+	ecfg.ParentID = dag.Execution.GetID()
 
 	if opts.Task.GetCachingOptions() != nil && opts.Task.GetCachingOptions().GetEnableCache() {
 		glog.Infof("Task {%s} enables cache", opts.Task.GetTaskInfo().GetName())
@@ -335,16 +329,13 @@ func validateContainer(opts Options) (err error) {
 	if opts.DAGExecutionID == 0 {
 		return fmt.Errorf("DAG execution ID is required")
 	}
-	if opts.DAGContextID == 0 {
-		return fmt.Errorf("DAG context ID is required")
-	}
 	if opts.Container == nil {
 		return fmt.Errorf("container spec is required")
 	}
 	return nil
 }
 
-func resolveInputs(ctx context.Context, dag *metadata.DAG, task *pipelinespec.PipelineTaskSpec, mlmd *metadata.Client) (*pipelinespec.ExecutorInput_Inputs, error) {
+func resolveInputs(ctx context.Context, dag *metadata.DAG, pipeline *metadata.Pipeline, task *pipelinespec.PipelineTaskSpec, mlmd *metadata.Client) (*pipelinespec.ExecutorInput_Inputs, error) {
 	inputParams, _, err := dag.Execution.GetParameters()
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve inputs: %w", err)
@@ -360,7 +351,7 @@ func resolveInputs(ctx context.Context, dag *metadata.DAG, task *pipelinespec.Pi
 		if tasksCache != nil {
 			return tasksCache, nil
 		}
-		tasks, err := mlmd.GetExecutionsInDAG(ctx, dag)
+		tasks, err := mlmd.GetExecutionsInDAG(ctx, dag, pipeline)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/metadata/client.go
+++ b/v2/metadata/client.go
@@ -116,9 +116,6 @@ type ExecutionConfig struct {
 	// ContainerExecution custom properties
 	Image, CachedMLMDExecutionID, FingerPrint string
 	PodName, PodUID, Namespace                string
-
-	// DAGExecution custom properties
-	PipelineRoot string
 }
 
 // InputArtifact is a wrapper around an MLMD artifact used as component inputs.
@@ -281,18 +278,6 @@ type DAG struct {
 // identifier info for error message purposes
 func (d *DAG) Info() string {
 	return fmt.Sprintf("DAG(executionID=%v)", d.Execution.GetID())
-}
-
-func (d *DAG) GetPipelineRoot() string {
-	if d == nil {
-		return ""
-	}
-	props := d.Execution.GetExecution().GetCustomProperties()
-	root, ok := props[keyPipelineRoot]
-	if !ok {
-		return ""
-	}
-	return root.GetStringValue()
 }
 
 func (c *Client) GetDAG(ctx context.Context, executionID int64) (*DAG, error) {
@@ -480,11 +465,6 @@ func (c *Client) CreateExecution(ctx context.Context, pipeline *Pipeline, config
 		}
 		if config.FingerPrint != "" {
 			e.CustomProperties[keyCacheFingerPrint] = stringValue(config.FingerPrint)
-		}
-	}
-	if config.ExecutionType == DagExecutionTypeName {
-		if config.PipelineRoot != "" {
-			e.CustomProperties[keyPipelineRoot] = stringValue(config.PipelineRoot)
 		}
 	}
 	if config.InputParameters != nil {

--- a/v2/metadata/client.go
+++ b/v2/metadata/client.go
@@ -43,10 +43,15 @@ import (
 const (
 	pipelineContextTypeName    = "system.Pipeline"
 	pipelineRunContextTypeName = "system.PipelineRun"
-	ContainerExecutionTypeName = "system.ContainerExecution"
-	DagExecutionTypeName       = "system.DAGExecution"
 	ImporterExecutionTypeName  = "system.ImporterExecution"
 	mlmdClientSideMaxRetries   = 3
+)
+
+type ExecutionType string
+
+const (
+	ContainerExecutionTypeName ExecutionType = "system.ContainerExecution"
+	DagExecutionTypeName       ExecutionType = "system.DAGExecution"
 )
 
 var (
@@ -60,11 +65,11 @@ var (
 	}
 
 	dagExecutionType = &pb.ExecutionType{
-		Name: proto.String(DagExecutionTypeName),
+		Name: proto.String(string(DagExecutionTypeName)),
 	}
 
 	containerExecutionType = &pb.ExecutionType{
-		Name: proto.String(ContainerExecutionTypeName),
+		Name: proto.String(string(ContainerExecutionTypeName)),
 	}
 	importerExecutionType = &pb.ExecutionType{
 		Name: proto.String(ImporterExecutionTypeName),
@@ -101,12 +106,19 @@ func NewClient(serverAddress, serverPort string) (*Client, error) {
 
 // ExecutionConfig represents the input parameters and artifacts to an Execution.
 type ExecutionConfig struct {
+	TaskName         string
+	Name             string // optional, MLMD execution name. When provided, this needs to be unique among all MLMD executions.
+	ExecutionType    ExecutionType
+	ParentID         int64 // parent execution ID, when not provided, it means root.
 	InputParameters  map[string]*structpb.Value
 	InputArtifactIDs map[string][]int64
-	TaskName, PodName, PodUID, Namespace,
-	Image, CachedMLMDExecutionID, ExecutionType, FingerPrint string
-	// a temporary flag to special case some logic for root DAG
-	IsRootDAG bool
+
+	// ContainerExecution custom properties
+	Image, CachedMLMDExecutionID, FingerPrint string
+	PodName, PodUID, Namespace                string
+
+	// DAGExecution custom properties
+	PipelineRoot string
 }
 
 // InputArtifact is a wrapper around an MLMD artifact used as component inputs.
@@ -264,19 +276,18 @@ func (c *Client) GetPipeline(ctx context.Context, pipelineName, pipelineRunID, n
 // a Kubeflow Pipelines DAG
 type DAG struct {
 	Execution *Execution
-	context   *pb.Context
 }
 
 // identifier info for error message purposes
 func (d *DAG) Info() string {
-	return fmt.Sprintf("DAG(executionID=%v, contextID=%v)", d.Execution.GetID(), d.context.GetId())
+	return fmt.Sprintf("DAG(executionID=%v)", d.Execution.GetID())
 }
 
 func (d *DAG) GetPipelineRoot() string {
 	if d == nil {
 		return ""
 	}
-	props := d.context.GetCustomProperties()
+	props := d.Execution.GetExecution().GetCustomProperties()
 	root, ok := props[keyPipelineRoot]
 	if !ok {
 		return ""
@@ -284,27 +295,17 @@ func (d *DAG) GetPipelineRoot() string {
 	return root.GetStringValue()
 }
 
-func (c *Client) GetDAG(ctx context.Context, executionID int64, contextID int64) (*DAG, error) {
+func (c *Client) GetDAG(ctx context.Context, executionID int64) (*DAG, error) {
 	dagError := func(err error) error {
-		return fmt.Errorf("failed to get DAG executionID=%v contextID=%v: %w", executionID, contextID, err)
+		return fmt.Errorf("failed to get DAG executionID=%v: %w", executionID, err)
 	}
-	executions, err := c.GetExecutions(ctx, []int64{executionID})
+	res, err := c.GetExecution(ctx, executionID)
 	if err != nil {
 		return nil, dagError(err)
 	}
-	if len(executions) != 1 {
-		return nil, dagError(fmt.Errorf("got %v executions, expect 1", len(executions)))
-	}
-	execution := executions[0]
-	context, err := c.getContextByID(ctx, contextID)
-	if err != nil {
-		return nil, dagError(err)
-	}
-	if context == nil {
-		return nil, dagError(fmt.Errorf("context not found"))
-	}
-	// TODO(Bobgy): verify execution type is system.DAGExecution & context type is system.PipelineRun or system.DAGExecution
-	return &DAG{Execution: &Execution{execution: execution}, context: context}, nil
+	execution := res.GetExecution()
+	// TODO(Bobgy): verify execution type is system.DAGExecution
+	return &DAG{Execution: &Execution{execution: execution}}, nil
 }
 
 func (c *Client) putParentContexts(ctx context.Context, req *pb.PutParentContextsRequest) error {
@@ -439,12 +440,16 @@ const (
 	keyCachedExecutionID = "cached_execution_id"
 	keyInputs            = "inputs"
 	keyOutputs           = "outputs"
+	keyParentID          = "parent_id" // Parent Execution ID. Optional for root DAG.
 )
 
 // CreateExecution creates a new MLMD execution under the specified Pipeline.
 func (c *Client) CreateExecution(ctx context.Context, pipeline *Pipeline, config *ExecutionConfig) (*Execution, error) {
+	if config == nil {
+		return nil, fmt.Errorf("metadata.CreateExecution got config == nil")
+	}
 	typeID, err := c.getExecutionTypeID(ctx, &pb.ExecutionType{
-		Name: proto.String(config.ExecutionType),
+		Name: proto.String(string(config.ExecutionType)),
 	})
 	if err != nil {
 		return nil, err
@@ -456,41 +461,43 @@ func (c *Client) CreateExecution(ctx context.Context, pipeline *Pipeline, config
 			// We should support overriding display name in the future, for now it defaults to task name.
 			keyDisplayName: stringValue(config.TaskName),
 			keyTaskName:    stringValue(config.TaskName),
-			keyPodName:     stringValue(config.PodName),
-			keyPodUID:      stringValue(config.PodUID),
-			keyNamespace:   stringValue(config.Namespace),
-			keyImage:       stringValue(config.Image),
 		},
 		LastKnownState: pb.Execution_RUNNING.Enum(),
 	}
-	if config.CachedMLMDExecutionID != "" {
-		e.CustomProperties[keyCachedExecutionID] = stringValue(config.CachedMLMDExecutionID)
+	if config.Name != "" {
+		e.Name = &config.Name
 	}
-	if config.FingerPrint != "" {
-		e.CustomProperties[keyCacheFingerPrint] = stringValue(config.FingerPrint)
+	if config.ParentID != 0 {
+		e.CustomProperties[keyParentID] = intValue(config.ParentID)
 	}
-
+	if config.ExecutionType == ContainerExecutionTypeName {
+		e.CustomProperties[keyPodName] = stringValue(config.PodName)
+		e.CustomProperties[keyPodUID] = stringValue(config.PodUID)
+		e.CustomProperties[keyNamespace] = stringValue(config.Namespace)
+		e.CustomProperties[keyImage] = stringValue(config.Image)
+		if config.CachedMLMDExecutionID != "" {
+			e.CustomProperties[keyCachedExecutionID] = stringValue(config.CachedMLMDExecutionID)
+		}
+		if config.FingerPrint != "" {
+			e.CustomProperties[keyCacheFingerPrint] = stringValue(config.FingerPrint)
+		}
+	}
+	if config.ExecutionType == DagExecutionTypeName {
+		if config.PipelineRoot != "" {
+			e.CustomProperties[keyPipelineRoot] = stringValue(config.PipelineRoot)
+		}
+	}
 	if config.InputParameters != nil {
-		inputs := &pb.Value_StructValue{
+		e.CustomProperties[keyInputs] = &pb.Value{Value: &pb.Value_StructValue{
 			StructValue: &structpb.Struct{
-				Fields: make(map[string]*structpb.Value),
+				Fields: config.InputParameters,
 			},
-		}
-		for n, p := range config.InputParameters {
-			inputs.StructValue.Fields[n] = p
-		}
-		e.CustomProperties[keyInputs] = &pb.Value{Value: inputs}
+		}}
 	}
 
 	req := &pb.PutExecutionRequest{
 		Execution: e,
-		Contexts:  []*pb.Context{pipeline.pipelineCtx},
-	}
-	if !config.IsRootDAG {
-		// For root DAG execution, it should not be part of the pipeline run context,
-		// because corresponds to the pipeline run.
-		// TODO(Bobgy): how do we record relationship between pipeilne run context and pipeline run execution?
-		req.Contexts = append(req.Contexts, pipeline.pipelineRunCtx)
+		Contexts:  []*pb.Context{pipeline.pipelineCtx, pipeline.pipelineRunCtx},
 	}
 
 	for name, ids := range config.InputArtifactIDs {
@@ -613,17 +620,26 @@ func (c *Client) GetPipelineFromExecution(ctx context.Context, id int64) (*Pipel
 	return pipeline, nil
 }
 
-// GetExecutionsInDAG gets all executions in the DAG context, and organize them
+// GetExecutionsInDAG gets all executions in the DAG, and organize them
 // into a map, keyed by task name.
-func (c *Client) GetExecutionsInDAG(ctx context.Context, dag *DAG) (executionsMap map[string]*Execution, err error) {
+func (c *Client) GetExecutionsInDAG(ctx context.Context, dag *DAG, pipeline *Pipeline) (executionsMap map[string]*Execution, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("failed to get executions in %s: %w", dag.Info(), err)
 		}
 	}()
 	executionsMap = make(map[string]*Execution)
+	// Documentation on query syntax:
+	// https://github.com/google/ml-metadata/blob/839c3501a195d340d2855b6ffdb2c4b0b49862c9/ml_metadata/proto/metadata_store.proto#L831
+	parentIDFilter := fmt.Sprintf("custom_properties.`parent_id`.int_value = %v", dag.Execution.GetID())
+	// Note, because MLMD does not have index on custom properties right now, we
+	// take a pipeline run context to limit the number of executions the DB needs to
+	// iterate through to find sub-executions.
 	res, err := c.svc.GetExecutionsByContext(ctx, &pb.GetExecutionsByContextRequest{
-		ContextId: dag.context.Id,
+		ContextId: pipeline.pipelineRunCtx.Id,
+		Options: &pb.ListOperationOptions{
+			FilterQuery: &parentIDFilter,
+		},
 	})
 	if err != nil {
 		return nil, err

--- a/v2/metadata/client.go
+++ b/v2/metadata/client.go
@@ -109,7 +109,7 @@ type ExecutionConfig struct {
 	TaskName         string
 	Name             string // optional, MLMD execution name. When provided, this needs to be unique among all MLMD executions.
 	ExecutionType    ExecutionType
-	ParentID         int64 // parent execution ID, when not provided, it means root.
+	ParentDagID      int64 // parent DAG execution ID. Only the root DAG does not have a parent DAG.
 	InputParameters  map[string]*structpb.Value
 	InputArtifactIDs map[string][]int64
 
@@ -452,8 +452,8 @@ func (c *Client) CreateExecution(ctx context.Context, pipeline *Pipeline, config
 	if config.Name != "" {
 		e.Name = &config.Name
 	}
-	if config.ParentID != 0 {
-		e.CustomProperties[keyParentID] = intValue(config.ParentID)
+	if config.ParentDagID != 0 {
+		e.CustomProperties[keyParentID] = intValue(config.ParentDagID)
 	}
 	if config.ExecutionType == ContainerExecutionTypeName {
 		e.CustomProperties[keyPodName] = stringValue(config.PodName)

--- a/v2/metadata/client_test.go
+++ b/v2/metadata/client_test.go
@@ -192,23 +192,23 @@ func Test_DAG(t *testing.T) {
 	root, err := client.CreateExecution(ctx, pipeline, &metadata.ExecutionConfig{
 		TaskName:      "root",
 		ExecutionType: metadata.DagExecutionTypeName,
-		ParentID:      0, // this is root DAG
+		ParentDagID:   0, // this is root DAG
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	task1, err := client.CreateExecution(ctx, pipeline, &metadata.ExecutionConfig{
+	task1DAG, err := client.CreateExecution(ctx, pipeline, &metadata.ExecutionConfig{
 		TaskName:      "task1",
 		ExecutionType: metadata.DagExecutionTypeName,
-		ParentID:      root.GetID(),
+		ParentDagID:   root.GetID(),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	task1a, err := client.CreateExecution(ctx, pipeline, &metadata.ExecutionConfig{
-		TaskName:      "task1a",
+	task1ChildA, err := client.CreateExecution(ctx, pipeline, &metadata.ExecutionConfig{
+		TaskName:      "task1ChildA",
 		ExecutionType: metadata.ContainerExecutionTypeName,
-		ParentID:      task1.GetID(),
+		ParentDagID:   task1DAG.GetID(),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -216,7 +216,7 @@ func Test_DAG(t *testing.T) {
 	task2, err := client.CreateExecution(ctx, pipeline, &metadata.ExecutionConfig{
 		TaskName:      "task2",
 		ExecutionType: metadata.ContainerExecutionTypeName,
-		ParentID:      root.GetID(),
+		ParentDagID:   root.GetID(),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -229,18 +229,18 @@ func Test_DAG(t *testing.T) {
 	if len(rootChildren) != 2 {
 		t.Errorf("len(rootChildren)=%v, expect 2", len(rootChildren))
 	}
-	if rootChildren["task1"].GetID() != task1.GetID() {
-		t.Errorf("executions[\"task1\"].GetID()=%v, task1.GetID()=%v. Not equal", rootChildren["task1"].GetID(), task1.GetID())
+	if rootChildren["task1"].GetID() != task1DAG.GetID() {
+		t.Errorf("executions[\"task1\"].GetID()=%v, task1.GetID()=%v. Not equal", rootChildren["task1"].GetID(), task1DAG.GetID())
 	}
 	if rootChildren["task2"].GetID() != task2.GetID() {
 		t.Errorf("executions[\"task2\"].GetID()=%v, task2.GetID()=%v. Not equal", rootChildren["task2"].GetID(), task2.GetID())
 	}
-	task1Children, err := client.GetExecutionsInDAG(ctx, &metadata.DAG{Execution: task1}, pipeline)
+	task1Children, err := client.GetExecutionsInDAG(ctx, &metadata.DAG{Execution: task1DAG}, pipeline)
 	if len(task1Children) != 1 {
 		t.Errorf("len(task1Children)=%v, expect 1", len(task1Children))
 	}
-	if task1Children["task1a"].GetID() != task1a.GetID() {
-		t.Errorf("executions[\"task1a\"].GetID()=%v, task1a.GetID()=%v. Not equal", task1Children["task1a"].GetID(), task1a.GetID())
+	if task1Children["task1ChildA"].GetID() != task1ChildA.GetID() {
+		t.Errorf("executions[\"task1ChildA\"].GetID()=%v, task1ChildA.GetID()=%v. Not equal", task1Children["task1ChildA"].GetID(), task1ChildA.GetID())
 	}
 }
 

--- a/v2/metadata/client_test.go
+++ b/v2/metadata/client_test.go
@@ -193,7 +193,6 @@ func Test_DAG(t *testing.T) {
 		TaskName:      "root",
 		ExecutionType: metadata.DagExecutionTypeName,
 		ParentID:      0, // this is root DAG
-		PipelineRoot:  pipelineRoot,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/v2/test/README.md
+++ b/v2/test/README.md
@@ -67,19 +67,34 @@ For why the caveat exists, refer to context rule in [Makefile](./Makefile).
 # These env vars are loaded by default, recommend configuring them in your
 # .bashrc or .zshrc
 export KFP_HOST=https://your.KFP.host
-export KFP_OUTPUT_DIRECTORY=gs://your-bucket/path/to/output/dir
+export KFP_PIPELINE_ROOT=gs://your-bucket/path/to/output/dir
 export METADATA_GRPC_SERVICE_HOST=localhost
-# optional, when you want to override launcher image to your dev project
-# export KFP_LAUNCHER_IMAGE=gcr.io/your-project/dev/kfp-launcher
+export PATH="$HOME/bin:$PATH" # Some CLI tools will be installed to ~/bin.
+# optional, when you want to override images to your dev project
+# export KFP_LAUNCHER_V2_IMAGE=gcr.io/your-project/dev/kfp-launcher-v2:latest
+# export KFP_DRIVER_IMAGE=gcr.io/your-project/kfp-driver:latest
 
-cd ${REPO_ROOT}
+# optional, when you want to override pipeline root
+# export KFP_PIPELINE_ROOT="gs://your-bucket/your-folder"
+
+# optional, when you need to override which KFP python package v2 components use:
+# export KFP_PACKAGE_PATH=git+https://github.com/kubeflow/pipelines#egg=kfp&subdirectory=sdk/python
+
+cd "${REPO_ROOT}/v2"
+# Installs kfp-v2-compiler as a CLI tool to ~/bin
+# Note, when you update backend compiler code, you need to run this again!
+make install-compiler
+
+# Note, for tests that use metadata grpc api, you should port-forward it locally in a separate terminal by:
+cd "${REPO_ROOT}/v2/test"
+make mlmd-port-forward
+
+# To run a single sample test:
+cd "${REPO_ROOT}"
 # if you have a sample test at samples/path/to/your/sample_test.py
 python -m samples.path.to.your.sample_test
 # or to look at command help
 python -m samples.path.to.your.sample_test --help
-
-# Note, for tests that use metadata grpc api, you should port-forward it locally in a separate terminal by:
-make mlmd-port-forward
 ```
 
 ## How to add a sample to this sample test?
@@ -93,7 +108,7 @@ existing [sample tests](../../samples/test) for how to implement the interface.
 
 ## How can a sample verify MLMD status of a run?
 
-Refer to [an existing test](../../samples/test/two_step_test.py).
+Refer to [an existing test](../../samples/v2/hello_world_test.py).
 
 ## FAQs
 

--- a/v2/test/components/run_sample.yaml
+++ b/v2/test/components/run_sample.yaml
@@ -46,7 +46,7 @@ implementation:
       python3 \
         -u \
         -m "$sample_path" \
-        --output_directory "$output_dir" \
+        --pipeline_root "$output_dir" \
         --host "$host" \
         --external_host "$external_host" \
         --launcher_image "$launcher_image" \


### PR DESCRIPTION
**Description of your changes:**

Previously, each KFP DAG execution had a corresponding context to group child tasks.

This PR changes it to:
Each child task has a custom property "parent_dag_id" with the parent DAG execution ID as value.
We no longer need the context, because MLMD has supported flexible filter queries on custom properties. We can get all child tasks of a DAG using custom_property.parent_dag_id = xxx filter.

Right now, MLMD does not have index on custom properties, so we also add a filter to run context for perf optimization.

TODO: We also need to update frontend to use the new format.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
