### PR TITLE
chore(sdk): use markdown for long description content type

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -59,6 +59,7 @@ setuptools.setup(
     version=find_version('kfp', '__init__.py'),
     description='Kubeflow Pipelines SDK',
     long_description=read_readme(),
+    long_description_content_type='text/markdown',
     author='The Kubeflow Authors',
     url="https://github.com/kubeflow/pipelines",
     project_urls={


### PR DESCRIPTION
**Description of your changes:**
Sets the `setuptools.setup` long description content type to 'text/markdown' so that PyPI 
can read markdown. For more info: 
https://packaging.python.org/en/latest/tutorials/packaging-projects/#configuring-metadata.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more 
about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
