### PR TITLE
fix(sample): fix static_loop_arguments

### DIFF
--- a/samples/core/loop_static/loop_static_v2.py
+++ b/samples/core/loop_static/loop_static_v2.py
@@ -19,15 +19,12 @@ def concat_op(a: str, b: str) -> str:
     return a + b
 
 
-_DEFAULT_LOOP_ARGUMENTS = [{'a': '1', 'b': '2'}, {'a': '10', 'b': '20'}]
-
-
 @dsl.pipeline(name='pipeline-with-loop-static')
 def my_pipeline(
-    static_loop_arguments: List[dict] = _DEFAULT_LOOP_ARGUMENTS,
     greeting: str = 'this is a test for looping through parameters',
 ):
     print_task = print_op(text=greeting)
+    static_loop_arguments = [{'a': '1', 'b': '2'}, {'a': '10', 'b': '20'}]
 
     with dsl.ParallelFor(static_loop_arguments) as item:
         concat_task = concat_op(a=item.a, b=item.b)


### PR DESCRIPTION
With the current code the input is not passed as static. Declaring the variable inside fixes it.

**Description of your changes:**


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
