### PR TITLE
fix(backend): module not found error with kfp.deprecated

### DIFF
--- a/samples/core/sequential/sequential.py
+++ b/samples/core/sequential/sequential.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 
 
-from kfp.deprecated import dsl, compiler
+try:
+    from kfp.deprecated import dsl, compiler
+except ModuleNotFoundError:
+    from kfp import dsl, compiler
 
 
 def gcs_download_op(url):


### PR DESCRIPTION
Adding a try except block in the import statement, so that there is backward compatibility for the package and imports work as long as the user has a version of kfp installed.
