### PR TITLE
feat(backend): Use cert-manager for multi-user aws

### DIFF
--- a/manifests/kustomize/env/aws/OWNERS
+++ b/manifests/kustomize/env/aws/OWNERS
@@ -1,3 +1,4 @@
 approvers:
   - Jeffwan
   - PatrickXYS
+  - akartsky

--- a/manifests/kustomize/env/aws/multi-user/base/kustomization.yaml
+++ b/manifests/kustomize/env/aws/multi-user/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../../platform-agnostic-multi-user

--- a/manifests/kustomize/env/aws/multi-user/cache-deployer-cert-manager/cache-cert-issuer.yaml
+++ b/manifests/kustomize/env/aws/multi-user/cache-deployer-cert-manager/cache-cert-issuer.yaml
@@ -1,0 +1,6 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kfp-cache-selfsigned-issuer
+spec:
+  selfSigned: {}

--- a/manifests/kustomize/env/aws/multi-user/cache-deployer-cert-manager/cache-cert.yaml
+++ b/manifests/kustomize/env/aws/multi-user/cache-deployer-cert-manager/cache-cert.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kfp-cache-cert
+spec:
+  commonName: kfp-cache-cert
+  isCA: true
+  dnsNames:
+  - cache-server
+  - cache-server.$(kfp-namespace)
+  - cache-server.$(kfp-namespace).svc
+  issuerRef:
+    kind: Issuer
+    name: kfp-cache-selfsigned-issuer
+  secretName: webhook-server-tls

--- a/manifests/kustomize/env/aws/multi-user/cache-deployer-cert-manager/cache-webhook-config.yaml
+++ b/manifests/kustomize/env/aws/multi-user/cache-deployer-cert-manager/cache-webhook-config.yaml
@@ -1,0 +1,25 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: cache-webhook-kubeflow
+  annotations:
+    cert-manager.io/inject-ca-from: $(kfp-namespace)/kfp-cache-cert
+webhooks:
+  - name: cache-server.$(kfp-namespace).svc
+    clientConfig:
+      service:
+        name: cache-server
+        namespace: $(kfp-namespace)
+        path: "/mutate"
+    failurePolicy: Ignore
+    rules:
+    - operations: [ "CREATE" ]
+      apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]
+    sideEffects: None
+    timeoutSeconds: 5
+    objectSelector:
+      matchLabels:
+        pipelines.kubeflow.org/cache_enabled: "true"
+    admissionReviewVersions: ["v1beta1"]

--- a/manifests/kustomize/env/aws/multi-user/cache-deployer-cert-manager/kustomization.yaml
+++ b/manifests/kustomize/env/aws/multi-user/cache-deployer-cert-manager/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow 
+
+resources:
+  - cache-cert-issuer.yaml
+  - cache-cert.yaml
+  - cache-webhook-config.yaml
+commonLabels:
+  app: cache-deployer-cert-manager

--- a/manifests/kustomize/env/aws/multi-user/cache-deployer-cert-manager/params.yaml
+++ b/manifests/kustomize/env/aws/multi-user/cache-deployer-cert-manager/params.yaml
@@ -1,0 +1,9 @@
+varReference:
+  - path: spec/commonName
+    kind: Certificate
+  - path: spec/dnsNames
+    kind: Certificate
+  - path: spec/issuerRef/name
+    kind: Certificate
+  - path: metadata/annotations
+    kind: MutatingWebhookConfiguration

--- a/manifests/kustomize/env/aws/multi-user/delete-cache-deployer.yaml
+++ b/manifests/kustomize/env/aws/multi-user/delete-cache-deployer.yaml
@@ -1,0 +1,35 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-pipelines-cache-deployer-clusterrole
+$patch: delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeflow-pipelines-cache-deployer-clusterrolebinding
+$patch: delete
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeflow-pipelines-cache-deployer-sa
+$patch: delete
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cache-deployer-deployment
+$patch: delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubeflow-pipelines-cache-deployer-role
+$patch: delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubeflow-pipelines-cache-deployer-rolebinding
+$patch: delete

--- a/manifests/kustomize/env/aws/multi-user/kustomization.yaml
+++ b/manifests/kustomize/env/aws/multi-user/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ./base
+  - ./cache-deployer-cert-manager
+
+namespace: kubeflow
+
+# Delete the cache deployer as we use the cert-manager instead 
+patchesStrategicMerge:
+  - ./delete-cache-deployer.yaml
+
+# Pass proper arguments to cache-server to use cert-manager certificate
+patches:
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls_cert_filename=tls.crt"
+  target:
+    kind: Deployment
+    name: cache-server
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls_key_filename=tls.key"
+  target:
+    kind: Deployment
+    name: cache-server


### PR DESCRIPTION
Cert-manager for multi-user aws

Use this in manifests repo : https://github.com/kubeflow/manifests/pull/2186

Also edited the OWNER file to add myself to `aws` folder