### PR TITLE
fix(backend): Setup the gRPC max message size

### DIFF
--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -52,6 +52,7 @@ type ExecutionType string
 const (
 	ContainerExecutionTypeName ExecutionType = "system.ContainerExecution"
 	DagExecutionTypeName       ExecutionType = "system.DAGExecution"
+	MaxClientGRPCMessageSize                 = 100 * 1024 * 1024
 )
 
 var (
@@ -93,6 +94,7 @@ func NewClient(serverAddress, serverPort string) (*Client, error) {
 		grpc.WithInsecure(),
 		grpc.WithStreamInterceptor(grpc_retry.StreamClientInterceptor(opts...)),
 		grpc.WithUnaryInterceptor(grpc_retry.UnaryClientInterceptor(opts...)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxClientGRPCMessageSize)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("metadata.NewClient() failed: %w", err)


### PR DESCRIPTION
**Description of your changes:**

Fix the error

```
Failed to execute component: unable to publish createdExecution: rpc error: code = ResourceExhausted desc = Received message larger than max (68362272 vs. 4194304)
```

similar with https://github.com/kubeflow/pipelines/pull/3004/files

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

