### PR TITLE
chore: update the eksctl version required for latest eks version

### DIFF
--- a/components/aws/sagemaker/tests/integration_tests/Dockerfile
+++ b/components/aws/sagemaker/tests/integration_tests/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update --allow-releaseinfo-change && apt-get install -y --no-install
     jq
 
 # Install eksctl
-RUN curl --location "https://github.com/weaveworks/eksctl/releases/download/0.43.0/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp \
+RUN curl --location "https://github.com/weaveworks/eksctl/releases/download/v0.86.0/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp \
  && mv /tmp/eksctl /usr/local/bin
 
 # Install aws-iam-authenticator


### PR DESCRIPTION
**Description of your changes:**
The current eksctl version fails to spin up an EKS 1.21 cluster. 
```
[Creating EKS] Launching EKS cluster sagemaker-kfp-.......>

--
46 | Error: invalid version, supported values: 1.15, 1.16, 1.17, 1.18, 1.19
```

Updated to eksctl 0.86.0. 


**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
