### PR TITLE
fix(frontend): Fix run comparison filter

### DIFF
--- a/frontend/src/pages/RunList.test.tsx
+++ b/frontend/src/pages/RunList.test.tsx
@@ -393,11 +393,14 @@ describe('RunList', () => {
         }),
       ),
     });
-    expect(tree.state('runs')).toMatchObject([{
-      'run': { 'name': 'run with id: filterRun1' }
-    }, {
-      'run': { 'name': 'run with id: filterRun2' }
-    }]);
+    expect(tree.state('runs')).toMatchObject([
+      {
+        run: { name: 'run with id: filterRun1' },
+      },
+      {
+        run: { name: 'run with id: filterRun2' },
+      },
+    ]);
   });
 
   it('adds metrics columns', async () => {

--- a/frontend/src/pages/RunList.test.tsx
+++ b/frontend/src/pages/RunList.test.tsx
@@ -381,6 +381,25 @@ describe('RunList', () => {
     expect(Apis.runServiceApi.getRun).toHaveBeenCalledWith('run2');
   });
 
+  it('loads given and filtered list of runs only', async () => {
+    mockNRuns(5, {});
+    const props = generateProps();
+    props.runIdListMask = ['filterRun1', 'filterRun2', 'notincluded'];
+    tree = shallow(<RunList {...props} />);
+    await (tree.instance() as RunListTest)._loadRuns({
+      filter: encodeURIComponent(
+        JSON.stringify({
+          predicates: [{ key: 'name', op: PredicateOp.ISSUBSTRING, string_value: 'filterRun' }],
+        }),
+      ),
+    });
+    expect(tree.state('runs')).toMatchObject([{
+      'run': { 'name': 'run with id: filterRun1' }
+    }, {
+      'run': { 'name': 'run with id: filterRun2' }
+    }]);
+  });
+
   it('adds metrics columns', async () => {
     mockNRuns(2, {
       run: {

--- a/frontend/src/pages/RunList.test.tsx
+++ b/frontend/src/pages/RunList.test.tsx
@@ -403,6 +403,28 @@ describe('RunList', () => {
     ]);
   });
 
+  it('loads given and filtered list of runs only through multiple filters', async () => {
+    mockNRuns(5, {});
+    const props = generateProps();
+    props.runIdListMask = ['filterRun1', 'filterRun2', 'notincluded1'];
+    tree = shallow(<RunList {...props} />);
+    await (tree.instance() as RunListTest)._loadRuns({
+      filter: encodeURIComponent(
+        JSON.stringify({
+          predicates: [
+            { key: 'name', op: PredicateOp.ISSUBSTRING, string_value: 'filterRun' },
+            { key: 'name', op: PredicateOp.ISSUBSTRING, string_value: '1' },
+          ],
+        }),
+      ),
+    });
+    expect(tree.state('runs')).toMatchObject([
+      {
+        run: { name: 'run with id: filterRun1' },
+      },
+    ]);
+  });
+
   it('adds metrics columns', async () => {
     mockNRuns(2, {
       run: {

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -189,12 +189,14 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
           noFilterBox={this.props.noFilterBox}
           emptyMessage={
             `No` +
-            `${this.props.storageState === ApiRunStorageState.ARCHIVED ? ' archived' : ' available'
+            `${
+              this.props.storageState === ApiRunStorageState.ARCHIVED ? ' archived' : ' available'
             }` +
             ` runs found` +
-            `${this.props.experimentIdMask
-              ? ' for this experiment'
-              : this.props.namespaceMask
+            `${
+              this.props.experimentIdMask
+                ? ' for this experiment'
+                : this.props.namespaceMask
                 ? ' for this namespace'
                 : ''
             }.`
@@ -236,13 +238,13 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
     const search = new URLParser(this.props).build({ [QUERY_PARAMS.fromRunId]: props.id });
     const url = props.value.usePlaceholder
       ? RoutePage.PIPELINE_DETAILS_NO_VERSION.replace(':' + RouteParams.pipelineId + '?', '') +
-      search
+        search
       : !!props.value.versionId
-        ? RoutePage.PIPELINE_DETAILS.replace(
+      ? RoutePage.PIPELINE_DETAILS.replace(
           ':' + RouteParams.pipelineId,
           props.value.pipelineId || '',
         ).replace(':' + RouteParams.pipelineVersionId, props.value.versionId || '')
-        : RoutePage.PIPELINE_DETAILS_NO_VERSION.replace(
+      : RoutePage.PIPELINE_DETAILS_NO_VERSION.replace(
           ':' + RouteParams.pipelineId,
           props.value.pipelineId || '',
         );
@@ -433,11 +435,14 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
    * Remove the run from the list if its name does not match the filter
    */
   private _getAndSetRuns(displayRuns: DisplayRun[], filter: ApiFilter): Promise<DisplayRun[]> {
-    const filterSubstring = (filter.predicates
-      && filter.predicates[0]
-      && filter.predicates[0].key === 'name'
-      && filter.predicates[0].op === PredicateOp.ISSUBSTRING
-      && filter.predicates[0].string_value) ? filter.predicates[0].string_value.toLowerCase() : '';
+    const filterSubstring =
+      filter.predicates &&
+      filter.predicates[0] &&
+      filter.predicates[0].key === 'name' &&
+      filter.predicates[0].op === PredicateOp.ISSUBSTRING &&
+      filter.predicates[0].string_value
+        ? filter.predicates[0].string_value.toLowerCase()
+        : '';
     return Promise.all(
       displayRuns.map(async displayRun => {
         let getRunResponse: ApiRunDetail;

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -444,7 +444,6 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
 
   /**
    * For each run ID, fetch its corresponding run, and set it in DisplayRuns
-   * Remove the run from the list if its name does not match the filter
    */
   private _getAndSetRuns(displayRuns: DisplayRun[]): Promise<DisplayRun[]> {
     return Promise.all(


### PR DESCRIPTION
**Description of your changes:**
- Fix #7827 

1. Add filter functionality for run lists with a run ID list mask
2. Add tests to verify that the filter mechanism for `RunList.tsx` works correctly in all cases

**Screen Recording:**

_This screencast shows both the "Runs" tab and the Run Comparison page working correctly (though only the latter needed a fix)._

https://user-images.githubusercontent.com/7987279/171758270-80080e81-4df8-4bf0-804d-8db4a5d61e8b.mp4

**Notes:**
- This issue occurred because the filtering mechanism typically occurs through the [`listRuns` API](https://github.com/kubeflow/pipelines/blob/340318625c527836af1c9abc0fd0d76c0a466333/frontend/src/apis/run/api.ts#L1725), but since that method does not have support for the `runIdListMask`, when a mask exists each run is fetched individually (see the [`_loadRuns`](https://github.com/kubeflow/pipelines/blob/0cf817364cc7b3156ea4b4e16fee3f193d8a6744/frontend/src/pages/RunList.tsx#L328-L337) method). This individual fetching of runs did not have a filtering mechanism, and I added that in this PR.
- Currently, only the ["name substring"](https://github.com/kubeflow/pipelines/blob/340318625c527836af1c9abc0fd0d76c0a466333/frontend/src/components/CustomTable.tsx#L519-L531) filtering is supported, so I have hard-coded the `filterSubstring` within `RunList.tsx` to detect and apply this filter. However, if more filter options are added in the future, we will likely want to separate this filter logic out.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
