### PR TITLE
fix(test): update v2 samples timeout default

### DIFF
--- a/backend/src/v2/test/sample_test.py
+++ b/backend/src/v2/test/sample_test.py
@@ -107,7 +107,7 @@ def main(
         gcr_root: str,
         gcs_root: str,
         experiment: str = 'v2_sample_test',
-        timeout_mins: float = 40,
+        timeout_mins: int = 60,
         kfp_package_path:
     str = 'git+https://github.com/kubeflow/pipelines#egg=kfp&subdirectory=sdk/python',
         samples_config: str = os.path.join('samples', 'test', 'config.yaml'),


### PR DESCRIPTION
**Description of your changes:**
Sample tests keep failing when they hit the timeout of 40 minutes. See "failed after 40m49s" 
[here](https://oss-prow.knative.dev/view/gs/oss-prow/pr-logs/pull/kubeflow_pipelines/7558/kubeflow-pipelines-samples-v2/1516532077070127104).

This PR increases the timeout from 40 minutes to 60 minutes

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this 
repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
