### PR TITLE
chore(sdk): add pre-commit hook to remove unused imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,16 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, master]
   # required formatting jobs (run these last)
+
+  # add comment "noqa" to ignore an import that should not be removed
+  # (e.g., for an import with desired side-effects)
+  - repo: https://github.com/hadialqattan/pycln
+    rev: v2.1.1
+    hooks:
+      - id: pycln
+        name: pycln
+        language: python
+        entry: pycln --all
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -34,8 +34,6 @@ from kfp.components import component_factory
 from kfp.components import for_loop
 from kfp.components import pipeline_channel
 from kfp.components import pipeline_context
-from kfp.components import pipeline_task
-from kfp.components import structures
 from kfp.components import tasks_group
 from kfp.components import utils as component_utils
 from kfp.components.types import type_utils

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 """Functions for creating PipelineSpec proto objects."""
 
-import collections
 import json
 import re
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 
 from google.protobuf import json_format
 from google.protobuf import struct_pb2
-import kfp
 from kfp import dsl
 from kfp.compiler import pipeline_spec_builder as builder
 from kfp.components import for_loop

--- a/sdk/python/kfp/compiler/test_data/components/unsupported/output_named_tuple.py
+++ b/sdk/python/kfp/compiler/test_data/components/unsupported/output_named_tuple.py
@@ -15,7 +15,6 @@ from typing import NamedTuple
 
 from kfp.dsl import component
 from kfp.dsl import Metrics
-from kfp.dsl import Model
 
 
 @component

--- a/sdk/python/kfp/components/yaml_component_test.py
+++ b/sdk/python/kfp/components/yaml_component_test.py
@@ -17,11 +17,9 @@ import os
 import tempfile
 import textwrap
 import unittest
-from unittest import mock
 
 from kfp.components import structures
 from kfp.components import yaml_component
-import requests
 
 SAMPLE_YAML = textwrap.dedent("""\
 components:

--- a/sdk/python/kfp/v2/compiler.py
+++ b/sdk/python/kfp/v2/compiler.py
@@ -12,5 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=wildcard-import,unused-wildcard-import
-from kfp.compiler import *
+from kfp.compiler import *  # noqa

--- a/sdk/python/kfp/v2/components.py
+++ b/sdk/python/kfp/v2/components.py
@@ -12,5 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=wildcard-import,unused-wildcard-import
-from kfp.components import *
+from kfp.components import *  # noqa

--- a/sdk/python/kfp/v2/dsl.py
+++ b/sdk/python/kfp/v2/dsl.py
@@ -12,5 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=wildcard-import,unused-wildcard-import
-from kfp.dsl import *
+from kfp.dsl import *  # noqa


### PR DESCRIPTION
**Description of your changes:**
Some pull requests create unused imports. This PR provides a pre-commit hook to automate the removal of unused imports to make code safer and PRs more effective.

**Safer code:** Some imports have desired (or undesired) side-effects. If we have spurious unused imports, it can challenging to know which "unused" imports we need and which we don't. Spurious imports are also superfluous code.

**Effective PRs:** Commenting on unused imports is also not meaningful PR feedback.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this 
repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
