### PR TITLE
feat(backend): Use cert-manager for cache-server certificate

### DIFF
--- a/manifests/kustomize/env/cert-manager/base/cache-cert-issuer.yaml
+++ b/manifests/kustomize/env/cert-manager/base/cache-cert-issuer.yaml
@@ -1,0 +1,6 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kfp-cache-selfsigned-issuer
+spec:
+  selfSigned: {}

--- a/manifests/kustomize/env/cert-manager/base/cache-cert.yaml
+++ b/manifests/kustomize/env/cert-manager/base/cache-cert.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kfp-cache-cert
+spec:
+  commonName: kfp-cache-cert
+  isCA: true
+  dnsNames:
+  - cache-server
+  - cache-server.$(kfp-namespace)
+  - cache-server.$(kfp-namespace).svc
+  issuerRef:
+    kind: Issuer
+    name: kfp-cache-selfsigned-issuer
+  secretName: webhook-server-tls

--- a/manifests/kustomize/env/cert-manager/base/cache-webhook-config.yaml
+++ b/manifests/kustomize/env/cert-manager/base/cache-webhook-config.yaml
@@ -1,0 +1,25 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: cache-webhook-kubeflow
+  annotations:
+    cert-manager.io/inject-ca-from: $(kfp-namespace)/kfp-cache-cert
+webhooks:
+  - name: cache-server.$(kfp-namespace).svc
+    clientConfig:
+      service:
+        name: cache-server
+        namespace: $(kfp-namespace)
+        path: "/mutate"
+    failurePolicy: Ignore
+    rules:
+    - operations: [ "CREATE" ]
+      apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]
+    sideEffects: None
+    timeoutSeconds: 5
+    objectSelector:
+      matchLabels:
+        pipelines.kubeflow.org/cache_enabled: "true"
+    admissionReviewVersions: ["v1beta1"]

--- a/manifests/kustomize/env/cert-manager/base/kustomization.yaml
+++ b/manifests/kustomize/env/cert-manager/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow 
+
+resources:
+  - cache-cert-issuer.yaml
+  - cache-cert.yaml
+  - cache-webhook-config.yaml
+commonLabels:
+  app: cache-server-cert-manager
+
+configurations:
+- params.yaml

--- a/manifests/kustomize/env/cert-manager/base/params.yaml
+++ b/manifests/kustomize/env/cert-manager/base/params.yaml
@@ -1,0 +1,13 @@
+varReference:
+  - path: spec/commonName
+    kind: Certificate
+  - path: spec/dnsNames
+    kind: Certificate
+  - path: spec/issuerRef/name
+    kind: Certificate
+  - path: metadata/annotations
+    kind: MutatingWebhookConfiguration
+  - path: webhooks/clientConfig/service/namespace
+    kind: MutatingWebhookConfiguration
+  - path: webhooks/name
+    kind: MutatingWebhookConfiguration

--- a/manifests/kustomize/env/cert-manager/cluster-scoped-resources/kustomization.yaml
+++ b/manifests/kustomize/env/cert-manager/cluster-scoped-resources/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../../../third-party/application/cluster-scoped
+- ../../../third-party/argo/installs/namespace/cluster-scoped
+- ../../../base/pipeline/cluster-scoped

--- a/manifests/kustomize/env/cert-manager/dev/delete-cache-deployer.yaml
+++ b/manifests/kustomize/env/cert-manager/dev/delete-cache-deployer.yaml
@@ -1,0 +1,18 @@
+# Delete cache deployer related resources as we use the cert-manager instead 
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cache-deployer-deployment
+$patch: delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubeflow-pipelines-cache-deployer-role
+$patch: delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubeflow-pipelines-cache-deployer-rolebinding
+$patch: delete

--- a/manifests/kustomize/env/cert-manager/dev/kustomization.yaml
+++ b/manifests/kustomize/env/cert-manager/dev/kustomization.yaml
@@ -1,0 +1,47 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../dev
+  - ../base
+namespace: kubeflow
+
+# Delete the cache deployer as we use the cert-manager instead 
+patchesStrategicMerge:
+  - ./delete-cache-deployer.yaml
+
+resources:
+- namespace.yaml
+
+vars:
+# NOTE: var name must be unique globally to allow composition of multiple kustomize
+# packages. Therefore, we added prefix `kfp-dev-` to distinguish it from
+# others.
+- name: kfp-dev-namespace
+  objref:
+    # ml-pipeline sa's metadata.namespace will be first transformed by namespace field in kustomization.yaml
+    # so that we only need to change kustomization.yaml's namespace field for namespace customization.
+    kind: ServiceAccount
+    name: ml-pipeline
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.namespace
+configurations:
+- params.yaml
+
+# Pass proper arguments to cache-server to use cert-manager certificate
+patches:
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls_cert_filename=tls.crt"
+  target:
+    kind: Deployment
+    name: cache-server
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls_key_filename=tls.key"
+  target:
+    kind: Deployment
+    name: cache-server

--- a/manifests/kustomize/env/cert-manager/dev/namespace.yaml
+++ b/manifests/kustomize/env/cert-manager/dev/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: '$(kfp-dev-namespace)'

--- a/manifests/kustomize/env/cert-manager/dev/params.yaml
+++ b/manifests/kustomize/env/cert-manager/dev/params.yaml
@@ -1,0 +1,4 @@
+# Allow Kustomize var to replace following fields.
+varReference:
+- path: metadata/name
+  kind: Namespace

--- a/manifests/kustomize/env/cert-manager/platform-agnostic-multi-user/delete-cache-deployer.yaml
+++ b/manifests/kustomize/env/cert-manager/platform-agnostic-multi-user/delete-cache-deployer.yaml
@@ -1,0 +1,36 @@
+# Delete cache deployer as we use the cert-manager instead 
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-pipelines-cache-deployer-clusterrole
+$patch: delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeflow-pipelines-cache-deployer-clusterrolebinding
+$patch: delete
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeflow-pipelines-cache-deployer-sa
+$patch: delete
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cache-deployer-deployment
+$patch: delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubeflow-pipelines-cache-deployer-role
+$patch: delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubeflow-pipelines-cache-deployer-rolebinding
+$patch: delete

--- a/manifests/kustomize/env/cert-manager/platform-agnostic-multi-user/kustomization.yaml
+++ b/manifests/kustomize/env/cert-manager/platform-agnostic-multi-user/kustomization.yaml
@@ -1,0 +1,28 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../platform-agnostic-multi-user
+  - ../base
+namespace: kubeflow
+
+# Delete the cache deployer as we use the cert-manager instead 
+patchesStrategicMerge:
+  - ./delete-cache-deployer.yaml
+
+# Pass proper arguments to cache-server to use cert-manager certificate
+patches:
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls_cert_filename=tls.crt"
+  target:
+    kind: Deployment
+    name: cache-server
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls_key_filename=tls.key"
+  target:
+    kind: Deployment
+    name: cache-server


### PR DESCRIPTION
**Description of your changes:**
- Manifests for using cert-manager for the certificate required by cache-server
  - Created a cert-manager directory under env instead of adding the manifests under aws since this issue was [also found on Mercedes Benz distribution of Kubernetes](https://github.com/kubeflow/manifests/issues/2165#issuecomment-1096633299). This means with the current implementation(which does not use cert-manager), caching will not work on any k8s distribution which issues certificates for CSRs with signerName `kubernetes.io/kubelet-serving` only to kubelets
  - Addressed comments from #7779. Will update 7779 once this is merged.
- cherry-pick of #7538 to this(release-1.8) branch (since it will be required for 1.8.2 release)

**Testing:**
- Manually tested both standalone installation and multi user with Kubeflow installed with a custom built cache-server image since there are changes to `backend/src/cache/main.go`
