### PR TITLE
feat(sdk): throw informative exception on uncalled @pipeline decorator

### DIFF
--- a/sdk/python/kfp/components/pipeline_context.py
+++ b/sdk/python/kfp/components/pipeline_context.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Definition for Pipeline."""
 
+import textwrap
 from typing import Callable, Optional
 
 from kfp.components import pipeline_task
@@ -49,6 +50,17 @@ def pipeline(name: Optional[str] = None,
             pipeline. This is required if input/output URI placeholder is used in
             this pipeline.
     """
+    if callable(name):
+        strikethrough_decorator = '\u0336'.join('@pipeline') + '\u0336'
+        raise RuntimeError(
+            textwrap.dedent(
+                f"""The @pipeline decorator must be called (optionally with arguments) in order to construct a pipeline. For example:
+
+                {strikethrough_decorator}
+                @pipeline()
+                def my_pipeline():
+                    ...
+            """))
 
     def _pipeline(func: Callable):
         func._is_pipeline = True

--- a/sdk/python/kfp/components/pipeline_context_test.py
+++ b/sdk/python/kfp/components/pipeline_context_test.py
@@ -55,6 +55,15 @@ class TestPipeline(unittest.TestCase):
         self.assertFalse(
             pipeline_context.Pipeline.is_pipeline_func(my_pipeline))
 
+    def test_pipeline_decorator_must_be_called(self):
+
+        with self.assertRaisesRegex(RuntimeError,
+                                    r'The @pipeline decorator must be called'):
+
+            @pipeline_context.pipeline
+            def my_pipeline(a: str, b: int):
+                pass
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of your changes:**
Provides an informative exception when `@pipeline` is called instead of `@pipeline()`.

/cc @ironpan

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request 
title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
