### PR TITLE
chore(sdk): use pytest instead of unittest for test execution

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,9 +1,24 @@
 ## Contributing to the `kfp` SDK
 KFP v2 for SDK is under development on the `master` branch.
 
-To contribute to v1, please go to [sdk/release-1.8 branch](https://github.com/kubeflow/pipelines/tree/sdk/release-1.8) to submit your change. 
+To contribute to v1, please go to [sdk/release-1.8 branch](https://github.com/kubeflow/pipelines/tree/sdk/release-1.8) to submit your change.
 
 For general contribution guidelines including pull request conventions, see [pipelines/CONTRIBUTING.md](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md).
+
+### Requirements
+All development requirement versions are pinned in [requirements-dev.txt](https://github.com/kubeflow/pipelines/blob/master/sdk/python/requirements-dev.txt).
+
+### Testing
+We suggest running unit tests using [`pytest`](https://docs.pytest.org/en/7.1.x/). From the project root, the following runs all KFP SDK unit tests:
+```sh
+pytest sdk/python
+```
+
+To run tests in parallel for faster execution, you can run the tests using the `pytest-xdist` plugin:
+
+```sh
+pytest sdk/python -n auto
+```
 
 ### Code Style
 Dependencies for code style checks/changes can be found in the kfp SDK [requirements-dev.txt](https://github.com/kubeflow/pipelines/blob/master/sdk/python/requirements-dev.txt).

--- a/sdk/python/kfp/components/structures_test.py
+++ b/sdk/python/kfp/components/structures_test.py
@@ -778,8 +778,7 @@ V1_YAML = textwrap.dedent("""\
     """)
 
 COMPILER_CLI_TEST_DATA_DIR = os.path.join(
-    os.path.dirname(os.path.dirname(__file__)), 'compiler_cli_tests',
-    'test_data')
+    os.path.dirname(os.path.dirname(__file__)), 'compiler', 'test_data')
 
 SUPPORTED_COMPONENTS_COMPILE_TEST_CASES = [
     {

--- a/sdk/python/requirements-dev.txt
+++ b/sdk/python/requirements-dev.txt
@@ -1,7 +1,11 @@
 docformatter==1.4
+docker==5.0.3
 mypy==0.941
 pip-tools==6.0.0
 pylint==2.12.2
+pytest==7.1.2
+pytest-cov==3.0.0
+pytest-xdist==2.5.0
 types-protobuf==3.19.15
 types-PyYAML==6.0.5
 types-requests==2.27.14

--- a/sdk/python/requirements-test.txt
+++ b/sdk/python/requirements-test.txt
@@ -1,3 +1,0 @@
--r requirements.txt
-docker
-mock

--- a/test/presubmit-tests-sdk.sh
+++ b/test/presubmit-tests-sdk.sh
@@ -16,15 +16,12 @@
 source_root=$(pwd)
 
 python3 -m pip install --upgrade pip
-python3 -m pip install coverage==4.5.4 coveralls==1.9.2
-python3 -m pip install -r "$source_root/sdk/python/requirements-test.txt"
+python3 -m pip install coveralls==1.9.2
+python3 -m pip install $(grep 'docker==' sdk/python/requirements-dev.txt)
+python3 -m pip install $(grep 'pytest==' sdk/python/requirements-dev.txt)
+python3 -m pip install $(grep 'pytest-xdist==' sdk/python/requirements-dev.txt)
+python3 -m pip install $(grep 'pytest-cov==' sdk/python/requirements-dev.txt)
 python3 -m pip install --upgrade protobuf
-
-# Testing the component authoring library
-pushd "${source_root}/sdk/python"
-python3 -m pip install -e .
-python3 -m unittest discover --verbose --pattern '*test*.py' --top-level-directory .
-popd
 
 # Installing Argo CLI to lint all compiled workflows
 "${source_root}/test/install-argo-cli.sh"
@@ -32,7 +29,7 @@ popd
 pushd "$source_root/sdk/python"
 python3 -m pip install -e .
 popd # Changing the current directory to the repo root for correct coverall paths
-coverage run --source=kfp --append -m unittest discover --verbose --start-dir sdk/python --pattern '*test*.py'
+pytest sdk/python -n auto --cov=kfp
 
 set +x
 # export COVERALLS_REPO_TOKEN=$(gsutil cat gs://ml-pipeline-test-keys/coveralls_repo_token)


### PR DESCRIPTION
**Description of your changes:**
#7868 fixed a break in our unit tests that `unittest` did not pick up. To avoid this sort of break in the future and to leverage the benefits of `pytest` over `unittest`, this PR switches our KFP SDK unit tests to use `pytest` as the command line executable, as it is fully compatible with tests written using the `unittest` library.

Note the much more readable test output compared to previous `unittest` executions.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this 
repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
