### PR TITLE
chore: update eks version to 1.19 for aws sagemaker integration tests

### DIFF
--- a/components/aws/sagemaker/tests/integration_tests/scripts/run_integration_tests
+++ b/components/aws/sagemaker/tests/integration_tests/scripts/run_integration_tests
@@ -17,7 +17,7 @@ REGION=${REGION:-"$(aws configure get region)"} # Deployment region
 
 ### Configuration parameters
 EKS_EXISTING_CLUSTER=${EKS_EXISTING_CLUSTER:-""} # Use an existing EKS cluster
-EKS_CLUSTER_VERSION=${EKS_CLUSTER_VERSION:-"1.18"} # EKS cluster K8s version
+EKS_CLUSTER_VERSION=${EKS_CLUSTER_VERSION:-"1.19"} # EKS cluster K8s version
 EKS_NODE_COUNT=${EKS_NODE_COUNT:-"1"} # The initial node count of the EKS cluster
 EKS_PUBLIC_SUBNETS=${EKS_PUBLIC_SUBNETS:-""}
 EKS_PRIVATE_SUBNETS=${EKS_PRIVATE_SUBNETS:-""}


### PR DESCRIPTION
Description of your changes:
Kubernetes version 1.18 will be deprecated by EKS, bumping up verison to v1.19