### PR TITLE
chore: skip building KFP sdk and python components in cloudbuild

### DIFF
--- a/.cloudbuild.yaml
+++ b/.cloudbuild.yaml
@@ -17,35 +17,35 @@
 
 steps:
 
-# Build the Python SDK
-- name: 'python:3-alpine'
-  entrypoint: '/bin/sh'
-  args: ['-c', 'cd /workspace/sdk/python/; python3 setup.py sdist --format=gztar; cp dist/*.tar.gz /workspace/kfp.tar.gz']
-  id:   'preparePythonSDK'
-  waitFor: ["-"]
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', '/workspace/kfp.tar.gz', 'gs://$PROJECT_ID/builds/$COMMIT_SHA/kfp.tar.gz']
-  id:   'copyPythonSDK'
-  waitFor: ['preparePythonSDK']
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', '/workspace/kfp.tar.gz', 'gs://$PROJECT_ID/builds/latest/kfp.tar.gz']
-  id:   'copyPythonSDKToLatest'
-  waitFor: ['preparePythonSDK']
+# # Build the Python SDK
+# - name: 'python:3-alpine'
+#   entrypoint: '/bin/sh'
+#   args: ['-c', 'cd /workspace/sdk/python/; python3 setup.py sdist --format=gztar; cp dist/*.tar.gz /workspace/kfp.tar.gz']
+#   id:   'preparePythonSDK'
+#   waitFor: ["-"]
+# - name: 'gcr.io/cloud-builders/gsutil'
+#   args: ['cp', '/workspace/kfp.tar.gz', 'gs://$PROJECT_ID/builds/$COMMIT_SHA/kfp.tar.gz']
+#   id:   'copyPythonSDK'
+#   waitFor: ['preparePythonSDK']
+# - name: 'gcr.io/cloud-builders/gsutil'
+#   args: ['cp', '/workspace/kfp.tar.gz', 'gs://$PROJECT_ID/builds/latest/kfp.tar.gz']
+#   id:   'copyPythonSDKToLatest'
+#   waitFor: ['preparePythonSDK']
 
-# Build the Python Component SDK
-- name: 'python:2-alpine'
-  entrypoint: '/bin/sh'
-  args: ['-c', 'cd /workspace/components/gcp/container/component_sdk/python;python setup.py sdist --format=gztar; cp dist/*.tar.gz /workspace/kfp-component.tar.gz']
-  id:   'preparePythonComponentSDK'
-  waitFor: ["-"]
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', '/workspace/kfp-component.tar.gz', 'gs://$PROJECT_ID/builds/$COMMIT_SHA/kfp-component.tar.gz']
-  id:   'copyPythonComponentSDK'
-  waitFor: ['preparePythonComponentSDK']
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', '/workspace/kfp-component.tar.gz', 'gs://$PROJECT_ID/builds/latest/kfp-component.tar.gz']
-  id:   'copyPythonComponentSDKToLatest'
-  waitFor: ['preparePythonComponentSDK']
+# # Build the Python Component SDK
+# - name: 'python:2-alpine'
+#   entrypoint: '/bin/sh'
+#   args: ['-c', 'cd /workspace/components/gcp/container/component_sdk/python;python setup.py sdist --format=gztar; cp dist/*.tar.gz /workspace/kfp-component.tar.gz']
+#   id:   'preparePythonComponentSDK'
+#   waitFor: ["-"]
+# - name: 'gcr.io/cloud-builders/gsutil'
+#   args: ['cp', '/workspace/kfp-component.tar.gz', 'gs://$PROJECT_ID/builds/$COMMIT_SHA/kfp-component.tar.gz']
+#   id:   'copyPythonComponentSDK'
+#   waitFor: ['preparePythonComponentSDK']
+# - name: 'gcr.io/cloud-builders/gsutil'
+#   args: ['cp', '/workspace/kfp-component.tar.gz', 'gs://$PROJECT_ID/builds/latest/kfp-component.tar.gz']
+#   id:   'copyPythonComponentSDKToLatest'
+#   waitFor: ['preparePythonComponentSDK']
 
 # Build the pipeline system images
 - name: 'gcr.io/cloud-builders/docker'
@@ -71,7 +71,7 @@ steps:
         --build-arg TAG_NAME="$(cat /workspace/VERSION)" \
         -f /workspace/backend/Dockerfile /workspace
   id:   'buildApiServer'
-  waitFor: ['copyPythonSDK']
+  waitFor: ['-']
 
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/scheduledworkflow:$COMMIT_SHA', '-f',

--- a/.release.cloudbuild.yaml
+++ b/.release.cloudbuild.yaml
@@ -568,31 +568,31 @@ steps:
     docker push gcr.io/ml-pipeline/google/pipelines:$(cat /workspace/mm.ver)
     docker push gcr.io/ml-pipeline/google/pipelines-test:$(cat /workspace/mm.ver)
 
-# Copy the Python SDK
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', 'gs://$PROJECT_ID/builds/$COMMIT_SHA/kfp.tar.gz', '/workspace/']
-  id:   'copyPythonSDKLocal'
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', '/workspace/kfp.tar.gz', 'gs://ml-pipeline/release/$TAG_NAME/kfp.tar.gz']
-  id:   'copyPythonSDK'
-  waitFor: ['copyPythonSDKLocal']
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', '/workspace/kfp.tar.gz', 'gs://ml-pipeline/release/latest/kfp.tar.gz']
-  id:   'copyPythonSDKToLatest'
-  waitFor: ['copyPythonSDKLocal']
+# # Copy the Python SDK
+# - name: 'gcr.io/cloud-builders/gsutil'
+#   args: ['cp', 'gs://$PROJECT_ID/builds/$COMMIT_SHA/kfp.tar.gz', '/workspace/']
+#   id:   'copyPythonSDKLocal'
+# - name: 'gcr.io/cloud-builders/gsutil'
+#   args: ['cp', '/workspace/kfp.tar.gz', 'gs://ml-pipeline/release/$TAG_NAME/kfp.tar.gz']
+#   id:   'copyPythonSDK'
+#   waitFor: ['copyPythonSDKLocal']
+# - name: 'gcr.io/cloud-builders/gsutil'
+#   args: ['cp', '/workspace/kfp.tar.gz', 'gs://ml-pipeline/release/latest/kfp.tar.gz']
+#   id:   'copyPythonSDKToLatest'
+#   waitFor: ['copyPythonSDKLocal']
 
-# Copy the Python Component SDK
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', 'gs://$PROJECT_ID/builds/$COMMIT_SHA/kfp-component.tar.gz', '/workspace/']
-  id:   'copyPythonComponentSDKLocal'
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', '/workspace/kfp-component.tar.gz', 'gs://ml-pipeline/release/$TAG_NAME/kfp-component.tar.gz']
-  id:   'copyPythonComponentSDK'
-  waitFor: ['copyPythonComponentSDKLocal']
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', '/workspace/kfp-component.tar.gz', 'gs://ml-pipeline/release/latest/kfp-component.tar.gz']
-  id:   'copyPythonComponentSDKToLatest'
-  waitFor: ['copyPythonComponentSDKLocal']
+# # Copy the Python Component SDK
+# - name: 'gcr.io/cloud-builders/gsutil'
+#   args: ['cp', 'gs://$PROJECT_ID/builds/$COMMIT_SHA/kfp-component.tar.gz', '/workspace/']
+#   id:   'copyPythonComponentSDKLocal'
+# - name: 'gcr.io/cloud-builders/gsutil'
+#   args: ['cp', '/workspace/kfp-component.tar.gz', 'gs://ml-pipeline/release/$TAG_NAME/kfp-component.tar.gz']
+#   id:   'copyPythonComponentSDK'
+#   waitFor: ['copyPythonComponentSDKLocal']
+# - name: 'gcr.io/cloud-builders/gsutil'
+#   args: ['cp', '/workspace/kfp-component.tar.gz', 'gs://ml-pipeline/release/latest/kfp-component.tar.gz']
+#   id:   'copyPythonComponentSDKToLatest'
+#   waitFor: ['copyPythonComponentSDKLocal']
 
 images:
 - 'gcr.io/ml-pipeline/scheduledworkflow:$TAG_NAME'


### PR DESCRIPTION
**Description of your changes:**
KFP SDK is currently released via a separate process, there's no need to build it during the backend release build.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
