### PR TITLE
chore(sdk): use unittest.mock instead of mock

### DIFF
--- a/sdk/python/kfp/registry/registry_client_test.py
+++ b/sdk/python/kfp/registry/registry_client_test.py
@@ -15,8 +15,8 @@
 
 import builtins
 import json
+from unittest import mock
 
-import mock
 from absl.testing import parameterized
 from kfp.registry import ApiAuth
 from kfp.registry import RegistryClient


### PR DESCRIPTION
**Description of your changes:**
Use the standard library `unittest.mock` instead of external dependency `mock`. Otherwise, tests fail outside of the test environment when the user does not first run `pip install mock`.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this 
repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
