### PR TITLE
feat(components/google-cloud): Expose reserved_ip_ranges as input spec for custom job

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/experimental/custom_job/utils.py
+++ b/components/google-cloud/google_cloud_pipeline_components/experimental/custom_job/utils.py
@@ -269,6 +269,8 @@ def create_custom_training_job_op_from_component(
           structures.InputSpec(
               name='network', type='String', optional=True, default=network),
           structures.InputSpec(
+              name='reserved_ip_ranges', type='JsonArray', optional=True, default=json.dumps(reserved_ip_ranges)),
+          structures.InputSpec(
               name='service_account',
               type='String',
               optional=True,

--- a/components/google-cloud/google_cloud_pipeline_components/v1/custom_job/utils.py
+++ b/components/google-cloud/google_cloud_pipeline_components/v1/custom_job/utils.py
@@ -277,6 +277,8 @@ def create_custom_training_job_op_from_component(
           structures.InputSpec(
               name='network', type='String', optional=True, default=network),
           structures.InputSpec(
+              name='reserved_ip_ranges', type='JsonArray', optional=True, default=json.dumps(reserved_ip_ranges)),
+          structures.InputSpec(
               name='service_account',
               type='String',
               optional=True,

--- a/components/google-cloud/tests/experimental/custom_job/unit/test_custom_job_utils.py
+++ b/components/google-cloud/tests/experimental/custom_job/unit/test_custom_job_utils.py
@@ -71,6 +71,11 @@ implementation:
             'default': '',
             'optional': True
         }, {
+            "name": "reserved_ip_ranges",
+            "type": "JsonArray",
+            "default": "[]",
+            "optional": True,
+        }, {
             'name': 'service_account',
             'type': 'String',
             'default': '',
@@ -112,6 +117,7 @@ implementation:
                     '"boot_disk_size_gb": 100}}], "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -220,6 +226,7 @@ implementation:
                     '"boot_disk_size_gb": 100}}], "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -277,6 +284,7 @@ implementation:
                     '"boot_disk_size_gb": 100}}], "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -326,6 +334,7 @@ implementation:
                     '2}, "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -377,6 +386,7 @@ implementation:
                     '"service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -426,6 +436,7 @@ implementation:
                     '"boot_disk_size_gb": 100}}], "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -474,6 +485,7 @@ implementation:
                     '"boot_disk_size_gb": 100}}], "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -522,6 +534,7 @@ implementation:
                     '"boot_disk_size_gb": 100}}], "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -571,6 +584,7 @@ implementation:
                     '"test_value"}, "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -620,6 +634,7 @@ implementation:
                     '["1.0.0.0", "2.0.0.0"], "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '

--- a/components/google-cloud/tests/v1/custom_job/unit/test_custom_job_utils.py
+++ b/components/google-cloud/tests/v1/custom_job/unit/test_custom_job_utils.py
@@ -71,6 +71,11 @@ implementation:
             'default': '',
             'optional': True
         }, {
+            "name": "reserved_ip_ranges",
+            "type": "JsonArray",
+            "default": "[]",
+            "optional": True,
+        }, {
             'name': 'service_account',
             'type': 'String',
             'default': '',
@@ -161,6 +166,7 @@ implementation:
                     '"boot_disk_size_gb": 100}}], "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -220,6 +226,7 @@ implementation:
                     '"boot_disk_size_gb": 100}}], "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -277,6 +284,7 @@ implementation:
                     '"boot_disk_size_gb": 100}}], "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -326,6 +334,7 @@ implementation:
                     '2}, "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -377,6 +386,7 @@ implementation:
                     '"service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -426,6 +436,7 @@ implementation:
                     '"boot_disk_size_gb": 100}}], "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -474,6 +485,7 @@ implementation:
                     '"boot_disk_size_gb": 100}}], "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -522,6 +534,7 @@ implementation:
                     '"boot_disk_size_gb": 100}}], "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -571,6 +584,7 @@ implementation:
                     '"test_value"}, "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -620,6 +634,7 @@ implementation:
                     '["1.0.0.0", "2.0.0.0"], "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '
@@ -669,6 +684,7 @@ implementation:
                     '[{"server": "s1", "path": "p1"}], "service_account": '
                     '"{{$.inputs.parameters[\'service_account\']}}", '
                     '"network": "{{$.inputs.parameters[\'network\']}}", '
+                    '"reserved_ip_ranges": "{{$.inputs.parameters[\'reserved_ip_ranges\']}}", '
                     '"tensorboard": '
                     '"{{$.inputs.parameters[\'tensorboard\']}}", '
                     '"base_output_directory": {"output_uri_prefix": '


### PR DESCRIPTION
**Description of your changes:**

Currently network is exposed at runtime. But since this impacts what network is being used this would also needed to be exposed at runtime. 

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
