### PR TITLE
Drop support for python 3.6

### DIFF
--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -34,5 +34,5 @@ absl-py>=0.9,<=0.11
 kfp-pipeline-spec>=0.1.13,<0.2.0
 fire>=0.3.1,<1
 pydantic>=1.8.2,<2
-dataclasses>=0.8,<1; python_version<"3.7"
+dataclasses>=0.8,<1; python_version<"3.8"
 typing-extensions>=3.7.4,<4; python_version<"3.9"

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -54,7 +54,7 @@ REQUIRES = [
     'pydantic>=1.8.2,<2',
     'typer>=0.3.2,<1.0',
     # Standard library backports
-    'dataclasses;python_version<"3.7"',
+    'dataclasses;python_version<"3.8"',
     'typing-extensions>=3.7.4,<4;python_version<"3.9"',
 ]
 
@@ -131,7 +131,7 @@ setup(
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    python_requires='>=3.6.1',
+    python_requires='>=3.7.1',
     include_package_data=True,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
**Description of your changes:**
Python 3.6 will be deprecated soon. Hence we need to drop the support for it and plan to use supported versions. 
Link to the issue -https://github.com/kubeflow/pipelines/issues/6687

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
