### PR TITLE
feat(sdk): add annotations to v2 component decorator

### DIFF
--- a/sdk/python/kfp/v2/components/component_decorator.py
+++ b/sdk/python/kfp/v2/components/component_decorator.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import functools
-from typing import Callable, Optional, List
+from typing import Callable, Optional, Dict, List
 
 from kfp.v2.components import component_factory
 
@@ -25,7 +25,8 @@ def component(func: Optional[Callable] = None,
               packages_to_install: List[str] = None,
               output_component_file: Optional[str] = None,
               install_kfp_package: bool = True,
-              kfp_package_path: Optional[str] = None):
+              kfp_package_path: Optional[str] = None,
+              annotations: Optional[Dict[str, str]] = None):
     """Decorator for Python-function based components in KFP v2.
 
     A KFP v2 component can either be a lightweight component, or a containerized
@@ -87,6 +88,8 @@ def component(func: Optional[Callable] = None,
             choose to override this to point to a Github pull request or
             other pip-compatible location when testing changes to lightweight
             Python functions.
+        annotations: Allows adding arbitrary key-value data to the component
+            specification.
 
     Returns:
         A component task factory that can be used in pipeline definitions.
@@ -99,7 +102,8 @@ def component(func: Optional[Callable] = None,
             packages_to_install=packages_to_install,
             output_component_file=output_component_file,
             install_kfp_package=install_kfp_package,
-            kfp_package_path=kfp_package_path)
+            kfp_package_path=kfp_package_path,
+            annotations=annotations)
 
     return component_factory.create_component_from_func(
         func,
@@ -108,4 +112,5 @@ def component(func: Optional[Callable] = None,
         packages_to_install=packages_to_install,
         output_component_file=output_component_file,
         install_kfp_package=install_kfp_package,
-        kfp_package_path=kfp_package_path)
+        kfp_package_path=kfp_package_path,
+        annotations=annotations)

--- a/sdk/python/kfp/v2/components/component_factory.py
+++ b/sdk/python/kfp/v2/components/component_factory.py
@@ -17,7 +17,7 @@ import itertools
 import pathlib
 import re
 import textwrap
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 import warnings
 
 import docstring_parser
@@ -367,7 +367,8 @@ def create_component_from_func(func: Callable,
                                packages_to_install: List[str] = None,
                                output_component_file: Optional[str] = None,
                                install_kfp_package: bool = True,
-                               kfp_package_path: Optional[str] = None):
+                               kfp_package_path: Optional[str] = None,
+                               annotations: Optional[Dict[str, str]] = None):
     """Implementation for the @component decorator.
 
     The decorator is defined under component_decorator.py. See the
@@ -422,6 +423,11 @@ def create_component_from_func(func: Callable,
 
     if REGISTERED_MODULES is not None:
         REGISTERED_MODULES[component_name] = component_info
+
+    if annotations is not None:
+        component_spec.metadata = structures.MetadataSpec(
+            annotations=annotations,
+        )
 
     if output_component_file:
         component_spec.save_to_component_yaml(output_component_file)


### PR DESCRIPTION
**Description of your changes:**
* Adds an optional `annotations` argument to the SDK V2 `component` decorator
    * The v1 `create_component_from_func` function has the option to specify attributes, which is useful for applying component-specific pod resource requests/limits, etc. 
* These changes are tested locally but would appreciate some recommendations on testing this further 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
