### PR TITLE
feat(sdk): add argument validation at run submission

### DIFF
--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -1579,7 +1579,7 @@ def _validate_pipeline_arguments(pipeline_obj: Dict[str, Any],
         arguments: Arguments to the pipeline function.
     """
 
-    input_definitions = pipeline_obj['root']['inputDefinitions']
+    input_definitions = pipeline_obj['root'].get('inputDefinitions', {})
     parameters = input_definitions.get('parameters', {})
     artifacts = input_definitions.get('artifacts', {})
     # note: artifact inputs are not supported at outermost pipeline level
@@ -1589,8 +1589,8 @@ def _validate_pipeline_arguments(pipeline_obj: Dict[str, Any],
     required_artifacts = {
         name for name, body in artifacts.items() if 'defaultValue' not in body
     }
-    not_provided_arguments = (required_parameters + required_artifacts) - set(
-        arguments.keys())
+    not_provided_arguments = required_parameters.union(
+        required_artifacts) - set(arguments.keys())
     if not_provided_arguments:
         raise ValueError(
             f'Cannot run pipeline. Pipeline submission is missing the following arguments: {not_provided_arguments}'

--- a/sdk/python/kfp/client/client_test.py
+++ b/sdk/python/kfp/client/client_test.py
@@ -17,6 +17,7 @@ import tempfile
 import unittest
 
 from absl.testing import parameterized
+from kfp import dsl
 from kfp.client import client
 from kfp.compiler import Compiler
 from kfp.dsl import component
@@ -47,7 +48,7 @@ class TestValidatePipelineName(parameterized.TestCase):
             client.validate_pipeline_resource_name(name)
 
 
-class TestOverrideCachingOptions(parameterized.TestCase):
+class TestOverrideCachingOptions(unittest.TestCase):
 
     def test_override_caching_from_pipeline(self):
 
@@ -63,7 +64,7 @@ class TestOverrideCachingOptions(parameterized.TestCase):
             hello_world(text=text).set_caching_options(True)
 
         with tempfile.TemporaryDirectory() as tempdir:
-            temp_filepath = os.path.join(tempdir, 'hello_world_pipeline.yaml')
+            temp_filepath = os.path.join(tempdir, 'pipeline.yaml')
             Compiler().compile(
                 pipeline_func=pipeline_hello_world, package_path=temp_filepath)
 
@@ -94,7 +95,7 @@ class TestOverrideCachingOptions(parameterized.TestCase):
                 text=component_1.output).set_caching_options(True)
 
         with tempfile.TemporaryDirectory() as tempdir:
-            temp_filepath = os.path.join(tempdir, 'hello_world_pipeline.yaml')
+            temp_filepath = os.path.join(tempdir, 'pipeline.yaml')
             Compiler().compile(
                 pipeline_func=pipeline_with_two_component,
                 package_path=temp_filepath)
@@ -108,6 +109,242 @@ class TestOverrideCachingOptions(parameterized.TestCase):
                     ['cachingOptions']['enableCache'])
                 self.assertFalse(pipeline_obj['root']['dag']['tasks']
                                  ['to-lower']['cachingOptions']['enableCache'])
+
+
+class TestValidatePipelineArguments(unittest.TestCase):
+
+    def test_success1(self):
+
+        @component
+        def hello_world(text: str) -> str:
+            return text
+
+        @pipeline(name='hello-world')
+        def my_pipeline(text: str = 'hi there'):
+            hello_world(text=text)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_filepath = os.path.join(tempdir, 'pipeline.yaml')
+            Compiler().compile(
+                pipeline_func=my_pipeline, package_path=temp_filepath)
+
+            with open(temp_filepath, 'r') as f:
+                pipeline_obj = yaml.safe_load(f)
+
+        client._validate_pipeline_arguments(pipeline_obj, {})
+
+    def test_success2(self):
+
+        @component
+        def hello_world(text: str) -> str:
+            return text
+
+        @pipeline(name='hello-world')
+        def my_pipeline(text: str):
+            hello_world(text=text)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_filepath = os.path.join(tempdir, 'pipeline.yaml')
+            Compiler().compile(
+                pipeline_func=my_pipeline, package_path=temp_filepath)
+
+            with open(temp_filepath, 'r') as f:
+                pipeline_obj = yaml.safe_load(f)
+
+        client._validate_pipeline_arguments(pipeline_obj, {'text': 'hi there'})
+
+    def test_success3(self):
+
+        from typing import Dict, List
+
+        from kfp.dsl import component
+        from kfp.dsl import Dataset
+        from kfp.dsl import Output
+        from kfp.dsl import OutputPath
+
+        @component
+        def preprocess(
+            # An input parameter of type string.
+            message: str,
+            # An input parameter of type dict.
+            input_dict_parameter: Dict[str, int],
+            # An input parameter of type list.
+            input_list_parameter: List[str],
+            # Use Output[T] to get a metadata-rich handle to the output artifact
+            # of type `Dataset`.
+            output_dataset_one: Output[Dataset],
+            # A locally accessible filepath for another output artifact of type
+            # `Dataset`.
+            output_dataset_two_path: OutputPath('Dataset'),
+            # A locally accessible filepath for an output parameter of type string.
+            output_parameter_path: OutputPath(str),
+            # A locally accessible filepath for an output parameter of type bool.
+            output_bool_parameter_path: OutputPath(bool),
+            # A locally accessible filepath for an output parameter of type dict.
+            output_dict_parameter_path: OutputPath(Dict[str, int]),
+            # A locally accessible filepath for an output parameter of type list.
+            output_list_parameter_path: OutputPath(List[str]),
+        ):
+            """Dummy preprocessing step."""
+
+            # Use Dataset.path to access a local file path for writing.
+            # One can also use Dataset.uri to access the actual URI file path.
+            with open(output_dataset_one.path, 'w') as f:
+                f.write(message)
+
+            # OutputPath is used to just pass the local file path of the output artifact
+            # to the function.
+            with open(output_dataset_two_path, 'w') as f:
+                f.write(message)
+
+            with open(output_parameter_path, 'w') as f:
+                f.write(message)
+
+            with open(output_bool_parameter_path, 'w') as f:
+                f.write(
+                    str(True)
+                )  # use either `str()` or `json.dumps()` for bool values.
+
+            import json
+            with open(output_dict_parameter_path, 'w') as f:
+                f.write(json.dumps(input_dict_parameter))
+
+            with open(output_list_parameter_path, 'w') as f:
+                f.write(json.dumps(input_list_parameter))
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_filepath = os.path.join(tempdir, 'pipeline.yaml')
+            Compiler().compile(
+                pipeline_func=preprocess, package_path=temp_filepath)
+
+            with open(temp_filepath, 'r') as f:
+                pipeline_obj = yaml.safe_load(f)
+
+        client._validate_pipeline_arguments(
+            pipeline_obj, {
+                'message': 'message',
+                'input_dict_parameter': {
+                    'key': 'value'
+                },
+                'input_list_parameter': [1, 2, 3]
+            })
+
+    def test_success4(self):
+
+        @component
+        def hello_world(text: str) -> str:
+            return text
+
+        @pipeline(name='hello-world')
+        def my_pipeline():
+            hello_world(text='text')
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_filepath = os.path.join(tempdir, 'pipeline.yaml')
+            Compiler().compile(
+                pipeline_func=my_pipeline, package_path=temp_filepath)
+
+            with open(temp_filepath, 'r') as f:
+                pipeline_obj = yaml.safe_load(f)
+
+        client._validate_pipeline_arguments(pipeline_obj, {})
+
+    def test_failure1(self):
+
+        @component
+        def hello_world(text: str) -> str:
+            return text
+
+        @pipeline(name='hello-world')
+        def my_pipeline(text: str):
+            hello_world(text=text)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_filepath = os.path.join(tempdir, 'pipeline.yaml')
+            Compiler().compile(
+                pipeline_func=my_pipeline, package_path=temp_filepath)
+
+            with open(temp_filepath, 'r') as f:
+                pipeline_obj = yaml.safe_load(f)
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Cannot run pipeline. Pipeline submission is missing the following arguments: {'text'}"
+        ):
+            client._validate_pipeline_arguments(pipeline_obj, {})
+
+    def test_failure2(self):
+
+        @component
+        def hello_world(text: str) -> str:
+            return text
+
+        @pipeline(name='hello-world')
+        def my_pipeline(text: str, integer: int = 1):
+            hello_world(text=text)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_filepath = os.path.join(tempdir, 'pipeline.yaml')
+            Compiler().compile(
+                pipeline_func=my_pipeline, package_path=temp_filepath)
+
+            with open(temp_filepath, 'r') as f:
+                pipeline_obj = yaml.safe_load(f)
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Cannot run pipeline. Pipeline submission is missing the following arguments: {'text'}"
+        ):
+            client._validate_pipeline_arguments(pipeline_obj, {})
+
+    def test_failure3(self):
+
+        @component
+        def hello_world(text: str) -> str:
+            return text
+
+        @pipeline(name='hello-world')
+        def my_pipeline(text: str, integer: int):
+            hello_world(text=text)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_filepath = os.path.join(tempdir, 'pipeline.yaml')
+            Compiler().compile(
+                pipeline_func=my_pipeline, package_path=temp_filepath)
+
+            with open(temp_filepath, 'r') as f:
+                pipeline_obj = yaml.safe_load(f)
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Cannot run pipeline. Pipeline submission is missing the following arguments: {'text'}"
+        ):
+            client._validate_pipeline_arguments(pipeline_obj, {'integer': 10})
+
+    def test_failure4(self):
+
+        @component
+        def hello_world(text: str) -> str:
+            return text
+
+        @pipeline(name='hello-world')
+        def my_pipeline(text: str, integer: int,
+                        artifact: dsl.Input[dsl.Artifact]):
+            hello_world(text=text)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_filepath = os.path.join(tempdir, 'pipeline.yaml')
+            Compiler().compile(
+                pipeline_func=my_pipeline, package_path=temp_filepath)
+
+            with open(temp_filepath, 'r') as f:
+                pipeline_obj = yaml.safe_load(f)
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r'Cannot run pipeline. Pipeline submission is missing the following arguments:'
+        ):
+            client._validate_pipeline_arguments(pipeline_obj, {'integer': 10})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of your changes:**
The KFP SDK should raise an exception if a user tries to submit a 
pipeline run without providing all parameters without defaults.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title 
convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
