### PR TITLE
feat(conformance): adapt remaining tests to KF env

### DIFF
--- a/backend/src/common/client/api_server/visualization_client.go
+++ b/backend/src/common/client/api_server/visualization_client.go
@@ -3,6 +3,7 @@ package api_server
 import (
 	"fmt"
 
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	apiclient "github.com/kubeflow/pipelines/backend/api/go_http_client/visualization_client"
 	params "github.com/kubeflow/pipelines/backend/api/go_http_client/visualization_client/visualization_service"
@@ -18,7 +19,8 @@ type VisualizationInterface interface {
 }
 
 type VisualizationClient struct {
-	apiClient *apiclient.Visualization
+	apiClient      *apiclient.Visualization
+	authInfoWriter runtime.ClientAuthInfoWriter
 }
 
 func NewVisualizationClient(clientConfig clientcmd.ClientConfig, debug bool) (
@@ -34,6 +36,20 @@ func NewVisualizationClient(clientConfig clientcmd.ClientConfig, debug bool) (
 	// Creating upload client
 	return &VisualizationClient{
 		apiClient: apiClient,
+	}, nil
+}
+
+func NewKubeflowInClusterVisualizationClient(namespace string, debug bool) (
+	*VisualizationClient, error) {
+
+	runtime := NewKubeflowInClusterHTTPRuntime(namespace, debug)
+
+	apiClient := apiclient.New(runtime, strfmt.Default)
+
+	// Creating upload client
+	return &VisualizationClient{
+		apiClient:      apiClient,
+		authInfoWriter: SATokenVolumeProjectionAuth,
 	}, nil
 }
 

--- a/backend/test/integration/run_api_test.go
+++ b/backend/test/integration/run_api_test.go
@@ -242,13 +242,9 @@ func (s *RunApiTestSuite) TestRunApis() {
 	assert.NotNil(t, err)
 
 	/* ---------- List runs for hello world experiment. One run should be returned ---------- */
-	runs, totalSize, _, err = test.ListRuns(
-		s.runClient,
-		&runparams.ListRunsParams{
-			ResourceReferenceKeyType: util.StringPointer(string(run_model.APIResourceTypeEXPERIMENT)),
-			ResourceReferenceKeyID:   util.StringPointer(helloWorldExperiment.ID)},
-		// Since namespace is implied by the experiment namespace, there is no need to set namespace in resource reference
-		"")
+	runs, totalSize, _, err = s.runClient.List(&runparams.ListRunsParams{
+		ResourceReferenceKeyType: util.StringPointer(string(run_model.APIResourceTypeEXPERIMENT)),
+		ResourceReferenceKeyID:   util.StringPointer(helloWorldExperiment.ID)})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(runs))
 	assert.Equal(t, 1, totalSize)
@@ -261,12 +257,9 @@ func (s *RunApiTestSuite) TestRunApis() {
 	assert.Nil(t, err)
 
 	/* ---------- List runs for hello world experiment. The same run should still be returned, but should be archived ---------- */
-	runs, totalSize, _, err = test.ListRuns(s.runClient,
-		&runparams.ListRunsParams{
-			ResourceReferenceKeyType: util.StringPointer(string(run_model.APIResourceTypeEXPERIMENT)),
-			ResourceReferenceKeyID:   util.StringPointer(helloWorldExperiment.ID)},
-		// Since namespace is implied by the experiment namespace, there is no need to set namespace in resource reference
-		"")
+	runs, totalSize, _, err = s.runClient.List(&runparams.ListRunsParams{
+		ResourceReferenceKeyType: util.StringPointer(string(run_model.APIResourceTypeEXPERIMENT)),
+		ResourceReferenceKeyID:   util.StringPointer(helloWorldExperiment.ID)})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(runs))
 	assert.Equal(t, 1, totalSize)

--- a/backend/test/test_utils.go
+++ b/backend/test/test_utils.go
@@ -96,7 +96,7 @@ func DeleteAllRuns(client *api_server.RunClient, namespace string, t *testing.T)
 }
 
 func DeleteAllJobs(client *api_server.JobClient, namespace string, t *testing.T) {
-	jobs, _, _, err := ListJobs(client, namespace)
+	jobs, _, _, err := ListAllJobs(client, namespace)
 	assert.Nil(t, err)
 	for _, j := range jobs {
 		assert.Nil(t, client.Delete(&jobparams.DeleteJobParams{ID: j.ID}))
@@ -148,8 +148,11 @@ func ListRuns(client *api_server.RunClient, parameters *runparams.ListRunsParams
 	return client.List(parameters)
 }
 
-func ListJobs(client *api_server.JobClient, namespace string) ([]*job_model.APIJob, int, string, error) {
-	parameters := &jobparams.ListJobsParams{}
+func ListAllJobs(client *api_server.JobClient, namespace string) ([]*job_model.APIJob, int, string, error) {
+	return ListJobs(client, &jobparams.ListJobsParams{}, namespace)
+}
+
+func ListJobs(client *api_server.JobClient, parameters *jobparams.ListJobsParams, namespace string) ([]*job_model.APIJob, int, string, error) {
 	if namespace != "" {
 		parameters.SetResourceReferenceKeyType(util.StringPointer(api.ResourceType_name[int32(api.ResourceType_NAMESPACE)]))
 		parameters.SetResourceReferenceKeyID(&namespace)


### PR DESCRIPTION
- Adapted job, rn, upgrade and visualization tests
- Undid earlier change where I had to pass in empty string to indicate
  that resource reference should not be overridden because experiment id
  is specified
- Updated visualization client to support SA token projection auth