### PR TITLE
feat(IR): adds IteratorPolicy to PipelineTaskSpec proto for support of parallelism setting on ParallelFor

### DIFF
--- a/api/v2alpha1/pipeline_spec.proto
+++ b/api/v2alpha1/pipeline_spec.proto
@@ -188,7 +188,7 @@ message ComponentInputsSpec {
 
     // Optional field. Default value of the input parameter.
     google.protobuf.Value default_value = 3;
-    
+
     // Whether this input parameter is optional or not.
     // - If required, the parameter should either have a default value, or have
     // to be able to resolve to a concrete value at runtime.
@@ -495,7 +495,7 @@ message PipelineTaskSpec {
     // Iterator to iterate over a parameter input.
     ParameterIteratorSpec parameter_iterator = 10;
   }
-  
+
   // User-configured task-level retry.
   message RetryPolicy {
     // Number of retries before considering a task as failed. Set to 0 or
@@ -518,6 +518,17 @@ message PipelineTaskSpec {
   // User-configured task-level retry.
   // Applicable only to component tasks.
   RetryPolicy retry_policy = 11;
+
+  // Iterator related settings.
+  message IteratorPolicy {
+    // The limit for the number of concurrent sub-tasks spawned by an iterator
+    // task. The value should be a non-negative integer. A value of 0 represents
+    // unconstrained parallelism.
+    int32 parallelism_limit = 1;
+  }
+
+  // Iterator related settings.
+  IteratorPolicy iterator_policy = 12;
 }
 
 // The spec of an artifact iterator. It supports fan-out a workflow from a list
@@ -597,7 +608,7 @@ message ArtifactTypeSchema {
     // the properties of the type.
     string instance_schema = 3;
   }
-  
+
   // The schema version of the artifact. If the value is not set, it defaults
   // to the the latest version in the system.
   string schema_version = 4;
@@ -685,7 +696,7 @@ message PipelineDeploymentConfig {
       AcceleratorConfig accelerator = 3;
     }
     ResourceSpec resources = 5;
-    
+
     // Environment variables to be passed to the container.
     // Represents an environment variable present in a container.
     message EnvVar {
@@ -924,7 +935,7 @@ message PipelineTaskFinalStatus {
 
   // The error of the task.
   google.rpc.Status error = 2;
-  
+
   // The pipeline job unique id.
   int64 pipeline_job_uuid = 3 [deprecated = true];
 
@@ -934,7 +945,7 @@ message PipelineTaskFinalStatus {
   // The pipeline job resource name, in the format of
   // `projects/{project}/locations/{location}/pipelineJobs/{pipeline_job}`.
   string pipeline_job_resource_name = 5;
-  
+
   // The pipeline task that produces this status.
   string pipeline_task_name = 6;
 }


### PR DESCRIPTION
**Description of your changes:**
- Adds `IteratorPolicy` message to IR proto definition, containing a single `parallelism_limit` field of type `int32`.
- Adds a `iterator_policy` field of `IteratorPolicy` type to `PipelineTaskSpec` IR definition, used for controlling ParallelFor iterator task parallelism limit.
- Also removes trailing white spaces in proto file

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
