### PR TITLE
feat(sdk): add support for custom pre-registered third party artifact types in lightweight components

### DIFF
--- a/samples/test/config.yaml
+++ b/samples/test/config.yaml
@@ -122,6 +122,8 @@
   path: samples.v2.producer_consumer_param_test
 - name: pipeline_with_importer
   path: samples.v2.pipeline_with_importer_test
+- name: pipeline_with_gcpc_types
+  path: samples.v2.pipeline_with_gcpc_types
 # TODO(capri-xiyue): Re-enable after figuring out V2 Engine
 # and protobuf.Value support.
 # - name: cache_v2

--- a/samples/v2/pipeline_with_gcpc_types.py
+++ b/samples/v2/pipeline_with_gcpc_types.py
@@ -1,0 +1,75 @@
+# Copyright 2021-2022 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# import os
+import subprocess
+from typing import NamedTuple
+
+# TODO: remove this subprocess when GCPC depends on KFP v2
+GCPC_PACKAGE_PATH = 'git+https://github.com/kubeflow/pipelines@temp-gcpc-kfpv2-compatibility-branch#subdirectory=components/google-cloud'
+PACKAGES_TO_INSTALL = [GCPC_PACKAGE_PATH]
+try:
+    print(
+        subprocess.check_output(
+            f'pip install --upgrade pip && pip install {GCPC_PACKAGE_PATH}',
+            shell=True))
+except subprocess.CalledProcessError as e:
+    print(e.stderr)
+    raise
+#######
+
+from google_cloud_pipeline_components.types import artifact_types
+from google_cloud_pipeline_components.types.artifact_types import VertexModel
+from kfp import compiler
+from kfp import dsl
+from kfp.dsl import Input
+from kfp.dsl import Output
+
+print('next')
+
+
+@dsl.component(packages_to_install=PACKAGES_TO_INSTALL)
+def model_producer(model: Output[artifact_types.VertexModel]):
+    with open(model.path, 'w') as f:
+        f.write('my model')
+
+
+@dsl.component(packages_to_install=PACKAGES_TO_INSTALL)
+def model_consumer(model: Input[VertexModel]):
+    print('artifact.type: ', type(model))
+    print('artifact.name: ', model.name)
+    print('artifact.uri: ', model.uri)
+    print('artifact.metadata: ', model.metadata)
+
+
+@dsl.component(packages_to_install=PACKAGES_TO_INSTALL)
+def model_consumer_with_named_tuple(
+    model: Input[VertexModel]
+) -> NamedTuple('NamedTupleOutput', [('model1', artifact_types.VertexModel),
+                                     ('model2', artifact_types.VertexModel)]):
+    NamedTupleOutput = NamedTuple('NamedTupleOutput',
+                                  [('model1', artifact_types.VertexModel),
+                                   ('model2', artifact_types.VertexModel)])
+    return NamedTupleOutput(model1=model, model2=model)
+
+
+@dsl.pipeline(name='pipeline-with-gcpc-types')
+def my_pipeline():
+    producer_task = model_producer()
+    model_consumer(model=producer_task.outputs['model'])
+    model_consumer_with_named_tuple(model=producer_task.outputs['model'])
+
+
+if __name__ == '__main__':
+    ir_file = __file__.replace('.py', '.yaml')
+    compiler.Compiler().compile(pipeline_func=my_pipeline, package_path=ir_file)

--- a/sdk/python/kfp/compiler/_read_write_test_config.py
+++ b/sdk/python/kfp/compiler/_read_write_test_config.py
@@ -42,6 +42,7 @@ CONFIG = {
             'pipeline_with_task_final_status',
             'pipeline_with_task_final_status_yaml',
             'component_with_pip_index_urls',
+            'pipeline_with_gcpc_types',
         ],
         'test_data_dir': 'sdk/python/kfp/compiler/test_data/pipelines',
         'config': {

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_gcpc_types.py
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_gcpc_types.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The Kubeflow Authors
+# Copyright 2021-2022 The Kubeflow Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,43 +11,52 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# import os
+from typing import NamedTuple
 
+from google_cloud_pipeline_components.types import artifact_types
+from google_cloud_pipeline_components.types.artifact_types import VertexModel
 from kfp import compiler
-from kfp import components
 from kfp import dsl
-from kfp.dsl import component
 from kfp.dsl import Input
+from kfp.dsl import Output
+
+GCPC_PACKAGE_PATH = 'git+https://github.com/kubeflow/pipelines@temp-gcpc-kfpv2-compatibility-branch#subdirectory=components/google-cloud'
+PACKAGES_TO_INSTALL = [GCPC_PACKAGE_PATH]
 
 
-class VertexModel(dsl.Artifact):
-    TYPE_NAME = 'google.VertexModel'
+@dsl.component(packages_to_install=PACKAGES_TO_INSTALL)
+def model_producer(model: Output[artifact_types.VertexModel]):
+    with open(model.path, 'w') as f:
+        f.write('my model')
 
 
-producer_op = components.load_component_from_text("""
-name: producer
-outputs:
-  - {name: model, type: google.VertexModel}
-implementation:
-  container:
-    image: dummy
-    command:
-    - cmd
-    args:
-    - {outputPath: model}
-""")
+@dsl.component(packages_to_install=PACKAGES_TO_INSTALL)
+def model_consumer(model: Input[VertexModel]):
+    print('artifact.type: ', type(model))
+    print('artifact.name: ', model.name)
+    print('artifact.uri: ', model.uri)
+    print('artifact.metadata: ', model.metadata)
 
 
-@component
-def consumer_op(model: Input[VertexModel]):
-    pass
+@dsl.component(packages_to_install=PACKAGES_TO_INSTALL)
+def model_consumer_with_named_tuple(
+    model: Input[VertexModel]
+) -> NamedTuple('NamedTupleOutput', [('model1', artifact_types.VertexModel),
+                                     ('model2', artifact_types.VertexModel)]):
+    NamedTupleOutput = NamedTuple('NamedTupleOutput',
+                                  [('model1', artifact_types.VertexModel),
+                                   ('model2', artifact_types.VertexModel)])
+    return NamedTupleOutput(model1=model, model2=model)
 
 
 @dsl.pipeline(name='pipeline-with-gcpc-types')
 def my_pipeline():
-    consumer_op(model=producer_op().outputs['model'])
+    producer_task = model_producer()
+    model_consumer(model=producer_task.outputs['model'])
+    model_consumer_with_named_tuple(model=producer_task.outputs['model'])
 
 
 if __name__ == '__main__':
-    compiler.Compiler().compile(
-        pipeline_func=my_pipeline,
-        package_path=__file__.replace('.py', '.yaml'))
+    ir_file = __file__.replace('.py', '.yaml')
+    compiler.Compiler().compile(pipeline_func=my_pipeline, package_path=ir_file)

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_gcpc_types.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_gcpc_types.yaml
@@ -1,14 +1,32 @@
 components:
-  comp-consumer-op:
-    executorLabel: exec-consumer-op
+  comp-model-consumer:
+    executorLabel: exec-model-consumer
     inputDefinitions:
       artifacts:
         model:
           artifactType:
             schemaTitle: google.VertexModel
             schemaVersion: 0.0.1
-  comp-producer:
-    executorLabel: exec-producer
+  comp-model-consumer-with-named-tuple:
+    executorLabel: exec-model-consumer-with-named-tuple
+    inputDefinitions:
+      artifacts:
+        model:
+          artifactType:
+            schemaTitle: google.VertexModel
+            schemaVersion: 0.0.1
+    outputDefinitions:
+      artifacts:
+        model1:
+          artifactType:
+            schemaTitle: google.VertexModel
+            schemaVersion: 0.0.1
+        model2:
+          artifactType:
+            schemaTitle: google.VertexModel
+            schemaVersion: 0.0.1
+  comp-model-producer:
+    executorLabel: exec-model-producer
     outputDefinitions:
       artifacts:
         model:
@@ -17,20 +35,20 @@ components:
             schemaVersion: 0.0.1
 deploymentSpec:
   executors:
-    exec-consumer-op:
+    exec-model-consumer:
       container:
         args:
         - --executor_input
         - '{{$}}'
         - --function_to_execute
-        - consumer_op
+        - model_consumer
         command:
         - sh
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location 'git+https://github.com/kubeflow/pipelines@temp-gcpc-kfpv2-compatibility-branch#subdirectory=components/google-cloud'\
+          \ 'kfp==2.0.0-beta.1' 'kfp==2.0.0-beta.1' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -41,41 +59,115 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef consumer_op(model: Input[VertexModel]):\n    pass\n\n"
+          \ *\nfrom google_cloud_pipeline_components.types.artifact_types import VertexModel\n\
+          \ndef model_consumer(model: Input[VertexModel]):\n    print('artifact.type:\
+          \ ', type(model))\n    print('artifact.name: ', model.name)\n    print('artifact.uri:\
+          \ ', model.uri)\n    print('artifact.metadata: ', model.metadata)\n\n"
         image: python:3.7
-    exec-producer:
+    exec-model-consumer-with-named-tuple:
       container:
         args:
-        - '{{$.outputs.artifacts[''model''].path}}'
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - model_consumer_with_named_tuple
         command:
-        - cmd
-        image: dummy
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'git+https://github.com/kubeflow/pipelines@temp-gcpc-kfpv2-compatibility-branch#subdirectory=components/google-cloud'\
+          \ 'kfp==2.0.0-beta.1' 'kfp==2.0.0-beta.1' 'kfp==2.0.0-beta.1' && \"$0\"\
+          \ \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\nfrom google_cloud_pipeline_components.types.artifact_types import VertexModel\n\
+          from google_cloud_pipeline_components.types import artifact_types\n\ndef\
+          \ model_consumer_with_named_tuple(\n    model: Input[VertexModel]\n) ->\
+          \ NamedTuple('NamedTupleOutput', [('model1', artifact_types.VertexModel),\n\
+          \                                     ('model2', artifact_types.VertexModel)]):\n\
+          \    NamedTupleOutput = NamedTuple('NamedTupleOutput',\n               \
+          \                   [('model1', artifact_types.VertexModel),\n         \
+          \                          ('model2', artifact_types.VertexModel)])\n  \
+          \  return NamedTupleOutput(model1=model, model2=model)\n\n"
+        image: python:3.7
+    exec-model-producer:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - model_producer
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'git+https://github.com/kubeflow/pipelines@temp-gcpc-kfpv2-compatibility-branch#subdirectory=components/google-cloud'\
+          \ 'kfp==2.0.0-beta.1' && \"$0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\nfrom google_cloud_pipeline_components.types import artifact_types\n\
+          \ndef model_producer(model: Output[artifact_types.VertexModel]):\n    with\
+          \ open(model.path, 'w') as f:\n        f.write('my model')\n\n"
+        image: python:3.7
 pipelineInfo:
   name: pipeline-with-gcpc-types
 root:
   dag:
     tasks:
-      consumer-op:
+      model-consumer:
         cachingOptions:
           enableCache: true
         componentRef:
-          name: comp-consumer-op
+          name: comp-model-consumer
         dependentTasks:
-        - producer
+        - model-producer
         inputs:
           artifacts:
             model:
               taskOutputArtifact:
                 outputArtifactKey: model
-                producerTask: producer
+                producerTask: model-producer
         taskInfo:
-          name: consumer-op
-      producer:
+          name: model-consumer
+      model-consumer-with-named-tuple:
         cachingOptions:
           enableCache: true
         componentRef:
-          name: comp-producer
+          name: comp-model-consumer-with-named-tuple
+        dependentTasks:
+        - model-producer
+        inputs:
+          artifacts:
+            model:
+              taskOutputArtifact:
+                outputArtifactKey: model
+                producerTask: model-producer
         taskInfo:
-          name: producer
+          name: model-consumer-with-named-tuple
+      model-producer:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-model-producer
+        taskInfo:
+          name: model-producer
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.1

--- a/sdk/python/kfp/components/component_factory.py
+++ b/sdk/python/kfp/components/component_factory.py
@@ -11,13 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import ast
 import dataclasses
 import inspect
 import itertools
 import pathlib
 import re
+import sys
 import textwrap
-from typing import Callable, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 import warnings
 
 import docstring_parser
@@ -29,6 +31,7 @@ from kfp.components.types import type_annotations
 from kfp.components.types import type_utils
 
 _DEFAULT_BASE_IMAGE = 'python:3.7'
+PYTHON_VERSION = str(sys.version_info.major) + '.' + str(sys.version_info.minor)
 
 
 @dataclasses.dataclass
@@ -248,13 +251,9 @@ def extract_component_interface(func: Callable) -> structures.ComponentSpec:
 
     #Analyzing the return type annotations.
     return_ann = signature.return_annotation
-    if hasattr(return_ann, '_fields'):  #NamedTuple
+    if is_typed_named_tuple_annotation(return_ann):
         # Getting field type annotations.
-        # __annotations__ does not exist in python 3.5 and earlier
-        # _field_types does not exist in python 3.9 and later
-        field_annotations = getattr(return_ann,
-                                    '__annotations__', None) or getattr(
-                                        return_ann, '_field_types', None)
+        field_annotations = getattr(return_ann, '__annotations__', {})
         for field_name in return_ann._fields:
             type_struct = None
             if field_annotations:
@@ -311,6 +310,260 @@ def extract_component_interface(func: Callable) -> structures.ComponentSpec:
     return component_spec
 
 
+def convert_arg_nodes_to_param_dict(args: List[ast.arg]) -> Dict[str, str]:
+    arg_to_ann = {}
+    for arg in args:
+        annotation = arg.annotation
+
+        if annotation is None:
+            arg_to_ann[arg.arg] = None
+        # Handle InputPath() and OutputPath()
+        elif isinstance(annotation, ast.Call):
+            if isinstance(annotation.func, ast.Name):
+                arg_to_ann[arg.arg] = annotation.func.id
+            elif isinstance(annotation.func, ast.Attribute):
+                arg_to_ann[arg.arg] = annotation.func.value.id
+            else:
+                raise TypeError(
+                    f'Unexpected type annotation for {annotation.func}.')
+        # annotations with variable name
+        elif isinstance(annotation, ast.Name):
+            arg_to_ann[arg.arg] = annotation.id
+        # annotations with a subtype like Input[Artifact]
+        elif isinstance(annotation, ast.Subscript):
+            # get inner type
+            if PYTHON_VERSION < '3.9':
+                # see "Changed in version 3.9" https://docs.python.org/3/library/ast.html#node-classes
+                if isinstance(annotation.slice.value, ast.Name):
+                    arg_to_ann[arg.arg] = annotation.slice.value.id
+                if isinstance(annotation.slice.value, ast.Attribute):
+                    arg_to_ann[arg.arg] = annotation.slice.value.value.id
+            else:
+                if isinstance(annotation.slice, ast.Name):
+                    arg_to_ann[arg.arg] = annotation.slice.id
+                if isinstance(annotation.slice, ast.Attribute):
+                    arg_to_ann[arg.arg] = annotation.slice.value.id
+
+        # annotations like type_annotations.Input[Artifact]
+        elif isinstance(annotation, ast.Attribute):
+            arg_to_ann[arg.arg] = annotation.value.id
+        else:
+            raise TypeError(
+                f'Unexpected type annotation for {arg.arg}: {annotation}.')
+    return arg_to_ann
+
+
+def convert_return_ann_to_dict(return_ann: ast.Return) -> Dict[str, str]:
+    return_dict = {}
+    if return_ann is None:
+        return_dict['return'] = None
+
+    # handles primtiive return types and -> Artifact
+    elif isinstance(return_ann, ast.Name):
+        return_dict['return'] = return_ann.id
+
+    # handles return type annotations like module.Artifact
+    elif isinstance(return_ann, ast.Attribute):
+        return_dict['return'] = return_ann.value.id
+
+    # handles return type annotations like List[Dict[str, str]] (gets 'List' and has no effect on import extraction)
+    elif isinstance(return_ann, ast.Subscript):
+        return_dict['return'] = return_ann.value.id
+
+    # handles any sort of call in the return type
+    elif isinstance(return_ann, ast.Call):
+        func = return_ann.func
+
+        # handles -> typing.NamedTuple
+        if isinstance(
+                func, ast.Attribute
+        ) and func.value.id == 'typing' and func.attr == 'NamedTuple':
+            nt_field_list = return_ann.args[1].elts
+            for el in nt_field_list:
+                return_dict[
+                    f'return-{el.elts[0].s}'] = el.elts[1].id if isinstance(
+                        el.elts[1], ast.Name) else el.elts[1].value.id
+
+        # handles -> NamedTuple
+        elif isinstance(func, ast.Name) and func.id == 'NamedTuple':
+            nt_field_list = return_ann.args[1].elts
+            for el in nt_field_list:
+                return_dict[
+                    f'return-{el.elts[0].s}'] = el.elts[1].id if isinstance(
+                        el.elts[1], ast.Name) else el.elts[1].value.id
+
+        elif isinstance(func, ast.Name):
+            return_dict['return'] = func.id
+        elif isinstance(func, ast.Attribute):
+            return_dict['return'] = func.value.id
+        else:
+            raise TypeError(
+                f"Unexpected type annotation '{return_ann}' for {func}.")
+
+    else:
+        raise TypeError(f"Unexpected type annotation '{return_ann}'")
+    return return_dict
+
+
+def get_param_to_ann_string(function: Callable) -> Dict[str, str]:
+    """Gets a dictionary of parameter name to type annotation string from a
+    function. Note: Input[] and Output[] (typing.Annotated) are stripped from
+    Artifact types.
+
+    Args:
+        func (Callable): The function.
+
+    Returns:
+        Dict[str, str]: Dictionary of parameter name to type annotation string.
+    """
+    module_node = ast.parse(_get_function_source_definition(function))
+    args = module_node.body[0].args.args
+    return_ann = module_node.body[0].returns
+    param_dict = convert_arg_nodes_to_param_dict(args)
+    return_dict = convert_return_ann_to_dict(return_ann)
+    return {**param_dict, **return_dict}
+
+
+def is_typed_named_tuple_annotation(annotation: Any) -> bool:
+    """Checks if the type is a namedtuple (either typing.NamedTuple or
+    collections.namedtuple).
+
+    Args:
+        annotation (Any): The type object.
+
+    Returns:
+        bool: Whether the type is a namedtuple type.
+    """
+    # it's possible to get false positives from this, but unlikely to be a problem for the KFP use-case unless someone creates a custom artifact class with the attribute ._fields
+    if hasattr(annotation, '_fields'):
+        is_typing_named_tuple = hasattr(annotation, '__annotations__')
+        if not is_typing_named_tuple:
+            raise TypeError(
+                'Named tuple return types annotations must be typed with field annotations using typing.NamedTuple, rather than collections.namedtuple.'
+            )
+        return True
+    return False
+
+
+def get_param_to_ann_obj(func: Callable) -> Dict[str, Any]:
+    """Gets a dictionary of parameter name to type annotation object from a
+    function.
+
+    Args:
+        func (Callable): The function.
+
+    Returns:
+        Dict[str, Any]: Dictionary of parameter name to type annotation object.
+    """
+    signature = inspect.signature(func)
+    param_to_ann_obj = {
+        name: parameter.annotation
+        for name, parameter in signature.parameters.items()
+    }
+    return_annotation = signature.return_annotation
+
+    if is_typed_named_tuple_annotation(return_annotation):
+        for name, annotation in return_annotation.__annotations__.items():
+            param_to_ann_obj[f'return-{name}'] = annotation
+    elif return_annotation is inspect.Signature.empty:
+        param_to_ann_obj['return'] = None
+    else:
+        param_to_ann_obj['return'] = return_annotation
+
+    return param_to_ann_obj
+
+
+def get_full_qualname_for_artifact(obj: type) -> str:
+    """Gets the fully qualified name for an annotation. For example, for class
+    Foo in module bar.baz, this function returns bar.baz.Foo.
+
+    Note: typing.get_type_hints purports to do the same thing, but it behaves differently when executed within the scope of a test, so preferring this approach instead.
+
+    Args:
+        obj (type): The class or module for which to get the fully qualified name.
+
+    Returns:
+        str: The fully qualified name for the class.
+    """
+    module = obj.__module__
+    name = obj.__qualname__
+    if module is not None and module != '__builtin__':
+        name = module + '.' + name
+    return name
+
+
+def get_import_item_from_annotation_string_and_ann_obj(artifact_str: str,
+                                                       qualname: str) -> str:
+    """Gets the fully qualified names of the module or type to import from the
+    annotation string and the annotation object.
+
+    Args:
+        artifact_str (str): The type annotation string.
+        qualname (str): The fully qualified type annotation name as a string.
+
+    Returns:
+        str: The fully qualified names of the module or type to import.
+    """
+    split_qualname = qualname.split('.')
+    if artifact_str in split_qualname:
+        name_to_import = '.'.join(
+            split_qualname[:split_qualname.index(artifact_str) + 1])
+    else:
+        raise TypeError(
+            f"Module or type name aliases are not supported. You appear to be using an alias in your type annotation: '{qualname}'. This may be due to use of an 'as' statement in an import statement or a reassignment of a module or type to a new name. Reference the module and/or type using the name as defined in the source from which the module or type is imported."
+        )
+    return name_to_import
+
+
+def get_artifact_import_items_from_function(func: Callable) -> List[str]:
+    """Gets a list of fully qualified names of the modules or types to import.
+
+    Args:
+        func (Callable): The component function.
+
+    Returns:
+        List[str]: A list containing the fully qualified names of the module or type to import.
+    """
+
+    param_to_ann_string = get_param_to_ann_string(func)
+    param_to_ann_obj = get_param_to_ann_obj(func)
+
+    named_tuple_did_not_expand = 'return' in param_to_ann_string and 'return' not in param_to_ann_obj
+    if named_tuple_did_not_expand:
+        raise TypeError(
+            "Error handling NamedTuple return type. The NamedTuple return type was assigned to a variable and referenced in the function signature. NamedTuple return types must be declared directly in the function signature like `-> NamedTuple('name', [('field', int)]):`."
+        )
+
+    import_items = []
+    seen = set()
+    for param_name, ann_string in param_to_ann_string.items():
+        # don't process the same annotation string multiple times... us the string, not the object in the seen set, since the same object can be referenced different ways in the same function signature
+        if ann_string in seen:
+            continue
+        else:
+            seen.add(ann_string)
+
+        actual_ann = param_to_ann_obj.get(param_name)
+        if actual_ann is None:
+            continue
+        if type_annotations.is_artifact_annotation(actual_ann):
+            artifact_class = type_annotations.get_io_artifact_class(actual_ann)
+        elif inspect.isclass(actual_ann) and issubclass(
+                actual_ann, artifact_types.Artifact):
+            artifact_class = actual_ann
+        else:
+            continue
+
+        artifact_qualname = get_full_qualname_for_artifact(artifact_class)
+        if artifact_qualname.startswith('kfp.'):
+            # kfp artifacts are already imported by default
+            continue
+        import_items.append(
+            get_import_item_from_annotation_string_and_ann_obj(
+                ann_string, artifact_qualname))
+    return import_items
+
+
 def _get_command_and_args_for_lightweight_component(
         func: Callable) -> Tuple[List[str], List[str]]:
     imports_source = [
@@ -319,6 +572,10 @@ def _get_command_and_args_for_lightweight_component(
         'from kfp.dsl import *',
         'from typing import *',
     ]
+    artifact_imports = get_artifact_import_items_from_function(func)
+    for obj_str in artifact_imports:
+        path, name = obj_str.rsplit('.', 1)
+        imports_source.append(f'from {path} import {name}')
 
     func_source = _get_function_source_definition(func)
     source = textwrap.dedent('''

--- a/sdk/python/kfp/components/component_factory_test.py
+++ b/sdk/python/kfp/components/component_factory_test.py
@@ -12,9 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
+import inspect
+import os
+import sys
+import tempfile
+import textwrap
+import typing
+from typing import Any
 import unittest
 
+from absl.testing import parameterized
+from kfp import dsl
 from kfp.components import component_factory
+from kfp.components.types import artifact_types
+from kfp.components.types import type_annotations
+from kfp.components.types.artifact_types import Artifact
+from kfp.components.types.artifact_types import Dataset
+from kfp.components.types.type_annotations import Input
+from kfp.components.types.type_annotations import InputPath
+from kfp.components.types.type_annotations import Output
+from kfp.components.types.type_annotations import OutputPath
+import typing_extensions
 
 
 class TestGetPackagesToInstallCommand(unittest.TestCase):
@@ -44,3 +63,373 @@ class TestGetPackagesToInstallCommand(unittest.TestCase):
         concat_command = ' '.join(command)
         for package in packages_to_install + pip_index_urls:
             self.assertTrue(package in concat_command)
+
+
+Alias = Artifact
+artifact_types_alias = artifact_types
+
+
+class TestGetParamToAnnString(unittest.TestCase):
+
+    def test_no_annotations(self):
+
+        def func(a, b):
+            pass
+
+        actual = component_factory.get_param_to_ann_string(func)
+        expected = {'a': None, 'b': None, 'return': None}
+        self.assertEqual(actual, expected)
+
+    def test_no_return(self):
+
+        def func(a: int, b: Input[Artifact]):
+            pass
+
+        actual = component_factory.get_param_to_ann_string(func)
+        expected = {'a': 'int', 'b': 'Artifact', 'return': None}
+        self.assertEqual(actual, expected)
+
+    def test_with_return(self):
+
+        def func(a: int, b: Input[Artifact]) -> int:
+            return 1
+
+        actual = component_factory.get_param_to_ann_string(func)
+        expected = {'a': 'int', 'b': 'Artifact', 'return': 'int'}
+        self.assertEqual(actual, expected)
+
+    def test_multiline(self):
+
+        def func(
+            a: int,
+            b: Input[Artifact],
+        ) -> int:
+            return 1
+
+        actual = component_factory.get_param_to_ann_string(func)
+        expected = {'a': 'int', 'b': 'Artifact', 'return': 'int'}
+        self.assertEqual(actual, expected)
+
+    def test_alias(self):
+
+        def func(a: int, b: Input[Alias]):
+            pass
+
+        actual = component_factory.get_param_to_ann_string(func)
+        expected = {'a': 'int', 'b': 'Alias', 'return': None}
+        self.assertEqual(actual, expected)
+
+    def test_long_form_annotation(self):
+
+        def func(a: int, b: Input[artifact_types.Artifact]):
+            pass
+
+        actual = component_factory.get_param_to_ann_string(func)
+        expected = {'a': 'int', 'b': 'artifact_types', 'return': None}
+        self.assertEqual(actual, expected)
+
+    def test_named_tuple(self):
+
+        def func(
+            a: int,
+            b: Input[Artifact],
+        ) -> typing.NamedTuple('MyNamedTuple', [('a', int), (
+                'b', Artifact), ('c', artifact_types.Artifact)]):
+            InnerNamedTuple = typing.NamedTuple(
+                'MyNamedTuple', [('a', int), ('b', Artifact),
+                                 ('c', artifact_types.Artifact)])
+            return InnerNamedTuple(a=a, b=b, c=b)  # type: ignore
+
+        actual = component_factory.get_param_to_ann_string(func)
+        expected = {
+            'a': 'int',
+            'b': 'Artifact',
+            'return-a': 'int',
+            'return-b': 'Artifact',
+            'return-c': 'artifact_types'
+        }
+        self.assertEqual(actual, expected)
+
+    def test_input_output_path(self):
+
+        def func(
+                a: int,
+                b: InputPath('Dataset'),
+        ) -> OutputPath('Dataset'):
+            return 'dataset'
+
+        actual = component_factory.get_param_to_ann_string(func)
+        expected = {
+            'a': 'int',
+            'b': 'InputPath',
+            'return': 'OutputPath',
+        }
+        self.assertEqual(actual, expected)
+
+
+class MyCustomArtifact:
+    TYPE_NAME = 'my_custom_artifact'
+
+
+class _TestCaseWithThirdPartyPackage(parameterized.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+
+        class ThirdPartyArtifact(artifact_types.Artifact):
+            TYPE_NAME = 'custom.my_third_party_artifact'
+
+        class_source = 'from kfp.components.types import artifact_types\n\n' + textwrap.dedent(
+            inspect.getsource(ThirdPartyArtifact))
+
+        tmp_dir = tempfile.TemporaryDirectory()
+        with open(os.path.join(tmp_dir.name, 'my_package.py'), 'w') as f:
+            f.write(class_source)
+        sys.path.append(tmp_dir.name)
+        cls.tmp_dir = tmp_dir
+
+    @classmethod
+    def teardownClass(cls):
+        sys.path.pop()
+        cls.tmp_dir.cleanup()
+
+
+class TestGetParamToAnnObj(unittest.TestCase):
+
+    def test_no_named_tuple(self):
+
+        def func(
+            a: int,
+            b: Input[Artifact],
+        ) -> int:
+            return 1
+
+        actual = component_factory.get_param_to_ann_obj(func)
+        expected = {
+            'a':
+                int,
+            'b':
+                typing_extensions.Annotated[Artifact,
+                                            type_annotations.InputAnnotation],
+            'return':
+                int
+        }
+        self.assertEqual(actual, expected)
+
+    def test_named_tuple(self):
+
+        MyNamedTuple = typing.NamedTuple('MyNamedTuple', [('a', int),
+                                                          ('b', Artifact)])
+
+        def func(
+            a: int,
+            b: Input[Artifact],
+        ) -> MyNamedTuple:
+            InnerNamedTuple = typing.NamedTuple('MyNamedTuple',
+                                                [('a', int), ('b', Artifact)])
+            return InnerNamedTuple(a=a, b=b)  # type: ignore
+
+        actual = component_factory.get_param_to_ann_obj(func)
+        expected = {
+            'a':
+                int,
+            'b':
+                typing_extensions.Annotated[Artifact,
+                                            type_annotations.InputAnnotation],
+            'return-a':
+                int,
+            'return-b':
+                Artifact
+        }
+        self.assertEqual(actual, expected)
+
+    def test_input_output_path(self):
+
+        def func(
+                a: int,
+                b: InputPath('Dataset'),
+        ) -> OutputPath('Dataset'):
+            return 'dataset'
+
+        actual = component_factory.get_param_to_ann_obj(func)
+        self.assertEqual(actual['a'], int)
+        self.assertIsInstance(actual['b'], InputPath)
+        self.assertIsInstance(actual['return'], OutputPath)
+
+
+class TestIsNamedTupleTypeAnnotation(unittest.TestCase):
+
+    def test_true_typing(self):
+        self.assertTrue(
+            component_factory.is_typed_named_tuple_annotation(
+                typing.NamedTuple('MyNamedTuple', [('a', int),
+                                                   ('b', Artifact)])))
+
+    def test_raises_for_collections(self):
+        with self.assertRaisesRegex(
+                TypeError,
+                r'must be typed with field annotations using typing\.NamedTuple'
+        ):
+            component_factory.is_typed_named_tuple_annotation(
+                collections.namedtuple('namedtuple', ['a', 'b']))
+
+    def test_false_for_primitive(self):
+        self.assertFalse(component_factory.is_typed_named_tuple_annotation(int))
+
+    def test_false_for_class(self):
+
+        class MyClass:
+            pass
+
+        self.assertFalse(
+            component_factory.is_typed_named_tuple_annotation(MyClass))
+
+
+class TestGetFullQualnameForClass(_TestCaseWithThirdPartyPackage):
+
+    @parameterized.parameters([
+        (Alias, 'kfp.components.types.artifact_types.Artifact'),
+        (Artifact, 'kfp.components.types.artifact_types.Artifact'),
+        (Dataset, 'kfp.components.types.artifact_types.Dataset'),
+    ])
+    def test(self, obj: Any, expected_qualname: str):
+        self.assertEqual(
+            component_factory.get_full_qualname_for_artifact(obj),
+            expected_qualname)
+
+    def test_my_package_artifact(self):
+        import my_package
+        self.assertEqual(
+            component_factory.get_full_qualname_for_artifact(
+                my_package.ThirdPartyArtifact), 'my_package.ThirdPartyArtifact')
+
+
+class GetArtifactImportItemsFromFunction(_TestCaseWithThirdPartyPackage):
+
+    def test_no_annotations(self):
+
+        def func(a, b):
+            pass
+
+        actual = component_factory.get_artifact_import_items_from_function(func)
+        expected = []
+        self.assertEqual(actual, expected)
+
+    def test_no_return(self):
+        from my_package import ThirdPartyArtifact
+
+        def func(a: int, b: Input[ThirdPartyArtifact]):
+            pass
+
+        actual = component_factory.get_artifact_import_items_from_function(func)
+        expected = ['my_package.ThirdPartyArtifact']
+        self.assertEqual(actual, expected)
+
+    def test_with_return(self):
+        from my_package import ThirdPartyArtifact
+
+        def func(a: int, b: Input[ThirdPartyArtifact]) -> int:
+            return 1
+
+        actual = component_factory.get_artifact_import_items_from_function(func)
+        expected = ['my_package.ThirdPartyArtifact']
+        self.assertEqual(actual, expected)
+
+    def test_multiline(self):
+        from my_package import ThirdPartyArtifact
+
+        def func(
+            a: int,
+            b: Input[ThirdPartyArtifact],
+        ) -> int:
+            return 1
+
+        actual = component_factory.get_artifact_import_items_from_function(func)
+        expected = ['my_package.ThirdPartyArtifact']
+        self.assertEqual(actual, expected)
+
+    def test_alias(self):
+        from my_package import ThirdPartyArtifact
+        Alias = ThirdPartyArtifact
+
+        def func(a: int, b: Input[Alias]):
+            pass
+
+        with self.assertRaisesRegex(
+                TypeError, r'Module or type name aliases are not supported'):
+            component_factory.get_artifact_import_items_from_function(func)
+
+    def test_long_form_annotation(self):
+        import my_package
+
+        def func(a: int, b: Output[my_package.ThirdPartyArtifact]):
+            pass
+
+        actual = component_factory.get_artifact_import_items_from_function(func)
+        expected = ['my_package']
+        self.assertEqual(actual, expected)
+
+    def test_aliased_module_throws_error(self):
+        import my_package as my_package_alias
+
+        def func(a: int, b: Output[my_package_alias.ThirdPartyArtifact]):
+            pass
+
+        with self.assertRaisesRegex(
+                TypeError, r'Module or type name aliases are not supported'):
+            component_factory.get_artifact_import_items_from_function(func)
+
+    def test_named_tuple_return(self):
+        from typing import NamedTuple
+
+        import my_package
+
+        def named_tuple_op(
+            artifact: Input[dsl.Artifact]
+        ) -> NamedTuple('Outputs', [('model1', my_package.ThirdPartyArtifact),
+                                    ('model2', my_package.ThirdPartyArtifact)]):
+            import collections
+
+            output = collections.namedtuple('Outputs', ['model1', 'model2'])
+            return output(model1=artifact, model2=artifact)
+
+        actual = component_factory.get_artifact_import_items_from_function(
+            named_tuple_op)
+        expected = ['my_package']
+        self.assertEqual(actual, expected)
+
+    def test_named_tuple_defined_outside_of_signature_throws_error(self):
+        from typing import NamedTuple
+
+        import my_package
+
+        nt = NamedTuple('Outputs', [('model1', my_package.ThirdPartyArtifact),
+                                    ('model2', my_package.ThirdPartyArtifact)])
+
+        def named_tuple_op(artifact: Input[dsl.Artifact]) -> nt:
+            import collections
+
+            output = collections.namedtuple('Outputs', ['model1', 'model2'])
+            return output(model1=artifact, model2=artifact)
+
+        with self.assertRaisesRegex(TypeError,
+                                    r'Error handling NamedTuple return type'):
+            component_factory.get_artifact_import_items_from_function(
+                named_tuple_op)
+
+    def test_input_output_path(self):
+        from my_package import ThirdPartyArtifact
+
+        def func(
+            a: int,
+            b: InputPath('Dataset'),
+            c: Output[ThirdPartyArtifact],
+        ) -> OutputPath('Dataset'):
+            return 'dataset'
+
+        actual = component_factory.get_artifact_import_items_from_function(func)
+        self.assertEqual(actual, ['my_package.ThirdPartyArtifact'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/python/kfp/components/executor.py
+++ b/sdk/python/kfp/components/executor.py
@@ -38,7 +38,7 @@ class Executor():
             artifacts_list = artifacts.get('artifacts')
             if artifacts_list:
                 self._input_artifacts[name] = self._make_input_artifact(
-                    artifacts_list[0])
+                    artifacts_list[0], name, self._func)
 
         for name, artifacts in self._input.get('outputs',
                                                {}).get('artifacts', {}).items():
@@ -51,9 +51,17 @@ class Executor():
             self._func).return_annotation
         self._executor_output = {}
 
-    @classmethod
-    def _make_input_artifact(cls, runtime_artifact: Dict):
-        return artifact_types.create_runtime_artifact(runtime_artifact)
+    def _make_input_artifact(
+        self,
+        runtime_artifact: Dict,
+        name: str,
+        func: Callable,
+    ):
+        annotations = inspect.getfullargspec(func).annotations
+        artifact_class = type_annotations.get_io_artifact_class(
+            annotations.get(name))
+        return artifact_types.create_runtime_artifact(runtime_artifact,
+                                                      artifact_class)
 
     @classmethod
     def _make_output_artifact(cls, runtime_artifact: Dict):

--- a/sdk/python/kfp/components/executor_test.py
+++ b/sdk/python/kfp/components/executor_test.py
@@ -119,6 +119,21 @@ class ExecutorTest(unittest.TestCase):
 
         self._get_executor(test_func).execute()
 
+    def test_input_artifact_custom_type(self):
+
+        class VertexDataset(Dataset):
+            pass
+
+        def test_func(input_artifact_one_path: Input[VertexDataset]):
+            self.assertEqual(input_artifact_one_path.uri,
+                             'gs://some-bucket/input_artifact_one')
+            self.assertEqual(
+                input_artifact_one_path.path,
+                os.path.join(self._test_dir, 'some-bucket/input_artifact_one'))
+            self.assertEqual(input_artifact_one_path.name, 'input_artifact_one')
+
+        self._get_executor(test_func).execute()
+
     def test_input_artifact(self):
 
         def test_func(input_artifact_one_path: Input[Dataset]):

--- a/sdk/python/kfp/components/types/artifact_types.py
+++ b/sdk/python/kfp/components/types/artifact_types.py
@@ -512,7 +512,10 @@ _SCHEMA_TITLE_TO_TYPE: Dict[str, Artifact] = {
 }
 
 
-def create_runtime_artifact(runtime_artifact: Dict) -> Artifact:
+def create_runtime_artifact(
+    runtime_artifact: Dict,
+    artifact_cls=None,
+) -> Artifact:
     """Creates an Artifact instance from the specified RuntimeArtifact.
 
     Args:
@@ -522,7 +525,7 @@ def create_runtime_artifact(runtime_artifact: Dict) -> Artifact:
 
     artifact_type = _SCHEMA_TITLE_TO_TYPE.get(schema_title)
     if not artifact_type:
-        artifact_type = Artifact
+        artifact_type = artifact_cls or Artifact
     return artifact_type(
         uri=runtime_artifact.get('uri', ''),
         name=runtime_artifact.get('name', ''),

--- a/sdk/python/kfp/components/types/artifact_types.py
+++ b/sdk/python/kfp/components/types/artifact_types.py
@@ -523,9 +523,8 @@ def create_runtime_artifact(
     """
     schema_title = runtime_artifact.get('type', {}).get('schemaTitle', '')
 
-    artifact_type = _SCHEMA_TITLE_TO_TYPE.get(schema_title)
-    if not artifact_type:
-        artifact_type = artifact_cls or Artifact
+    artifact_type = _SCHEMA_TITLE_TO_TYPE.get(
+        schema_title) or artifact_cls or Artifact
     return artifact_type(
         uri=runtime_artifact.get('uri', ''),
         name=runtime_artifact.get('name', ''),

--- a/test/presubmit-tests-sdk.sh
+++ b/test/presubmit-tests-sdk.sh
@@ -21,6 +21,7 @@ python3 -m pip install $(grep 'docker==' sdk/python/requirements-dev.txt)
 python3 -m pip install $(grep 'pytest==' sdk/python/requirements-dev.txt)
 python3 -m pip install $(grep 'pytest-xdist==' sdk/python/requirements-dev.txt)
 python3 -m pip install $(grep 'pytest-cov==' sdk/python/requirements-dev.txt)
+python3 -m pip install -e components/google-cloud
 python3 -m pip install --upgrade protobuf
 
 # Installing Argo CLI to lint all compiled workflows


### PR DESCRIPTION
**Description of your changes:**
Adds support for pre-registered custom artifact types imported from third-party libraries when used in lightweight components. Previously, the custom artifact symbol would not be imported into the component body and would not be used correctly by the executor.

Example usage:
```python
from my_library.artifacts import CustomArtifact

@component
def my_component(custom_artifact: Input[CustomArtifact]):
    ...
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the 
pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
