### PR TITLE
docs(sdk): clean up kfp v2 cli reference docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,6 @@ Kubeflow Pipelines SDK API Reference
 
    Home <self>
    API Reference <source/kfp>
-   kfp CLI <source/cli>
+   Command Line Interface <source/cli>
    Usage Docs (kubeflow.org) <https://kubeflow.org/docs/pipelines/>
    Source Code <https://github.com/kubeflow/pipelines/>

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1,4 +1,4 @@
-kfp CLI
+Command Line Interface
 ==========================
 
 .. contents:: All commands

--- a/sdk/python/kfp/cli/cli.py
+++ b/sdk/python/kfp/cli/cli.py
@@ -96,10 +96,7 @@ def _install_completion(shell: str) -> None:
 def cli(ctx: click.Context, endpoint: str, iap_client_id: str, namespace: str,
         other_client_id: str, other_client_secret: str, output: OutputFormat,
         show_completion: str, install_completion: str):
-    """Kubeflow Pipelines CLI.
-
-    The KFP CLI is currently in Alpha feature stage (https://github.com/kubeflow/pipelines/blob/07328e5094ac2981d3059314cc848fbb71437a76/docs/release/feature-stages.md#alpha).
-    """
+    """Kubeflow Pipelines CLI."""
     if show_completion:
         click.echo(_create_completion(show_completion))
         return

--- a/sdk/python/kfp/cli/cli_test.py
+++ b/sdk/python/kfp/cli/cli_test.py
@@ -26,7 +26,7 @@ from absl.testing import parameterized
 import click
 from click import testing
 from kfp.cli import cli
-from kfp.cli import dsl_compile
+from kfp.cli import compile_
 
 
 class TestCliNounAliases(unittest.TestCase):
@@ -154,10 +154,7 @@ class TestDslCompile(parameterized.TestCase):
     def invoke_deprecated(self, args: List[str]) -> testing.Result:
         runner = testing.CliRunner()
         return runner.invoke(
-            cli=dsl_compile.dsl_compile,
-            args=args,
-            catch_exceptions=False,
-            obj={})
+            cli=compile_.compile_, args=args, catch_exceptions=False, obj={})
 
     def test_deprecated_command_is_found(self):
         result = self.invoke_deprecated(['--help'])

--- a/sdk/python/kfp/cli/compile_.py
+++ b/sdk/python/kfp/cli/compile_.py
@@ -75,7 +75,7 @@ def parse_parameters(parameters: Optional[str]) -> Dict:
         raise e
 
 
-@click.command()
+@click.command(name='compile')
 @click.option(
     '--py',
     type=click.Path(exists=True, dir_okay=False),
@@ -103,7 +103,7 @@ def parse_parameters(parameters: Optional[str]) -> Dict:
     is_flag=True,
     default=False,
     help='Whether to disable type checking.')
-def dsl_compile(
+def compile_(
     py: str,
     output: str,
     function_name: Optional[str] = None,
@@ -127,13 +127,13 @@ def dsl_compile(
 def main():
     logging.basicConfig(format='%(message)s', level=logging.INFO)
     try:
-        dsl_compile.help = '(Deprecated. Please use `kfp dsl compile` instead.)\n\n' + dsl_compile.help
+        compile_.help = '(Deprecated. Please use `kfp dsl compile` instead.)\n\n' + compile_.help
 
         click.echo(
             '`dsl-compile` is deprecated. Please use `kfp dsl compile` instead.',
             err=True)
 
-        dsl_compile(obj={}, auto_envvar_prefix='KFP')
+        compile_(obj={}, auto_envvar_prefix='KFP')
     except Exception as e:
         click.echo(str(e), err=True)
         sys.exit(1)

--- a/sdk/python/kfp/cli/component.py
+++ b/sdk/python/kfp/cli/component.py
@@ -340,7 +340,8 @@ def component():
     '--engine',
     type=str,
     default='docker',
-    help="Engine to use to build the component's container.")
+    help="[Deprecated] Engine to use to build the component's container.",
+    hidden=True)
 @click.option(
     '--kfp-package-path',
     type=click.Path(exists=True),

--- a/sdk/python/kfp/cli/dsl.py
+++ b/sdk/python/kfp/cli/dsl.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import click
-from kfp.cli import dsl_compile
+from kfp.cli import compile_
 
 
-@click.group(commands={'compile': dsl_compile.dsl_compile})
+@click.group(commands={'compile': compile_.compile_})
 def dsl():
     """Command group for compiling DSL to IR."""

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -97,7 +97,7 @@ setuptools.setup(
     include_package_data=True,
     entry_points={
         'console_scripts': [
-            'dsl-compile = kfp.cli.dsl_compile:main',
+            'dsl-compile = kfp.cli.compile_:main',
             'dsl-compile-deprecated = kfp.deprecated.compiler.main:main',
             'kfp=kfp.cli.__main__:main',
         ]


### PR DESCRIPTION
**Description of your changes:**
This PR cleans up a few aspects of the [KFP CLI reference docs](https://kubeflow-pipelines.readthedocs.io/en/master/source/cli.html) discovered while working on the kubeflow.org docs. After this PR the docs will:

- use expanded "Command Line Interface" for title of section (instead of "kfp CLI")
- not show an alpha feature stage notice in docs or cli help text
- hide the deprecated `--engine argument` on `kfp component build`
- currently show the `kfp dsl compile` command as such, instead of as `kfp dsl dsl-compile`


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
