### PR TITLE
chore(sdk): remove the unreachable validation code

### DIFF
--- a/sdk/python/kfp/components/base_component.py
+++ b/sdk/python/kfp/components/base_component.py
@@ -66,10 +66,6 @@ class BaseComponent(abc.ABC):
             if k not in self._component_inputs:
                 raise TypeError(
                     f'{self.name}() got an unexpected keyword argument "{k}".')
-
-            if k in task_inputs:
-                raise TypeError(
-                    f'{self.name}() got multiple values for argument "{k}".')
             task_inputs[k] = v
 
         # Skip optional inputs and arguments typed as PipelineTaskFinalStatus.


### PR DESCRIPTION
**Description of your changes:**

Because `kwargs` is a dictionary, and `task_inputs` starts off empty, it's not possible to get multiple values for a key. 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
