### PR TITLE
fix(backend) - Normalize the generated mane to follow K8s convention

### DIFF
--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -1440,7 +1440,7 @@ func TestCreateJob_ThroughWorkflowSpec(t *testing.T) {
 	expectedJob := &model.Job{
 		UUID:           "123e4567-e89b-12d3-a456-426655440000",
 		DisplayName:    "j1",
-		Name:           "j1",
+		Name:           "j1-",
 		Namespace:      "ns1",
 		ServiceAccount: "pipeline-runner",
 		Enabled:        true,
@@ -1470,7 +1470,7 @@ func TestCreateJob_ThroughWorkflowSpecV2(t *testing.T) {
 	expectedJob := &model.Job{
 		UUID:           "123e4567-e89b-12d3-a456-426655440000",
 		DisplayName:    "j1",
-		Name:           "j1",
+		Name:           "j1-",
 		Namespace:      "ns1",
 		ServiceAccount: "pipeline-runner",
 		Enabled:        true,
@@ -1530,7 +1530,7 @@ func TestCreateJob_ThroughPipelineID(t *testing.T) {
 	version, err := manager.CreatePipelineVersion(&api.PipelineVersion{
 		Name: "version_for_run",
 		ResourceReferences: []*api.ResourceReference{
-			&api.ResourceReference{
+			{
 				Key: &api.ResourceKey{
 					Id:   pipeline.UUID,
 					Type: api.ResourceType_PIPELINE,
@@ -1547,7 +1547,7 @@ func TestCreateJob_ThroughPipelineID(t *testing.T) {
 	expectedJob := &model.Job{
 		UUID:           "123e4567-e89b-12d3-a456-426655440000",
 		DisplayName:    "j1",
-		Name:           "j1",
+		Name:           "j1-",
 		Namespace:      "ns1",
 		ServiceAccount: "pipeline-runner",
 		Enabled:        true,
@@ -1593,7 +1593,7 @@ func TestCreateJob_ThroughPipelineVersion(t *testing.T) {
 	version, err := manager.CreatePipelineVersion(&api.PipelineVersion{
 		Name: "version_for_job",
 		ResourceReferences: []*api.ResourceReference{
-			&api.ResourceReference{
+			{
 				Key: &api.ResourceKey{
 					Id:   pipeline.UUID,
 					Type: api.ResourceType_PIPELINE,
@@ -1605,7 +1605,7 @@ func TestCreateJob_ThroughPipelineVersion(t *testing.T) {
 	assert.Nil(t, err)
 
 	job := &api.Job{
-		Name:    "j1",
+		Name:    "j1-",
 		Enabled: true,
 		PipelineSpec: &api.PipelineSpec{
 			Parameters: []*api.Parameter{
@@ -1626,8 +1626,8 @@ func TestCreateJob_ThroughPipelineVersion(t *testing.T) {
 	newJob, err := manager.CreateJob(context.Background(), job)
 	expectedJob := &model.Job{
 		UUID:           "123e4567-e89b-12d3-a456-426655440000",
-		DisplayName:    "j1",
-		Name:           "j1",
+		DisplayName:    "j1-",
+		Name:           "j1-",
 		Namespace:      "ns1",
 		ServiceAccount: "pipeline-runner",
 		Enabled:        true,
@@ -1671,7 +1671,7 @@ func TestCreateJob_ThroughPipelineIdAndPipelineVersion(t *testing.T) {
 	version, err := manager.CreatePipelineVersion(&api.PipelineVersion{
 		Name: "version_for_job",
 		ResourceReferences: []*api.ResourceReference{
-			&api.ResourceReference{
+			{
 				Key: &api.ResourceKey{
 					Id:   pipeline.UUID,
 					Type: api.ResourceType_PIPELINE,
@@ -1683,7 +1683,7 @@ func TestCreateJob_ThroughPipelineIdAndPipelineVersion(t *testing.T) {
 	assert.Nil(t, err)
 
 	job := &api.Job{
-		Name:    "j1",
+		Name:    "j1-",
 		Enabled: true,
 		PipelineSpec: &api.PipelineSpec{
 			PipelineId: pipeline.UUID,
@@ -1705,8 +1705,8 @@ func TestCreateJob_ThroughPipelineIdAndPipelineVersion(t *testing.T) {
 	newJob, err := manager.CreateJob(context.Background(), job)
 	expectedJob := &model.Job{
 		UUID:           "123e4567-e89b-12d3-a456-426655440000",
-		DisplayName:    "j1",
-		Name:           "j1",
+		DisplayName:    "j1-",
+		Name:           "j1-",
 		Namespace:      "ns1",
 		ServiceAccount: "pipeline-runner",
 		Enabled:        true,
@@ -1838,7 +1838,7 @@ func TestEnableJob(t *testing.T) {
 	expectedJob := &model.Job{
 		UUID:           "123e4567-e89b-12d3-a456-426655440000",
 		DisplayName:    "j1",
-		Name:           "j1",
+		Name:           "j1-",
 		Namespace:      "ns1",
 		ServiceAccount: "pipeline-runner",
 		Enabled:        false,
@@ -2075,7 +2075,7 @@ func TestReportWorkflowResource_ScheduledWorkflowIDNotEmpty_Success(t *testing.T
 					ResourceUUID:  "WORKFLOW_1",
 					ResourceType:  common.Run,
 					ReferenceUUID: job.UUID,
-					ReferenceName: job.Name,
+					ReferenceName: "j1",
 					ReferenceType: common.Job,
 					Relationship:  common.Creator,
 				},
@@ -2092,7 +2092,7 @@ func TestReportWorkflowResource_ScheduledWorkflowIDNotEmpty_NoExperiment_Success
 	defer store.Close()
 	manager := NewResourceManager(store)
 	job := &api.Job{
-		Name:         "j1",
+		Name:         "j1-",
 		Enabled:      true,
 		PipelineSpec: &api.PipelineSpec{WorkflowManifest: testWorkflow.ToStringForStore()},
 		// no experiment reference

--- a/backend/src/apiserver/server/job_server_test.go
+++ b/backend/src/apiserver/server/job_server_test.go
@@ -2,9 +2,10 @@ package server
 
 import (
 	"context"
-	"google.golang.org/protobuf/testing/protocmp"
 	"strings"
 	"testing"
+
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/go-cmp/cmp"
@@ -25,7 +26,7 @@ import (
 
 var (
 	commonApiJob = &api.Job{
-		Name:           "job1",
+		Name:           "job1-",
 		Enabled:        true,
 		MaxConcurrency: 1,
 		Trigger: &api.Trigger{
@@ -47,7 +48,7 @@ var (
 
 	commonExpectedJob = &api.Job{
 		Id:             "123e4567-e89b-12d3-a456-426655440000",
-		Name:           "job1",
+		Name:           "job1-",
 		ServiceAccount: "pipeline-runner",
 		Enabled:        true,
 		MaxConcurrency: 1,

--- a/backend/src/apiserver/template/template.go
+++ b/backend/src/apiserver/template/template.go
@@ -188,6 +188,8 @@ func toSWFCRDResourceGeneratedName(displayName string) (string, error) {
 	processedName := reg.ReplaceAllString(strings.ToLower(displayName), "")
 	if processedName == "" {
 		processedName = "job-"
+	} else if !strings.HasSuffix(processedName, "-") {
+		processedName += "-"
 	}
 	return util.Truncate(processedName, 25), nil
 }

--- a/backend/src/apiserver/template/template.go
+++ b/backend/src/apiserver/template/template.go
@@ -188,10 +188,17 @@ func toSWFCRDResourceGeneratedName(displayName string) (string, error) {
 	processedName := reg.ReplaceAllString(strings.ToLower(displayName), "")
 	if processedName == "" {
 		processedName = "job-"
-	} else if !strings.HasSuffix(processedName, "-") {
-		processedName += "-"
 	}
-	return util.Truncate(processedName, 25), nil
+
+	if len(processedName) < 25 {
+		if !strings.HasSuffix(processedName, "-") {
+			processedName += "-"
+		}
+		return processedName, nil
+	}
+
+	processedName = util.Truncate(processedName, 24)
+	return processedName + "-", nil
 }
 
 func toCRDTrigger(apiTrigger *api.Trigger) *scheduledworkflow.Trigger {

--- a/backend/src/apiserver/template/template_test.go
+++ b/backend/src/apiserver/template/template_test.go
@@ -206,6 +206,12 @@ schemaVersion: 2.0.0
 sdkVersion: kfp-1.6.5
 `
 
+func TestToSwfCRDResourceGeneratedName_HasSuffix(t *testing.T) {
+	name, err := toSWFCRDResourceGeneratedName("name-")
+	assert.Nil(t, err)
+	assert.Equal(t, name, "name-")
+}
+
 func TestToSwfCRDResourceGeneratedName_SpecialCharsAndSpace(t *testing.T) {
 	name, err := toSWFCRDResourceGeneratedName("! HaVe ä £unky name")
 	assert.Nil(t, err)

--- a/backend/src/apiserver/template/template_test.go
+++ b/backend/src/apiserver/template/template_test.go
@@ -215,7 +215,7 @@ func TestToSwfCRDResourceGeneratedName_SpecialCharsAndSpace(t *testing.T) {
 func TestToSwfCRDResourceGeneratedName_TruncateLongName(t *testing.T) {
 	name, err := toSWFCRDResourceGeneratedName("AloooooooooooooooooongName")
 	assert.Nil(t, err)
-	assert.Equal(t, name, "aloooooooooooooooooongnam-")
+	assert.Equal(t, name, "aloooooooooooooooooongna-")
 }
 
 func TestToSwfCRDResourceGeneratedName_EmptyName(t *testing.T) {

--- a/backend/src/apiserver/template/template_test.go
+++ b/backend/src/apiserver/template/template_test.go
@@ -15,12 +15,13 @@
 package template
 
 import (
+	"testing"
+	"time"
+
 	"github.com/golang/protobuf/ptypes/timestamp"
 	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
 	scheduledworkflow "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
-	"time"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/ghodss/yaml"
@@ -208,13 +209,13 @@ sdkVersion: kfp-1.6.5
 func TestToSwfCRDResourceGeneratedName_SpecialCharsAndSpace(t *testing.T) {
 	name, err := toSWFCRDResourceGeneratedName("! HaVe ä £unky name")
 	assert.Nil(t, err)
-	assert.Equal(t, name, "haveunkyname")
+	assert.Equal(t, name, "haveunkyname-")
 }
 
 func TestToSwfCRDResourceGeneratedName_TruncateLongName(t *testing.T) {
 	name, err := toSWFCRDResourceGeneratedName("AloooooooooooooooooongName")
 	assert.Nil(t, err)
-	assert.Equal(t, name, "aloooooooooooooooooongnam")
+	assert.Equal(t, name, "aloooooooooooooooooongnam-")
 }
 
 func TestToSwfCRDResourceGeneratedName_EmptyName(t *testing.T) {


### PR DESCRIPTION
**Description of your changes:**

The current run mane is `export-reportpt64z-2-536368156`
I think it's better to add a `-` suffix, will be `export-report-pt64z-2-536368156`

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
