### PR TITLE
chore(manifests): Use Secret for GCP marketplace minio manifests

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/minio.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/minio.yaml
@@ -14,6 +14,14 @@ spec:
     app: minio
     app.kubernetes.io/name: {{ .Release.Name }}
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mlpipeline-minio-artifact
+stringData:
+  accesskey: minio
+  secretkey: minio123
+---
 {{ if .Values.managedstorage.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -47,9 +55,15 @@ spec:
                   name: "{{ .Values.gcpDefaultConfigName }}"
                   key: "project_id"
             - name: MINIO_ACCESS_KEY
-              value: minio
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: accesskey
             - name: MINIO_SECRET_KEY
-              value: minio123
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: secretkey
             # Minio is KFP system workload and we use GCE's default service account
             # or later Workload Identity's corresponding service account.
             # So here no need to setup GOOGLE_APPLICATION_CREDENTIALS.
@@ -105,9 +119,15 @@ spec:
             - /data
           env:
             - name: MINIO_ACCESS_KEY
-              value: minio
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: accesskey
             - name: MINIO_SECRET_KEY
-              value: minio123
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: secretkey
           image: {{ .Values.images.minio }}
           name: minio
           ports:

--- a/manifests/gcp_marketplace/test/snapshot-base.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-base.yaml
@@ -2067,9 +2067,15 @@ spec:
             - /data
           env:
             - name: MINIO_ACCESS_KEY
-              value: minio
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: accesskey
             - name: MINIO_SECRET_KEY
-              value: minio123
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: secretkey
           image: gcr.io/ml-pipeline/google/pipelines/minio:dummy
           name: minio
           ports:

--- a/manifests/gcp_marketplace/test/snapshot-emissary.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-emissary.yaml
@@ -2067,9 +2067,15 @@ spec:
             - /data
           env:
             - name: MINIO_ACCESS_KEY
-              value: minio
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: accesskey
             - name: MINIO_SECRET_KEY
-              value: minio123
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: secretkey
           image: gcr.io/ml-pipeline/google/pipelines/minio:dummy
           name: minio
           ports:

--- a/manifests/gcp_marketplace/test/snapshot-managed-storage-with-db-prefix.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-managed-storage-with-db-prefix.yaml
@@ -2096,9 +2096,15 @@ spec:
                   name: "gcp-default-config"
                   key: "project_id"
             - name: MINIO_ACCESS_KEY
-              value: minio
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: accesskey
             - name: MINIO_SECRET_KEY
-              value: minio123
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: secretkey
             # Minio is KFP system workload and we use GCE's default service account
             # or later Workload Identity's corresponding service account.
             # So here no need to setup GOOGLE_APPLICATION_CREDENTIALS.

--- a/manifests/gcp_marketplace/test/snapshot-managed-storage.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-managed-storage.yaml
@@ -2096,9 +2096,15 @@ spec:
                   name: "gcp-default-config"
                   key: "project_id"
             - name: MINIO_ACCESS_KEY
-              value: minio
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: accesskey
             - name: MINIO_SECRET_KEY
-              value: minio123
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: secretkey
             # Minio is KFP system workload and we use GCE's default service account
             # or later Workload Identity's corresponding service account.
             # So here no need to setup GOOGLE_APPLICATION_CREDENTIALS.


### PR DESCRIPTION
**Description of your changes:**

We should use Secret to store minio access token, instead of clear text in resource yaml.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
