### PR TITLE
refactor(v2): driver decides container spec via pod spec patch

### DIFF
--- a/samples/core/XGBoost/xgboost_sample.py
+++ b/samples/core/XGBoost/xgboost_sample.py
@@ -54,7 +54,7 @@ def xgboost_pipeline():
         label_column_name='tips',
         objective='reg:squarederror',
         num_iterations=200,
-    ).outputs['model']
+    ).set_memory_limit('1Gi').outputs['model']
 
     xgboost_predict_on_parquet_op(
         data=training_data_parquet,

--- a/v2/compiler/argo.go
+++ b/v2/compiler/argo.go
@@ -159,6 +159,7 @@ const (
 	paramExecutorInput  = "executor-input"
 	paramDriverType     = "driver-type"
 	paramCachedDecision = "cached-decision" // indicate hit cache or not
+	paramPodSpecPatch   = "pod-spec-patch"  // a strategic patch merged with the pod spec
 )
 
 func runID() string {

--- a/v2/compiler/common.go
+++ b/v2/compiler/common.go
@@ -1,0 +1,44 @@
+// Copyright 2021 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compiler
+
+import k8score "k8s.io/api/core/v1"
+
+// env vars in metadata-grpc-configmap is defined in component package
+var metadataConfigIsOptional bool = true
+var metadataEnvFrom = k8score.EnvFromSource{
+	ConfigMapRef: &k8score.ConfigMapEnvSource{
+		LocalObjectReference: k8score.LocalObjectReference{
+			Name: "metadata-grpc-configmap",
+		},
+		Optional: &metadataConfigIsOptional,
+	},
+}
+
+var commonEnvs = []k8score.EnvVar{{
+	Name: "KFP_POD_NAME",
+	ValueFrom: &k8score.EnvVarSource{
+		FieldRef: &k8score.ObjectFieldSelector{
+			FieldPath: "metadata.name",
+		},
+	},
+}, {
+	Name: "KFP_POD_UID",
+	ValueFrom: &k8score.EnvVarSource{
+		FieldRef: &k8score.ObjectFieldSelector{
+			FieldPath: "metadata.uid",
+		},
+	},
+}}

--- a/v2/compiler/container.go
+++ b/v2/compiler/container.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	wfapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/v2/component"
 	k8score "k8s.io/api/core/v1"
@@ -18,12 +17,11 @@ func (c *workflowCompiler) Container(name string, component *pipelinespec.Compon
 	if component == nil {
 		return fmt.Errorf("workflowCompiler.Container: component spec must be non-nil")
 	}
-	marshaler := jsonpb.Marshaler{}
-	componentJson, err := marshaler.MarshalToString(component)
+	componentJson, err := stablyMarshalJSON(component)
 	if err != nil {
 		return fmt.Errorf("workflowCompiler.Container: marlshaling component spec to proto JSON failed: %w", err)
 	}
-	containerJson, err := marshaler.MarshalToString(container)
+	containerJson, err := stablyMarshalJSON(container)
 	if err != nil {
 		return fmt.Errorf("workflowCompiler.Container: marlshaling pipeline container spec to proto JSON failed: %w", err)
 	}

--- a/v2/compiler/container.go
+++ b/v2/compiler/container.go
@@ -6,8 +6,12 @@ import (
 	wfapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
+	"github.com/kubeflow/pipelines/v2/component"
 	k8score "k8s.io/api/core/v1"
-	k8sres "k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	volumeNameKFPLauncher = "kfp-launcher"
 )
 
 func (c *workflowCompiler) Container(name string, component *pipelinespec.ComponentSpec, container *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec) error {
@@ -23,7 +27,7 @@ func (c *workflowCompiler) Container(name string, component *pipelinespec.Compon
 	if err != nil {
 		return fmt.Errorf("workflowCompiler.Container: marlshaling pipeline container spec to proto JSON failed: %w", err)
 	}
-	driverTask, driverOutputs := c.containerDriverTask(
+	driver, driverOutputs := c.containerDriverTask(
 		"driver",
 		containerDriverInputs{
 			component:      inputParameter(paramComponent),
@@ -33,45 +37,28 @@ func (c *workflowCompiler) Container(name string, component *pipelinespec.Compon
 			iterationIndex: inputParameter(paramIterationIndex),
 		},
 	)
-	t, err := containerExecutorTemplate(container, c.launcherImage, c.spec.PipelineInfo.GetName())
-	if err != nil {
-		return err
-	}
-	// TODO(Bobgy): how can we avoid template name collisions?
-	containerTemplateName, err := c.addTemplate(t, name+"-container")
-	if err != nil {
-		return err
-	}
+	executor := c.containerExecutorTask(
+		"container",
+		driverOutputs.podSpecPatch,
+	)
+	// TODO(Bobgy): can we add dependencies automatically
+	executor.Dependencies = []string{driver.Name}
+	executor.When = driverOutputs.cached + " != true"
+
+	// TODO(Bobgy): reuse the entire 2-step container template
 	wrapper := &wfapi.Template{
 		Inputs: wfapi.Inputs{
 			Parameters: []wfapi.Parameter{
 				{Name: paramTask},
 				{Name: paramDAGExecutionID},
-				// TODO(Bobgy): reuse the entire 2-step container template
 				{Name: paramComponent, Default: wfapi.AnyStringPtr(componentJson)},
 				{Name: paramIterationIndex, Default: wfapi.AnyStringPtr("-1")},
 			},
 		},
 		DAG: &wfapi.DAGTemplate{
 			Tasks: []wfapi.DAGTask{
-				*driverTask,
-				{
-					Name:         "container",
-					Template:     containerTemplateName,
-					Dependencies: []string{driverTask.Name},
-					When:         taskOutputParameter(driverTask.Name, paramCachedDecision) + " != true",
-					Arguments: wfapi.Arguments{
-						Parameters: []wfapi.Parameter{{
-							Name:  paramExecutorInput,
-							Value: wfapi.AnyStringPtr(driverOutputs.executorInput),
-						}, {
-							Name:  paramExecutionID,
-							Value: wfapi.AnyStringPtr(driverOutputs.executionID),
-						}, {
-							Name:  paramComponent,
-							Value: wfapi.AnyStringPtr(inputParameter(paramComponent)),
-						}},
-					}},
+				*driver,
+				*executor,
 			},
 		},
 	}
@@ -80,9 +67,8 @@ func (c *workflowCompiler) Container(name string, component *pipelinespec.Compon
 }
 
 type containerDriverOutputs struct {
-	executorInput string
-	executionID   string
-	cached        string
+	podSpecPatch string
+	cached       string
 }
 
 type containerDriverInputs struct {
@@ -108,9 +94,8 @@ func (c *workflowCompiler) containerDriverTask(name string, inputs containerDriv
 		},
 	}
 	outputs := &containerDriverOutputs{
-		executorInput: taskOutputParameter(name, paramExecutorInput),
-		executionID:   taskOutputParameter(name, paramExecutionID),
-		cached:        taskOutputParameter(name, paramCachedDecision),
+		podSpecPatch: taskOutputParameter(name, paramPodSpecPatch),
+		cached:       taskOutputParameter(name, paramCachedDecision),
 	}
 	return dagTask, outputs
 }
@@ -134,8 +119,7 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 		},
 		Outputs: wfapi.Outputs{
 			Parameters: []wfapi.Parameter{
-				{Name: paramExecutionID, ValueFrom: &wfapi.ValueFrom{Path: "/tmp/outputs/execution-id"}},
-				{Name: paramExecutorInput, ValueFrom: &wfapi.ValueFrom{Path: "/tmp/outputs/executor-input"}},
+				{Name: paramPodSpecPatch, ValueFrom: &wfapi.ValueFrom{Path: "/tmp/outputs/pod-spec-patch", Default: wfapi.AnyStringPtr("")}},
 				{Name: paramCachedDecision, Default: wfapi.AnyStringPtr("false"), ValueFrom: &wfapi.ValueFrom{Path: "/tmp/outputs/cached-decision", Default: wfapi.AnyStringPtr("false")}},
 			},
 		},
@@ -151,9 +135,8 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 				"--task", inputValue(paramTask),
 				"--container", inputValue(paramContainer),
 				"--iteration_index", inputValue(paramIterationIndex),
-				"--execution_id_path", outputPath(paramExecutionID),
-				"--executor_input_path", outputPath(paramExecutorInput),
 				"--cached_decision_path", outputPath(paramCachedDecision),
+				"--pod_spec_patch_path", outputPath(paramPodSpecPatch),
 			},
 			Resources: driverResources,
 		},
@@ -163,68 +146,40 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 	return name
 }
 
-func containerExecutorTemplate(container *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec, launcherImage, pipelineName string) (*wfapi.Template, error) {
-	userCmdArgs := make([]string, 0, len(container.Command)+len(container.Args))
-	userCmdArgs = append(userCmdArgs, container.Command...)
-	userCmdArgs = append(userCmdArgs, container.Args...)
-	launcherCmd := []string{
-		volumePathKFPLauncher + "/launch",
-		// TODO(Bobgy): no need to pass pipeline_name and run_id, these info can be fetched via pipeline context and pipeline run context which have been created by root DAG driver.
-		"--pipeline_name", pipelineName,
-		"--run_id", runID(),
-		"--execution_id", inputValue(paramExecutionID),
-		"--executor_input", inputValue(paramExecutorInput),
-		"--component_spec", inputValue(paramComponent),
-		"--pod_name",
-		"$(KFP_POD_NAME)",
-		"--pod_uid",
-		"$(KFP_POD_UID)",
-		"--mlmd_server_address", // METADATA_GRPC_SERVICE_* come from metadata-grpc-configmap
-		"$(METADATA_GRPC_SERVICE_HOST)",
-		"--mlmd_server_port",
-		"$(METADATA_GRPC_SERVICE_PORT)",
-		"--", // separater before user command and args
-	}
-	// TODO(Bobgy): support resource limits from parameters: https://github.com/kubeflow/pipelines/issues/6354.
-	res := k8score.ResourceRequirements{
-		Limits: map[k8score.ResourceName]k8sres.Quantity{},
-	}
-	memoryLimit := container.GetResources().GetMemoryLimit()
-	if memoryLimit != 0 {
-		q, err := k8sres.ParseQuantity(fmt.Sprintf("%vG", memoryLimit))
-		if err != nil {
-			return nil, err
-		}
-		res.Limits[k8score.ResourceMemory] = q
-	}
-	cpuLimit := container.GetResources().GetCpuLimit()
-	if cpuLimit != 0 {
-		q, err := k8sres.ParseQuantity(fmt.Sprintf("%v", cpuLimit))
-		if err != nil {
-			return nil, err
-		}
-		res.Limits[k8score.ResourceCPU] = q
-	}
-	// Normalize to make snapshot testing easier.
-	if len(res.Limits) == 0 {
-		res.Limits = nil
-	}
-	if len(res.Requests) == 0 {
-		res.Requests = nil
-	}
-	accelerator := container.GetResources().GetAccelerator()
-	if accelerator != nil {
-		return nil, fmt.Errorf("accelerator resources are not supported yet: https://github.com/kubeflow/pipelines/issues/7043")
-	}
-	mlmdConfigOptional := true
-	return &wfapi.Template{
-		Inputs: wfapi.Inputs{
+// containerExecutorTask returns an argo workflows DAGTask.
+// name: argo workflows DAG task name
+// podSpecPatch: argo workflows DAG parameter, it can be either a string or a placeholder
+func (c *workflowCompiler) containerExecutorTask(name string, podSpecPatch string) *wfapi.DAGTask {
+	return &wfapi.DAGTask{
+		Name:     name,
+		Template: c.addContainerExecutorTemplate(),
+		Arguments: wfapi.Arguments{
 			Parameters: []wfapi.Parameter{
-				{Name: paramExecutorInput},
-				{Name: paramExecutionID},
-				{Name: paramComponent},
+				{Name: paramPodSpecPatch, Value: wfapi.AnyStringPtr(podSpecPatch)},
 			},
 		},
+	}
+}
+
+// addContainerExecutorTemplate adds a generic container executor template for
+// any container component task.
+// During runtime, it's expected that pod-spec-patch will specify command, args
+// and resources etc, that are different for different tasks.
+func (c *workflowCompiler) addContainerExecutorTemplate() string {
+	name := "system-container-executor"
+	_, ok := c.templates[name]
+	if ok {
+		return name
+	}
+	mlmdConfigOptional := true
+	t := &wfapi.Template{
+		Name: name,
+		Inputs: wfapi.Inputs{
+			Parameters: []wfapi.Parameter{
+				{Name: paramPodSpecPatch},
+			},
+		},
+		PodSpecPatch: inputValue(paramPodSpecPatch),
 		Volumes: []k8score.Volume{{
 			Name: volumeNameKFPLauncher,
 			VolumeSource: k8score.VolumeSource{
@@ -234,23 +189,27 @@ func containerExecutorTemplate(container *pipelinespec.PipelineDeploymentConfig_
 		InitContainers: []wfapi.UserContainer{{
 			Container: k8score.Container{
 				Name:    "kfp-launcher",
-				Image:   launcherImage,
-				Command: []string{"launcher-v2", "--copy", "/kfp-launcher/launch"},
+				Image:   c.launcherImage,
+				Command: []string{"launcher-v2", "--copy", component.KFPLauncherPath},
 				VolumeMounts: []k8score.VolumeMount{{
 					Name:      volumeNameKFPLauncher,
-					MountPath: volumePathKFPLauncher,
+					MountPath: component.VolumePathKFPLauncher,
 				}},
-				ImagePullPolicy: "Always",
-				Resources:       launcherResources,
+				Resources: launcherResources,
 			},
 		}},
 		Container: &k8score.Container{
-			Command: launcherCmd,
-			Args:    userCmdArgs,
-			Image:   container.Image,
+			// The placeholder image and command should always be
+			// overridden in podSpecPatch.
+			// In case we have a bug, the placeholder image is kept
+			// in gcr.io/ml-pipeline, so that we are sure the image
+			// never exists.
+			// These are added to pass argo workflows linting.
+			Image:   "gcr.io/ml-pipeline/should-be-overridden-during-runtime",
+			Command: []string{"should-be-overridden-during-runtime"},
 			VolumeMounts: []k8score.VolumeMount{{
 				Name:      volumeNameKFPLauncher,
-				MountPath: volumePathKFPLauncher,
+				MountPath: component.VolumePathKFPLauncher,
 			}},
 			EnvFrom: []k8score.EnvFromSource{{
 				ConfigMapRef: &k8score.ConfigMapEnvSource{
@@ -275,7 +234,9 @@ func containerExecutorTemplate(container *pipelinespec.PipelineDeploymentConfig_
 					},
 				},
 			}},
-			Resources: res,
 		},
-	}, nil
+	}
+	c.templates[name] = t
+	c.wf.Spec.Templates = append(c.wf.Spec.Templates, *t)
+	return name
 }

--- a/v2/compiler/executor.go
+++ b/v2/compiler/executor.go
@@ -1,7 +1,0 @@
-package compiler
-
-const (
-	volumeNameKFPLauncher = "kfp-launcher"
-	volumePathKFPLauncher = "/kfp-launcher"
-)
-

--- a/v2/compiler/importer.go
+++ b/v2/compiler/importer.go
@@ -2,8 +2,8 @@ package compiler
 
 import (
 	"fmt"
+
 	wfapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	k8score "k8s.io/api/core/v1"
 )
@@ -12,12 +12,11 @@ func (c *workflowCompiler) Importer(name string, component *pipelinespec.Compone
 	if component == nil {
 		return fmt.Errorf("workflowCompiler.Importer: component spec must be non-nil")
 	}
-	marshaler := jsonpb.Marshaler{}
-	componentJson, err := marshaler.MarshalToString(component)
+	componentJson, err := stablyMarshalJSON(component)
 	if err != nil {
 		return fmt.Errorf("workflowCompiler.Importer: marshaling component spec to proto JSON failed: %w", err)
 	}
-	importerJson, err := marshaler.MarshalToString(importer)
+	importerJson, err := stablyMarshalJSON(importer)
 	if err != nil {
 		return fmt.Errorf("workflowCompiler.Importer: marlshaling importer spec to proto JSON failed: %w", err)
 	}
@@ -39,7 +38,7 @@ func (c *workflowCompiler) Importer(name string, component *pipelinespec.Compone
 		"$(METADATA_GRPC_SERVICE_PORT)",
 	}
 	mlmdConfigOptional := true
-	importerTemplate :=  &wfapi.Template{
+	importerTemplate := &wfapi.Template{
 		Inputs: wfapi.Inputs{
 			Parameters: []wfapi.Parameter{
 				{Name: paramTask},

--- a/v2/compiler/proto.go
+++ b/v2/compiler/proto.go
@@ -1,0 +1,28 @@
+package compiler
+
+import (
+	"encoding/json"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// stablyMarshalJSON makes sure result is stable, so we can use it for snapshot
+// testing.
+func stablyMarshalJSON(msg proto.Message) (string, error) {
+	unstableJSON, err := protojson.Marshal(msg)
+	if err != nil {
+		return "", err
+	}
+	// This json unmarshal and marshal is to use encoding/json formatter to format the bytes[] returned by protojson
+	// Do the json formatter because of https://developers.google.com/protocol-buffers/docs/reference/go/faq#unstable-json
+	var v interface{}
+	if err := json.Unmarshal(unstableJSON, &v); err != nil {
+		return "", err
+	}
+	stableJSON, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(stableJSON), err
+}

--- a/v2/compiler/testdata/hello_world.yaml
+++ b/v2/compiler/testdata/hello_world.yaml
@@ -33,12 +33,10 @@ spec:
       - '{{inputs.parameters.container}}'
       - --iteration_index
       - '{{inputs.parameters.iteration-index}}'
-      - --execution_id_path
-      - '{{outputs.parameters.execution-id.path}}'
-      - --executor_input_path
-      - '{{outputs.parameters.executor-input.path}}'
       - --cached_decision_path
       - '{{outputs.parameters.cached-decision.path}}'
+      - --pod_spec_patch_path
+      - '{{outputs.parameters.pod-spec-patch.path}}'
       command:
       - driver
       image: gcr.io/ml-pipeline/kfp-driver:latest
@@ -61,59 +59,18 @@ spec:
     name: system-container-driver
     outputs:
       parameters:
-      - name: execution-id
+      - name: pod-spec-patch
         valueFrom:
-          path: /tmp/outputs/execution-id
-      - name: executor-input
-        valueFrom:
-          path: /tmp/outputs/executor-input
+          default: ""
+          path: /tmp/outputs/pod-spec-patch
       - default: "false"
         name: cached-decision
         valueFrom:
           default: "false"
           path: /tmp/outputs/cached-decision
   - container:
-      args:
-      - sh
-      - -ec
-      - |
-        program_path=$(mktemp)
-        printf "%s" "$0" > "$program_path"
-        python3 -u "$program_path" "$@"
-      - |
-        def hello_world(text):
-            print(text)
-            return text
-
-        import argparse
-        _parser = argparse.ArgumentParser(prog='Hello world', description='')
-        _parser.add_argument("--text", dest="text", type=str, required=True, default=argparse.SUPPRESS)
-        _parsed_args = vars(_parser.parse_args())
-
-        _outputs = hello_world(**_parsed_args)
-      - --text
-      - '{{$.inputs.parameters[''text'']}}'
       command:
-      - /kfp-launcher/launch
-      - --pipeline_name
-      - namespace/n1/pipeline/hello-world
-      - --run_id
-      - '{{workflow.uid}}'
-      - --execution_id
-      - '{{inputs.parameters.execution-id}}'
-      - --executor_input
-      - '{{inputs.parameters.executor-input}}'
-      - --component_spec
-      - '{{inputs.parameters.component}}'
-      - --pod_name
-      - $(KFP_POD_NAME)
-      - --pod_uid
-      - $(KFP_POD_UID)
-      - --mlmd_server_address
-      - $(METADATA_GRPC_SERVICE_HOST)
-      - --mlmd_server_port
-      - $(METADATA_GRPC_SERVICE_PORT)
-      - --
+      - should-be-overridden-during-runtime
       env:
       - name: KFP_POD_NAME
         valueFrom:
@@ -127,7 +84,7 @@ spec:
       - configMapRef:
           name: metadata-grpc-configmap
           optional: true
-      image: python:3.7
+      image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
       name: ""
       resources: {}
       volumeMounts:
@@ -139,7 +96,6 @@ spec:
       - --copy
       - /kfp-launcher/launch
       image: gcr.io/ml-pipeline/kfp-launcher-v2:latest
-      imagePullPolicy: Always
       name: kfp-launcher
       resources:
         limits:
@@ -152,12 +108,11 @@ spec:
         name: kfp-launcher
     inputs:
       parameters:
-      - name: executor-input
-      - name: execution-id
-      - name: component
+      - name: pod-spec-patch
     metadata: {}
-    name: comp-hello-world-container
+    name: system-container-executor
     outputs: {}
+    podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
     volumes:
     - emptyDir: {}
       name: kfp-launcher
@@ -184,16 +139,12 @@ spec:
         template: system-container-driver
       - arguments:
           parameters:
-          - name: executor-input
-            value: '{{tasks.driver.outputs.parameters.executor-input}}'
-          - name: execution-id
-            value: '{{tasks.driver.outputs.parameters.execution-id}}'
-          - name: component
-            value: '{{inputs.parameters.component}}'
+          - name: pod-spec-patch
+            value: '{{tasks.driver.outputs.parameters.pod-spec-patch}}'
         dependencies:
         - driver
         name: container
-        template: comp-hello-world-container
+        template: system-container-executor
         when: '{{tasks.driver.outputs.parameters.cached-decision}} != true'
     inputs:
       parameters:
@@ -213,7 +164,8 @@ spec:
           - name: dag-execution-id
             value: '{{inputs.parameters.dag-execution-id}}'
           - name: task
-            value: '{"taskInfo":{"name":"hello-world"},"inputs":{"parameters":{"text":{"componentInputParameter":"text"}}},"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-hello-world"}}'
+            value: '{"taskInfo":{"name":"hello-world"}, "inputs":{"parameters":{"text":{"componentInputParameter":"text"}}},
+              "cachingOptions":{"enableCache":true}, "componentRef":{"name":"comp-hello-world"}}'
         name: hello-world
         template: comp-hello-world
     inputs:
@@ -284,7 +236,9 @@ spec:
           - name: dag-execution-id
             value: '{{inputs.parameters.dag-execution-id}}'
           - name: component
-            value: '{"inputDefinitions":{"parameters":{"text":{"type":"STRING"}}},"dag":{"tasks":{"hello-world":{"taskInfo":{"name":"hello-world"},"inputs":{"parameters":{"text":{"componentInputParameter":"text"}}},"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-hello-world"}}}}}'
+            value: '{"inputDefinitions":{"parameters":{"text":{"type":"STRING"}}},
+              "dag":{"tasks":{"hello-world":{"taskInfo":{"name":"hello-world"}, "inputs":{"parameters":{"text":{"componentInputParameter":"text"}}},
+              "cachingOptions":{"enableCache":true}, "componentRef":{"name":"comp-hello-world"}}}}}'
           - name: task
             value: '{{inputs.parameters.task}}'
           - name: runtime-config

--- a/v2/compiler/testdata/hello_world.yaml
+++ b/v2/compiler/testdata/hello_world.yaml
@@ -125,12 +125,12 @@ spec:
           - name: task
             value: '{{inputs.parameters.task}}'
           - name: container
-            value: '{"image":"python:3.7","command":["sh","-ec","program_path=$(mktemp)\nprintf
+            value: '{"args":["--text","{{$.inputs.parameters[''text'']}}"],"command":["sh","-ec","program_path=$(mktemp)\nprintf
               \"%s\" \"$0\" \u003e \"$program_path\"\npython3 -u \"$program_path\"
               \"$@\"\n","def hello_world(text):\n    print(text)\n    return text\n\nimport
               argparse\n_parser = argparse.ArgumentParser(prog=''Hello world'', description='''')\n_parser.add_argument(\"--text\",
               dest=\"text\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
-              = vars(_parser.parse_args())\n\n_outputs = hello_world(**_parsed_args)\n"],"args":["--text","{{$.inputs.parameters[''text'']}}"]}'
+              = vars(_parser.parse_args())\n\n_outputs = hello_world(**_parsed_args)\n"],"image":"python:3.7"}'
           - name: dag-execution-id
             value: '{{inputs.parameters.dag-execution-id}}'
           - name: iteration-index
@@ -150,7 +150,7 @@ spec:
       parameters:
       - name: task
       - name: dag-execution-id
-      - default: '{"inputDefinitions":{"parameters":{"text":{"type":"STRING"}}},"executorLabel":"exec-hello-world"}'
+      - default: '{"executorLabel":"exec-hello-world","inputDefinitions":{"parameters":{"text":{"type":"STRING"}}}}'
         name: component
       - default: "-1"
         name: iteration-index
@@ -164,8 +164,7 @@ spec:
           - name: dag-execution-id
             value: '{{inputs.parameters.dag-execution-id}}'
           - name: task
-            value: '{"taskInfo":{"name":"hello-world"}, "inputs":{"parameters":{"text":{"componentInputParameter":"text"}}},
-              "cachingOptions":{"enableCache":true}, "componentRef":{"name":"comp-hello-world"}}'
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-hello-world"},"inputs":{"parameters":{"text":{"componentInputParameter":"text"}}},"taskInfo":{"name":"hello-world"}}'
         name: hello-world
         template: comp-hello-world
     inputs:
@@ -236,9 +235,7 @@ spec:
           - name: dag-execution-id
             value: '{{inputs.parameters.dag-execution-id}}'
           - name: component
-            value: '{"inputDefinitions":{"parameters":{"text":{"type":"STRING"}}},
-              "dag":{"tasks":{"hello-world":{"taskInfo":{"name":"hello-world"}, "inputs":{"parameters":{"text":{"componentInputParameter":"text"}}},
-              "cachingOptions":{"enableCache":true}, "componentRef":{"name":"comp-hello-world"}}}}}'
+            value: '{"dag":{"tasks":{"hello-world":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-hello-world"},"inputs":{"parameters":{"text":{"componentInputParameter":"text"}}},"taskInfo":{"name":"hello-world"}}}},"inputDefinitions":{"parameters":{"text":{"type":"STRING"}}}}'
           - name: task
             value: '{{inputs.parameters.task}}'
           - name: runtime-config

--- a/v2/compiler/testdata/importer.yaml
+++ b/v2/compiler/testdata/importer.yaml
@@ -58,7 +58,7 @@ spec:
     inputs:
       parameters:
       - name: task
-      - default: '{"inputDefinitions":{"parameters":{"uri":{"type":"STRING"}}},"outputDefinitions":{"artifacts":{"artifact":{"artifactType":{"schemaTitle":"system.Dataset"}}}},"executorLabel":"exec-importer"}'
+      - default: '{"executorLabel":"exec-importer","inputDefinitions":{"parameters":{"uri":{"type":"STRING"}}},"outputDefinitions":{"artifacts":{"artifact":{"artifactType":{"schemaTitle":"system.Dataset"}}}}}'
         name: component
       - default: '{"artifactUri":{"constantValue":{"stringValue":"gs://ml-pipeline-playground/shakespeare1.txt"}},"typeSchema":{"schemaTitle":"system.Dataset"}}'
         name: importer
@@ -72,8 +72,7 @@ spec:
           - name: dag-execution-id
             value: '{{inputs.parameters.dag-execution-id}}'
           - name: task
-            value: '{"taskInfo":{"name":"importer"}, "inputs":{"parameters":{"uri":{"runtimeValue":{"constantValue":{"stringValue":"gs://ml-pipeline-playground/shakespeare1.txt"}}}}},
-              "cachingOptions":{"enableCache":true}, "componentRef":{"name":"comp-importer"}}'
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-importer"},"inputs":{"parameters":{"uri":{"runtimeValue":{"constantValue":{"stringValue":"gs://ml-pipeline-playground/shakespeare1.txt"}}}}},"taskInfo":{"name":"importer"}}'
         name: importer
         template: comp-importer
     inputs:
@@ -144,9 +143,7 @@ spec:
           - name: dag-execution-id
             value: '{{inputs.parameters.dag-execution-id}}'
           - name: component
-            value: '{"inputDefinitions":{"parameters":{"dataset2":{"type":"STRING"}}},
-              "dag":{"tasks":{"importer":{"taskInfo":{"name":"importer"}, "inputs":{"parameters":{"uri":{"runtimeValue":{"constantValue":{"stringValue":"gs://ml-pipeline-playground/shakespeare1.txt"}}}}},
-              "cachingOptions":{"enableCache":true}, "componentRef":{"name":"comp-importer"}}}}}'
+            value: '{"dag":{"tasks":{"importer":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-importer"},"inputs":{"parameters":{"uri":{"runtimeValue":{"constantValue":{"stringValue":"gs://ml-pipeline-playground/shakespeare1.txt"}}}}},"taskInfo":{"name":"importer"}}}},"inputDefinitions":{"parameters":{"dataset2":{"type":"STRING"}}}}'
           - name: task
             value: '{{inputs.parameters.task}}'
           - name: runtime-config

--- a/v2/compiler/testdata/importer.yaml
+++ b/v2/compiler/testdata/importer.yaml
@@ -54,7 +54,13 @@ spec:
           optional: true
       image: gcr.io/ml-pipeline/kfp-launcher-v2:latest
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
     inputs:
       parameters:
       - name: task

--- a/v2/compiler/testdata/importer.yaml
+++ b/v2/compiler/testdata/importer.yaml
@@ -72,7 +72,8 @@ spec:
           - name: dag-execution-id
             value: '{{inputs.parameters.dag-execution-id}}'
           - name: task
-            value: '{"taskInfo":{"name":"importer"},"inputs":{"parameters":{"uri":{"runtimeValue":{"constantValue":{"stringValue":"gs://ml-pipeline-playground/shakespeare1.txt"}}}}},"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-importer"}}'
+            value: '{"taskInfo":{"name":"importer"}, "inputs":{"parameters":{"uri":{"runtimeValue":{"constantValue":{"stringValue":"gs://ml-pipeline-playground/shakespeare1.txt"}}}}},
+              "cachingOptions":{"enableCache":true}, "componentRef":{"name":"comp-importer"}}'
         name: importer
         template: comp-importer
     inputs:
@@ -143,7 +144,9 @@ spec:
           - name: dag-execution-id
             value: '{{inputs.parameters.dag-execution-id}}'
           - name: component
-            value: '{"inputDefinitions":{"parameters":{"dataset2":{"type":"STRING"}}},"dag":{"tasks":{"importer":{"taskInfo":{"name":"importer"},"inputs":{"parameters":{"uri":{"runtimeValue":{"constantValue":{"stringValue":"gs://ml-pipeline-playground/shakespeare1.txt"}}}}},"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-importer"}}}}}'
+            value: '{"inputDefinitions":{"parameters":{"dataset2":{"type":"STRING"}}},
+              "dag":{"tasks":{"importer":{"taskInfo":{"name":"importer"}, "inputs":{"parameters":{"uri":{"runtimeValue":{"constantValue":{"stringValue":"gs://ml-pipeline-playground/shakespeare1.txt"}}}}},
+              "cachingOptions":{"enableCache":true}, "componentRef":{"name":"comp-importer"}}}}}'
           - name: task
             value: '{{inputs.parameters.task}}'
           - name: runtime-config

--- a/v2/component/constants.go
+++ b/v2/component/constants.go
@@ -21,4 +21,8 @@ const (
 	// Env var names
 	EnvPodName = "KFP_POD_NAME"
 	EnvPodUID  = "KFP_POD_UID"
+
+	// Env vars in metadata-grpc-configmap
+	EnvMetadataHost = "METADATA_GRPC_SERVICE_HOST"
+	EnvMetadataPort = "METADATA_GRPC_SERVICE_PORT"
 )

--- a/v2/component/constants.go
+++ b/v2/component/constants.go
@@ -1,0 +1,24 @@
+// Copyright 2021 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package component
+
+const (
+	VolumePathKFPLauncher = "/kfp-launcher"
+	KFPLauncherPath       = VolumePathKFPLauncher + "/launch"
+
+	// Env var names
+	EnvPodName = "KFP_POD_NAME"
+	EnvPodUID  = "KFP_POD_UID"
+)

--- a/v2/component/importer_launcher.go
+++ b/v2/component/importer_launcher.go
@@ -184,7 +184,7 @@ func (l *ImportLauncher) ImportSpecToMLMDArtifact(ctx context.Context) (artifact
 
 func (l *ImportLauncher) getOutPutArtifactName() (string, error) {
 	outPutNames := make([]string, 0, len(l.component.GetOutputDefinitions().GetArtifacts()))
-	for name, _ := range l.component.GetOutputDefinitions().GetArtifacts() {
+	for name := range l.component.GetOutputDefinitions().GetArtifacts() {
 		outPutNames = append(outPutNames, name)
 	}
 	if len(outPutNames) != 1 {

--- a/v2/driver/driver.go
+++ b/v2/driver/driver.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path"
 	"strconv"
@@ -15,7 +16,10 @@ import (
 	"github.com/kubeflow/pipelines/v2/config"
 	"github.com/kubeflow/pipelines/v2/expression"
 	"github.com/kubeflow/pipelines/v2/metadata"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
+	k8score "k8s.io/api/core/v1"
+	k8sres "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -73,7 +77,10 @@ type Execution struct {
 	ExecutorInput  *pipelinespec.ExecutorInput
 	IterationCount *int  // number of iterations, -1 means not an iterator
 	Condition      *bool // true -> trigger the task, false -> not trigger the task, nil -> the task is unconditional
-	Cached         *bool // only specified when this is a Container execution
+
+	// only specified when this is a Container execution
+	Cached       *bool
+	PodSpecPatch string
 }
 
 func (e *Execution) WillTrigger() bool {
@@ -277,7 +284,92 @@ func Container(ctx context.Context, opts Options, mlmd *metadata.Client, cacheCl
 		*execution.Cached = true
 		return execution, nil
 	}
+
+	podSpec, err := makePodSpecPatch(opts.Container, opts.Component, executorInput, execution.ID, opts.PipelineName, opts.RunID)
+	if err != nil {
+		return execution, err
+	}
+	podSpecPatchBytes, err := json.Marshal(podSpec)
+	if err != nil {
+		return execution, fmt.Errorf("failed to JSON marshal pod spec patch: %w", err)
+	}
+	execution.PodSpecPatch = string(podSpecPatchBytes)
 	return execution, nil
+}
+
+func makePodSpecPatch(
+	container *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec,
+	componentSpec *pipelinespec.ComponentSpec,
+	executorInput *pipelinespec.ExecutorInput,
+	executionID int64,
+	pipelineName string,
+	runID string,
+) (*k8score.PodSpec, error) {
+	executorInputJSON, err := protojson.Marshal(executorInput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make podSpecPatch: %w", err)
+	}
+	componentJSON, err := protojson.Marshal(componentSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make podSpecPatch: %w", err)
+	}
+
+	userCmdArgs := make([]string, 0, len(container.Command)+len(container.Args))
+	userCmdArgs = append(userCmdArgs, container.Command...)
+	userCmdArgs = append(userCmdArgs, container.Args...)
+	launcherCmd := []string{
+		// TODO(Bobgy): workaround argo emissary executor bug, after we upgrade to an argo version with the bug fix, we can remove the following line.
+		// Reference: https://github.com/argoproj/argo-workflows/issues/7406
+		"/var/run/argo/argoexec", "emissary", "--",
+		component.KFPLauncherPath,
+		// TODO(Bobgy): no need to pass pipeline_name and run_id, these info can be fetched via pipeline context and pipeline run context which have been created by root DAG driver.
+		"--pipeline_name", pipelineName,
+		"--run_id", runID,
+		"--execution_id", fmt.Sprintf("%v", executionID),
+		"--executor_input", string(executorInputJSON),
+		"--component_spec", string(componentJSON),
+		"--pod_name",
+		fmt.Sprintf("$(%s)", component.EnvPodName),
+		"--pod_uid",
+		fmt.Sprintf("$(%s)", component.EnvPodUID),
+		"--mlmd_server_address", // METADATA_GRPC_SERVICE_* come from metadata-grpc-configmap
+		"$(METADATA_GRPC_SERVICE_HOST)",
+		"--mlmd_server_port",
+		"$(METADATA_GRPC_SERVICE_PORT)",
+		"--", // separater before user command and args
+	}
+	res := k8score.ResourceRequirements{
+		Limits: map[k8score.ResourceName]k8sres.Quantity{},
+	}
+	memoryLimit := container.GetResources().GetMemoryLimit()
+	if memoryLimit != 0 {
+		q, err := k8sres.ParseQuantity(fmt.Sprintf("%vG", memoryLimit))
+		if err != nil {
+			return nil, err
+		}
+		res.Limits[k8score.ResourceMemory] = q
+	}
+	cpuLimit := container.GetResources().GetCpuLimit()
+	if cpuLimit != 0 {
+		q, err := k8sres.ParseQuantity(fmt.Sprintf("%v", cpuLimit))
+		if err != nil {
+			return nil, err
+		}
+		res.Limits[k8score.ResourceCPU] = q
+	}
+	accelerator := container.GetResources().GetAccelerator()
+	if accelerator != nil {
+		return nil, fmt.Errorf("accelerator resources are not supported yet: https://github.com/kubeflow/pipelines/issues/7043")
+	}
+	return &k8score.PodSpec{
+		Containers: []k8score.Container{{
+			Name:      "main", // argo task user container is always called "main"
+			Command:   launcherCmd,
+			Args:      userCmdArgs,
+			Image:     container.Image,
+			Resources: res,
+		}},
+	}, nil
 }
 
 // TODO(Bobgy): merge DAG driver and container driver, because they are very similar.


### PR DESCRIPTION
**Description of your changes:**
Part of #6159 
This refactoring makes the implementation adhere to [bit.ly/kfp-v2](bit.ly/kfp-v2), because some fields of pod spec should come from driver dynamically.

Change: previously, we generate container executor templates directly in the workflow, now the container driver has an output of podSpecPatch that decides the pod spec. So the logic to determine pod spec has been moved to container driver.

Benefits:
* save generated workflow template size, because container executor template can now be generic, since podspecpatch can determine everything dynamically.
* using the generic container executor template also simplifies compiler implementation to prepare for #6159 
* in the future, this opens up the possibility to implement #7046 

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
