### PR TITLE
chore(sdk): bump version to 2.0.0-alpha.0

### DIFF
--- a/sdk/python/kfp/__init__.py
+++ b/sdk/python/kfp/__init__.py
@@ -16,7 +16,7 @@
 # https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
-__version__ = '1.8.11'
+__version__ = '2.0.0-alpha.0'
 
 from . import components
 from . import containers

--- a/sdk/python/kfp/v2/compiler_cli_tests/compiler_cli_tests.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/compiler_cli_tests.py
@@ -33,7 +33,7 @@ def _ignore_kfp_version_helper(spec):
         for executor in pipeline_spec['deploymentSpec']['executors']:
             pipeline_spec['deploymentSpec']['executors'][executor] = json.loads(
                 re.sub(
-                    "'kfp==(\d+).(\d+).(\d+)'", 'kfp',
+                    "'kfp==(\d+).(\d+).(\d+)(-[a-z]+.\d+)?'", 'kfp',
                     json.dumps(pipeline_spec['deploymentSpec']['executors']
                                [executor])))
     return spec


### PR DESCRIPTION
**Description of your changes:**
Not intended for an actual release. But in case someone install the SDK from GitHub master HEAD, they'd better get a version different from a stable release version. This helps remove potential confusion in debugging, telemetry, etc.

**Caveat:**
After this change. For users install SDK from GitHub master HEAD and use v2 Python lightweight component.
The code 
```python
@component
def my_component(...):
    ...
```
needs to be updated to 
```python
@component(
    kfp_package_path='git+https://github.com/kubeflow/pipelines.git@master#subdirectory=sdk/python',
)
def my_component(...):
    ...
```
Otherwise, pipeline will fail at runtime, as it will try to `pip install kfp==2.0.0-alpha.0`, which does not exist on PyPi.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
