### PR TITLE
chore(sdk): remove unused imports and variables

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -33,11 +33,9 @@ from kfp.compiler import pipeline_spec_builder as builder
 from kfp.components import utils as component_utils
 from kfp.components import component_factory
 from kfp.components import for_loop
-from kfp.components import pipeline_channel
 from kfp.components import pipeline_context
 from kfp.components import pipeline_task
 from kfp.components import tasks_group
-from kfp.components.types import artifact_types
 from kfp.components.types import type_utils
 
 _GroupOrTask = Union[tasks_group.TasksGroup, pipeline_task.PipelineTask]
@@ -557,7 +555,6 @@ class Compiler:
         for task in pipeline.tasks.values():
             # task's inputs and all channels used in conditions for that task are
             # considered.
-            task_inputs = task.channel_inputs
             task_condition_inputs = list(condition_channels[task.name])
 
             for channel in task.channel_inputs + task_condition_inputs:

--- a/sdk/python/kfp/compiler/main.py
+++ b/sdk/python/kfp/compiler/main.py
@@ -19,7 +19,6 @@ import os
 import sys
 from typing import Any, Callable, List, Mapping, Optional
 
-import kfp.deprecated.dsl as dsl
 from kfp import compiler
 from kfp.components import pipeline_context
 

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -124,8 +124,6 @@ def build_task_spec_for_task(
         task.task_spec.enable_caching)
 
     for input_name, input_value in task.inputs.items():
-        input_type = task.component_spec.inputs[input_name].type
-
         if isinstance(input_value, pipeline_channel.PipelineArtifactChannel):
 
             if input_value.task_name:
@@ -571,7 +569,6 @@ def _update_task_spec_for_loop_group(
                     _additional_input_name_for_pipeline_channel(
                         loop_items_channel.loop_argument))
 
-        remove_input_name = loop_argument_item_name
     else:
         input_parameter_name = _additional_input_name_for_pipeline_channel(
             group.loop_argument)
@@ -603,8 +600,6 @@ def _resolve_condition_operands(
     """
 
     # Pre-scan the operand to get the type of constant value if there's any.
-    # The value_type can be used to backfill missing PipelineChannel.channel_type.
-    value_type = None
     for value_or_reference in [left_operand, right_operand]:
         if isinstance(value_or_reference, pipeline_channel.PipelineChannel):
             parameter_type = type_utils.get_parameter_type(
@@ -871,7 +866,6 @@ def populate_metrics_in_dag_outputs(
         pipeline_spec: The pipeline_spec to update in-place.
     """
     for task in tasks:
-        task_spec = task_name_to_task_spec[task.name]
         component_spec = task_name_to_component_spec[task.name]
 
         # Get the tuple of (component_name, task_name) of all its parent groups.

--- a/sdk/python/kfp/compiler/pipeline_spec_builder_test.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder_test.py
@@ -16,12 +16,10 @@
 import unittest
 
 from absl.testing import parameterized
-from google.protobuf import json_format
 from google.protobuf import struct_pb2
 from kfp.pipeline_spec import pipeline_spec_pb2
 from kfp.compiler import pipeline_spec_builder
 from kfp.components import pipeline_channel
-from kfp.components import structures
 
 
 class PipelineSpecBuilderTest(parameterized.TestCase):

--- a/sdk/python/kfp/components/for_loop.py
+++ b/sdk/python/kfp/components/for_loop.py
@@ -14,7 +14,7 @@
 """Classes and methods that supports argument for ParallelFor."""
 
 import re
-from typing import Any, Dict, List, Optional, Tuple, Union, get_type_hints
+from typing import Any, Dict, List, Optional, Union
 
 from kfp.components import pipeline_channel
 

--- a/sdk/python/kfp/components/pipeline_channel.py
+++ b/sdk/python/kfp/components/pipeline_channel.py
@@ -18,7 +18,6 @@ import json
 import re
 from typing import Dict, List, Optional, Union
 
-from kfp.components import utils
 from kfp.components.types import type_utils
 
 

--- a/sdk/python/kfp/components/pipeline_task_test.py
+++ b/sdk/python/kfp/components/pipeline_task_test.py
@@ -15,12 +15,10 @@
 
 import textwrap
 import unittest
-from typing import Union
 
 from absl.testing import parameterized
 from kfp.components import pipeline_task
 from kfp.components import structures
-from kfp.components import pipeline_channel
 
 V2_YAML = textwrap.dedent("""\
     name: component1


### PR DESCRIPTION
**Description of your changes:**
Removes unused imports and unused variables from v2.

This is mostly done via [autoflake](https://github.com/PyCQA/autoflake) (with some additional modifications):
```sh
autoflake --in-place --remove-all-unused-imports --remove-unused-variables -v --exclude=__init__.py sdk/python/kfp/compiler/*.py sdk/python/kfp/compiler_cli_tests/*.py sdk/python/kfp/components/*.py sdk/python/kfp/dsl/*.py sdk/python/kfp/v2/*.py
```

_Note_: The variable `output` in [this codeblock](https://github.com/kubeflow/pipelines/blob/82d17ff616c5975f537dacf6c461040f2406e7e8/sdk/python/kfp/components/executor.py#L111-L121) is not currently doing anything. I left this unchanged, since 1) it's possible one path through this block could result in a `ValueError` and 2) I'm not totally sure if `output` _should_ be doing something. Perhaps we can leave this for now, since this is intended to be a PR without any functional changes.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
