### PR TITLE
Update the controller python image version 3.8.13

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/deployment.yaml
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: profile-controller
-        image: python:3.7
+        image: python:3.8.13-slim-bullseye
         command: ["python", "/hooks/sync.py"]
         envFrom:
         - configMapRef:


### PR DESCRIPTION
**Description of your changes:**

Update the controller python image version 3.8.13.
 - This resolved multiple CRITICAL CVEs registering against this image.
 - Controller runs fine on slim image.
 - Explicitly set version to bullseye and full python version number for stability.

This fixes many **Critical CVEs** including:

NAME | VULNERABILITY | SEVERITY
-- | -- | --
curl | CVE-2022-32207 | Critical
curl | CVE-2021-22945 | Critical
dpkg | CVE-2022-1664 | Critical
dpkg-dev | CVE-2022-1664 | Critical
libaom0 | CVE-2021-30474 | Critical
libaom0 | CVE-2021-30475 | Critical
libaom0 | CVE-2021-30473 | Critical
libbluetooth-dev | CVE-2021-43400 | Critical
libbluetooth3 | CVE-2021-43400 | Critical
libc-bin | CVE-2022-23219 | Critical
libc-bin | CVE-2022-23218 | Critical
libc-bin | CVE-2021-33574 | Critical
libc-dev-bin | CVE-2021-33574 | Critical
libc-dev-bin | CVE-2022-23219 | Critical
libc-dev-bin | CVE-2022-23218 | Critical
libc6 | CVE-2021-33574 | Critical
libc6 | CVE-2022-23219 | Critical
libc6 | CVE-2022-23218 | Critical
libc6-dev | CVE-2021-33574 | Critical
libc6-dev | CVE-2022-23219 | Critical
libc6-dev | CVE-2022-23218 | Critical
libcurl3-gnutls | CVE-2022-32207 | Critical
libcurl3-gnutls | CVE-2021-22945 | Critical
libcurl4 | CVE-2022-32207 | Critical
libcurl4 | CVE-2021-22945 | Critical
libcurl4-openssl-dev | CVE-2021-22945 | Critical
libcurl4-openssl-dev | CVE-2022-32207 | Critical
libde265-0 | CVE-2022-1253 | Critical
libdpkg-perl | CVE-2022-1664 | Critical
libexpat1 | CVE-2022-23852 | Critical
libexpat1 | CVE-2022-25315 | Critical
libexpat1 | CVE-2022-25235 | Critical
libexpat1 | CVE-2022-25236 | Critical
libexpat1 | CVE-2022-23990 | Critical
libexpat1 | CVE-2022-22824 | Critical
libexpat1 | CVE-2022-22822 | Critical
libexpat1 | CVE-2022-22823 | Critical
libexpat1-dev | CVE-2022-22822 | Critical
libexpat1-dev | CVE-2022-25315 | Critical
libexpat1-dev | CVE-2022-25236 | Critical
libexpat1-dev | CVE-2022-23990 | Critical
libexpat1-dev | CVE-2022-22823 | Critical
libexpat1-dev | CVE-2022-22824 | Critical
libexpat1-dev | CVE-2022-25235 | Critical
libexpat1-dev | CVE-2022-23852 | Critical
libfreetype-dev | CVE-2022-27404 | Critical
libfreetype6 | CVE-2022-27404 | Critical
libfreetype6-dev | CVE-2022-27404 | Critical
libldap-2.4-2 | CVE-2022-29155 | Critical
libmariadb-dev | CVE-2022-32091 | Critical
libmariadb-dev | CVE-2022-32081 | Critical
libmariadb-dev-compat | CVE-2022-32081 | Critical
libmariadb-dev-compat | CVE-2022-32091 | Critical
libmariadb3 | CVE-2022-32081 | Critical
libmariadb3 | CVE-2022-32091 | Critical
libpython3.9-minimal | CVE-2021-29921 | Critical
libpython3.9-minimal | CVE-2015-20107 | Critical
libpython3.9-stdlib | CVE-2021-29921 | Critical
libpython3.9-stdlib | CVE-2015-20107 | Critical
libssl-dev | CVE-2022-2068 | Critical
libssl-dev | CVE-2022-1292 | Critical
libssl1.1 | CVE-2022-1292 | Critical
libssl1.1 | CVE-2022-2068 | Critical
mariadb-common | CVE-2022-32091 | Critical
mariadb-common | CVE-2022-32081 | Critical
openssl | CVE-2022-2068 | Critical
openssl | CVE-2022-1292 | Critical
python3.9 | CVE-2015-20107 | Critical
python3.9 | CVE-2021-29921 | Critical
python3.9-minimal | CVE-2015-20107 | Critical
python3.9-minimal | CVE-2021-29921 | Critical
