### PR TITLE
fix(sdk): removed KFP client requirement for "kfp components build"

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -14,6 +14,37 @@
 
 ## Documentation Updates
 
+# 1.8.8
+
+## Major Features and Improvements
+
+* N/A
+
+## Breaking Changes
+
+* N/A
+
+### For Pipeline Authors
+
+* N/A
+
+### For Component Authors
+
+* N/A
+
+## Deprecations
+
+* N/A
+
+## Bug Fixes and Other Changes
+
+* Fix cloud scheduler's job name [\#6844](https://github.com/kubeflow/pipelines/pull/6844)
+* Add deprecation warnings for v2 [\#6851](https://github.com/kubeflow/pipelines/pull/6851)
+
+## Documentation Updates
+
+* N/A
+
 # 1.8.7
 
 ## Major Features and Improvements

--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -2,6 +2,8 @@
 
 ## Major Features and Improvements
 
+* Improve CLI experience for archiving experiments, managing recurring runs and listing resources [\#6934](https://github.com/kubeflow/pipelines/pull/6934)
+
 ## Breaking Changes
 
 ### For Pipeline Authors

--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -2,8 +2,6 @@
 
 ## Major Features and Improvements
 
-* Improve CLI experience for archiving experiments, managing recurring runs and listing resources [\#6934](https://github.com/kubeflow/pipelines/pull/6934)
-
 ## Breaking Changes
 
 ### For Pipeline Authors
@@ -15,6 +13,39 @@
 ## Bug Fixes and Other Changes
 
 ## Documentation Updates
+
+# 1.8.10
+
+## Major Features and Improvements
+
+* Improve CLI experience for archiving experiments, managing recurring runs and listing resources [\#6934](https://github.com/kubeflow/pipelines/pull/6934)
+
+## Breaking Changes
+
+* N/A
+
+### For Pipeline Authors
+
+* N/A
+
+### For Component Authors
+
+* N/A
+
+## Deprecations
+
+* N/A
+
+## Bug Fixes and Other Changes
+
+* Visualizations and metrics do not work with data_passing_methods. [\#6882](https://github.com/kubeflow/pipelines/pull/6882)
+* Fix a warning message. [\#6911](https://github.com/kubeflow/pipelines/pull/6911)
+* Refresh access token only when it expires. [\#6941](https://github.com/kubeflow/pipelines/pull/6941)
+* Fix bug in checking values in _param_values. [\#6965](https://github.com/kubeflow/pipelines/pull/6965)
+
+## Documentation Updates
+
+* N/A
 
 # 1.8.9
 

--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -2,6 +2,8 @@
 
 ## Major Features and Improvements
 
+* Add importer_spec metadata to v1 [\#7180](https://github.com/kubeflow/pipelines/pull/7180)
+
 ## Breaking Changes
 
 ### For Pipeline Authors

--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -14,6 +14,36 @@
 
 ## Documentation Updates
 
+# 1.8.9
+
+## Major Features and Improvements
+
+* N/A
+
+## Breaking Changes
+
+* N/A
+
+### For Pipeline Authors
+
+* N/A
+
+### For Component Authors
+
+* N/A
+
+## Deprecations
+
+* N/A
+
+## Bug Fixes and Other Changes
+
+* Make `Artifact` type be compatible with any sub-artifact types bidirectionally [\#6859](https://github.com/kubeflow/pipelines/pull/6859)
+
+## Documentation Updates
+
+* N/A
+
 # 1.8.8
 
 ## Major Features and Improvements

--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -2,9 +2,19 @@
 
 ## Major Features and Improvements
 
-* Add importer_spec metadata to v1 [\#7180](https://github.com/kubeflow/pipelines/pull/7180)
+* Support passing parameters in v2 using google.protobuf.Value [\#6804](https://github.com/kubeflow/pipelines/pull/6804).
+* Implement experimental v2 `@component` component [\#6825](https://github.com/kubeflow/pipelines/pull/6825)
+* Add load_component_from_* for v2 [\#6822](https://github.com/kubeflow/pipelines/pull/6822)
+* Merge v2 experimental change back to v2 namespace [\#6890](https://github.com/kubeflow/pipelines/pull/6890)
+* Add ImporterSpec v2 [\#6917](https://github.com/kubeflow/pipelines/pull/6917)
+* Add add set_env_variable for Pipeline task [\#6919](https://github.com/kubeflow/pipelines/pull/6919)
+* Add metadata field for importer [\#7112](https://github.com/kubeflow/pipelines/pull/7112)
 
 ## Breaking Changes
+
+* Remove sdk/python/kfp/v2/google directory for v2, including google client and custom job [\#6886](https://github.com/kubeflow/pipelines/pull/6886)
+* APIs imported from the v1 namespace are no longer supported by the v2 compiler. [\#6890](https://github.com/kubeflow/pipelines/pull/6890)
+* Deprecate v2 compatible mode in v1 compiler. [\#6958](https://github.com/kubeflow/pipelines/pull/6958)
 
 ### For Pipeline Authors
 
@@ -13,6 +23,42 @@
 ## Deprecations
 
 ## Bug Fixes and Other Changes
+
+* Fix importer ignoring reimport setting, and switch to Protobuf.Value for import uri [\#6827](https://github.com/kubeflow/pipelines/pull/6827)
+* Fix display name support for groups [\#6832](https://github.com/kubeflow/pipelines/pull/6832)
+* Fix regression on optional inputs [\#6905](https://github.com/kubeflow/pipelines/pull/6905) [\#6937](https://github.com/kubeflow/pipelines/pull/6937)
+* Depends on `google-auth>=1.6.1,<3` [\#6939](https://github.com/kubeflow/pipelines/pull/6939)
+* Change otherwise to else in yaml [\#6952](https://github.com/kubeflow/pipelines/pull/6952)
+* Avoid pydantic bug on Union type [\#6957](https://github.com/kubeflow/pipelines/pull/6957)
+* Fix bug for if and concat placeholders [\#6978](https://github.com/kubeflow/pipelines/pull/6978)
+* Fix bug for resourceSpec [\#6979](https://github.com/kubeflow/pipelines/pull/6979)
+* Fix regression on nested loops [\#6990](https://github.com/kubeflow/pipelines/pull/6990)
+* Fix bug for input/outputspec and positional arguments [\#6980](https://github.com/kubeflow/pipelines/pull/6980)
+
+## Documentation Updates
+
+# 1.8.11
+
+## Major Features and Improvements
+
+* kfp.Client uses namespace from initialization if set for the instance context [\#7056](https://github.com/kubeflow/pipelines/pull/7056)
+* Add importer_spec metadata to v1 [\#7180](https://github.com/kubeflow/pipelines/pull/7180)
+
+## Breaking Changes
+
+* Fix breaking change in Argo 3.0, to define TTL for workflows. Makes SDK incompatible with KFP pre-1.7 versions [\#7141](https://github.com/kubeflow/pipelines/pull/7141)
+
+### For Pipeline Authors
+
+### For Component Authors
+
+## Deprecations
+
+## Bug Fixes and Other Changes
+
+* Remove redundant check in set_gpu_limit [\#6866](https://github.com/kubeflow/pipelines/pull/6866)
+* Fix create_runtime_artifact not covering all types. [\#7168](https://github.com/kubeflow/pipelines/pull/7168)
+* Depend on `absl-py>=0.9,<2` [\#7172](https://github.com/kubeflow/pipelines/pull/7172)
 
 ## Documentation Updates
 

--- a/sdk/python/kfp/__init__.py
+++ b/sdk/python/kfp/__init__.py
@@ -16,7 +16,7 @@
 # https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
-__version__ = '1.8.10'
+__version__ = '1.8.11'
 
 from . import components
 from . import containers

--- a/sdk/python/kfp/__init__.py
+++ b/sdk/python/kfp/__init__.py
@@ -16,7 +16,7 @@
 # https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
-__version__ = '1.8.9'
+__version__ = '1.8.10'
 
 from . import components
 from . import containers

--- a/sdk/python/kfp/__init__.py
+++ b/sdk/python/kfp/__init__.py
@@ -16,7 +16,7 @@
 # https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
-__version__ = '1.8.8'
+__version__ = '1.8.9'
 
 from . import components
 from . import containers

--- a/sdk/python/kfp/__init__.py
+++ b/sdk/python/kfp/__init__.py
@@ -16,7 +16,7 @@
 # https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
-__version__ = '1.8.7'
+__version__ = '1.8.8'
 
 from . import components
 from . import containers

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -372,7 +372,7 @@ class Client(object):
         config.refresh_api_key_hook(config)
         return config
 
-    def set_user_namespace(self, namespace):
+    def set_user_namespace(self, namespace: str):
         """Set user namespace into local context setting file.
 
         This function should only be used when Kubeflow Pipelines is in the multi-user mode.
@@ -386,7 +386,7 @@ class Client(object):
         with open(Client.LOCAL_KFP_CONTEXT, 'w') as f:
             json.dump(self._context_setting, f)
 
-    def get_kfp_healthz(self):
+    def get_kfp_healthz(self) -> kfp_server_api.ApiGetHealthzResponse:
         """Gets healthz info of KFP deployment.
 
         Returns:
@@ -412,7 +412,7 @@ class Client(object):
                     'Failed to get healthz info attempt {} of 5.'.format(count))
                 time.sleep(5)
 
-    def get_user_namespace(self):
+    def get_user_namespace(self) -> str:
         """Get user namespace in context config.
 
         Returns:
@@ -420,7 +420,11 @@ class Client(object):
         """
         return self._context_setting['namespace']
 
-    def create_experiment(self, name, description=None, namespace=None):
+    def create_experiment(
+            self,
+            name: str,
+            description: str = None,
+            namespace: str = None) -> kfp_server_api.ApiExperiment:
         """Create a new experiment.
 
         Args:
@@ -470,7 +474,7 @@ class Client(object):
             IPython.display.display(IPython.display.HTML(html))
         return experiment
 
-    def get_pipeline_id(self, name):
+    def get_pipeline_id(self, name) -> Optional[str]:
         """Find the id of a pipeline by name.
 
         Args:
@@ -497,12 +501,13 @@ class Client(object):
                 .format(name))
         return None
 
-    def list_experiments(self,
-                         page_token='',
-                         page_size=10,
-                         sort_by='',
-                         namespace=None,
-                         filter=None):
+    def list_experiments(
+            self,
+            page_token='',
+            page_size=10,
+            sort_by='',
+            namespace=None,
+            filter=None) -> kfp_server_api.ApiListExperimentsResponse:
         """List experiments.
 
         Args:
@@ -532,7 +537,7 @@ class Client(object):
     def get_experiment(self,
                        experiment_id=None,
                        experiment_name=None,
-                       namespace=None):
+                       namespace=None) -> kfp_server_api.ApiExperiment:
         """Get details of an experiment.
 
         Either experiment_id or experiment_name is required
@@ -547,8 +552,8 @@ class Client(object):
         Returns:
           A response object including details of a experiment.
 
-        Throws:
-          Exception if experiment is not found or None of the arguments is provided
+        Raises:
+          kfp_server_api.ApiException: If experiment is not found or None of the arguments is provided
         """
         namespace = namespace or self.get_user_namespace()
         if experiment_id is None and experiment_name is None:
@@ -581,6 +586,17 @@ class Client(object):
                     experiment_name))
         return result.experiments[0]
 
+    def archive_experiment(self, experiment_id: str):
+        """Archive experiment.
+
+        Args:
+          experiment_id: id of the experiment.
+
+        Raises:
+          kfp_server_api.ApiException: If experiment is not found.
+        """
+        self._experiment_api.archive_experiment(experiment_id)
+
     def delete_experiment(self, experiment_id):
         """Delete experiment.
 
@@ -590,8 +606,8 @@ class Client(object):
         Returns:
           Object. If the method is called asynchronously, returns the request thread.
 
-        Throws:
-          Exception if experiment is not found.
+        Raises:
+          kfp_server_api.ApiException: If experiment is not found.
         """
         return self._experiment_api.delete_experiment(id=experiment_id)
 
@@ -643,7 +659,11 @@ class Client(object):
                     'pipelines.kubeflow.org/enable_caching'] = str(
                         enable_caching).lower()
 
-    def list_pipelines(self, page_token='', page_size=10, sort_by='', filter=None):
+    def list_pipelines(self,
+                       page_token='',
+                       page_size=10,
+                       sort_by='',
+                       filter=None) -> kfp_server_api.ApiListPipelinesResponse:
         """List pipelines.
 
         Args:
@@ -674,7 +694,7 @@ class Client(object):
         pipeline_root: Optional[str] = None,
         enable_caching: Optional[str] = None,
         service_account: Optional[str] = None,
-    ):
+    ) -> kfp_server_api.ApiRun:
         """Run a specified pipeline.
 
         Args:
@@ -751,7 +771,7 @@ class Client(object):
         enabled: bool = True,
         enable_caching: Optional[bool] = None,
         service_account: Optional[str] = None,
-    ):
+    ) -> kfp_server_api.ApiJob:
         """Create a recurring run.
 
         Args:
@@ -790,7 +810,11 @@ class Client(object):
 
         Returns:
           A Job object. Most important field is id.
+
+        Raises:
+          ValueError: If required parameters are not supplied.
         """
+
         job_config = self._create_job_config(
             experiment_id=experiment_id,
             params=params,
@@ -1060,7 +1084,7 @@ class Client(object):
         )
         return RunPipelineResult(self, run_info)
 
-    def delete_job(self, job_id):
+    def delete_job(self, job_id: str):
         """Deletes a job.
 
         Args:
@@ -1070,11 +1094,11 @@ class Client(object):
           Object. If the method is called asynchronously, returns the request thread.
 
         Raises:
-          ApiException: If the job is not found.
+          kfp_server_api.ApiException: If the job is not found.
         """
         return self._job_api.delete_job(id=job_id)
 
-    def disable_job(self, job_id):
+    def disable_job(self, job_id: str):
         """Disables a job.
 
         Args:
@@ -1094,7 +1118,7 @@ class Client(object):
                   sort_by='',
                   experiment_id=None,
                   namespace=None,
-                  filter=None):
+                  filter=None) -> kfp_server_api.ApiListRunsResponse:
         """List runs, optionally can be filtered by experiment or namespace.
 
         Args:
@@ -1143,7 +1167,7 @@ class Client(object):
                             page_size=10,
                             sort_by='',
                             experiment_id=None,
-                            filter=None):
+                            filter=None) -> kfp_server_api.ApiListJobsResponse:
         """List recurring runs.
 
         Args:
@@ -1174,7 +1198,7 @@ class Client(object):
                 filter=filter)
         return response
 
-    def get_recurring_run(self, job_id):
+    def get_recurring_run(self, job_id: str) -> kfp_server_api.ApiJob:
         """Get recurring_run details.
 
         Args:
@@ -1183,12 +1207,12 @@ class Client(object):
         Returns:
           A response object including details of a recurring_run.
 
-        Throws:
-          Exception if recurring_run is not found.
+        Raises:
+          kfp_server_api.ApiException: If recurring_run is not found.
         """
         return self._job_api.get_job(id=job_id)
 
-    def get_run(self, run_id):
+    def get_run(self, run_id: str) -> kfp_server_api.ApiRun:
         """Get run details.
 
         Args:
@@ -1197,12 +1221,12 @@ class Client(object):
         Returns:
           A response object including details of a run.
 
-        Throws:
-          Exception if run is not found.
+        Raises:
+          kfp_server_api.ApiException: If run is not found.
         """
         return self._run_api.get_run(run_id=run_id)
 
-    def wait_for_run_completion(self, run_id, timeout):
+    def wait_for_run_completion(self, run_id: str, timeout: int):
         """Waits for a run to complete.
 
         Args:
@@ -1262,7 +1286,7 @@ class Client(object):
         pipeline_package_path: str = None,
         pipeline_name: str = None,
         description: str = None,
-    ):
+    ) -> kfp_server_api.ApiPipeline:
         """Uploads the pipeline to the Kubeflow Pipelines cluster.
 
         Args:
@@ -1283,14 +1307,15 @@ class Client(object):
             IPython.display.display(IPython.display.HTML(html))
         return response
 
-    def upload_pipeline_version(self,
-                                pipeline_package_path,
-                                pipeline_version_name: str,
-                                pipeline_id: Optional[str] = None,
-                                pipeline_name: Optional[str] = None,
-                                description: Optional[str] = None):
-        """Uploads a new version of the pipeline to the Kubeflow Pipelines
-        cluster.
+    def upload_pipeline_version(
+        self,
+        pipeline_package_path,
+        pipeline_version_name: str,
+        pipeline_id: Optional[str] = None,
+        pipeline_name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> kfp_server_api.ApiPipelineVersion:
+        """Uploads a new version of the pipeline to the Kubeflow Pipelines cluster.
 
         Args:
           pipeline_package_path: Local path to the pipeline package.
@@ -1298,11 +1323,13 @@ class Client(object):
           pipeline_id: Optional. Id of the pipeline.
           pipeline_name: Optional. Name of the pipeline.
           description: Optional. Description of the pipeline version to be shown in the UI.
+
         Returns:
           Server response object containing pipleine id and other information.
-        Throws:
+
+        Raises:
           ValueError when none or both of pipeline_id or pipeline_name are specified
-          Exception if pipeline id is not found.
+          kfp_server_api.ApiException: If pipeline id is not found.
         """
 
         if all([pipeline_id, pipeline_name
@@ -1337,7 +1364,7 @@ class Client(object):
             IPython.display.display(IPython.display.HTML(html))
         return response
 
-    def get_pipeline(self, pipeline_id):
+    def get_pipeline(self, pipeline_id: str) -> kfp_server_api.ApiPipeline:
         """Get pipeline details.
 
         Args:
@@ -1346,8 +1373,8 @@ class Client(object):
         Returns:
           A response object including details of a pipeline.
 
-        Throws:
-          Exception if pipeline is not found.
+        Raises:
+          kfp_server_api.ApiException: If pipeline is not found.
         """
         return self._pipelines_api.get_pipeline(id=pipeline_id)
 
@@ -1360,16 +1387,18 @@ class Client(object):
         Returns:
           Object. If the method is called asynchronously, returns the request thread.
 
-        Throws:
-          Exception if pipeline is not found.
+        Raises:
+          kfp_server_api.ApiException: If pipeline is not found.
         """
         return self._pipelines_api.delete_pipeline(id=pipeline_id)
 
-    def list_pipeline_versions(self,
-                               pipeline_id,
-                               page_token='',
-                               page_size=10,
-                               sort_by=''):
+    def list_pipeline_versions(
+            self,
+            pipeline_id: str,
+            page_token: str = '',
+            page_size: int = 10,
+            sort_by: str = ''
+    ) -> kfp_server_api.ApiListPipelineVersionsResponse:
         """Lists pipeline versions.
 
         Args:
@@ -1380,6 +1409,9 @@ class Client(object):
 
         Returns:
           A response object including a list of versions and next page token.
+
+        Raises:
+          kfp_server_api.ApiException: If pipeline is not found.
         """
 
         return self._pipelines_api.list_pipeline_versions(
@@ -1389,3 +1421,18 @@ class Client(object):
             resource_key_type=kfp_server_api.models.api_resource_type
             .ApiResourceType.PIPELINE,
             resource_key_id=pipeline_id)
+
+    def delete_pipeline_version(self, version_id: str):
+        """Delete pipeline version.
+
+        Args:
+          version_id: id of the pipeline version.
+
+        Returns:
+          Object. If the method is called asynchronously, returns the request thread.
+
+        Raises:
+          Exception if pipeline version is not found.
+        """
+        return self._pipelines_api.delete_pipeline_version(
+            version_id=version_id)

--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -165,6 +165,12 @@ class Client(object):
         # Save the loaded API client configuration, as a reference if update is
         # needed.
         self._load_context_setting_or_default()
+
+        # If custom namespace provided, overwrite the loaded or default one in
+        # context settings for current client instance
+        if namespace != 'kubeflow':
+            self._context_setting['namespace'] = namespace
+
         self._existing_config = config
         if cookies is None:
             cookies = self._context_setting.get('client_authentication_cookie')

--- a/sdk/python/kfp/_local_client.py
+++ b/sdk/python/kfp/_local_client.py
@@ -472,7 +472,7 @@ class LocalClient:
                 with open(_altered_list_file, "r") as f:
                     _param_values = json.load(f)
                 for index, _param_value in enumerate(_param_values):
-                    if isinstance(_param_values, object):
+                    if isinstance(_param_values, (dict, list)):
                         _param_value = json.dumps(_param_value)
                     stack[_loop_args.pattern] = _param_value
                     loop_run_name = "{run_name}/{loop_index}".format(

--- a/sdk/python/kfp/cli/cli.py
+++ b/sdk/python/kfp/cli/cli.py
@@ -20,6 +20,7 @@ import typer
 
 from kfp._client import Client
 from kfp.cli.run import run
+from kfp.cli.recurring_run import recurring_run
 from kfp.cli.pipeline import pipeline
 from kfp.cli.diagnose_me_cli import diagnose_me
 from kfp.cli.experiment import experiment
@@ -49,8 +50,8 @@ from kfp.cli import components
     show_default=True,
     help='The formatting style for command output.')
 @click.pass_context
-def cli(ctx, endpoint, iap_client_id, namespace, other_client_id,
-        other_client_secret, output):
+def cli(ctx: click.Context, endpoint: str, iap_client_id: str, namespace: str,
+        other_client_id: str, other_client_secret: str, output: OutputFormat):
     """kfp is the command line interface to KFP service.
 
     Feature stage:
@@ -68,6 +69,7 @@ def cli(ctx, endpoint, iap_client_id, namespace, other_client_id,
 def main():
     logging.basicConfig(format='%(message)s', level=logging.INFO)
     cli.add_command(run)
+    cli.add_command(recurring_run)
     cli.add_command(pipeline)
     cli.add_command(diagnose_me, 'diagnose_me')
     cli.add_command(experiment)

--- a/sdk/python/kfp/cli/cli.py
+++ b/sdk/python/kfp/cli/cli.py
@@ -27,6 +27,10 @@ from kfp.cli.experiment import experiment
 from kfp.cli.output import OutputFormat
 from kfp.cli import components
 
+_NO_CLIENT_COMMANDS = [
+    'diagnose_me',
+    'components'
+]
 
 @click.group()
 @click.option('--endpoint', help='Endpoint of the KFP API service to connect.')
@@ -57,8 +61,8 @@ def cli(ctx: click.Context, endpoint: str, iap_client_id: str, namespace: str,
     Feature stage:
     [Alpha](https://github.com/kubeflow/pipelines/blob/07328e5094ac2981d3059314cc848fbb71437a76/docs/release/feature-stages.md#alpha)
     """
-    if ctx.invoked_subcommand == 'diagnose_me':
-        # Do not create a client for diagnose_me
+    if ctx.invoked_subcommand in _NO_CLIENT_COMMANDS:
+        # Do not create a client for these subcommands
         return
     ctx.obj['client'] = Client(endpoint, iap_client_id, namespace,
                                other_client_id, other_client_secret)

--- a/sdk/python/kfp/cli/diagnose_me_cli.py
+++ b/sdk/python/kfp/cli/diagnose_me_cli.py
@@ -35,7 +35,8 @@ def diagnose_me():
     help='Namespace to use for Kubernetes cluster.all-namespaces is used if not specified.'
 )
 @click.pass_context
-def diagnose_me(ctx, json, project_id, namespace):
+def diagnose_me(ctx: click.Context, json: bool, project_id: str,
+                namespace: str):
     """Runs environment diagnostic with specified parameters.
 
     Feature stage:

--- a/sdk/python/kfp/cli/experiment.py
+++ b/sdk/python/kfp/cli/experiment.py
@@ -1,7 +1,10 @@
 import click
 import json
+from typing import List
 
 from kfp.cli.output import print_output, OutputFormat
+import kfp_server_api
+from kfp_server_api.models.api_experiment import ApiExperiment
 
 
 @click.group()
@@ -14,7 +17,7 @@ def experiment():
 @click.option('-d', '--description', help="Description of the experiment.")
 @click.argument("name")
 @click.pass_context
-def create(ctx, description, name):
+def create(ctx: click.Context, description: str, name: str):
     """Create an experiment."""
     client = ctx.obj["client"]
     output_format = ctx.obj["output"]
@@ -25,15 +28,32 @@ def create(ctx, description, name):
 
 @experiment.command()
 @click.option(
+    '--page-token', default='', help="Token for starting of the page.")
+@click.option(
     '-m', '--max-size', default=100, help="Max size of the listed experiments.")
+@click.option(
+    '--sort-by',
+    default="created_at desc",
+    help="Can be '[field_name]', '[field_name] desc'. For example, 'name desc'."
+)
+@click.option(
+    '--filter',
+    help=(
+        "filter: A url-encoded, JSON-serialized Filter protocol buffer "
+        "(see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto))."
+    ))
 @click.pass_context
-def list(ctx, max_size):
+def list(ctx: click.Context, page_token: str, max_size: int, sort_by: str,
+         filter: str):
     """List experiments."""
     client = ctx.obj['client']
     output_format = ctx.obj['output']
 
     response = client.list_experiments(
-        page_size=max_size, sort_by="created_at desc")
+        page_token=page_token,
+        page_size=max_size,
+        sort_by=sort_by,
+        filter=filter)
     if response.experiments:
         _display_experiments(response.experiments, output_format)
     else:
@@ -47,7 +67,7 @@ def list(ctx, max_size):
 @experiment.command()
 @click.argument("experiment-id")
 @click.pass_context
-def get(ctx, experiment_id):
+def get(ctx: click.Context, experiment_id: str):
     """Get detailed information about an experiment."""
     client = ctx.obj["client"]
     output_format = ctx.obj["output"]
@@ -59,7 +79,7 @@ def get(ctx, experiment_id):
 @experiment.command()
 @click.argument("experiment-id")
 @click.pass_context
-def delete(ctx, experiment_id):
+def delete(ctx: click.Context, experiment_id: str):
     """Delete an experiment."""
 
     confirmation = "Caution. The RunDetails page could have an issue" \
@@ -74,7 +94,8 @@ def delete(ctx, experiment_id):
     click.echo("{} is deleted.".format(experiment_id))
 
 
-def _display_experiments(experiments, output_format):
+def _display_experiments(experiments: List[ApiExperiment],
+                         output_format: OutputFormat):
     headers = ["Experiment ID", "Name", "Created at"]
     data = [
         [exp.id, exp.name, exp.created_at.isoformat()] for exp in experiments
@@ -82,7 +103,8 @@ def _display_experiments(experiments, output_format):
     print_output(data, headers, output_format, table_format="grid")
 
 
-def _display_experiment(exp, output_format):
+def _display_experiment(exp: kfp_server_api.ApiExperiment,
+                        output_format: OutputFormat):
     table = [
         ["ID", exp.id],
         ["Name", exp.name],
@@ -94,3 +116,27 @@ def _display_experiment(exp, output_format):
         print_output(table, [], output_format, table_format="plain")
     elif output_format == OutputFormat.json.name:
         print_output(dict(table), [], output_format)
+
+
+@experiment.command()
+@click.option(
+    "--experiment-id",
+    default=None,
+    help="The ID of the experiment to archive, can only supply either an experiment ID or name.")
+@click.option(
+    "--experiment-name",
+    default=None,
+    help="The name of the experiment to archive, can only supply either an experiment ID or name.")
+@click.pass_context
+def archive(ctx: click.Context, experiment_id: str, experiment_name: str):
+    """Archive an experiment"""
+    client = ctx.obj["client"]
+
+    if (experiment_id is None) == (experiment_name is None):
+        raise ValueError('Either experiment_id or experiment_name is required')
+
+    if not experiment_id:
+        experiment = client.get_experiment(experiment_name=experiment_name)
+        experiment_id = experiment.id
+
+    client.archive_experiment(experiment_id=experiment_id)

--- a/sdk/python/kfp/cli/pipeline.py
+++ b/sdk/python/kfp/cli/pipeline.py
@@ -14,7 +14,9 @@
 
 import click
 import json
+from typing import List, Optional
 
+import kfp_server_api
 from kfp.cli.output import print_output, OutputFormat
 
 
@@ -29,7 +31,10 @@ def pipeline():
 @click.option("-d", "--description", help="Description for the pipeline.")
 @click.argument("package-file")
 @click.pass_context
-def upload(ctx, pipeline_name, package_file, description=None):
+def upload(ctx: click.Context,
+           pipeline_name: str,
+           package_file: str,
+           description: str = None):
     """Upload a KFP pipeline."""
     client = ctx.obj["client"]
     output_format = ctx.obj["output"]
@@ -50,11 +55,11 @@ def upload(ctx, pipeline_name, package_file, description=None):
     required=True)
 @click.argument("package-file")
 @click.pass_context
-def upload_version(ctx,
-                   package_file,
-                   pipeline_version,
-                   pipeline_id=None,
-                   pipeline_name=None):
+def upload_version(ctx: click.Context,
+                   package_file: str,
+                   pipeline_version: str,
+                   pipeline_id: Optional[str] = None,
+                   pipeline_name: Optional[str] = None):
     """Upload a version of the KFP pipeline."""
     client = ctx.obj["client"]
     output_format = ctx.obj["output"]
@@ -72,15 +77,32 @@ def upload_version(ctx,
 
 @pipeline.command()
 @click.option(
-    "-m", "--max-size", default=100, help="Max size of the listed pipelines.")
+    '--page-token', default='', help="Token for starting of the page.")
+@click.option(
+    '-m', '--max-size', default=100, help="Max size of the listed pipelines.")
+@click.option(
+    '--sort-by',
+    default="created_at desc",
+    help="Can be '[field_name]', '[field_name] desc'. For example, 'name desc'."
+)
+@click.option(
+    '--filter',
+    help=(
+        "filter: A url-encoded, JSON-serialized Filter protocol buffer "
+        "(see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto))."
+    ))
 @click.pass_context
-def list(ctx, max_size):
+def list(ctx: click.Context, page_token: str, max_size: int, sort_by: str,
+         filter: str):
     """List uploaded KFP pipelines."""
     client = ctx.obj["client"]
     output_format = ctx.obj["output"]
 
     response = client.list_pipelines(
-        page_size=max_size, sort_by="created_at desc")
+        page_token=page_token,
+        page_size=max_size,
+        sort_by=sort_by,
+        filter=filter)
     if response.pipelines:
         _print_pipelines(response.pipelines, output_format)
     else:
@@ -94,15 +116,36 @@ def list(ctx, max_size):
 @pipeline.command()
 @click.argument("pipeline-id")
 @click.option(
-    "-m", "--max-size", default=10, help="Max size of the listed pipelines.")
+    '--page-token', default='', help="Token for starting of the page.")
+@click.option(
+    '-m',
+    '--max-size',
+    default=100,
+    help="Max size of the listed pipeline versions.")
+@click.option(
+    '--sort-by',
+    default="created_at desc",
+    help="Can be '[field_name]', '[field_name] desc'. For example, 'name desc'."
+)
+@click.option(
+    '--filter',
+    help=(
+        "filter: A url-encoded, JSON-serialized Filter protocol buffer "
+        "(see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto))."
+    ))
 @click.pass_context
-def list_versions(ctx, pipeline_id, max_size):
-    """List versions of an uploaded KFP pipeline."""
+def list_versions(ctx: click.Context, pipeline_id: str, page_token: str,
+                  max_size: int, sort_by: str, filter: str):
+    """List versions of an uploaded KFP pipeline"""
     client = ctx.obj["client"]
     output_format = ctx.obj["output"]
 
     response = client.list_pipeline_versions(
-        pipeline_id=pipeline_id, page_size=max_size, sort_by="created_at desc")
+        pipeline_id,
+        page_token=page_token,
+        page_size=max_size,
+        sort_by=sort_by,
+        filter=filter)
     if response.versions:
         _print_pipeline_versions(response.versions, output_format)
     else:
@@ -114,10 +157,29 @@ def list_versions(ctx, pipeline_id, max_size):
 
 
 @pipeline.command()
+@click.argument("version-id")
+@click.pass_context
+def delete_version(ctx: click.Context, version_id: str):
+    """Delete pipeline version.
+
+    Args:
+      version_id: id of the pipeline version.
+
+    Returns:
+      Object. If the method is called asynchronously, returns the request thread.
+
+    Throws:
+      Exception if pipeline version is not found.
+    """
+    client = ctx.obj["client"]
+    return client.delete_pipeline_version(version_id)
+
+
+@pipeline.command()
 @click.argument("pipeline-id")
 @click.pass_context
-def get(ctx, pipeline_id):
-    """Get detailed information about an uploaded KFP pipeline."""
+def get(ctx: click.Context, pipeline_id: str):
+    """Get detailed information about an uploaded KFP pipeline"""
     client = ctx.obj["client"]
     output_format = ctx.obj["output"]
 
@@ -128,36 +190,43 @@ def get(ctx, pipeline_id):
 @pipeline.command()
 @click.argument("pipeline-id")
 @click.pass_context
-def delete(ctx, pipeline_id):
+def delete(ctx: click.Context, pipeline_id: str):
     """Delete an uploaded KFP pipeline."""
     client = ctx.obj["client"]
 
     client.delete_pipeline(pipeline_id)
-    click.echo("{} is deleted".format(pipeline_id))
+    click.echo(f"{pipeline_id} is deleted")
 
 
-def _print_pipelines(pipelines, output_format):
+def _print_pipelines(pipelines: List[kfp_server_api.ApiPipeline],
+                     output_format: OutputFormat):
     headers = ["Pipeline ID", "Name", "Uploaded at"]
     data = [[pipeline.id, pipeline.name,
              pipeline.created_at.isoformat()] for pipeline in pipelines]
     print_output(data, headers, output_format, table_format="grid")
 
 
-def _print_pipeline_versions(versions, output_format):
-    headers = ["Version ID", "Version name", "Uploaded at"]
-    data = [[version.id, version.name,
-             version.created_at.isoformat()] for version in versions]
+def _print_pipeline_versions(versions: List[kfp_server_api.ApiPipelineVersion],
+                             output_format: OutputFormat):
+    headers = ["Version ID", "Version name", "Uploaded at", "Pipeline ID"]
+    data = [[
+        version.id, version.name,
+        version.created_at.isoformat(),
+        next(rr
+             for rr in version.resource_references
+             if rr.key.type == kfp_server_api.ApiResourceType.PIPELINE).id
+    ]
+            for version in versions]
     print_output(data, headers, output_format, table_format="grid")
 
 
-def _display_pipeline(pipeline, output_format):
+def _display_pipeline(pipeline: kfp_server_api.ApiPipeline,
+                      output_format: OutputFormat):
     # Pipeline information
-    table = [
-        ["ID", pipeline.id],
-        ["Name", pipeline.name],
-        ["Description", pipeline.description],
-        ["Uploaded at", pipeline.created_at.isoformat()],
-    ]
+    table = [["Pipeline ID", pipeline.id], ["Name", pipeline.name],
+             ["Description", pipeline.description],
+             ["Uploaded at", pipeline.created_at.isoformat()],
+             ["Version ID", pipeline.default_version.id]]
 
     # Pipeline parameter details
     headers = ["Parameter Name", "Default Value"]
@@ -179,13 +248,14 @@ def _display_pipeline(pipeline, output_format):
         print_output(output, [], output_format)
 
 
-def _display_pipeline_version(version, output_format):
-    pipeline_id = version.resource_references[0].key.id
-    table = [
-        ["Pipeline ID", pipeline_id],
-        ["Version Name", version.name],
-        ["Uploaded at", version.created_at.isoformat()],
-    ]
+def _display_pipeline_version(version: kfp_server_api.ApiPipelineVersion,
+                              output_format: OutputFormat):
+    pipeline_id = next(
+        rr for rr in version.resource_references
+        if rr.key.type == kfp_server_api.ApiResourceType.PIPELINE).id
+    table = [["Pipeline ID", pipeline_id], ["Version name", version.name],
+             ["Uploaded at", version.created_at.isoformat()],
+             ["Version ID", version.id]]
 
     if output_format == OutputFormat.table.name:
         print_output([], ["Pipeline Version Details"], output_format)

--- a/sdk/python/kfp/cli/pipeline.py
+++ b/sdk/python/kfp/cli/pipeline.py
@@ -214,7 +214,7 @@ def _print_pipeline_versions(versions: List[kfp_server_api.ApiPipelineVersion],
         version.created_at.isoformat(),
         next(rr
              for rr in version.resource_references
-             if rr.key.type == kfp_server_api.ApiResourceType.PIPELINE).id
+             if rr.key.type == kfp_server_api.ApiResourceType.PIPELINE).key.id
     ]
             for version in versions]
     print_output(data, headers, output_format, table_format="grid")
@@ -252,7 +252,7 @@ def _display_pipeline_version(version: kfp_server_api.ApiPipelineVersion,
                               output_format: OutputFormat):
     pipeline_id = next(
         rr for rr in version.resource_references
-        if rr.key.type == kfp_server_api.ApiResourceType.PIPELINE).id
+        if rr.key.type == kfp_server_api.ApiResourceType.PIPELINE).key.id
     table = [["Pipeline ID", pipeline_id], ["Version name", version.name],
              ["Uploaded at", version.created_at.isoformat()],
              ["Version ID", version.id]]

--- a/sdk/python/kfp/cli/recurring_run.py
+++ b/sdk/python/kfp/cli/recurring_run.py
@@ -1,0 +1,213 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, List, Optional
+import json
+import click
+from kfp.cli.output import print_output, OutputFormat
+import kfp_server_api
+
+
+@click.group()
+def recurring_run():
+    """Manage recurring-run resources"""
+    pass
+
+
+@recurring_run.command()
+@click.option(
+    '--catchup/--no-catchup',
+    help='Whether the recurring run should catch up if behind schedule.',
+    type=bool)
+@click.option(
+    '--cron-expression',
+    help='A cron expression representing a set of times, using 6 space-separated fields, e.g. "0 0 9 ? * 2-6".'
+)
+@click.option('--description', help='The description of the recurring run.')
+@click.option(
+    '--enable-caching/--disable-caching',
+    help='Optional. Whether or not to enable caching for the run.',
+    type=bool)
+@click.option(
+    '--enabled/--disabled',
+    help='A bool indicating whether the recurring run is enabled or disabled.',
+    type=bool)
+@click.option(
+    '--end-time',
+    help='The RFC3339 time string of the time when to end the job.')
+@click.option(
+    '--experiment-id',
+    help='The ID of the experiment to create the recurring run under, can only supply either an experiment ID or name.')
+@click.option(
+    '--experiment-name',
+    help='The name of the experiment to create the recurring run under, can only supply either an experiment ID or name.')
+@click.option('--job-name', help='The name of the recurring run.')
+@click.option(
+    '--interval-second',
+    help='Integer indicating the seconds between two recurring runs in for a periodic schedule.'
+)
+@click.option(
+    '--max-concurrency',
+    help='Integer indicating how many jobs can be run in parallel.',
+    type=int)
+@click.option(
+    '--pipeline-id',
+    help='The ID of the pipeline to use to create the recurring run.')
+@click.option(
+    '--pipeline-package-path',
+    help='Local path of the pipeline package(the filename should end with one of the following .tar.gz, .tgz, .zip, .yaml, .yml).'
+)
+@click.option(
+    '--start-time',
+    help='The RFC3339 time string of the time when to start the job.')
+@click.option('--version-id', help='The id of a pipeline version.')
+@click.argument("args", nargs=-1)
+@click.pass_context
+def create(ctx: click.Context,
+           job_name: str,
+           experiment_id: Optional[str] = None,
+           experiment_name: Optional[str] = None,
+           catchup: Optional[bool] = None,
+           cron_expression: Optional[str] = None,
+           enabled: Optional[bool] = None,
+           description: Optional[str] = None,
+           enable_caching: Optional[bool] = None,
+           end_time: Optional[str] = None,
+           interval_second: Optional[int] = None,
+           max_concurrency: Optional[int] = None,
+           params: Optional[dict] = None,
+           pipeline_package_path: Optional[str] = None,
+           pipeline_id: Optional[str] = None,
+           start_time: Optional[str] = None,
+           version_id: Optional[str] = None,
+           args: Optional[List[str]] = None):
+    """Create a recurring run."""
+    client = ctx.obj["client"]
+    output_format = ctx.obj['output']
+
+    if (experiment_id is None) == (experiment_name is None):
+        raise ValueError('Either experiment_id or experiment_name is required')
+    if not experiment_id:
+        experiment = client.create_experiment(experiment_name)
+        experiment_id = experiment.id
+
+    # Ensure we only split on the first equals char so the value can contain
+    # equals signs too.
+    split_args: List = [arg.split("=", 1) for arg in args or []]
+    params: Dict[str, Any] = dict(split_args)
+    recurring_run = client.create_recurring_run(
+        cron_expression=cron_expression,
+        description=description,
+        enabled=enabled,
+        enable_caching=enable_caching,
+        end_time=end_time,
+        experiment_id=experiment_id,
+        interval_second=interval_second,
+        job_name=job_name,
+        max_concurrency=max_concurrency,
+        no_catchup=not catchup,
+        params=params,
+        pipeline_package_path=pipeline_package_path,
+        pipeline_id=pipeline_id,
+        start_time=start_time,
+        version_id=version_id)
+
+    _display_recurring_run(recurring_run, output_format)
+
+
+@recurring_run.command()
+@click.option(
+    '-e',
+    '--experiment-id',
+    help='Parent experiment ID of listed recurring runs.')
+@click.option(
+    '--page-token', default='', help="Token for starting of the page.")
+@click.option(
+    '-m',
+    '--max-size',
+    default=100,
+    help="Max size of the listed recurring runs.")
+@click.option(
+    '--sort-by',
+    default="created_at desc",
+    help="Can be '[field_name]', '[field_name] desc'. For example, 'name desc'."
+)
+@click.option(
+    '--filter',
+    help=(
+        "filter: A url-encoded, JSON-serialized Filter protocol buffer "
+        "(see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto))."
+    ))
+@click.pass_context
+def list(ctx: click.Context, experiment_id: str, page_token: str, max_size: int,
+         sort_by: str, filter: str):
+    """List recurring runs"""
+    client = ctx.obj['client']
+    output_format = ctx.obj['output']
+
+    response = client.list_recurring_runs(
+        experiment_id=experiment_id,
+        page_token=page_token,
+        page_size=max_size,
+        sort_by=sort_by,
+        filter=filter)
+    if response.jobs:
+        _display_recurring_runs(response.jobs, output_format)
+    else:
+        if output_format == OutputFormat.json.name:
+            msg = json.dumps([])
+        else:
+            msg = "No recurring runs found"
+        click.echo(msg)
+
+
+@recurring_run.command()
+@click.argument("job-id")
+@click.pass_context
+def get(ctx: click.Context, job_id: str):
+    """Get detailed information about an experiment"""
+    client = ctx.obj["client"]
+    output_format = ctx.obj["output"]
+
+    response = client.get_recurring_run(job_id)
+    _display_recurring_run(response, output_format)
+
+
+@recurring_run.command()
+@click.argument("job-id")
+@click.pass_context
+def delete(ctx: click.Context, job_id: str):
+    """Delete a recurring run"""
+    client = ctx.obj["client"]
+    client.delete_job(job_id)
+
+
+def _display_recurring_runs(recurring_runs: List[kfp_server_api.ApiJob],
+                            output_format: OutputFormat):
+    headers = ["Recurring Run ID", "Name"]
+    data = [[rr.id, rr.name] for rr in recurring_runs]
+    print_output(data, headers, output_format, table_format="grid")
+
+
+def _display_recurring_run(recurring_run: kfp_server_api.ApiJob,
+                           output_format: OutputFormat):
+    table = [
+        ["Recurring Run ID", recurring_run.id],
+        ["Name", recurring_run.name],
+    ]
+    if output_format == OutputFormat.table.name:
+        print_output([], ["Recurring Run Details"], output_format)
+        print_output(table, [], output_format, table_format="plain")
+    elif output_format == OutputFormat.json.name:
+        print_output(dict(table), [], output_format)

--- a/sdk/python/kfp/cli/run.py
+++ b/sdk/python/kfp/cli/run.py
@@ -222,7 +222,7 @@ def _print_runs(runs: List[kfp_server_api.ApiRun], output_format: OutputFormat):
         run.created_at.isoformat(),
         next(rr
              for rr in run.resource_references
-             if rr.key.type == kfp_server_api.ApiResourceType.EXPERIMENT).id
+             if rr.key.type == kfp_server_api.ApiResourceType.EXPERIMENT).key.id
     ]
             for run in runs]
     print_output(data, headers, output_format, table_format='grid')

--- a/sdk/python/kfp/cli/run.py
+++ b/sdk/python/kfp/cli/run.py
@@ -18,8 +18,10 @@ import json
 import click
 import shutil
 import datetime
+from typing import List
 
-import kfp
+import kfp_server_api
+from kfp._client import Client
 from kfp.cli.output import print_output, OutputFormat
 
 
@@ -33,16 +35,32 @@ def run():
 @click.option(
     '-e', '--experiment-id', help='Parent experiment ID of listed runs.')
 @click.option(
-    '-m', '--max-size', default=100, help='Max size of the listed runs.')
+    '--page-token', default='', help="Token for starting of the page.")
+@click.option(
+    '-m', '--max-size', default=100, help="Max size of the listed runs.")
+@click.option(
+    '--sort-by',
+    default="created_at desc",
+    help="Can be '[field_name]', '[field_name] desc'. For example, 'name desc'."
+)
+@click.option(
+    '--filter',
+    help=(
+        "filter: A url-encoded, JSON-serialized Filter protocol buffer "
+        "(see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto))."
+    ))
 @click.pass_context
-def list(ctx, experiment_id, max_size):
+def list(ctx: click.Context, experiment_id: str, page_token: str, max_size: int,
+         sort_by: str, filter: str):
     """list recent KFP runs."""
     client = ctx.obj['client']
     output_format = ctx.obj['output']
     response = client.list_runs(
         experiment_id=experiment_id,
+        page_token=page_token,
         page_size=max_size,
-        sort_by='created_at desc')
+        sort_by=sort_by,
+        filter=filter)
     if response and response.runs:
         _print_runs(response.runs, output_format)
     else:
@@ -82,8 +100,9 @@ def list(ctx, experiment_id, max_size):
     type=int)
 @click.argument('args', nargs=-1)
 @click.pass_context
-def submit(ctx, experiment_name, run_name, package_file, pipeline_id,
-           pipeline_name, watch, timeout, version, args):
+def submit(ctx: click.Context, experiment_name: str, run_name: str,
+           package_file: str, pipeline_id: str, pipeline_name: str, watch: bool,
+           timeout: int, version: str, args: List[str]):
     """submit a KFP run."""
     client = ctx.obj['client']
     namespace = ctx.obj['namespace']
@@ -131,7 +150,7 @@ def submit(ctx, experiment_name, run_name, package_file, pipeline_id,
     help='Get detailed information of the run in json format.')
 @click.argument('run-id')
 @click.pass_context
-def get(ctx, watch, detail, run_id):
+def get(ctx: click.Context, watch: bool, detail: bool, run_id: str):
     """display the details of a KFP run."""
     client = ctx.obj['client']
     namespace = ctx.obj['namespace']
@@ -140,7 +159,12 @@ def get(ctx, watch, detail, run_id):
     _display_run(client, namespace, run_id, watch, output_format, detail)
 
 
-def _display_run(client, namespace, run_id, watch, output_format, detail=False):
+def _display_run(client: click.Context,
+                 namespace: str,
+                 run_id: str,
+                 watch: bool,
+                 output_format: OutputFormat,
+                 detail: bool = False):
     run = client.get_run(run_id).run
 
     if detail:
@@ -185,13 +209,20 @@ def _display_run(client, namespace, run_id, watch, output_format, detail=False):
         _print_runs([run], output_format)
 
 
-def _wait_for_run_completion(client, run_id, timeout, output_format):
+def _wait_for_run_completion(client: Client, run_id: str, timeout: int,
+                             output_format: OutputFormat):
     run_detail = client.wait_for_run_completion(run_id, timeout)
     _print_runs([run_detail.run], output_format)
 
 
-def _print_runs(runs, output_format):
-    headers = ['run id', 'name', 'status', 'created at']
-    data = [[run.id, run.name, run.status,
-             run.created_at.isoformat()] for run in runs]
+def _print_runs(runs: List[kfp_server_api.ApiRun], output_format: OutputFormat):
+    headers = ['run id', 'name', 'status', 'created at', 'experiment id']
+    data = [[
+        run.id, run.name, run.status,
+        run.created_at.isoformat(),
+        next(rr
+             for rr in run.resource_references
+             if rr.key.type == kfp_server_api.ApiResourceType.EXPERIMENT).id
+    ]
+            for run in runs]
     print_output(data, headers, output_format, table_format='grid')

--- a/sdk/python/kfp/compiler/_data_passing_using_volume.py
+++ b/sdk/python/kfp/compiler/_data_passing_using_volume.py
@@ -128,7 +128,12 @@ def rewrite_data_passing_to_use_volumes(
                     'name': subpath_parameter_name,
                     'value': output_subpath,  # Requires Argo 2.3.0+
                 })
-            template.get('outputs', {}).pop('artifacts', None)
+            whitelist = ['mlpipeline-ui-metadata', 'mlpipeline-metrics']
+            output_artifacts = [artifact for artifact in output_artifacts if artifact['name'] in whitelist]
+            if not output_artifacts:
+              template.get('outputs', {}).pop('artifacts', None)
+            else:
+                template.get('outputs', {}).update({'artifacts': output_artifacts})
 
     # Rewrite DAG templates
     for template in templates:

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -831,8 +831,7 @@ class Compiler(object):
 
         # set ttl after workflow finishes
         if pipeline_conf.ttl_seconds_after_finished >= 0:
-            workflow['spec'][
-                'ttlSecondsAfterFinished'] = pipeline_conf.ttl_seconds_after_finished
+            workflow['spec']['ttlStrategy'] = {'secondsAfterCompletion': pipeline_conf.ttl_seconds_after_finished}
 
         if pipeline_conf._pod_disruption_budget_min_available:
             pod_disruption_budget = {

--- a/sdk/python/kfp/components/_python_op.py
+++ b/sdk/python/kfp/components/_python_op.py
@@ -983,7 +983,7 @@ def create_component_from_func_v2(func: Callable,
     warnings.warn(
         'create_component_from_func_v2() has been deprecated and will be'
         ' removed in KFP v1.9. Please use'
-        ' kfp.v2.components.create_component_from_func() instead.',
+        ' @kfp.v2.dsl.component() instead.',
         category=FutureWarning,
     )
     from kfp.v2.components import component_factory

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -411,8 +411,7 @@ class Container(V1Container):
             ignored in v2.
         """
 
-        if not isinstance(gpu, _pipeline_param.PipelineParam) or not isinstance(
-                gpu, _pipeline_param.PipelineParam):
+        if not isinstance(gpu, _pipeline_param.PipelineParam):
             self._validate_positive_number(gpu, 'gpu')
 
             if self._container_spec:

--- a/sdk/python/kfp/dsl/types.py
+++ b/sdk/python/kfp/dsl/types.py
@@ -140,12 +140,15 @@ def verify_type_compatibility(given_type: TypeSpecType,
     if given_type is None or expected_type is None:
         return True
 
-    # Generic artifacts resulted from missing type or explicit "Artifact" type can
-    # be passed to inputs expecting any artifact types.
-    # However, generic artifacts resulted from arbitrary unknown types do not have
-    # such "compatible" feature.
-    if not type_utils.is_parameter_type(str(expected_type)) and (
-            given_type is None or str(given_type).lower() == "artifact"):
+    # Generic artifacts resulted from missing type or explicit "Artifact" type
+    # is compatible with any artifact types.
+    # However, generic artifacts resulted from arbitrary unknown types do not
+    # have such "compatible" feature.
+    if not type_utils.is_parameter_type(
+            str(expected_type)) and str(given_type).lower() == "artifact":
+        return True
+    if not type_utils.is_parameter_type(
+            str(given_type)) and str(expected_type).lower() == "artifact":
         return True
 
     types_are_compatible = check_types(given_type, expected_type)

--- a/sdk/python/kfp/v2/compiler/compiler.py
+++ b/sdk/python/kfp/v2/compiler/compiler.py
@@ -1260,6 +1260,12 @@ class Compiler(object):
           pipeline_parameters: The mapping from parameter names to values. Optional.
           type_check: Whether to enable the type check or not, default: True.
         """
+        warnings.warn(
+            'APIs imported from the v1 namespace (e.g. kfp.dsl, kfp.components, '
+            'etc) will not be supported by the v2 compiler since v2.0.0',
+            category=FutureWarning,
+        )
+
         type_check_old_value = kfp.TYPE_CHECK
         compiling_for_v2_old_value = kfp.COMPILING_FOR_V2
         try:

--- a/sdk/python/kfp/v2/components/importer_node_test.py
+++ b/sdk/python/kfp/v2/components/importer_node_test.py
@@ -30,11 +30,15 @@ class ImporterNodeTest(parameterized.TestCase):
                 'gs://artifact',
             'artifact_type_schema':
                 pb.ArtifactTypeSchema(schema_title='system.Dataset'),
+            'metadata': {'key':'value'},
             'expected_result': {
                 'artifactUri': {
                     'constantValue': {
                         'stringValue': 'gs://artifact'
                     }
+                },
+                'metadata': {
+                    'key': 'value'
                 },
                 'typeSchema': {
                     'schemaTitle': 'system.Dataset'
@@ -47,6 +51,7 @@ class ImporterNodeTest(parameterized.TestCase):
                 _pipeline_param.PipelineParam(name='uri_to_import'),
             'artifact_type_schema':
                 pb.ArtifactTypeSchema(schema_title='system.Model'),
+            'metadata': {},
             'expected_result': {
                 'artifactUri': {
                     'runtimeParameter': 'uri'
@@ -56,12 +61,11 @@ class ImporterNodeTest(parameterized.TestCase):
                 }
             },
         })
-    def test_build_importer_spec(self, input_uri, artifact_type_schema,
-                                 expected_result):
+    def test_build_importer_spec(self, input_uri, artifact_type_schema, metadata, expected_result):
         expected_importer_spec = pb.PipelineDeploymentConfig.ImporterSpec()
         json_format.ParseDict(expected_result, expected_importer_spec)
         importer_spec = importer_node._build_importer_spec(
-            artifact_uri=input_uri, artifact_type_schema=artifact_type_schema)
+            artifact_uri=input_uri, artifact_type_schema=artifact_type_schema, metadata=metadata)
 
         self.maxDiff = None
         self.assertEqual(expected_importer_spec, importer_spec)

--- a/sdk/python/kfp/v2/components/types/artifact_types.py
+++ b/sdk/python/kfp/v2/components/types/artifact_types.py
@@ -429,8 +429,16 @@ class Markdown(Artifact):
 
 
 _SCHEMA_TITLE_TO_TYPE: Dict[str, Artifact] = {
-    x.TYPE_NAME: x
-    for x in [Artifact, Model, Dataset, Metrics, ClassificationMetrics]
+    x.TYPE_NAME: x for x in [
+        Artifact,
+        Model,
+        Dataset,
+        Metrics,
+        ClassificationMetrics,
+        SlicedClassificationMetrics,
+        HTML,
+        Markdown,
+    ]
 }
 
 

--- a/sdk/python/kfp/v2/components/types/artifact_types_test.py
+++ b/sdk/python/kfp/v2/components/types/artifact_types_test.py
@@ -17,10 +17,11 @@ import unittest
 import json
 import os
 
+from absl.testing import parameterized
 from kfp.v2.components.types import artifact_types
 
 
-class ArtifactsTest(unittest.TestCase):
+class ArtifactsTest(parameterized.TestCase):
 
     def test_complex_metrics(self):
         metrics = artifact_types.ClassificationMetrics()
@@ -54,6 +55,105 @@ class ArtifactsTest(unittest.TestCase):
         ) as json_file:
             expected_json = json.load(json_file)
             self.assertEqual(expected_json, metrics.metadata)
+
+    @parameterized.parameters(
+        {
+            'runtime_artifact': {
+                "metadata": {},
+                "name": "input_artifact_one",
+                "type": {
+                    "schemaTitle": "system.Artifact"
+                },
+                "uri": "gs://some-bucket/input_artifact_one"
+            },
+            'expected_type': artifact_types.Artifact,
+        },
+        {
+            'runtime_artifact': {
+                "metadata": {},
+                "name": "input_artifact_one",
+                "type": {
+                    "schemaTitle": "system.Model"
+                },
+                "uri": "gs://some-bucket/input_artifact_one"
+            },
+            'expected_type': artifact_types.Model,
+        },
+        {
+            'runtime_artifact': {
+                "metadata": {},
+                "name": "input_artifact_one",
+                "type": {
+                    "schemaTitle": "system.Dataset"
+                },
+                "uri": "gs://some-bucket/input_artifact_one"
+            },
+            'expected_type': artifact_types.Dataset,
+        },
+        {
+            'runtime_artifact': {
+                "metadata": {},
+                "name": "input_artifact_one",
+                "type": {
+                    "schemaTitle": "system.Metrics"
+                },
+                "uri": "gs://some-bucket/input_artifact_one"
+            },
+            'expected_type': artifact_types.Metrics,
+        },
+        {
+            'runtime_artifact': {
+                "metadata": {},
+                "name": "input_artifact_one",
+                "type": {
+                    "schemaTitle": "system.ClassificationMetrics"
+                },
+                "uri": "gs://some-bucket/input_artifact_one"
+            },
+            'expected_type': artifact_types.ClassificationMetrics,
+        },
+        {
+            'runtime_artifact': {
+                "metadata": {},
+                "name": "input_artifact_one",
+                "type": {
+                    "schemaTitle": "system.SlicedClassificationMetrics"
+                },
+                "uri": "gs://some-bucket/input_artifact_one"
+            },
+            'expected_type': artifact_types.SlicedClassificationMetrics,
+        },
+        {
+            'runtime_artifact': {
+                "metadata": {},
+                "name": "input_artifact_one",
+                "type": {
+                    "schemaTitle": "system.HTML"
+                },
+                "uri": "gs://some-bucket/input_artifact_one"
+            },
+            'expected_type': artifact_types.HTML,
+        },
+        {
+            'runtime_artifact': {
+                "metadata": {},
+                "name": "input_artifact_one",
+                "type": {
+                    "schemaTitle": "system.Markdown"
+                },
+                "uri": "gs://some-bucket/input_artifact_one"
+            },
+            'expected_type': artifact_types.Markdown,
+        },
+    )
+    def test_create_runtime_artifact(
+        self,
+        runtime_artifact,
+        expected_type,
+    ):
+        self.assertIsInstance(
+            artifact_types.create_runtime_artifact(runtime_artifact),
+            expected_type)
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/v2/google/client/client.py
+++ b/sdk/python/kfp/v2/google/client/client.py
@@ -167,7 +167,7 @@ class AIPlatformClient(object):
           region: GCP project region.
         """
         warnings.warn(
-            'AIPlatformClient will be deprecated in v1.9. Please use PipelineJob'
+            'AIPlatformClient will be deprecated in v2.0.0. Please use PipelineJob'
             ' https://googleapis.dev/python/aiplatform/latest/_modules/google/cloud/aiplatform/pipeline_jobs.html'
             ' in Vertex SDK. Install the SDK using "pip install google-cloud-aiplatform"',
             category=FutureWarning,

--- a/sdk/python/kfp/v2/google/client/schedule.py
+++ b/sdk/python/kfp/v2/google/client/schedule.py
@@ -136,7 +136,8 @@ def _create_from_pipeline_dict(
     pipeline_jobs_api_url = f'https://{region}-{_CAIPP_ENDPOINT_WITHOUT_REGION}/{_CAIPP_API_VERSION}/projects/{project_id}/locations/{region}/pipelineJobs'
 
     # Preparing the request body for the Cloud Function processing
-    full_pipeline_name = pipeline_dict.get('name')
+    pipeline_name = pipeline_dict['pipelineSpec']['pipelineInfo']['name']
+    full_pipeline_name = 'projects/{}/pipelineJobs/{}'.format(project_id, pipeline_name)
     pipeline_display_name = pipeline_dict.get('displayName')
     time_format_suffix = "-{{$.scheduledTime.strftime('%Y-%m-%d-%H-%M-%S')}}"
     if 'name' in pipeline_dict:

--- a/sdk/python/kfp/v2/google/experimental/custom_job.py
+++ b/sdk/python/kfp/v2/google/experimental/custom_job.py
@@ -14,6 +14,7 @@
 """Module for supporting Google Cloud AI Platform Custom Job."""
 
 import copy
+import warnings
 from typing import Any, List, Mapping, Optional
 
 from kfp import dsl
@@ -73,6 +74,10 @@ def run_as_aiplatform_custom_job(
         distributed training. For details, please see:
         https://cloud.google.com/ai-platform-unified/docs/training/distributed-training
     """
+    warnings.warn(
+        'This function will be deprecated in v2.0.0', category=FutureWarning,
+    )
+
     job_spec = {}
 
     if worker_pool_specs is not None:

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -20,6 +20,7 @@ kubernetes>=8.0.0,<19
 kfp-server-api>=1.1.2,<2.0.0
 
 # kfp.Client GCP auth
+google-api-core>=1.31.5,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0
 google-cloud-storage>=1.20.0,<2
 google-auth>=1.6.1,<2
 requests-toolbelt>=0.8.0,<1

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -29,8 +29,9 @@ docstring-parser==0.11
     # via -r requirements.in
 fire==0.4.0
     # via -r requirements.in
-google-api-core==1.31.3
+google-api-core==1.31.5
     # via
+    #   -r requirements.in
     #   google-api-python-client
     #   google-cloud-core
     #   google-cloud-storage

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -23,7 +23,7 @@ NAME = 'kfp'
 # NOTICE, after any updates to the following, ./requirements.in should be updated
 # accordingly.
 REQUIRES = [
-    'absl-py>=0.9,<=0.11',
+    'absl-py>=0.9,<2',
     'PyYAML>=5.3,<6',
     # `Blob.from_string` was introduced in google-cloud-storage 1.20.0
     # https://github.com/googleapis/python-storage/blob/master/CHANGELOG.md#1200

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -25,6 +25,9 @@ NAME = 'kfp'
 REQUIRES = [
     'absl-py>=0.9,<2',
     'PyYAML>=5.3,<6',
+    # Pin google-api-core version for the bug fixing in 1.31.5
+    # https://github.com/googleapis/python-api-core/releases/tag/v1.31.5
+    'google-api-core>=1.31.5,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0',
     # `Blob.from_string` was introduced in google-cloud-storage 1.20.0
     # https://github.com/googleapis/python-storage/blob/master/CHANGELOG.md#1200
     'google-cloud-storage>=1.20.0,<2',

--- a/sdk/python/tests/compiler/compiler_tests.py
+++ b/sdk/python/tests/compiler/compiler_tests.py
@@ -981,7 +981,7 @@ implementation:
             dsl.get_pipeline_conf().set_ttl_seconds_after_finished(86400)
 
         workflow_dict = kfp.compiler.Compiler()._compile(some_pipeline)
-        self.assertEqual(workflow_dict['spec']['ttlSecondsAfterFinished'],
+        self.assertEqual(workflow_dict['spec']['ttlStrategy']['secondsAfterCompletion'],
                          86400)
 
     def test_pod_disruption_budget(self):

--- a/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.yaml
+++ b/sdk/python/tests/compiler/testdata/artifact_passing_using_volume.yaml
@@ -1,83 +1,159 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  annotations:
-    pipelines.kubeflow.org/pipeline_spec: '{"name": "artifact_passing_pipeline"}'
   generateName: artifact-passing-pipeline-
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.8.9, pipelines.kubeflow.org/pipeline_compilation_time: '2021-11-15T11:23:42.469722',
+    pipelines.kubeflow.org/pipeline_spec: '{"name": "Artifact passing pipeline"}'}
+  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.8.9}
 spec:
-  arguments:
-    parameters: []
   entrypoint: artifact-passing-pipeline
-  serviceAccountName: pipeline-runner
   templates:
   - name: artifact-passing-pipeline
     dag:
       tasks:
       - name: consumer
         template: consumer
+        dependencies: [processor]
         arguments:
           parameters:
-          - name: processor-Output-1
-            value: '{{tasks.processor.outputs.parameters.processor-Output-1}}'
-          - name: processor-Output-2-subpath
-            value: '{{tasks.processor.outputs.parameters.processor-Output-2-subpath}}'
-        dependencies:
-        - processor
+          - {name: processor-Output-1, value: '{{tasks.processor.outputs.parameters.processor-Output-1}}'}
+          - {name: processor-Output-2-subpath, value: '{{tasks.processor.outputs.parameters.processor-Output-2-subpath}}'}
+      - {name: metadata-and-metrics, template: metadata-and-metrics}
       - name: processor
         template: processor
+        dependencies: [producer]
         arguments:
           parameters:
-          - name: producer-Output-1
-            value: '{{tasks.producer.outputs.parameters.producer-Output-1}}'
-          - name: producer-Output-2-subpath
-            value: '{{tasks.producer.outputs.parameters.producer-Output-2-subpath}}'
-        dependencies:
-        - producer
-      - name: producer
-        template: producer
+          - {name: producer-Output-1, value: '{{tasks.producer.outputs.parameters.producer-Output-1}}'}
+          - {name: producer-Output-2-subpath, value: '{{tasks.producer.outputs.parameters.producer-Output-2-subpath}}'}
+      - {name: producer, template: producer}
   - name: consumer
-    metadata:
-      annotations:
-        pipelines.kubeflow.org/component_spec: '{"inputs": [{"name": "Input parameter"}, {"name": "Input artifact"}], "name": "Consumer"}'
-    inputs:
-      parameters:
-      - name: processor-Output-1
-      - name: processor-Output-2-subpath
     container:
-      image: alpine
+      args: ['{{inputs.parameters.processor-Output-1}}', /tmp/inputs/Input_artifact/data]
       command:
       - sh
       - -c
       - |
         echo "Input parameter = $0"
         echo "Input artifact = " && cat "$1"
-      args:
-      - '{{inputs.parameters.processor-Output-1}}'
-      - /tmp/inputs/Input_artifact/data
+      image: alpine
       volumeMounts:
-      - name: data-storage
-        mountPath: /tmp/inputs/Input_artifact
-        readOnly: true
-        subPath: '{{inputs.parameters.processor-Output-2-subpath}}'
-  - name: processor
-    metadata:
-      annotations:
-        pipelines.kubeflow.org/component_spec: '{"inputs": [{"name": "Input parameter"}, {"name": "Input artifact"}], "name": "Processor", "outputs": [{"name": "Output 1"}, {"name": "Output 2"}]}'
+      - {mountPath: /tmp/inputs/Input_artifact, name: data-storage, subPath: '{{inputs.parameters.processor-Output-2-subpath}}',
+        readOnly: true}
     inputs:
       parameters:
-      - name: producer-Output-1
-      - name: producer-Output-2-subpath
+      - {name: processor-Output-1}
+      - {name: processor-Output-2-subpath}
+    metadata:
+      labels:
+        pipelines.kubeflow.org/kfp_sdk_version: 1.8.9
+        pipelines.kubeflow.org/pipeline-sdk-type: kfp
+        pipelines.kubeflow.org/enable_caching: "true"
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": [{"inputValue": "Input parameter"}, {"inputPath": "Input artifact"}],
+          "command": ["sh", "-c", "echo \"Input parameter = $0\"\necho \"Input artifact
+          = \" && cat \"$1\"\n"], "image": "alpine"}}, "inputs": [{"name": "Input
+          parameter"}, {"name": "Input artifact"}], "name": "Consumer"}', pipelines.kubeflow.org/component_ref: '{"digest":
+          "1a8ea3c29c7853bf63d9b4fbd76a66b273621d2229c3cfe08ed68620ebf02982", "url":
+          "testdata/test_data/consume_2.component.yaml"}',
+        pipelines.kubeflow.org/arguments.parameters: '{"Input parameter": "{{inputs.parameters.processor-Output-1}}"}'}
+  - name: metadata-and-metrics
+    container:
+      args: ['----output-paths', /tmp/outputs/mlpipeline_ui_metadata/data, /tmp/outputs/mlpipeline_metrics/data]
+      command:
+      - sh
+      - -ec
+      - |
+        program_path=$(mktemp)
+        printf "%s" "$0" > "$program_path"
+        python3 -u "$program_path" "$@"
+      - |
+        def metadata_and_metrics():
+            metadata = {
+                "outputs": [
+                    {"storage": "inline", "source": "*this should be bold*", "type": "markdown"}
+                ]
+            }
+            metrics = {
+                "metrics": [
+                    {
+                        "name": "train-accuracy",
+                        "numberValue": 0.9,
+                    },
+                    {
+                        "name": "test-accuracy",
+                        "numberValue": 0.7,
+                    },
+                ]
+            }
+            from collections import namedtuple
+            import json
+
+            return namedtuple("output", ["mlpipeline_ui_metadata", "mlpipeline_metrics"])(
+                json.dumps(metadata), json.dumps(metrics)
+            )
+
+        import argparse
+        _parser = argparse.ArgumentParser(prog='Metadata and metrics', description='')
+        _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=2)
+        _parsed_args = vars(_parser.parse_args())
+        _output_files = _parsed_args.pop("_output_paths", [])
+
+        _outputs = metadata_and_metrics(**_parsed_args)
+
+        _output_serializers = [
+            str,
+            str,
+
+        ]
+
+        import os
+        for idx, output_file in enumerate(_output_files):
+            try:
+                os.makedirs(os.path.dirname(output_file))
+            except OSError:
+                pass
+            with open(output_file, 'w') as f:
+                f.write(_output_serializers[idx](_outputs[idx]))
+      image: python:3.7
+      volumeMounts:
+      - {mountPath: /tmp/outputs/mlpipeline_ui_metadata, name: data-storage, subPath: 'artifact_data/{{workflow.uid}}_{{pod.name}}/mlpipeline-ui-metadata'}
+      - {mountPath: /tmp/outputs/mlpipeline_metrics, name: data-storage, subPath: 'artifact_data/{{workflow.uid}}_{{pod.name}}/mlpipeline-metrics'}
     outputs:
       parameters:
-      - name: processor-Output-1
-        valueFrom:
-          path: /tmp/outputs/Output_1/data
-      - name: processor-Output-1-subpath
-        value: artifact_data/{{workflow.uid}}_{{pod.name}}/processor-Output-1
-      - name: processor-Output-2-subpath
-        value: artifact_data/{{workflow.uid}}_{{pod.name}}/processor-Output-2
+      - {name: mlpipeline-ui-metadata-subpath, value: 'artifact_data/{{workflow.uid}}_{{pod.name}}/mlpipeline-ui-metadata'}
+      - {name: mlpipeline-metrics-subpath, value: 'artifact_data/{{workflow.uid}}_{{pod.name}}/mlpipeline-metrics'}
+      artifacts:
+      - {name: mlpipeline-ui-metadata, path: /tmp/outputs/mlpipeline_ui_metadata/data}
+      - {name: mlpipeline-metrics, path: /tmp/outputs/mlpipeline_metrics/data}
+    metadata:
+      labels:
+        pipelines.kubeflow.org/kfp_sdk_version: 1.8.9
+        pipelines.kubeflow.org/pipeline-sdk-type: kfp
+        pipelines.kubeflow.org/enable_caching: "true"
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": ["----output-paths", {"outputPath": "mlpipeline_ui_metadata"},
+          {"outputPath": "mlpipeline_metrics"}], "command": ["sh", "-ec", "program_path=$(mktemp)\nprintf
+          \"%s\" \"$0\" > \"$program_path\"\npython3 -u \"$program_path\" \"$@\"\n",
+          "def metadata_and_metrics():\n    metadata = {\n        \"outputs\": [\n            {\"storage\":
+          \"inline\", \"source\": \"*this should be bold*\", \"type\": \"markdown\"}\n        ]\n    }\n    metrics
+          = {\n        \"metrics\": [\n            {\n                \"name\": \"train-accuracy\",\n                \"numberValue\":
+          0.9,\n            },\n            {\n                \"name\": \"test-accuracy\",\n                \"numberValue\":
+          0.7,\n            },\n        ]\n    }\n    from collections import namedtuple\n    import
+          json\n\n    return namedtuple(\"output\", [\"mlpipeline_ui_metadata\", \"mlpipeline_metrics\"])(\n        json.dumps(metadata),
+          json.dumps(metrics)\n    )\n\nimport argparse\n_parser = argparse.ArgumentParser(prog=''Metadata
+          and metrics'', description='''')\n_parser.add_argument(\"----output-paths\",
+          dest=\"_output_paths\", type=str, nargs=2)\n_parsed_args = vars(_parser.parse_args())\n_output_files
+          = _parsed_args.pop(\"_output_paths\", [])\n\n_outputs = metadata_and_metrics(**_parsed_args)\n\n_output_serializers
+          = [\n    str,\n    str,\n\n]\n\nimport os\nfor idx, output_file in enumerate(_output_files):\n    try:\n        os.makedirs(os.path.dirname(output_file))\n    except
+          OSError:\n        pass\n    with open(output_file, ''w'') as f:\n        f.write(_output_serializers[idx](_outputs[idx]))\n"],
+          "image": "python:3.7"}}, "name": "Metadata and metrics", "outputs": [{"name":
+          "mlpipeline_ui_metadata", "type": "UI_metadata"}, {"name": "mlpipeline_metrics",
+          "type": "Metrics"}]}', pipelines.kubeflow.org/component_ref: '{}'}
+  - name: processor
     container:
-      image: alpine
+      args: ['{{inputs.parameters.producer-Output-1}}', /tmp/inputs/Input_artifact/data,
+        /tmp/outputs/Output_1/data, /tmp/outputs/Output_2/data]
       command:
       - sh
       - -c
@@ -86,37 +162,40 @@ spec:
         mkdir -p "$(dirname "$3")"
         echo "$0" > "$2"
         cp "$1" "$3"
-      args:
-      - '{{inputs.parameters.producer-Output-1}}'
-      - /tmp/inputs/Input_artifact/data
-      - /tmp/outputs/Output_1/data
-      - /tmp/outputs/Output_2/data
+      image: alpine
       volumeMounts:
-      - mountPath: /tmp/inputs/Input_artifact
-        name: data-storage
-        readOnly: true
-        subPath: '{{inputs.parameters.producer-Output-2-subpath}}'
-      - mountPath: /tmp/outputs/Output_1
-        name: data-storage
-        subPath: artifact_data/{{workflow.uid}}_{{pod.name}}/processor-Output-1
-      - mountPath: /tmp/outputs/Output_2
-        name: data-storage
-        subPath: artifact_data/{{workflow.uid}}_{{pod.name}}/processor-Output-2
-  - name: producer
-    metadata:
-      annotations:
-        pipelines.kubeflow.org/component_spec: '{"name": "Producer", "outputs": [{"name": "Output 1"}, {"name": "Output 2"}]}'
+      - {mountPath: /tmp/inputs/Input_artifact, name: data-storage, subPath: '{{inputs.parameters.producer-Output-2-subpath}}',
+        readOnly: true}
+      - {mountPath: /tmp/outputs/Output_1, name: data-storage, subPath: 'artifact_data/{{workflow.uid}}_{{pod.name}}/processor-Output-1'}
+      - {mountPath: /tmp/outputs/Output_2, name: data-storage, subPath: 'artifact_data/{{workflow.uid}}_{{pod.name}}/processor-Output-2'}
+    inputs:
+      parameters:
+      - {name: producer-Output-1}
+      - {name: producer-Output-2-subpath}
     outputs:
       parameters:
-      - name: producer-Output-1
-        valueFrom:
-          path: /tmp/outputs/Output_1/data
-      - name: producer-Output-1-subpath
-        value: artifact_data/{{workflow.uid}}_{{pod.name}}/producer-Output-1
-      - name: producer-Output-2-subpath
-        value: artifact_data/{{workflow.uid}}_{{pod.name}}/producer-Output-2
+      - name: processor-Output-1
+        valueFrom: {path: /tmp/outputs/Output_1/data}
+      - {name: processor-Output-1-subpath, value: 'artifact_data/{{workflow.uid}}_{{pod.name}}/processor-Output-1'}
+      - {name: processor-Output-2-subpath, value: 'artifact_data/{{workflow.uid}}_{{pod.name}}/processor-Output-2'}
+    metadata:
+      labels:
+        pipelines.kubeflow.org/kfp_sdk_version: 1.8.9
+        pipelines.kubeflow.org/pipeline-sdk-type: kfp
+        pipelines.kubeflow.org/enable_caching: "true"
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": [{"inputValue": "Input parameter"}, {"inputPath": "Input artifact"},
+          {"outputPath": "Output 1"}, {"outputPath": "Output 2"}], "command": ["sh",
+          "-c", "mkdir -p \"$(dirname \"$2\")\"\nmkdir -p \"$(dirname \"$3\")\"\necho
+          \"$0\" > \"$2\"\ncp \"$1\" \"$3\"\n"], "image": "alpine"}}, "inputs": [{"name":
+          "Input parameter"}, {"name": "Input artifact"}], "name": "Processor", "outputs":
+          [{"name": "Output 1"}, {"name": "Output 2"}]}', pipelines.kubeflow.org/component_ref: '{"digest":
+          "f11a277f5c5cbc27a2e2cda412547b607671d88a4e7aa8a1665dadb836b592b3", "url":
+          "testdata/test_data/process_2_2.component.yaml"}',
+        pipelines.kubeflow.org/arguments.parameters: '{"Input parameter": "{{inputs.parameters.producer-Output-1}}"}'}
+  - name: producer
     container:
-      image: alpine
+      args: [/tmp/outputs/Output_1/data, /tmp/outputs/Output_2/data]
       command:
       - sh
       - -c
@@ -125,17 +204,31 @@ spec:
         mkdir -p "$(dirname "$1")"
         echo "Data 1" > $0
         echo "Data 2" > $1
-      args:
-      - /tmp/outputs/Output_1/data
-      - /tmp/outputs/Output_2/data
+      image: alpine
       volumeMounts:
-      - mountPath: /tmp/outputs/Output_1
-        name: data-storage
-        subPath: artifact_data/{{workflow.uid}}_{{pod.name}}/producer-Output-1
-      - mountPath: /tmp/outputs/Output_2
-        name: data-storage
-        subPath: artifact_data/{{workflow.uid}}_{{pod.name}}/producer-Output-2
+      - {mountPath: /tmp/outputs/Output_1, name: data-storage, subPath: 'artifact_data/{{workflow.uid}}_{{pod.name}}/producer-Output-1'}
+      - {mountPath: /tmp/outputs/Output_2, name: data-storage, subPath: 'artifact_data/{{workflow.uid}}_{{pod.name}}/producer-Output-2'}
+    outputs:
+      parameters:
+      - name: producer-Output-1
+        valueFrom: {path: /tmp/outputs/Output_1/data}
+      - {name: producer-Output-1-subpath, value: 'artifact_data/{{workflow.uid}}_{{pod.name}}/producer-Output-1'}
+      - {name: producer-Output-2-subpath, value: 'artifact_data/{{workflow.uid}}_{{pod.name}}/producer-Output-2'}
+    metadata:
+      labels:
+        pipelines.kubeflow.org/kfp_sdk_version: 1.8.9
+        pipelines.kubeflow.org/pipeline-sdk-type: kfp
+        pipelines.kubeflow.org/enable_caching: "true"
+      annotations: {pipelines.kubeflow.org/component_spec: '{"implementation": {"container":
+          {"args": [{"outputPath": "Output 1"}, {"outputPath": "Output 2"}], "command":
+          ["sh", "-c", "mkdir -p \"$(dirname \"$0\")\"\nmkdir -p \"$(dirname \"$1\")\"\necho
+          \"Data 1\" > $0\necho \"Data 2\" > $1\n"], "image": "alpine"}}, "name":
+          "Producer", "outputs": [{"name": "Output 1"}, {"name": "Output 2"}]}', pipelines.kubeflow.org/component_ref: '{"digest":
+          "7399eb54ee94a95708fa9f8a47330a39258b22a319a48458e14a63dcedb87ea4", "url":
+          "testdata/test_data/produce_2.component.yaml"}'}
+  arguments:
+    parameters: []
+  serviceAccountName: pipeline-runner
   volumes:
   - name: data-storage
-    persistentVolumeClaim:
-      claimName: data-volume
+    persistentVolumeClaim: {claimName: data-volume}

--- a/test/presubmit-tests-tfx.sh
+++ b/test/presubmit-tests-tfx.sh
@@ -41,7 +41,8 @@ chmod +x bazel_installer.sh
 
 # Install TFX from head
 cd $source_root
-git clone --depth 1 https://github.com/tensorflow/tfx.git
+# TODO(#6906): unpin release branch
+git clone --branch r1.4.0 --depth 1 https://github.com/tensorflow/tfx.git
 cd $source_root/tfx
 python3 -m pip install .[test] --upgrade \
   --extra-index-url https://pypi-nightly.tensorflow.org/simple

--- a/test/presubmit-tests-tfx.sh
+++ b/test/presubmit-tests-tfx.sh
@@ -17,6 +17,8 @@ source_root=$(pwd)
 
 # TODO(#5051) Unpin pip version once we figure out how to make the new dependency resolver in pip 20.3+ work in our case.
 python3 -m pip install --upgrade pip==20.2.3
+# TODO(#7142): remove future
+python3 -m pip install --upgrade future==0.18.2
 # TODO: unpin google-cloud-bigquery once TFX revert https://github.com/tensorflow/tfx/commit/f8c1dea2095197ceda60e1c4d67c4c90fc17ed44
 python3 -m pip install --upgrade google-cloud-bigquery==1.28.0
 python3 -m pip install -r "$source_root/sdk/python/requirements.txt"


### PR DESCRIPTION
Fixed issue where the `kfp components build` command didn't work unless a connection was made to a KFP API server


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
