### PR TITLE
fix(samples): Use TFX library version for parameterized_tfx_oss. Fix #6974

### DIFF
--- a/samples/core/parameterized_tfx_oss/parameterized_tfx_oss.py
+++ b/samples/core/parameterized_tfx_oss/parameterized_tfx_oss.py
@@ -164,7 +164,7 @@ if __name__ == '__main__':
   config = tfx.orchestration.experimental.KubeflowDagRunnerConfig(
       kubeflow_metadata_config=tfx.orchestration.experimental.
       get_default_kubeflow_metadata_config(),
-      tfx_image='gcr.io/tfx-oss-public/tfx:%s' % tfx.version.__version__,
+      tfx_image='gcr.io/tfx-oss-public/tfx:%s' % tfx.__version__,
   )
   kfp_runner = tfx.orchestration.experimental.KubeflowDagRunner(
       output_filename=__file__ + '.yaml', config=config

--- a/samples/core/parameterized_tfx_oss/parameterized_tfx_oss.py
+++ b/samples/core/parameterized_tfx_oss/parameterized_tfx_oss.py
@@ -164,7 +164,7 @@ if __name__ == '__main__':
   config = tfx.orchestration.experimental.KubeflowDagRunnerConfig(
       kubeflow_metadata_config=tfx.orchestration.experimental.
       get_default_kubeflow_metadata_config(),
-      tfx_image='gcr.io/tfx-oss-public/tfx:1.2.0',
+      tfx_image='gcr.io/tfx-oss-public/tfx:%s' % tfx.version.__version__,
   )
   kfp_runner = tfx.orchestration.experimental.KubeflowDagRunner(
       output_filename=__file__ + '.yaml', config=config

--- a/samples/core/parameterized_tfx_oss/taxi_pipeline_notebook.ipynb
+++ b/samples/core/parameterized_tfx_oss/taxi_pipeline_notebook.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# TFX pipeline example - Chicago Taxi tips prediction\n",
     "\n",
@@ -18,63 +19,64 @@
     "This pipeline requires Google Cloud Storage permission to run. \n",
     "If KFP was deployed through K8S marketplace, please make sure **\"Allow access to the following Cloud APIs\"** is checked when creating the cluster. <img src=\"check_permission.png\">\n",
     "Otherwise, follow instructions in [the guideline](https://github.com/kubeflow/pipelines/blob/master/manifests/gcp_marketplace/guide.md#gcp-service-account-credentials) to guarantee at least, that the service account has `storage.admin` role."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "!python3 -m pip install pip --upgrade --quiet --user\n",
     "!python3 -m pip install kfp --upgrade --quiet --user\n",
-    "pip install tfx==1.2.0 tensorflow==2.5.1 --quiet --user"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "pip install tfx==1.4.0 tensorflow==2.5.1 --quiet --user"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Note: if you're warned by \n",
     "```\n",
     "WARNING: The script {LIBRARY_NAME} is installed in '/home/jupyter/.local/bin' which is not on PATH.\n",
     "```\n",
     "You might need to fix by running the next cell and restart the kernel."
-   ],
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "# Set `PATH` to include user python binary directory and a directory containing `skaffold`.\n",
-    "PATH=%env PATH\n",
-    "%env PATH={PATH}:/home/jupyter/.local/bin"
-   ],
-   "outputs": [],
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "# Set `PATH` to include user python binary directory and a directory containing `skaffold`.\n",
+    "PATH=%env PATH\n",
+    "%env PATH={PATH}:/home/jupyter/.local/bin"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "In this example we'll need TFX SDK later than 0.21 to leverage the [`RuntimeParameter`](https://github.com/tensorflow/tfx/blob/93ea0b4eda5a6000a07a1e93d93a26441094b6f5/tfx/orchestration/data_types.py#L137) feature.\n",
     "\n",
     "## RuntimeParameter in TFX DSL\n",
     "Currently, TFX DSL only supports parameterizing field in the `PARAMETERS` section of `ComponentSpec`, see [here](https://github.com/tensorflow/tfx/blob/93ea0b4eda5a6000a07a1e93d93a26441094b6f5/tfx/types/component_spec.py#L126). This prevents runtime-parameterizing the pipeline topology. Also, if the declared type of the field is a protobuf, the user needs to pass in a dictionary with exactly the same names for each field, and specify one or more value as `RuntimeParameter` objects. In other word, the dictionary should be able to be passed in to [`ParseDict()` method](https://github.com/protocolbuffers/protobuf/blob/04a11fc91668884d1793bff2a0f72ee6ce4f5edd/python/google/protobuf/json_format.py#L433) and produce the correct pb message."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import json\n",
     "import os\n",
@@ -82,13 +84,13 @@
     "import kfp\n",
     "import tensorflow_model_analysis as tfma\n",
     "from tfx import v1 as tfx"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# In TFX MLMD schema, pipeline name is used as the unique id of each pipeline.\n",
     "# Assigning workflow ID as part of pipeline name allows the user to bypass\n",
@@ -121,22 +123,22 @@
     "     default=json.dumps({'filesystem': {'base_directory': serving_model_dir}}),\n",
     "     ptype=str,\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## TFX Components\n",
     "\n",
     "Please refer to the [official guide](https://www.tensorflow.org/tfx/guide#tfx_pipeline_components) for the detailed explanation and purpose of each TFX component."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "example_gen = tfx.components.CsvExampleGen(input_base=data_root)\n",
     "\n",
@@ -213,13 +215,13 @@
     "  model=trainer.outputs['model'],\n",
     "  model_blessing=evaluator.outputs['blessing'],\n",
     "  push_destination=push_destination)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Create the DSL pipeline object.\n",
     "# This pipeline obj carries the business logic of the pipeline, but no runner-specific information\n",
@@ -234,17 +236,17 @@
     "  enable_cache=True,\n",
     "  beam_pipeline_args=['--direct_num_workers=%d' % 0],\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Specify a TFX docker image. For the full list of tags please see:\n",
     "# https://hub.docker.com/r/tensorflow/tfx/tags\n",
-    "tfx_image = 'gcr.io/tfx-oss-public/tfx:1.2.0'\n",
+    "tfx_image = 'gcr.io/tfx-oss-public/tfx:1.4.0'\n",
     "config = tfx.orchestration.experimental.KubeflowDagRunnerConfig(\n",
     "      kubeflow_metadata_config=tfx.orchestration.experimental\n",
     "      .get_default_kubeflow_metadata_config(),\n",
@@ -253,13 +255,13 @@
     "# KubeflowDagRunner compiles the DSL pipeline object into KFP pipeline package.\n",
     "# By default it is named <pipeline_name>.tar.gz\n",
     "kfp_runner.run(dsl_pipeline)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "run_result = kfp.Client(\n",
     "    host='1234567abcde-dot-us-central2.pipelines.googleusercontent.com'  # Put your KFP endpoint here\n",
@@ -271,9 +273,7 @@
     "        # 'module-file': '<gcs path to the module file>',  # delete this line to use default module file.\n",
     "        # 'data-root': '<gcs path to the data>'  # delete this line to use default data.\n",
     "})"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
**Description of your changes:**
With KFP 1.8 release, we are upgrading MLMD to 1.4.0, which enforced a TFX upgrade. And it broke the post-submit of parameterized_tfx_oss pipeline, which is using the old version of TFX. This PR move away from hardcoded version to dynamic value which relies on tfx library version.

cc @jiyongjung0 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
