### PR TITLE
feat(component): Add BigQuery export component to run extract job

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/container/v1/gcp_launcher/launcher.py
+++ b/components/google-cloud/google_cloud_pipeline_components/container/v1/gcp_launcher/launcher.py
@@ -70,6 +70,8 @@ _JOB_TYPE_TO_ACTION_MAP = {
         bigquery_job_remote_runner.bigquery_explain_forecast_model_job,
     'BigqueryExportModelJob':
         bigquery_job_remote_runner.bigquery_export_model_job,
+    'BigqueryExportTableJob':
+        bigquery_job_remote_runner.bigquery_export_table_job,
     'BigqueryEvaluateModelJob':
         bigquery_job_remote_runner.bigquery_evaluate_model_job,
     'BigqueryMLArimaCoefficientsJob':
@@ -260,6 +262,18 @@ def _parse_args(args):
       required=(parsed_args.type == 'BigqueryExportModelJob'),
       default=argparse.SUPPRESS)
   parser.add_argument(
+      '--destination_path',
+      dest='destination_path',
+      type=str,
+      required=(parsed_args.type == 'BigqueryExportTableJob'),
+      default=argparse.SUPPRESS)
+  parser.add_argument(
+      '--destination_format',
+      dest='destination_format',
+      type=str,
+      required=(parsed_args.type == 'BigqueryExportTableJob'),
+      default=argparse.SUPPRESS)
+  parser.add_argument(
       '--exported_model_path',
       dest='exported_model_path',
       type=str,
@@ -273,7 +287,7 @@ def _parse_args(args):
       required=(parsed_args.type in {
           'BigqueryPredictModelJob', 'BigQueryEvaluateModelJob',
           'BigqueryMLReconstructionLossJob', 'BigqueryMLConfusionMatrixJob',
-          'BigqueryMLRocCurveJob'
+          'BigqueryMLRocCurveJob', 'BigqueryExportTableJob'
       }),
       default=argparse.SUPPRESS)
   parser.add_argument(

--- a/components/google-cloud/google_cloud_pipeline_components/v1/bigquery/export_table/component.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/v1/bigquery/export_table/component.yaml
@@ -1,0 +1,92 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: bigquery_export_table_job
+description: |
+  Launch a BigQuery export table job and waits for it to finish.
+
+    Args:
+        project (str):
+            Required. Project to run BigQuery table export job.
+        location (Optional[str]):
+            Location of the job to export the BigQuery table. If not set,
+            default to `US` multi-region.
+
+            For more details, see https://cloud.google.com/bigquery/docs/locations#specifying_your_location
+        table (google.BQTable):
+            Required. BigQuery table URI to export.
+        destination_path (str):
+            Required. The file path to export the table to.
+        destination_format (Optional[str]):
+            File format of the destination files. If not set,
+            default to `CSV`.
+  
+            For more details, see https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationextract
+        job_configuration_extract (Optional[dict]):
+            A json formatted string describing the rest of the job configuration.
+
+            For more details, see https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationextract
+        labels (Optional[dict]):
+            The labels associated with this job. You can use these to organize and group your jobs.
+            Label keys and values can be no longer than 63 characters, can only containlowercase
+            letters, numeric characters, underscores and dashes. International characters are
+            allowed. Label values are optional. Label keys must start with a letter and each label
+            in the list must have a different key.
+
+            Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+    Returns:
+        gcp_resources (str):
+            Serialized gcp_resources proto tracking the BigQuery job.
+            For more details, see https://github.com/kubeflow/pipelines/blob/master/components/google-cloud/google_cloud_pipeline_components/proto/README.md.
+inputs:
+- {name: project, type: String}
+- {name: location, type: String, default: 'us-central1'}
+- {name: table, type: google.BQTable}
+- {name: destination_path, type: String}
+- {name: destination_format, type: String, default: 'CSV'}
+- {name: job_configuration_extract, type: JsonObject, optional: true, default: '{}'}
+- {name: labels, type: JsonObject, optional: true, default: '{}'}
+outputs:
+- {name: gcs_output_directory, type: system.Artifact}
+- {name: gcp_resources, type: String}
+implementation:
+  container:
+    image: gcr.io/ml-pipeline/google-cloud-pipeline-components:latest
+    command: [python3, -u, -m, google_cloud_pipeline_components.container.v1.gcp_launcher.launcher]
+    args: [
+      --type, BigqueryExportTableJob,
+      --project, {inputValue: project},
+      --location, {inputValue: location},
+      --table_name,
+      concat: [
+          "{{$.inputs.artifacts['table'].metadata['projectId']}}",
+          '.',
+          "{{$.inputs.artifacts['table'].metadata['datasetId']}}",
+          '.',
+          "{{$.inputs.artifacts['table'].metadata['tableId']}}"
+          ],
+      --destination_path, {inputValue: destination_path},
+      --destination_format, {inputValue: destination_format},
+      --payload,
+      concat: [
+          '{',
+            '"configuration": {',
+              '"extract": ', {inputValue: job_configuration_extract},
+              ', "labels": ', {inputValue: labels},
+            '}',
+          '}'
+      ],
+      --gcp_resources, {outputPath: gcp_resources},
+      --executor_input, "{{$}}",
+    ]

--- a/components/google-cloud/tests/container/v1/gcp_launcher/test_launcher.py
+++ b/components/google-cloud/tests/container/v1/gcp_launcher/test_launcher.py
@@ -317,6 +317,41 @@ class LauncherBigqueryExportModelJobUtilsTests(unittest.TestCase):
           executor_input='executor_input')
 
 
+class LauncherBigqueryExportTableJobUtilsTests(unittest.TestCase):
+
+  def setUp(self):
+    super(LauncherBigqueryExportTableJobUtilsTests, self).setUp()
+    self._gcp_resources = os.path.join(
+        os.getenv('TEST_UNDECLARED_OUTPUTS_DIR'),
+        'test_file_path/test_file.txt')
+    self._input_args = [
+        '--type', 'BigqueryExportTableJob', '--project', 'test_project',
+        '--location', 'us_central1', '--payload', 'test_payload',
+        '--table_name', 'test_project.test_dataset.test_table_name',
+        '--destination_path', 'gs://test_destination_path/testpath',
+        '--destination_format', 'test_format',
+        '--gcp_resources', self._gcp_resources,
+        '--executor_input', 'executor_input'
+    ]
+
+  def test_launcher_on_bigquery_export_table_job_type(self):
+    mock_bigquery_export_table_job = mock.Mock()
+    with mock.patch.dict(
+        launcher._JOB_TYPE_TO_ACTION_MAP,
+        {'BigqueryExportTableJob': mock_bigquery_export_table_job}):
+      launcher.main(self._input_args)
+      mock_bigquery_export_table_job.assert_called_once_with(
+          type='BigqueryExportTableJob',
+          project='test_project',
+          location='us_central1',
+          payload='test_payload',
+          table_name='test_project.test_dataset.test_table_name',
+          destination_path='gs://test_destination_path/testpath',
+          destination_format='test_format',
+          gcp_resources=self._gcp_resources,
+          executor_input='executor_input')
+
+
 class LauncherUnsupportedJobTypeTests(unittest.TestCase):
 
   def setUp(self):


### PR DESCRIPTION
**Description of your changes:**
- Added a component to export tables from BigQuery to GCS
   - Previously, tables could be exported by using the `EXPORT DATA` statement in the bigquery_query_job component, but this usage is not essential, and parameters and artifact lineges could not be easily managed.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
