### PR TITLE
fix(components): Preserve empty features in explanation_spec

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/container/v1/gcp_launcher/upload_model_remote_runner.py
+++ b/components/google-cloud/google_cloud_pipeline_components/container/v1/gcp_launcher/upload_model_remote_runner.py
@@ -61,8 +61,8 @@ def upload_model(
   }
 
   # Add explanation_spec details back into the request if metadata is non-empty, as sklearn/xgboost input features can be empty.
-  if (('explanation_spec' in model_spec) and 
-      ('metadata' in model_spec['explanation_spec']) and 
+  if (('explanation_spec' in model_spec) and
+      ('metadata' in model_spec['explanation_spec']) and
       model_spec['explanation_spec']['metadata']):
     upload_model_request['model']['explanation_spec']['metadata'] = model_spec['explanation_spec']['metadata']
 

--- a/components/google-cloud/google_cloud_pipeline_components/container/v1/gcp_launcher/upload_model_remote_runner.py
+++ b/components/google-cloud/google_cloud_pipeline_components/container/v1/gcp_launcher/upload_model_remote_runner.py
@@ -60,6 +60,12 @@ def upload_model(
                   executor_input, model_spec))
   }
 
+  # Add explanation_spec details back into the request if metadata is non-empty, as sklearn/xgboost input features can be empty.
+  if (('explanation_spec' in model_spec) and 
+      ('metadata' in model_spec['explanation_spec']) and 
+      model_spec['explanation_spec']['metadata']):
+    upload_model_request['model']['explanation_spec']['metadata'] = model_spec['explanation_spec']['metadata']
+
   try:
     remote_runner = lro_remote_runner.LroRemoteRunner(location)
     upload_model_lro = remote_runner.create_lro(


### PR DESCRIPTION
**Description of your changes:**
[ModelUploadOp](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.7/google_cloud_pipeline_components.v1.model.html#google_cloud_pipeline_components.v1.model.ModelUploadOp) allows users to specify `explanation_metadata` so that they may provide a list of features and labels to be used with Explainable AI on model upload. This currently works fine for models built with TensorFlow, but for models built using scikit-learn or xgboost, the list of features provided in the `explanation_metadata` argument are dropped.

Because features and outputs provided in `explanation_metadata` should be empty for scikit-learn/xgboost produced models ([per the API spec](https://cloud.google.com/vertex-ai/docs/explainable-ai/configuring-explanations)), the features in the request are dropped by [json_util.recursive_remove_empty](https://github.com/kubeflow/pipelines/blob/master/components/google-cloud/google_cloud_pipeline_components/container/v1/gcp_launcher/upload_model_remote_runner.py#L58).

It looks like [batch predictions](https://github.com/kubeflow/pipelines/blob/master/components/google-cloud/google_cloud_pipeline_components/container/v1/gcp_launcher/batch_prediction_job_remote_runner.py#L32)  are already taken care of by using `ExplanationMetadata.from_json` to parse + evaluate the explanation spec. 


**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
