### PR TITLE
feature(sdk): print links outside of ipython. Fixes #8141

### DIFF
--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -477,11 +477,14 @@ class Client:
                 resource_references=resource_references)
             experiment = self._experiment_api.create_experiment(body=experiment)
 
+        link = f"{self._get_url_prefix()}/#/experiments/details/{experiment.id}"
         if self._is_ipython():
             import IPython
-            html = \
-                f'<a href="{self._get_url_prefix()}/#/experiments/details/{experiment.id}" target="_blank" >Experiment details</a>.'
+            html = f'<a href="{link}" target="_blank" >Experiment details</a>.'
             IPython.display.display(IPython.display.HTML(html))
+        else:
+            print(f"Experiment details: {link}")
+
         return experiment
 
     def get_pipeline_id(self, name: str) -> Optional[str]:
@@ -781,12 +784,14 @@ class Client:
 
         response = self._run_api.create_run(body=run_body)
 
+        link = f"{self._get_url_prefix()}/#/runs/details/{response.run.id}"
         if self._is_ipython():
             import IPython
-            html = (
-                f'<a href="{self._get_url_prefix()}/#/runs/details/{response.run.id}" target="_blank" >Run details</a>.'
-            )
+            html = (f'<a href="{link}" target="_blank" >Run details</a>.')
             IPython.display.display(IPython.display.HTML(html))
+        else:
+            print(f"Run details: {link}")
+
         return response.run
 
     def archive_run(self, run_id: str) -> dict:
@@ -1372,10 +1377,14 @@ class Client:
         validate_pipeline_resource_name(pipeline_name)
         response = self._upload_api.upload_pipeline(
             pipeline_package_path, name=pipeline_name, description=description)
+        link = f"{self._get_url_prefix()}/#/pipelines/details/{response.id}"
         if self._is_ipython():
             import IPython
-            html = f'<a href={self._get_url_prefix()}/#/pipelines/details/{response.id}>Pipeline details</a>.'
+            html = f'<a href="{link}" target="_blank" >Pipeline details</a>.'
             IPython.display.display(IPython.display.HTML(html))
+        else:
+            print(f"Pipeline details: {link}")
+
         return response
 
     def upload_pipeline_version(
@@ -1417,10 +1426,14 @@ class Client:
         response = self._upload_api.upload_pipeline_version(
             pipeline_package_path, **kwargs)
 
+        link = f"{self._get_url_prefix()}/#/pipelines/details/{response.id}"
         if self._is_ipython():
             import IPython
-            html = f'<a href={self._get_url_prefix()}/#/pipelines/details/{response.id}>Pipeline details</a>.'
+            html = f'<a href="{link}" target="_blank" >Pipeline details</a>.'
             IPython.display.display(IPython.display.HTML(html))
+        else:
+            print(f"Pipeline details: {link}")
+
         return response
 
     def get_pipeline(self, pipeline_id: str) -> kfp_server_api.ApiPipeline:


### PR DESCRIPTION
This PR implements a tiny change that enables deep link printing outside of IPython. It also adds some missing quotation marks that wrap around the link in three of the constructed `html` variables. Lastly, it adds `target="_blank"` attributes to the pipeline details html values to standardize things. 

[Here's](https://github.com/kubeflow/pipelines/issues/8141) a link to the relevant issue.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
