### PR TITLE
feat(component): Log the job launcher's pods

### DIFF
--- a/components/kubeflow/launcher/src/launch_tfjob.py
+++ b/components/kubeflow/launcher/src/launch_tfjob.py
@@ -131,6 +131,7 @@ def main(argv=None):
         timeout=datetime.timedelta(minutes=args.tfjobTimeoutMinutes))
     if args.deleteAfterDone:
         tfjob.delete(args.name, args.namespace)
+    tfjob.log_job_pods(args.namespace, args.name)
 
 if __name__== "__main__":
     main()

--- a/components/kubeflow/pytorch-launcher/src/launch_pytorchjob.py
+++ b/components/kubeflow/pytorch-launcher/src/launch_pytorchjob.py
@@ -143,6 +143,7 @@ def main(args):
     if args.deleteAfterDone:
         logging.info('Deleting job.')
         launcher_client.delete(args.name, args.namespace)
+    launcher_client.log_job_pods(args.namespace, args.name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description of your changes:**

Currently, job launcher only launch job, so it can't save training logs.
Fixed to log pods launched from the job.

- [ ] Need to update [`component.yaml`](https://github.com/kubeflow/pipelines/blob/master/components/kubeflow/launcher/component.yaml#L19)

ex)
**Before**
```bash
INFO:root:Generating tfjob template.
INFO:launch_crd:Creating kubeflow.org/tfjobs ml-e2e-pipeline-9lbhp-hdfs in namespace wangyuhan.
INFO:launch_crd:Created kubeflow.org/tfjobs ml-e2e-pipeline-9lbhp-hdfs in namespace wangyuhan.
INFO:launch_crd:Current condition of kubeflow.org/tfjobs ml-e2e-pipeline-9lbhp-hdfs in namespace wangyuhan is Running.
INFO:launch_crd:kubeflow.org/tfjobs ml-e2e-pipeline-9lbhp-hdfs in namespace wangyuhan has reached the expected condition: Succeeded.
INFO:launch_crd:Deleteing kubeflow.org/tfjobs ml-e2e-pipeline-9lbhp-hdfs in namespace wangyuhan.
INFO:launch_crd:Deleted kubeflow.org/tfjobs ml-e2e-pipeline-9lbhp-hdfs in namespace wangyuhan.
```
**After**
```bash
INFO:root:Generating tfjob template.
INFO:launch_crd:Creating kubeflow.org/tfjobs ml-e2e-pipeline-9lbhp-hdfs in namespace wangyuhan.
INFO:launch_crd:Created kubeflow.org/tfjobs ml-e2e-pipeline-9lbhp-hdfs in namespace wangyuhan.
INFO:launch_crd:Current condition of kubeflow.org/tfjobs ml-e2e-pipeline-9lbhp-hdfs in namespace wangyuhan is Running.
INFO:launch_crd:kubeflow.org/tfjobs ml-e2e-pipeline-9lbhp-hdfs in namespace wangyuhan has reached the expected condition: Succeeded.
INFO:launch_crd:Deleteing kubeflow.org/tfjobs ml-e2e-pipeline-9lbhp-hdfs in namespace wangyuhan.
INFO:launch_crd:Deleted kubeflow.org/tfjobs ml-e2e-pipeline-9lbhp-hdfs in namespace wangyuhan.


=========== Pod "ml-e2e-pipeline-9lbhp-hdfs-worker-0" log ============

WARNING: Logging before flag parsing goes to stderr.
W0224 11:35:51.424665 140650391357248 deprecation.py:323] From /usr/local/lib/python2.7/dist-packages/tensorflow/python/compat/v2_compat.py:61: disable_resource_variables (from tensorflow.python.ops.variable_scope) is deprecated and will be removed in a future version.
Instructions for updating:
non-resource variables are not supported in the long term
W0224 11:35:51.847697 140650391357248 deprecation.py:323] From /work/main.py:39: conv2d (from tensorflow.python.layers.convolutional) is deprecated and will be removed in a future version.
Instructions for updating:
Use `tf.keras.layers.Conv2D` instead.
W0224 11:35:51.850488 140650391357248 deprecation.py:506] From /usr/local/lib/python2.7/dist-packages/tensorflow/python/ops/init_ops.py:1251: calling __init__ (from tensorflow.python.ops.init_ops) with dtype is deprecated and will be removed in a future version.
Instructions for updating:
Call initializer instance with the dtype argument instead of passing it to the constructor
W0224 11:35:52.039252 140650391357248 deprecation.py:323] From /work/main.py:40: max_pooling2d (from tensorflow.python.layers.pooling) is deprecated and will be removed in a future version.
Instructions for updating:
Use keras.layers.MaxPooling2D instead.
W0224 11:35:52.164997 140650391357248 deprecation.py:323] From /work/main.py:44: dense (from tensorflow.python.layers.core) is deprecated and will be removed in a future version.
Instructions for updating:
Use keras.layers.dense instead.
W0224 11:35:52.414972 140650391357248 deprecation.py:323] From /work/main.py:45: dropout (from tensorflow.python.layers.core) is deprecated and will be removed in a future version.
Instructions for updating:
Use keras.layers.dropout instead.
2022-02-24 11:35:52.653593: I tensorflow/core/platform/cpu_feature_guard.cc:142] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 AVX512F FMA
2022-02-24 11:35:52.661210: I tensorflow/core/platform/profile_utils/cpu_utils.cc:94] CPU Frequency: 2200000000 Hz
2022-02-24 11:35:52.664640: I tensorflow/compiler/xla/service/service.cc:168] XLA service 0x55b5e4716ea0 executing computations on platform Host. Devices:
2022-02-24 11:35:52.664665: I tensorflow/compiler/xla/service/service.cc:175]   StreamExecutor device (0): <undefined>, <undefined>
2022-02-24 11:35:52.749272: W tensorflow/compiler/jit/mark_for_compilation_pass.cc:1412] (One-time warning): Not using XLA:CPU for cluster because envvar TF_XLA_FLAGS=--tf_xla_cpu_global_jit was not set.  If you want XLA:CPU, either set that envvar, or use experimental_jit_scope to enable XLA:CPU.  To confirm that XLA is active, pass --vmodule=xla_compilation_cache=1 (as a proper command-line flag, not via TF_XLA_FLAGS) or set the envvar XLA_FLAGS=--xla_hlo_profile.
W0224 11:35:58.705255 140650391357248 deprecation.py:323] From /work/main.py:105: simple_save (from tensorflow.python.saved_model.simple_save) is deprecated and will be removed in a future version.
Instructions for updating:
This function will only be available through the v1 compatibility library as tf.compat.v1.saved_model.simple_save.
W0224 11:35:58.705485 140650391357248 deprecation.py:323] From /usr/local/lib/python2.7/dist-packages/tensorflow/python/saved_model/signature_def_utils_impl.py:201: build_tensor_info (from tensorflow.python.saved_model.utils_impl) is deprecated and will be removed in a future version.
Instructions for updating:
This function will only be available through the v1 compatibility library as tf.compat.v1.saved_model.utils.build_tensor_info or tf.compat.v1.saved_model.build_tensor_info.
Loading training data...
train_data len: 28
test_data len: 2
('Epoch:', '0001', 'Avg. loss =', '2.381')
('Epoch:', '0002', 'Avg. loss =', '1.836')
('Epoch:', '0003', 'Avg. loss =', '1.180')
('Epoch:', '0004', 'Avg. loss =', '0.423')
('Epoch:', '0005', 'Avg. loss =', '0.135')
('Epoch:', '0006', 'Avg. loss =', '0.106')
('Epoch:', '0007', 'Avg. loss =', '0.134')
('Epoch:', '0008', 'Avg. loss =', '0.085')
('Epoch:', '0009', 'Avg. loss =', '0.008')
('Epoch:', '0010', 'Avg. loss =', '0.004')
('Epoch:', '0011', 'Avg. loss =', '0.002')
('Epoch:', '0012', 'Avg. loss =', '0.001')
('Epoch:', '0013', 'Avg. loss =', '0.001')
('Epoch:', '0014', 'Avg. loss =', '0.001')
('Epoch:', '0015', 'Avg. loss =', '0.001')
('Epoch:', '0016', 'Avg. loss =', '0.001')
('Epoch:', '0017', 'Avg. loss =', '0.000')
('Epoch:', '0018', 'Avg. loss =', '0.000')
('Epoch:', '0019', 'Avg. loss =', '0.000')
('Epoch:', '0020', 'Avg. loss =', '0.000')
Training Complete!
Accuracy: 50.00%


======================================================================================
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
