### PR TITLE
feat[deployment]: add startup probe to pipeline API deployment

### DIFF
--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -105,6 +105,21 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 5
           timeoutSeconds: 2
+        # This startup probe provides up to a 60 second grace window before the
+        # liveness probe takes over to accomodate the occasional database
+        # migration.
+        startupProbe:
+          exec:
+            command:
+              - wget
+              - -q # quiet
+              - -S # show server response
+              - -O
+              - "-" # Redirect output to stdout
+              - http://localhost:8888/apis/v1beta1/healthz
+          failureThreshold: 12
+          periodSeconds: 5
+          timeoutSeconds: 2
         resources:
           requests:
             cpu: 250m


### PR DESCRIPTION
Co-authored-by: moorthy156 <narayanamoorthy.mari@gmail.com>

**Description of your changes:**
When we pivoted from an in-cluster mysql deployment to an externally hosted RDS instance for the metadata store, we ran into a scenario where the ml-pipeline-apiserver pod entered a crash loop because it didn't have a long enough grace period to complete its database migration.

This pod is unique in that its startup time is variable depending on whether or not a migration needs to occur. A [startup probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) is perfect for this, since it offers a grace period in the event of a migration, but doesn't delay pod readiness when a migration does not need to happen.

Relevant issue:
https://github.com/kubeflow/pipelines/issues/7740

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
