### PR TITLE
feat(backend): Forbid unarchive runs that belog to archived experiment

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -390,13 +390,13 @@ func (r *ResourceManager) CreateRun(ctx context.Context, apiRun *api.Run) (*mode
 
 	// Patched the default value to apiRun
 	if common.GetBoolConfigWithDefault(common.HasDefaultBucketEnvVar, false) {
-	for _, param := range apiRun.PipelineSpec.Parameters {
-		var err error
-		param.Value, err = common.PatchPipelineDefaultParameter(param.Value)
-		if err != nil {
-			return nil, fmt.Errorf("failed to patch default value to pipeline. Error: %v", err)
+		for _, param := range apiRun.PipelineSpec.Parameters {
+			var err error
+			param.Value, err = common.PatchPipelineDefaultParameter(param.Value)
+			if err != nil {
+				return nil, fmt.Errorf("failed to patch default value to pipeline. Error: %v", err)
+			}
 		}
-	}
 	}
 
 	// Store run metadata into database
@@ -424,6 +424,20 @@ func (r *ResourceManager) ArchiveRun(runId string) error {
 }
 
 func (r *ResourceManager) UnarchiveRun(runId string) error {
+	experimentRef, err := r.resourceReferenceStore.GetResourceReference(runId, common.Run, common.Experiment)
+	if err != nil {
+		return util.Wrap(err, "Failed to retrieve resource reference")
+	}
+
+	experiment, err := r.GetExperiment(experimentRef.ReferenceUUID)
+	if err != nil {
+		return errors.Wrap(err, "Failed to retrieve experiment")
+	}
+
+	if experiment.StorageState == api.Experiment_STORAGESTATE_ARCHIVED.String() {
+		return util.NewFailedPreconditionError(errors.New("Cannot unarchive a run that belong to archived experiment"),
+			fmt.Sprintf("Cannot unarchive run %s because it belongs to achived experiment with name `%s`.", runId, experimentRef.ReferenceName))
+	}
 	return r.runStore.UnarchiveRun(runId)
 }
 

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -435,8 +435,8 @@ func (r *ResourceManager) UnarchiveRun(runId string) error {
 	}
 
 	if experiment.StorageState == api.Experiment_STORAGESTATE_ARCHIVED.String() {
-		return util.NewFailedPreconditionError(errors.New("Cannot unarchive a run that belong to archived experiment"),
-			fmt.Sprintf("Cannot unarchive run %s because it belongs to achived experiment with name `%s`.", runId, experimentRef.ReferenceName))
+		return util.NewFailedPreconditionError(errors.New("Unarchive the experiment first to allow the run to be restored"),
+			fmt.Sprintf("Unarchive experiment with name `%s` first to allow run `%s` to be restored", experimentRef.ReferenceName, runId))
 	}
 	return r.runStore.UnarchiveRun(runId)
 }

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -668,7 +668,6 @@ func TestCreateRun_ThroughWorkflowSpecV2(t *testing.T) {
 	assert.Equal(t, expectedRunDetail, runDetail, "CreateRun stored invalid data in database")
 }
 
-
 func TestCreateRun_ThroughWorkflowSpec(t *testing.T) {
 	store, manager, runDetail := initWithOneTimeRun(t)
 	expectedExperimentUUID := runDetail.ExperimentUUID
@@ -1327,6 +1326,33 @@ func TestRetryRun_UpdateAndCreateFailed(t *testing.T) {
 	err := manager.RetryRun(context.Background(), runDetail.UUID)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Failed to create or update the run")
+}
+
+func TestUnarchiveRun_OK(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeRun(t)
+	defer store.Close()
+	err := manager.UnarchiveRun(runDetail.UUID)
+	assert.Nil(t, err)
+}
+
+func TestUnarchiveRun_Failed_ExperimentArchived(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeRun(t)
+	defer store.Close()
+	err := manager.ArchiveExperiment(context.Background(), runDetail.ExperimentUUID)
+	assert.Nil(t, err)
+	err = manager.UnarchiveRun(runDetail.UUID)
+	assert.NotNil(t, err)
+	assert.Equal(t, codes.FailedPrecondition, err.(*util.UserError).ExternalStatusCode())
+	assert.Contains(t, err.Error(), "Cannot unarchive a run that belong to archived experiment")
+}
+
+func TestUnarchiveRun_Failed_ResourceNotFound(t *testing.T) {
+	store, manager, _ := initWithExperiment(t)
+	defer store.Close()
+	err := manager.UnarchiveRun(FakeUUIDOne)
+	assert.NotNil(t, err)
+	assert.Equal(t, codes.NotFound, err.(*util.UserError).ExternalStatusCode())
+	assert.Contains(t, err.Error(), "Failed to retrieve resource reference")
 }
 
 // TODO Use table driven to write UT to test CreateJob

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -1343,7 +1343,7 @@ func TestUnarchiveRun_Failed_ExperimentArchived(t *testing.T) {
 	err = manager.UnarchiveRun(runDetail.UUID)
 	assert.NotNil(t, err)
 	assert.Equal(t, codes.FailedPrecondition, err.(*util.UserError).ExternalStatusCode())
-	assert.Contains(t, err.Error(), "Cannot unarchive a run that belong to archived experiment")
+	assert.Contains(t, err.Error(), "Unarchive the experiment first to allow")
 }
 
 func TestUnarchiveRun_Failed_ResourceNotFound(t *testing.T) {

--- a/backend/src/common/util/error.go
+++ b/backend/src/common/util/error.go
@@ -194,6 +194,14 @@ func NewBadRequestError(err error, externalFormat string, a ...interface{}) *Use
 		codes.Aborted)
 }
 
+func NewFailedPreconditionError(err error, externalFormat string, a ...interface{}) *UserError {
+	externalMessage := fmt.Sprintf(externalFormat, a...)
+	return newUserError(
+		errors.Wrapf(err, fmt.Sprintf("FailedPreconditionError: %v", externalMessage)),
+		externalMessage,
+		codes.FailedPrecondition)
+}
+
 func NewUnauthenticatedError(err error, externalFormat string, a ...interface{}) *UserError {
 	externalMessage := fmt.Sprintf(externalFormat, a...)
 	return newUserError(


### PR DESCRIPTION
Adds validation so that the user cannot activate a Run that belongs to Archived Experiment.

Fixes: https://github.com/kubeflow/pipelines/issues/7014

Signed-off-by: Diana Atanasova <dianaa@vmware.com>

**Description of your changes:**


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
