### PR TITLE
chore(deps): Bump google-cloud-storage to 2.2.1

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -19,6 +19,7 @@
 * Support submitting pipeline IR in yaml format via `kfp.client`. [\#7458](https://github.com/kubeflow/pipelines/pull/7458)
 * Add pipeline_task_name to PipelineTaskFinalStatus [\#7464](https://github.com/kubeflow/pipelines/pull/7464)
 * Depends on `kfp-pipeline-spec>=0.1.14,<0.2.0` [\#7464](https://github.com/kubeflow/pipelines/pull/7464)
+* Depends on `google-cloud-storage>=2.2.1,<3` [\#7493](https://github.com/kubeflow/pipelines/pull/7493)
 
 ## Documentation Updates
 

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -10,9 +10,8 @@ docstring-parser>=0.7.3,<1
 # https://github.com/googleapis/python-api-core/releases/tag/v1.31.5
 google-api-core>=1.31.5,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0
 google-auth>=1.6.1,<3
-# `Blob.from_string` was introduced in google-cloud-storage 1.20.0
-# https://github.com/googleapis/python-storage/blob/master/CHANGELOG.md#1200
-google-cloud-storage>=1.20.0,<2
+# https://github.com/googleapis/python-storage/blob/main/CHANGELOG.md#221-2022-03-15
+google-cloud-storage>=2.2.1,<3
 # NOTE: Maintainers, please do not require google-auth>=2.x.x
 # Until this issue is closed
 # https://github.com/googleapis/google-cloud-python/issues/10566

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -43,11 +43,11 @@ google-auth==1.35.0
     #   kubernetes
 google-cloud-core==2.1.0
     # via google-cloud-storage
-google-cloud-storage==1.42.3
+google-cloud-storage==2.2.1
     # via -r requirements.in
 google-crc32c==1.3.0
     # via google-resumable-media
-google-resumable-media==2.0.3
+google-resumable-media==2.3.2
     # via google-cloud-storage
 googleapis-common-protos==1.53.0
     # via google-api-core


### PR DESCRIPTION
**Description of your changes:**

Fix the pip conflicts **warning** if the user also installed latest `google-cloud-storage`

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. 
This behaviour is the source of the following dependency conflicts.
kfp 1.8.11 requires google-cloud-storage<2,>=1.20.0, but you have google-cloud-storage 2.2.1 which is incompatible.
```

According to the change log https://github.com/googleapis/python-storage/blob/main/CHANGELOG.md#200-2022-01-12

The only breaking change is **Remove Python 2 Support**, which should be fine for `kfp`

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
