### PR TITLE
chore(sdk): remove unused kfp command line command

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -108,6 +108,5 @@ setuptools.setup(
         'console_scripts': [
             'dsl-compile = kfp.deprecated.compiler.main:main',
             'dsl-compile-v2 = kfp.compiler.main:main',
-            'kfp=kfp.__main__:main',
         ]
     })


### PR DESCRIPTION
**Description of your changes:**
The `kfp` command line command currently throws an exception because 
`kfp.__main__` is not included in v2. This PR removes `kfp` from the `console_scripts` list.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title 
convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
