### PR TITLE
fix(components): remove rsync usage in gcp container build

### DIFF
--- a/components/gcp/container/build_image.sh
+++ b/components/gcp/container/build_image.sh
@@ -14,8 +14,7 @@
 # limitations under the License.
 
 mkdir -p ./build
-apt install -y rsync
-rsync -arvp --exclude=.tox "component_sdk/python"/ ./build/
+cp -r "component_sdk/python"/ ./build/
 
 ../../build_image.sh -l ml-pipeline-gcp "$@"
 rm -rf ./build


### PR DESCRIPTION
**Description of your changes:**
Got a postsubmit build error on installing rsync
```
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/r/rsync/rsync_3.1.3-8ubuntu0.1_amd64.deb  404  Not Found [IP: 91.189.88.152 80]
```
Looking at the usage, it seems like it could be replaced via `cp`.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
