### PR TITLE
feat(frontend): Update compare page and banner states based on run versions and count

### DIFF
--- a/frontend/src/pages/Compare.test.tsx
+++ b/frontend/src/pages/Compare.test.tsx
@@ -254,7 +254,7 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
     getRunSpy.mockImplementation((id: string) => runs.find(r => r.run!.id === id));
 
     // v2 feature is turn off.
-    jest.spyOn(features, 'isFeatureEnabled').mockImplementation(_ => false);
+    jest.spyOn(features, 'isFeatureEnabled').mockReturnValue(false);
 
     render(
       <CommonTestWrapper>
@@ -273,7 +273,7 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
     getRunSpy.mockImplementation((id: string) => runs.find(r => r.run!.id === id));
 
     // v2 feature is turn off.
-    jest.spyOn(features, 'isFeatureEnabled').mockImplementation(_ => false);
+    jest.spyOn(features, 'isFeatureEnabled').mockReturnValue(false);
 
     const props = generateProps();
     props.location.search = `?${QUERY_PARAMS.runlist}=${MOCK_RUN_1_ID}`;
@@ -324,7 +324,7 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
     getRunSpy.mockImplementation((id: string) => runs.find(r => r.run!.id === id));
 
     // v2 feature is turn off.
-    jest.spyOn(features, 'isFeatureEnabled').mockImplementation(_ => false);
+    jest.spyOn(features, 'isFeatureEnabled').mockReturnValue(false);
 
     render(
       <CommonTestWrapper>
@@ -345,7 +345,7 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
     getRunSpy.mockImplementation((id: string) => runs.find(r => r.run!.id === id));
 
     // v2 feature is turn off.
-    jest.spyOn(features, 'isFeatureEnabled').mockImplementation(_ => false);
+    jest.spyOn(features, 'isFeatureEnabled').mockReturnValue(false);
 
     render(
       <CommonTestWrapper>

--- a/frontend/src/pages/Compare.test.tsx
+++ b/frontend/src/pages/Compare.test.tsx
@@ -185,7 +185,8 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
     await TestUtils.flushPromises();
 
     expect(updateBannerSpy).toHaveBeenLastCalledWith({
-      additionalInfo: 'At least two runs and at most ten runs must be selected to view the Run Comparison page.',
+      additionalInfo:
+        'At least two runs and at most ten runs must be selected to view the Run Comparison page.',
       message: 'Error: failed loading the Run Comparison page. Click Details for more information.',
       mode: 'error',
     });
@@ -227,7 +228,8 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
     await TestUtils.flushPromises();
 
     expect(updateBannerSpy).toHaveBeenLastCalledWith({
-      additionalInfo: 'At least two runs and at most ten runs must be selected to view the Run Comparison page.',
+      additionalInfo:
+        'At least two runs and at most ten runs must be selected to view the Run Comparison page.',
       message: 'Error: failed loading the Run Comparison page. Click Details for more information.',
       mode: 'error',
     });

--- a/frontend/src/pages/Compare.test.tsx
+++ b/frontend/src/pages/Compare.test.tsx
@@ -152,13 +152,16 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
 
     await TestUtils.flushPromises();
 
-    expect(updateBannerSpy).toHaveBeenLastCalledWith({
-      additionalInfo:
-        'The selected runs are a mix of V1 and V2.' +
-        ' Please select all V1 or all V2 runs to view the associated Run Comparison page.',
-      message: 'Error: failed loading the Run Comparison page. Click Details for more information.',
-      mode: 'error',
-    });
+    await waitFor(() =>
+      expect(updateBannerSpy).toHaveBeenLastCalledWith({
+        additionalInfo:
+          'The selected runs are a mix of V1 and V2.' +
+          ' Please select all V1 or all V2 runs to view the associated Run Comparison page.',
+        message:
+          'Error: failed loading the Run Comparison page. Click Details for more information.',
+        mode: 'error',
+      }),
+    );
   });
 
   it('Show invalid run count page error if there are less than two runs', async () => {
@@ -184,12 +187,15 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
 
     await TestUtils.flushPromises();
 
-    expect(updateBannerSpy).toHaveBeenLastCalledWith({
-      additionalInfo:
-        'At least two runs and at most ten runs must be selected to view the Run Comparison page.',
-      message: 'Error: failed loading the Run Comparison page. Click Details for more information.',
-      mode: 'error',
-    });
+    await waitFor(() =>
+      expect(updateBannerSpy).toHaveBeenLastCalledWith({
+        additionalInfo:
+          'At least two runs and at most ten runs must be selected to view the Run Comparison page.',
+        message:
+          'Error: failed loading the Run Comparison page. Click Details for more information.',
+        mode: 'error',
+      }),
+    );
   });
 
   it('Show invalid run count page error if there are more than ten runs', async () => {
@@ -227,12 +233,15 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
 
     await TestUtils.flushPromises();
 
-    expect(updateBannerSpy).toHaveBeenLastCalledWith({
-      additionalInfo:
-        'At least two runs and at most ten runs must be selected to view the Run Comparison page.',
-      message: 'Error: failed loading the Run Comparison page. Click Details for more information.',
-      mode: 'error',
-    });
+    await waitFor(() =>
+      expect(updateBannerSpy).toHaveBeenLastCalledWith({
+        additionalInfo:
+          'At least two runs and at most ten runs must be selected to view the Run Comparison page.',
+        message:
+          'Error: failed loading the Run Comparison page. Click Details for more information.',
+        mode: 'error',
+      }),
+    );
   });
 
   it('Show no error on v1 page if run versions are mixed between v1 and v2 and feature flag disabled', async () => {
@@ -256,7 +265,6 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
     await TestUtils.flushPromises();
 
     await waitFor(() => screen.getByText('Run overview'));
-    expect(updateBannerSpy).toHaveBeenLastCalledWith({});
   });
 
   it('Show no error on v1 page if there are less than two runs and v2 feature flag disabled', async () => {
@@ -278,38 +286,6 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
     await TestUtils.flushPromises();
 
     await waitFor(() => screen.getByText('Run overview'));
-    expect(updateBannerSpy).toHaveBeenLastCalledWith({});
-  });
-
-  it('Show info banner on v1 page if all runs are v2 and v2 feature flag disabled', async () => {
-    const getRunSpy = jest.spyOn(Apis.runServiceApi, 'getRun');
-    runs = [
-      newMockRun(MOCK_RUN_1_ID, true),
-      newMockRun(MOCK_RUN_2_ID, true),
-      newMockRun(MOCK_RUN_3_ID, true),
-    ];
-    getRunSpy.mockImplementation((id: string) => runs.find(r => r.run!.id === id));
-
-    // v2 feature is turn off.
-    jest.spyOn(features, 'isFeatureEnabled').mockImplementation(_ => false);
-
-    render(
-      <CommonTestWrapper>
-        <Compare {...generateProps()} />
-      </CommonTestWrapper>,
-    );
-
-    await TestUtils.flushPromises();
-
-    await waitFor(() => screen.getByText('Run overview'));
-    expect(updateBannerSpy).toHaveBeenLastCalledWith({
-      additionalInfo:
-        'The selected runs are all V2, but the V2_ALPHA feature flag is disabled.' +
-        ' The V1 page will not show any useful information for these runs.',
-      message:
-        'Info: enable the V2_ALPHA feature flag in order to view the updated Run Comparison page.',
-      mode: 'info',
-    });
   });
 
   it('Show v2 page if all runs are v2 and the v2 feature flag is enabled', async () => {
@@ -409,10 +385,12 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
 
     await TestUtils.flushPromises();
 
-    expect(updateBannerSpy).toHaveBeenLastCalledWith({
-      additionalInfo: 'test error',
-      message: 'Error: failed loading 3 runs. Click Details for more information.',
-      mode: 'error',
-    });
+    await waitFor(() =>
+      expect(updateBannerSpy).toHaveBeenLastCalledWith({
+        additionalInfo: 'test error',
+        message: 'Error: failed loading 3 runs. Click Details for more information.',
+        mode: 'error',
+      }),
+    );
   });
 });

--- a/frontend/src/pages/Compare.test.tsx
+++ b/frontend/src/pages/Compare.test.tsx
@@ -21,7 +21,7 @@ import { Apis } from 'src/lib/Apis';
 import { PageProps } from './Page';
 import { QUERY_PARAMS } from 'src/components/Router';
 import { ApiRunDetail } from 'src/apis/run';
-import Compare, { CompareProps } from './Compare';
+import Compare from './Compare';
 import * as features from 'src/features';
 import { testBestPractices } from 'src/TestUtils';
 import TestUtils from 'src/TestUtils';
@@ -33,7 +33,7 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
   const MOCK_RUN_3_ID = 'mock-run-3-id';
   const updateBannerSpy = jest.fn();
 
-  function generateProps(): CompareProps {
+  function generateProps(): PageProps {
     const pageProps: PageProps = {
       history: {} as any,
       location: {
@@ -46,16 +46,7 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
       updateSnackbar: () => null,
       updateToolbar: () => null,
     };
-    return Object.assign(pageProps, {
-      collapseSections: {},
-      fullscreenViewerConfig: null,
-      metricsCompareProps: { rows: [], xLabels: [], yLabels: [] },
-      paramsCompareProps: { rows: [], xLabels: [], yLabels: [] },
-      runs: [],
-      selectedIds: [],
-      viewersMap: new Map(),
-      workflowObjects: [],
-    });
+    return pageProps;
   }
 
   let runs: ApiRunDetail[] = [];

--- a/frontend/src/pages/Compare.test.tsx
+++ b/frontend/src/pages/Compare.test.tsx
@@ -161,7 +161,7 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
     });
   });
 
-  it('Show too few runs page error if there are less than two runs', async () => {
+  it('Show invalid run count page error if there are less than two runs', async () => {
     const getRunSpy = jest.spyOn(Apis.runServiceApi, 'getRun');
     runs = [newMockRun(MOCK_RUN_1_ID, true)];
     getRunSpy.mockImplementation((id: string) => runs.find(r => r.run!.id === id));
@@ -185,7 +185,49 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
     await TestUtils.flushPromises();
 
     expect(updateBannerSpy).toHaveBeenLastCalledWith({
-      additionalInfo: 'At least two runs must be selected to view the Run Comparison page.',
+      additionalInfo: 'At least two runs and at most ten runs must be selected to view the Run Comparison page.',
+      message: 'Error: failed loading the Run Comparison page. Click Details for more information.',
+      mode: 'error',
+    });
+  });
+
+  it('Show invalid run count page error if there are more than ten runs', async () => {
+    const getRunSpy = jest.spyOn(Apis.runServiceApi, 'getRun');
+    runs = [
+      newMockRun('1', true),
+      newMockRun('2', true),
+      newMockRun('3', true),
+      newMockRun('4', true),
+      newMockRun('5', true),
+      newMockRun('6', true),
+      newMockRun('7', true),
+      newMockRun('8', true),
+      newMockRun('9', true),
+      newMockRun('10', true),
+      newMockRun('11', true),
+    ];
+    getRunSpy.mockImplementation((id: string) => runs.find(r => r.run!.id === id));
+
+    // v2 feature is turn on.
+    jest.spyOn(features, 'isFeatureEnabled').mockImplementation(featureKey => {
+      if (featureKey === features.FeatureKey.V2_ALPHA) {
+        return true;
+      }
+      return false;
+    });
+
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.runlist}=1,2,3,4,5,6,7,8,9,10,11`;
+    render(
+      <CommonTestWrapper>
+        <Compare {...props} />
+      </CommonTestWrapper>,
+    );
+
+    await TestUtils.flushPromises();
+
+    expect(updateBannerSpy).toHaveBeenLastCalledWith({
+      additionalInfo: 'At least two runs and at most ten runs must be selected to view the Run Comparison page.',
       message: 'Error: failed loading the Run Comparison page. Click Details for more information.',
       mode: 'error',
     });

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { useQuery } from 'react-query';
 import { ApiRunDetail } from 'src/apis/run';
 import { QUERY_PARAMS } from 'src/components/Router';
@@ -28,16 +28,25 @@ import { PageProps } from './Page';
 
 export type CompareProps = PageProps & CompareState;
 
+enum CompareVersion {
+  V1,
+  V2,
+  Mixed,
+  TooFewRuns,
+}
+
 // This is a router to determine whether to show V1 or V2 compare page.
 export default function Compare(props: CompareProps) {
+  const [compareVersion, setCompareVersion] = useState<CompareVersion>(CompareVersion.TooFewRuns);
   const queryParamRunIds = new URLParser(props).get(QUERY_PARAMS.runlist);
   const runIds = (queryParamRunIds && queryParamRunIds.split(',')) || [];
 
-  // Retrieves run details.
-  const { isSuccess, isError, data } = useQuery<ApiRunDetail[], Error>(
+  // Retrieves run details, set page version on success.
+  const { isError } = useQuery<ApiRunDetail[], Error>(
     ['run_details', { ids: runIds }],
     () => Promise.all(runIds.map(async id => await Apis.runServiceApi.getRun(id))),
     {
+      refetchOnMount: 'always',
       staleTime: Infinity,
       onError: async error => {
         const errorMessage = await errorToMessage(error);
@@ -47,23 +56,67 @@ export default function Compare(props: CompareProps) {
           mode: 'error',
         });
       },
-      onSuccess: () => props.updateBanner({}),
+      onSuccess: data => {
+        // Set the version based on the runs included.
+        let version: CompareVersion = CompareVersion.TooFewRuns;
+        if (data && data.length > 1) {
+          for (const run of data) {
+            const runVersion = run.run?.pipeline_spec?.hasOwnProperty('pipeline_manifest')
+              ? CompareVersion.V2
+              : CompareVersion.V1;
+            if (version === CompareVersion.TooFewRuns) {
+              version = runVersion;
+            } else if (version !== runVersion) {
+              version = CompareVersion.Mixed;
+            }
+          }
+        }
+
+        // Update banner based on feature flag, run versions, and run count.
+        if (isFeatureEnabled(FeatureKey.V2_ALPHA) && version === CompareVersion.TooFewRuns) {
+          props.updateBanner({
+            additionalInfo: 'At least two runs must be selected to view the Run Comparison page.',
+            message:
+              'Error: failed loading the Run Comparison page. Click Details for more information.',
+            mode: 'error',
+          });
+        } else if (isFeatureEnabled(FeatureKey.V2_ALPHA) && version === CompareVersion.Mixed) {
+          props.updateBanner({
+            additionalInfo:
+              'The selected runs are a mix of V1 and V2.' +
+              ' Please select all V1 or all V2 runs to view the associated Run Comparison page.',
+            message:
+              'Error: failed loading the Run Comparison page. Click Details for more information.',
+            mode: 'error',
+          });
+        } else if (!isFeatureEnabled(FeatureKey.V2_ALPHA) && version === CompareVersion.V2) {
+          props.updateBanner({
+            additionalInfo:
+              'The selected runs are all V2, but the V2_ALPHA feature flag is disabled.' +
+              ' The V1 page will not show any useful information for these runs.',
+            message:
+              'Info: enable the V2_ALPHA feature flag in order to view the updated Run Comparison page.',
+            mode: 'info',
+          });
+        } else {
+          props.updateBanner({});
+        }
+
+        setCompareVersion(version);
+      },
     },
   );
 
-  if (isError || data === undefined) {
+  if (isError) {
     return <></>;
   }
 
-  // Display the V2 Compare page if all selected runs are V2.
-  if (
-    isFeatureEnabled(FeatureKey.V2_ALPHA) &&
-    isSuccess &&
-    data &&
-    data.every(run => run.run?.pipeline_spec?.hasOwnProperty('pipeline_manifest'))
-  ) {
+  if (isFeatureEnabled(FeatureKey.V2_ALPHA) && compareVersion === CompareVersion.V2) {
     return <CompareV2 />;
-  } else {
+  } else if (!isFeatureEnabled(FeatureKey.V2_ALPHA) || compareVersion === CompareVersion.V1) {
     return <CompareV1 {...props} />;
   }
+
+  // Only the error banner shown for mixed run versions or less than two selected runs.
+  return <></>;
 }

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -22,11 +22,9 @@ import { FeatureKey, isFeatureEnabled } from 'src/features';
 import { Apis } from 'src/lib/Apis';
 import { errorToMessage } from 'src/lib/Utils';
 import { URLParser } from '../lib/URLParser';
-import CompareV1, { CompareState } from './CompareV1';
+import CompareV1 from './CompareV1';
 import CompareV2 from './CompareV2';
 import { PageProps } from './Page';
-
-export type CompareProps = PageProps & CompareState;
 
 enum CompareVersion {
   V1,
@@ -36,7 +34,7 @@ enum CompareVersion {
 }
 
 // This is a router to determine whether to show V1 or V2 compare page.
-export default function Compare(props: CompareProps) {
+export default function Compare(props: PageProps) {
   const [compareVersion, setCompareVersion] = useState<CompareVersion>(
     CompareVersion.InvalidRunCount,
   );

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -37,7 +37,9 @@ enum CompareVersion {
 
 // This is a router to determine whether to show V1 or V2 compare page.
 export default function Compare(props: CompareProps) {
-  const [compareVersion, setCompareVersion] = useState<CompareVersion>(CompareVersion.InvalidRunCount);
+  const [compareVersion, setCompareVersion] = useState<CompareVersion>(
+    CompareVersion.InvalidRunCount,
+  );
   const queryParamRunIds = new URLParser(props).get(QUERY_PARAMS.runlist);
   const runIds = (queryParamRunIds && queryParamRunIds.split(',')) || [];
 

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -108,12 +108,21 @@ export default function Compare(props: PageProps) {
     return <></>;
   }
 
-  if (isFeatureEnabled(FeatureKey.V2_ALPHA) && compareVersion === CompareVersion.V2) {
-    return <CompareV2 />;
-  } else if (!isFeatureEnabled(FeatureKey.V2_ALPHA) || compareVersion === CompareVersion.V1) {
+  if (!isFeatureEnabled(FeatureKey.V2_ALPHA)) {
     return <CompareV1 {...props} />;
+  } else {
+    if (compareVersion === CompareVersion.V2) {
+      return <CompareV2 />;
+    } else if (compareVersion === CompareVersion.V1) {
+      return <CompareV1 {...props} />;
+    } else if (
+      compareVersion === CompareVersion.Mixed ||
+      compareVersion === CompareVersion.InvalidRunCount ||
+      compareVersion === CompareVersion.Unknown
+    ) {
+      return <></>;
+    }
   }
 
-  // Only the error banner shown for mixed run versions or less than two selected runs.
   return <></>;
 }

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
 import { ApiRunDetail } from 'src/apis/run';
 import { QUERY_PARAMS } from 'src/components/Router';
@@ -31,82 +31,78 @@ enum CompareVersion {
   V2,
   Mixed,
   InvalidRunCount,
+  Unknown,
 }
 
 // This is a router to determine whether to show V1 or V2 compare page.
 export default function Compare(props: PageProps) {
-  const [compareVersion, setCompareVersion] = useState<CompareVersion>(
-    CompareVersion.InvalidRunCount,
-  );
+  const { updateBanner } = props;
+  const [compareVersion, setCompareVersion] = useState<CompareVersion>(CompareVersion.Unknown);
   const queryParamRunIds = new URLParser(props).get(QUERY_PARAMS.runlist);
   const runIds = (queryParamRunIds && queryParamRunIds.split(',')) || [];
 
   // Retrieves run details, set page version on success.
-  const { isError } = useQuery<ApiRunDetail[], Error>(
+  const { isError, error } = useQuery<ApiRunDetail[], Error>(
     ['run_details', { ids: runIds }],
     () => Promise.all(runIds.map(async id => await Apis.runServiceApi.getRun(id))),
     {
-      refetchOnMount: 'always',
       staleTime: Infinity,
-      onError: async error => {
+      onSuccess: data => {
+        // Set the version based on the runs included.
+        if (data.length < 2 || data.length > 10) {
+          setCompareVersion(CompareVersion.InvalidRunCount);
+        } else {
+          const v2runs = data.filter(run =>
+            run.run?.pipeline_spec?.hasOwnProperty('pipeline_manifest'),
+          );
+          if (v2runs.length === 0) {
+            setCompareVersion(CompareVersion.V1);
+          } else if (v2runs.length === data.length) {
+            setCompareVersion(CompareVersion.V2);
+          } else {
+            setCompareVersion(CompareVersion.Mixed);
+          }
+        }
+      },
+    },
+  );
+
+  useEffect(() => {
+    // Update banner based on error, feature flag, run versions, and run count.
+    if (isError) {
+      (async function() {
         const errorMessage = await errorToMessage(error);
-        props.updateBanner({
+        updateBanner({
           additionalInfo: errorMessage ? errorMessage : undefined,
           message: `Error: failed loading ${runIds.length} runs. Click Details for more information.`,
           mode: 'error',
         });
-      },
-      onSuccess: data => {
-        // Set the version based on the runs included.
-        let version: CompareVersion = CompareVersion.InvalidRunCount;
-        if (data && data.length >= 2 && data.length <= 10) {
-          for (const run of data) {
-            const runVersion = run.run?.pipeline_spec?.hasOwnProperty('pipeline_manifest')
-              ? CompareVersion.V2
-              : CompareVersion.V1;
-            if (version === CompareVersion.InvalidRunCount) {
-              version = runVersion;
-            } else if (version !== runVersion) {
-              version = CompareVersion.Mixed;
-            }
-          }
-        }
-
-        // Update banner based on feature flag, run versions, and run count.
-        if (isFeatureEnabled(FeatureKey.V2_ALPHA) && version === CompareVersion.InvalidRunCount) {
-          props.updateBanner({
-            additionalInfo:
-              'At least two runs and at most ten runs must be selected to view the Run Comparison page.',
-            message:
-              'Error: failed loading the Run Comparison page. Click Details for more information.',
-            mode: 'error',
-          });
-        } else if (isFeatureEnabled(FeatureKey.V2_ALPHA) && version === CompareVersion.Mixed) {
-          props.updateBanner({
-            additionalInfo:
-              'The selected runs are a mix of V1 and V2.' +
-              ' Please select all V1 or all V2 runs to view the associated Run Comparison page.',
-            message:
-              'Error: failed loading the Run Comparison page. Click Details for more information.',
-            mode: 'error',
-          });
-        } else if (!isFeatureEnabled(FeatureKey.V2_ALPHA) && version === CompareVersion.V2) {
-          props.updateBanner({
-            additionalInfo:
-              'The selected runs are all V2, but the V2_ALPHA feature flag is disabled.' +
-              ' The V1 page will not show any useful information for these runs.',
-            message:
-              'Info: enable the V2_ALPHA feature flag in order to view the updated Run Comparison page.',
-            mode: 'info',
-          });
-        } else {
-          props.updateBanner({});
-        }
-
-        setCompareVersion(version);
-      },
-    },
-  );
+      })();
+    } else if (
+      isFeatureEnabled(FeatureKey.V2_ALPHA) &&
+      compareVersion === CompareVersion.InvalidRunCount
+    ) {
+      updateBanner({
+        additionalInfo:
+          'At least two runs and at most ten runs must be selected to view the Run Comparison page.',
+        message:
+          'Error: failed loading the Run Comparison page. Click Details for more information.',
+        mode: 'error',
+      });
+    } else if (isFeatureEnabled(FeatureKey.V2_ALPHA) && compareVersion === CompareVersion.Mixed) {
+      updateBanner({
+        additionalInfo:
+          'The selected runs are a mix of V1 and V2.' +
+          ' Please select all V1 or all V2 runs to view the associated Run Comparison page.',
+        message:
+          'Error: failed loading the Run Comparison page. Click Details for more information.',
+        mode: 'error',
+      });
+    } else if (isFeatureEnabled(FeatureKey.V2_ALPHA) && compareVersion !== CompareVersion.V1) {
+      // Clear the banner unless the V1 page is shown, as that page handles its own banner state.
+      updateBanner({});
+    }
+  }, [compareVersion, isError, error, updateBanner, runIds.length]);
 
   if (isError) {
     return <></>;

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -42,7 +42,7 @@ export default function Compare(props: PageProps) {
   const runIds = (queryParamRunIds && queryParamRunIds.split(',')) || [];
 
   // Retrieves run details, set page version on success.
-  const { isError, error, data } = useQuery<ApiRunDetail[], Error>(
+  const { isLoading, isError, error, data } = useQuery<ApiRunDetail[], Error>(
     ['run_details', { ids: runIds }],
     () => Promise.all(runIds.map(async id => await Apis.runServiceApi.getRun(id))),
     {
@@ -71,6 +71,10 @@ export default function Compare(props: PageProps) {
   }, [data]);
 
   useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+
     // Update banner based on error, feature flag, run versions, and run count.
     if (isError) {
       (async function() {
@@ -107,7 +111,7 @@ export default function Compare(props: PageProps) {
     }
   }, [compareVersion, isError, error, updateBanner, runIds.length]);
 
-  if (isError) {
+  if (isError || isLoading) {
     return <></>;
   }
 

--- a/frontend/src/pages/CompareV1.test.tsx
+++ b/frontend/src/pages/CompareV1.test.tsx
@@ -153,12 +153,6 @@ describe('CompareV1', () => {
     }
   });
 
-  it('clears banner upon initial load', () => {
-    tree = shallow(<CompareV1 {...generateProps()} />);
-    expect(updateBannerSpy).toHaveBeenCalledTimes(1);
-    expect(updateBannerSpy).toHaveBeenLastCalledWith({});
-  });
-
   it('renders a page with no runs', async () => {
     const props = generateProps();
     // Ensure there are no run IDs in the query
@@ -166,8 +160,7 @@ describe('CompareV1', () => {
     tree = shallow(<CompareV1 {...props} />);
     await TestUtils.flushPromises();
 
-    expect(updateBannerSpy).toHaveBeenCalledTimes(1);
-    expect(updateBannerSpy).toHaveBeenLastCalledWith({});
+    expect(updateBannerSpy).toHaveBeenCalledTimes(0);
 
     expect(tree).toMatchSnapshot();
   });
@@ -228,21 +221,6 @@ describe('CompareV1', () => {
         mode: 'error',
       }),
     );
-  });
-
-  it('clears the error banner on refresh', async () => {
-    TestUtils.makeErrorResponseOnce(getRunSpy, 'test error');
-
-    tree = shallow(<CompareV1 {...generateProps()} />);
-    await TestUtils.flushPromises();
-
-    // Verify that error banner is being shown
-    expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({ mode: 'error' }));
-
-    (tree.instance() as Compare).refresh();
-
-    // Error banner should be cleared
-    expect(updateBannerSpy).toHaveBeenLastCalledWith({});
   });
 
   it("displays run's parameters if the run has any", async () => {

--- a/frontend/src/pages/CompareV1.test.tsx
+++ b/frontend/src/pages/CompareV1.test.tsx
@@ -75,7 +75,7 @@ describe('CompareV1', () => {
 
   let runs: ApiRunDetail[] = [];
 
-  function newMockRun(id?: string): ApiRunDetail {
+  function newMockRun(id?: string, v2?: boolean): ApiRunDetail {
     return {
       pipeline_runtime: {
         workflow_manifest: '{}',
@@ -83,6 +83,7 @@ describe('CompareV1', () => {
       run: {
         id: id || 'test-run-id',
         name: 'test run ' + id,
+        pipeline_spec: v2 ? { pipeline_manifest: '' } : { workflow_manifest: '' },
       },
     };
   }
@@ -153,6 +154,12 @@ describe('CompareV1', () => {
     }
   });
 
+  it('clears banner upon initial load', () => {
+    tree = shallow(<CompareV1 {...generateProps()} />);
+    expect(updateBannerSpy).toHaveBeenCalledTimes(1);
+    expect(updateBannerSpy).toHaveBeenLastCalledWith({});
+  });
+
   it('renders a page with no runs', async () => {
     const props = generateProps();
     // Ensure there are no run IDs in the query
@@ -160,7 +167,8 @@ describe('CompareV1', () => {
     tree = shallow(<CompareV1 {...props} />);
     await TestUtils.flushPromises();
 
-    expect(updateBannerSpy).toHaveBeenCalledTimes(0);
+    expect(updateBannerSpy).toHaveBeenCalledTimes(1);
+    expect(updateBannerSpy).toHaveBeenLastCalledWith({});
 
     expect(tree).toMatchSnapshot();
   });
@@ -204,6 +212,27 @@ describe('CompareV1', () => {
     );
   });
 
+  it('shows an info banner if all runs are v2', async () => {
+    runs = [
+      newMockRun(MOCK_RUN_1_ID, true),
+      newMockRun(MOCK_RUN_2_ID, true),
+      newMockRun(MOCK_RUN_3_ID, true),
+    ];
+    getRunSpy.mockImplementation((id: string) => runs.find(r => r.run!.id === id));
+
+    tree = shallow(<CompareV1 {...generateProps()} />);
+    await TestUtils.flushPromises();
+
+    expect(updateBannerSpy).toHaveBeenLastCalledWith({
+      additionalInfo:
+        'The selected runs are all V2, but the V2_ALPHA feature flag is disabled.' +
+        ' The V1 page will not show any useful information for these runs.',
+      message:
+        'Info: enable the V2_ALPHA feature flag in order to view the updated Run Comparison page.',
+      mode: 'info',
+    });
+  });
+
   it('shows an error banner indicating the number of getRun calls that failed', async () => {
     getRunSpy.mockImplementation(() => {
       throw {
@@ -221,6 +250,21 @@ describe('CompareV1', () => {
         mode: 'error',
       }),
     );
+  });
+
+  it('clears the error banner on refresh', async () => {
+    TestUtils.makeErrorResponseOnce(getRunSpy, 'test error');
+
+    tree = shallow(<CompareV1 {...generateProps()} />);
+    await TestUtils.flushPromises();
+
+    // Verify that error banner is being shown
+    expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({ mode: 'error' }));
+
+    (tree.instance() as Compare).refresh();
+
+    // Error banner should be cleared
+    expect(updateBannerSpy).toHaveBeenLastCalledWith({});
   });
 
   it("displays run's parameters if the run has any", async () => {

--- a/frontend/src/pages/CompareV1.tsx
+++ b/frontend/src/pages/CompareV1.tsx
@@ -216,8 +216,6 @@ class CompareV1 extends Page<{}, CompareState> {
   }
 
   public async load(): Promise<void> {
-    this.clearBanner();
-
     const queryParamRunIds = new URLParser(this.props).get(QUERY_PARAMS.runlist);
     const runIds = (queryParamRunIds && queryParamRunIds.split(',')) || [];
     const runs: ApiRunDetail[] = [];

--- a/frontend/src/pages/CompareV1.tsx
+++ b/frontend/src/pages/CompareV1.tsx
@@ -216,6 +216,8 @@ class CompareV1 extends Page<{}, CompareState> {
   }
 
   public async load(): Promise<void> {
+    this.clearBanner();
+
     const queryParamRunIds = new URLParser(this.props).get(QUERY_PARAMS.runlist);
     const runIds = (queryParamRunIds && queryParamRunIds.split(',')) || [];
     const runs: ApiRunDetail[] = [];
@@ -242,6 +244,18 @@ class CompareV1 extends Page<{}, CompareState> {
         `Failed loading ${failingRuns.length} runs, last failed with the error: ${lastError}`,
       );
       return;
+    } else if (
+      runs.length > 0 &&
+      runs.every(runDetail => runDetail.run?.pipeline_spec?.hasOwnProperty('pipeline_manifest'))
+    ) {
+      this.props.updateBanner({
+        additionalInfo:
+          'The selected runs are all V2, but the V2_ALPHA feature flag is disabled.' +
+          ' The V1 page will not show any useful information for these runs.',
+        message:
+          'Info: enable the V2_ALPHA feature flag in order to view the updated Run Comparison page.',
+        mode: 'info',
+      });
     }
 
     const selectedIds = runs.map(r => r.run!.id!);


### PR DESCRIPTION
**Description of your changes:**

1. Show a page error when selected runs are a mix of v1 and v2 (and the v2 feature flag is enabled), as referenced in [this GitHub discussion](https://github.com/kubeflow/pipelines/pull/7793#discussion_r883989251)
2. Show a page error when there are fewer than two selected runs, or greater than ten selected runs
    - This is only achievable for the user by hard-coding the URL, but I decided to handle that edge case regardless to be thorough
3. Display an info banner on the v1 page when the v2 feature flag is disabled and all runs are v2, notifying the user that in order to view any useful information they must enable the v2 feature flag

**Screencast:**

https://user-images.githubusercontent.com/7987279/172077141-724d08b0-f676-4359-82e4-bcaf28c01f5d.mp4

_The screencast shows the different Compare page states depending on the run versions and count, including the following scenarios:_
1. All v2 runs
2. All v1 runs
3. A mix of v1 and v2 runs
4. Too few runs (`<= 2`)
5. Too many runs (`>= 10`)
6. All v2 runs and v2 feature flag disabled
7. All v1 runs and v2 feature flag disabled

**Notes:**

- I removed the `this.clearBanner()` call on the `CompareV1.tsx` `load()` function because it was overriding the info banner that I set within `Compare.tsx`. This should not present any issues as the `CompareV1.tsx` page is now only loaded through the `Compare.tsx` page, and the banner is cleared within `Compare.tsx` if there are no errors or info to set.
- The `props.updateBanner` function is called within the `onSuccess` option of the `useQuery` hook, as it does not cause a refresh loop if this occurs.
  - The `refetchOnMount` condition was added to the `useQuery` hook so that the banner will always be updated to its correct state whenever the page has been loaded; otherwise, the page banner will not refresh if the same run list has been queried in the current user session.
- I decided to always display the v1 page if the v2 feature flag is disabled (even if the runs are mixed or have an invalid count), because this is an accurate representation of what the user would be shown in KFPv1.
- Ideally, if there are an invalid number of runs (fewer than two or greater than ten), we would update the banner prior to the `useQuery` as that would prevent an unnecessary request. However, I'm not sure how to cleanly achieve that without causing a refresh loop due to the updating banner. Is this code acceptable or should we investigate a different solution for that?

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
