### PR TITLE
feat(sdk): import typing at component runtime

### DIFF
--- a/samples/test/config.yaml
+++ b/samples/test/config.yaml
@@ -124,6 +124,8 @@
   path: samples.v2.pipeline_with_importer_test
 - name: pipeline_container_no_input
   path: samples.v2.pipeline_container_no_input_test
+- name: pipeline_with_named_tuples
+  path: samples.v2.pipeline_with_named_tuples_test
 # TODO(capri-xiyue): Re-enable after figuring out V2 Engine
 # and protobuf.Value support.
 # - name: cache_v2

--- a/samples/v2/pipeline_with_named_tuples.py
+++ b/samples/v2/pipeline_with_named_tuples.py
@@ -1,0 +1,51 @@
+# Copyright 2022 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import typing
+from typing import NamedTuple
+
+from kfp import compiler
+from kfp import dsl
+
+# In tests, we install a KFP package from the PR under test. Users should not
+# normally need to specify `kfp_package_path` in their component definitions.
+_KFP_PACKAGE_PATH = os.getenv('KFP_PACKAGE_PATH')
+
+
+@dsl.component(kfp_package_path=_KFP_PACKAGE_PATH)
+def create_named_tuple_from_module(
+) -> typing.NamedTuple('Output', [('name', str), ('id', int)]):
+    import typing
+    nt = typing.NamedTuple('Output', [('name', str), ('id', int)])
+    return nt(name='name', id=1)
+
+
+@dsl.component(kfp_package_path=_KFP_PACKAGE_PATH)
+def create_named_tuple_from_class_factory(
+) -> NamedTuple('Output', [('name', str), ('id', int)]):
+    from typing import NamedTuple
+    nt = NamedTuple('Output', [('name', str), ('id', int)])
+    return nt(name='name', id=1)
+
+
+@dsl.pipeline()
+def pipeline_with_named_tuples():
+    create_named_tuple_from_module()
+    create_named_tuple_from_class_factory()
+
+
+if __name__ == '__main__':
+    compiler.Compiler().compile(
+        pipeline_func=pipeline_with_named_tuples,
+        package_path='pipeline_with_named_tuples.json')

--- a/samples/v2/pipeline_with_named_tuples_test.py
+++ b/samples/v2/pipeline_with_named_tuples_test.py
@@ -1,0 +1,39 @@
+# Copyright 2022 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict
+import unittest
+
+import kfp.deprecated as kfp
+from kfp.samples.test.utils import KfpTask
+from kfp.samples.test.utils import run_pipeline_func
+from kfp.samples.test.utils import TestCase
+import kfp_server_api
+
+from .pipeline_with_named_tuples import pipeline_with_named_tuples
+
+
+def verify(t: unittest.TestCase, run: kfp_server_api.ApiRun,
+           tasks: Dict[str, KfpTask], **kwargs):
+    t.assertEqual(run.status, 'Succeeded')
+
+
+if __name__ == '__main__':
+    run_pipeline_func([
+        TestCase(
+            pipeline_func=pipeline_with_named_tuples,
+            verify_func=verify,
+            mode=kfp.dsl.PipelineExecutionMode.V2_ENGINE,
+        ),
+    ])

--- a/sdk/python/kfp/compiler/test_data/components/add_numbers.yaml
+++ b/sdk/python/kfp/compiler/test_data/components/add_numbers.yaml
@@ -25,7 +25,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -37,7 +37,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef add_numbers(a: int, b: int) -> int:\n    return a + b\n\n"
+          \ *\nimport typing\n\ndef add_numbers(a: int, b: int) -> int:\n    return\
+          \ a + b\n\n"
         image: python:3.7
 pipelineInfo:
   name: add-numbers
@@ -64,4 +65,4 @@ root:
       b:
         parameterType: NUMBER_INTEGER
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/components/component_with_pip_install.yaml
+++ b/sdk/python/kfp/compiler/test_data/components/component_with_pip_install.yaml
@@ -17,7 +17,7 @@ deploymentSpec:
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet     --no-warn-script-location --index-url\
           \ https://pypi.org/simple --trusted-host https://pypi.org/simple 'yapf'\
-          \ 'kfp==2.0.0-alpha.5' && \"$0\" \"$@\"\n"
+          \ 'kfp==2.0.0-beta.3' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -28,8 +28,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef component_with_pip_install():\n    import yapf\n    print(dir(yapf))\n\
-          \n"
+          \ *\nimport typing\n\ndef component_with_pip_install():\n    import yapf\n\
+          \    print(dir(yapf))\n\n"
         image: python:3.7
 pipelineInfo:
   name: component-with-pip-install
@@ -44,4 +44,4 @@ root:
         taskInfo:
           name: component-with-pip-install
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/components/concat_message.yaml
+++ b/sdk/python/kfp/compiler/test_data/components/concat_message.yaml
@@ -25,7 +25,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -37,8 +37,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef concat_message(message1: str, message2: str) -> str:\n    return\
-          \ message1 + message2\n\n"
+          \ *\nimport typing\n\ndef concat_message(message1: str, message2: str) ->\
+          \ str:\n    return message1 + message2\n\n"
         image: python:3.7
 pipelineInfo:
   name: concat-message
@@ -65,4 +65,4 @@ root:
       message2:
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/components/container_io.yaml
+++ b/sdk/python/kfp/compiler/test_data/components/container_io.yaml
@@ -41,4 +41,4 @@ root:
       text:
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-beta.1
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/components/container_no_input.yaml
+++ b/sdk/python/kfp/compiler/test_data/components/container_no_input.yaml
@@ -22,4 +22,4 @@ root:
         taskInfo:
           name: container-no-input
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-beta.1
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/components/container_with_artifact_output.yaml
+++ b/sdk/python/kfp/compiler/test_data/components/container_with_artifact_output.yaml
@@ -52,4 +52,4 @@ root:
       num_epochs:
         parameterType: NUMBER_INTEGER
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-beta.2
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/components/container_with_concat_placeholder.yaml
+++ b/sdk/python/kfp/compiler/test_data/components/container_with_concat_placeholder.yaml
@@ -46,4 +46,4 @@ root:
       text1:
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-beta.1
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/components/container_with_if_placeholder.yaml
+++ b/sdk/python/kfp/compiler/test_data/components/container_with_if_placeholder.yaml
@@ -52,4 +52,4 @@ root:
         defaultValue: default
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-beta.1
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/components/dict_input.yaml
+++ b/sdk/python/kfp/compiler/test_data/components/dict_input.yaml
@@ -19,7 +19,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -31,7 +31,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef dict_input(struct: Dict):\n    print(struct)\n\n"
+          \ *\nimport typing\n\ndef dict_input(struct: Dict):\n    print(struct)\n\
+          \n"
         image: python:3.7
 pipelineInfo:
   name: dict-input
@@ -54,4 +55,4 @@ root:
       struct:
         parameterType: STRUCT
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/components/identity.yaml
+++ b/sdk/python/kfp/compiler/test_data/components/identity.yaml
@@ -23,7 +23,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -35,7 +35,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef identity(value: str) -> str:\n    return value\n\n"
+          \ *\nimport typing\n\ndef identity(value: str) -> str:\n    return value\n\
+          \n"
         image: python:3.7
 pipelineInfo:
   name: identity
@@ -58,4 +59,4 @@ root:
       value:
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/components/input_artifact.yaml
+++ b/sdk/python/kfp/compiler/test_data/components/input_artifact.yaml
@@ -21,7 +21,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.1'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -33,7 +33,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef input_artifact(data: Input[Dataset]):\n    print(data.name)\n\
+          \ *\nimport typing\n\ndef input_artifact(data: Input[Dataset]):\n    print(data.name)\n\
           \    print(data.uri)\n    print(data.metadata)\n\n"
         image: python:3.7
 pipelineInfo:
@@ -59,4 +59,4 @@ root:
           schemaTitle: system.Dataset
           schemaVersion: 0.0.1
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-beta.1
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/components/nested_return.yaml
+++ b/sdk/python/kfp/compiler/test_data/components/nested_return.yaml
@@ -19,7 +19,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -31,8 +31,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef nested_return() -> List[Dict[str, str]]:\n    return [{'A_a':\
-          \ '1', 'B_b': '2'}, {'A_a': '10', 'B_b': '20'}]\n\n"
+          \ *\nimport typing\n\ndef nested_return() -> List[Dict[str, str]]:\n   \
+          \ return [{'A_a': '1', 'B_b': '2'}, {'A_a': '10', 'B_b': '20'}]\n\n"
         image: python:3.7
 pipelineInfo:
   name: nested-return
@@ -47,4 +47,4 @@ root:
         taskInfo:
           name: nested-return
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/components/output_metrics.yaml
+++ b/sdk/python/kfp/compiler/test_data/components/output_metrics.yaml
@@ -21,7 +21,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -33,9 +33,9 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef output_metrics(metrics: Output[Metrics]):\n    \"\"\"Dummy component\
-          \ that outputs metrics with a random accuracy.\"\"\"\n    import random\n\
-          \    result = random.randint(0, 100)\n    metrics.log_metric('accuracy',\
+          \ *\nimport typing\n\ndef output_metrics(metrics: Output[Metrics]):\n  \
+          \  \"\"\"Dummy component that outputs metrics with a random accuracy.\"\"\
+          \"\n    import random\n    result = random.randint(0, 100)\n    metrics.log_metric('accuracy',\
           \ result)\n\n"
         image: python:3.7
 pipelineInfo:
@@ -63,4 +63,4 @@ root:
           schemaTitle: system.Metrics
           schemaVersion: 0.0.1
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/components/preprocess.yaml
+++ b/sdk/python/kfp/compiler/test_data/components/preprocess.yaml
@@ -42,7 +42,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -54,26 +54,26 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef preprocess(\n    # An input parameter of type string.\n    message:\
-          \ str,\n    # An input parameter of type dict.\n    input_dict_parameter:\
-          \ Dict[str, int],\n    # An input parameter of type list.\n    input_list_parameter:\
-          \ List[str],\n    # Use Output[T] to get a metadata-rich handle to the output\
-          \ artifact\n    # of type `Dataset`.\n    output_dataset_one: Output[Dataset],\n\
-          \    # A locally accessible filepath for another output artifact of type\n\
-          \    # `Dataset`.\n    output_dataset_two_path: OutputPath('Dataset'),\n\
-          \    # A locally accessible filepath for an output parameter of type string.\n\
-          \    output_parameter_path: OutputPath(str),\n    # A locally accessible\
-          \ filepath for an output parameter of type bool.\n    output_bool_parameter_path:\
-          \ OutputPath(bool),\n    # A locally accessible filepath for an output parameter\
-          \ of type dict.\n    output_dict_parameter_path: OutputPath(Dict[str, int]),\n\
-          \    # A locally accessible filepath for an output parameter of type list.\n\
-          \    output_list_parameter_path: OutputPath(List[str]),\n):\n    \"\"\"\
-          Dummy preprocessing step.\"\"\"\n\n    # Use Dataset.path to access a local\
-          \ file path for writing.\n    # One can also use Dataset.uri to access the\
-          \ actual URI file path.\n    with open(output_dataset_one.path, 'w') as\
-          \ f:\n        f.write(message)\n\n    # OutputPath is used to just pass\
-          \ the local file path of the output artifact\n    # to the function.\n \
-          \   with open(output_dataset_two_path, 'w') as f:\n        f.write(message)\n\
+          \ *\nimport typing\n\ndef preprocess(\n    # An input parameter of type\
+          \ string.\n    message: str,\n    # An input parameter of type dict.\n \
+          \   input_dict_parameter: Dict[str, int],\n    # An input parameter of type\
+          \ list.\n    input_list_parameter: List[str],\n    # Use Output[T] to get\
+          \ a metadata-rich handle to the output artifact\n    # of type `Dataset`.\n\
+          \    output_dataset_one: Output[Dataset],\n    # A locally accessible filepath\
+          \ for another output artifact of type\n    # `Dataset`.\n    output_dataset_two_path:\
+          \ OutputPath('Dataset'),\n    # A locally accessible filepath for an output\
+          \ parameter of type string.\n    output_parameter_path: OutputPath(str),\n\
+          \    # A locally accessible filepath for an output parameter of type bool.\n\
+          \    output_bool_parameter_path: OutputPath(bool),\n    # A locally accessible\
+          \ filepath for an output parameter of type dict.\n    output_dict_parameter_path:\
+          \ OutputPath(Dict[str, int]),\n    # A locally accessible filepath for an\
+          \ output parameter of type list.\n    output_list_parameter_path: OutputPath(List[str]),\n\
+          ):\n    \"\"\"Dummy preprocessing step.\"\"\"\n\n    # Use Dataset.path\
+          \ to access a local file path for writing.\n    # One can also use Dataset.uri\
+          \ to access the actual URI file path.\n    with open(output_dataset_one.path,\
+          \ 'w') as f:\n        f.write(message)\n\n    # OutputPath is used to just\
+          \ pass the local file path of the output artifact\n    # to the function.\n\
+          \    with open(output_dataset_two_path, 'w') as f:\n        f.write(message)\n\
           \n    with open(output_parameter_path, 'w') as f:\n        f.write(message)\n\
           \n    with open(output_bool_parameter_path, 'w') as f:\n        f.write(\n\
           \            str(True))  # use either `str()` or `json.dumps()` for bool\
@@ -111,4 +111,4 @@ root:
       message:
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/component_with_optional_inputs.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/component_with_optional_inputs.yaml
@@ -22,7 +22,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -34,11 +34,11 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef component_op(\n    input1: str = 'default value',\n    input2:\
-          \ Optional[str] = None,\n    input3: Optional[str] = None,\n):\n    print(f'input1:\
-          \ {input1}, type: {type(input1)}')\n    print(f'input2: {input2}, type:\
-          \ {type(input2)}')\n    print(f'input3: {input3}, type: {type(input3)}')\n\
-          \n"
+          \ *\nimport typing\n\ndef component_op(\n    input1: str = 'default value',\n\
+          \    input2: Optional[str] = None,\n    input3: Optional[str] = None,\n\
+          ):\n    print(f'input1: {input1}, type: {type(input1)}')\n    print(f'input2:\
+          \ {input2}, type: {type(input2)}')\n    print(f'input3: {input3}, type:\
+          \ {type(input3)}')\n\n"
         image: python:3.7
 pipelineInfo:
   name: v2-component-optional-input
@@ -61,4 +61,4 @@ root:
         taskInfo:
           name: component-op
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/component_with_pip_index_urls.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/component_with_pip_index_urls.yaml
@@ -17,7 +17,7 @@ deploymentSpec:
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet     --no-warn-script-location --index-url\
           \ https://pypi.org/simple --trusted-host https://pypi.org/simple 'yapf'\
-          \ 'kfp==2.0.0-alpha.5' && \"$0\" \"$@\"\n"
+          \ 'kfp==2.0.0-beta.3' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -28,7 +28,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef component_op():\n    import yapf\n    print(dir(yapf))\n\n"
+          \ *\nimport typing\n\ndef component_op():\n    import yapf\n    print(dir(yapf))\n\
+          \n"
         image: python:3.7
 pipelineInfo:
   name: v2-component-pip-index-urls
@@ -43,4 +44,4 @@ root:
         taskInfo:
           name: component-op
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/container_component_with_no_inputs.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/container_component_with_no_inputs.yaml
@@ -22,4 +22,4 @@ root:
         taskInfo:
           name: hello-world-container
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-beta.0
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/lightweight_python_functions_pipeline.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/lightweight_python_functions_pipeline.yaml
@@ -73,7 +73,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -85,26 +85,26 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef preprocess(\n    # An input parameter of type string.\n    message:\
-          \ str,\n    # An input parameter of type dict.\n    input_dict_parameter:\
-          \ Dict[str, int],\n    # An input parameter of type list.\n    input_list_parameter:\
-          \ List[str],\n    # Use Output[T] to get a metadata-rich handle to the output\
-          \ artifact\n    # of type `Dataset`.\n    output_dataset_one: Output[Dataset],\n\
-          \    # A locally accessible filepath for another output artifact of type\n\
-          \    # `Dataset`.\n    output_dataset_two_path: OutputPath('Dataset'),\n\
-          \    # A locally accessible filepath for an output parameter of type string.\n\
-          \    output_parameter_path: OutputPath(str),\n    # A locally accessible\
-          \ filepath for an output parameter of type bool.\n    output_bool_parameter_path:\
-          \ OutputPath(bool),\n    # A locally accessible filepath for an output parameter\
-          \ of type dict.\n    output_dict_parameter_path: OutputPath(Dict[str, int]),\n\
-          \    # A locally accessible filepath for an output parameter of type list.\n\
-          \    output_list_parameter_path: OutputPath(List[str]),\n):\n    \"\"\"\
-          Dummy preprocessing step.\"\"\"\n\n    # Use Dataset.path to access a local\
-          \ file path for writing.\n    # One can also use Dataset.uri to access the\
-          \ actual URI file path.\n    with open(output_dataset_one.path, 'w') as\
-          \ f:\n        f.write(message)\n\n    # OutputPath is used to just pass\
-          \ the local file path of the output artifact\n    # to the function.\n \
-          \   with open(output_dataset_two_path, 'w') as f:\n        f.write(message)\n\
+          \ *\nimport typing\n\ndef preprocess(\n    # An input parameter of type\
+          \ string.\n    message: str,\n    # An input parameter of type dict.\n \
+          \   input_dict_parameter: Dict[str, int],\n    # An input parameter of type\
+          \ list.\n    input_list_parameter: List[str],\n    # Use Output[T] to get\
+          \ a metadata-rich handle to the output artifact\n    # of type `Dataset`.\n\
+          \    output_dataset_one: Output[Dataset],\n    # A locally accessible filepath\
+          \ for another output artifact of type\n    # `Dataset`.\n    output_dataset_two_path:\
+          \ OutputPath('Dataset'),\n    # A locally accessible filepath for an output\
+          \ parameter of type string.\n    output_parameter_path: OutputPath(str),\n\
+          \    # A locally accessible filepath for an output parameter of type bool.\n\
+          \    output_bool_parameter_path: OutputPath(bool),\n    # A locally accessible\
+          \ filepath for an output parameter of type dict.\n    output_dict_parameter_path:\
+          \ OutputPath(Dict[str, int]),\n    # A locally accessible filepath for an\
+          \ output parameter of type list.\n    output_list_parameter_path: OutputPath(List[str]),\n\
+          ):\n    \"\"\"Dummy preprocessing step.\"\"\"\n\n    # Use Dataset.path\
+          \ to access a local file path for writing.\n    # One can also use Dataset.uri\
+          \ to access the actual URI file path.\n    with open(output_dataset_one.path,\
+          \ 'w') as f:\n        f.write(message)\n\n    # OutputPath is used to just\
+          \ pass the local file path of the output artifact\n    # to the function.\n\
+          \    with open(output_dataset_two_path, 'w') as f:\n        f.write(message)\n\
           \n    with open(output_parameter_path, 'w') as f:\n        f.write(message)\n\
           \n    with open(output_bool_parameter_path, 'w') as f:\n        f.write(\n\
           \            str(True))  # use either `str()` or `json.dumps()` for bool\
@@ -125,7 +125,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -137,8 +137,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef train(\n    # Use InputPath to get a locally accessible path\
-          \ for the input artifact\n    # of type `Dataset`.\n    dataset_one_path:\
+          \ *\nimport typing\n\ndef train(\n    # Use InputPath to get a locally accessible\
+          \ path for the input artifact\n    # of type `Dataset`.\n    dataset_one_path:\
           \ InputPath('Dataset'),\n    # Use Input[T] to get a metadata-rich handle\
           \ to the input artifact\n    # of type `Dataset`.\n    dataset_two: Input[Dataset],\n\
           \    # An input parameter of type string.\n    message: str,\n    # Use\
@@ -232,4 +232,4 @@ root:
       message:
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/lightweight_python_functions_with_outputs.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/lightweight_python_functions_with_outputs.yaml
@@ -73,7 +73,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -85,8 +85,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef add_numbers(first: int, second: int) -> int:\n    return first\
-          \ + second\n\n"
+          \ *\nimport typing\n\ndef add_numbers(first: int, second: int) -> int:\n\
+          \    return first + second\n\n"
         image: python:3.7
     exec-concat-message:
       container:
@@ -100,7 +100,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -112,8 +112,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef concat_message(first: str, second: str) -> str:\n    return first\
-          \ + second\n\n"
+          \ *\nimport typing\n\ndef concat_message(first: str, second: str) -> str:\n\
+          \    return first + second\n\n"
         image: python:3.7
     exec-output-artifact:
       container:
@@ -127,7 +127,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -139,8 +139,9 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef output_artifact(number: int, message: str) -> Dataset:\n    result\
-          \ = [message for _ in range(number)]\n    return '\\n'.join(result)\n\n"
+          \ *\nimport typing\n\ndef output_artifact(number: int, message: str) ->\
+          \ Dataset:\n    result = [message for _ in range(number)]\n    return '\\\
+          n'.join(result)\n\n"
         image: python:3.7
     exec-output-named-tuple:
       container:
@@ -154,7 +155,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -166,15 +167,16 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef output_named_tuple(\n    artifact: Input[Dataset]\n) -> NamedTuple('Outputs',\
-          \ [\n    ('scalar', str),\n    ('metrics', Metrics),\n    ('model', Model),\n\
-          ]):\n    scalar = '123'\n\n    import json\n    metrics = json.dumps({\n\
-          \        'metrics': [{\n            'name': 'accuracy',\n            'numberValue':\
-          \ 0.9,\n            'format': 'PERCENTAGE',\n        }]\n    })\n\n    with\
-          \ open(artifact.path) as f:\n        artifact_contents = f.read()\n    model\
-          \ = 'Model contents: ' + artifact_contents\n\n    from collections import\
-          \ namedtuple\n    output = namedtuple('Outputs', ['scalar', 'metrics', 'model'])\n\
-          \    return output(scalar, metrics, model)\n\n"
+          \ *\nimport typing\n\ndef output_named_tuple(\n    artifact: Input[Dataset]\n\
+          ) -> NamedTuple('Outputs', [\n    ('scalar', str),\n    ('metrics', Metrics),\n\
+          \    ('model', Model),\n]):\n    scalar = '123'\n\n    import json\n   \
+          \ metrics = json.dumps({\n        'metrics': [{\n            'name': 'accuracy',\n\
+          \            'numberValue': 0.9,\n            'format': 'PERCENTAGE',\n\
+          \        }]\n    })\n\n    with open(artifact.path) as f:\n        artifact_contents\
+          \ = f.read()\n    model = 'Model contents: ' + artifact_contents\n\n   \
+          \ from collections import namedtuple\n    output = namedtuple('Outputs',\
+          \ ['scalar', 'metrics', 'model'])\n    return output(scalar, metrics, model)\n\
+          \n"
         image: python:3.7
 pipelineInfo:
   name: functions-with-outputs
@@ -265,4 +267,4 @@ root:
           schemaTitle: system.Metrics
           schemaVersion: 0.0.1
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_after.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_after.yaml
@@ -103,4 +103,4 @@ root:
         taskInfo:
           name: print-text-3
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_concat_placeholder.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_concat_placeholder.yaml
@@ -32,4 +32,4 @@ root:
         taskInfo:
           name: component-with-concat-placeholder
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_condition.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_condition.yaml
@@ -85,7 +85,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -97,9 +97,10 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef flip_coin_op() -> str:\n    \"\"\"Flip a coin and output heads\
-          \ or tails randomly.\"\"\"\n    import random\n    result = 'heads' if random.randint(0,\
-          \ 1) == 0 else 'tails'\n    return result\n\n"
+          \ *\nimport typing\n\ndef flip_coin_op() -> str:\n    \"\"\"Flip a coin\
+          \ and output heads or tails randomly.\"\"\"\n    import random\n    result\
+          \ = 'heads' if random.randint(0, 1) == 0 else 'tails'\n    return result\n\
+          \n"
         image: python:3.7
     exec-flip-coin-op-2:
       container:
@@ -113,7 +114,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -125,9 +126,10 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef flip_coin_op() -> str:\n    \"\"\"Flip a coin and output heads\
-          \ or tails randomly.\"\"\"\n    import random\n    result = 'heads' if random.randint(0,\
-          \ 1) == 0 else 'tails'\n    return result\n\n"
+          \ *\nimport typing\n\ndef flip_coin_op() -> str:\n    \"\"\"Flip a coin\
+          \ and output heads or tails randomly.\"\"\"\n    import random\n    result\
+          \ = 'heads' if random.randint(0, 1) == 0 else 'tails'\n    return result\n\
+          \n"
         image: python:3.7
     exec-print-op:
       container:
@@ -141,7 +143,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -153,8 +155,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(msg: str):\n    \"\"\"Print a message.\"\"\"\n    print(msg)\n\
-          \n"
+          \ *\nimport typing\n\ndef print_op(msg: str):\n    \"\"\"Print a message.\"\
+          \"\"\n    print(msg)\n\n"
         image: python:3.7
     exec-print-op-2:
       container:
@@ -168,7 +170,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -180,8 +182,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(msg: str):\n    \"\"\"Print a message.\"\"\"\n    print(msg)\n\
-          \n"
+          \ *\nimport typing\n\ndef print_op(msg: str):\n    \"\"\"Print a message.\"\
+          \"\"\n    print(msg)\n\n"
         image: python:3.7
     exec-print-op-3:
       container:
@@ -195,7 +197,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -207,8 +209,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(msg: str):\n    \"\"\"Print a message.\"\"\"\n    print(msg)\n\
-          \n"
+          \ *\nimport typing\n\ndef print_op(msg: str):\n    \"\"\"Print a message.\"\
+          \"\"\n    print(msg)\n\n"
         image: python:3.7
 pipelineInfo:
   name: single-condition-pipeline
@@ -260,4 +262,4 @@ root:
         defaultValue: condition test
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_env.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_env.yaml
@@ -36,7 +36,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -48,7 +48,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_env_op():\n    import os\n    print(os.environ['ENV1'])\n\
+          \ *\nimport typing\n\ndef print_env_op():\n    import os\n    print(os.environ['ENV1'])\n\
           \n"
         env:
         - name: ENV1
@@ -74,4 +74,4 @@ root:
         taskInfo:
           name: print-env-op
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_exit_handler.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_exit_handler.yaml
@@ -61,7 +61,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -73,8 +73,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef fail_op(message: str):\n    \"\"\"Fails.\"\"\"\n    import sys\n\
-          \    print(message)\n    sys.exit(1)\n\n"
+          \ *\nimport typing\n\ndef fail_op(message: str):\n    \"\"\"Fails.\"\"\"\
+          \n    import sys\n    print(message)\n    sys.exit(1)\n\n"
         image: python:3.7
     exec-print-op:
       container:
@@ -88,7 +88,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -100,8 +100,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\"\"\n\
-          \    print(message)\n\n"
+          \ *\nimport typing\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\
+          \"\"\n    print(message)\n\n"
         image: python:3.7
     exec-print-op-2:
       container:
@@ -115,7 +115,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -127,8 +127,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\"\"\n\
-          \    print(message)\n\n"
+          \ *\nimport typing\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\
+          \"\"\n    print(message)\n\n"
         image: python:3.7
 pipelineInfo:
   name: pipeline-with-exit-handler
@@ -166,4 +166,4 @@ root:
         defaultValue: Hello World!
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_gcpc_types.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_gcpc_types.yaml
@@ -29,7 +29,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -41,7 +41,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef consumer_op(model: Input[VertexModel]):\n    pass\n\n"
+          \ *\nimport typing\n\ndef consumer_op(model: Input[VertexModel]):\n    pass\n\
+          \n"
         image: python:3.7
     exec-producer:
       container:
@@ -78,4 +79,4 @@ root:
         taskInfo:
           name: producer
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_if_placeholder.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_if_placeholder.yaml
@@ -46,4 +46,4 @@ root:
       input2:
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_importer.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_importer.yaml
@@ -124,7 +124,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -136,7 +136,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef train(\n    dataset: Input[Dataset]\n) -> NamedTuple('Outputs',\
+          \ *\nimport typing\n\ndef train(\n    dataset: Input[Dataset]\n) -> NamedTuple('Outputs',\
           \ [\n    ('scalar', str),\n    ('model', Model),\n]):\n    \"\"\"Dummy Training\
           \ step.\"\"\"\n    with open(dataset.path) as f:\n        data = f.read()\n\
           \    print('Dataset:', data)\n\n    scalar = '123'\n    model = f'My model\
@@ -156,7 +156,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -168,7 +168,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef train(\n    dataset: Input[Dataset]\n) -> NamedTuple('Outputs',\
+          \ *\nimport typing\n\ndef train(\n    dataset: Input[Dataset]\n) -> NamedTuple('Outputs',\
           \ [\n    ('scalar', str),\n    ('model', Model),\n]):\n    \"\"\"Dummy Training\
           \ step.\"\"\"\n    with open(dataset.path) as f:\n        data = f.read()\n\
           \    print('Dataset:', data)\n\n    scalar = '123'\n    model = f'My model\
@@ -231,4 +231,4 @@ root:
         defaultValue: gs://ml-pipeline-playground/shakespeare2.txt
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_loops.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_loops.yaml
@@ -167,7 +167,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -179,8 +179,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef args_generator_op() -> List[Dict[str, str]]:\n    return [{'A_a':\
-          \ '1', 'B_b': '2'}, {'A_a': '10', 'B_b': '20'}]\n\n"
+          \ *\nimport typing\n\ndef args_generator_op() -> List[Dict[str, str]]:\n\
+          \    return [{'A_a': '1', 'B_b': '2'}, {'A_a': '10', 'B_b': '20'}]\n\n"
         image: python:3.7
     exec-print-struct:
       container:
@@ -194,7 +194,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -206,7 +206,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_struct(struct: Dict):\n    print(struct)\n\n"
+          \ *\nimport typing\n\ndef print_struct(struct: Dict):\n    print(struct)\n\
+          \n"
         image: python:3.7
     exec-print-struct-2:
       container:
@@ -220,7 +221,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -232,7 +233,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_struct(struct: Dict):\n    print(struct)\n\n"
+          \ *\nimport typing\n\ndef print_struct(struct: Dict):\n    print(struct)\n\
+          \n"
         image: python:3.7
     exec-print-text:
       container:
@@ -246,7 +248,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -258,7 +260,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str):\n    print(msg)\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str):\n    print(msg)\n\n"
         image: python:3.7
     exec-print-text-2:
       container:
@@ -272,7 +274,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -284,7 +286,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str):\n    print(msg)\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str):\n    print(msg)\n\n"
         image: python:3.7
     exec-print-text-3:
       container:
@@ -298,7 +300,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -310,7 +312,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str):\n    print(msg)\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str):\n    print(msg)\n\n"
         image: python:3.7
     exec-print-text-4:
       container:
@@ -324,7 +326,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -336,7 +338,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str):\n    print(msg)\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str):\n    print(msg)\n\n"
         image: python:3.7
     exec-print-text-5:
       container:
@@ -350,7 +352,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -362,7 +364,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str):\n    print(msg)\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str):\n    print(msg)\n\n"
         image: python:3.7
 pipelineInfo:
   name: pipeline-with-loops
@@ -420,4 +422,4 @@ root:
       loop_parameter:
         parameterType: LIST
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_loops_and_conditions.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_loops_and_conditions.yaml
@@ -572,7 +572,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -584,10 +584,10 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef args_generator_op() -> list:\n    return [\n        {\n     \
-          \       'A_a': '1',\n            'B_b': ['2', '20'],\n        },\n     \
-          \   {\n            'A_a': '10',\n            'B_b': ['22', '222'],\n   \
-          \     },\n    ]\n\n"
+          \ *\nimport typing\n\ndef args_generator_op() -> list:\n    return [\n \
+          \       {\n            'A_a': '1',\n            'B_b': ['2', '20'],\n  \
+          \      },\n        {\n            'A_a': '10',\n            'B_b': ['22',\
+          \ '222'],\n        },\n    ]\n\n"
         image: python:3.7
     exec-args-generator-op-2:
       container:
@@ -601,7 +601,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -613,10 +613,10 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef args_generator_op() -> list:\n    return [\n        {\n     \
-          \       'A_a': '1',\n            'B_b': ['2', '20'],\n        },\n     \
-          \   {\n            'A_a': '10',\n            'B_b': ['22', '222'],\n   \
-          \     },\n    ]\n\n"
+          \ *\nimport typing\n\ndef args_generator_op() -> list:\n    return [\n \
+          \       {\n            'A_a': '1',\n            'B_b': ['2', '20'],\n  \
+          \      },\n        {\n            'A_a': '10',\n            'B_b': ['22',\
+          \ '222'],\n        },\n    ]\n\n"
         image: python:3.7
     exec-flip-coin-op:
       container:
@@ -630,7 +630,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -642,9 +642,10 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef flip_coin_op() -> str:\n    \"\"\"Flip a coin and output heads\
-          \ or tails randomly.\"\"\"\n    import random\n    result = 'heads' if random.randint(0,\
-          \ 1) == 0 else 'tails'\n    return result\n\n"
+          \ *\nimport typing\n\ndef flip_coin_op() -> str:\n    \"\"\"Flip a coin\
+          \ and output heads or tails randomly.\"\"\"\n    import random\n    result\
+          \ = 'heads' if random.randint(0, 1) == 0 else 'tails'\n    return result\n\
+          \n"
         image: python:3.7
     exec-print-struct:
       container:
@@ -658,7 +659,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -670,7 +671,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_struct(struct: dict):\n    print(struct)\n\n"
+          \ *\nimport typing\n\ndef print_struct(struct: dict):\n    print(struct)\n\
+          \n"
         image: python:3.7
     exec-print-text:
       container:
@@ -684,7 +686,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -696,8 +698,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n    print(f'msg:\
-          \ {msg}, msg2: {msg2}')\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n\
+          \    print(f'msg: {msg}, msg2: {msg2}')\n\n"
         image: python:3.7
     exec-print-text-2:
       container:
@@ -711,7 +713,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -723,8 +725,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n    print(f'msg:\
-          \ {msg}, msg2: {msg2}')\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n\
+          \    print(f'msg: {msg}, msg2: {msg2}')\n\n"
         image: python:3.7
     exec-print-text-3:
       container:
@@ -738,7 +740,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -750,8 +752,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n    print(f'msg:\
-          \ {msg}, msg2: {msg2}')\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n\
+          \    print(f'msg: {msg}, msg2: {msg2}')\n\n"
         image: python:3.7
     exec-print-text-4:
       container:
@@ -765,7 +767,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -777,8 +779,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n    print(f'msg:\
-          \ {msg}, msg2: {msg2}')\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n\
+          \    print(f'msg: {msg}, msg2: {msg2}')\n\n"
         image: python:3.7
     exec-print-text-5:
       container:
@@ -792,7 +794,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -804,8 +806,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n    print(f'msg:\
-          \ {msg}, msg2: {msg2}')\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n\
+          \    print(f'msg: {msg}, msg2: {msg2}')\n\n"
         image: python:3.7
     exec-print-text-6:
       container:
@@ -819,7 +821,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -831,8 +833,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n    print(f'msg:\
-          \ {msg}, msg2: {msg2}')\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n\
+          \    print(f'msg: {msg}, msg2: {msg2}')\n\n"
         image: python:3.7
     exec-print-text-7:
       container:
@@ -846,7 +848,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -858,8 +860,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n    print(f'msg:\
-          \ {msg}, msg2: {msg2}')\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n\
+          \    print(f'msg: {msg}, msg2: {msg2}')\n\n"
         image: python:3.7
     exec-print-text-8:
       container:
@@ -873,7 +875,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -885,8 +887,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n    print(f'msg:\
-          \ {msg}, msg2: {msg2}')\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n\
+          \    print(f'msg: {msg}, msg2: {msg2}')\n\n"
         image: python:3.7
     exec-print-text-9:
       container:
@@ -900,7 +902,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -912,8 +914,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n    print(f'msg:\
-          \ {msg}, msg2: {msg2}')\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str, msg2: Optional[str] = None):\n\
+          \    print(f'msg: {msg}, msg2: {msg2}')\n\n"
         image: python:3.7
 pipelineInfo:
   name: pipeline-with-loops-and-conditions-multi-layers
@@ -990,4 +992,4 @@ root:
         defaultValue: hello
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_metrics_outputs.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_metrics_outputs.yaml
@@ -56,7 +56,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -68,9 +68,9 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef output_metrics(metrics: Output[Metrics]):\n    \"\"\"Dummy component\
-          \ that outputs metrics with a random accuracy.\"\"\"\n    import random\n\
-          \    result = random.randint(0, 100)\n    metrics.log_metric('accuracy',\
+          \ *\nimport typing\n\ndef output_metrics(metrics: Output[Metrics]):\n  \
+          \  \"\"\"Dummy component that outputs metrics with a random accuracy.\"\"\
+          \"\n    import random\n    result = random.randint(0, 100)\n    metrics.log_metric('accuracy',\
           \ result)\n\n"
         image: python:3.7
     exec-output-metrics-2:
@@ -85,7 +85,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -97,9 +97,9 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef output_metrics(metrics: Output[Metrics]):\n    \"\"\"Dummy component\
-          \ that outputs metrics with a random accuracy.\"\"\"\n    import random\n\
-          \    result = random.randint(0, 100)\n    metrics.log_metric('accuracy',\
+          \ *\nimport typing\n\ndef output_metrics(metrics: Output[Metrics]):\n  \
+          \  \"\"\"Dummy component that outputs metrics with a random accuracy.\"\"\
+          \"\n    import random\n    result = random.randint(0, 100)\n    metrics.log_metric('accuracy',\
           \ result)\n\n"
         image: python:3.7
 pipelineInfo:
@@ -144,4 +144,4 @@ root:
           schemaTitle: system.Metrics
           schemaVersion: 0.0.1
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_multiple_exit_handlers.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_multiple_exit_handlers.yaml
@@ -121,7 +121,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.1'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -133,8 +133,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef fail_op(message: str):\n    \"\"\"Fails.\"\"\"\n    import sys\n\
-          \    print(message)\n    sys.exit(1)\n\n"
+          \ *\nimport typing\n\ndef fail_op(message: str):\n    \"\"\"Fails.\"\"\"\
+          \n    import sys\n    print(message)\n    sys.exit(1)\n\n"
         image: python:3.7
     exec-print-op:
       container:
@@ -148,7 +148,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.1'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -160,8 +160,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\"\"\n\
-          \    print(message)\n\n"
+          \ *\nimport typing\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\
+          \"\"\n    print(message)\n\n"
         image: python:3.7
     exec-print-op-2:
       container:
@@ -175,7 +175,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.1'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -187,8 +187,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\"\"\n\
-          \    print(message)\n\n"
+          \ *\nimport typing\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\
+          \"\"\n    print(message)\n\n"
         image: python:3.7
     exec-print-op-3:
       container:
@@ -202,7 +202,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.1'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -214,8 +214,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\"\"\n\
-          \    print(message)\n\n"
+          \ *\nimport typing\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\
+          \"\"\n    print(message)\n\n"
         image: python:3.7
     exec-print-op-4:
       container:
@@ -229,7 +229,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.1'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -241,8 +241,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\"\"\n\
-          \    print(message)\n\n"
+          \ *\nimport typing\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\
+          \"\"\n    print(message)\n\n"
         image: python:3.7
     exec-print-op-5:
       container:
@@ -256,7 +256,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.1'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -268,8 +268,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\"\"\n\
-          \    print(message)\n\n"
+          \ *\nimport typing\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\
+          \"\"\n    print(message)\n\n"
         image: python:3.7
     exec-print-op-6:
       container:
@@ -283,7 +283,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.1'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -295,8 +295,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\"\"\n\
-          \    print(message)\n\n"
+          \ *\nimport typing\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\
+          \"\"\n    print(message)\n\n"
         image: python:3.7
 pipelineInfo:
   name: pipeline-with-multiple-exit-handlers
@@ -384,4 +384,4 @@ root:
         defaultValue: Hello World!
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-beta.1
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_nested_conditions.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_nested_conditions.yaml
@@ -145,7 +145,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -157,9 +157,10 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef flip_coin_op() -> str:\n    \"\"\"Flip a coin and output heads\
-          \ or tails randomly.\"\"\"\n    import random\n    result = 'heads' if random.randint(0,\
-          \ 1) == 0 else 'tails'\n    return result\n\n"
+          \ *\nimport typing\n\ndef flip_coin_op() -> str:\n    \"\"\"Flip a coin\
+          \ and output heads or tails randomly.\"\"\"\n    import random\n    result\
+          \ = 'heads' if random.randint(0, 1) == 0 else 'tails'\n    return result\n\
+          \n"
         image: python:3.7
     exec-flip-coin-op-2:
       container:
@@ -173,7 +174,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -185,9 +186,10 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef flip_coin_op() -> str:\n    \"\"\"Flip a coin and output heads\
-          \ or tails randomly.\"\"\"\n    import random\n    result = 'heads' if random.randint(0,\
-          \ 1) == 0 else 'tails'\n    return result\n\n"
+          \ *\nimport typing\n\ndef flip_coin_op() -> str:\n    \"\"\"Flip a coin\
+          \ and output heads or tails randomly.\"\"\"\n    import random\n    result\
+          \ = 'heads' if random.randint(0, 1) == 0 else 'tails'\n    return result\n\
+          \n"
         image: python:3.7
     exec-flip-coin-op-3:
       container:
@@ -201,7 +203,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -213,9 +215,10 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef flip_coin_op() -> str:\n    \"\"\"Flip a coin and output heads\
-          \ or tails randomly.\"\"\"\n    import random\n    result = 'heads' if random.randint(0,\
-          \ 1) == 0 else 'tails'\n    return result\n\n"
+          \ *\nimport typing\n\ndef flip_coin_op() -> str:\n    \"\"\"Flip a coin\
+          \ and output heads or tails randomly.\"\"\"\n    import random\n    result\
+          \ = 'heads' if random.randint(0, 1) == 0 else 'tails'\n    return result\n\
+          \n"
         image: python:3.7
     exec-flip-coin-op-4:
       container:
@@ -229,7 +232,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -241,9 +244,10 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef flip_coin_op() -> str:\n    \"\"\"Flip a coin and output heads\
-          \ or tails randomly.\"\"\"\n    import random\n    result = 'heads' if random.randint(0,\
-          \ 1) == 0 else 'tails'\n    return result\n\n"
+          \ *\nimport typing\n\ndef flip_coin_op() -> str:\n    \"\"\"Flip a coin\
+          \ and output heads or tails randomly.\"\"\"\n    import random\n    result\
+          \ = 'heads' if random.randint(0, 1) == 0 else 'tails'\n    return result\n\
+          \n"
         image: python:3.7
     exec-print-op:
       container:
@@ -257,7 +261,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -269,8 +273,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(msg: str):\n    \"\"\"Print a message.\"\"\"\n    print(msg)\n\
-          \n"
+          \ *\nimport typing\n\ndef print_op(msg: str):\n    \"\"\"Print a message.\"\
+          \"\"\n    print(msg)\n\n"
         image: python:3.7
     exec-print-op-2:
       container:
@@ -284,7 +288,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -296,8 +300,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(msg: str):\n    \"\"\"Print a message.\"\"\"\n    print(msg)\n\
-          \n"
+          \ *\nimport typing\n\ndef print_op(msg: str):\n    \"\"\"Print a message.\"\
+          \"\"\n    print(msg)\n\n"
         image: python:3.7
     exec-print-op-3:
       container:
@@ -311,7 +315,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -323,8 +327,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(msg: str):\n    \"\"\"Print a message.\"\"\"\n    print(msg)\n\
-          \n"
+          \ *\nimport typing\n\ndef print_op(msg: str):\n    \"\"\"Print a message.\"\
+          \"\"\n    print(msg)\n\n"
         image: python:3.7
     exec-print-op-4:
       container:
@@ -338,7 +342,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -350,8 +354,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(msg: str):\n    \"\"\"Print a message.\"\"\"\n    print(msg)\n\
-          \n"
+          \ *\nimport typing\n\ndef print_op(msg: str):\n    \"\"\"Print a message.\"\
+          \"\"\n    print(msg)\n\n"
         image: python:3.7
 pipelineInfo:
   name: nested-conditions-pipeline
@@ -424,4 +428,4 @@ root:
         taskInfo:
           name: print-op-2
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_nested_conditions_yaml.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_nested_conditions_yaml.yaml
@@ -343,4 +343,4 @@ root:
         taskInfo:
           name: flip-coin
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_nested_loops.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_nested_loops.yaml
@@ -134,7 +134,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -146,8 +146,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(msg: str, msg2: Optional[str] = None):\n    print(f'msg:\
-          \ {msg}, msg2: {msg2}')\n\n"
+          \ *\nimport typing\n\ndef print_op(msg: str, msg2: Optional[str] = None):\n\
+          \    print(f'msg: {msg}, msg2: {msg2}')\n\n"
         image: python:3.7
     exec-print-op-2:
       container:
@@ -161,7 +161,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -173,8 +173,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(msg: str, msg2: Optional[str] = None):\n    print(f'msg:\
-          \ {msg}, msg2: {msg2}')\n\n"
+          \ *\nimport typing\n\ndef print_op(msg: str, msg2: Optional[str] = None):\n\
+          \    print(f'msg: {msg}, msg2: {msg2}')\n\n"
         image: python:3.7
     exec-print-op-3:
       container:
@@ -188,7 +188,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -200,8 +200,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(msg: str, msg2: Optional[str] = None):\n    print(f'msg:\
-          \ {msg}, msg2: {msg2}')\n\n"
+          \ *\nimport typing\n\ndef print_op(msg: str, msg2: Optional[str] = None):\n\
+          \    print(f'msg: {msg}, msg2: {msg2}')\n\n"
         image: python:3.7
 pipelineInfo:
   name: pipeline-with-nested-loops
@@ -244,4 +244,4 @@ root:
           p_b: halo
         parameterType: LIST
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_ontology.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_ontology.yaml
@@ -101,4 +101,4 @@ root:
         defaultValue: sgd
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_parallelfor_parallelism.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_parallelfor_parallelism.yaml
@@ -175,7 +175,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.2'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -187,7 +187,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str):\n    print(msg)\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str):\n    print(msg)\n\n"
         image: python:3.7
     exec-print-text-2:
       container:
@@ -201,7 +201,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.2'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -213,7 +213,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str):\n    print(msg)\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str):\n    print(msg)\n\n"
         image: python:3.7
     exec-print-text-3:
       container:
@@ -227,7 +227,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.2'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -239,7 +239,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str):\n    print(msg)\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str):\n    print(msg)\n\n"
         image: python:3.7
     exec-print-text-4:
       container:
@@ -253,7 +253,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.2'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -265,7 +265,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str):\n    print(msg)\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str):\n    print(msg)\n\n"
         image: python:3.7
     exec-print-text-5:
       container:
@@ -279,7 +279,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.2'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -291,7 +291,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str):\n    print(msg)\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str):\n    print(msg)\n\n"
         image: python:3.7
     exec-print-text-6:
       container:
@@ -305,7 +305,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.2'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -317,7 +317,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_text(msg: str):\n    print(msg)\n\n"
+          \ *\nimport typing\n\ndef print_text(msg: str):\n    print(msg)\n\n"
         image: python:3.7
 pipelineInfo:
   name: pipeline-with-loops
@@ -353,4 +353,4 @@ root:
       loop_parameter:
         parameterType: LIST
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-beta.2
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_params_containing_format.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_params_containing_format.yaml
@@ -70,7 +70,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -82,8 +82,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(text: str) -> str:\n    print(text)\n    return text\n\
-          \n"
+          \ *\nimport typing\n\ndef print_op(text: str) -> str:\n    print(text)\n\
+          \    return text\n\n"
         image: python:3.7
     exec-print-op-2:
       container:
@@ -97,7 +97,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -109,8 +109,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(text: str) -> str:\n    print(text)\n    return text\n\
-          \n"
+          \ *\nimport typing\n\ndef print_op(text: str) -> str:\n    print(text)\n\
+          \    return text\n\n"
         image: python:3.7
     exec-print-op2:
       container:
@@ -124,7 +124,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -136,8 +136,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op2(text1: str, text2: str) -> str:\n    print(text1 +\
-          \ text2)\n    return text1 + text2\n\n"
+          \ *\nimport typing\n\ndef print_op2(text1: str, text2: str) -> str:\n  \
+          \  print(text1 + text2)\n    return text1 + text2\n\n"
         image: python:3.7
 pipelineInfo:
   name: pipeline-with-pipelineparam-containing-format
@@ -195,4 +195,4 @@ root:
         defaultValue: KFP
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_placeholders.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_placeholders.yaml
@@ -53,7 +53,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -65,7 +65,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(msg: str, value: str):\n    print(msg, value)\n\n"
+          \ *\nimport typing\n\ndef print_op(msg: str, value: str):\n    print(msg,\
+          \ value)\n\n"
         image: python:3.7
     exec-print-op-2:
       container:
@@ -79,7 +80,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -91,7 +92,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(msg: str, value: str):\n    print(msg, value)\n\n"
+          \ *\nimport typing\n\ndef print_op(msg: str, value: str):\n    print(msg,\
+          \ value)\n\n"
         image: python:3.7
     exec-print-op-3:
       container:
@@ -105,7 +107,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -117,7 +119,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(msg: str, value: str):\n    print(msg, value)\n\n"
+          \ *\nimport typing\n\ndef print_op(msg: str, value: str):\n    print(msg,\
+          \ value)\n\n"
         image: python:3.7
     exec-print-op-4:
       container:
@@ -131,7 +134,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -143,7 +146,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(msg: str, value: str):\n    print(msg, value)\n\n"
+          \ *\nimport typing\n\ndef print_op(msg: str, value: str):\n    print(msg,\
+          \ value)\n\n"
         image: python:3.7
     exec-print-op-5:
       container:
@@ -157,7 +161,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -169,7 +173,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(msg: str, value: str):\n    print(msg, value)\n\n"
+          \ *\nimport typing\n\ndef print_op(msg: str, value: str):\n    print(msg,\
+          \ value)\n\n"
         image: python:3.7
 pipelineInfo:
   name: pipeline-with-placeholders
@@ -252,4 +257,4 @@ root:
         taskInfo:
           name: print-op-5
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_resource_spec.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_resource_spec.yaml
@@ -107,4 +107,4 @@ root:
         defaultValue: sgd
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_retry.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_retry.yaml
@@ -25,7 +25,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -37,7 +37,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef add(a: float, b: float) -> float:\n    return a + b\n\n"
+          \ *\nimport typing\n\ndef add(a: float, b: float) -> float:\n    return\
+          \ a + b\n\n"
         image: python:3.7
 pipelineInfo:
   name: test-pipeline
@@ -71,4 +72,4 @@ root:
         defaultValue: 7.0
         parameterType: NUMBER_DOUBLE
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_reused_component.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_reused_component.yaml
@@ -143,4 +143,4 @@ root:
         defaultValue: 5.0
         parameterType: NUMBER_INTEGER
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_task_final_status.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_task_final_status.yaml
@@ -63,7 +63,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -75,7 +75,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef exit_op(user_input: str, status: PipelineTaskFinalStatus):\n\
+          \ *\nimport typing\n\ndef exit_op(user_input: str, status: PipelineTaskFinalStatus):\n\
           \    \"\"\"Checks pipeline run status.\"\"\"\n    print('Pipeline status:\
           \ ', status.state)\n    print('Job resource name: ', status.pipeline_job_resource_name)\n\
           \    print('Pipeline task name: ', status.pipeline_task_name)\n    print('Error\
@@ -94,7 +94,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -106,8 +106,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef fail_op(message: str):\n    \"\"\"Fails.\"\"\"\n    import sys\n\
-          \    print(message)\n    sys.exit(1)\n\n"
+          \ *\nimport typing\n\ndef fail_op(message: str):\n    \"\"\"Fails.\"\"\"\
+          \n    import sys\n    print(message)\n    sys.exit(1)\n\n"
         image: python:3.7
     exec-print-op:
       container:
@@ -121,7 +121,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-alpha.5'\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -133,8 +133,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\"\"\n\
-          \    print(message)\n\n"
+          \ *\nimport typing\n\ndef print_op(message: str):\n    \"\"\"Prints a message.\"\
+          \"\"\n    print(message)\n\n"
         image: python:3.7
 pipelineInfo:
   name: pipeline-with-task-final-status
@@ -174,4 +174,4 @@ root:
         defaultValue: Hello World!
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_task_final_status_yaml.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_task_final_status_yaml.yaml
@@ -86,4 +86,4 @@ root:
         defaultValue: Hello World!
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_various_io_types.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/pipeline_with_various_io_types.yaml
@@ -206,4 +206,4 @@ root:
         defaultValue: ''
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-beta.1
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/two_step_pipeline.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/two_step_pipeline.yaml
@@ -84,4 +84,4 @@ root:
         defaultValue: Hello KFP!
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/two_step_pipeline_containerized.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/two_step_pipeline_containerized.yaml
@@ -76,4 +76,4 @@ root:
       text:
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-beta.1
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/compiler/test_data/pipelines/xgboost_sample_pipeline.yaml
+++ b/sdk/python/kfp/compiler/test_data/pipelines/xgboost_sample_pipeline.yaml
@@ -884,4 +884,4 @@ root:
         taskInfo:
           name: xgboost-train-2
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.0.0-alpha.5
+sdkVersion: kfp-2.0.0-beta.3

--- a/sdk/python/kfp/components/component_factory.py
+++ b/sdk/python/kfp/components/component_factory.py
@@ -330,6 +330,7 @@ def _get_command_and_args_for_lightweight_component(
         'from kfp import dsl',
         'from kfp.dsl import *',
         'from typing import *',
+        'import typing',
     ]
 
     func_source = _get_function_source_definition(func)


### PR DESCRIPTION
**Description of your changes:**
Currently, a component with the following  signature fails at runtime:

```python
from kfp import dsl

@dsl.component
def comp() -> typing.NamedTuple('Output', [('field',  int)]):
    ...
```

This PR adds `import typing` to the lightweight component definition to enable this style of authoring.

**Checklist:**
- [x] The title for your pull request (PR) should follow 
our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
