### PR TITLE
feat(sdk): add retry policy support for IR compilation support in kfp==1.8

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -4,6 +4,7 @@
 ## Breaking Changes
 
 ### For Pipeline Authors
+* Add support for task-level retry policy when compiling pipeline to IR [\#7875](https://github.com/kubeflow/pipelines/pull/7875)
 
 ### For Component Authors
 

--- a/sdk/python/kfp/v2/compiler/compiler.py
+++ b/sdk/python/kfp/v2/compiler/compiler.py
@@ -1,4 +1,4 @@
-# Copyright 2020 The Kubeflow Authors
+# Copyright 2020-2022 The Kubeflow Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -739,6 +739,20 @@ class Compiler(object):
 
                 # Task level caching option.
                 subgroup.task_spec.caching_options.enable_cache = subgroup.enable_caching
+                if subgroup.num_retries or subgroup.backoff_duration or subgroup.backoff_factor or subgroup.backoff_max_duration:
+
+                    if subgroup.retry_policy is not None:
+                        warnings.warn(
+                            "'retry_policy' is ignored when compiling to IR using the v2 compiler.",
+                            compiler_utils.NoOpWarning)
+
+                    retry_policy_proto = compiler_utils.make_retry_policy_proto(
+                        max_retry_count=subgroup.num_retries,
+                        backoff_duration=subgroup.backoff_duration,
+                        backoff_factor=subgroup.backoff_factor,
+                        backoff_max_duration=subgroup.backoff_max_duration,
+                    )
+                    subgroup.task_spec.retry_policy.CopyFrom(retry_policy_proto)
 
             subgroup_inputs = inputs.get(subgroup.name, [])
             subgroup_params = [param for param, _ in subgroup_inputs]

--- a/sdk/python/kfp/v2/compiler/compiler_utils_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_utils_test.py
@@ -20,6 +20,7 @@ from kfp.v2.compiler import compiler_utils
 from kfp.pipeline_spec import pipeline_spec_pb2
 from google.protobuf import json_format
 from google.protobuf import message
+from absl.testing import parameterized
 
 
 class CompilerUtilsTest(unittest.TestCase):
@@ -96,6 +97,67 @@ class CompilerUtilsTest(unittest.TestCase):
             ])
         compiler_utils.refactor_v2_container_spec(test_v2_container_spec)
         self.assertProtoEquals(expected_container_spec, test_v2_container_spec)
+
+
+class TestNormalizeTimeString(parameterized.TestCase):
+
+    @parameterized.parameters([
+        ('1 hour', '1h'),
+        ('2 hours', '2h'),
+        ('2hours', '2h'),
+        ('2 w', '2w'),
+        ('2d', '2d'),
+    ])
+    def test(self, unnorm: str, norm: str):
+        self.assertEqual(compiler_utils.normalize_time_string(unnorm), norm)
+
+    def test_multipart_duration_raises(self):
+        with self.assertRaisesRegex(ValueError, 'Invalid duration string:'):
+            compiler_utils.convert_duration_to_seconds('1 day 1 hour')
+
+    def test_non_int_value_raises(self):
+        with self.assertRaisesRegex(ValueError, 'Invalid duration string:'):
+            compiler_utils.convert_duration_to_seconds('one hour')
+
+
+class TestConvertDurationToSeconds(parameterized.TestCase):
+
+    @parameterized.parameters([
+        ('1 hour', 3600),
+        ('2 hours', 7200),
+        ('2hours', 7200),
+        ('2 w', 1209600),
+        ('2d', 172800),
+    ])
+    def test(self, duration: str, seconds: int):
+        self.assertEqual(
+            compiler_utils.convert_duration_to_seconds(duration), seconds)
+
+    def test_unsupported_duration_unit(self):
+        with self.assertRaisesRegex(ValueError, 'Unsupported duration unit:'):
+            compiler_utils.convert_duration_to_seconds('1 year')
+
+
+class TestMakeRetryPolicyProto(unittest.TestCase):
+
+    def test_defaults(self):
+        retry_policy_proto = compiler_utils.make_retry_policy_proto()
+        self.assertEqual(retry_policy_proto.max_retry_count, 0)
+        self.assertEqual(retry_policy_proto.backoff_duration.seconds, 0)
+        self.assertEqual(retry_policy_proto.backoff_factor, 2.0)
+        self.assertEqual(retry_policy_proto.backoff_max_duration.seconds, 3600)
+
+    def test_with_args(self):
+        retry_policy_proto = compiler_utils.make_retry_policy_proto(
+            max_retry_count=10,
+            backoff_duration='1h',
+            backoff_factor=1.5,
+            backoff_max_duration='2 weeks')
+        self.assertEqual(retry_policy_proto.max_retry_count, 10)
+        self.assertEqual(retry_policy_proto.backoff_duration.seconds, 3600)
+        self.assertEqual(retry_policy_proto.backoff_factor, 1.5)
+        # tests cap
+        self.assertEqual(retry_policy_proto.backoff_max_duration.seconds, 3600)
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/v2/compiler/compiler_utils_test.py
+++ b/sdk/python/kfp/v2/compiler/compiler_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 The Kubeflow Authors
+# Copyright 2020-2022 The Kubeflow Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_retry.json
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_retry.json
@@ -1,0 +1,108 @@
+{
+  "pipelineSpec": {
+    "components": {
+      "comp-add": {
+        "executorLabel": "exec-add",
+        "inputDefinitions": {
+          "parameters": {
+            "a": {
+              "type": "DOUBLE"
+            },
+            "b": {
+              "type": "DOUBLE"
+            }
+          }
+        },
+        "outputDefinitions": {
+          "parameters": {
+            "Output": {
+              "type": "DOUBLE"
+            }
+          }
+        }
+      }
+    },
+    "deploymentSpec": {
+      "executors": {
+        "exec-add": {
+          "container": {
+            "args": [
+              "--executor_input",
+              "{{$}}",
+              "--function_to_execute",
+              "add"
+            ],
+            "command": [
+              "sh",
+              "-c",
+              "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet     --no-warn-script-location 'kfp==1.8.12' && \"$0\" \"$@\"\n",
+              "sh",
+              "-ec",
+              "program_path=$(mktemp -d)\nprintf \"%s\" \"$0\" > \"$program_path/ephemeral_component.py\"\npython3 -m kfp.v2.components.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n",
+              "\nimport kfp\nfrom kfp.v2 import dsl\nfrom kfp.v2.dsl import *\nfrom typing import *\n\ndef add(a: float, b: float) -> float:\n    return a + b\n\n"
+            ],
+            "image": "python:3.7"
+          }
+        }
+      }
+    },
+    "pipelineInfo": {
+      "name": "test-pipeline"
+    },
+    "root": {
+      "dag": {
+        "tasks": {
+          "add": {
+            "cachingOptions": {
+              "enableCache": true
+            },
+            "componentRef": {
+              "name": "comp-add"
+            },
+            "inputs": {
+              "parameters": {
+                "a": {
+                  "componentInputParameter": "a"
+                },
+                "b": {
+                  "componentInputParameter": "b"
+                }
+              }
+            },
+            "retryPolicy": {
+              "backoffDuration": "0s",
+              "backoffFactor": 2.0,
+              "backoffMaxDuration": "3600s",
+              "maxRetryCount": 3.0
+            },
+            "taskInfo": {
+              "name": "add"
+            }
+          }
+        }
+      },
+      "inputDefinitions": {
+        "parameters": {
+          "a": {
+            "type": "DOUBLE"
+          },
+          "b": {
+            "type": "DOUBLE"
+          }
+        }
+      }
+    },
+    "schemaVersion": "2.0.0",
+    "sdkVersion": "kfp-1.8.12"
+  },
+  "runtimeConfig": {
+    "parameters": {
+      "a": {
+        "doubleValue": 1.0
+      },
+      "b": {
+        "doubleValue": 7.0
+      }
+    }
+  }
+}

--- a/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_retry.py
+++ b/sdk/python/kfp/v2/compiler_cli_tests/test_data/pipeline_with_retry.py
@@ -1,0 +1,33 @@
+# Copyright 2022 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kfp.v2 import dsl
+from kfp.v2 import compiler
+
+
+@dsl.component
+def add(a: float, b: float) -> float:
+    return a + b
+
+
+@dsl.pipeline(name='test-pipeline')
+def my_pipeline(a: float = 1, b: float = 7):
+    add_task = add(a, b)
+    add_task.set_retry(num_retries=3)
+
+
+if __name__ == '__main__':
+    compiler.Compiler().compile(
+        pipeline_func=my_pipeline,
+        package_path=__file__.replace('.py', '.json'))

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -32,7 +32,7 @@ typer>=0.3.2,<1.0
 
 # kfp.v2
 absl-py>=0.9,<=0.11
-kfp-pipeline-spec>=0.1.14,<0.2.0
+kfp-pipeline-spec>=0.1.16,<0.2.0
 fire>=0.3.1,<1
 google-api-python-client>=1.7.8,<2
 pydantic>=1.8.2,<2


### PR DESCRIPTION
**Description of your changes:**
Adds support for retry policy message when compiling pipelines to IR in the v1 version of the KFP SDK.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title 
convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
