### PR TITLE
Fixing the training component for stopped jobs

### DIFF
--- a/components/aws/sagemaker/tests/unit_tests/tests/train/test_train_component.py
+++ b/components/aws/sagemaker/tests/unit_tests/tests/train/test_train_component.py
@@ -121,6 +121,19 @@ class TrainingComponentTestCase(unittest.TestCase):
         )
 
         self.component._sm_client.describe_training_job.return_value = {
+            "TrainingJobStatus": "Stopped",
+            "FailureReason": "lolidk"
+        }
+        self.assertEqual(
+            self.component._get_job_status(),
+            SageMakerJobStatus(
+                is_completed=True,
+                raw_status="Stopped",
+                has_error=False
+            ),
+        )
+
+        self.component._sm_client.describe_training_job.return_value = {
             "TrainingJobStatus": "Failed",
             "FailureReason": "lolidk",
         }

--- a/components/aws/sagemaker/train/src/sagemaker_training_component.py
+++ b/components/aws/sagemaker/train/src/sagemaker_training_component.py
@@ -56,6 +56,8 @@ class SageMakerTrainingComponent(SageMakerComponent):
 
         if status == "Completed":
             return self._get_debug_rule_status()
+        if status == "Stopped":
+            return SageMakerJobStatus(is_completed=True, has_error=False, raw_status=status)
         if status == "Failed":
             message = response["FailureReason"]
             return SageMakerJobStatus(


### PR DESCRIPTION
**Description of your changes:**
Adding the scenario when training jobs are stopped.  Fixes #6465

```
PASSED tests/unit_tests/tests/robomaker/test_robomaker_simulation_job_spec.py::RoboMakerSimulationJobSpecTestCase::test_minimum_required_args
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_after_job_completed
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_create_training_job
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_cw_logs
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_do_sets_name
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_empty_hyperparameters
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_first_party_algorithm
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_get_job_status
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_hook_max_args
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_hook_min_args
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_known_algorithm_key
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_known_algorithm_value
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_metric_definitions
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_no_channels
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_no_defined_image
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_object_hyperparameters
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_rule_max_args
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_rule_min_good_args
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_training_mode
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_unknown_algorithm
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_valid_hyperparameters
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_vpc_configuration
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_wait_for_debug_rules
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingComponentTestCase::test_wait_for_errored_rule
PASSED tests/unit_tests/tests/train/test_train_component.py::TrainingSpecTestCase::test_minimum_required_args
PASSED tests/unit_tests/tests/train/test_train_spec.py::TrainingSpecTestCase::test_minimum_required_args
PASSED tests/unit_tests/tests/workteam/test_workteam_component.py::WorkteamComponentTestCase::test_after_job_completed
```