### PR TITLE
Feat(frontend, sdk) towards namespaced pipelines - issue #4197

### DIFF
--- a/backend/api/go_http_client/pipeline_upload_client/pipeline_upload_service/upload_pipeline_parameters.go
+++ b/backend/api/go_http_client/pipeline_upload_client/pipeline_upload_service/upload_pipeline_parameters.go
@@ -65,6 +65,8 @@ type UploadPipelineParams struct {
 	Description *string
 	/*Name*/
 	Name *string
+	/*Namespace*/
+	Namespace *string
 	/*Uploadfile
 	  The pipeline to upload. Maximum size of 32MB is supported.
 
@@ -131,6 +133,17 @@ func (o *UploadPipelineParams) SetName(name *string) {
 	o.Name = name
 }
 
+// WithNamespace adds the namespace to the upload pipeline params
+func (o *UploadPipelineParams) WithNamespace(namespace *string) *UploadPipelineParams {
+	o.SetNamespace(namespace)
+	return o
+}
+
+// SetNamespace adds the namespace to the upload pipeline params
+func (o *UploadPipelineParams) SetNamespace(namespace *string) {
+	o.Namespace = namespace
+}
+
 // WithUploadfile adds the uploadfile to the upload pipeline params
 func (o *UploadPipelineParams) WithUploadfile(uploadfile runtime.NamedReadCloser) *UploadPipelineParams {
 	o.SetUploadfile(uploadfile)
@@ -176,6 +189,22 @@ func (o *UploadPipelineParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		qName := qrName
 		if qName != "" {
 			if err := r.SetQueryParam("name", qName); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	if o.Namespace != nil {
+
+		// query param namespace
+		var qrNamespace string
+		if o.Namespace != nil {
+			qrNamespace = *o.Namespace
+		}
+		qNamespace := qrNamespace
+		if qNamespace != "" {
+			if err := r.SetQueryParam("namespace", qNamespace); err != nil {
 				return err
 			}
 		}

--- a/backend/api/swagger/kfp_api_single_file.swagger.json
+++ b/backend/api/swagger/kfp_api_single_file.swagger.json
@@ -1367,6 +1367,12 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "namespace",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [

--- a/backend/api/swagger/pipeline.upload.swagger.json
+++ b/backend/api/swagger/pipeline.upload.swagger.json
@@ -51,7 +51,13 @@
             "in": "query",
             "required": false,
             "type": "string"
-          }
+          },
+	  {
+            "name": "namespace",
+	    "in": "query",
+	    "required": false,
+	    "type": "string"
+	  }
         ],
         "tags": [
           "PipelineUploadService"

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -343,7 +343,7 @@ export class Apis {
       '/pipelines/upload_version',
       v1beta1Prefix,
       `name=${encodeURIComponent(versionName)}&pipelineid=${encodeURIComponent(pipelineId)}` +
-	 (namespace != undefined ? `&namespace=${encodeURIComponent(namespace)}` : ''),
+        (namespace != undefined ? `&namespace=${encodeURIComponent(namespace)}` : ''),
       {
         body: fd,
         cache: 'no-cache',

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -313,6 +313,7 @@ export class Apis {
     pipelineName: string,
     pipelineDescription: string,
     pipelineData: File,
+    namespace?: string,
   ): Promise<ApiPipeline> {
     const fd = new FormData();
     fd.append('uploadfile', pipelineData, pipelineData.name);
@@ -321,7 +322,7 @@ export class Apis {
       v1beta1Prefix,
       `name=${encodeURIComponent(pipelineName)}&description=${encodeURIComponent(
         pipelineDescription,
-      )}`,
+      )}` + (namespace != undefined ? `&namespace=${encodeURIComponent(namespace)}` : ''),
       {
         body: fd,
         cache: 'no-cache',
@@ -334,13 +335,15 @@ export class Apis {
     versionName: string,
     pipelineId: string,
     versionData: File,
+    namespace?: string,
   ): Promise<ApiPipelineVersion> {
     const fd = new FormData();
     fd.append('uploadfile', versionData, versionData.name);
     return await this._fetchAndParse<ApiPipelineVersion>(
       '/pipelines/upload_version',
       v1beta1Prefix,
-      `name=${encodeURIComponent(versionName)}&pipelineid=${encodeURIComponent(pipelineId)}`,
+      `name=${encodeURIComponent(versionName)}&pipelineid=${encodeURIComponent(pipelineId)}` +
+	 (namespace != undefined ? `&namespace=${encodeURIComponent(namespace)}` : ''),
       {
         body: fd,
         cache: 'no-cache',

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -49,6 +49,8 @@ import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import { compareGraphEdges, transitiveReduction } from '../lib/StaticGraphParser';
 import ReduceGraphSwitch from '../components/ReduceGraphSwitch';
+import { useNamespaceChangeEvent } from 'src/lib/KubeflowClient';
+import { Redirect } from 'react-router-dom';
 
 interface PipelineDetailsState {
   graph: dagre.graphlib.Graph | null;
@@ -112,7 +114,7 @@ export const css = stylesheet({
   },
 });
 
-class PipelineDetails extends Page<{}, PipelineDetailsState> {
+export class PipelineDetails extends Page<{}, PipelineDetailsState> {
   constructor(props: any) {
     super(props);
 
@@ -604,4 +606,15 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
   }
 }
 
-export default PipelineDetails;
+const EnhancedPipelineDetails: React.FC<PageProps> = props => {
+  // When namespace changes, this pipeline no longer belongs to new namespace.
+  // So we redirect to pipeline list page instead.
+  const namespaceChanged = useNamespaceChangeEvent();
+  if (namespaceChanged) {
+    return <Redirect to={RoutePage.PIPELINES} />;
+  }
+
+  return <PipelineDetails {...props} />;
+};
+
+export default EnhancedPipelineDetails;

--- a/frontend/src/pages/PipelineList.test.tsx
+++ b/frontend/src/pages/PipelineList.test.tsx
@@ -73,7 +73,8 @@ describe('PipelineList', () => {
       });
   }
 
-  async function mountWithNPipelines(n: number,
+  async function mountWithNPipelines(
+    n: number,
     { namespace }: { namespace?: string } = {},
   ): Promise<ReactWrapper> {
     listPipelinesSpy.mockImplementation(() => ({
@@ -163,7 +164,14 @@ describe('PipelineList', () => {
     listPipelinesSpy.mockImplementationOnce(() => ({ pipelines: [{ name: 'pipeline1' }] }));
     tree = TestUtils.mountWithRouter(<PipelineList {...generateProps()} />);
     await listPipelinesSpy;
-    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '', undefined, undefined);
+    expect(listPipelinesSpy).toHaveBeenLastCalledWith(
+      '',
+      10,
+      'created_at desc',
+      '',
+      undefined,
+      undefined,
+    );
     expect(tree.state()).toHaveProperty('displayPipelines', [
       { expandState: 0, name: 'pipeline1' },
     ]);
@@ -177,7 +185,14 @@ describe('PipelineList', () => {
     expect(refreshBtn).toBeDefined();
     await refreshBtn!.action();
     expect(listPipelinesSpy.mock.calls.length).toBe(2);
-    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '', undefined, undefined);
+    expect(listPipelinesSpy).toHaveBeenLastCalledWith(
+      '',
+      10,
+      'created_at desc',
+      '',
+      undefined,
+      undefined,
+    );
     expect(updateBannerSpy).toHaveBeenLastCalledWith({});
   });
 
@@ -203,7 +218,14 @@ describe('PipelineList', () => {
     TestUtils.makeErrorResponseOnce(listPipelinesSpy, 'bad stuff happened');
     await refreshBtn!.action();
     expect(listPipelinesSpy.mock.calls.length).toBe(2);
-    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '', undefined, undefined);
+    expect(listPipelinesSpy).toHaveBeenLastCalledWith(
+      '',
+      10,
+      'created_at desc',
+      '',
+      undefined,
+      undefined,
+    );
     expect(updateBannerSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
         additionalInfo: 'bad stuff happened',
@@ -581,26 +603,26 @@ describe('PipelineList', () => {
   });
 
   it("doesn't keep error message for request from previous namespace", async () => {
-      listPipelinesSpy.mockImplementation(() => Promise.reject('namespace cannot be empty'));
-      const { rerender } = render(
-        <MemoryRouter>
-          <NamespaceContext.Provider value={undefined}>
-            <EnhancedPipelineList {...generateProps()} />
-          </NamespaceContext.Provider>
-        </MemoryRouter>,
-      );
+    listPipelinesSpy.mockImplementation(() => Promise.reject('namespace cannot be empty'));
+    const { rerender } = render(
+      <MemoryRouter>
+        <NamespaceContext.Provider value={undefined}>
+          <EnhancedPipelineList {...generateProps()} />
+        </NamespaceContext.Provider>
+      </MemoryRouter>,
+    );
 
-      listPipelinesSpy.mockImplementation(mockListNPipelines());
-      rerender(
-        <MemoryRouter>
-          <NamespaceContext.Provider value={'test-ns'}>
-            <EnhancedPipelineList {...generateProps()} />
-          </NamespaceContext.Provider>
-        </MemoryRouter>,
-      );
-      await act(TestUtils.flushPromises);
-      expect(updateBannerSpy).toHaveBeenLastCalledWith(
-        {}, // Empty object means banner has no error message
-      );
+    listPipelinesSpy.mockImplementation(mockListNPipelines());
+    rerender(
+      <MemoryRouter>
+        <NamespaceContext.Provider value={'test-ns'}>
+          <EnhancedPipelineList {...generateProps()} />
+        </NamespaceContext.Provider>
+      </MemoryRouter>,
+    );
+    await act(TestUtils.flushPromises);
+    expect(updateBannerSpy).toHaveBeenLastCalledWith(
+      {}, // Empty object means banner has no error message
+    );
   });
 });

--- a/frontend/src/pages/PipelineList.test.tsx
+++ b/frontend/src/pages/PipelineList.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from 'react';
-import PipelineList from './PipelineList';
+import EnhancedPipelineList, { PipelineList } from './PipelineList';
 import TestUtils from '../TestUtils';
 import { Apis } from '../lib/Apis';
 import { PageProps } from './Page';
@@ -23,6 +23,9 @@ import { RoutePage, RouteParams } from '../components/Router';
 import { shallow, ReactWrapper, ShallowWrapper } from 'enzyme';
 import { range } from 'lodash';
 import { ButtonKeys } from '../lib/Buttons';
+import { render, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { NamespaceContext } from 'src/lib/KubeflowClient';
 
 describe('PipelineList', () => {
   let tree: ReactWrapper | ShallowWrapper;
@@ -60,7 +63,19 @@ describe('PipelineList', () => {
     );
   }
 
-  async function mountWithNPipelines(n: number): Promise<ReactWrapper> {
+  function mockListNPipelines(n: number = 1) {
+    return () =>
+      Promise.resolve({
+        pipelines: range(n).map(i => ({
+          id: 'test-pipeline-id' + i,
+          name: 'test pipeline name' + i,
+        })),
+      });
+  }
+
+  async function mountWithNPipelines(n: number,
+    { namespace }: { namespace?: string } = {},
+  ): Promise<ReactWrapper> {
     listPipelinesSpy.mockImplementation(() => ({
       pipelines: range(n).map(i => ({
         id: 'test-pipeline-id' + i,
@@ -71,7 +86,7 @@ describe('PipelineList', () => {
         },
       })),
     }));
-    tree = TestUtils.mountWithRouter(<PipelineList {...generateProps()} />);
+    tree = TestUtils.mountWithRouter(<PipelineList {...generateProps()} namespace={namespace} />);
     await listPipelinesSpy;
     await TestUtils.flushPromises();
     tree.update(); // Make sure the tree is updated before returning it
@@ -86,7 +101,9 @@ describe('PipelineList', () => {
   afterEach(async () => {
     // unmount() should be called before resetAllMocks() in case any part of the unmount life cycle
     // depends on mocks/spies
-    await tree.unmount();
+    if (tree.exists()) {
+      await tree.unmount();
+    }
     jest.restoreAllMocks();
   });
 
@@ -146,7 +163,7 @@ describe('PipelineList', () => {
     listPipelinesSpy.mockImplementationOnce(() => ({ pipelines: [{ name: 'pipeline1' }] }));
     tree = TestUtils.mountWithRouter(<PipelineList {...generateProps()} />);
     await listPipelinesSpy;
-    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '');
+    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '', undefined, undefined);
     expect(tree.state()).toHaveProperty('displayPipelines', [
       { expandState: 0, name: 'pipeline1' },
     ]);
@@ -160,7 +177,7 @@ describe('PipelineList', () => {
     expect(refreshBtn).toBeDefined();
     await refreshBtn!.action();
     expect(listPipelinesSpy.mock.calls.length).toBe(2);
-    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '');
+    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '', undefined, undefined);
     expect(updateBannerSpy).toHaveBeenLastCalledWith({});
   });
 
@@ -186,7 +203,7 @@ describe('PipelineList', () => {
     TestUtils.makeErrorResponseOnce(listPipelinesSpy, 'bad stuff happened');
     await refreshBtn!.action();
     expect(listPipelinesSpy.mock.calls.length).toBe(2);
-    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '');
+    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '', undefined, undefined);
     expect(updateBannerSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
         additionalInfo: 'bad stuff happened',
@@ -561,5 +578,29 @@ describe('PipelineList', () => {
       message: 'Deletion succeeded for 1 pipeline and 1 pipeline version',
       open: true,
     });
+  });
+
+  it("doesn't keep error message for request from previous namespace", async () => {
+      listPipelinesSpy.mockImplementation(() => Promise.reject('namespace cannot be empty'));
+      const { rerender } = render(
+        <MemoryRouter>
+          <NamespaceContext.Provider value={undefined}>
+            <EnhancedPipelineList {...generateProps()} />
+          </NamespaceContext.Provider>
+        </MemoryRouter>,
+      );
+
+      listPipelinesSpy.mockImplementation(mockListNPipelines());
+      rerender(
+        <MemoryRouter>
+          <NamespaceContext.Provider value={'test-ns'}>
+            <EnhancedPipelineList {...generateProps()} />
+          </NamespaceContext.Provider>
+        </MemoryRouter>,
+      );
+      await act(TestUtils.flushPromises);
+      expect(updateBannerSpy).toHaveBeenLastCalledWith(
+        {}, // Empty object means banner has no error message
+      );
   });
 });

--- a/frontend/src/pages/PipelineList.tsx
+++ b/frontend/src/pages/PipelineList.tsx
@@ -251,18 +251,21 @@ export class PipelineList extends Page<{ namespace?: string }, PipelineListState
     try {
       method === ImportMethod.LOCAL
         ? await Apis.uploadPipeline(name, description || '', file!, this.props.namespace)
-        : await Apis.pipelineServiceApi.createPipeline({ name, url: { pipeline_url: url },
-        resource_references: this.props.namespace
-        ? [
-            {
-              key: {
-                id: this.props.namespace,
-                type: ApiResourceType.NAMESPACE,
-              },
-              relationship: ApiRelationship.OWNER,
-            },
-        ]: '',
-      });
+        : await Apis.pipelineServiceApi.createPipeline({
+            name,
+            url: { pipeline_url: url },
+            resource_references: this.props.namespace
+              ? [
+                  {
+                    key: {
+                      id: this.props.namespace,
+                      type: ApiResourceType.NAMESPACE,
+                    },
+                    relationship: ApiRelationship.OWNER,
+                  },
+                ]
+              : '',
+          });
 
       this.setStateSafe({ uploadDialogOpen: false });
       this.refresh();

--- a/frontend/src/pages/PipelineList.tsx
+++ b/frontend/src/pages/PipelineList.tsx
@@ -36,6 +36,7 @@ import { formatDateString, errorToMessage } from '../lib/Utils';
 import { Description } from '../components/Description';
 import produce from 'immer';
 import Tooltip from '@material-ui/core/Tooltip';
+import { NamespaceContext } from 'src/lib/KubeflowClient';
 
 interface DisplayPipeline extends ApiPipeline {
   expandState?: ExpandState;
@@ -57,7 +58,7 @@ const descriptionCustomRenderer: React.FC<CustomRendererProps<string>> = (
   return <Description description={props.value || ''} forceInline={true} />;
 };
 
-class PipelineList extends Page<{}, PipelineListState> {
+export class PipelineList extends Page<{ namespace?: string }, PipelineListState> {
   private _tableRef = React.createRef<CustomTable>();
 
   constructor(props: any) {
@@ -176,6 +177,8 @@ class PipelineList extends Page<{}, PipelineListState> {
         request.pageSize,
         request.sortBy,
         request.filter,
+        this.props.namespace ? 'NAMESPACE' : undefined,
+        this.props.namespace || undefined,
       );
       displayPipelines = response.pipelines || [];
       displayPipelines.forEach(exp => (exp.expandState = ExpandState.COLLAPSED));
@@ -247,8 +250,20 @@ class PipelineList extends Page<{}, PipelineListState> {
 
     try {
       method === ImportMethod.LOCAL
-        ? await Apis.uploadPipeline(name, description || '', file!)
-        : await Apis.pipelineServiceApi.createPipeline({ name, url: { pipeline_url: url } });
+        ? await Apis.uploadPipeline(name, description || '', file!, this.props.namespace)
+        : await Apis.pipelineServiceApi.createPipeline({ name, url: { pipeline_url: url },
+        resource_references: this.props.namespace
+        ? [
+            {
+              key: {
+                id: this.props.namespace,
+                type: ApiResourceType.NAMESPACE,
+              },
+              relationship: ApiRelationship.OWNER,
+            },
+        ]: '',
+      });
+
       this.setStateSafe({ uploadDialogOpen: false });
       this.refresh();
       return true;
@@ -264,4 +279,9 @@ class PipelineList extends Page<{}, PipelineListState> {
   }
 }
 
-export default PipelineList;
+const EnhancedPipelineList: React.FC<PageProps> = props => {
+  const namespace = React.useContext(NamespaceContext);
+  return <PipelineList key={namespace} {...props} namespace={namespace} />;
+};
+
+export default EnhancedPipelineList;

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -945,7 +945,6 @@ class Client(object):
     pipeline_version_name: str,
     pipeline_id: Optional[str] = None,
     pipeline_name: Optional[str] = None,
-    namespace: Optional[str] = None,
   ):
     """Uploads a new version of the pipeline to the Kubeflow Pipelines cluster.
     Args:
@@ -953,7 +952,6 @@ class Client(object):
       pipeline_version_name:  Name of the pipeline version to be shown in the UI.
       pipeline_id: Optional. Id of the pipeline.
       pipeline_name: Optional. Name of the pipeline.
-      namespace: Optional. Namespace for the pipeline.
     Returns:
       Server response object containing pipleine id and other information.
     Throws:
@@ -971,7 +969,6 @@ class Client(object):
       pipeline_package_path,
       name=pipeline_version_name,
       pipelineid=pipeline_id,
-      namespace=namespace,
     )
 
     if self._is_ipython():

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -917,6 +917,7 @@ class Client(object):
     pipeline_package_path: str = None,
     pipeline_name: str = None,
     description: str = None,
+    namespace: str = None,
   ):
     """Uploads the pipeline to the Kubeflow Pipelines cluster.
 
@@ -924,12 +925,14 @@ class Client(object):
       pipeline_package_path: Local path to the pipeline package.
       pipeline_name: Optional. Name of the pipeline to be shown in the UI.
       description: Optional. Description of the pipeline to be shown in the UI.
+      namespace: Optional. Namespace of the pipeline.
 
     Returns:
       Server response object containing pipleine id and other information.
     """
 
-    response = self._upload_api.upload_pipeline(pipeline_package_path, name=pipeline_name, description=description)
+    response = self._upload_api.upload_pipeline(pipeline_package_path, name=pipeline_name, 
+            description=description, namespace=namespace)
     if self._is_ipython():
       import IPython
       html = '<a href=%s/#/pipelines/details/%s>Pipeline details</a>.' % (self._get_url_prefix(), response.id)
@@ -941,7 +944,8 @@ class Client(object):
     pipeline_package_path,
     pipeline_version_name: str,
     pipeline_id: Optional[str] = None,
-    pipeline_name: Optional[str] = None
+    pipeline_name: Optional[str] = None,
+    namespace: Optional[str] = None,
   ):
     """Uploads a new version of the pipeline to the Kubeflow Pipelines cluster.
     Args:
@@ -949,6 +953,7 @@ class Client(object):
       pipeline_version_name:  Name of the pipeline version to be shown in the UI.
       pipeline_id: Optional. Id of the pipeline.
       pipeline_name: Optional. Name of the pipeline.
+      namespace: Optional. Namespace for the pipeline.
     Returns:
       Server response object containing pipleine id and other information.
     Throws:
@@ -965,7 +970,8 @@ class Client(object):
     response = self._upload_api.upload_pipeline_version(
       pipeline_package_path,
       name=pipeline_version_name,
-      pipelineid=pipeline_id
+      pipelineid=pipeline_id,
+      namespace=namespace,
     )
 
     if self._is_ipython():


### PR DESCRIPTION
Add some features to limit users' access to pipelines to pipelines in the user's own namespace and non-namespaced pipelines, in the web front end and in the Python SDK. The necessary backend RBAC hooks are already available and implemented.
Note that I think relevant CRDs, roles and rolebindings will still be needed in order to properly close the circle on this.
