### PR TITLE
fix(sdk): no longer require KFP client for kfp components build

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -44,6 +44,7 @@
 * Add verify_ssl for Kubeflow client [\#7174](https://github.com/kubeflow/pipelines/pull/7174)
 * Depends on `typing-extensions>=3.7.4,<5; python_version<"3.9"` [\#7288](https://github.com/kubeflow/pipelines/pull/7288)
 * Depends on `google-api-core>=1.31.5, >=2.3.2` [\#7377](https://github.com/kubeflow/pipelines/pull/7377)
+* Fix bug that required KFP API server for `kfp components build` command to work [\#7430](https://github.com/kubeflow/pipelines/pull/7430)
 
 ## Documentation Updates
 

--- a/sdk/python/kfp/deprecated/cli/cli.py
+++ b/sdk/python/kfp/deprecated/cli/cli.py
@@ -27,6 +27,10 @@ from kfp.deprecated.cli.experiment import experiment
 from kfp.deprecated.cli.output import OutputFormat
 from kfp.deprecated.cli import components
 
+_NO_CLIENT_COMMANDS = [
+    'diagnose_me',
+    'components'
+]
 
 @click.group()
 @click.option('--endpoint', help='Endpoint of the KFP API service to connect.')
@@ -57,8 +61,8 @@ def cli(ctx: click.Context, endpoint: str, iap_client_id: str, namespace: str,
     Feature stage:
     [Alpha](https://github.com/kubeflow/pipelines/blob/07328e5094ac2981d3059314cc848fbb71437a76/docs/release/feature-stages.md#alpha)
     """
-    if ctx.invoked_subcommand == 'diagnose_me':
-        # Do not create a client for diagnose_me
+    if ctx.invoked_subcommand in _NO_CLIENT_COMMANDS:
+        # Do not create a client for these subcommands
         return
     ctx.obj['client'] = Client(endpoint, iap_client_id, namespace,
                                other_client_id, other_client_secret)


### PR DESCRIPTION
**Description of your changes:**

Fixed issue where kfp components build command required a connection to a KFP API server

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
