### PR TITLE
feat(sdk): add archive, unarchive, and delete run methods and tidy docstrings

### DIFF
--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -353,7 +353,7 @@ class Client:
         config.refresh_api_key_hook(config)
         return config
 
-    def set_user_namespace(self, namespace: str):
+    def set_user_namespace(self, namespace: str) -> None:
         """Set user namespace into local context setting file.
 
         This function should only be used when Kubeflow Pipelines is in the
@@ -361,6 +361,9 @@ class Client:
 
         Args:
             namespace: kubernetes namespace the user has access to.
+
+        Returns:
+            None
         """
         self._context_setting['namespace'] = namespace
         if not os.path.exists(os.path.dirname(Client.LOCAL_KFP_CONTEXT)):
@@ -590,6 +593,9 @@ class Client:
 
         Args:
             experiment_id: id of the experiment.
+
+        Returns:
+            None
         """
         self._experiment_api.archive_experiment(id=experiment_id)
 
@@ -598,10 +604,13 @@ class Client:
 
         Args:
             experiment_id: id of the experiment.
+
+        Returns:
+            None
         """
         self._experiment_api.unarchive_experiment(id=experiment_id)
 
-    def delete_experiment(self, experiment_id):
+    def delete_experiment(self, experiment_id: str):
         """Delete experiment.
 
         Args:
@@ -764,6 +773,39 @@ class Client:
                 % (self._get_url_prefix(), response.run.id))
             IPython.display.display(IPython.display.HTML(html))
         return response.run
+
+    def archive_run(self, run_id: str) -> None:
+        """Archives a run.
+
+        Args:
+            run_id: id of the run.
+
+        Returns:
+            None
+        """
+        self._run_api.archive_run(id=run_id)
+
+    def unarchive_run(self, run_id: str) -> None:
+        """Restores an archived run.
+
+        Args:
+            run_id: id of the run.
+
+        Returns:
+            None
+        """
+        self._run_api.unarchive_run(id=run_id)
+
+    def delete_run(self, run_id: str):
+        """Deletes a run.
+
+        Args:
+            run_id: id of the run.
+
+        Returns:
+            Object.
+        """
+        return self._run_api.delete_run(id=run_id)
 
     def create_recurring_run(
         self,
@@ -1098,8 +1140,7 @@ class Client:
             job_id: id of the job.
 
         Returns:
-            Object. If the method is called asynchronously, returns the request
-            thread.
+            Object.
 
         Raises:
             kfp_server_api.ApiException: If the job is not found.
@@ -1113,8 +1154,7 @@ class Client:
             job_id: id of the job.
 
         Returns:
-            Object. If the method is called asynchronously, returns the request
-            thread.
+            Object.
 
         Raises:
             kfp_server_api.ApiException: If the job is not found.
@@ -1125,11 +1165,10 @@ class Client:
         """Enables a job.
 
         Args:
-           job_id: id of the job.
+            job_id: id of the job.
 
         Returns:
-           Object. If the method is called asynchronously, returns the request
-           thread.
+            Object.
 
         Raises:
             kfp_server_api.ApiException: If the job is not found.
@@ -1436,8 +1475,7 @@ class Client:
             pipeline_id: id of the pipeline.
 
         Returns:
-            Object. If the method is called asynchronously, returns the request
-            thread.
+            Object.
 
         Raises:
             kfp_server_api.ApiException: If pipeline is not found.
@@ -1515,8 +1553,7 @@ class Client:
             version_id: id of the pipeline version.
 
         Returns:
-            Object. If the method is called asynchronously, returns the request
-            thread.
+            Object.
 
         Raises:
             kfp_server_api.ApiException: If pipeline is not found.


### PR DESCRIPTION
**Description of your changes:**
The PR adds `archive_run`, `unarchive_run`, and `delete_run` methods to the `Client` class. It just consumes the associated methods in the Python client. No additional logic. Please let me know if you'd like me to add it the v1 client as well.

It also tidies up some of the type hints and docstrings. 

Once this is merged, I can contribute a discrete PR to update [this](https://github.com/kubeflow/pipelines/blob/master/test/sample-test/run_resnet_cmle_test.py#L119) test and potentially others that don't clean up artifacts.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
