### PR TITLE
fix(backend): AIP-5634: Add in LRU cache and temp file rotation for metadata-writer. Relates to #4347

### DIFF
--- a/backend/metadata_writer/requirements.in
+++ b/backend/metadata_writer/requirements.in
@@ -1,3 +1,3 @@
 kubernetes>=8.0.0,<11.0.0
 ml-metadata==1.5.0
-lru-dict>=1.1.7
+lru-dict>=1.1.7,<2.0.0

--- a/backend/metadata_writer/requirements.in
+++ b/backend/metadata_writer/requirements.in
@@ -1,2 +1,3 @@
 kubernetes>=8.0.0,<11.0.0
 ml-metadata==1.5.0
+lru-dict>=1.1.7

--- a/backend/metadata_writer/requirements.txt
+++ b/backend/metadata_writer/requirements.txt
@@ -6,26 +6,27 @@
 #
 absl-py==0.12.0           # via ml-metadata
 attrs==20.3.0             # via ml-metadata
-cachetools==4.2.2         # via google-auth
-certifi==2021.5.30        # via kubernetes, requests
-charset-normalizer==2.0.4  # via requests
-google-auth==2.0.1        # via kubernetes
-grpcio==1.39.0            # via ml-metadata
-idna==3.2                 # via requests
+cachetools==5.0.0         # via google-auth
+certifi==2021.10.8        # via kubernetes, requests
+charset-normalizer==2.0.10  # via requests
+google-auth==2.4.1        # via kubernetes
+grpcio==1.43.0            # via ml-metadata
+idna==3.3                 # via requests
 kubernetes==10.1.0        # via -r -
-ml-metadata==1.2.0        # via -r -
+lru-dict==1.1.7           # via -r -
+ml-metadata==1.5.0        # via -r -
 oauthlib==3.1.1           # via requests-oauthlib
-protobuf==3.17.3          # via ml-metadata
+protobuf==3.19.3          # via ml-metadata
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 python-dateutil==2.8.2    # via kubernetes
 pyyaml==3.13              # via kubernetes
 requests-oauthlib==1.3.0  # via kubernetes
-requests==2.26.0          # via kubernetes, requests-oauthlib
-rsa==4.7.2                # via google-auth
-six==1.16.0               # via absl-py, grpcio, kubernetes, ml-metadata, protobuf, python-dateutil
-urllib3==1.26.6           # via kubernetes, requests
-websocket-client==1.2.1   # via kubernetes
+requests==2.27.1          # via kubernetes, requests-oauthlib
+rsa==4.8                  # via google-auth
+six==1.16.0               # via absl-py, google-auth, grpcio, kubernetes, ml-metadata, python-dateutil
+urllib3==1.26.8           # via kubernetes, requests
+websocket-client==1.2.3   # via kubernetes
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -15,16 +15,21 @@
 import json
 import hashlib
 import os
-import sys
 import re
+import glob
 import kubernetes
 import yaml
 from time import sleep
+from lru import LRU
 
 from metadata_helpers import *
 
 
 namespace_to_watch = os.environ.get('NAMESPACE_TO_WATCH', 'default')
+pod_name_to_execution_id_size = os.environ.get('POD_NAME_TO_EXECUTION_ID_SIZE', 5000)
+workflow_name_to_context_id_size = os.environ.get('WORKFLOW_NAME_TO_CONTEXT_ID_SIZE', 5000)
+pods_with_written_metadata_size = os.environ.get('PODS_WITH_WRITTEN_METADATA_SIZE', 5000)
+debug_files_size = os.environ.get('DEBUG_FILES_SIZE', 5000)
 
 
 kubernetes.config.load_incluster_config()
@@ -133,9 +138,9 @@ def is_kfp_v2_pod(pod) -> bool:
 # They are expected to be lost when restarting the service.
 # The operation of the Metadata Writer remains correct even if it's getting restarted frequently. (Kubernetes only sends the latest version of resource for new watchers.)
 # Technically, we could remove the objects from cache as soon as we see that our labels have been applied successfully.
-pod_name_to_execution_id = {}
-workflow_name_to_context_id = {}
-pods_with_written_metadata = set()
+pod_name_to_execution_id = LRU(pod_name_to_execution_id_size)
+workflow_name_to_context_id = LRU(workflow_name_to_context_id_size)
+pods_with_written_metadata = LRU(pods_with_written_metadata_size)
 
 while True:
     print("Start watching Kubernetes Pods created by Argo")
@@ -164,8 +169,16 @@ while True:
             pod_name = obj.metadata.name
 
             # Logging pod changes for debugging
-            with open('/tmp/pod_' + obj.metadata.name + '_' + obj.metadata.resource_version, 'w') as f:
+            debug_prefix = '/tmp/pod_'
+            with open(debug_prefix + obj.metadata.name + '_' + obj.metadata.resource_version, 'w') as f:
                 f.write(yaml.dump(obj.to_dict()))
+
+            # Do some housekeeping, ensure we only keep a fixed size buffer of debug files so we don't
+            # grow the disk size indefinitely for long running pods.
+            debug_files = filter(os.path.isfile, glob.glob(debug_prefix + '*'))
+            if len(debug_files) > debug_files_size:
+                for debug_file in sorted(debug_files, key=os.path.getmtime)[debug_files_size:]:
+                    os.remove(debug_file)
 
             assert obj.kind == 'Pod'
 
@@ -372,7 +385,7 @@ while True:
                     patch=metadata_to_add,
                 )
 
-                pods_with_written_metadata.add(obj.metadata.name)
+                pods_with_written_metadata[obj.metadata.name] = None
 
         except Exception as e:
             import traceback

--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -16,7 +16,6 @@ import json
 import hashlib
 import os
 import re
-import glob
 import kubernetes
 import yaml
 from time import sleep
@@ -177,7 +176,9 @@ while True:
 
             # Do some housekeeping, ensure we only keep a fixed size buffer of debug files so we don't
             # grow the disk size indefinitely for long running pods.
-            for debug_path in debug_paths[debug_files_size:]:
+            debug_paths_to_remove = debug_paths[:-debug_files_size]
+            debug_paths = debug_paths[-debug_files_size:]
+            for debug_path in debug_paths_to_remove:
                 os.remove(debug_path)
 
             assert obj.kind == 'Pod'


### PR DESCRIPTION
**Description of your changes:**

In #4347 it was mentioned that there is a memory leak in `metadata-writer`, we are certainly seeing similar behavior given the cache variables (code [here](https://github.com/kubeflow/pipelines/blob/master/backend/metadata_writer/src/metadata_writer.py#L136)) are not bounded by an upper limit and the same with the "debug" files dumped to `/tmp` this causes `memory.working_set` to slowly rise and `memory.cache` to do so also. 

This change introduces a bounded size via an LRU cache (limited to 5k items for each, open to discussion on implementation of this), so that we can avoid any OOM issues entirely! Looking at the discussion on #4347 the current resolution is simply to let it OOM and the `ReplicaSet` to restart it, this works great but we have alerting on our KF clusters to notify our on-call on any OOM restarts so this one occasionally hits us!

/area backend