### PR TITLE
feat(conformance): adapt run api tests to KF env

### DIFF
--- a/backend/test/integration/experiment_api_test.go
+++ b/backend/test/integration/experiment_api_test.go
@@ -170,10 +170,9 @@ func (s *ExperimentApiTest) TestExperimentAPI() {
 	/* ---------- Verify list experiments sorted by names ---------- */
 	experiments, totalSize, nextPageToken, err = test.ListExperiment(
 		s.experimentClient,
-		nil,
-		util.Int32Pointer(2),
-		nil,
-		util.StringPointer("name"),
+		&params.ListExperimentParams{
+			PageSize: util.Int32Pointer(2),
+			SortBy:   util.StringPointer("name")},
 		s.resourceNamespace)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, totalSize)
@@ -184,10 +183,10 @@ func (s *ExperimentApiTest) TestExperimentAPI() {
 
 	experiments, totalSize, nextPageToken, err = test.ListExperiment(
 		s.experimentClient,
-		nil,
-		util.Int32Pointer(2),
-		util.StringPointer(nextPageToken),
-		util.StringPointer("name"),
+		&params.ListExperimentParams{
+			PageToken: util.StringPointer(nextPageToken),
+			PageSize:  util.Int32Pointer(2),
+			SortBy:    util.StringPointer("name")},
 		s.resourceNamespace)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, totalSize)
@@ -198,10 +197,9 @@ func (s *ExperimentApiTest) TestExperimentAPI() {
 	/* ---------- Verify list experiments sorted by creation time ---------- */
 	experiments, totalSize, nextPageToken, err = test.ListExperiment(
 		s.experimentClient,
-		nil,
-		util.Int32Pointer(2),
-		nil,
-		util.StringPointer("created_at"),
+		&params.ListExperimentParams{
+			PageSize: util.Int32Pointer(2),
+			SortBy:   util.StringPointer("created_at")},
 		s.resourceNamespace)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, totalSize)
@@ -212,10 +210,10 @@ func (s *ExperimentApiTest) TestExperimentAPI() {
 
 	experiments, totalSize, nextPageToken, err = test.ListExperiment(
 		s.experimentClient,
-		nil,
-		util.Int32Pointer(2),
-		util.StringPointer(nextPageToken),
-		util.StringPointer("created_at"),
+		&params.ListExperimentParams{
+			PageToken: util.StringPointer(nextPageToken),
+			PageSize:  util.Int32Pointer(2),
+			SortBy:    util.StringPointer("created_at")},
 		s.resourceNamespace)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, totalSize)
@@ -226,20 +224,18 @@ func (s *ExperimentApiTest) TestExperimentAPI() {
 	/* ---------- List experiments sort by unsupported field. Should fail. ---------- */
 	_, _, _, err = test.ListExperiment(
 		s.experimentClient,
-		nil,
-		util.Int32Pointer(2),
-		nil,
-		util.StringPointer("unknownfield"),
+		&params.ListExperimentParams{
+			PageSize: util.Int32Pointer(2),
+			SortBy:   util.StringPointer("unknownfield")},
 		s.resourceNamespace)
 	assert.NotNil(t, err)
 
 	/* ---------- List experiments sorted by names descend order ---------- */
 	experiments, totalSize, nextPageToken, err = test.ListExperiment(
 		s.experimentClient,
-		nil,
-		util.Int32Pointer(2),
-		nil,
-		util.StringPointer("name desc"),
+		&params.ListExperimentParams{
+			PageSize: util.Int32Pointer(2),
+			SortBy:   util.StringPointer("name desc")},
 		s.resourceNamespace)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, totalSize)
@@ -250,10 +246,10 @@ func (s *ExperimentApiTest) TestExperimentAPI() {
 
 	experiments, totalSize, nextPageToken, err = test.ListExperiment(
 		s.experimentClient,
-		nil,
-		util.Int32Pointer(2),
-		util.StringPointer(nextPageToken),
-		util.StringPointer("name desc"),
+		&params.ListExperimentParams{
+			PageToken: util.StringPointer(nextPageToken),
+			PageSize:  util.Int32Pointer(2),
+			SortBy:    util.StringPointer("name desc")},
 		s.resourceNamespace)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, totalSize)

--- a/backend/test/integration/run_api_test.go
+++ b/backend/test/integration/run_api_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/golang/glog"
 	api "github.com/kubeflow/pipelines/backend/api/go_client"
 	experimentparams "github.com/kubeflow/pipelines/backend/api/go_http_client/experiment_client/experiment_service"
-	"github.com/kubeflow/pipelines/backend/api/go_http_client/experiment_model"
 	uploadParams "github.com/kubeflow/pipelines/backend/api/go_http_client/pipeline_upload_client/pipeline_upload_service"
 	runparams "github.com/kubeflow/pipelines/backend/api/go_http_client/run_client/run_service"
 	"github.com/kubeflow/pipelines/backend/api/go_http_client/run_model"
@@ -25,6 +24,7 @@ import (
 type RunApiTestSuite struct {
 	suite.Suite
 	namespace            string
+	resourceNamespace    string
 	experimentClient     *api_server.ExperimentClient
 	pipelineClient       *api_server.PipelineClient
 	pipelineUploadClient *api_server.PipelineUploadClient
@@ -51,21 +51,58 @@ func (s *RunApiTestSuite) SetupTest() {
 		}
 	}
 	s.namespace = *namespace
-	clientConfig := test.GetClientConfig(*namespace)
+
+	var newExperimentClient func() (*api_server.ExperimentClient, error)
+	var newPipelineUploadClient func() (*api_server.PipelineUploadClient, error)
+	var newPipelineClient func() (*api_server.PipelineClient, error)
+	var newRunClient func() (*api_server.RunClient, error)
+
+	if *isKubeflowMode {
+		s.resourceNamespace = *resourceNamespace
+
+		newExperimentClient = func() (*api_server.ExperimentClient, error) {
+			return api_server.NewKubeflowInClusterExperimentClient(s.namespace, *isDebugMode)
+		}
+		newPipelineUploadClient = func() (*api_server.PipelineUploadClient, error) {
+			return api_server.NewKubeflowInClusterPipelineUploadClient(s.namespace, *isDebugMode)
+		}
+		newPipelineClient = func() (*api_server.PipelineClient, error) {
+			return api_server.NewKubeflowInClusterPipelineClient(s.namespace, *isDebugMode)
+		}
+		newRunClient = func() (*api_server.RunClient, error) {
+			return api_server.NewKubeflowInClusterRunClient(s.namespace, *isDebugMode)
+		}
+	} else {
+		clientConfig := test.GetClientConfig(*namespace)
+
+		newExperimentClient = func() (*api_server.ExperimentClient, error) {
+			return api_server.NewExperimentClient(clientConfig, *isDebugMode)
+		}
+		newPipelineUploadClient = func() (*api_server.PipelineUploadClient, error) {
+			return api_server.NewPipelineUploadClient(clientConfig, *isDebugMode)
+		}
+		newPipelineClient = func() (*api_server.PipelineClient, error) {
+			return api_server.NewPipelineClient(clientConfig, *isDebugMode)
+		}
+		newRunClient = func() (*api_server.RunClient, error) {
+			return api_server.NewRunClient(clientConfig, *isDebugMode)
+		}
+	}
+
 	var err error
-	s.experimentClient, err = api_server.NewExperimentClient(clientConfig, false)
+	s.experimentClient, err = newExperimentClient()
+	if err != nil {
+		glog.Exitf("Failed to get experiment client. Error: %v", err)
+	}
+	s.pipelineUploadClient, err = newPipelineUploadClient()
 	if err != nil {
 		glog.Exitf("Failed to get pipeline upload client. Error: %s", err.Error())
 	}
-	s.pipelineUploadClient, err = api_server.NewPipelineUploadClient(clientConfig, false)
-	if err != nil {
-		glog.Exitf("Failed to get pipeline upload client. Error: %s", err.Error())
-	}
-	s.pipelineClient, err = api_server.NewPipelineClient(clientConfig, false)
+	s.pipelineClient, err = newPipelineClient()
 	if err != nil {
 		glog.Exitf("Failed to get pipeline client. Error: %s", err.Error())
 	}
-	s.runClient, err = api_server.NewRunClient(clientConfig, false)
+	s.runClient, err = newRunClient()
 	if err != nil {
 		glog.Exitf("Failed to get run client. Error: %s", err.Error())
 	}
@@ -90,7 +127,7 @@ func (s *RunApiTestSuite) TestRunApis() {
 	assert.Nil(t, err)
 
 	/* ---------- Create a new hello world experiment ---------- */
-	experiment := &experiment_model.APIExperiment{Name: "hello world experiment"}
+	experiment := test.GetExperiment("hello world experiment", "", s.resourceNamespace)
 	helloWorldExperiment, err := s.experimentClient.Create(&experimentparams.CreateExperimentParams{Body: experiment})
 	assert.Nil(t, err)
 
@@ -115,7 +152,8 @@ func (s *RunApiTestSuite) TestRunApis() {
 	s.checkHelloWorldRunDetail(t, helloWorldRunDetail, helloWorldExperiment.ID, helloWorldExperiment.Name, helloWorldPipelineVersion.ID, helloWorldPipelineVersion.Name)
 
 	/* ---------- Create a new argument parameter experiment ---------- */
-	createExperimentRequest := &experimentparams.CreateExperimentParams{Body: &experiment_model.APIExperiment{Name: "argument parameter experiment"}}
+	createExperimentRequest := &experimentparams.CreateExperimentParams{
+		Body: test.GetExperiment("argument parameter experiment", "", s.resourceNamespace)}
 	argParamsExperiment, err := s.experimentClient.Create(createExperimentRequest)
 	assert.Nil(t, err)
 
@@ -144,21 +182,29 @@ func (s *RunApiTestSuite) TestRunApis() {
 	s.checkArgParamsRunDetail(t, argParamsRunDetail, argParamsExperiment.ID, argParamsExperiment.Name)
 
 	/* ---------- List all the runs. Both runs should be returned ---------- */
-	runs, totalSize, _, err := s.runClient.List(&runparams.ListRunsParams{})
+	runs, totalSize, _, err := test.ListAllRuns(s.runClient, s.resourceNamespace)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(runs))
 	assert.Equal(t, 2, totalSize)
 
 	/* ---------- List the runs, paginated, sorted by creation time ---------- */
-	runs, totalSize, nextPageToken, err := s.runClient.List(
-		&runparams.ListRunsParams{PageSize: util.Int32Pointer(1), SortBy: util.StringPointer("created_at")})
+	runs, totalSize, nextPageToken, err := test.ListRuns(
+		s.runClient,
+		&runparams.ListRunsParams{
+			PageSize: util.Int32Pointer(1),
+			SortBy:   util.StringPointer("created_at")},
+		s.resourceNamespace)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(runs))
 	assert.Equal(t, 2, totalSize)
 	/* TODO(issues/1762): fix the following flaky assertion. */
 	/* assert.Equal(t, "hello world", runs[0].Name) */
-	runs, totalSize, _, err = s.runClient.List(&runparams.ListRunsParams{
-		PageSize: util.Int32Pointer(1), PageToken: util.StringPointer(nextPageToken)})
+	runs, totalSize, _, err = test.ListRuns(
+		s.runClient,
+		&runparams.ListRunsParams{
+			PageSize:  util.Int32Pointer(1),
+			PageToken: util.StringPointer(nextPageToken)},
+		s.resourceNamespace)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(runs))
 	assert.Equal(t, 2, totalSize)
@@ -166,28 +212,43 @@ func (s *RunApiTestSuite) TestRunApis() {
 	/* assert.Equal(t, "argument parameter", runs[0].Name) */
 
 	/* ---------- List the runs, paginated, sort by name ---------- */
-	runs, totalSize, nextPageToken, err = s.runClient.List(&runparams.ListRunsParams{
-		PageSize: util.Int32Pointer(1), SortBy: util.StringPointer("name")})
+	runs, totalSize, nextPageToken, err = test.ListRuns(
+		s.runClient,
+		&runparams.ListRunsParams{
+			PageSize: util.Int32Pointer(1),
+			SortBy:   util.StringPointer("name")},
+		s.resourceNamespace)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(runs))
 	assert.Equal(t, 2, totalSize)
 	assert.Equal(t, "argument parameter", runs[0].Name)
-	runs, totalSize, _, err = s.runClient.List(&runparams.ListRunsParams{
-		PageSize: util.Int32Pointer(1), SortBy: util.StringPointer("name"), PageToken: util.StringPointer(nextPageToken)})
+	runs, totalSize, _, err = test.ListRuns(
+		s.runClient,
+		&runparams.ListRunsParams{
+			PageSize:  util.Int32Pointer(1),
+			SortBy:    util.StringPointer("name"),
+			PageToken: util.StringPointer(nextPageToken)},
+		s.resourceNamespace)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(runs))
 	assert.Equal(t, 2, totalSize)
 	assert.Equal(t, "hello world", runs[0].Name)
 
 	/* ---------- List the runs, sort by unsupported field ---------- */
-	_, _, _, err = s.runClient.List(&runparams.ListRunsParams{
-		PageSize: util.Int32Pointer(2), SortBy: util.StringPointer("unknownfield")})
+	_, _, _, err = test.ListRuns(
+		s.runClient,
+		&runparams.ListRunsParams{PageSize: util.Int32Pointer(2), SortBy: util.StringPointer("unknownfield")},
+		s.resourceNamespace)
 	assert.NotNil(t, err)
 
 	/* ---------- List runs for hello world experiment. One run should be returned ---------- */
-	runs, totalSize, _, err = s.runClient.List(&runparams.ListRunsParams{
-		ResourceReferenceKeyType: util.StringPointer(string(run_model.APIResourceTypeEXPERIMENT)),
-		ResourceReferenceKeyID:   util.StringPointer(helloWorldExperiment.ID)})
+	runs, totalSize, _, err = test.ListRuns(
+		s.runClient,
+		&runparams.ListRunsParams{
+			ResourceReferenceKeyType: util.StringPointer(string(run_model.APIResourceTypeEXPERIMENT)),
+			ResourceReferenceKeyID:   util.StringPointer(helloWorldExperiment.ID)},
+		// Since namespace is implied by the experiment namespace, there is no need to set namespace in resource reference
+		"")
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(runs))
 	assert.Equal(t, 1, totalSize)
@@ -200,9 +261,12 @@ func (s *RunApiTestSuite) TestRunApis() {
 	assert.Nil(t, err)
 
 	/* ---------- List runs for hello world experiment. The same run should still be returned, but should be archived ---------- */
-	runs, totalSize, _, err = s.runClient.List(&runparams.ListRunsParams{
-		ResourceReferenceKeyType: util.StringPointer(string(run_model.APIResourceTypeEXPERIMENT)),
-		ResourceReferenceKeyID:   util.StringPointer(helloWorldExperiment.ID)})
+	runs, totalSize, _, err = test.ListRuns(s.runClient,
+		&runparams.ListRunsParams{
+			ResourceReferenceKeyType: util.StringPointer(string(run_model.APIResourceTypeEXPERIMENT)),
+			ResourceReferenceKeyID:   util.StringPointer(helloWorldExperiment.ID)},
+		// Since namespace is implied by the experiment namespace, there is no need to set namespace in resource reference
+		"")
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(runs))
 	assert.Equal(t, 1, totalSize)
@@ -258,7 +322,7 @@ func (s *RunApiTestSuite) checkTerminatedRunDetail(t *testing.T, runDetail *run_
 		Name:           "long running",
 		Description:    "this pipeline will run long enough for us to manually terminate it before it finishes",
 		Status:         "Terminating",
-		ServiceAccount: "pipeline-runner",
+		ServiceAccount: test.GetDefaultPipelineRunnerServiceAccount(*isKubeflowMode),
 		PipelineSpec: &run_model.APIPipelineSpec{
 			WorkflowManifest: runDetail.Run.PipelineSpec.WorkflowManifest,
 		},
@@ -291,7 +355,7 @@ func (s *RunApiTestSuite) checkHelloWorldRunDetail(t *testing.T, runDetail *run_
 		Name:           "hello world",
 		Description:    "this is hello world",
 		Status:         runDetail.Run.Status,
-		ServiceAccount: "pipeline-runner",
+		ServiceAccount: test.GetDefaultPipelineRunnerServiceAccount(*isKubeflowMode),
 		PipelineSpec: &run_model.APIPipelineSpec{
 			WorkflowManifest: runDetail.Run.PipelineSpec.WorkflowManifest,
 		},
@@ -326,7 +390,7 @@ func (s *RunApiTestSuite) checkArgParamsRunDetail(t *testing.T, runDetail *run_m
 		Name:           "argument parameter",
 		Description:    "this is argument parameter",
 		Status:         runDetail.Run.Status,
-		ServiceAccount: "pipeline-runner",
+		ServiceAccount: test.GetDefaultPipelineRunnerServiceAccount(*isKubeflowMode),
 		PipelineSpec: &run_model.APIPipelineSpec{
 			WorkflowManifest: string(argParamsBytes),
 			Parameters: []*run_model.APIParameter{
@@ -361,7 +425,7 @@ func (s *RunApiTestSuite) TearDownSuite() {
 
 func (s *RunApiTestSuite) cleanUp() {
 	/* ---------- Clean up ---------- */
-	test.DeleteAllExperiments(s.experimentClient, "", s.T())
+	test.DeleteAllExperiments(s.experimentClient, s.resourceNamespace, s.T())
 	test.DeleteAllPipelines(s.pipelineClient, s.T())
-	test.DeleteAllRuns(s.runClient, "", s.T())
+	test.DeleteAllRuns(s.runClient, s.resourceNamespace, s.T())
 }


### PR DESCRIPTION
- Undid earlier refactoring in test_util.go. I think having the util
  function to take a parameter structure is much more readable than
  constructing api parameters in the util function.

