### PR TITLE
fix(frontend): make frontend server config s3 endpoint url configurable via environment variable. Fixes #7995

### DIFF
--- a/frontend/server/configs.ts
+++ b/frontend/server/configs.ts
@@ -59,6 +59,7 @@ export function loadConfigs(argv: string[], env: ProcessEnv): UIConfigs {
     AWS_ACCESS_KEY_ID,
     AWS_SECRET_ACCESS_KEY,
     AWS_REGION,
+    AWS_S3_ENDPOINT,
     /** http/https base URL */
     HTTP_BASE_URL = '',
     /** http/https fetch with this authorization header key (for example: 'Authorization') */
@@ -124,7 +125,7 @@ export function loadConfigs(argv: string[], env: ProcessEnv): UIConfigs {
     artifacts: {
       aws: {
         accessKey: AWS_ACCESS_KEY_ID || '',
-        endPoint: 's3.amazonaws.com',
+        endPoint: AWS_S3_ENDPOINT || 's3.amazonaws.com',
         region: AWS_REGION || 'us-east-1',
         secretKey: AWS_SECRET_ACCESS_KEY || '',
       },


### PR DESCRIPTION

**Description of your changes:**
Currently the S3 endpoint in the frontend server config is hard coded to `s3.amazonaws.com`.
This endpoint is not valid for China regions (`s3.amazonaws.com.cn`), preventing users in those regions from accessing artifacts via the KFP UI. 

This PR supports reading the endpoint as a passable environment variable `AWS_S3_ENDPOINT` so that users can specify the endpoint that is compatible with their region. If no `AWS_S3_ENDPOINT` variable is found, the default `s3.amazonaws.com` endpoint will be used.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
