### PR TITLE
fix(sdk): fix wrong kfp import causes wrong sdk_version being set in pipeline_spec.

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -12,6 +12,8 @@
 
 ## Bug Fixes and Other Changes
 
+* Fix wrong kfp import causes wrong sdk_version being set in pipeline_spec. [\#7433](https://github.com/kubeflow/pipelines/pull/7433)
+
 ## Documentation Updates
 
 # 2.0.0-alpha.1

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -25,7 +25,7 @@ import uuid
 from typing import (Any, Callable, Dict, List, Mapping, Optional, Set, Tuple,
                     Union)
 
-import kfp.deprecated as kfp
+import kfp
 from google.protobuf import json_format
 from kfp.pipeline_spec import pipeline_spec_pb2
 from kfp import dsl


### PR DESCRIPTION
**Description of your changes:**
The wrong import caused setting the wrong SDK version in `pipeline_spec.sdk_version`:
https://github.com/kubeflow/pipelines/blob/481b108319fe998847c5b8bbb26782b0fb3707f8/sdk/python/kfp/compiler/compiler.py#L279
which is
https://github.com/kubeflow/pipelines/blob/481b108319fe998847c5b8bbb26782b0fb3707f8/sdk/python/kfp/deprecated/__init__.py#L15

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
