### PR TITLE
fix(backend): Read env var for default service account in multi-user mode. Fix #7336

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -27,7 +27,7 @@ const (
 	MultiUserModeSharedReadAccess           string = "MULTIUSER_SHARED_READ"
 	PodNamespace                            string = "POD_NAMESPACE"
 	CacheEnabled                            string = "CacheEnabled"
-	DefaultPipelineRunnerServiceAccountFlag string = "DefaultPipelineRunnerServiceAccount"
+	DefaultPipelineRunnerServiceAccountFlag string = "DEFAULTPIPELINERUNNERSERVICEACCOUNT"
 	KubeflowUserIDHeader                    string = "KUBEFLOW_USERID_HEADER"
 	KubeflowUserIDPrefix                    string = "KUBEFLOW_USERID_PREFIX"
 	UpdatePipelineVersionByDefault          string = "AUTO_UPDATE_PIPELINE_DEFAULT_VERSION"

--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -23,14 +23,15 @@ import (
 )
 
 const (
-	MultiUserMode                       string = "MULTIUSER"
-	MultiUserModeSharedReadAccess       string = "MULTIUSER_SHARED_READ"
-	PodNamespace                        string = "POD_NAMESPACE"
-	CacheEnabled                        string = "CacheEnabled"
-	KubeflowUserIDHeader                string = "KUBEFLOW_USERID_HEADER"
-	KubeflowUserIDPrefix                string = "KUBEFLOW_USERID_PREFIX"
-	UpdatePipelineVersionByDefault      string = "AUTO_UPDATE_PIPELINE_DEFAULT_VERSION"
-	TokenReviewAudience                 string = "TOKEN_REVIEW_AUDIENCE"
+	MultiUserMode                           string = "MULTIUSER"
+	MultiUserModeSharedReadAccess           string = "MULTIUSER_SHARED_READ"
+	PodNamespace                            string = "POD_NAMESPACE"
+	CacheEnabled                            string = "CacheEnabled"
+	DefaultPipelineRunnerServiceAccountFlag string = "DefaultPipelineRunnerServiceAccount"
+	KubeflowUserIDHeader                    string = "KUBEFLOW_USERID_HEADER"
+	KubeflowUserIDPrefix                    string = "KUBEFLOW_USERID_PREFIX"
+	UpdatePipelineVersionByDefault          string = "AUTO_UPDATE_PIPELINE_DEFAULT_VERSION"
+	TokenReviewAudience                     string = "TOKEN_REVIEW_AUDIENCE"
 )
 
 func IsPipelineVersionUpdatedByDefault() bool {

--- a/backend/src/apiserver/config/config.json
+++ b/backend/src/apiserver/config/config.json
@@ -15,7 +15,7 @@
   "ARCHIVE_CONFIG_LOG_FILE_NAME": "main.log",
   "ARCHIVE_CONFIG_LOG_PATH_PREFIX": "/artifacts",
   "InitConnectionTimeout": "6m",
-  "DefaultPipelineRunnerServiceAccount": "pipeline-runner",
+  "DEFAULTPIPELINERUNNERSERVICEACCOUNT": "pipeline-runner",
   "CacheEnabled": "true",
   "CRON_SCHEDULE_TIMEZONE": "UTC",
   "CACHE_IMAGE": "gcr.io/google-containers/busybox",

--- a/backend/src/apiserver/server/run_server_test.go
+++ b/backend/src/apiserver/server/run_server_test.go
@@ -183,9 +183,9 @@ func TestCreateRun_Unauthorized(t *testing.T) {
 
 func TestCreateRun_Multiuser(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
-	viper.Set(common.DefaultPipelineRunnerServiceAccount, "default-editor")
+	viper.Set(common.DefaultPipelineRunnerServiceAccountFlag, "default-editor")
 	defer viper.Set(common.MultiUserMode, "false")
-	defer viper.Set(common.DefaultPipelineRunnerServiceAccount, "pipeline-runner")
+	defer viper.Set(common.DefaultPipelineRunnerServiceAccountFlag, "pipeline-runner")
 
 	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)

--- a/backend/src/apiserver/template/template.go
+++ b/backend/src/apiserver/template/template.go
@@ -17,11 +17,12 @@ package template
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
-	api "github.com/kubeflow/pipelines/backend/api/go_client"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
+	api "github.com/kubeflow/pipelines/backend/api/go_client"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -196,7 +197,7 @@ func setDefaultServiceAccount(workflow *util.Workflow, serviceAccount string) {
 	if len(workflowServiceAccount) == 0 || workflowServiceAccount == common.DefaultPipelineRunnerServiceAccount {
 		// To reserve SDK backward compatibility, the backend only replaces
 		// serviceaccount when it is empty or equal to default value set by SDK.
-		workflow.SetServiceAccount(common.GetStringConfigWithDefault(common.DefaultPipelineRunnerServiceAccount, common.DefaultPipelineRunnerServiceAccount))
+		workflow.SetServiceAccount(common.GetStringConfigWithDefault(common.DefaultPipelineRunnerServiceAccountFlag, common.DefaultPipelineRunnerServiceAccount))
 	}
 }
 


### PR DESCRIPTION
**Description of your changes:**
Fix #7336

Due to the change in https://github.com/kubeflow/pipelines/pull/6689/files#diff-2bc2047e64f4bb524fb40748997d97f0c96c1c8884a87c81ffa3a7177f8cf0f1R195-R206, we cannot use the env var `DefaultPipelineRunnerServiceAccount` to set service account in multi-user mode. It is because the previous change will try to read a env var flag `pipeline-runner` instead of `DefaultPipelineRunnerServiceAccount` as this is deleted: https://github.com/kubeflow/pipelines/pull/6689/files#diff-47d6ab6bca869e0559465170316707ceda42f65103bd0d4e93519294305e62d1. But we should keep the flag.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
