### PR TITLE
fix(samples): Replace deprecated tfx kubeflow example

### DIFF
--- a/samples/core/tfx-oss/TFX Example.ipynb
+++ b/samples/core/tfx-oss/TFX Example.ipynb
@@ -69,7 +69,7 @@
    "source": [
     "# copy the trainer code to a storage bucket as the TFX pipeline will need that code file in GCS\n",
     "from tensorflow.compat.v1 import gfile\n",
-    "gfile.Copy('utils/taxi_utils.py', _input_bucket + '/taxi_utils.py')"
+    "gfile.Copy('examples/penguin/penguin_utils_cloud_tuner.py', _input_bucket + '/penguin_utils_cloud_tuner.py')"
    ]
   },
   {
@@ -80,11 +80,11 @@
     "\n",
     "Reload this cell by running the load command to get the pipeline configuration file\n",
     "```\n",
-    "%load https://raw.githubusercontent.com/tensorflow/tfx/master/tfx/examples/chicago_taxi_pipeline/taxi_pipeline_kubeflow_gcp.py\n",
+    "%load https://raw.githubusercontent.com/tensorflow/tfx/master/tfx/examples/penguin/penguin_pipeline_kubeflow.py\n",
     "```\n",
     "\n",
     "Configure:\n",
-    "- Set `_input_bucket` to the GCS directory where you've copied taxi_utils.py. I.e. gs://<my bucket>/<path>/\n",
+    "- Set `_input_bucket` to the GCS directory where you've copied penguin_utils_cloud_tuner.py. I.e. gs://<my bucket>/<path>/\n",
     "- Set `_output_bucket` to the GCS directory where you've want the results to be written\n",
     "- Set GCP project ID (replace my-gcp-project). Note that it should be project ID, not project name.\n",
     "\n",
@@ -99,7 +99,7 @@
    },
    "outputs": [],
    "source": [
-    "%load https://raw.githubusercontent.com/tensorflow/tfx/master/tfx/examples/chicago_taxi_pipeline/taxi_pipeline_kubeflow_gcp.py"
+    "%load https://raw.githubusercontent.com/tensorflow/tfx/master/tfx/examples/penguin/penguin_pipeline_kubeflow.py"
    ]
   },
   {
@@ -121,7 +121,7 @@
     "\n",
     "run_result = kfp.Client(\n",
     "    host=None  # replace with Kubeflow Pipelines endpoint if this notebook is run outside of the Kubeflow cluster.\n",
-    ").create_run_from_pipeline_package('chicago_taxi_pipeline_kubeflow.tar.gz', arguments={})"
+    ").create_run_from_pipeline_package('penguin_kubeflow.tar.gz', arguments={})"
    ]
   }
  ],


### PR DESCRIPTION
**Problem:**

In this commit https://github.com/tensorflow/tfx/commit/cd029714cb3a9818273c6b2c67a1d3f271f1584f, TFX removed a kubeflow gcp example for Chicago taxi data. However, it is still referenced in this "TFX on KubeFlow Pipelines Example", e.g. https://raw.githubusercontent.com/tensorflow/tfx/master/tfx/examples/chicago_taxi_pipeline/taxi_pipeline_kubeflow_gcp.py (broken link).

**Solution:**

Replace references to taxi tfx kubeflow example with penguin tfx kubeflow example.

**Description of your changes:**


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
