### PR TITLE
docs(sdk): refresh SDK public API docstrings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,6 @@ repos:
       - id: trailing-whitespace
       - id: debug-statements
       - id: check-merge-conflict
-      - id: check-docstring-first
       - id: name-tests-test
       - id: double-quote-string-fixer
       - id: no-commit-to-branch

--- a/docs/source/dsl.rst
+++ b/docs/source/dsl.rst
@@ -6,3 +6,6 @@ kfp.dsl
    :undoc-members:
    :show-inheritance:
    :noindex:
+
+   .. autodata:: Input
+   .. autodata:: Output

--- a/sdk/python/kfp/__init__.py
+++ b/sdk/python/kfp/__init__.py
@@ -20,9 +20,4 @@ __version__ = '2.0.0-beta.1'
 
 TYPE_CHECK = True
 
-from kfp.client import Client  # pylint: disable=wrong-import-position
-
-# TODO: clean up COMPILING_FOR_V2
-# COMPILING_FOR_V2 is True when using kfp.compiler or use (v1) kfp.compiler
-# with V2_COMPATIBLE or V2_ENGINE mode
-COMPILING_FOR_V2 = False
+from kfp.client import Client

--- a/sdk/python/kfp/cli/utils/parsing_test.py
+++ b/sdk/python/kfp/cli/utils/parsing_test.py
@@ -128,7 +128,7 @@ class TestGetParamDescr(unittest.TestCase):
 
         self.assertEqual(
             host_descr,
-            "The host name to use to talk to Kubeflow Pipelines. If not set, the in-cluster service DNS name will be used, which only works if the current environment is a pod in the same cluster (such as a Jupyter instance spawned by Kubeflow's JupyterHub). Set the host based on https://www.kubeflow.org/docs/components/pipelines/sdk/connect-api/"
+            "Host name to use to talk to Kubeflow Pipelines. If not set, the in-cluster service DNS name will be used, which only works if the current environment is a pod in the same cluster (such as a Jupyter instance spawned by Kubeflow's JupyterHub). (`More information on connecting. <https://www.kubeflow.org/docs/components/pipelines/sdk/connect-api/>`_)"
         )
 
 

--- a/sdk/python/kfp/client/__init__.py
+++ b/sdk/python/kfp/client/__init__.py
@@ -1,3 +1,4 @@
+"""The `kfp.client` module contains the KFP API client."""
 # Copyright 2022 The Kubeflow Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -83,18 +83,15 @@ class Client:
     """The KFP SDK client for the Kubeflow Pipelines backend API.
 
     Args:
-        host: The host name to use to talk to Kubeflow Pipelines. If not set,
+        host: Host name to use to talk to Kubeflow Pipelines. If not set,
             the in-cluster service DNS name will be used, which only works if
             the current environment is a pod in the same cluster (such as a
-            Jupyter instance spawned by Kubeflow's JupyterHub).
-            Set the host based on
-            https://www.kubeflow.org/docs/components/pipelines/sdk/connect-api/
-        client_id: The client ID used by Identity-Aware Proxy.
-        namespace: The Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as None.
-        other_client_id: The client ID used to obtain the auth codes and refresh
-            tokens. References:
-            https://cloud.google.com/iap/docs/authentication-howto#authenticating_from_a_desktop_app.
-        other_client_secret: The client secret used to obtain the auth codes and
+            Jupyter instance spawned by Kubeflow's JupyterHub). (`More information on connecting. <https://www.kubeflow.org/docs/components/pipelines/sdk/connect-api/>`_)
+        client_id: Client ID used by Identity-Aware Proxy.
+        namespace: Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as ``None``.
+        other_client_id: Client ID used to obtain the auth codes and refresh
+            tokens (`reference <https://cloud.google.com/iap/docs/authentication-howto#authenticating_from_a_desktop_app>`_).
+        other_client_secret: Client secret used to obtain the auth codes and
             refresh tokens.
         existing_token: Authentication token to pass in directly. Used in cases where the token is
             generated from outside the SDK.
@@ -102,8 +99,8 @@ class Client:
             Pipelines API.
         proxy: HTTP or HTTPS proxy server.
         ssl_ca_cert: Certification for proxy.
-        kube_context: The kubectl context to use. Must be a context listed in the kubeconfig file. Defaults to the current-context set within kubeconfig.
-        credentials: A TokenCredentialsBase object which provides the logic to
+        kube_context: kubectl context to use. Must be a context listed in the kubeconfig file. Defaults to the current-context set within kubeconfig.
+        credentials: ``TokenCredentialsBase`` object which provides the logic to
             populate the requests with credentials to authenticate against the
             API server.
         ui_host: Base URL to use to open the Kubeflow Pipelines UI. This is used
@@ -394,7 +391,7 @@ class Client:
         multi-user mode.
 
         Args:
-            namespace: The namespace to use within the Kubernetes cluster containing the Kubeflow Pipelines deployment.
+            namespace: Namespace to use within the Kubernetes cluster (namespace containing the Kubeflow Pipelines deployment).
         """
         self._context_setting['namespace'] = namespace
         if not os.path.exists(os.path.dirname(Client._LOCAL_KFP_CONTEXT)):
@@ -403,10 +400,10 @@ class Client:
             json.dump(self._context_setting, f)
 
     def get_kfp_healthz(self) -> kfp_server_api.ApiGetHealthzResponse:
-        """Gets healthz info of KFP deployment.
+        """Gets healthz info for KFP deployment.
 
         Returns:
-            json formatted response from the healtz endpoint.
+            JSON response from the healtz endpoint.
         """
         count = 0
         response = None
@@ -430,10 +427,10 @@ class Client:
                 time.sleep(5)
 
     def get_user_namespace(self) -> str:
-        """Get user namespace in context config.
+        """Gets user namespace in context config.
 
         Returns:
-            kubernetes namespace from the local context file or empty if it
+            Kubernetes namespace from the local context file or empty if it
             wasn't set.
         """
         return self._context_setting['namespace']
@@ -446,12 +443,12 @@ class Client:
         """Creates a new experiment.
 
         Args:
-            name: The name of the experiment.
+            name: Name of the experiment.
             description: Description of the experiment.
-            namespace: The Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as None.
+            namespace: Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as ``None``.
 
         Returns:
-            ApiExperiment object.
+            ``ApiExperiment`` object.
         """
         namespace = namespace or self.get_user_namespace()
         experiment = None
@@ -487,8 +484,8 @@ class Client:
             IPython.display.display(IPython.display.HTML(html))
         return experiment
 
-    def get_pipeline_id(self, name) -> Optional[str]:
-        """Find the ID of a pipeline by name.
+    def get_pipeline_id(self, name: str) -> Optional[str]:
+        """Gets the ID of a pipeline by its name.
 
         Args:
             name: Pipeline name.
@@ -525,18 +522,15 @@ class Client:
         """Lists experiments.
 
         Args:
-            page_token: Token for starting of the page.
+            page_token: Page token for obtaining page from paginated response.
             page_size: Size of the page.
-            sort_by: Can be '[field_name]', '[field_name] desc'. For example,
-                'name desc'.
-            namespace: The Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as None.
+            sort_by: Sort string of format ``'[field_name]', '[field_name] desc'``. For example, ``'name desc'``.
+            namespace: Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as ``None``.
             filter: A url-encoded, JSON-serialized Filter protocol buffer
-                (see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto)).
+                (see `filter.proto message <https://github.com/kubeflow/pipelines/blob/777c98153daf3dfae82730e14ff37bdddc334c4d/backend/api/filter.proto>`_). For a list of all filter operations ``'op'``, see `here <https://github.com/kubeflow/pipelines/blob/777c98153daf3dfae82730e14ff37bdddc334c4d/sdk/python/kfp/client/client.py#L37-L45>`_. Example:
 
-                An example filter string would be:
+                  ::
 
-                    # For the list of filter operations please see:
-                    # https://github.com/kubeflow/pipelines/blob/master/sdk/python/kfp/client/client.py#L36
                     json.dumps({
                         "predicates": [{
                             "op": _FILTER_OPERATIONS["EQUALS"],
@@ -546,7 +540,7 @@ class Client:
                     })
 
         Returns:
-            ApiListExperimentsResponse object.
+            ``ApiListExperimentsResponse`` object.
         """
         namespace = namespace or self.get_user_namespace()
         response = self._experiment_api.list_experiment(
@@ -565,15 +559,15 @@ class Client:
                        namespace=None) -> kfp_server_api.ApiExperiment:
         """Gets details of an experiment.
 
-        Either experiment_id or experiment_name is required.
+        Either ``experiment_id`` or ``experiment_name`` is required.
 
         Args:
             experiment_id: ID of the experiment.
             experiment_name: Name of the experiment.
-            namespace: The Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as None.
+            namespace: Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as ``None``.
 
         Returns:
-            ApiExperiment object.
+            ``ApiExperiment`` object.
         """
         namespace = namespace or self.get_user_namespace()
         if experiment_id is None and experiment_name is None:
@@ -702,17 +696,14 @@ class Client:
         """Lists pipelines.
 
         Args:
-            page_token: Token for starting of the page.
+            page_token: Page token for obtaining page from paginated response.
             page_size: Size of the page.
-            sort_by: one of 'field_name', 'field_name desc'. For example,
-                'name desc'.
+            sort_by: Sort string of format ``'[field_name]', '[field_name] desc'``. For example, ``'name desc'``.
             filter: A url-encoded, JSON-serialized Filter protocol buffer
-                (see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto)).
+                (see `filter.proto message <https://github.com/kubeflow/pipelines/blob/777c98153daf3dfae82730e14ff37bdddc334c4d/backend/api/filter.proto>`_). For a list of all filter operations ``'op'``, see `here <https://github.com/kubeflow/pipelines/blob/777c98153daf3dfae82730e14ff37bdddc334c4d/sdk/python/kfp/client/client.py#L37-L45>`_. Example:
 
-                An example filter string would be:
+                  ::
 
-                    # For the list of filter operations please see:
-                    # https://github.com/kubeflow/pipelines/blob/master/sdk/python/kfp/_client.py#L40
                     json.dumps({
                         "predicates": [{
                             "op": _FILTER_OPERATIONS["EQUALS"],
@@ -722,7 +713,7 @@ class Client:
                     })
 
         Returns:
-            ApiListPipelinesResponse object.
+            ``ApiListPipelinesResponse`` object.
         """
         return self._pipelines_api.list_pipelines(
             page_token=page_token,
@@ -746,29 +737,29 @@ class Client:
         """Runs a specified pipeline.
 
         Args:
-            experiment_id: The ID of an experiment.
+            experiment_id: ID of an experiment.
             job_name: Name of the job.
             pipeline_package_path: Local path of the pipeline package (the
                 filename should end with one of the following .tar.gz, .tgz,
                 .zip, .json).
             params: Arguments to the pipeline function provided as a dict.
-            pipeline_id: The ID of the pipeline.
-            version_id: The ID of the pipeline version to run.
+            pipeline_id: ID of the pipeline.
+            version_id: ID of the pipeline version to run.
                 If both pipeline_id and version_id are specified, version_id
                 will take precendence.
                 If only pipeline_id is specified, the default version of this
                 pipeline is used to create the run.
-            pipeline_root: The root path of the pipeline outputs.
+            pipeline_root: Root path of the pipeline outputs.
             enable_caching: Whether or not to enable caching for the
                 run. If not set, defaults to the compile-time settings, which
-                are True for all tasks by default. If set, the
+                is ``True`` for all tasks by default. If set, the
                 setting applies to all tasks in the pipeline (overrides the
                 compile time settings).
             service_account: Specifies which Kubernetes service
                 account to use for this run.
 
         Returns:
-            ApiRun object.
+            ``ApiRun`` object.
         """
         if params is None:
             params = {}
@@ -868,47 +859,46 @@ class Client:
             experiment_id: ID of the experiment.
             job_name: Name of the job.
             description: Description of the job.
-            start_time: The RFC3339 time string of the time when to start the
+            start_time: RFC3339 time string of the time when to start the
                 job.
-            end_time: The RFC3339 time string of the time when to end the job.
+            end_time: RFC3339 time string of the time when to end the job.
             interval_second: Integer indicating the seconds between two
                 recurring runs in for a periodic schedule.
-            cron_expression: A cron expression representing a set of times,
-                using 6 space-separated fields, e.g. "0 0 9 ? * 2-6". See:
-                https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format
+            cron_expression: Cron expression representing a set of times,
+                using 6 space-separated fields (e.g., ``'0 0 9 ? * 2-6'``). See `cron format
+                <https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format>`_.
             max_concurrency: Integer indicating how many jobs can be run in
                 parallel.
             no_catchup: Whether the recurring run should catch up if behind
                 schedule. For example, if the recurring run is paused for a
-                while and re-enabled afterwards. If no_catchup=False, the
+                while and re-enabled afterwards. If ``no_catchup=False``, the
                 scheduler will catch up on (backfill) each missed interval.
                 Otherwise, it only schedules the latest interval if more than
                 one interval is ready to be scheduled. Usually, if your pipeline
                 handles backfill internally, you should turn catchup off to
-                avoid duplicate backfill. Defaults to False.
+                avoid duplicate backfill.
             pipeline_package_path: Local path of the pipeline package (the
                 filename should end with one of the following .tar.gz, .tgz,
                 .zip, .json).
-            params: A dictionary with key as param name and value as param value.
-            pipeline_id: The ID of a pipeline.
-            version_id: The ID of a pipeline version.
-                If both pipeline_id and version_id are specified, version_id
+            params: Arguments to the pipeline function provided as a dict.
+            pipeline_id: ID of a pipeline.
+            version_id: ID of a pipeline version.
+                If both ``pipeline_id`` and ``version_id`` are specified, ``version_id``
                 will take precedence.
-                If only pipeline_id is specified, the default version of this
+                If only ``pipeline_id`` is specified, the default version of this
                 pipeline is used to create the run.
-            enabled: A bool indicating whether the recurring run is enabled or
-                disabled.
-            pipeline_root: The root path of the pipeline outputs.
+            enabled: Whether to enable or disable the recurring run.
+            pipeline_root: Root path of the pipeline outputs.
             enable_caching: Whether or not to enable caching for the
                 run. If not set, defaults to the compile time settings, which
-                are True for all tasks by default, while users may specify
+                is ``True`` for all tasks by default, while users may specify
                 different caching options for individual tasks. If set, the
                 setting applies to all tasks in the pipeline (overrides the
                 compile time settings).
             service_account: Specifies which Kubernetes service
                 account this recurring run uses.
         Returns:
-            ApiJob object.
+            ``ApiJob`` object.
         """
 
         job_config = self._create_job_config(
@@ -963,23 +953,23 @@ class Client:
         """Creates a JobConfig with spec and resource_references.
 
         Args:
-            experiment_id: The ID of an experiment.
+            experiment_id: ID of an experiment.
             pipeline_package_path: Local path of the pipeline package (the
                 filename should end with one of the following .tar.gz, .tgz,
                 .zip, .yaml, .yml).
             params: A dictionary with key as param name and value as param value.
-            pipeline_id: The ID of a pipeline.
-            version_id: The ID of a pipeline version.
+            pipeline_id: ID of a pipeline.
+            version_id: ID of a pipeline version.
                 If both pipeline_id and version_id are specified, version_id
                 will take precedence. If only pipeline_id is specified, the
                 default version of this pipeline is used to create the run.
             enable_caching: Whether or not to enable caching for the
                 run. If not set, defaults to the compile time settings, which
-                are True for all tasks by default, while users may specify
+                is ``True`` for all tasks by default, while users may specify
                 different caching options for individual tasks. If set, the
                 setting applies to all tasks in the pipeline (overrides the
                 compile time settings).
-            pipeline_root: The root path of the pipeline outputs.
+            pipeline_root: Root path of the pipeline outputs.
 
         Returns:
             A JobConfig object with attributes .spec and .resource_reference.
@@ -1040,23 +1030,23 @@ class Client:
         experiment, then submits the pipeline for execution.
 
         Args:
-            pipeline_func: A pipeline function.
+            pipeline_func: Pipeline function constructed with ``@kfp.dsl.pipeline`` decorator.
             arguments: Arguments to the pipeline function provided as a dict.
             run_name: Name of the run to be shown in the UI.
             experiment_name: Name of the experiment to add the run to.
-            namespace: The Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as None.
-            pipeline_root: The root path of the pipeline outputs.
+            namespace: Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as ``None``.
+            pipeline_root: Root path of the pipeline outputs.
             enable_caching: Whether or not to enable caching for the
                 run. If not set, defaults to the compile time settings, which
-                are True for all tasks by default, while users may specify
+                is ``True`` for all tasks by default, while users may specify
                 different caching options for individual tasks. If set, the
                 setting applies to all tasks in the pipeline (overrides the
                 compile time settings).
             service_account: Specifies which Kubernetes service
-                account this run uses.
+                account to use for this run.
 
         Returns:
-            RunPipelineResult object containing information about the pipeline run.
+            ``RunPipelineResult`` object containing information about the pipeline run.
         """
         #TODO: Check arguments against the pipeline function
         pipeline_name = pipeline_func.__name__
@@ -1095,26 +1085,26 @@ class Client:
         """Runs pipeline on KFP-enabled Kubernetes cluster.
 
         This command takes a local pipeline package, creates or gets an
-        experiment and submits the pipeline for execution.
+        experiment, then submits the pipeline for execution.
 
         Args:
             pipeline_file: A compiled pipeline package file.
             arguments: Arguments to the pipeline function provided as a dict.
             run_name:  Name of the run to be shown in the UI.
             experiment_name: Name of the experiment to add the run to.
-            namespace: The Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as None.
-            pipeline_root: The root path of the pipeline outputs.
+            namespace: Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as ``None``.
+            pipeline_root: Root path of the pipeline outputs.
             enable_caching: Whether or not to enable caching for the
                 run. If not set, defaults to the compile time settings, which
-                are True for all tasks by default, while users may specify
+                is ``True`` for all tasks by default, while users may specify
                 different caching options for individual tasks. If set, the
                 setting applies to all tasks in the pipeline (overrides the
                 compile time settings).
             service_account: Specifies which Kubernetes service
-                account this run uses.
+                account to use for this run.
 
         Returns:
-            RunPipelineResult object containing information about the pipeline run.
+            ``RunPipelineResult`` object containing information about the pipeline run.
         """
 
         #TODO: Check arguments against the pipeline function
@@ -1185,22 +1175,19 @@ class Client:
             experiment_id: Optional[str] = None,
             namespace: Optional[str] = None,
             filter: Optional[str] = None) -> kfp_server_api.ApiListRunsResponse:
-        """List runs, optionally can be filtered by experiment or namespace.
+        """List runs.
 
         Args:
-            page_token: Token for starting of the page.
+            page_token: Page token for obtaining page from paginated response.
             page_size: Size of the page.
-            sort_by: One of 'field_name', 'field_name desc'. For example,
-                'name desc'.
+            sort_by: Sort string of format ``'[field_name]', '[field_name] desc'``. For example, ``'name desc'``.
             experiment_id: Experiment ID to filter upon
-            namespace: The Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as None.
+            namespace: Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as ``None``.
             filter: A url-encoded, JSON-serialized Filter protocol buffer
-                (see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto)).
+                (see `filter.proto message <https://github.com/kubeflow/pipelines/blob/777c98153daf3dfae82730e14ff37bdddc334c4d/backend/api/filter.proto>`_). For a list of all filter operations ``'op'``, see `here <https://github.com/kubeflow/pipelines/blob/777c98153daf3dfae82730e14ff37bdddc334c4d/sdk/python/kfp/client/client.py#L37-L45>`_. Example:
 
-                An example filter string would be:
+                  ::
 
-                    # For the list of filter operations please see:
-                    # https://github.com/kubeflow/pipelines/blob/master/sdk/python/kfp/_client.py#L40
                     json.dumps({
                         "predicates": [{
                             "op": _FILTER_OPERATIONS["EQUALS"],
@@ -1210,7 +1197,7 @@ class Client:
                     })
 
           Returns:
-            ApiListRunsResponse object.
+            ``ApiListRunsResponse`` object.
         """
         namespace = namespace or self.get_user_namespace()
         if experiment_id is not None:
@@ -1249,18 +1236,15 @@ class Client:
         """Lists recurring runs.
 
         Args:
-            page_token: Token for starting of the page.
+            page_token: Page token for obtaining page from paginated response.
             page_size: Size of the page.
-            sort_by: One of 'field_name', 'field_name desc'. For example,
-                'name desc'.
+            sort_by: Sort string of format ``'[field_name]', '[field_name] desc'``. For example, ``'name desc'``.
             experiment_id: Experiment ID to filter upon.
             filter: A url-encoded, JSON-serialized Filter protocol buffer
-                (see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto)).
+                (see `filter.proto message <https://github.com/kubeflow/pipelines/blob/777c98153daf3dfae82730e14ff37bdddc334c4d/backend/api/filter.proto>`_). For a list of all filter operations ``'op'``, see `here <https://github.com/kubeflow/pipelines/blob/777c98153daf3dfae82730e14ff37bdddc334c4d/sdk/python/kfp/client/client.py#L37-L45>`_. Example:
 
-                An example filter string would be:
+                  ::
 
-                    # For the list of filter operations please see:
-                    # https://github.com/kubeflow/pipelines/blob/master/sdk/python/kfp/_client.py#L40
                     json.dumps({
                         "predicates": [{
                             "op": _FILTER_OPERATIONS["EQUALS"],
@@ -1270,7 +1254,7 @@ class Client:
                     })
 
         Returns:
-            ApiListJobsResponse object.
+            ``ApiListJobsResponse`` object.
         """
         if experiment_id is not None:
             response = self._job_api.list_jobs(
@@ -1290,13 +1274,13 @@ class Client:
         return response
 
     def get_recurring_run(self, job_id: str) -> kfp_server_api.ApiJob:
-        """Gets recurring_run details.
+        """Gets recurring run (job) details.
 
         Args:
-            job_id: ID of the recurring_run.
+            job_id: ID of the recurring run (job).
 
         Returns:
-            ApiJob object.
+            ``ApiJob`` object.
         """
         return self._job_api.get_job(id=job_id)
 
@@ -1307,7 +1291,7 @@ class Client:
             run_id: ID of the run.
 
         Returns:
-            ApiRun object.
+            ``ApiRun`` object.
         """
         return self._run_api.get_run(run_id=run_id)
 
@@ -1316,11 +1300,11 @@ class Client:
         """Waits for a run to complete.
 
         Args:
-            run_id: If of the run.
+            run_id: ID of the run.
             timeout: Timeout after which the client should stop waiting for run completion (seconds).
 
         Returns:
-            ApiRun object.
+            ``ApiRun`` object.
         """
         status = 'Running:'
         start_time = datetime.datetime.now()
@@ -1379,7 +1363,7 @@ class Client:
                 the UI.
 
         Returns:
-            ApiPipeline object.
+            ``ApiPipeline`` object.
         """
         if pipeline_name is None:
             pipeline_name = os.path.splitext(
@@ -1413,7 +1397,7 @@ class Client:
             description: Description of the pipeline version to show in the UI.
 
         Returns:
-            ApiPipelineVersion object.
+            ``ApiPipelineVersion`` object.
         """
 
         if all([pipeline_id, pipeline_name
@@ -1446,7 +1430,7 @@ class Client:
             pipeline_id: ID of the pipeline.
 
         Returns:
-            ApiPipeline object.
+            ``ApiPipeline`` object.
         """
         return self._pipelines_api.get_pipeline(id=pipeline_id)
 
@@ -1472,18 +1456,15 @@ class Client:
         """Lists pipeline versions.
 
         Args:
-            pipeline_id: ID of the pipeline to list versions
-            page_token: Token for starting of the page.
+            pipeline_id: ID of the pipeline for which to list versions.
+            page_token: Page token for obtaining page from paginated response.
             page_size: Size of the page.
-            sort_by: One of 'field_name', 'field_name desc'. For example,
-                'name desc'.
+            sort_by: Sort string of format ``'[field_name]', '[field_name] desc'``. For example, ``'name desc'``.
             filter: A url-encoded, JSON-serialized Filter protocol buffer
-                (see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto)).
+                (see `filter.proto message <https://github.com/kubeflow/pipelines/blob/777c98153daf3dfae82730e14ff37bdddc334c4d/backend/api/filter.proto>`_). For a list of all filter operations ``'op'``, see `here <https://github.com/kubeflow/pipelines/blob/777c98153daf3dfae82730e14ff37bdddc334c4d/sdk/python/kfp/client/client.py#L37-L45>`_. Example:
 
-                An example filter string would be:
+                  ::
 
-                    # For the list of filter operations please see:
-                    # https://github.com/kubeflow/pipelines/blob/master/sdk/python/kfp/_client.py#L40
                     json.dumps({
                         "predicates": [{
                             "op": _FILTER_OPERATIONS["EQUALS"],
@@ -1493,7 +1474,7 @@ class Client:
                     })
 
         Returns:
-            ApiListPipelineVersionsResponse object.
+            ``ApiListPipelineVersionsResponse`` object.
         """
 
         return self._pipelines_api.list_pipeline_versions(
@@ -1512,7 +1493,7 @@ class Client:
             version_id: ID of the pipeline version.
 
         Returns:
-            ApiPipelineVersion object.
+            ``ApiPipelineVersion`` object.
         """
         return self._pipelines_api.get_pipeline_version(version_id=version_id)
 
@@ -1564,20 +1545,6 @@ def _add_generated_apis(target_struct: Any, api_module: ModuleType,
             setattr(models_struct, member_name,
                     getattr(api_module.models, member_name))
     target_struct.api_models = models_struct
-
-
-# TODO: merge with maybe_rename_for_k8s or not?
-def _sanitize_k8s_name(name: str) -> str:
-    """Cleans and converts the name for k8s requirements.
-
-    Args:
-        name: The original name.
-
-    Returns:
-        The sanitized name.
-    """
-    return re.sub('-+', '-', re.sub('[^-_0-9A-Za-z]+', '-',
-                                    name)).lstrip('-').rstrip('-')
 
 
 def validate_pipeline_resource_name(name: str) -> None:

--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -23,12 +23,13 @@ import tarfile
 import tempfile
 import time
 from types import ModuleType
-from typing import Any, Callable, List, Mapping, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 import warnings
 import zipfile
 
 from kfp import compiler
 from kfp.client import auth
+from kfp.components import base_component
 import kfp_server_api
 import yaml
 
@@ -79,7 +80,7 @@ class RunPipelineResult:
 
 
 class Client:
-    """The API Client for KubeFlow Pipelines.
+    """The KFP SDK client for the Kubeflow Pipelines backend API.
 
     Args:
         host: The host name to use to talk to Kubeflow Pipelines. If not set,
@@ -89,39 +90,37 @@ class Client:
             Set the host based on
             https://www.kubeflow.org/docs/components/pipelines/sdk/connect-api/
         client_id: The client ID used by Identity-Aware Proxy.
-        namespace: The namespace where the kubeflow pipeline system is run.
+        namespace: The Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as None.
         other_client_id: The client ID used to obtain the auth codes and refresh
             tokens. References:
             https://cloud.google.com/iap/docs/authentication-howto#authenticating_from_a_desktop_app.
         other_client_secret: The client secret used to obtain the auth codes and
             refresh tokens.
-        existing_token: Pass in token directly, it's used for cases better get
-            token outside of SDK, e.x. GCP Cloud Functions or caller already has
-            a token.
+        existing_token: Authentication token to pass in directly. Used in cases where the token is
+            generated from outside the SDK.
         cookies: CookieJar object containing cookies that will be passed to the
-            pipelines API.
+            Pipelines API.
         proxy: HTTP or HTTPS proxy server.
-        ssl_ca_cert: Cert for proxy.
-        kube_context: String name of context within kubeconfig to use, defaults
-            to the current-context set within kubeconfig.
+        ssl_ca_cert: Certification for proxy.
+        kube_context: The kubectl context to use. Must be a context listed in the kubeconfig file. Defaults to the current-context set within kubeconfig.
         credentials: A TokenCredentialsBase object which provides the logic to
             populate the requests with credentials to authenticate against the
             API server.
-        ui_host: Base url to use to open the Kubeflow Pipelines UI. This is used
+        ui_host: Base URL to use to open the Kubeflow Pipelines UI. This is used
             when running the client from a notebook to generate and print links.
-        verify_ssl: Whether to verify the servers TLS certificate or not.
+        verify_ssl: Whether to verify the server's TLS certificate.
     """
 
     # in-cluster DNS name of the pipeline service
-    IN_CLUSTER_DNS_NAME = 'ml-pipeline.{}.svc.cluster.local:8888'
-    KUBE_PROXY_PATH = 'api/v1/namespaces/{}/services/ml-pipeline:http/proxy/'
+    _IN_CLUSTER_DNS_NAME = 'ml-pipeline.{}.svc.cluster.local:8888'
+    _KUBE_PROXY_PATH = 'api/v1/namespaces/{}/services/ml-pipeline:http/proxy/'
 
     # Auto populated path in pods
     # https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
     # https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#serviceaccount-admission-controller
-    NAMESPACE_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
+    _NAMESPACE_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
 
-    LOCAL_KFP_CONTEXT = os.path.expanduser('~/.config/kfp/context.json')
+    _LOCAL_KFP_CONTEXT = os.path.expanduser('~/.config/kfp/context.json')
 
     # TODO: Wrap the configurations for different authentication methods.
     def __init__(
@@ -188,7 +187,7 @@ class Client:
         if not self._context_setting['namespace'] and self.get_kfp_healthz(
         ).multi_user is True:
             try:
-                with open(Client.NAMESPACE_PATH, 'r') as f:
+                with open(Client._NAMESPACE_PATH, 'r') as f:
                     current_namespace = f.read()
                     self.set_user_namespace(current_namespace)
             except FileNotFoundError:
@@ -196,12 +195,19 @@ class Client:
                     'Failed to automatically set namespace.', exc_info=False)
 
     def _load_config(
-            self, host: Optional[str], client_id: Optional[str], namespace: str,
-            other_client_id: Optional[str], other_client_secret: Optional[str],
-            existing_token: Optional[str], proxy: Optional[str],
-            ssl_ca_cert: Optional[str], kube_context: Optional[str],
-            credentials: Optional[str],
-            verify_ssl: Optional[bool]) -> kfp_server_api.Configuration:
+        self,
+        host: Optional[str],
+        client_id: Optional[str],
+        namespace: str,
+        other_client_id: Optional[str],
+        other_client_secret: Optional[str],
+        existing_token: Optional[str],
+        proxy: Optional[str],
+        ssl_ca_cert: Optional[str],
+        kube_context: Optional[str],
+        credentials: Optional[str],
+        verify_ssl: Optional[bool],
+    ) -> kfp_server_api.Configuration:
         config = kfp_server_api.Configuration()
 
         if proxy:
@@ -284,7 +290,7 @@ class Client:
             in_cluster = False
 
         if in_cluster:
-            config.host = Client.IN_CLUSTER_DNS_NAME.format(namespace)
+            config.host = Client._IN_CLUSTER_DNS_NAME.format(namespace)
             config = self._get_config_with_default_credentials(config)
             return config
 
@@ -296,7 +302,7 @@ class Client:
             return config
 
         if config.host:
-            config.host = config.host + '/' + Client.KUBE_PROXY_PATH.format(
+            config.host = config.host + '/' + Client._KUBE_PROXY_PATH.format(
                 namespace)
         return config
 
@@ -335,8 +341,8 @@ class Client:
         return '/pipeline'
 
     def _load_context_setting_or_default(self) -> None:
-        if os.path.exists(Client.LOCAL_KFP_CONTEXT):
-            with open(Client.LOCAL_KFP_CONTEXT, 'r') as f:
+        if os.path.exists(Client._LOCAL_KFP_CONTEXT):
+            with open(Client._LOCAL_KFP_CONTEXT, 'r') as f:
                 self._context_setting = json.load(f)
         else:
             self._context_setting = {
@@ -382,21 +388,18 @@ class Client:
         return config
 
     def set_user_namespace(self, namespace: str) -> None:
-        """Set user namespace into local context setting file.
+        """Sets the namespace in the Kuberenetes cluster to use.
 
         This function should only be used when Kubeflow Pipelines is in the
         multi-user mode.
 
         Args:
-            namespace: kubernetes namespace the user has access to.
-
-        Returns:
-            None
+            namespace: The namespace to use within the Kubernetes cluster containing the Kubeflow Pipelines deployment.
         """
         self._context_setting['namespace'] = namespace
-        if not os.path.exists(os.path.dirname(Client.LOCAL_KFP_CONTEXT)):
-            os.makedirs(os.path.dirname(Client.LOCAL_KFP_CONTEXT))
-        with open(Client.LOCAL_KFP_CONTEXT, 'w') as f:
+        if not os.path.exists(os.path.dirname(Client._LOCAL_KFP_CONTEXT)):
+            os.makedirs(os.path.dirname(Client._LOCAL_KFP_CONTEXT))
+        with open(Client._LOCAL_KFP_CONTEXT, 'w') as f:
             json.dump(self._context_setting, f)
 
     def get_kfp_healthz(self) -> kfp_server_api.ApiGetHealthzResponse:
@@ -440,18 +443,15 @@ class Client:
             name: str,
             description: str = None,
             namespace: str = None) -> kfp_server_api.ApiExperiment:
-        """Create a new experiment.
+        """Creates a new experiment.
 
         Args:
             name: The name of the experiment.
             description: Description of the experiment.
-            namespace: The Kubernetes namespace where the experiment should be
-                created.
-                For single user deployment, leave it as None;
-                For multi user, input a namespace where the user is authorized.
+            namespace: The Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as None.
 
         Returns:
-            kfp_server_api.ApiExperiment: ApiExperiment object.
+            ApiExperiment object.
         """
         namespace = namespace or self.get_user_namespace()
         experiment = None
@@ -488,13 +488,13 @@ class Client:
         return experiment
 
     def get_pipeline_id(self, name) -> Optional[str]:
-        """Find the id of a pipeline by name.
+        """Find the ID of a pipeline by name.
 
         Args:
             name: Pipeline name.
 
         Returns:
-            The pipeline id if a pipeline with the name exists.
+            The pipeline ID if a pipeline with the name exists.
         """
         pipeline_filter = json.dumps({
             'predicates': [{
@@ -529,9 +529,7 @@ class Client:
             page_size: Size of the page.
             sort_by: Can be '[field_name]', '[field_name] desc'. For example,
                 'name desc'.
-            namespace: Kubernetes namespace where the experiment was created.
-                For single user deployment, leave it as None;
-                For multi user, input a namespace where the user is authorized.
+            namespace: The Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as None.
             filter: A url-encoded, JSON-serialized Filter protocol buffer
                 (see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto)).
 
@@ -548,7 +546,7 @@ class Client:
                     })
 
         Returns:
-            kfp_server_api.ApiListExperimentsResponse: ApiListExperimentsResponse object.
+            ApiListExperimentsResponse object.
         """
         namespace = namespace or self.get_user_namespace()
         response = self._experiment_api.list_experiment(
@@ -570,18 +568,12 @@ class Client:
         Either experiment_id or experiment_name is required.
 
         Args:
-            experiment_id (Optional): Id of the experiment.
-            experiment_name (Optional): Name of the experiment.
-            namespace: Kubernetes namespace where the experiment was created.
-                For single user deployment, leave it as None;
-                For multi user, input the namespace where the user is authorized.
+            experiment_id: ID of the experiment.
+            experiment_name: Name of the experiment.
+            namespace: The Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as None.
 
         Returns:
-            kfp_server_api.ApiExperiment: ApiExperiment object.
-
-        Raises:
-            kfp_server_api.ApiException: If experiment is not found or None of
-              the arguments is provided
+            ApiExperiment object.
         """
         namespace = namespace or self.get_user_namespace()
         if experiment_id is None and experiment_name is None:
@@ -617,10 +609,10 @@ class Client:
         """Archives an experiment.
 
         Args:
-            experiment_id: id of the experiment.
+            experiment_id: ID of the experiment.
 
         Returns:
-            dict: Empty dictionary.
+            Empty dictionary.
         """
         return self._experiment_api.archive_experiment(id=experiment_id)
 
@@ -628,10 +620,10 @@ class Client:
         """Unarchives an experiment.
 
         Args:
-            experiment_id: id of the experiment.
+            experiment_id: ID of the experiment.
 
         Returns:
-            dict: Empty dictionary.
+            Empty dictionary.
         """
         return self._experiment_api.unarchive_experiment(id=experiment_id)
 
@@ -639,13 +631,10 @@ class Client:
         """Delete experiment.
 
         Args:
-            experiment_id: id of the experiment.
+            experiment_id: ID of the experiment.
 
         Returns:
-            dict: Empty dictionary.
-
-        Raises:
-            kfp_server_api.ApiException: If experiment is not found.
+            Empty dictionary.
         """
         return self._experiment_api.delete_experiment(id=experiment_id)
 
@@ -694,8 +683,8 @@ class Client:
         """Overrides caching options.
 
         Args:
-            pipeline_obj (dict): Dict object parsed from the yaml file.
-            enable_caching (bool): Overrides options, one of 'True', 'False'.
+            pipeline_obj: Dict object parsed from the yaml file.
+            enable_caching: Overrides options, one of 'True', 'False'.
         """
         for _, task in pipeline_obj['root']['dag']['tasks'].items():
             if 'cachingOptions' in task:
@@ -733,7 +722,7 @@ class Client:
                     })
 
         Returns:
-            kfp_server_api.ApiListPipelinesResponse: ApiListPipelinesResponse object.
+            ApiListPipelinesResponse object.
         """
         return self._pipelines_api.list_pipelines(
             page_token=page_token,
@@ -747,7 +736,7 @@ class Client:
         experiment_id: str,
         job_name: str,
         pipeline_package_path: Optional[str] = None,
-        params: Optional[Mapping[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
         pipeline_id: Optional[str] = None,
         version_id: Optional[str] = None,
         pipeline_root: Optional[str] = None,
@@ -757,31 +746,29 @@ class Client:
         """Runs a specified pipeline.
 
         Args:
-            experiment_id: The id of an experiment.
+            experiment_id: The ID of an experiment.
             job_name: Name of the job.
             pipeline_package_path: Local path of the pipeline package (the
                 filename should end with one of the following .tar.gz, .tgz,
                 .zip, .json).
-            params: A dictionary with key (string) as param name and value
-                (string) as as param value.
-            pipeline_id: The id of a pipeline.
-            version_id: The id of a pipeline version.
+            params: Arguments to the pipeline function provided as a dict.
+            pipeline_id: The ID of the pipeline.
+            version_id: The ID of the pipeline version to run.
                 If both pipeline_id and version_id are specified, version_id
                 will take precendence.
                 If only pipeline_id is specified, the default version of this
                 pipeline is used to create the run.
             pipeline_root: The root path of the pipeline outputs.
-            enable_caching (Optional): . Whether or not to enable caching for the
-                run. If not set, defaults to the compile time settings, which
-                are True for all tasks by default, while users may specify
-                different caching options for individual tasks. If set, the
+            enable_caching: Whether or not to enable caching for the
+                run. If not set, defaults to the compile-time settings, which
+                are True for all tasks by default. If set, the
                 setting applies to all tasks in the pipeline (overrides the
                 compile time settings).
-            service_account (Optional): Specifies which Kubernetes service
-                account this run uses.
+            service_account: Specifies which Kubernetes service
+                account to use for this run.
 
         Returns:
-            kfp_server_api.ApiRun: ApiRun object.
+            ApiRun object.
         """
         if params is None:
             params = {}
@@ -815,10 +802,10 @@ class Client:
         """Archives a run.
 
         Args:
-            run_id: id of the run.
+            run_id: ID of the run.
 
         Returns:
-            dict: Empty dictionary.
+            Empty dictionary.
         """
         return self._run_api.archive_run(id=run_id)
 
@@ -826,10 +813,10 @@ class Client:
         """Restores an archived run.
 
         Args:
-            run_id: id of the run.
+            run_id: ID of the run.
 
         Returns:
-            dict: Empty dictionary.
+            Empty dictionary.
         """
         return self._run_api.unarchive_run(id=run_id)
 
@@ -837,10 +824,10 @@ class Client:
         """Deletes a run.
 
         Args:
-            run_id: id of the run.
+            run_id: ID of the run.
 
         Returns:
-            dict: Empty dictionary.
+            Empty dictionary.
         """
         return self._run_api.delete_run(id=run_id)
 
@@ -848,10 +835,10 @@ class Client:
         """Terminates a run.
 
         Args:
-            run_id: id of the run.
+            run_id: ID of the run.
 
         Returns:
-            dict: Empty dictionary.
+            Empty dictionary.
         """
         return self._run_api.terminate_run(run_id=run_id)
 
@@ -878,9 +865,9 @@ class Client:
         """Creates a recurring run.
 
         Args:
-            experiment_id: The string id of an experiment.
+            experiment_id: ID of the experiment.
             job_name: Name of the job.
-            description (Optional): Job description.
+            description: Description of the job.
             start_time: The RFC3339 time string of the time when to start the
                 job.
             end_time: The RFC3339 time string of the time when to end the job.
@@ -898,13 +885,13 @@ class Client:
                 Otherwise, it only schedules the latest interval if more than
                 one interval is ready to be scheduled. Usually, if your pipeline
                 handles backfill internally, you should turn catchup off to
-                avoid duplicate backfill. (default: {False})
+                avoid duplicate backfill. Defaults to False.
             pipeline_package_path: Local path of the pipeline package (the
                 filename should end with one of the following .tar.gz, .tgz,
                 .zip, .json).
             params: A dictionary with key as param name and value as param value.
-            pipeline_id: The id of a pipeline.
-            version_id: The id of a pipeline version.
+            pipeline_id: The ID of a pipeline.
+            version_id: The ID of a pipeline version.
                 If both pipeline_id and version_id are specified, version_id
                 will take precedence.
                 If only pipeline_id is specified, the default version of this
@@ -912,19 +899,16 @@ class Client:
             enabled: A bool indicating whether the recurring run is enabled or
                 disabled.
             pipeline_root: The root path of the pipeline outputs.
-            enable_caching (Optional): Whether or not to enable caching for the
+            enable_caching: Whether or not to enable caching for the
                 run. If not set, defaults to the compile time settings, which
                 are True for all tasks by default, while users may specify
                 different caching options for individual tasks. If set, the
                 setting applies to all tasks in the pipeline (overrides the
                 compile time settings).
-            service_account (Optional): Specifies which Kubernetes service
+            service_account: Specifies which Kubernetes service
                 account this recurring run uses.
         Returns:
-            kfp_server_api.ApiJob: ApiJob object.
-
-        Raises:
-            ValueError: If required parameters are not supplied.
+            ApiJob object.
         """
 
         job_config = self._create_job_config(
@@ -969,7 +953,7 @@ class Client:
     def _create_job_config(
         self,
         experiment_id: str,
-        params: Optional[Mapping[str, Any]],
+        params: Optional[Dict[str, Any]],
         pipeline_package_path: Optional[str],
         pipeline_id: Optional[str],
         version_id: Optional[str],
@@ -979,17 +963,17 @@ class Client:
         """Creates a JobConfig with spec and resource_references.
 
         Args:
-            experiment_id: The id of an experiment.
+            experiment_id: The ID of an experiment.
             pipeline_package_path: Local path of the pipeline package (the
                 filename should end with one of the following .tar.gz, .tgz,
                 .zip, .yaml, .yml).
             params: A dictionary with key as param name and value as param value.
-            pipeline_id: The id of a pipeline.
-            version_id: The id of a pipeline version.
+            pipeline_id: The ID of a pipeline.
+            version_id: The ID of a pipeline version.
                 If both pipeline_id and version_id are specified, version_id
                 will take precedence. If only pipeline_id is specified, the
                 default version of this pipeline is used to create the run.
-            enable_caching (Optional): Whether or not to enable caching for the
+            enable_caching: Whether or not to enable caching for the
                 run. If not set, defaults to the compile time settings, which
                 are True for all tasks by default, while users may specify
                 different caching options for individual tasks. If set, the
@@ -998,7 +982,7 @@ class Client:
             pipeline_root: The root path of the pipeline outputs.
 
         Returns:
-            JobConfig: A JobConfig object with attributes .spec and .resource_reference.
+            A JobConfig object with attributes .spec and .resource_reference.
         """
 
         params = params or {}
@@ -1041,8 +1025,8 @@ class Client:
 
     def create_run_from_pipeline_func(
         self,
-        pipeline_func: Callable,
-        arguments: Optional[Mapping[str, Any]] = None,
+        pipeline_func: Union[Callable[..., Any], base_component.BaseComponent],
+        arguments: Optional[Dict[str, Any]] = None,
         run_name: Optional[str] = None,
         experiment_name: Optional[str] = None,
         namespace: Optional[str] = None,
@@ -1053,29 +1037,26 @@ class Client:
         """Runs pipeline on KFP-enabled Kubernetes cluster.
 
         This command compiles the pipeline function, creates or gets an
-        experiment and submits the pipeline for execution.
+        experiment, then submits the pipeline for execution.
 
         Args:
-            pipeline_func: A function that describes a pipeline by calling
-                components and composing them into execution graph.
+            pipeline_func: A pipeline function.
             arguments: Arguments to the pipeline function provided as a dict.
-            run_name (Optional): Name of the run to be shown in the UI.
-            experiment_name (Optional): Name of the experiment to add the run to.
-            namespace: Kubernetes namespace where the pipeline runs are created.
-                For single user deployment, leave it as None;
-                For multi user, input a namespace where the user is authorized
+            run_name: Name of the run to be shown in the UI.
+            experiment_name: Name of the experiment to add the run to.
+            namespace: The Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as None.
             pipeline_root: The root path of the pipeline outputs.
-            enable_caching (Optional): Whether or not to enable caching for the
+            enable_caching: Whether or not to enable caching for the
                 run. If not set, defaults to the compile time settings, which
                 are True for all tasks by default, while users may specify
                 different caching options for individual tasks. If set, the
                 setting applies to all tasks in the pipeline (overrides the
                 compile time settings).
-            service_account (Optional): Specifies which Kubernetes service
+            service_account: Specifies which Kubernetes service
                 account this run uses.
 
         Returns:
-            RunPipelineResult: RunPipelineResult object containing information about the pipeline run.
+            RunPipelineResult object containing information about the pipeline run.
         """
         #TODO: Check arguments against the pipeline function
         pipeline_name = pipeline_func.__name__
@@ -1103,7 +1084,7 @@ class Client:
     def create_run_from_pipeline_package(
         self,
         pipeline_file: str,
-        arguments: Optional[Mapping[str, str]] = None,
+        arguments: Optional[Dict[str, str]] = None,
         run_name: Optional[str] = None,
         experiment_name: Optional[str] = None,
         namespace: Optional[str] = None,
@@ -1119,23 +1100,21 @@ class Client:
         Args:
             pipeline_file: A compiled pipeline package file.
             arguments: Arguments to the pipeline function provided as a dict.
-            run_name (Optional):  Name of the run to be shown in the UI.
-            experiment_name (Optional): Name of the experiment to add the run to.
-            namespace (Optional): Kubernetes namespace where the pipeline runs are created.
-              For single user deployment, leave it as None;
-              For multi user, input a namespace where the user is authorized
-            pipeline_root (Optional): The root path of the pipeline outputs.
-            enable_caching (Optional): Whether or not to enable caching for the
+            run_name:  Name of the run to be shown in the UI.
+            experiment_name: Name of the experiment to add the run to.
+            namespace: The Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as None.
+            pipeline_root: The root path of the pipeline outputs.
+            enable_caching: Whether or not to enable caching for the
                 run. If not set, defaults to the compile time settings, which
                 are True for all tasks by default, while users may specify
                 different caching options for individual tasks. If set, the
                 setting applies to all tasks in the pipeline (overrides the
                 compile time settings).
-            service_account (Optional): Specifies which Kubernetes service
+            service_account: Specifies which Kubernetes service
                 account this run uses.
 
         Returns:
-            RunPipelineResult: RunPipelineResult object containing information about the pipeline run.
+            RunPipelineResult object containing information about the pipeline run.
         """
 
         #TODO: Check arguments against the pipeline function
@@ -1166,44 +1145,35 @@ class Client:
         return RunPipelineResult(self, run_info)
 
     def delete_job(self, job_id: str) -> dict:
-        """Deletes a job.
+        """Deletes a job (recurring run).
 
         Args:
-            job_id: id of the job.
+            job_id: ID of the job.
 
         Returns:
-            dict: Empty dictionary.
-
-        Raises:
-            kfp_server_api.ApiException: If the job is not found.
+            Empty dictionary.
         """
         return self._job_api.delete_job(id=job_id)
 
     def disable_job(self, job_id: str) -> dict:
-        """Disables a job.
+        """Disables a job (recurring run).
 
         Args:
-            job_id: id of the job.
+            job_id: ID of the job.
 
         Returns:
-            dict: Empty dictionary.
-
-        Raises:
-            kfp_server_api.ApiException: If the job is not found.
+            Empty dictionary.
         """
         return self._job_api.disable_job(id=job_id)
 
     def enable_job(self, job_id: str) -> dict:
-        """Enables a job.
+        """Enables a job (recurring run).
 
         Args:
-            job_id: id of the job.
+            job_id: ID of the job.
 
         Returns:
-            dict: Empty dictionary.
-
-        Raises:
-            kfp_server_api.ApiException: If the job is not found.
+            Empty dictionary.
         """
         return self._job_api.enable_job(id=job_id)
 
@@ -1222,10 +1192,8 @@ class Client:
             page_size: Size of the page.
             sort_by: One of 'field_name', 'field_name desc'. For example,
                 'name desc'.
-            experiment_id: Experiment id to filter upon
-            namespace: Kubernetes namespace to filter upon.
-                For single user deployment, leave it as None;
-                For multi user, input a namespace where the user is authorized.
+            experiment_id: Experiment ID to filter upon
+            namespace: The Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as None.
             filter: A url-encoded, JSON-serialized Filter protocol buffer
                 (see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto)).
 
@@ -1242,7 +1210,7 @@ class Client:
                     })
 
           Returns:
-              kfp_server_api.ApiListRunsResponse: ApiListRunsResponse object.
+            ApiListRunsResponse object.
         """
         namespace = namespace or self.get_user_namespace()
         if experiment_id is not None:
@@ -1285,7 +1253,7 @@ class Client:
             page_size: Size of the page.
             sort_by: One of 'field_name', 'field_name desc'. For example,
                 'name desc'.
-            experiment_id: Experiment id to filter upon.
+            experiment_id: Experiment ID to filter upon.
             filter: A url-encoded, JSON-serialized Filter protocol buffer
                 (see [filter.proto](https://github.com/kubeflow/pipelines/blob/master/backend/api/filter.proto)).
 
@@ -1302,7 +1270,7 @@ class Client:
                     })
 
         Returns:
-            kfp_server_api.ApiListJobsResponse: ApiListJobsResponse object.
+            ApiListJobsResponse object.
         """
         if experiment_id is not None:
             response = self._job_api.list_jobs(
@@ -1325,13 +1293,10 @@ class Client:
         """Gets recurring_run details.
 
         Args:
-            job_id: id of the recurring_run.
+            job_id: ID of the recurring_run.
 
         Returns:
-            kfp_server_api.ApiJob: ApiJob object.
-
-        Raises:
-            kfp_server_api.ApiException: If recurring_run is not found.
+            ApiJob object.
         """
         return self._job_api.get_job(id=job_id)
 
@@ -1339,13 +1304,10 @@ class Client:
         """Gets run details.
 
         Args:
-            run_id: id of the run.
+            run_id: ID of the run.
 
         Returns:
-            kfp_server_api.ApiRun: ApiRun object.
-
-        Raises:
-            kfp_server_api.ApiException: If run is not found.
+            ApiRun object.
         """
         return self._run_api.get_run(run_id=run_id)
 
@@ -1354,15 +1316,11 @@ class Client:
         """Waits for a run to complete.
 
         Args:
-            run_id: Run id, returned from run_pipeline.
-            timeout: Timeout in seconds.
+            run_id: If of the run.
+            timeout: Timeout after which the client should stop waiting for run completion (seconds).
 
         Returns:
-            kfp_server_api.ApiRun: ApiRun object.
-
-        Raises:
-            TimeoutError: if the pipeline run failed to finish before the
-                specified timeout.
+            ApiRun object.
         """
         status = 'Running:'
         start_time = datetime.datetime.now()
@@ -1412,16 +1370,16 @@ class Client:
         pipeline_name: str = None,
         description: str = None,
     ) -> kfp_server_api.ApiPipeline:
-        """Uploads the pipeline to the Kubeflow Pipelines cluster.
+        """Uploads a pipeline.
 
         Args:
             pipeline_package_path: Local path to the pipeline package.
-            pipeline_name (Optional): Name of the pipeline to be shown in the UI.
-            description (Optional): Description of the pipeline to be shown in
+            pipeline_name: Name of the pipeline to be shown in the UI.
+            description: Description of the pipeline to be shown in
                 the UI.
 
         Returns:
-            kfp_server_api.ApiPipeline: ApiPipeline object.
+            ApiPipeline object.
         """
         if pipeline_name is None:
             pipeline_name = os.path.splitext(
@@ -1444,24 +1402,18 @@ class Client:
         pipeline_name: Optional[str] = None,
         description: Optional[str] = None,
     ) -> kfp_server_api.ApiPipelineVersion:
-        """Uploads a new version of the pipeline to the KFP cluster.
+        """Uploads a new version of the pipeline.
 
         Args:
             pipeline_package_path: Local path to the pipeline package.
             pipeline_version_name:  Name of the pipeline version to be shown in
                 the UI.
-            pipeline_id (Optional): Id of the pipeline.
-            pipeline_name (Optional): Name of the pipeline.
-            description (Optional): Description of the pipeline version to be
-                shown in the UI.
+            pipeline_id: ID of the pipeline.
+            pipeline_name: Name of the pipeline.
+            description: Description of the pipeline version to show in the UI.
 
         Returns:
-            kfp_server_api.ApiPipelineVersion: ApiPipelineVersion object.
-
-        Raises:
-            ValueError: when none or both of pipeline_id or pipeline_name are
-                specified.
-            kfp_server_api.ApiException: If pipeline id is not found.
+            ApiPipelineVersion object.
         """
 
         if all([pipeline_id, pipeline_name
@@ -1491,13 +1443,10 @@ class Client:
         """Gets pipeline details.
 
         Args:
-            pipeline_id: id of the pipeline.
+            pipeline_id: ID of the pipeline.
 
         Returns:
-            kfp_server_api.ApiPipeline: ApiPipeline object.
-
-        Raises:
-            kfp_server_api.ApiException: If pipeline is not found.
+            ApiPipeline object.
         """
         return self._pipelines_api.get_pipeline(id=pipeline_id)
 
@@ -1505,13 +1454,10 @@ class Client:
         """Deletes a pipeline.
 
         Args:
-            pipeline_id: id of the pipeline.
+            pipeline_id: ID of the pipeline.
 
         Returns:
-            dict: Empty dictionary.
-
-        Raises:
-            kfp_server_api.ApiException: If pipeline is not found.
+            Empty dictionary.
         """
         return self._pipelines_api.delete_pipeline(id=pipeline_id)
 
@@ -1526,7 +1472,7 @@ class Client:
         """Lists pipeline versions.
 
         Args:
-            pipeline_id: Id of the pipeline to list versions
+            pipeline_id: ID of the pipeline to list versions
             page_token: Token for starting of the page.
             page_size: Size of the page.
             sort_by: One of 'field_name', 'field_name desc'. For example,
@@ -1547,10 +1493,7 @@ class Client:
                     })
 
         Returns:
-            kfp_server_api.ApiListPipelineVersionsResponse: ApiListPipelineVersionsResponse object.
-
-        Raises:
-            kfp_server_api.ApiException: If pipeline is not found.
+            ApiListPipelineVersionsResponse object.
         """
 
         return self._pipelines_api.list_pipeline_versions(
@@ -1566,13 +1509,10 @@ class Client:
         """Gets a pipeline version.
 
         Args:
-            version_id: id of the pipeline version.
+            version_id: ID of the pipeline version.
 
         Returns:
-            kfp_server_api.ApiPipelineVersion: ApiPipelineVersion object.
-
-        Raises:
-            kfp_server_api.ApiException: If pipeline version is not found.
+            ApiPipelineVersion object.
         """
         return self._pipelines_api.get_pipeline_version(version_id=version_id)
 
@@ -1580,13 +1520,10 @@ class Client:
         """Deletes a pipeline version.
 
         Args:
-            version_id: id of the pipeline version.
+            version_id: ID of the pipeline version.
 
         Returns:
-            dict: Empty dictionary.
-
-        Raises:
-            kfp_server_api.ApiException: If pipeline is not found.
+            Empty dictionary.
         """
         return self._pipelines_api.delete_pipeline_version(
             version_id=version_id)

--- a/sdk/python/kfp/compiler/__init__.py
+++ b/sdk/python/kfp/compiler/__init__.py
@@ -1,3 +1,5 @@
+"""The `kfp.compiler` module contains the compiler for compiling pipeline
+definitions."""
 # Copyright 2020 The Kubeflow Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -43,14 +43,10 @@ import yaml
 
 
 class Compiler:
-    """Experimental DSL compiler that targets the PipelineSpec IR.
+    """Compiles pipelines composed using the KFP SDK DSL to PipelineSpec IR,
+    the protobuf message that defines a pipeline.
 
-    It compiles pipeline function into PipelineSpec json string.
-    PipelineSpec is the IR protobuf message that defines a pipeline:
-    https://github.com/kubeflow/pipelines/blob/237795539f7b85bac77435e2464367226ee19391/api/v2alpha1/pipeline_spec.proto#L8
-    In this initial implementation, we only support components authored through
-    Component yaml spec. And we don't support advanced features like conditions,
-    static and dynamic loops, etc.
+    PipelineSpec IR definition: https://github.com/kubeflow/pipelines/blob/2060e38c5591806d657d85b53eed2eef2e5de2ae/api/v2alpha1/pipeline_spec.proto#L50
 
     Example::
 
@@ -58,12 +54,12 @@ class Compiler:
           name='name',
           description='description',
         )
-        def my_pipeline(a: int = 1, b: str = "default value"):
+        def my_pipeline(a: int = 1, b: str = 'default value'):
             ...
 
         kfp.compiler.Compiler().compile(
             pipeline_func=my_pipeline,
-            package_path='path/to/pipeline.json',
+            package_path='path/to/pipeline.yaml',
         )
     """
 
@@ -72,20 +68,17 @@ class Compiler:
         pipeline_func: Union[Callable[..., Any], base_component.BaseComponent],
         package_path: str,
         pipeline_name: Optional[str] = None,
-        pipeline_parameters: Optional[Mapping[str, Any]] = None,
+        pipeline_parameters: Optional[Dict[str, Any]] = None,
         type_check: bool = True,
     ) -> None:
-        """Compile the given pipeline function or component into pipeline job
-        json.
+        """Compiles the pipeline or component function into IR YAML.
 
         Args:
-            pipeline_func: Pipeline function with @dsl.pipeline or component with @dsl.component decorator.
-            package_path: The output pipeline spec .yaml file path. For example, "~/pipeline.yaml" or "~/component.yaml".
-            pipeline_name: Optional; the name of the pipeline.
-            pipeline_parameters: Optional; the mapping from parameter names to
-                values.
-            type_check: Optional; whether to enable the type check or not.
-                Default is True.
+            pipeline_func: Pipeline function constructed with the @dsl.pipeline or component with @dsl.component decorator.
+            package_path: The output pipeline spec .yaml file path. For example, '~/my_pipeline.yaml' or '~/my_component.yaml'.
+            pipeline_name: The name of the pipeline. Defaults to None.
+            pipeline_parameters: Map of parameter names to argument values. Defaults to None.
+            type_check: Whether to enable type checking of component interfaces during compilation. Defaults to True.
         """
 
         with type_utils.TypeCheckManager(enable=type_check):

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -32,6 +32,7 @@ from kfp.compiler.pipeline_spec_builder import GroupOrTaskType
 from kfp.components import base_component
 from kfp.components import component_factory
 from kfp.components import for_loop
+from kfp.components import pipeline_channel
 from kfp.components import pipeline_context
 from kfp.components import pipeline_task
 from kfp.components import structures
@@ -43,23 +44,24 @@ import yaml
 
 
 class Compiler:
-    """Compiles pipelines composed using the KFP SDK DSL to PipelineSpec IR,
-    the protobuf message that defines a pipeline.
+    """Compiles pipelines composed using the KFP SDK DSL to a YAML pipeline
+    definition.
 
-    PipelineSpec IR definition: https://github.com/kubeflow/pipelines/blob/2060e38c5591806d657d85b53eed2eef2e5de2ae/api/v2alpha1/pipeline_spec.proto#L50
+    The pipeline definition is `PipelineSpec IR <https://github.com/kubeflow/pipelines/blob/2060e38c5591806d657d85b53eed2eef2e5de2ae/api/v2alpha1/pipeline_spec.proto#L50>`_, the protobuf message that defines a pipeline.
 
-    Example::
+    Example:
+      ::
 
         @dsl.pipeline(
           name='name',
-          description='description',
         )
-        def my_pipeline(a: int = 1, b: str = 'default value'):
+        def my_pipeline(a: int, b: str = 'default value'):
             ...
 
         kfp.compiler.Compiler().compile(
             pipeline_func=my_pipeline,
             package_path='path/to/pipeline.yaml',
+            pipeline_parameters={'a': 1},
         )
     """
 
@@ -74,11 +76,11 @@ class Compiler:
         """Compiles the pipeline or component function into IR YAML.
 
         Args:
-            pipeline_func: Pipeline function constructed with the @dsl.pipeline or component with @dsl.component decorator.
-            package_path: The output pipeline spec .yaml file path. For example, '~/my_pipeline.yaml' or '~/my_component.yaml'.
-            pipeline_name: The name of the pipeline. Defaults to None.
-            pipeline_parameters: Map of parameter names to argument values. Defaults to None.
-            type_check: Whether to enable type checking of component interfaces during compilation. Defaults to True.
+            pipeline_func: Pipeline function constructed with the ``@dsl.pipeline`` or component constructed with the ``@dsl.component`` decorator.
+            package_path: Output YAML file path. For example, ``'~/my_pipeline.yaml'`` or ``'~/my_component.yaml'``.
+            pipeline_name: Name of the pipeline.
+            pipeline_parameters: Map of parameter names to argument values.
+            type_check: Whether to enable type checking of component interfaces during compilation.
         """
 
         with type_utils.TypeCheckManager(enable=type_check):
@@ -141,7 +143,7 @@ class Compiler:
                     builder.make_invalid_input_type_error_msg(
                         arg_name, arg_type))
             args_list.append(
-                dsl.PipelineParameterChannel(
+                pipeline_channel.PipelineParameterChannel(
                     name=arg_name, channel_type=arg_type))
 
         with pipeline_context.Pipeline(pipeline_name) as dsl_pipeline:
@@ -165,7 +167,7 @@ class Compiler:
 
         # Fill in the default values.
         args_list_with_defaults = [
-            dsl.PipelineParameterChannel(
+            pipeline_channel.PipelineParameterChannel(
                 name=input_name,
                 channel_type=input_spec.type,
                 value=pipeline_parameters_override.get(input_name) or
@@ -210,7 +212,7 @@ class Compiler:
                 raise TypeError(
                     builder.make_invalid_input_type_error_msg(
                         arg_name, arg_type))
-            args_dict[arg_name] = dsl.PipelineParameterChannel(
+            args_dict[arg_name] = pipeline_channel.PipelineParameterChannel(
                 name=arg_name, channel_type=arg_type)
 
         task = pipeline_task.PipelineTask(component_spec, args_dict)
@@ -225,7 +227,7 @@ class Compiler:
 
         # Fill in the default values.
         args_list_with_defaults = [
-            dsl.PipelineParameterChannel(
+            pipeline_channel.PipelineParameterChannel(
                 name=input_name,
                 channel_type=input_spec.type,
                 value=input_spec.default,
@@ -280,7 +282,7 @@ class Compiler:
 
     def _create_pipeline_spec(
         self,
-        pipeline_args: List[dsl.PipelineChannel],
+        pipeline_args: List[pipeline_channel.PipelineChannel],
         pipeline: pipeline_context.Pipeline,
     ) -> pipeline_spec_pb2.PipelineSpec:
         """Creates a pipeline spec object.
@@ -429,7 +431,7 @@ class Compiler:
     def _get_condition_channels_for_tasks(
         self,
         root_group: tasks_group.TasksGroup,
-    ) -> Mapping[str, Set[dsl.PipelineChannel]]:
+    ) -> Mapping[str, Set[pipeline_channel.PipelineChannel]]:
         """Gets channels referenced in conditions of tasks' parents.
 
         Args:
@@ -450,11 +452,11 @@ class Compiler:
                 new_current_conditions_channels = list(
                     current_conditions_channels)
                 if isinstance(group.condition.left_operand,
-                              dsl.PipelineChannel):
+                              pipeline_channel.PipelineChannel):
                     new_current_conditions_channels.append(
                         group.condition.left_operand)
                 if isinstance(group.condition.right_operand,
-                              dsl.PipelineChannel):
+                              pipeline_channel.PipelineChannel):
                     new_current_conditions_channels.append(
                         group.condition.right_operand)
             for task in group.tasks:
@@ -470,13 +472,14 @@ class Compiler:
     def _get_inputs_for_all_groups(
         self,
         pipeline: pipeline_context.Pipeline,
-        pipeline_args: List[dsl.PipelineChannel],
+        pipeline_args: List[pipeline_channel.PipelineChannel],
         root_group: tasks_group.TasksGroup,
         task_name_to_parent_groups: Mapping[str, List[GroupOrTaskType]],
         group_name_to_parent_groups: Mapping[str, List[tasks_group.TasksGroup]],
-        condition_channels: Mapping[str, Set[dsl.PipelineParameterChannel]],
+        condition_channels: Mapping[
+            str, Set[pipeline_channel.PipelineParameterChannel]],
         name_to_for_loop_group: Mapping[str, dsl.ParallelFor],
-    ) -> Mapping[str, List[Tuple[dsl.PipelineChannel, str]]]:
+    ) -> Mapping[str, List[Tuple[pipeline_channel.PipelineChannel, str]]]:
         """Get inputs and outputs of each group and op.
 
         Args:
@@ -560,7 +563,7 @@ class Compiler:
                     else:
                         channel_to_add = channel_to_add.items_or_pipeline_channel
 
-                if isinstance(channel_to_add, dsl.PipelineChannel):
+                if isinstance(channel_to_add, pipeline_channel.PipelineChannel):
                     channels_to_add.append(channel_to_add)
 
                 if channel.task_name:
@@ -703,7 +706,7 @@ class Compiler:
         task_name_to_parent_groups: Mapping[str, List[GroupOrTaskType]],
         group_name_to_parent_groups: Mapping[str, List[tasks_group.TasksGroup]],
         group_name_to_group: Mapping[str, tasks_group.TasksGroup],
-        condition_channels: Dict[str, dsl.PipelineChannel],
+        condition_channels: Dict[str, pipeline_channel.PipelineChannel],
     ) -> Mapping[str, List[GroupOrTaskType]]:
         """Gets dependent groups and tasks for all tasks and groups.
 

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -122,18 +122,18 @@ def build_task_spec_for_task(
     """
     pipeline_task_spec = pipeline_spec_pb2.PipelineTaskSpec()
     pipeline_task_spec.task_info.name = (
-        task.task_spec.display_name or task.name)
+        task._task_spec.display_name or task.name)
     # Use task.name for component_ref.name because we may customize component
     # spec for individual tasks to work around the lack of optional inputs
     # support in IR.
     pipeline_task_spec.component_ref.name = (
         component_utils.sanitize_component_name(task.name))
     pipeline_task_spec.caching_options.enable_cache = (
-        task.task_spec.enable_caching)
+        task._task_spec.enable_caching)
 
-    if task.task_spec.retry_policy is not None:
+    if task._task_spec.retry_policy is not None:
         pipeline_task_spec.retry_policy.CopyFrom(
-            task.task_spec.retry_policy.to_proto())
+            task._task_spec.retry_policy.to_proto())
 
     for input_name, input_value in task.inputs.items():
         if isinstance(input_value, pipeline_channel.PipelineArtifactChannel):
@@ -975,7 +975,7 @@ def build_spec_by_group(
     pipeline_spec: pipeline_spec_pb2.PipelineSpec,
     deployment_config: pipeline_spec_pb2.PipelineDeploymentConfig,
     group: tasks_group.TasksGroup,
-    inputs: Mapping[str, List[Tuple[dsl.PipelineChannel, str]]],
+    inputs: Mapping[str, List[Tuple[pipeline_channel.PipelineChannel, str]]],
     dependencies: Dict[str, List[GroupOrTaskType]],
     rootgroup_name: str,
     task_name_to_parent_groups: Mapping[str, List[GroupOrTaskType]],
@@ -1127,7 +1127,7 @@ def build_spec_by_group(
                     subgroup.condition.left_operand,
                     subgroup.condition.right_operand,
             ]:
-                if isinstance(operand, dsl.PipelineChannel):
+                if isinstance(operand, pipeline_channel.PipelineChannel):
                     condition_subgroup_channels.append(operand)
 
             subgroup_component_spec = builder.build_component_spec_for_group(
@@ -1269,7 +1269,8 @@ def validate_pipeline_name(name: str) -> None:
 
 
 def create_pipeline_spec_for_component(
-        pipeline_name: str, pipeline_args: List[dsl.PipelineChannel],
+        pipeline_name: str,
+        pipeline_args: List[pipeline_channel.PipelineChannel],
         task_group: tasks_group.TasksGroup) -> pipeline_spec_pb2.PipelineSpec:
     """Creates a pipeline spec object for a component (single-component
     pipeline).

--- a/sdk/python/kfp/components/__init__.py
+++ b/sdk/python/kfp/components/__init__.py
@@ -1,3 +1,5 @@
+"""The `kfp.components` module contains functions for loading components from
+compiled YAML."""
 # Copyright 2021 The Kubeflow Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sdk/python/kfp/components/__init__.py
+++ b/sdk/python/kfp/components/__init__.py
@@ -18,8 +18,14 @@ __all__ = [
     'load_component_from_text',
     'load_component_from_file',
     'load_component_from_url',
+    'PythonComponent',
+    'BaseComponent',
+    'YamlComponent',
 ]
 
+from kfp.components.base_component import BaseComponent
+from kfp.components.python_component import PythonComponent
 from kfp.components.yaml_component import load_component_from_file
 from kfp.components.yaml_component import load_component_from_text
 from kfp.components.yaml_component import load_component_from_url
+from kfp.components.yaml_component import YamlComponent

--- a/sdk/python/kfp/components/base_component.py
+++ b/sdk/python/kfp/components/base_component.py
@@ -21,13 +21,13 @@ from kfp.components.types import type_utils
 
 
 class BaseComponent(abc.ABC):
-    """**Note:** ``BaseComponent`` is not intended to be used to construct components directly. Use ``@kfp.dsl.component`` or ``kfp.components.load_component_from_*()`` instead.
+    """Base class for a component.
 
-    Base class for a component.
+    **Note:** ``BaseComponent`` is not intended to be used to construct components directly. Use ``@kfp.dsl.component`` or ``kfp.components.load_component_from_*()`` instead.
 
     Attributes:
-      name: The name of the component.
-      component_spec: The component definition.
+      name: Name of the component.
+      component_spec: Component definition.
     """
 
     def __init__(self, component_spec: structures.ComponentSpec):
@@ -95,11 +95,5 @@ class BaseComponent(abc.ABC):
 
     @abc.abstractmethod
     def execute(self, **kwargs):
-        """Executes the component given the required inputs.
-
-        Subclasses of BaseComponent must override this abstract method
-        in order to be instantiated. For Python function-based
-        component, the implementation of this method could be calling
-        the function. For "Bring your own container" component, the
-        implementation of this method could be `docker run`.
-        """
+        """Executes the component locally if implemented by the inheriting
+        subclass."""

--- a/sdk/python/kfp/components/base_component.py
+++ b/sdk/python/kfp/components/base_component.py
@@ -20,8 +20,10 @@ from kfp.components import structures
 from kfp.components.types import type_utils
 
 
-class BaseComponent(metaclass=abc.ABCMeta):
-    """Base class for a component.
+class BaseComponent(abc.ABC):
+    """**Note:** ``BaseComponent`` is not intended to be used to construct components directly. Use ``@kfp.dsl.component`` or ``kfp.components.load_component_from_*()`` instead.
+
+    Base class for a component.
 
     Attributes:
       name: The name of the component.

--- a/sdk/python/kfp/components/component_decorator.py
+++ b/sdk/python/kfp/components/component_decorator.py
@@ -28,10 +28,10 @@ def component(func: Optional[Callable] = None,
               output_component_file: Optional[str] = None,
               install_kfp_package: bool = True,
               kfp_package_path: Optional[str] = None):
-    """Decorator for Python-function based components in KFP v2.
+    """Decorator for Python-function based components.
 
-    A KFP v2 component can either be a lightweight component, or a containerized
-    one.
+    A KFP component can either be a lightweight component or a containerized
+    component.
 
     If target_image is not specified, this function creates a lightweight
     component. A lightweight component is a self-contained Python function that
@@ -42,36 +42,37 @@ def component(func: Optional[Callable] = None,
 
     If target_image is specified, this function creates a component definition
     based around the target_image. The assumption is that the function in func
-    will be packaged by KFP into this target_image. Use the KFP CLI's `build`
+    will be packaged by KFP into this target_image. Use the KFP CLI's ``build``
     command to package func into target_image.
 
-    Example usage:
+    Example::
 
-    from kfp import dsl
-    @dsl.component
-    def my_function_one(input: str, output: Output[Model]):
-      ...
+        from kfp import dsl
 
-    @dsl.component(
-      base_image='python:3.9',
-      output_component_file='my_function.yaml'
-    )
-    def my_function_two(input: Input[Mode])):
-      ...
+        @dsl.component
+        def my_function_one(input: str, output: Output[Model]):
+            ...
 
-    @dsl.pipeline(pipeline_root='...',
-                  name='my-pipeline')
-    def pipeline():
-      my_function_one_task = my_function_one(input=...)
-      my_function_two_task = my_function_two(input=my_function_one_task.outputs..
+        @dsl.component(
+        base_image='python:3.9',
+        output_component_file='my_function.yaml'
+        )
+        def my_function_two(input: Input[Mode])):
+            ...
+
+        @dsl.pipeline(name='my-pipeline', pipeline_root='...')
+        def pipeline():
+            my_function_one_task = my_function_one(input=...)
+            my_function_two_task = my_function_two(input=my_function_one_task.outputs)
 
     Args:
-        func: The python function to create a component from. The function
+        func: The Python function to create a component from. The function
             should have type annotations for all its arguments, indicating how
-            it is intended to be used (e.g. as an input/output Artifact object,
+            each argument is intended to be used (e.g. as an input/output Artifact object,
             a plain parameter, or a path to a file).
         base_image: The image to use when executing func. It should
             contain a default Python interpreter that is compatible with KFP.
+        target_image: The image to build for creation of containerized components.
         packages_to_install: A list of optional packages to install before
             executing func. These will always be installed at component runtime.
         pip_index_urls: Python Package Index base URLS from which to
@@ -79,7 +80,7 @@ def component(func: Optional[Callable] = None,
             "https://pypi.org/simple". For more information, see:
             https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-0.
         output_component_file: If specified, this function will write a
-            shareable/loadable version of the component spec into this file.
+            shareable/loadable version of the component spec into this file. Deprecated.
         install_kfp_package: Specifies if we should add a KFP Python package to
             packages_to_install. Lightweight Python functions always require
             an installation of KFP in base_image to work. If you specify

--- a/sdk/python/kfp/components/importer_node.py
+++ b/sdk/python/kfp/components/importer_node.py
@@ -32,7 +32,7 @@ def importer(
     reimport: bool = False,
     metadata: Optional[Mapping[str, Any]] = None,
 ) -> pipeline_task.PipelineTask:
-    """Imports an existing artifact.
+    """Imports an existing artifact for use in a downstream component.
 
     Args:
       artifact_uri: The URI of the artifact to import.
@@ -41,10 +41,7 @@ def importer(
       metadata: Properties of the artifact.
 
     Returns:
-      A PipelineTask instance.
-
-    Raises:
-      ValueError: if the passed in artifact_uri is neither a PipelineParam nor a constant string value.
+      A task with the artifact accessible via its ``.output`` attribute.
 
     Examples::
 

--- a/sdk/python/kfp/components/importer_node.py
+++ b/sdk/python/kfp/components/importer_node.py
@@ -32,21 +32,30 @@ def importer(
     reimport: bool = False,
     metadata: Optional[Mapping[str, Any]] = None,
 ) -> pipeline_task.PipelineTask:
-    """dsl.importer for importing an existing artifact. Only for v2 pipeline.
+    """Imports an existing artifact.
 
     Args:
-      artifact_uri: The artifact uri to import from.
-      artifact_type_schema: The user specified artifact type schema of the
-        artifact to be imported.
-      reimport: Whether to reimport the artifact. Defaults to False.
+      artifact_uri: The URI of the artifact to import.
+      artifact_class: The artifact class being imported.
+      reimport: Whether to reimport the artifact.
       metadata: Properties of the artifact.
 
     Returns:
       A PipelineTask instance.
 
     Raises:
-      ValueError if the passed in artifact_uri is neither a PipelineParam nor a
-        constant string value.
+      ValueError: if the passed in artifact_uri is neither a PipelineParam nor a constant string value.
+
+    Examples::
+
+      @dsl.pipeline(name='pipeline-with-importer')
+      def pipeline_with_importer():
+
+          importer1 = importer(
+              artifact_uri='gs://ml-pipeline-playground/shakespeare1.txt',
+              artifact_class=Dataset,
+              reimport=False)
+          train(dataset=importer1.output)
     """
     component_spec = structures.ComponentSpec(
         name='importer',

--- a/sdk/python/kfp/components/pipeline_channel.py
+++ b/sdk/python/kfp/components/pipeline_channel.py
@@ -130,7 +130,7 @@ class PipelineChannel(abc.ABC):
         We make repr return the placeholder string so that if someone
         uses str()-based serialization of complex objects containing
         `PipelineChannel`, it works properly. (e.g. str([1, 2, 3,
-        kfp.dsl.PipelineParameterChannel("aaa"), 4, 5, 6,]))
+        kfp.pipeline_channel.PipelineParameterChannel("aaa"), 4, 5, 6,]))
         """
         return str(self)
 

--- a/sdk/python/kfp/components/pipeline_context.py
+++ b/sdk/python/kfp/components/pipeline_context.py
@@ -28,8 +28,8 @@ pipeline_decorator_handler = None
 
 def pipeline(name: Optional[str] = None,
              description: Optional[str] = None,
-             pipeline_root: Optional[str] = None):
-    """Decorator of pipeline functions.
+             pipeline_root: Optional[str] = None) -> Callable:
+    """Decorator used to construct a pipeline.
 
     Example
       ::
@@ -43,12 +43,9 @@ def pipeline(name: Optional[str] = None,
           ...
 
     Args:
-        name: The pipeline name. Default to a sanitized version of the function
-            name.
-        description: Optionally, a human-readable description of the pipeline.
-        pipeline_root: The root directory to generate input/output URI under this
-            pipeline. This is required if input/output URI placeholder is used in
-            this pipeline.
+        name: The pipeline name. Defaults to a sanitized version of the decorated function name.
+        description: A human-readable description of the pipeline.
+        pipeline_root: The root directory to generate input/output URI under this pipeline. This is required if input/output URI placeholder is used in this pipeline.
     """
     if callable(name):
         strikethrough_decorator = '\u0336'.join('@pipeline') + '\u0336'
@@ -62,7 +59,7 @@ def pipeline(name: Optional[str] = None,
                     ...
             """))
 
-    def _pipeline(func: Callable):
+    def _pipeline(func: Callable) -> Callable:
         func._is_pipeline = True
         if name:
             func._component_human_name = name

--- a/sdk/python/kfp/components/pipeline_context.py
+++ b/sdk/python/kfp/components/pipeline_context.py
@@ -45,7 +45,7 @@ def pipeline(name: Optional[str] = None,
     Args:
         name: The pipeline name. Defaults to a sanitized version of the decorated function name.
         description: A human-readable description of the pipeline.
-        pipeline_root: The root directory to generate input/output URI under this pipeline. This is required if input/output URI placeholder is used in this pipeline.
+        pipeline_root: The root directory from which to read input and output parameters and artifacts.
     """
     if callable(name):
         strikethrough_decorator = '\u0336'.join('@pipeline') + '\u0336'
@@ -135,15 +135,15 @@ class Pipeline:
                 add_to_group=not getattr(task, 'is_exit_handler', False))
 
         self._old_register_task_handler = (
-            pipeline_task.PipelineTask.register_task_handler)
-        pipeline_task.PipelineTask.register_task_handler = (
+            pipeline_task.PipelineTask._register_task_handler)
+        pipeline_task.PipelineTask._register_task_handler = (
             register_task_and_generate_id)
         return self
 
     def __exit__(self, *unused_args):
 
         Pipeline._default_pipeline = None
-        pipeline_task.PipelineTask.register_task_handler = (
+        pipeline_task.PipelineTask._register_task_handler = (
             self._old_register_task_handler)
 
     def add_task(

--- a/sdk/python/kfp/components/pipeline_task.py
+++ b/sdk/python/kfp/components/pipeline_task.py
@@ -33,11 +33,19 @@ def create_pipeline_task(
 
 
 class PipelineTask:
-    """Represents a pipeline task (an instantiated component).
+    """Represents a pipeline task (instantiated component).
 
-    **Note:** ``PipelineTask`` should not be constructed by pipeline authors directly, but instead obtained via an instantiated component.
+    **Note:** ``PipelineTask`` should not be constructed by pipeline authors directly, but instead obtained via an instantiated component (see example).
 
-    Example::
+    Replaces ``ContainerOp`` from ``kfp`` v1. Holds operations available on a task object, such as
+    ``.after()``, ``.set_memory_limit()``, ``.enable_caching()``, etc.
+
+    Args:
+        component_spec: The component definition.
+        args: The dictionary of arguments on which the component was called to instantiate this task.
+
+    Example:
+      ::
 
         @dsl.component
         def identity(message: str) -> str:
@@ -47,29 +55,12 @@ class PipelineTask:
         def my_pipeline():
             # task is an instance of PipelineTask
             task = identity(message='my string')
-
-    Replaces ``ContainerOp`` from kfp v1. Holds operations available on a task object, such as
-    ``.after()``, ``.set_memory_limit()`, ``.enable_caching()``, etc.
-
-    Args:
-        component_spec: The component definition.
-        args: The dictionary of component arguments.
-
-    Attributes:
-        name: The name of the task. Unique within its parent group.
-        outputs:
-        task_spec: The task spec of the task.
-        component_spec: The component spec of the task.
-        container_spec: The resolved container spec of the task. Only one of
-            container_spec and importer_spec should be filled.
-        importer_spec: The resolved importer spec of the task. Only one of
-            container_spec and importer_spec should be filled.
     """
 
     # Fallback behavior for compiling a component. This should be overriden by
     # pipeline `register_task_and_generate_id` if compiling a pipeline (more
     # than one component).
-    register_task_handler = lambda task: utils.maybe_rename_for_k8s(
+    _register_task_handler = lambda task: utils.maybe_rename_for_k8s(
         task.component_spec.name)
 
     def __init__(
@@ -120,8 +111,8 @@ class PipelineTask:
 
         self.component_spec = component_spec
 
-        self.task_spec = structures.TaskSpec(
-            name=self.register_task_handler(),
+        self._task_spec = structures.TaskSpec(
+            name=self._register_task_handler(),
             inputs={input_name: value for input_name, value in args.items()},
             dependent_tasks=[],
             component_ref=component_spec.name,
@@ -145,7 +136,7 @@ class PipelineTask:
             output_name: pipeline_channel.create_pipeline_channel(
                 name=output_name,
                 channel_type=output_spec.type,
-                task_name=self.task_spec.name,
+                task_name=self._task_spec.name,
             ) for output_name, output_spec in (
                 component_spec.outputs or {}).items()
         }
@@ -162,38 +153,51 @@ class PipelineTask:
 
     @property
     def name(self) -> str:
-        """Returns the name of the task."""
-        return self.task_spec.name
+        """The name of the task.
+
+        Unique within its parent group.
+        """
+        return self._task_spec.name
 
     @property
     def inputs(
         self
     ) -> List[Union[type_utils.PARAMETER_TYPES,
                     pipeline_channel.PipelineChannel]]:
-        """Returns the list of actual inputs passed to the task."""
+        """The list of actual inputs passed to the task."""
         return self._inputs
 
     @property
     def channel_inputs(self) -> List[pipeline_channel.PipelineChannel]:
-        """Returns the list of all PipelineChannels passed to the task."""
+        """The list of all channel inputs passed to the task.
+
+        :meta private:
+        """
         return self._channel_inputs
 
     @property
     def output(self) -> pipeline_channel.PipelineChannel:
-        """Returns the single output object (a PipelineChannel) of the task."""
+        """The single output of the task.
+
+        Used when a task has exactly one output parameter.
+        """
         if len(self._outputs) != 1:
             raise AttributeError
         return list(self._outputs.values())[0]
 
     @property
     def outputs(self) -> Mapping[str, pipeline_channel.PipelineChannel]:
-        """Returns the dictionary of outputs (PipelineChannels) of the task."""
+        """The dictionary of outputs of the task.
+
+        Used when a task has more the one output or uses an
+        ``OutputPath`` or ``Output[Artifact]`` type annotation.
+        """
         return self._outputs
 
     @property
     def dependent_tasks(self) -> List[str]:
-        """Returns the list of dependent task names."""
-        return self.task_spec.dependent_tasks
+        """A list of the dependent task names."""
+        return self._task_spec.dependent_tasks
 
     def _resolve_command_line_and_arguments(
         self,
@@ -335,23 +339,22 @@ class PipelineTask:
         return resolved_container_spec
 
     def set_caching_options(self, enable_caching: bool) -> 'PipelineTask':
-        """Sets caching options for the Pipeline task.
+        """Sets caching options for the task.
 
         Args:
-            enable_caching: Whether or not to enable caching for this task.
+            enable_caching: Whether to enable caching.
 
         Returns:
             Self return to allow chained setting calls.
         """
-        self.task_spec.enable_caching = enable_caching
+        self._task_spec.enable_caching = enable_caching
         return self
 
     def set_cpu_limit(self, cpu: str) -> 'PipelineTask':
-        """Set cpu limit (maximum) for this operator.
+        """Sets CPU limit (maximum) for the task.
 
         Args:
-            cpu(str): A string which can be a
-                number or a number followed by "m", whichmeans 1/1000.
+            cpu: Maximum CPU requests allowed. This string should be a number or a number followed by an "m" to indicate millicores (1/1000). For more information, see `Specify a CPU Request and a CPU Limit <https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/#specify-a-cpu-request-and-a-cpu-limit>`_.
 
         Returns:
             Self return to allow chained setting calls.
@@ -379,10 +382,10 @@ class PipelineTask:
         return self
 
     def set_gpu_limit(self, gpu: str) -> 'PipelineTask':
-        """Set gpu limit (maximum) for this operator.
+        """Sets GPU limit (maximum) for the task.
 
         Args:
-            gpu(str): Positive number required for number of GPUs.
+            gpu: The maximum GPU reuqests allowed. This string should be a positive integer number of GPUs.
 
         Returns:
             Self return to allow chained setting calls.
@@ -405,12 +408,10 @@ class PipelineTask:
         return self
 
     def set_memory_limit(self, memory: str) -> 'PipelineTask':
-        """Set memory limit (maximum) for this operator.
+        """Sets memory limit (maximum) for the task.
 
         Args:
-            memory(str): a string which can be a number or a number followed by
-                one of "E", "Ei", "P", "Pi", "T", "Ti", "G", "Gi", "M", "Mi",
-                "K", "Ki".
+            memory: The maximum memory requests allowed. This string should be a number or a number followed by one of "E", "Ei", "P", "Pi", "T", "Ti", "G", "Gi", "M", "Mi", "K", or "Ki".
 
         Returns:
             Self return to allow chained setting calls.
@@ -470,15 +471,15 @@ class PipelineTask:
         """Sets task retry parameters.
 
         Args:
-            num_retries (int): Number of times to retry on failure.
-            backoff_duration (Optional[int]): The the number of seconds to wait before triggering a retry. Defaults to '0s' (immediate retry).
-            backoff_factor (Optional[float]): The exponential backoff factor applied to backoff_duration. For example, if backoff_duration="60" (60 seconds) and backoff_factor=2, the first retry will happen after 60 seconds, then after 120, 240, and so on. Defaults to 2.0.
-            backoff_max_duration (Optional[int]): The maximum duration during which the task will be retried. Maximum duration is 1 hour (3600s). Defaults to '3600s'.
+            num_retries : Number of times to retry on failure.
+            backoff_duration: Number of seconds to wait before triggering a retry. Defaults to ``'0s'`` (immediate retry).
+            backoff_factor: Exponential backoff factor applied to ``backoff_duration``. For example, if ``backoff_duration="60"`` (60 seconds) and ``backoff_factor=2``, the first retry will happen after 60 seconds, then again after 120, 240, and so on. Defaults to ``2.0``.
+            backoff_max_duration: Maximum duration during which the task will be retried. Maximum duration is 1 hour (3600s). Defaults to ``'3600s'``.
 
         Returns:
             Self return to allow chained setting calls.
         """
-        self.task_spec.retry_policy = structures.RetryPolicy(
+        self._task_spec.retry_policy = structures.RetryPolicy(
             max_retry_count=num_retries,
             backoff_duration=backoff_duration,
             backoff_factor=backoff_factor,
@@ -487,11 +488,11 @@ class PipelineTask:
         return self
 
     def add_node_selector_constraint(self, accelerator: str) -> 'PipelineTask':
-        """Sets accelerator type requirement for this task.
+        """Sets accelerator type to use when executing this task.
 
         Args:
-            value(str): The name of the accelerator. Available values include
-                'NVIDIA_TESLA_K80', 'TPU_V3'.
+            value: The name of the accelerator. Available values include
+                ``'NVIDIA_TESLA_K80'`` and ``'TPU_V3'``.
 
         Returns:
             Self return to allow chained setting calls.
@@ -511,23 +512,23 @@ class PipelineTask:
         return self
 
     def set_display_name(self, name: str) -> 'PipelineTask':
-        """Set display name for the pipelineTask.
+        """Sets display name for the task.
 
         Args:
-            name(str): display name for the task.
+            name: Display name.
 
         Returns:
             Self return to allow chained setting calls.
         """
-        self.task_spec.display_name = name
+        self._task_spec.display_name = name
         return self
 
     def set_env_variable(self, name: str, value: str) -> 'PipelineTask':
-        """Set environment variable for the pipelineTask.
+        """Sets environment variable for the task.
 
         Args:
-            name: The name of the environment variable.
-            value: The value of the environment variable.
+            name: Environment variable name.
+            value: Environment variable value.
 
         Returns:
             Self return to allow chained setting calls.
@@ -539,14 +540,23 @@ class PipelineTask:
         return self
 
     def after(self, *tasks) -> 'PipelineTask':
-        """Specify explicit dependency on other tasks.
+        """Specifies an explicit dependency on other tasks by requiring this
+        task be executed after other tasks finish completion.
 
         Args:
-            name(tasks): dependent tasks.
+            *tasks: Tasks after which this task should be executed.
 
         Returns:
             Self return to allow chained setting calls.
+
+        Example:
+          ::
+
+            @dsl.pipeline(name='my-pipeline')
+            def my_pipeline():
+                task1 = my_component(text='1st task')
+                task2 = my_component(text='2nd task').after(task1)
         """
         for task in tasks:
-            self.task_spec.dependent_tasks.append(task.name)
+            self._task_spec.dependent_tasks.append(task.name)
         return self

--- a/sdk/python/kfp/components/pipeline_task.py
+++ b/sdk/python/kfp/components/pipeline_task.py
@@ -33,10 +33,27 @@ def create_pipeline_task(
 
 
 class PipelineTask:
-    """Represents a pipeline task -- an instantiated component.
+    """Represents a pipeline task (an instantiated component).
 
-    Replaces `ContainerOp`. Holds operations available on a task object, such as
-    `.after()`, `.set_memory_limit()`, `enable_caching()`, etc.
+    **Note:** ``PipelineTask`` should not be constructed by pipeline authors directly, but instead obtained via an instantiated component.
+
+    Example::
+
+        @dsl.component
+        def identity(message: str) -> str:
+            return message
+
+        @dsl.pipeline(name='my_pipeline')
+        def my_pipeline():
+            # task is an instance of PipelineTask
+            task = identity(message='my string')
+
+    Replaces ``ContainerOp`` from kfp v1. Holds operations available on a task object, such as
+    ``.after()``, ``.set_memory_limit()`, ``.enable_caching()``, etc.
+
+    Args:
+        component_spec: The component definition.
+        args: The dictionary of component arguments.
 
     Attributes:
         name: The name of the task. Unique within its parent group.
@@ -60,12 +77,7 @@ class PipelineTask:
         component_spec: structures.ComponentSpec,
         args: Mapping[str, Any],
     ):
-        """Initilizes a PipelineTask instance.
-
-        Args:
-            component_spec: The component definition.
-            args: The dictionary of component arguments.
-        """
+        """Initilizes a PipelineTask instance."""
         args = args or {}
 
         for input_name, argument_value in args.items():

--- a/sdk/python/kfp/components/pipeline_task_test.py
+++ b/sdk/python/kfp/components/pipeline_task_test.py
@@ -114,7 +114,7 @@ class PipelineTaskTest(parameterized.TestCase):
                 V2_YAML),
             args={'input1': 'value'},
         )
-        self.assertEqual(task.task_spec, expected_task_spec)
+        self.assertEqual(task._task_spec, expected_task_spec)
         self.assertEqual(task.component_spec, expected_component_spec)
         self.assertEqual(task.container_spec, expected_container_spec)
 
@@ -147,7 +147,7 @@ class PipelineTaskTest(parameterized.TestCase):
             args={'input1': 'value'},
         )
         task.set_caching_options(False)
-        self.assertEqual(False, task.task_spec.enable_caching)
+        self.assertEqual(False, task._task_spec.enable_caching)
 
     @parameterized.parameters(
         {
@@ -298,7 +298,7 @@ class PipelineTaskTest(parameterized.TestCase):
             args={'input1': 'value'},
         )
         task.set_display_name('test_name')
-        self.assertEqual('test_name', task.task_spec.display_name)
+        self.assertEqual('test_name', task._task_spec.display_name)
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/components/python_component.py
+++ b/sdk/python/kfp/components/python_component.py
@@ -15,15 +15,18 @@
 
 from typing import Callable
 
-from kfp.components import base_component
+from kfp import components
 from kfp.components import structures
 
 
-class PythonComponent(base_component.BaseComponent):
-    """Component defined via Python function.
+class PythonComponent(components.BaseComponent):
+    """**Note:** ``PythonComponent`` is not intended to be used to construct components directly. Use ``@kfp.dsl.component`` instead.
 
-    Attribute:
-        pipeline_func: The Python function that becomes the implementation of
+    A component defined via Python function.
+
+    Args:
+        component_spec: The component definition.
+        python_func: The Python function that becomes the implementation of
             this component.
     """
 
@@ -36,4 +39,8 @@ class PythonComponent(base_component.BaseComponent):
         self.python_func = python_func
 
     def execute(self, **kwargs):
-        return python_func(**kwargs)
+        """Executes the Python function that became the component definition.
+
+        Must be called using keyword arguments.
+        """
+        return self.python_func(**kwargs)

--- a/sdk/python/kfp/components/python_component.py
+++ b/sdk/python/kfp/components/python_component.py
@@ -20,14 +20,13 @@ from kfp.components import structures
 
 
 class PythonComponent(components.BaseComponent):
-    """**Note:** ``PythonComponent`` is not intended to be used to construct components directly. Use ``@kfp.dsl.component`` instead.
+    """A component defined via Python function.
 
-    A component defined via Python function.
+    **Note:** ``PythonComponent`` is not intended to be used to construct components directly. Use ``@kfp.dsl.component`` instead.
 
     Args:
-        component_spec: The component definition.
-        python_func: The Python function that becomes the implementation of
-            this component.
+        component_spec: Component definition.
+        python_func: Python function that becomes the implementation of this component.
     """
 
     def __init__(
@@ -39,8 +38,5 @@ class PythonComponent(components.BaseComponent):
         self.python_func = python_func
 
     def execute(self, **kwargs):
-        """Executes the Python function that became the component definition.
-
-        Must be called using keyword arguments.
-        """
+        """Executes the Python function that defines the component."""
         return self.python_func(**kwargs)

--- a/sdk/python/kfp/components/structures.py
+++ b/sdk/python/kfp/components/structures.py
@@ -23,9 +23,9 @@ import uuid
 
 from google.protobuf import json_format
 import kfp
-from kfp import dsl
 from kfp.compiler import compiler
 from kfp.components import base_model
+from kfp.components import pipeline_channel
 from kfp.components import placeholders
 from kfp.components import utils
 from kfp.components import v1_components
@@ -671,7 +671,7 @@ class ComponentSpec(base_model.BaseModel):
                 raise TypeError(
                     builder.make_invalid_input_type_error_msg(
                         arg_name, arg_type))
-            args_dict[arg_name] = dsl.PipelineParameterChannel(
+            args_dict[arg_name] = pipeline_channel.PipelineParameterChannel(
                 name=arg_name, channel_type=arg_type)
 
         task = pipeline_task.PipelineTask(self, args_dict)
@@ -684,7 +684,7 @@ class ComponentSpec(base_model.BaseModel):
 
         # Fill in the default values.
         args_list_with_defaults = [
-            dsl.PipelineParameterChannel(
+            pipeline_channel.PipelineParameterChannel(
                 name=input_name,
                 channel_type=input_spec.type,
                 value=input_spec.default,

--- a/sdk/python/kfp/components/task_final_status.py
+++ b/sdk/python/kfp/components/task_final_status.py
@@ -19,25 +19,37 @@ from typing import Optional
 
 @dataclasses.dataclass
 class PipelineTaskFinalStatus:
-    """The final status of a pipeline task.
+    """A final status of a pipeline task. Annotate a component parameter with
+    this class to obtain a handle to a task's status (see example).
 
-    This is the Python representation of the proto ``PipelineTaskFinalStatus``
-    https://github.com/kubeflow/pipelines/blob/d8b9439ef92b88da3420df9e8c67db0f1e89d4ef/api/v2alpha1/pipeline_spec.proto#L929-L951
+    This is the Python representation of the proto message `PipelineTaskFinalStatus <https://github.com/kubeflow/pipelines/blob/d8b9439ef92b88da3420df9e8c67db0f1e89d4ef/api/v2alpha1/pipeline_spec.proto#L929-L951>`_.
 
-    Attributes:
-        state: The final state of the task. The value could be one of
-            ``'SUCCEEDED'``, ``'FAILED'`` or ``'CANCELLED'``.
-        pipeline_job_resource_name: The pipeline job resource name, in the format
-            of `projects/{project}/locations/{location}/pipelineJobs/{pipeline_job}`.
-        pipeline_task_name: The pipeline task that produced this status.
-        error_code: In case of error, the google.rpc.Code
-            https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
-            If state is ``'SUCCEEDED'``, this is ``None``.
-        error_message: In case of error, the detailed error message.
-            If state is ``'SUCCEEDED'``, this is ``None``.
+    Examples:
+      ::
+
+        @dsl.component
+        def task_status(user_input: str, status: PipelineTaskFinalStatus):
+            print('Pipeline status: ', status.state)
+            print('Job resource name: ', status.pipeline_job_resource_name)
+            print('Pipeline task name: ', status.pipeline_task_name)
+            print('Error code: ', status.error_code)
+            print('Error message: ', status.error_message)
+
+        @dsl.pipeline(name='my_pipeline')
+        def my_pipeline():
+            task = task_status(user_input='my_input')
     """
     state: str
+    """Final state of the task. The value could be one of ``'SUCCEEDED'``, ``'FAILED'`` or ``'CANCELLED'``."""
+
     pipeline_job_resource_name: str
+    """Pipeline job resource name, in the format of ``projects/{project}/locations/{location}/pipelineJobs/{pipeline_job}``."""
+
     pipeline_task_name: str
+    """Name of the task that produced this status."""
+
     error_code: Optional[int]
+    """The `google.rpc.Code <github.com/googleapis/googleapis/blob/master/google/rpc/code.proto>`_ in case of error. If state is ``'SUCCEEDED'``, this is ``None``."""
+
     error_message: Optional[str]
+    """In case of error, the detailed error message. If state is ``'SUCCEEDED'``, this is ``None``."""

--- a/sdk/python/kfp/components/task_final_status.py
+++ b/sdk/python/kfp/components/task_final_status.py
@@ -21,20 +21,20 @@ from typing import Optional
 class PipelineTaskFinalStatus:
     """The final status of a pipeline task.
 
-    This is the Python representation of the proto: PipelineTaskFinalStatus
-    https://github.com/kubeflow/pipelines/blob/1c3e2768e6177d5d6e3f4b8eff8fafb9a3b76c1f/api/v2alpha1/pipeline_spec.proto#L886
+    This is the Python representation of the proto ``PipelineTaskFinalStatus``
+    https://github.com/kubeflow/pipelines/blob/d8b9439ef92b88da3420df9e8c67db0f1e89d4ef/api/v2alpha1/pipeline_spec.proto#L929-L951
 
     Attributes:
         state: The final state of the task. The value could be one of
-            'SUCCEEDED', 'FAILED' or 'CANCELLED'.
+            ``'SUCCEEDED'``, ``'FAILED'`` or ``'CANCELLED'``.
         pipeline_job_resource_name: The pipeline job resource name, in the format
             of `projects/{project}/locations/{location}/pipelineJobs/{pipeline_job}`.
-        pipeline_task_name: The pipeline task that produces this status.
-        error_code: In case of error, the oogle.rpc.Code
+        pipeline_task_name: The pipeline task that produced this status.
+        error_code: In case of error, the google.rpc.Code
             https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
-            If state is 'SUCCEEDED', this is None.
+            If state is ``'SUCCEEDED'``, this is ``None``.
         error_message: In case of error, the detailed error message.
-            If state is 'SUCCEEDED', this is None.
+            If state is ``'SUCCEEDED'``, this is ``None``.
     """
     state: str
     pipeline_job_resource_name: str

--- a/sdk/python/kfp/components/tasks_group.py
+++ b/sdk/python/kfp/components/tasks_group.py
@@ -94,8 +94,12 @@ class TasksGroup:
 
 
 class ExitHandler(TasksGroup):
-    """Represents an exit handler that is invoked upon exiting a group of
-    tasks.
+    """A class for setting an exit handler task that is invoked upon exiting a
+    group of other tasks.
+
+    Args:
+        exit_task: The task that is invoked after exiting a group of other tasks.
+        name: The name of the exit handler group.
 
     Example:
       ::
@@ -104,9 +108,6 @@ class ExitHandler(TasksGroup):
         with ExitHandler(exit_task):
             task1 = MyComponent1(...)
             task2 = MyComponent2(...)
-
-    Attributes:
-        exit_task: The exit handler task.
     """
 
     def __init__(
@@ -114,15 +115,7 @@ class ExitHandler(TasksGroup):
         exit_task: pipeline_task.PipelineTask,
         name: Optional[str] = None,
     ):
-        """Initializes a Condition task group.
-
-        Args:
-            exit_task: An operator invoked at exiting a group of ops.
-            name: Optional; the name of the exit handler group.
-
-        Raises:
-            ValueError: Raised if the exit_task is invalid.
-        """
+        """Initializes a Condition task group."""
         super().__init__(group_type=TasksGroupType.EXIT_HANDLER, name=name)
 
         if exit_task.dependent_tasks:
@@ -139,7 +132,12 @@ class ExitHandler(TasksGroup):
 
 
 class Condition(TasksGroup):
-    """Represents an condition group with a condition.
+    """A class for creating conditional control flow within a pipeline
+    definition.
+
+    Args:
+        condition: The condition expression. Can be constructed using constants or outputs from upstream tasks.
+        name: The name of the condition group.
 
     Example:
       ::
@@ -147,9 +145,6 @@ class Condition(TasksGroup):
         with Condition(param1=='pizza', '[param1 is pizza]'):
             task1 = MyComponent1(...)
             task2 = MyComponent2(...)
-
-    Attributes:
-        condition: The condition expression.
     """
 
     def __init__(
@@ -157,18 +152,16 @@ class Condition(TasksGroup):
         condition: pipeline_channel.ConditionOperator,
         name: Optional[str] = None,
     ):
-        """Initializes a conditional task group.
-
-        Args:
-            condition: The condition expression.
-            name: Optional; the name of the condition group.
-        """
+        """Initializes a conditional task group."""
         super().__init__(group_type=TasksGroupType.CONDITION, name=name)
         self.condition = condition
 
 
 class ParallelFor(TasksGroup):
-    """Represents a parallel for loop over a static set of items.
+    """A class for creating parallelized for loop control flow over a static set of items within a pipeline definition.
+    Args:
+        items: The items to loop over. It can be either a raw list or an output from an upstream task.
+        name: The name of the for loop group.
 
     Example:
       ::
@@ -179,12 +172,6 @@ class ParallelFor(TasksGroup):
 
     In this case :code:`task1` would be executed twice, once with case
     :code:`args=['echo 1']` and once with case :code:`args=['echo 2']`::
-
-
-    Attributes:
-        loop_argument: The argument for each loop iteration.
-        items_is_pipeline_channel: Whether the loop items is PipelineChannel
-            instead of raw items.
     """
 
     def __init__(
@@ -192,13 +179,7 @@ class ParallelFor(TasksGroup):
         items: Union[for_loop.ItemList, pipeline_channel.PipelineChannel],
         name: Optional[str] = None,
     ):
-        """Initializes a for loop task group.
-
-        Args:
-            items: The argument to loop over. It can be either a raw list or a
-                pipeline channel.
-            name: Optional; the name of the for loop group.
-        """
+        """Initializes a for loop task group."""
         super().__init__(group_type=TasksGroupType.FOR_LOOP, name=name)
 
         if isinstance(items, pipeline_channel.PipelineChannel):

--- a/sdk/python/kfp/components/tasks_group.py
+++ b/sdk/python/kfp/components/tasks_group.py
@@ -158,9 +158,11 @@ class Condition(TasksGroup):
 
 
 class ParallelFor(TasksGroup):
-    """A class for creating parallelized for loop control flow over a static set of items within a pipeline definition.
+    """A class for creating parallelized for loop control flow over a static
+    set of items within a pipeline definition.
+
     Args:
-        items: The items to loop over. It can be either a raw list or an output from an upstream task.
+        items: The items to loop over. It can be either a constant Python list or a list output from an upstream task.
         name: The name of the for loop group.
 
     Example:
@@ -170,8 +172,8 @@ class ParallelFor(TasksGroup):
             task1 = MyComponent(..., item.a)
             task2 = MyComponent(..., item.b)
 
-    In this case :code:`task1` would be executed twice, once with case
-    :code:`args=['echo 1']` and once with case :code:`args=['echo 2']`::
+    In the example, ``task1`` would be executed twice, once with case
+    ``args=['echo 1']`` and once with case ``args=['echo 2']``.
     """
 
     def __init__(

--- a/sdk/python/kfp/components/types/artifact_types.py
+++ b/sdk/python/kfp/components/types/artifact_types.py
@@ -23,16 +23,15 @@ _MINIO_LOCAL_MOUNT_PREFIX = '/minio/'
 _S3_LOCAL_MOUNT_PREFIX = '/s3/'
 
 
-class Artifact(object):
-    """Generic Artifact class.
+class Artifact:
+    """Represents a generic machine learning artifact.
 
-    This class is meant to represent the metadata around an input or output
-    machine-learning Artifact. Artifacts have URIs, which can either be a location
-    on disk (or Cloud storage) or some other resource identifier such as
-    an API resource name.
+    This class stores the name, uri, and metadata for a machine learning artifact.
 
-    Artifacts carry a `metadata` field, which is a dictionary for storing
-    metadata related to this artifact.
+    Args:
+        name: The name of the artifact.
+        uri: The artifact's location on disk or cloud storage.
+        metadata: Arbitrary key-value pairs about the artifact.
     """
     TYPE_NAME = 'system.Artifact'
     VERSION = '0.0.1'
@@ -40,18 +39,18 @@ class Artifact(object):
     def __init__(self,
                  name: Optional[str] = None,
                  uri: Optional[str] = None,
-                 metadata: Optional[Dict] = None):
+                 metadata: Optional[Dict] = None) -> None:
         """Initializes the Artifact with the given name, URI and metadata."""
         self.uri = uri or ''
         self.name = name or ''
         self.metadata = metadata or {}
 
     @property
-    def path(self):
+    def path(self) -> str:
         return self._get_path()
 
     @path.setter
-    def path(self, path):
+    def path(self, path: str) -> None:
         self._set_path(path)
 
     def _get_path(self) -> Optional[str]:
@@ -63,7 +62,7 @@ class Artifact(object):
             return _S3_LOCAL_MOUNT_PREFIX + self.uri[len('s3://'):]
         return None
 
-    def _set_path(self, path):
+    def _set_path(self, path: str) -> None:
         if path.startswith(_GCS_LOCAL_MOUNT_PREFIX):
             path = 'gs://' + path[len(_GCS_LOCAL_MOUNT_PREFIX):]
         elif path.startswith(_MINIO_LOCAL_MOUNT_PREFIX):
@@ -74,13 +73,19 @@ class Artifact(object):
 
 
 class Model(Artifact):
-    """An artifact representing an ML Model."""
+    """An artifact representing a machine learning model.
+
+    Args:
+        name: The name of the model.
+        uri: The model's location on disk or cloud storage.
+        metadata: Arbitrary key-value pairs about the model.
+    """
     TYPE_NAME = 'system.Model'
 
     def __init__(self,
                  name: Optional[str] = None,
                  uri: Optional[str] = None,
-                 metadata: Optional[Dict] = None):
+                 metadata: Optional[Dict] = None) -> None:
         super().__init__(uri=uri, name=name, metadata=metadata)
 
     @property
@@ -91,47 +96,64 @@ class Model(Artifact):
         return self.metadata.get('framework', '')
 
     @framework.setter
-    def framework(self, framework: str):
+    def framework(self, framework: str) -> None:
         self._set_framework(framework)
 
-    def _set_framework(self, framework: str):
+    def _set_framework(self, framework: str) -> None:
         self.metadata['framework'] = framework
 
 
 class Dataset(Artifact):
-    """An artifact representing an ML Dataset."""
+    """An artifact representing a machine learning dataset.
+
+    Args:
+        name: The name of the dataset.
+        uri: The dataset's location on disk or cloud storage.
+        metadata: Arbitrary key-value pairs about the dataset.
+    """
     TYPE_NAME = 'system.Dataset'
 
     def __init__(self,
                  name: Optional[str] = None,
                  uri: Optional[str] = None,
-                 metadata: Optional[Dict] = None):
+                 metadata: Optional[Dict] = None) -> None:
         super().__init__(uri=uri, name=name, metadata=metadata)
 
 
 class Metrics(Artifact):
-    """Represent a simple base Artifact type to store key-value scalar
-    metrics."""
+    """An artifact for storing key-value scalar metrics.
+
+    Args:
+        name: The name of the metrics artifact.
+        uri: The metrics artifact's location on disk or cloud storage.
+        metadata: The key-value scalar metrics.
+    """
     TYPE_NAME = 'system.Metrics'
 
     def __init__(self,
                  name: Optional[str] = None,
                  uri: Optional[str] = None,
-                 metadata: Optional[Dict] = None):
+                 metadata: Optional[Dict] = None) -> None:
         super().__init__(uri=uri, name=name, metadata=metadata)
 
-    def log_metric(self, metric: str, value: float):
-        """Sets a custom scalar metric.
+    def log_metric(self, metric: str, value: float) -> None:
+        """Sets a custom scalar metric in the artifact's metadata.
 
         Args:
-          metric: Metric key
-          value: Value of the metric.
+          metric: The metric key.
+          value: The metric value.
         """
         self.metadata[metric] = value
 
 
 class ClassificationMetrics(Artifact):
-    """Represents Artifact class to store Classification Metrics."""
+    """An artifact for storing classification metrics.
+
+    Args:
+        name: The name of the metrics artifact.
+        uri: The metrics artifact's location on disk or cloud storage.
+        metadata: The key-value scalar metrics.
+    """
     TYPE_NAME = 'system.ClassificationMetrics'
 
     def __init__(self,
@@ -140,8 +162,9 @@ class ClassificationMetrics(Artifact):
                  metadata: Optional[Dict] = None):
         super().__init__(uri=uri, name=name, metadata=metadata)
 
-    def log_roc_data_point(self, fpr: float, tpr: float, threshold: float):
-        """Logs a single data point in the ROC Curve.
+    def log_roc_data_point(self, fpr: float, tpr: float,
+                           threshold: float) -> None:
+        """Logs a single data point in the ROC Curve to metadata.
 
         Args:
           fpr: False positive rate value of the data point.
@@ -160,8 +183,8 @@ class ClassificationMetrics(Artifact):
         self.metadata['confidenceMetrics'].append(roc_reading)
 
     def log_roc_curve(self, fpr: List[float], tpr: List[float],
-                      threshold: List[float]):
-        """Logs an ROC curve.
+                      threshold: List[float]) -> None:
+        """Logs an ROC curve to metadata.
 
         The list length of fpr, tpr and threshold must be the same.
 
@@ -181,8 +204,8 @@ class ClassificationMetrics(Artifact):
             self.log_roc_data_point(
                 fpr=fpr[i], tpr=tpr[i], threshold=threshold[i])
 
-    def set_confusion_matrix_categories(self, categories: List[str]):
-        """Stores confusion matrix categories.
+    def set_confusion_matrix_categories(self, categories: List[str]) -> None:
+        """Stores confusion matrix categories to metadata.
 
         Args:
           categories: List of strings specifying the categories.
@@ -204,8 +227,9 @@ class ClassificationMetrics(Artifact):
         self._confusion_matrix['rows'] = self._matrix
         self.metadata['confusionMatrix'] = self._confusion_matrix
 
-    def log_confusion_matrix_row(self, row_category: str, row: List[float]):
-        """Logs a confusion matrix row.
+    def log_confusion_matrix_row(self, row_category: str,
+                                 row: List[float]) -> None:
+        """Logs a confusion matrix row to metadata.
 
         Args:
           row_category: Category to which the row belongs.
@@ -227,8 +251,8 @@ class ClassificationMetrics(Artifact):
         self.metadata['confusionMatrix'] = self._confusion_matrix
 
     def log_confusion_matrix_cell(self, row_category: str, col_category: str,
-                                  value: int):
-        """Logs a cell in the confusion matrix.
+                                  value: int) -> None:
+        """Logs a cell in the confusion matrix to metadata.
 
         Args:
           row_category: String representing the name of the row category.
@@ -252,8 +276,8 @@ class ClassificationMetrics(Artifact):
         self.metadata['confusionMatrix'] = self._confusion_matrix
 
     def log_confusion_matrix(self, categories: List[str],
-                             matrix: List[List[int]]):
-        """Logs a confusion matrix.
+                             matrix: List[List[int]]) -> None:
+        """Logs a confusion matrix to metadata.
 
         Args:
           categories: List of the category names.
@@ -279,9 +303,9 @@ class ClassificationMetrics(Artifact):
 
 
 class SlicedClassificationMetrics(Artifact):
-    """Metrics class representing Sliced Classification Metrics.
+    """An artifact for storing sliced classification metrics.
 
-    Similar to ClassificationMetrics clients using this class are
+    Similar to ``ClassificationMetrics``, clients using this class are
     expected to use log methods of the class to log metrics with the
     difference being each log method takes a slice to associate the
     ClassificationMetrics.
@@ -292,15 +316,15 @@ class SlicedClassificationMetrics(Artifact):
     def __init__(self,
                  name: Optional[str] = None,
                  uri: Optional[str] = None,
-                 metadata: Optional[Dict] = None):
+                 metadata: Optional[Dict] = None) -> None:
         super().__init__(uri=uri, name=name, metadata=metadata)
 
-    def _upsert_classification_metrics_for_slice(self, slice: str):
+    def _upsert_classification_metrics_for_slice(self, slice: str) -> None:
         """Upserts the classification metrics instance for a slice."""
         if slice not in self._sliced_metrics:
             self._sliced_metrics[slice] = ClassificationMetrics()
 
-    def _update_metadata(self, slice: str):
+    def _update_metadata(self, slice: str) -> None:
         """Updates metadata to adhere to the metrics schema."""
         self.metadata = {}
         self.metadata['evaluationSlices'] = []
@@ -314,8 +338,8 @@ class SlicedClassificationMetrics(Artifact):
             self.metadata['evaluationSlices'].append(slice_metrics)
 
     def log_roc_reading(self, slice: str, threshold: float, tpr: float,
-                        fpr: float):
-        """Logs a single data point in the ROC Curve of a slice.
+                        fpr: float) -> None:
+        """Logs a single data point in the ROC Curve of a slice to metadata.
 
         Args:
           slice: String representing slice label.
@@ -328,8 +352,9 @@ class SlicedClassificationMetrics(Artifact):
         self._sliced_metrics[slice].log_roc_reading(threshold, tpr, fpr)
         self._update_metadata(slice)
 
-    def load_roc_readings(self, slice: str, readings: List[List[float]]):
-        """Supports bulk loading ROC Curve readings for a slice.
+    def load_roc_readings(self, slice: str,
+                          readings: List[List[float]]) -> None:
+        """Bulk loads ROC Curve readings for a slice.
 
         Args:
           slice: String representing slice label.
@@ -342,8 +367,8 @@ class SlicedClassificationMetrics(Artifact):
         self._update_metadata(slice)
 
     def set_confusion_matrix_categories(self, slice: str,
-                                        categories: List[str]):
-        """Stores confusion matrix categories for a slice..
+                                        categories: List[str]) -> None:
+        """Logs confusion matrix categories for a slice to metadata.
 
         Categories are stored in the internal metrics_utils.ConfusionMatrix
         instance of the slice.
@@ -357,8 +382,8 @@ class SlicedClassificationMetrics(Artifact):
         self._update_metadata(slice)
 
     def log_confusion_matrix_row(self, slice: str, row_category: str,
-                                 row: List[int]):
-        """Logs a confusion matrix row for a slice.
+                                 row: List[int]) -> None:
+        """Logs a confusion matrix row for a slice to metadata.
 
         Row is updated on the internal metrics_utils.ConfusionMatrix
         instance of the slice.
@@ -373,8 +398,8 @@ class SlicedClassificationMetrics(Artifact):
         self._update_metadata(slice)
 
     def log_confusion_matrix_cell(self, slice: str, row_category: str,
-                                  col_category: str, value: int):
-        """Logs a confusion matrix cell for a slice..
+                                  col_category: str, value: int) -> None:
+        """Logs a confusion matrix cell for a slice to metadata.
 
         Cell is updated on the internal metrics_utils.ConfusionMatrix
         instance of the slice.
@@ -391,8 +416,8 @@ class SlicedClassificationMetrics(Artifact):
         self._update_metadata(slice)
 
     def load_confusion_matrix(self, slice: str, categories: List[str],
-                              matrix: List[List[int]]):
-        """Supports bulk loading the whole confusion matrix for a slice.
+                              matrix: List[List[int]]) -> None:
+        """Bulk loads the whole confusion matrix for a slice.
 
         Args:
           slice: String representing slice label.
@@ -406,18 +431,30 @@ class SlicedClassificationMetrics(Artifact):
 
 
 class HTML(Artifact):
-    """An artifact representing an HTML file."""
+    """An artifact representing an HTML file.
+
+    Args:
+        name: The name of the HTML file.
+        uri: The HTML file's location on disk or cloud storage.
+        metadata: Arbitrary key-value pairs about the HTML file.
+    """
     TYPE_NAME = 'system.HTML'
 
     def __init__(self,
                  name: Optional[str] = None,
                  uri: Optional[str] = None,
-                 metadata: Optional[Dict] = None):
+                 metadata: Optional[Dict] = None) -> None:
         super().__init__(uri=uri, name=name, metadata=metadata)
 
 
 class Markdown(Artifact):
-    """An artifact representing an Markdown file."""
+    """An artifact representing a markdown file.
+
+    Args:
+        name: The name of the markdown file.
+        uri: The markdown file's location on disk or cloud storage.
+        metadata: Arbitrary key-value pairs about the markdown file.
+    """
     TYPE_NAME = 'system.Markdown'
 
     def __init__(self,

--- a/sdk/python/kfp/components/yaml_component.py
+++ b/sdk/python/kfp/components/yaml_component.py
@@ -21,10 +21,12 @@ import requests
 
 
 class YamlComponent(components.BaseComponent):
-    """**Note:** ``PythonComponent`` is not intended to be used to construct components directly. Use ``kfp.components.load_component_from_*()`` instead.
+    """A component loaded from a YAML file.
+
+    **Note:** ``YamlComponent`` is not intended to be used to construct components directly. Use ``kfp.components.load_component_from_*()`` instead.
 
     Args:
-        component_spec: The component definition.
+        component_spec: Component definition.
     """
 
     def execute(self, *args, **kwargs):
@@ -36,10 +38,10 @@ def load_component_from_text(text: str) -> YamlComponent:
     """Loads a component from text.
 
     Args:
-        text (str): The component YAML text.
+        text (str): Component YAML text.
 
     Returns:
-        YamlComponent: In-memory representation of a component loaded from YAML.
+        Component loaded from YAML.
     """
     return YamlComponent(
         structures.ComponentSpec.load_from_component_yaml(text))
@@ -49,10 +51,17 @@ def load_component_from_file(file_path: str) -> YamlComponent:
     """Loads a component from a file.
 
     Args:
-        file_path (str): The file path to a YAML component.
+        file_path (str): Filepath to a YAML component.
 
     Returns:
-        YamlComponent: In-memory representation of a component loaded from YAML.
+        Component loaded from YAML.
+
+    Example:
+      ::
+
+        from kfp import components
+
+        components.load_component_from_file('~/path/to/pipeline.yaml')
     """
     with open(file_path, 'r') as component_stream:
         return load_component_from_text(component_stream.read())
@@ -61,14 +70,23 @@ def load_component_from_file(file_path: str) -> YamlComponent:
 def load_component_from_url(url: str,
                             auth: Optional[Tuple[str,
                                                  str]] = None) -> YamlComponent:
-    """Loads a component from a url.
+    """Loads a component from a URL.
 
     Args:
-        file_path (str): The url to a YAML component.
-        auth (Tuple[str, str], optional): The a ('username', 'password') tuple of authentication credentials necessary for url access. See Requests Authorization for more information: https://requests.readthedocs.io/en/latest/user/authentication/#authentication
+        url (str): URL to a YAML component.
+        auth (Tuple[str, str], optional): A ``('<username>', '<password>')`` tuple of authentication credentials necessary for URL access. See `Requests Authorization <https://requests.readthedocs.io/en/latest/user/authentication/#authentication>`_ for more information.
 
     Returns:
-        YamlComponent: In-memory representation of a component loaded from YAML.
+        Component loaded from YAML.
+
+    Example:
+      ::
+
+        from kfp import components
+
+        components.load_component_from_url('https://raw.githubusercontent.com/kubeflow/pipelines/7b49eadf621a9054e1f1315c86f95fb8cf8c17c3/sdk/python/kfp/compiler/test_data/components/identity.yaml')
+
+        components.load_component_from_url('gs://path/to/pipeline.yaml')
     """
     if url is None:
         raise ValueError('url must be a string.')

--- a/sdk/python/kfp/components/yaml_component.py
+++ b/sdk/python/kfp/components/yaml_component.py
@@ -15,16 +15,21 @@
 
 from typing import Optional, Tuple
 
-from kfp.components import base_component
+from kfp import components
 from kfp.components import structures
 import requests
 
 
-class YamlComponent(base_component.BaseComponent):
-    """A component loaded from YAML."""
+class YamlComponent(components.BaseComponent):
+    """**Note:** ``PythonComponent`` is not intended to be used to construct components directly. Use ``kfp.components.load_component_from_*()`` instead.
+
+    Args:
+        component_spec: The component definition.
+    """
 
     def execute(self, *args, **kwargs):
-        pass
+        """Not implemented."""
+        raise NotImplementedError
 
 
 def load_component_from_text(text: str) -> YamlComponent:

--- a/sdk/python/kfp/dsl/__init__.py
+++ b/sdk/python/kfp/dsl/__init__.py
@@ -17,9 +17,6 @@ compose pipelines."""
 __all__ = [
     'component',
     'importer',
-    'PipelineArtifactChannel',
-    'PipelineChannel',
-    'PipelineParameterChannel',
     'pipeline',
     'PipelineTask',
     'PipelineTaskFinalStatus',
@@ -47,9 +44,6 @@ __all__ = [
 
 from kfp.components.component_decorator import component
 from kfp.components.importer_node import importer
-from kfp.components.pipeline_channel import PipelineArtifactChannel
-from kfp.components.pipeline_channel import PipelineChannel
-from kfp.components.pipeline_channel import PipelineParameterChannel
 from kfp.components.pipeline_context import pipeline
 from kfp.components.pipeline_task import PipelineTask
 from kfp.components.task_final_status import PipelineTaskFinalStatus
@@ -72,12 +66,13 @@ from kfp.components.types.type_annotations import OutputPath
 PIPELINE_JOB_NAME_PLACEHOLDER = '{{$.pipeline_job_name}}'
 """A placeholder used to obtain a pipeline job name within a task at pipeline runtime.
 
-    Example::
+    Example:
+      ::
+
         @dsl.pipeline(name='my-pipeline')
         def my_pipeline():
-
             print_op(
-                msg='job name:',
+                msg='Job name:',
                 value=dsl.PIPELINE_JOB_NAME_PLACEHOLDER,
             )
 """
@@ -85,12 +80,13 @@ PIPELINE_JOB_NAME_PLACEHOLDER = '{{$.pipeline_job_name}}'
 PIPELINE_JOB_RESOURCE_NAME_PLACEHOLDER = '{{$.pipeline_job_resource_name}}'
 """A placeholder used to obtain a pipeline job resource name within a task at pipeline runtime.
 
-    Example::
+    Example:
+      ::
+
         @dsl.pipeline(name='my-pipeline')
         def my_pipeline():
-
             print_op(
-                msg='job name:',
+                msg='Job resource name:',
                 value=dsl.PIPELINE_JOB_RESOURCE_NAME_PLACEHOLDER,
             )
 """
@@ -98,12 +94,13 @@ PIPELINE_JOB_RESOURCE_NAME_PLACEHOLDER = '{{$.pipeline_job_resource_name}}'
 PIPELINE_JOB_ID_PLACEHOLDER = '{{$.pipeline_job_uuid}}'
 """A placeholder used to obtain a pipeline job ID within a task at pipeline runtime.
 
-    Example::
+    Example:
+      ::
+
         @dsl.pipeline(name='my-pipeline')
         def my_pipeline():
-
             print_op(
-                msg='job name:',
+                msg='Job ID:',
                 value=dsl.PIPELINE_JOB_ID_PLACEHOLDER,
             )
 """
@@ -111,12 +108,13 @@ PIPELINE_JOB_ID_PLACEHOLDER = '{{$.pipeline_job_uuid}}'
 PIPELINE_TASK_NAME_PLACEHOLDER = '{{$.pipeline_task_name}}'
 """A placeholder used to obtain a task name within a task at pipeline runtime.
 
-    Example::
+    Example:
+      ::
+
         @dsl.pipeline(name='my-pipeline')
         def my_pipeline():
-
             print_op(
-                msg='job name:',
+                msg='Task name:',
                 value=dsl.PIPELINE_TASK_NAME_PLACEHOLDER,
             )
 """
@@ -124,12 +122,13 @@ PIPELINE_TASK_NAME_PLACEHOLDER = '{{$.pipeline_task_name}}'
 PIPELINE_TASK_ID_PLACEHOLDER = '{{$.pipeline_task_uuid}}'
 """A placeholder used to obtain a task ID within a task at pipeline runtime.
 
-    Example::
+    Example:
+      ::
+
         @dsl.pipeline(name='my-pipeline')
         def my_pipeline():
-
             print_op(
-                msg='job name:',
+                msg='Task ID:',
                 value=dsl.PIPELINE_TASK_ID_PLACEHOLDER,
             )
 """

--- a/sdk/python/kfp/dsl/__init__.py
+++ b/sdk/python/kfp/dsl/__init__.py
@@ -1,3 +1,5 @@
+"""The `kfp.dsl` module contains domain-specific language objects used to
+compose pipelines."""
 # Copyright 2020 The Kubeflow Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sdk/python/kfp/dsl/__init__.py
+++ b/sdk/python/kfp/dsl/__init__.py
@@ -70,7 +70,66 @@ from kfp.components.types.type_annotations import Output
 from kfp.components.types.type_annotations import OutputPath
 
 PIPELINE_JOB_NAME_PLACEHOLDER = '{{$.pipeline_job_name}}'
+"""A placeholder used to obtain a pipeline job name within a task at pipeline runtime.
+
+    Example::
+        @dsl.pipeline(name='my-pipeline')
+        def my_pipeline():
+
+            print_op(
+                msg='job name:',
+                value=dsl.PIPELINE_JOB_NAME_PLACEHOLDER,
+            )
+"""
+
 PIPELINE_JOB_RESOURCE_NAME_PLACEHOLDER = '{{$.pipeline_job_resource_name}}'
+"""A placeholder used to obtain a pipeline job resource name within a task at pipeline runtime.
+
+    Example::
+        @dsl.pipeline(name='my-pipeline')
+        def my_pipeline():
+
+            print_op(
+                msg='job name:',
+                value=dsl.PIPELINE_JOB_RESOURCE_NAME_PLACEHOLDER,
+            )
+"""
+
 PIPELINE_JOB_ID_PLACEHOLDER = '{{$.pipeline_job_uuid}}'
+"""A placeholder used to obtain a pipeline job ID within a task at pipeline runtime.
+
+    Example::
+        @dsl.pipeline(name='my-pipeline')
+        def my_pipeline():
+
+            print_op(
+                msg='job name:',
+                value=dsl.PIPELINE_JOB_ID_PLACEHOLDER,
+            )
+"""
+
 PIPELINE_TASK_NAME_PLACEHOLDER = '{{$.pipeline_task_name}}'
+"""A placeholder used to obtain a task name within a task at pipeline runtime.
+
+    Example::
+        @dsl.pipeline(name='my-pipeline')
+        def my_pipeline():
+
+            print_op(
+                msg='job name:',
+                value=dsl.PIPELINE_TASK_NAME_PLACEHOLDER,
+            )
+"""
+
 PIPELINE_TASK_ID_PLACEHOLDER = '{{$.pipeline_task_uuid}}'
+"""A placeholder used to obtain a task ID within a task at pipeline runtime.
+
+    Example::
+        @dsl.pipeline(name='my-pipeline')
+        def my_pipeline():
+
+            print_op(
+                msg='job name:',
+                value=dsl.PIPELINE_TASK_ID_PLACEHOLDER,
+            )
+"""

--- a/sdk/python/kfp/registry/__init__.py
+++ b/sdk/python/kfp/registry/__init__.py
@@ -1,3 +1,5 @@
+"""The `kfp.registry` module contains objects for communicating with registry
+client hosts."""
 # Copyright 2022 The Kubeflow Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sdk/python/kfp/registry/registry_client.py
+++ b/sdk/python/kfp/registry/registry_client.py
@@ -59,12 +59,13 @@ class _SafeDict(dict):
 
 
 class ApiAuth(requests.auth.AuthBase):
-    """Class for authentication using API token.
+    """Class for registry authentication using an API token.
 
     Args:
         token: The API token.
 
-    Example::
+    Example:
+      ::
 
         client = RegistryClient(
             host='https://us-central1-kfp.pkg.dev/proj/repo', auth=ApiAuth('my_token'))
@@ -81,13 +82,13 @@ class ApiAuth(requests.auth.AuthBase):
 
 
 class RegistryClient:
-    """Registry Client class for communicating with registry hosts.
+    """Class for communicating with registry hosts.
 
     Args:
         host: The address of the registry host. The host needs to be specified here or in the config file.
-        auth: Authentication using python requests or google.auth.credentials.
-        config_file: The location of the local config file. If not specified, defaults to ~/.config/kfp/context.json (if it exists).
-        auth_file: The location of the local config file that contains the authentication token. If not specified, defaults to '~/.config/kfp/registry_credentials.json' (if it exists).
+        auth: Authentication using ``requests.auth.AuthBase`` or ``google.auth.credentials.Credentials``.
+        config_file: The location of the local config file. If not specified, defaults to ``'~/.config/kfp/context.json'`` (if it exists).
+        auth_file: The location of the local config file that contains the authentication token. If not specified, defaults to ``'~/.config/kfp/registry_credentials.json'`` (if it exists).
     """
 
     def __init__(self,
@@ -99,8 +100,8 @@ class RegistryClient:
         """Initializes the RegistryClient."""
         self._host = ''
         self._known_host_key = ''
-        self._config = self.load_config(host, config_file)
-        self._auth = self.load_auth(auth, auth_file)
+        self._config = self._load_config(host, config_file)
+        self._auth = self._load_auth(auth, auth_file)
 
     def _request(self,
                  request_url: str,
@@ -167,7 +168,7 @@ class RegistryClient:
         if tag.startswith(_VERSION_PREFIX):
             raise ValueError('Tag should not start with \"sha256:\".')
 
-    def load_auth(
+    def _load_auth(
         self,
         auth: Optional[Union[requests.auth.AuthBase,
                              credentials.Credentials]] = None,
@@ -176,10 +177,10 @@ class RegistryClient:
         """Loads the credentials for authentication.
 
         Args:
-            auth: Authentication using python requests or google.auth credentials.
+            auth: Authentication using ``requests.auth.AuthBase`` or ``google.auth.credentials.Credentials``.
             auth_file: The location of the local config file that contains the
                 authentication token. If not specified, defaults to
-                ~/.config/kfp/registry_credentials.json (if it exists).
+                ``'~/.config/kfp/registry_credentials.json'`` (if it exists).
 
         Returns:
             The loaded authentication token.
@@ -204,15 +205,14 @@ class RegistryClient:
                 return ApiAuth(auth_token)
         return None
 
-    def load_config(self, host: Optional[str],
-                    config_file: Optional[str]) -> dict:
+    def _load_config(self, host: Optional[str],
+                     config_file: Optional[str]) -> dict:
         """Loads the config.
 
         Args:
-            host: The address of the registry host. The host needs to be specified here
-                or in the config file.
+            host: The address of the registry host.
             config_file: The location of the local config file. If not specified,
-                defaults to ~/.config/kfp/context.json (if it exists).
+                defaults to ``'~/.config/kfp/context.json'`` (if it exists).
 
         Returns:
             The loaded config.
@@ -329,7 +329,7 @@ class RegistryClient:
             extra_headers: Any extra headers required.
 
         Returns:
-            A tuple representing the package name and the version.
+            A tuple of the package name and the version.
         """
         url = self._config['upload_url']
         self._refresh_creds()
@@ -523,7 +523,7 @@ class RegistryClient:
             tag: Tag to be attached to the package version.
 
         Returns:
-            The metadata for the created tag.
+            Metadata for the created tag.
         """
         self._validate_version(version)
         self._validate_tag(tag)

--- a/sdk/python/kfp/registry/registry_client.py
+++ b/sdk/python/kfp/registry/registry_client.py
@@ -59,9 +59,19 @@ class _SafeDict(dict):
 
 
 class ApiAuth(requests.auth.AuthBase):
-    """Class for authentication using API token."""
+    """Class for authentication using API token.
+
+    Args:
+        token: The API token.
+
+    Example::
+
+        client = RegistryClient(
+            host='https://us-central1-kfp.pkg.dev/proj/repo', auth=ApiAuth('my_token'))
+    """
 
     def __init__(self, token: str) -> None:
+        """Initializes the ApiAuth object."""
         self._token = token
 
     def __call__(self,
@@ -71,7 +81,14 @@ class ApiAuth(requests.auth.AuthBase):
 
 
 class RegistryClient:
-    """Registry Client class for communicating with registry hosts."""
+    """Registry Client class for communicating with registry hosts.
+
+    Args:
+        host: The address of the registry host. The host needs to be specified here or in the config file.
+        auth: Authentication using python requests or google.auth.credentials.
+        config_file: The location of the local config file. If not specified, defaults to ~/.config/kfp/context.json (if it exists).
+        auth_file: The location of the local config file that contains the authentication token. If not specified, defaults to '~/.config/kfp/registry_credentials.json' (if it exists).
+    """
 
     def __init__(self,
                  host: Optional[str],
@@ -79,18 +96,7 @@ class RegistryClient:
                                       credentials.Credentials]] = None,
                  config_file: Optional[str] = None,
                  auth_file: Optional[str] = None) -> None:
-        """Initializes the RegistryClient.
-
-        Args:
-            host: The address of the registry host. The host needs to be specified here
-                or in the config file.
-            auth: Optional. Authentication using python requests or google.auth.credentials.
-            config_file: Optional. The location of the local config file. If not specified,
-                defaults to ~/.config/kfp/context.json (if it exists).
-            auth_file: Optional. The location of the local config file that contains the
-                authentication token. If not specified, defaults to
-                ~/.config/kfp/registry_credentials.json (if it exists).
-        """
+        """Initializes the RegistryClient."""
         self._host = ''
         self._known_host_key = ''
         self._config = self.load_config(host, config_file)
@@ -170,8 +176,8 @@ class RegistryClient:
         """Loads the credentials for authentication.
 
         Args:
-            auth: Optional. Authentication using python requests or google.auth credentials.
-            auth_file: Optional. The location of the local config file that contains the
+            auth: Authentication using python requests or google.auth credentials.
+            auth_file: The location of the local config file that contains the
                 authentication token. If not specified, defaults to
                 ~/.config/kfp/registry_credentials.json (if it exists).
 
@@ -205,7 +211,7 @@ class RegistryClient:
         Args:
             host: The address of the registry host. The host needs to be specified here
                 or in the config file.
-            config_file: Optional. The location of the local config file. If not specified,
+            config_file: The location of the local config file. If not specified,
                 defaults to ~/.config/kfp/context.json (if it exists).
 
         Returns:
@@ -276,7 +282,7 @@ class RegistryClient:
 
         Args:
             config_file: The location of the config file.
-            config: Optional. An existing config to set as the default config.
+            config: An existing config to set as the default config.
 
         Returns:
             The loaded config.
@@ -323,7 +329,7 @@ class RegistryClient:
             extra_headers: Any extra headers required.
 
         Returns:
-            A tuple representing the package name and the version
+            A tuple representing the package name and the version.
         """
         url = self._config['upload_url']
         self._refresh_creds()
@@ -384,7 +390,7 @@ class RegistryClient:
                           version: Optional[str] = None,
                           tag: Optional[str] = None,
                           file_name: Optional[str] = None) -> str:
-        """Downloads a pipeline - either version or tag must be specified.
+        """Downloads a pipeline. Either version or tag must be specified.
 
         Args:
             package_name: Name of the package.


### PR DESCRIPTION
**Description of your changes:**
This PR refreshes the KFP SDK's public API 
docstrings. This includes:
- Updating what is considered part of our public api 
via the `__all__` special module variables
- Adds module docstrings for all public modules.
- Removes stale v1 language
- Adds significant number of usage examples
- Improves some of the conventions, including:
  - Tone of argument descriptions
  - Not including parameter type strings in docstring
  - Using code style like `this` when referring to 
parameters, other package objects, 
programmatic names, or defaults
  - Order of parameters and example code
  - Style of example code

**Checklist:**
- [x] The title for your pull request (PR) should 
follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
