### PR TITLE
feat(sdk): add clone_recurring_run method

### DIFF
--- a/manifests/kustomize/env/aws/README.md
+++ b/manifests/kustomize/env/aws/README.md
@@ -30,7 +30,7 @@ aws s3 mb s3://$S3_BUCKET --region $AWS_REGION
 
 3. Prepare RDS
 
-Follow this [doc](https://www.kubeflow.org/docs/aws/rds/#deploy-amazon-rds-mysql-in-your-environment) to set up AWS RDS instance.
+Follow this [doc](https://awslabs.github.io/kubeflow-manifests/docs/deployment/rds-s3/guide/) to set up AWS RDS instance.
 
 4. Customize your values
 - Edit [params.env](params.env), [secret.env](secret.env) and [minio-artifact-secret-patch.env](minio-artifact-secret-patch.env)


### PR DESCRIPTION
Co-authored-by: js0823 <js0823@gmail.com>
Co-authored-by: travischeung <travis.cheung98@gmail.com>

**Description of your changes:**
There's no way to patch an existing recurring run via the SDK (or GUI), which is a little bit odd given that Argo Workflows supports patching CronWorkflows, but perhaps the goal is to make recurring runs immutable, which makes sense. The GUI gets around this with the `clone recurring run` button, but there's no equivalent in the SDK.

To address this feature gap, this PR adds a `clone_recurring_run` method to the SDK. The docstring is copied almost verbatim from the `create_recurring_run` method. 

We're completely amenable to feedback / input. If exposing patching capabilities makes more sense, we're happy to contribute to that as well.

We're also happy to add a `clone_run` method. 

On a separate note, bandwidth permitting, we might be able to start contributing unit test coverage to the SDK.

We'd also be happy to make a pass through of the SDK to contribute some improved formatting and line-wrapping to the docstrings. Happy to open a standalone issue if that seems reasonable. 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 