### PR TITLE
feat(IR): add is_optional to ParameterSpec proto

### DIFF
--- a/api/v2alpha1/pipeline_spec.proto
+++ b/api/v2alpha1/pipeline_spec.proto
@@ -188,6 +188,17 @@ message ComponentInputsSpec {
 
     // Optional field. Default value of the input parameter.
     google.protobuf.Value default_value = 3;
+    
+    // Whether this input parameter is optional or not.
+    // - If required, the parameter should either have a default value, or have
+    // to be able to resolve to a concrete value at runtime.
+    // - If it's optional, it can be missing from the
+    // PipelineTaskInputsSpec.InputParameterSpec (if it's instantiated into a
+    // task), or can be missing from the runtimeParameter (if it's the root
+    // component). If the value is missing, the default_value will be used. Or
+    // if default_value is not provided, the default value of the parameter's
+    // type will be used.
+    bool is_optional = 4;
   }
   // Name to artifact input.
   map<string, ArtifactSpec> artifacts = 1;


### PR DESCRIPTION
**Description of your changes:**
Adds the `is_optional` field to ParameterSpec proto.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. 
[Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
