### PR TITLE
fix(sdk): Workaround for deprecated Google OAuth oob flow

### DIFF
--- a/sdk/python/kfp/client/auth.py
+++ b/sdk/python/kfp/client/auth.py
@@ -190,12 +190,14 @@ def get_refresh_token_from_client_id(client_id, client_secret):
 
 
 def get_auth_code(client_id):
-    auth_url = "https://accounts.google.com/o/oauth2/v2/auth?client_id=%s&response_type=code&scope=openid%%20email&access_type=offline&redirect_uri=urn:ietf:wg:oauth:2.0:oob" % client_id
+    auth_url = "https://accounts.google.com/o/oauth2/v2/auth?client_id=%s&response_type=code&scope=openid%%20email&access_type=offline&redirect_uri=http://localhost:1" % client_id
     print(auth_url)
     open_new_tab(auth_url)
     return input(
-        "If there's no browser window prompt, please direct to the URL above, "
-        "then copy and paste the authorization code here: ")
+        "If there's no browser window prompt, please direct to the URL above,\n"
+        "At the end the browser will fail to connect to http://localhost:1/?code=SOMECODE&scope=... \n"
+        "Copy the value of SOMECODE from the address and paste it below")
+        
 
 
 def get_refresh_token_from_code(auth_code, client_id, client_secret):
@@ -203,7 +205,7 @@ def get_refresh_token_from_code(auth_code, client_id, client_secret):
         "code": auth_code,
         "client_id": client_id,
         "client_secret": client_secret,
-        "redirect_uri": "urn:ietf:wg:oauth:2.0:oob",
+        "redirect_uri": "http://localhost:1",
         "grant_type": "authorization_code"
     }
     res = requests.post(OAUTH_TOKEN_URI, data=payload)


### PR DESCRIPTION
**Description of your changes:**

This is a workaround for the deprecation of copy-paste based
OAuth out-of-band (oob) flow for Google Cloud ( #7474 ).

As described in (1) deprecation for this workflow started on Feb 28, 2022, thus the current authentication workflow is currently broken.

The workaround implemented here was found in (2) and consists of replacing the `redirect_uri` to `http://localhost:1` and capturing the return code form the error URL.  
While this is arguably a suboptimal user experience, at least the workflow works again. Maybe a Google Oauth expert could suggest a better solution?

References:
1) https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html#disallowed-oob
2) Workaround from: https://stackoverflow.com/questions/71318804/google-oauth-2-0-failing-with-error-400-invalid-request-for-some-client-id-but/71327990#71327990

