### PR TITLE
chore: Components - PyTorch - Create_PyTorch_Model_Archive - Updated the torchserve image to the latest version that does not include vulnerable log4j package

### DIFF
--- a/components/PyTorch/Create_PyTorch_Model_Archive/component.yaml
+++ b/components/PyTorch/Create_PyTorch_Model_Archive/component.yaml
@@ -12,7 +12,7 @@ metadata:
     canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/PyTorch/Create_PyTorch_Model_Archive/component.yaml'
 implementation:
   container:
-    image: pytorch/torchserve:0.3.0-cpu
+    image: pytorch/torchserve:0.5.2-cpu
     command:
     - bash
     - -exc
@@ -22,13 +22,13 @@ implementation:
       model_name=$2
       model_version=$3
       output_model_archive_path=$4
-      
+
       mkdir -p "$(dirname "$output_model_archive_path")"
 
       # torch-model-archiver needs the handler to have .py extension
       cp "$handler_path" handler.py
       torch-model-archiver --model-name "$model_name" --version "$model_version" --serialized-file "$model_path" --handler handler.py
-      
+
       # torch-model-archiver does not allow specifying the output path, but always writes to "${model_name}.<format>"
       expected_model_archive_path="${model_name}.mar"
       mv "$expected_model_archive_path" "$output_model_archive_path"


### PR DESCRIPTION
There was no vulnerability here, but this gives people peace of mind.

Unfortunately, the image size has grown dramatically between v0.4.0 and v0.4.1.

**Description of your changes:**


**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
