### PR TITLE
fix(sdk): require google-api-core>=1.31.5, >=2.3.2

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -42,6 +42,7 @@
 * Fix importer not using correct output artifact type [\#7235](https://github.com/kubeflow/pipelines/pull/7235)
 * Add verify_ssl for Kubeflow client [\#7174](https://github.com/kubeflow/pipelines/pull/7174)
 * Depends on `typing-extensions>=3.7.4,<5; python_version<"3.9"` [\#7288](https://github.com/kubeflow/pipelines/pull/7288)
+* Depends on `google-api-core>=1.31.5, >=2.3.2` [\#7377](https://github.com/kubeflow/pipelines/pull/7377)
 
 ## Documentation Updates
 

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -20,6 +20,7 @@ kubernetes>=8.0.0,<19
 kfp-server-api>=1.1.2,<2.0.0
 
 # kfp.Client GCP auth
+google-api-core>=1.31.5,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0
 google-cloud-storage>=1.20.0,<2
 google-auth>=1.6.1,<3
 requests-toolbelt>=0.8.0,<1

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -29,8 +29,9 @@ docstring-parser==0.11
     # via -r requirements.in
 fire==0.4.0
     # via -r requirements.in
-google-api-core==1.31.3
+google-api-core==2.6.0
     # via
+    #   -r requirements.in
     #   google-cloud-core
     #   google-cloud-storage
 google-auth==1.35.0
@@ -62,8 +63,6 @@ kubernetes==18.20.0
     # via -r requirements.in
 oauthlib==3.1.1
     # via requests-oauthlib
-packaging==21.0
-    # via google-api-core
 protobuf==3.17.3
     # via
     #   google-api-core
@@ -78,16 +77,12 @@ pyasn1-modules==0.2.8
     # via google-auth
 pydantic==1.8.2
     # via -r requirements.in
-pyparsing==2.4.7
-    # via packaging
 pyrsistent==0.18.0
     # via jsonschema
 python-dateutil==2.8.2
     # via
     #   kfp-server-api
     #   kubernetes
-pytz==2021.3
-    # via google-api-core
 pyyaml==5.4.1
     # via
     #   -r requirements.in
@@ -109,7 +104,6 @@ six==1.16.0
     # via
     #   absl-py
     #   fire
-    #   google-api-core
     #   google-auth
     #   google-cloud-storage
     #   jsonschema
@@ -125,10 +119,8 @@ termcolor==1.1.0
     # via fire
 typer==0.4.0
     # via -r requirements.in
-typing-extensions==3.10.0.2 ; python_version < "3.9"
-    # via
-    #   -r requirements.in
-    #   pydantic
+typing-extensions==3.10.0.2
+    # via pydantic
 uritemplate==3.0.1
     # via -r requirements.in
 urllib3==1.26.7

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -25,6 +25,9 @@ NAME = 'kfp'
 REQUIRES = [
     'absl-py>=0.9,<2',
     'PyYAML>=5.3,<6',
+    # Pin google-api-core version for the bug fixing in 1.31.5
+    # https://github.com/googleapis/python-api-core/releases/tag/v1.31.5
+    'google-api-core>=1.31.5,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0',
     # `Blob.from_string` was introduced in google-cloud-storage 1.20.0
     # https://github.com/googleapis/python-storage/blob/master/CHANGELOG.md#1200
     'google-cloud-storage>=1.20.0,<2',


### PR DESCRIPTION
**Description of your changes:**
Require google-api-core>=1.31.5, >=2.3.2, to avoid the bug exists before these versions. See the python-api-core release notes for details.
- https://github.com/googleapis/python-api-core/releases/tag/v1.31.5
- https://github.com/googleapis/python-api-core/releases/tag/v2.3.2

KFP SDK does not have a direct dependency on `google-api-core`, but gets it via `google-cloud-storage`, which got the same fix (https://github.com/googleapis/python-storage/commit/e9aab389f868799d4425133954bad4f1cbb85786) but not released yet. Until we can depend on a newer version of `google-cloud-storage`, we need to temporarily pin `google-api-core` versions from our end.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
