### PR TITLE
chore(backend): modify default_experiments and db_statuses tables to have primary keys. Fixes #8014

### DIFF
--- a/backend/src/apiserver/model/db_status.go
+++ b/backend/src/apiserver/model/db_status.go
@@ -15,5 +15,5 @@
 package model
 
 type DBStatus struct {
-	HaveSamplesLoaded bool `gorm:"column:HaveSamplesLoaded; not null"`
+	HaveSamplesLoaded bool `gorm:"column:HaveSamplesLoaded; not null; primary_key"`
 }

--- a/backend/src/apiserver/model/default_experiment.go
+++ b/backend/src/apiserver/model/default_experiment.go
@@ -15,5 +15,5 @@
 package model
 
 type DefaultExperiment struct {
-	DefaultExperimentId string `gorm:"column:DefaultExperimentId; not null"`
+	DefaultExperimentId string `gorm:"column:DefaultExperimentId; not null; primary_key"`
 }


### PR DESCRIPTION
**Description of your changes:**
The `db_statuses` and `default_experiments` models in the backend apiserver do not contain primary keys. This prevents the apiserver from being deployed with MySQL with Group Replication enabled ([as MySQL with Group Replication requires primary keys](https://lefred.be/content/mysql-group-replication-and-table-design/)). This change add the `primary_key` tag to the sole column in these tables (`db_statuses` and `default_experiments`).

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
