### PR TITLE
chore: remove building sdist for `kfp-pipeline-spec`

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -39,7 +39,7 @@ clean-go:
 # Generate Python package.
 .PHONY: python
 python: v2alpha1/pipeline_spec.proto v2alpha1/google/rpc/status.proto
-	python3 v2alpha1/python/generate_proto.py && cd v2alpha1/python && python3 setup.py sdist bdist_wheel
+	python3 v2alpha1/python/generate_proto.py && cd v2alpha1/python && python3 setup.py bdist_wheel
 
 # Delete all generated Python packages
 .PHONY: clean-python


### PR DESCRIPTION
**Description of your changes:**

Building `sdist` in addition to `bdist_wheel` was introduced in https://github.com/kubeflow/pipelines/pull/7165, with the goal to make `kfp-pipeline-spec` available on conda forge. 
Later https://github.com/conda-forge/staged-recipes/pull/18184 solved the problem without needing for a `sdist` release. So I think we can revert this part of change and continue our previous release process.

/cc @akchinSTC 


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
