### PR TITLE
chore(sdk): stop using pydantic for serialization

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -38,6 +38,7 @@ from kfp.components import tasks_group
 from kfp.components import utils as component_utils
 from kfp.components.types import type_utils
 from kfp.pipeline_spec import pipeline_spec_pb2
+from kfp.utils import ir_utils
 
 _GroupOrTask = Union[tasks_group.TasksGroup, pipeline_task.PipelineTask]
 
@@ -200,26 +201,8 @@ class Compiler:
             package_path: The file path to be written.
         """
 
-        json_text = json_format.MessageToJson(pipeline_spec, sort_keys=True)
-
-        if package_path.endswith(".json"):
-            warnings.warn(
-                ("Compiling pipline spec to JSON is deprecated and will be "
-                 "removed in a future version. Please compile to a YAML file by "
-                 "providing a file path with .yaml extension instead."),
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-            with open(package_path, 'w') as json_file:
-                json_file.write(json_text)
-
-        elif package_path.endswith((".yaml", ".yml")):
-            json_dict = json.loads(json_text)
-            with open(package_path, 'w') as yaml_file:
-                yaml.dump(json_dict, yaml_file, sort_keys=True)
-        else:
-            raise ValueError(
-                f'The output path {package_path} should end with ".yaml".')
+        json_dict = json_format.MessageToDict(pipeline_spec)
+        ir_utils._write_ir_to_file(json_dict, package_path)
 
     def _validate_exit_handler(self,
                                pipeline: pipeline_context.Pipeline) -> None:

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -700,9 +700,8 @@ class TestWriteToFileTypes(parameterized.TestCase):
             pipeline_spec = self.make_pipeline_spec()
 
             target_file = os.path.join(tmpdir, 'result.json')
-            with self.assertWarnsRegex(
-                    DeprecationWarning,
-                    r"Compiling pipline spec to JSON is deprecated"):
+            with self.assertWarnsRegex(DeprecationWarning,
+                                       r"Compiling to JSON is deprecated"):
                 compiler.Compiler().compile(
                     pipeline_func=pipeline_spec, package_path=target_file)
             with open(target_file) as f:
@@ -758,6 +757,7 @@ class TestWriteToFileTypes(parameterized.TestCase):
                 pass
         finally:
             shutil.rmtree(tmpdir)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/components/structures.py
+++ b/sdk/python/kfp/components/structures.py
@@ -23,6 +23,7 @@ import yaml
 from kfp.components import utils
 from kfp.components import v1_components
 from kfp.components import v1_structures
+from kfp.utils import ir_utils
 
 
 class BaseModel(pydantic.BaseModel):
@@ -595,11 +596,4 @@ class ComponentSpec(BaseModel):
         Args:
             output_file: File path to store the component yaml.
         """
-        with open(output_file, 'a') as output_file:
-            json_component = self.json(
-                exclude_none=False, exclude_unset=True, by_alias=True)
-            yaml_file = yaml.safe_dump(
-                json.loads(json_component),
-                default_flow_style=None,
-                sort_keys=True)
-            output_file.write(yaml_file)
+        ir_utils._write_ir_to_file(self.dict(), output_file)

--- a/sdk/python/kfp/deprecated/cli/components.py
+++ b/sdk/python/kfp/deprecated/cli/components.py
@@ -274,7 +274,7 @@ class _ComponentBuilder():
                 self._context_directory / _COMPONENT_METADATA_DIR / filename)
             container_filename.parent.mkdir(exist_ok=True, parents=True)
             component_info.component_spec.save_to_component_yaml(
-                container_filename)
+                str(container_filename))
 
     def generate_kfp_config(self):
         config = kfp_config.KFPConfig(config_directory=self._context_directory)

--- a/sdk/python/kfp/utils/__init__.py
+++ b/sdk/python/kfp/utils/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/kfp/utils/ir_utils.py
+++ b/sdk/python/kfp/utils/ir_utils.py
@@ -1,0 +1,34 @@
+from typing import Dict, Any
+import warnings
+import json
+import yaml
+
+
+def _write_ir_to_file(ir_dict: Dict[str, Any], output_file: str) -> None:
+    """Writes the IR JSON to a file.
+
+    Args:
+        ir_dict (Dict[str, Any]): IR JSON.
+        output_file (str): Output file path.
+
+    Raises:
+        ValueError: If output file path is not JSON or YAML.
+    """
+
+    if output_file.endswith(".json"):
+        warnings.warn(
+            ("Compiling to JSON is deprecated and will be "
+             "removed in a future version. Please compile to a YAML file by "
+             "providing a file path with a .yaml extension instead."),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        ir_json = json.dumps(ir_dict, sort_keys=True)
+        with open(output_file, 'w') as json_file:
+            json_file.write(ir_json)
+    elif output_file.endswith((".yaml", ".yml")):
+        with open(output_file, 'w') as yaml_file:
+            yaml.dump(ir_dict, yaml_file, sort_keys=True)
+    else:
+        raise ValueError(
+            f'The output path {output_file} should end with ".yaml".')

--- a/sdk/python/kfp/utils/ir_utils.py
+++ b/sdk/python/kfp/utils/ir_utils.py
@@ -1,3 +1,17 @@
+# Copyright 2022 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Dict, Any
 import warnings
 import json

--- a/sdk/python/kfp/utils/ir_utils_test.py
+++ b/sdk/python/kfp/utils/ir_utils_test.py
@@ -1,0 +1,36 @@
+import json
+import os
+import tempfile
+import unittest
+
+import yaml
+from kfp.utils import ir_utils
+
+json_string = json.dumps({"key": "val", "list": ["1", 2, 3.0]})
+
+
+def load_from_file(filepath: str) -> str:
+    with open(filepath, "r") as f:
+        return json.dumps(yaml.safe_load(f))
+
+
+class TestWriteIrToFile(unittest.TestCase):
+
+    def test_yaml(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_filepath = os.path.join(tempdir, 'output.yaml')
+            ir_utils._write_ir_to_file(json_string, temp_filepath)
+            actual = load_from_file(temp_filepath)
+        self.assertEqual(actual, json_string)
+
+    def test_json(self):
+        with tempfile.TemporaryDirectory() as tempdir, self.assertWarnsRegex(
+                DeprecationWarning, r"Compiling to JSON is deprecated"):
+            temp_filepath = os.path.join(tempdir, 'output.json')
+            ir_utils._write_ir_to_file(json_string, temp_filepath)
+            actual = load_from_file(temp_filepath)
+        self.assertEqual(actual, json_string)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/python/kfp/utils/ir_utils_test.py
+++ b/sdk/python/kfp/utils/ir_utils_test.py
@@ -24,7 +24,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import os
 import tempfile
 import unittest

--- a/sdk/python/kfp/utils/ir_utils_test.py
+++ b/sdk/python/kfp/utils/ir_utils_test.py
@@ -6,12 +6,12 @@ import unittest
 import yaml
 from kfp.utils import ir_utils
 
-json_string = json.dumps({"key": "val", "list": ["1", 2, 3.0]})
+json_dict = {"key": "val", "list": ["1", 2, 3.0]}
 
 
 def load_from_file(filepath: str) -> str:
     with open(filepath, "r") as f:
-        return json.dumps(yaml.safe_load(f))
+        return yaml.safe_load(f)
 
 
 class TestWriteIrToFile(unittest.TestCase):
@@ -19,17 +19,30 @@ class TestWriteIrToFile(unittest.TestCase):
     def test_yaml(self):
         with tempfile.TemporaryDirectory() as tempdir:
             temp_filepath = os.path.join(tempdir, 'output.yaml')
-            ir_utils._write_ir_to_file(json_string, temp_filepath)
+            ir_utils._write_ir_to_file(json_dict, temp_filepath)
             actual = load_from_file(temp_filepath)
-        self.assertEqual(actual, json_string)
+        self.assertEqual(actual, json_dict)
+
+    def test_yml(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_filepath = os.path.join(tempdir, 'output.yml')
+            ir_utils._write_ir_to_file(json_dict, temp_filepath)
+            actual = load_from_file(temp_filepath)
+        self.assertEqual(actual, json_dict)
 
     def test_json(self):
         with tempfile.TemporaryDirectory() as tempdir, self.assertWarnsRegex(
                 DeprecationWarning, r"Compiling to JSON is deprecated"):
             temp_filepath = os.path.join(tempdir, 'output.json')
-            ir_utils._write_ir_to_file(json_string, temp_filepath)
+            ir_utils._write_ir_to_file(json_dict, temp_filepath)
             actual = load_from_file(temp_filepath)
-        self.assertEqual(actual, json_string)
+        self.assertEqual(actual, json_dict)
+
+    def test_incorrect_extension(self):
+        with tempfile.TemporaryDirectory() as tempdir, self.assertRaisesRegex(
+                ValueError, r'should end with "\.yaml"\.'):
+            temp_filepath = os.path.join(tempdir, 'output.txt')
+            ir_utils._write_ir_to_file(json_dict, temp_filepath)
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/utils/ir_utils_test.py
+++ b/sdk/python/kfp/utils/ir_utils_test.py
@@ -1,3 +1,29 @@
+# Copyright 2022 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.# Copyright 2021-2022 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import os
 import tempfile

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -86,6 +86,7 @@ setuptools.setup(
         'kfp.components',
         'kfp.components.types',
         'kfp.dsl',
+        'kfp.utils',
     ],
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
**Description of your changes:**
This PR removes `pydantic` from the component serialization process. A separate PR will remove use of the `pydantic` `BaseModel` and the `pydantic` library from dependencies.

**Checklist:**
- [x] The title for your pull request (PR) should follow 
our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
