### PR TITLE
chore(sdk): use click for dsl-compile command

### DIFF
--- a/samples/test/utils/kfp/samples/test/utils.py
+++ b/samples/test/utils/kfp/samples/test/utils.py
@@ -17,26 +17,29 @@ from __future__ import annotations
 import json
 import logging
 import os
-import sys
-import time
 import random
-import tempfile
 import subprocess
-from dataclasses import dataclass, asdict
+import sys
+import tempfile
+import time
+import unittest
+from dataclasses import asdict
+from dataclasses import dataclass
 from pprint import pprint
 from typing import Callable, Optional
-import unittest
-from google.protobuf.json_format import MessageToDict
-import nbformat
-from nbconvert import PythonExporter
 
 import kfp
-from kfp.deprecated.onprem import add_default_resource_spec
 import kfp.compiler
 import kfp_server_api
+import nbformat
+from google.protobuf.json_format import MessageToDict
+from kfp.deprecated.onprem import add_default_resource_spec
 from ml_metadata import metadata_store
 from ml_metadata.metadata_store.metadata_store import ListOptions
-from ml_metadata.proto import Event, Execution, metadata_store_pb2
+from ml_metadata.proto import Event
+from ml_metadata.proto import Execution
+from ml_metadata.proto import metadata_store_pb2
+from nbconvert import PythonExporter
 
 MINUTE = 60
 
@@ -66,7 +69,8 @@ Verifier = Callable[[
 
 @dataclass
 class TestCase:
-    """Test case for running a KFP sample. One of pipeline_func or pipeline_file is required.
+    """Test case for running a KFP sample. One of pipeline_func or
+    pipeline_file is required.
 
     :param run_pipeline: when False, it means the test case just runs the python file.
     :param pipeline_file_compile_path: when specified, the pipeline file can compile
@@ -96,7 +100,8 @@ def run_pipeline_func(test_cases: list[TestCase]):
 
     def test_wrapper(
         run_pipeline: Callable[[
-            Callable, str, str, kfp.deprecated.dsl.PipelineExecutionMode, bool, dict, bool
+            Callable, str, str, kfp.deprecated.dsl
+            .PipelineExecutionMode, bool, dict, bool
         ], kfp_server_api.ApiRunDetail],
         mlmd_connection_config: metadata_store_pb2.MetadataStoreClientConfig,
     ):
@@ -173,7 +178,8 @@ def run_pipeline_func(test_cases: list[TestCase]):
 
 
 def debug_verify(run_id: str, verify_func: Verifier):
-    '''Debug a verify function quickly using MLMD data from an existing KFP run ID.'''
+    """Debug a verify function quickly using MLMD data from an existing KFP run
+    ID."""
     t = unittest.TestCase()
     t.maxDiff = None  # we always want to see full diff
     client = KfpMlmdClient()
@@ -216,10 +222,11 @@ def _run_test(callback):
         metadata_service_host: Optional[str] = None,
         metadata_service_port: int = 8080,
     ):
-        """Test file CLI entrypoint used by Fire.
-        To configure KFP endpoint, configure env vars following:
-        https://www.kubeflow.org/docs/components/pipelines/sdk/connect-api/#configure-sdk-client-by-environment-variables.
-        KFP UI endpoint can be configured by KF_PIPELINES_UI_ENDPOINT env var.
+        """Test file CLI entrypoint used by Fire. To configure KFP endpoint,
+        configure env vars following:
+        https://www.kubeflow.org/docs/components/pipelines/sdk/connect-
+        api/#configure-sdk-client-by-environment-variables. KFP UI endpoint can
+        be configured by KF_PIPELINES_UI_ENDPOINT env var.
 
         :param pipeline_root: pipeline root that holds intermediate
         artifacts, example gs://your-bucket/path/to/workdir.
@@ -271,8 +278,8 @@ def _run_test(callback):
             pipeline_func: Optional[Callable],
             pipeline_file: Optional[str],
             pipeline_file_compile_path: Optional[str],
-            mode: kfp.deprecated.dsl.PipelineExecutionMode = kfp.deprecated.dsl.PipelineExecutionMode
-            .V2_ENGINE,
+            mode: kfp.deprecated.dsl.PipelineExecutionMode = kfp.deprecated.dsl
+            .PipelineExecutionMode.V2_ENGINE,
             enable_caching: bool = False,
             arguments: Optional[dict] = None,
             dry_run: bool = False,  # just compile the pipeline without running it
@@ -329,7 +336,8 @@ def _run_test(callback):
                         else:
                             package_path = tempfile.mktemp(
                                 suffix='.yaml', prefix="kfp_package")
-                            from kfp.deprecated.compiler.main import compile_pyfile
+                            from kfp.deprecated.compiler.main import \
+                                compile_pyfile
                             compile_pyfile(
                                 pyfile=pyfile,
                                 output_path=package_path,
@@ -396,8 +404,8 @@ def run_v2_pipeline(
         if file.endswith(".ipynb"):
             pyfile = tempfile.mktemp(suffix='.py', prefix="pipeline_py_code")
             _nb_sample_to_py(file, pyfile)
-        from kfp.compiler.main import compile_pyfile
-        compile_pyfile(pyfile=pyfile, package_path=original_pipeline_spec)
+        from kfp.cli.compile import dsl_compile
+        dsl_compile(py=pyfile, output=original_pipeline_spec)
 
     # remove following overriding logic once we use create_run_from_job_spec to trigger kfp pipeline run
     with open(original_pipeline_spec) as f:
@@ -721,7 +729,10 @@ def _disable_cache(task):
 
 
 def _nb_sample_to_py(notebook_path: str, output_path: str):
-    """nb_sample_to_py converts notebook kfp sample to a python file. Cells with tag "skip-in-test" will be omitted."""
+    """nb_sample_to_py converts notebook kfp sample to a python file.
+
+    Cells with tag "skip-in-test" will be omitted.
+    """
     with open(notebook_path, 'r') as f:
         nb = nbformat.read(f, as_version=4)
         # Cells with skip-in-test tag will be omitted.

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -89,7 +89,7 @@ setuptools.setup(
     include_package_data=True,
     entry_points={
         'console_scripts': [
-            'dsl-compile = kfp.compiler.main:main',
+            'dsl-compile = kfp.cli.compile:main',
             'dsl-compile-deprecated = kfp.deprecated.compiler.main:main',
             'kfp=kfp.cli.__main__:main',
         ]


### PR DESCRIPTION
**Description of your changes:**
Uses `click` for `dsl-compile` command, instead of `argparse`. A 
future PR will migrate `dsl-compile` to the main `kfp` namespace.

Notes for reviewer:

- Tests continue to pass
- The CLI signature is the same, though the help messages vary 
slightly:

Before:
```txt
usage: dsl-compile [-h] --py PY [--function FUNCTION]
                   [--pipeline-parameters PIPELINE_PARAMETERS]
                   [--namespace NAMESPACE] --output OUTPUT
                   [--disable-type-check]

optional arguments:
  -h, --help            show this help message and exit
  --py PY               local absolute path to a py file.
  --function FUNCTION   The name of the function to compile if 
there are
                        multiple.
  --pipeline-parameters PIPELINE_PARAMETERS
                        The pipeline parameters in JSON dict 
format.
  --namespace NAMESPACE
                        The namespace for the pipeline function
  --output OUTPUT       local path to the output PipelineJob 
json file.
  --disable-type-check  disable the type check, default is 
enabled.
```

After:
```txt
Usage: dsl-compile [OPTIONS]

  Compiles a pipeline written in a .py file.

Options:
  --py TEXT                   Local absolute path to a py file.
                              [required]
  --output TEXT               Local path to the output 
PipelineJob 
JSON
                              file.  [required]
  --function TEXT             The name of the function to 
compile if 
there
                              are multiple.
  --pipeline-parameters TEXT  The pipeline parameters in JSON 
dict 
format.
  --disable-type-check        Disable the type check. Default: 
type 
check
                              is not disabled.
  --help                      Show this message and exit.
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our 
title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
