### PR TITLE
chore(backend.v2): Honor Argoworkflow generateName format, only use pipeline template name. Fix #6972

### DIFF
--- a/backend/src/apiserver/template/template.go
+++ b/backend/src/apiserver/template/template.go
@@ -44,7 +44,6 @@ const (
 	argoGroup       = "argoproj.io/"
 	argoVersion     = "argoproj.io/v1alpha1"
 	argoK8sResource = "Workflow"
-
 )
 
 // Unmarshal parameters from JSON encoded string.
@@ -147,10 +146,6 @@ func New(bytes []byte) (Template, error) {
 		return nil, util.NewInvalidInputErrorWithDetails(ErrorInvalidPipelineSpec, "unknown template format")
 	}
 }
-
-
-
-
 
 func toParametersMap(apiParams []*api.Parameter) map[string]string {
 	// Preprocess workflow by appending parameter and add pipeline specific labels

--- a/backend/src/apiserver/template/template_test.go
+++ b/backend/src/apiserver/template/template_test.go
@@ -179,7 +179,7 @@ var v2SpecHelloWorld = `
     }
   },
   "pipelineInfo": {
-    "name": "hello-world"
+    "name": "namespace/n1/pipeline/hello-world"
   },
   "root": {
     "dag": {

--- a/backend/src/apiserver/template/v2_template.go
+++ b/backend/src/apiserver/template/v2_template.go
@@ -2,8 +2,8 @@ package template
 
 import (
 	"fmt"
-    "regexp"
 	structpb "github.com/golang/protobuf/ptypes/struct"
+	"regexp"
 
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	api "github.com/kubeflow/pipelines/backend/api/go_client"
@@ -77,7 +77,7 @@ func NewV2SpecTemplate(template []byte) (*V2Spec, error) {
 	match, _ := regexp.MatchString("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*", spec.GetPipelineInfo().GetName())
 	if !match {
 		return nil, util.NewInvalidInputErrorWithDetails(ErrorInvalidPipelineSpec, "invalid v2 pipeline spec: name should consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character")
-	} 
+	}
 	if spec.GetRoot() == nil {
 		return nil, util.NewInvalidInputErrorWithDetails(ErrorInvalidPipelineSpec, "invalid v2 pipeline spec: root component is empty")
 	}

--- a/backend/src/apiserver/template/v2_template.go
+++ b/backend/src/apiserver/template/v2_template.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"fmt"
+    "regexp"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
@@ -73,6 +74,10 @@ func NewV2SpecTemplate(template []byte) (*V2Spec, error) {
 	if spec.GetPipelineInfo().GetName() == "" {
 		return nil, util.NewInvalidInputErrorWithDetails(ErrorInvalidPipelineSpec, "invalid v2 pipeline spec: name is empty")
 	}
+	match, _ := regexp.MatchString("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*", spec.GetPipelineInfo().GetName())
+	if !match {
+		return nil, util.NewInvalidInputErrorWithDetails(ErrorInvalidPipelineSpec, "invalid v2 pipeline spec: name should consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character")
+	} 
 	if spec.GetRoot() == nil {
 		return nil, util.NewInvalidInputErrorWithDetails(ErrorInvalidPipelineSpec, "invalid v2 pipeline spec: root component is empty")
 	}

--- a/v2/compiler/argo.go
+++ b/v2/compiler/argo.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"fmt"
+	"strings"
 
 	wfapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
@@ -106,7 +107,7 @@ func Compile(jobArg *pipelinespec.PipelineJob, opts *Options) (*wfapi.Workflow, 
 
 func retrieveLastValidString(s string) string {
 	sections := strings.Split(s, "/")
-	return sections[len(sections) - 1]
+	return sections[len(sections)-1]
 }
 
 type workflowCompiler struct {

--- a/v2/compiler/argo.go
+++ b/v2/compiler/argo.go
@@ -58,7 +58,7 @@ func Compile(jobArg *pipelinespec.PipelineJob, opts *Options) (*wfapi.Workflow, 
 			Kind:       "Workflow",
 		},
 		ObjectMeta: k8smeta.ObjectMeta{
-			GenerateName: spec.GetPipelineInfo().GetName() + "-",
+			GenerateName: retrieveLastValidString(spec.GetPipelineInfo().GetName()) + "-",
 			// Note, uncomment the following during development to view argo inputs/outputs in KFP UI.
 			Annotations: map[string]string{
 				"pipelines.kubeflow.org/v2_pipeline": "true",
@@ -102,6 +102,11 @@ func Compile(jobArg *pipelinespec.PipelineJob, opts *Options) (*wfapi.Workflow, 
 	Accept(job, compiler)
 
 	return compiler.wf, nil
+}
+
+func retrieveLastValidString(s string) string {
+	sections := strings.Split(s, "/")
+	return sections[len(sections) - 1]
 }
 
 type workflowCompiler struct {

--- a/v2/compiler/argo_test.go
+++ b/v2/compiler/argo_test.go
@@ -39,7 +39,7 @@ func Test_argo_compiler(t *testing.T) {
               - --type
               - CONTAINER
               - --pipeline_name
-              - hello-world
+              - namespace/n1/pipeline/hello-world
               - --run_id
               - '{{workflow.uid}}'
               - --dag_execution_id
@@ -106,7 +106,7 @@ func Test_argo_compiler(t *testing.T) {
               command:
               - /kfp-launcher/launch
               - --pipeline_name
-              - hello-world
+              - namespace/n1/pipeline/hello-world
               - --run_id
               - '{{workflow.uid}}'
               - --execution_id
@@ -228,7 +228,7 @@ func Test_argo_compiler(t *testing.T) {
               - --type
               - ROOT_DAG
               - --pipeline_name
-              - hello-world
+              - namespace/n1/pipeline/hello-world
               - --run_id
               - '{{workflow.uid}}'
               - --component

--- a/v2/compiler/testdata/hello_world.json
+++ b/v2/compiler/testdata/hello_world.json
@@ -32,7 +32,7 @@
       }
     },
     "pipelineInfo": {
-      "name": "hello-world"
+      "name": "namespace/n1/pipeline/hello-world"
     },
     "root": {
       "dag": {


### PR DESCRIPTION
**Description of your changes:**

Fix #6972

In KFPv2, the pipeline template name is in format of `namespace/<namespace>/pipeline/<pipelinename>` or `pipeline/<pipelinename>`. The `/` symbol is disallowed by Argo. Therefore we will remove those prefix when writing `generateName` in Argo workflow. We also check whether the <pipelinename> is valid before creating pipeline object.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
