### PR TITLE
feat(conformance): Enable experiment API tests in KF mode. 

### DIFF
--- a/backend/src/common/client/api_server/experiment_client.go
+++ b/backend/src/common/client/api_server/experiment_client.go
@@ -3,6 +3,7 @@ package api_server
 import (
 	"fmt"
 
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	apiclient "github.com/kubeflow/pipelines/backend/api/go_http_client/experiment_client"
 	params "github.com/kubeflow/pipelines/backend/api/go_http_client/experiment_client/experiment_service"
@@ -23,7 +24,8 @@ type ExperimentInterface interface {
 }
 
 type ExperimentClient struct {
-	apiClient *apiclient.Experiment
+	apiClient      *apiclient.Experiment
+	authInfoWriter runtime.ClientAuthInfoWriter
 }
 
 func NewExperimentClient(clientConfig clientcmd.ClientConfig, debug bool) (
@@ -36,9 +38,27 @@ func NewExperimentClient(clientConfig clientcmd.ClientConfig, debug bool) (
 
 	apiClient := apiclient.New(runtime, strfmt.Default)
 
-	// Creating upload client
+	// Creating experiment client
 	return &ExperimentClient{
-		apiClient: apiClient,
+		apiClient:      apiClient,
+		authInfoWriter: PassThroughAuth,
+	}, nil
+}
+
+func NewKubeflowInClusterExperimentClient(namespace string, debug bool) (
+	*ExperimentClient, error) {
+
+	runtime, err := NewKubeflowInClusterHTTPRuntime(namespace, debug)
+	if err != nil {
+		return nil, err
+	}
+
+	apiClient := apiclient.New(runtime, strfmt.Default)
+
+	// Creating experiment client
+	return &ExperimentClient{
+		apiClient:      apiClient,
+		authInfoWriter: SATokenVolumeProjectionAuth,
 	}, nil
 }
 
@@ -50,7 +70,7 @@ func (c *ExperimentClient) Create(parameters *params.CreateExperimentParams) (*m
 
 	// Make service call
 	parameters.Context = ctx
-	response, err := c.apiClient.ExperimentService.CreateExperiment(parameters, PassThroughAuth)
+	response, err := c.apiClient.ExperimentService.CreateExperiment(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.CreateExperimentDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -74,7 +94,7 @@ func (c *ExperimentClient) Get(parameters *params.GetExperimentParams) (*model.A
 
 	// Make service call
 	parameters.Context = ctx
-	response, err := c.apiClient.ExperimentService.GetExperiment(parameters, PassThroughAuth)
+	response, err := c.apiClient.ExperimentService.GetExperiment(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.GetExperimentDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -98,7 +118,7 @@ func (c *ExperimentClient) List(parameters *params.ListExperimentParams) (
 
 	// Make service call
 	parameters.Context = ctx
-	response, err := c.apiClient.ExperimentService.ListExperiment(parameters, PassThroughAuth)
+	response, err := c.apiClient.ExperimentService.ListExperiment(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.ListExperimentDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -121,7 +141,7 @@ func (c *ExperimentClient) Delete(parameters *params.DeleteExperimentParams) err
 
 	// Make service call
 	parameters.Context = ctx
-	_, err := c.apiClient.ExperimentService.DeleteExperiment(parameters, PassThroughAuth)
+	_, err := c.apiClient.ExperimentService.DeleteExperiment(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.DeleteExperimentDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -174,7 +194,7 @@ func (c *ExperimentClient) Archive(parameters *params.ArchiveExperimentParams) e
 
 	// Make service call
 	parameters.Context = ctx
-	_, err := c.apiClient.ExperimentService.ArchiveExperiment(parameters, PassThroughAuth)
+	_, err := c.apiClient.ExperimentService.ArchiveExperiment(parameters, c.authInfoWriter)
 
 	if err != nil {
 		if defaultError, ok := err.(*params.ArchiveExperimentDefault); ok {
@@ -198,7 +218,7 @@ func (c *ExperimentClient) Unarchive(parameters *params.UnarchiveExperimentParam
 
 	// Make service call
 	parameters.Context = ctx
-	_, err := c.apiClient.ExperimentService.UnarchiveExperiment(parameters, PassThroughAuth)
+	_, err := c.apiClient.ExperimentService.UnarchiveExperiment(parameters, c.authInfoWriter)
 
 	if err != nil {
 		if defaultError, ok := err.(*params.UnarchiveExperimentDefault); ok {

--- a/backend/src/common/client/api_server/job_client.go
+++ b/backend/src/common/client/api_server/job_client.go
@@ -3,6 +3,7 @@ package api_server
 import (
 	"fmt"
 
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	apiclient "github.com/kubeflow/pipelines/backend/api/go_http_client/job_client"
 	params "github.com/kubeflow/pipelines/backend/api/go_http_client/job_client/job_service"
@@ -24,7 +25,8 @@ type JobInterface interface {
 }
 
 type JobClient struct {
-	apiClient *apiclient.Job
+	apiClient      *apiclient.Job
+	authInfoWriter runtime.ClientAuthInfoWriter
 }
 
 func NewJobClient(clientConfig clientcmd.ClientConfig, debug bool) (
@@ -37,9 +39,26 @@ func NewJobClient(clientConfig clientcmd.ClientConfig, debug bool) (
 
 	apiClient := apiclient.New(runtime, strfmt.Default)
 
-	// Creating upload client
+	// Creating job client
 	return &JobClient{
 		apiClient: apiClient,
+	}, nil
+}
+
+func NewKubeflowInClusterJobClient(namespace string, debug bool) (
+	*JobClient, error) {
+
+	runtime, err := NewKubeflowInClusterHTTPRuntime(namespace, debug)
+	if err != nil {
+		return nil, err
+	}
+
+	apiClient := apiclient.New(runtime, strfmt.Default)
+
+	// Creating job client
+	return &JobClient{
+		apiClient:      apiClient,
+		authInfoWriter: SATokenVolumeProjectionAuth,
 	}, nil
 }
 
@@ -51,7 +70,7 @@ func (c *JobClient) Create(parameters *params.CreateJobParams) (*model.APIJob,
 
 	// Make service call
 	parameters.Context = ctx
-	response, err := c.apiClient.JobService.CreateJob(parameters, PassThroughAuth)
+	response, err := c.apiClient.JobService.CreateJob(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.CreateJobDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -75,7 +94,7 @@ func (c *JobClient) Get(parameters *params.GetJobParams) (*model.APIJob,
 
 	// Make service call
 	parameters.Context = ctx
-	response, err := c.apiClient.JobService.GetJob(parameters, PassThroughAuth)
+	response, err := c.apiClient.JobService.GetJob(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.GetJobDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -98,7 +117,7 @@ func (c *JobClient) Delete(parameters *params.DeleteJobParams) error {
 
 	// Make service call
 	parameters.Context = ctx
-	_, err := c.apiClient.JobService.DeleteJob(parameters, PassThroughAuth)
+	_, err := c.apiClient.JobService.DeleteJob(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.DeleteJobDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -121,7 +140,7 @@ func (c *JobClient) Enable(parameters *params.EnableJobParams) error {
 
 	// Make service call
 	parameters.Context = ctx
-	_, err := c.apiClient.JobService.EnableJob(parameters, PassThroughAuth)
+	_, err := c.apiClient.JobService.EnableJob(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.EnableJobDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -144,7 +163,7 @@ func (c *JobClient) Disable(parameters *params.DisableJobParams) error {
 
 	// Make service call
 	parameters.Context = ctx
-	_, err := c.apiClient.JobService.DisableJob(parameters, PassThroughAuth)
+	_, err := c.apiClient.JobService.DisableJob(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.DisableJobDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -168,7 +187,7 @@ func (c *JobClient) List(parameters *params.ListJobsParams) (
 
 	// Make service call
 	parameters.Context = ctx
-	response, err := c.apiClient.JobService.ListJobs(parameters, PassThroughAuth)
+	response, err := c.apiClient.JobService.ListJobs(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.ListJobsDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)

--- a/backend/src/common/client/api_server/pipeline_client.go
+++ b/backend/src/common/client/api_server/pipeline_client.go
@@ -3,6 +3,7 @@ package api_server
 import (
 	"fmt"
 
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	apiclient "github.com/kubeflow/pipelines/backend/api/go_http_client/pipeline_client"
 	params "github.com/kubeflow/pipelines/backend/api/go_http_client/pipeline_client/pipeline_service"
@@ -26,7 +27,8 @@ type PipelineInterface interface {
 }
 
 type PipelineClient struct {
-	apiClient *apiclient.Pipeline
+	apiClient      *apiclient.Pipeline
+	authInfoWriter runtime.ClientAuthInfoWriter
 }
 
 func (c *PipelineClient) UpdateDefaultVersion(parameters *params.UpdatePipelineDefaultVersionParams) error {
@@ -35,7 +37,7 @@ func (c *PipelineClient) UpdateDefaultVersion(parameters *params.UpdatePipelineD
 	defer cancel()
 	// Make service call
 	parameters.Context = ctx
-	_, err := c.apiClient.PipelineService.UpdatePipelineDefaultVersion(parameters, PassThroughAuth)
+	_, err := c.apiClient.PipelineService.UpdatePipelineDefaultVersion(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.GetPipelineDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -61,9 +63,26 @@ func NewPipelineClient(clientConfig clientcmd.ClientConfig, debug bool) (
 
 	apiClient := apiclient.New(runtime, strfmt.Default)
 
-	// Creating upload client
+	// Creating pipeline client
 	return &PipelineClient{
 		apiClient: apiClient,
+	}, nil
+}
+
+func NewKubeflowInClusterPipelineClient(namespace string, debug bool) (
+	*PipelineClient, error) {
+
+	runtime, err := NewKubeflowInClusterHTTPRuntime(namespace, debug)
+	if err != nil {
+		return nil, err
+	}
+
+	apiClient := apiclient.New(runtime, strfmt.Default)
+
+	// Creating pipeline client
+	return &PipelineClient{
+		apiClient:      apiClient,
+		authInfoWriter: SATokenVolumeProjectionAuth,
 	}, nil
 }
 
@@ -74,7 +93,7 @@ func (c *PipelineClient) Create(parameters *params.CreatePipelineParams) (*model
 	defer cancel()
 
 	parameters.Context = ctx
-	response, err := c.apiClient.PipelineService.CreatePipeline(parameters, PassThroughAuth)
+	response, err := c.apiClient.PipelineService.CreatePipeline(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.CreatePipelineDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -98,7 +117,7 @@ func (c *PipelineClient) Get(parameters *params.GetPipelineParams) (*model.APIPi
 
 	// Make service call
 	parameters.Context = ctx
-	response, err := c.apiClient.PipelineService.GetPipeline(parameters, PassThroughAuth)
+	response, err := c.apiClient.PipelineService.GetPipeline(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.GetPipelineDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -121,7 +140,7 @@ func (c *PipelineClient) Delete(parameters *params.DeletePipelineParams) error {
 
 	// Make service call
 	parameters.Context = ctx
-	_, err := c.apiClient.PipelineService.DeletePipeline(parameters, PassThroughAuth)
+	_, err := c.apiClient.PipelineService.DeletePipeline(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.DeletePipelineDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -144,7 +163,7 @@ func (c *PipelineClient) GetTemplate(parameters *params.GetTemplateParams) (temp
 
 	// Make service call
 	parameters.Context = ctx
-	response, err := c.apiClient.PipelineService.GetTemplate(parameters, PassThroughAuth)
+	response, err := c.apiClient.PipelineService.GetTemplate(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.GetTemplateDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -169,7 +188,7 @@ func (c *PipelineClient) List(parameters *params.ListPipelinesParams) (
 
 	// Make service call
 	parameters.Context = ctx
-	response, err := c.apiClient.PipelineService.ListPipelines(parameters, PassThroughAuth)
+	response, err := c.apiClient.PipelineService.ListPipelines(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.ListPipelinesDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -222,7 +241,7 @@ func (c *PipelineClient) CreatePipelineVersion(parameters *params.CreatePipeline
 	defer cancel()
 
 	parameters.Context = ctx
-	response, err := c.apiClient.PipelineService.CreatePipelineVersion(parameters, PassThroughAuth)
+	response, err := c.apiClient.PipelineService.CreatePipelineVersion(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.CreatePipelineVersionDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -246,7 +265,7 @@ func (c *PipelineClient) ListPipelineVersions(parameters *params.ListPipelineVer
 
 	// Make service call
 	parameters.Context = ctx
-	response, err := c.apiClient.PipelineService.ListPipelineVersions(parameters, PassThroughAuth)
+	response, err := c.apiClient.PipelineService.ListPipelineVersions(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.ListPipelineVersionsDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -270,7 +289,7 @@ func (c *PipelineClient) GetPipelineVersion(parameters *params.GetPipelineVersio
 
 	// Make service call
 	parameters.Context = ctx
-	response, err := c.apiClient.PipelineService.GetPipelineVersion(parameters, PassThroughAuth)
+	response, err := c.apiClient.PipelineService.GetPipelineVersion(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.GetPipelineVersionDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -294,7 +313,7 @@ func (c *PipelineClient) GetPipelineVersionTemplate(parameters *params.GetPipeli
 
 	// Make service call
 	parameters.Context = ctx
-	response, err := c.apiClient.PipelineService.GetPipelineVersionTemplate(parameters, PassThroughAuth)
+	response, err := c.apiClient.PipelineService.GetPipelineVersionTemplate(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.GetPipelineVersionTemplateDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)

--- a/backend/src/common/client/api_server/run_client.go
+++ b/backend/src/common/client/api_server/run_client.go
@@ -5,6 +5,7 @@ import (
 
 	workflowapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/ghodss/yaml"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	apiclient "github.com/kubeflow/pipelines/backend/api/go_http_client/run_client"
 	params "github.com/kubeflow/pipelines/backend/api/go_http_client/run_client/run_service"
@@ -25,7 +26,8 @@ type RunInterface interface {
 }
 
 type RunClient struct {
-	apiClient *apiclient.Run
+	apiClient      *apiclient.Run
+	authInfoWriter runtime.ClientAuthInfoWriter
 }
 
 func NewRunClient(clientConfig clientcmd.ClientConfig, debug bool) (
@@ -38,9 +40,26 @@ func NewRunClient(clientConfig clientcmd.ClientConfig, debug bool) (
 
 	apiClient := apiclient.New(runtime, strfmt.Default)
 
-	// Creating upload client
+	// Creating run client
 	return &RunClient{
 		apiClient: apiClient,
+	}, nil
+}
+
+func NewKubeflowInClusterRunClient(namespace string, debug bool) (
+	*RunClient, error) {
+
+	runtime, err := NewKubeflowInClusterHTTPRuntime(namespace, debug)
+	if err != nil {
+		return nil, err
+	}
+
+	apiClient := apiclient.New(runtime, strfmt.Default)
+
+	// Creating run client
+	return &RunClient{
+		apiClient:      apiClient,
+		authInfoWriter: SATokenVolumeProjectionAuth,
 	}, nil
 }
 
@@ -52,7 +71,7 @@ func (c *RunClient) Create(parameters *params.CreateRunParams) (*model.APIRunDet
 
 	// Make service call
 	parameters.Context = ctx
-	response, err := c.apiClient.RunService.CreateRun(parameters, PassThroughAuth)
+	response, err := c.apiClient.RunService.CreateRun(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.GetRunDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -86,7 +105,7 @@ func (c *RunClient) Get(parameters *params.GetRunParams) (*model.APIRunDetail,
 
 	// Make service call
 	parameters.Context = ctx
-	response, err := c.apiClient.RunService.GetRun(parameters, PassThroughAuth)
+	response, err := c.apiClient.RunService.GetRun(parameters, c.authInfoWriter)
 	if err != nil {
 		if defaultError, ok := err.(*params.GetRunDefault); ok {
 			err = CreateErrorFromAPIStatus(defaultError.Payload.Error, defaultError.Payload.Code)
@@ -119,7 +138,7 @@ func (c *RunClient) Archive(parameters *params.ArchiveRunParams) error {
 
 	// Make service call
 	parameters.Context = ctx
-	_, err := c.apiClient.RunService.ArchiveRun(parameters, PassThroughAuth)
+	_, err := c.apiClient.RunService.ArchiveRun(parameters, c.authInfoWriter)
 
 	if err != nil {
 		if defaultError, ok := err.(*params.ListRunsDefault); ok {
@@ -143,7 +162,7 @@ func (c *RunClient) Unarchive(parameters *params.UnarchiveRunParams) error {
 
 	// Make service call
 	parameters.Context = ctx
-	_, err := c.apiClient.RunService.UnarchiveRun(parameters, PassThroughAuth)
+	_, err := c.apiClient.RunService.UnarchiveRun(parameters, c.authInfoWriter)
 
 	if err != nil {
 		if defaultError, ok := err.(*params.ListRunsDefault); ok {
@@ -167,7 +186,7 @@ func (c *RunClient) Delete(parameters *params.DeleteRunParams) error {
 
 	// Make service call
 	parameters.Context = ctx
-	_, err := c.apiClient.RunService.DeleteRun(parameters, PassThroughAuth)
+	_, err := c.apiClient.RunService.DeleteRun(parameters, c.authInfoWriter)
 
 	if err != nil {
 		if defaultError, ok := err.(*params.ListRunsDefault); ok {
@@ -192,7 +211,7 @@ func (c *RunClient) List(parameters *params.ListRunsParams) (
 
 	// Make service call
 	parameters.Context = ctx
-	response, err := c.apiClient.RunService.ListRuns(parameters, PassThroughAuth)
+	response, err := c.apiClient.RunService.ListRuns(parameters, c.authInfoWriter)
 
 	if err != nil {
 		if defaultError, ok := err.(*params.ListRunsDefault); ok {
@@ -245,7 +264,7 @@ func (c *RunClient) Terminate(parameters *params.TerminateRunParams) error {
 
 	// Make service call
 	parameters.Context = ctx
-	_, err := c.apiClient.RunService.TerminateRun(parameters, PassThroughAuth)
+	_, err := c.apiClient.RunService.TerminateRun(parameters, c.authInfoWriter)
 	if err != nil {
 		return util.NewUserError(err,
 			fmt.Sprintf("Failed to terminate run. Params: %+v", parameters),

--- a/backend/test/integration/flags.go
+++ b/backend/test/integration/flags.go
@@ -16,3 +16,8 @@ var runUpgradeTests = flag.Bool("runUpgradeTests", false, "Whether to run upgrad
  * 2. One step that doesn't work locally is skipped.
  */
 var isDevMode = flag.Bool("isDevMode", false, "Dev mode helps local development of integration tests")
+
+var isDebugMode = flag.Bool("isDebugMode", false, "Whether to enable debug mode. Debug mode will log more diagnostics messages.")
+
+var isKubeflowMode = flag.Bool("isKubeflowMode", false, "Runs tests in full Kubeflow mode")
+var resourceNamespace = flag.String("resourceNamespace", "", "The namespace that will store the test resources in Kubeflow mode")

--- a/backend/test/integration/job_api_test.go
+++ b/backend/test/integration/job_api_test.go
@@ -587,10 +587,10 @@ func (s *JobApiTestSuite) TearDownSuite() {
 /** ======== the following are util functions ========= **/
 
 func (s *JobApiTestSuite) cleanUp() {
-	test.DeleteAllExperiments(s.experimentClient, s.T())
+	test.DeleteAllExperiments(s.experimentClient, "", s.T())
 	test.DeleteAllPipelines(s.pipelineClient, s.T())
-	test.DeleteAllJobs(s.jobClient, s.T())
-	test.DeleteAllRuns(s.runClient, s.T())
+	test.DeleteAllJobs(s.jobClient, "", s.T())
+	test.DeleteAllRuns(s.runClient, "", s.T())
 }
 
 func defaultApiJob(pipelineVersionId, experimentId string) *job_model.APIJob {

--- a/backend/test/integration/run_api_test.go
+++ b/backend/test/integration/run_api_test.go
@@ -361,7 +361,7 @@ func (s *RunApiTestSuite) TearDownSuite() {
 
 func (s *RunApiTestSuite) cleanUp() {
 	/* ---------- Clean up ---------- */
-	test.DeleteAllExperiments(s.experimentClient, s.T())
+	test.DeleteAllExperiments(s.experimentClient, "", s.T())
 	test.DeleteAllPipelines(s.pipelineClient, s.T())
-	test.DeleteAllRuns(s.runClient, s.T())
+	test.DeleteAllRuns(s.runClient, "", s.T())
 }

--- a/backend/test/integration/upgrade_test.go
+++ b/backend/test/integration/upgrade_test.go
@@ -46,10 +46,10 @@ func TestUpgrade(t *testing.T) {
 func (s *UpgradeTests) TestPrepare() {
 	t := s.T()
 
-	test.DeleteAllJobs(s.jobClient, t)
-	test.DeleteAllRuns(s.runClient, t)
+	test.DeleteAllJobs(s.jobClient, "", t)
+	test.DeleteAllRuns(s.runClient, "", t)
 	test.DeleteAllPipelines(s.pipelineClient, t)
-	test.DeleteAllExperiments(s.experimentClient, t)
+	test.DeleteAllExperiments(s.experimentClient, "", t)
 
 	s.PrepareExperiments()
 	s.PreparePipelines()
@@ -112,10 +112,10 @@ func (s *UpgradeTests) TearDownSuite() {
 			// Clean up after the suite to unblock other tests. (Not needed for upgrade
 			// tests because it needs changes in prepare tests to persist and verified
 			// later.)
-			test.DeleteAllExperiments(s.experimentClient, t)
+			test.DeleteAllExperiments(s.experimentClient, "", t)
 			test.DeleteAllPipelines(s.pipelineClient, t)
-			test.DeleteAllRuns(s.runClient, t)
-			test.DeleteAllJobs(s.jobClient, t)
+			test.DeleteAllRuns(s.runClient, "", t)
+			test.DeleteAllJobs(s.jobClient, "", t)
 		}
 	}
 }


### PR DESCRIPTION
Added 3 flags:
- isDebugMode is enables HTTP request/response logging
- IsKubeflowMode enables the tests in full Kubeflow mode
- resourceNamespace: the namespace/profile under which the test
  resources are created

Added a new HTTP client that uses SA token volume projection auth. The
test pods will be set up to project SA token.

Plumbed everything through for experiment API tests. The other tests
will be enabled in subsequent PRs.