### PR TITLE
fix(manifests): Use number for cloudsql liveness port

### DIFF
--- a/manifests/kustomize/env/gcp/cloudsql-proxy/cloudsql-proxy-deployment.yaml
+++ b/manifests/kustomize/env/gcp/cloudsql-proxy/cloudsql-proxy-deployment.yaml
@@ -43,7 +43,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /liveness
-              port: '8090'
+              port: 8090
             # Number of seconds after the container has started before the first probe is scheduled. Defaults to 0.
             # Not necessary when the startup probe is in use.
             initialDelaySeconds: 0


### PR DESCRIPTION
**Description of your changes:**
When deploying on GKE 1.20, I see this error:

```
The Deployment "cloudsqlproxy" is invalid: spec.template.spec.containers[0].livenessProbe.httpGet.port: Invalid value: "8090": must contain at least one letter or number (a-z, 0-9)
```

I need to remove the double quote in order to make deployment successful.

I am expecting to include this for 1.8.0 release.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
