### PR TITLE
chore(sdk): Relax Typing Extensions Constraint

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -55,7 +55,7 @@ REQUIRES = [
     'typer>=0.3.2,<1.0',
     # Standard library backports
     'dataclasses;python_version<"3.7"',
-    'typing-extensions>=3.7.4,<4;python_version<"3.9"',
+    'typing-extensions>=3.7.4,<5;python_version<"3.9"',
 ]
 
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
**Description of your changes:**
Typing extensions changed version scheme a couple months ago. The old schema was not semantic versioning based and was python version based. The new scheme is based on semantic versioning and moved to 4.0. 4.0+ is fully backwards compatible. So it's safe to move the bound to 5.0. And current bound unnecessarily prevents usage of some optional typing features like typeguard and pretty soon variadic types.

I would also be open to dropping upper bound entirely. It's unlikely most breaking type changes would affect normal type usage. It would heavily fracture python typing ecosystem for something core to change. And current stability focus of python devs (includes typing portion) I think it should be safe for most packages to not upper bound typing extensions. If in the future a package discovers they are affected they can add upper bound then.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 