### PR TITLE
 fix(deployment): the viewer controller does not work because of missing permissions

### DIFF
--- a/manifests/kustomize/base/pipeline/ml-pipeline-viewer-crd-role.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-viewer-crd-role.yaml
@@ -20,6 +20,7 @@ rules:
   - kubeflow.org
   resources:
   - viewers
+  - viewers/finalizers
   verbs:
   - create
   - get


### PR DESCRIPTION
As a follow up of https://github.com/kubeflow/pipelines/pull/6892 this must also be changed in the namespace level role for standalone pipelines.
