### PR TITLE
feat(sdk): Allow ephemeral-storage to be defined as a Runtime resource

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -12,6 +12,7 @@
 ## Bug Fixes and Other Changes
 * Depends on `google-cloud-storage>=2.2.1,<3` [\#7502](https://github.com/kubeflow/pipelines/pull/7502)
 * Accepts `typing-extensions>=4,<5` in addition to `typing-extensions>=3.7.4,<4` [\#7801](https://github.com/kubeflow/pipelines/pull/7801)
+* Allow ephemeral-storage as a runtime resource [\#7574](https://github.com/kubeflow/pipelines/pull/7574)
 
 ## Documentation Updates
 

--- a/sdk/python/kfp/compiler/_op_to_template.py
+++ b/sdk/python/kfp/compiler/_op_to_template.py
@@ -315,13 +315,17 @@ def _op_to_template(op: BaseOp):
     if isinstance(op, dsl.ContainerOp) and ('resources' in op.container.keys()):
         for setting, val in op.container['resources'].items():
             for resource, param in val.items():
-                if (resource in ['cpu', 'memory', 'amd.com/gpu', 'nvidia.com/gpu'] or re.match('^{{inputs.parameters.*}}$', resource))\
-                    and re.match('^{{inputs.parameters.*}}$', str(param)):
+                if (resource in [
+                        'cpu', 'memory', 'amd.com/gpu', 'nvidia.com/gpu',
+                        'ephemeral-storage'
+                ] or re.match('^{{inputs.parameters.*}}$',
+                              resource)) and re.match(
+                                  '^{{inputs.parameters.*}}$', str(param)):
                     if not 'containers' in podSpecPatch:
                         podSpecPatch['containers'] = [{
-                                'name': 'main',
-                                'resources': {}
-                            }]
+                            'name': 'main',
+                            'resources': {}
+                        }]
                     if setting not in podSpecPatch['containers'][0][
                             'resources']:
                         podSpecPatch['containers'][0]['resources'][setting] = {


### PR DESCRIPTION
For V1 compiler, it seems that which resources are allowed to be PipelineVariables is hard-coded in the compiler, and ephemeral-storage is not one of them, although Argo does seem to allow it. This is just to add ephemeral-storage to that list

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
