### PR TITLE
fix(frontend): Fix Run Comparison refresh button

### DIFF
--- a/frontend/src/pages/CompareV1.tsx
+++ b/frontend/src/pages/CompareV1.tsx
@@ -69,6 +69,8 @@ const paramsSectionName = 'Parameters';
 const metricsSectionName = 'Metrics';
 
 class CompareV1 extends Page<{}, CompareState> {
+  private _runlistRef = React.createRef<RunList>();
+
   constructor(props: any) {
     super(props);
 
@@ -123,6 +125,7 @@ class CompareV1 extends Page<{}, CompareState> {
               onError={this.showPageError.bind(this)}
               {...this.props}
               selectedIds={selectedIds}
+              ref={this._runlistRef}
               runIdListMask={runIds}
               disablePaging={true}
               onSelectionChange={this._selectionChanged.bind(this)}
@@ -208,6 +211,9 @@ class CompareV1 extends Page<{}, CompareState> {
   }
 
   public async refresh(): Promise<void> {
+    if (this._runlistRef.current) {
+      await this._runlistRef.current.refresh();
+    }
     return this.load();
   }
 


### PR DESCRIPTION
**Description of your changes:**
- Fix #7855

**Screencast:**

https://user-images.githubusercontent.com/7987279/172735401-8a6c7dc2-2689-4df3-93f8-2e6be9b5ff3a.mp4

_The screencast shows how the Refresh button on the Run Comparison page now updates the run list table._

**Notes:**

- I modeled the changes off of the code in `AllRunsList.tsx`, as shown here: https://github.com/kubeflow/pipelines/blob/e7dbbcb3b43006fc60c335f814b87b776f4cee96/frontend/src/pages/AllRunsList.tsx#L79-L85 However, I left in the existing call to `this.load()` because that handles the banner refresh.
- I didn't add any new tests as the table is handled by a separate component - please let me know if I should add something to verify this fixed behavior.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
