### PR TITLE
fix(backend): set correct permissions for local directory

### DIFF
--- a/backend/src/v2/objectstore/object_store.go
+++ b/backend/src/v2/objectstore/object_store.go
@@ -263,7 +263,7 @@ func downloadFile(ctx context.Context, bucket *blob.Bucket, blobFilePath, localF
 	defer r.Close()
 
 	localDir := filepath.Dir(localFilePath)
-	if err := os.MkdirAll(localDir, 0644); err != nil {
+	if err := os.MkdirAll(localDir, 0755); err != nil {
 		return errorF(fmt.Errorf("failed to create local directory %q: %w", localDir, err))
 	}
 


### PR DESCRIPTION
**Description of your changes:**
Set correct directory permissions

https://github.com/bentoml/BentoML/issues/2199
https://stackoverflow.com/questions/14249467/os-mkdir-and-os-mkdirall-permissions

```Dockerfile
Step 19/22 : USER bentoml
 ---> Running in 311f178ebf3b
Removing intermediate container 311f178ebf3b
 ---> c0093bf0d047
Step 20/22 : RUN chmod +x ./env/docker/entrypoint.sh
 ---> Running in a843ef55675e
+ chmod +x ./env/docker/entrypoint.sh
chmod: cannot access './env/docker/entrypoint.sh': Permission denied
The command '/bin/bash -exo pipefail -c chmod +x ./env/docker/entrypoint.sh' returned a non-zero code: 1
```