### PR TITLE
fix(sdk): Make name argument mandatory

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -67,7 +67,7 @@ class Compiler:
         self,
         pipeline_func: Union[Callable[..., Any], base_component.BaseComponent],
         package_path: str,
-        pipeline_name: Optional[str] = None,
+        pipeline_name: str = None,
         pipeline_parameters: Optional[Dict[str, Any]] = None,
         type_check: bool = True,
     ) -> None:


### PR DESCRIPTION
**Description of your changes:**

The `pipeline_name` argument already needs to specified for the pipeline to compile however it is denoted as `Optional`.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
 Also, closes #7013 