### PR TITLE
chore(sdk): fix component compilation test path

### DIFF
--- a/sdk/python/kfp/components/structures_test.py
+++ b/sdk/python/kfp/components/structures_test.py
@@ -778,8 +778,7 @@ V1_YAML = textwrap.dedent("""\
     """)
 
 COMPILER_CLI_TEST_DATA_DIR = os.path.join(
-    os.path.dirname(os.path.dirname(__file__)), 'compiler_cli_tests',
-    'test_data')
+    os.path.dirname(os.path.dirname(__file__)), 'compiler', 'test_data')
 
 SUPPORTED_COMPONENTS_COMPILE_TEST_CASES = [
     {


### PR DESCRIPTION
**Description of your changes:**
I missed a path that needed to be updated in my review of #7849. `unittest` fails to catch this, while `pytest` reliably catches this. I am unsure why this is. I will make changes to prevent similar failures in the future in a separate PR.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title 
convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
