### PR TITLE
chore: fix `go-licenses` usage in `third_party/argo/imp-1-update-notices.sh`

### DIFF
--- a/third_party/argo/imp-1-update-notices.sh
+++ b/third_party/argo/imp-1-update-notices.sh
@@ -52,9 +52,9 @@ mkdir -p "${DIR}/NOTICES/argoexec"
 echo "Temporary dir:"
 echo "${WORK_DIR}"
 cp "${DIR}/go-licenses.yaml" .
-go-licenses csv dist/workflow-controller > licenses-workflow-controller.csv
+go-licenses csv ./cmd/workflow-controller > licenses-workflow-controller.csv
 cp licenses-workflow-controller.csv "${DIR}/licenses-workflow-controller.csv"
-go-licenses csv dist/argoexec > licenses-argoexec.csv
+go-licenses csv ./cmd/argoexec > licenses-argoexec.csv
 cp licenses-argoexec.csv "${DIR}/licenses-argoexec.csv"
-go-licenses save licenses-workflow-controller.csv --save_path "${DIR}/NOTICES/workflow-controller" --force
-go-licenses save licenses-argoexec.csv --save_path "${DIR}/NOTICES/argoexec" --force
+go-licenses save ./cmd/workflow-controller --save_path "${DIR}/NOTICES/workflow-controller" --force
+go-licenses save ./cmd/argoexec --save_path "${DIR}/NOTICES/argoexec" --force


### PR DESCRIPTION
**Description of your changes:**
The new version of go-licenses tool no longer accept a binary but only go package or local path. Update its usage.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
