### PR TITLE
feat(sdk): update component deserialization logic for custom artifacts (support custom artifact types pt. 3)

### DIFF
--- a/sdk/python/kfp/compiler/_read_write_test_config.py
+++ b/sdk/python/kfp/compiler/_read_write_test_config.py
@@ -82,6 +82,9 @@ CONFIG = {
             'if_placeholder_component',
             'add_component',
             'ingestion_component',
+            'fancy_trainer_component',
+            'trainer_component',
+            'serving_component',
         ],
         'test_data_dir': 'sdk/python/kfp/compiler/test_data/v1_component_yaml',
         'config': {

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -430,15 +430,13 @@ class TestCompilePipeline(parameterized.TestCase):
         @dsl.pipeline(name='test-pipeline')
         def my_pipeline():
             consumer_op(input1=producer_op1().output)
-            consumer_op(input1=producer_op2().output)
 
-        with self.assertRaisesRegex(
-                type_utils.InconsistentTypeException,
-                'Incompatible argument passed to the input "input1" of component'
-                ' "consumer-op": Argument type "SomeArbitraryType" is'
-                ' incompatible with the input type "Dataset"'):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_yaml_file = os.path.join(tmpdir, 'result.yaml')
             compiler.Compiler().compile(
-                pipeline_func=my_pipeline, package_path='result.yaml')
+                pipeline_func=my_pipeline, package_path=target_yaml_file)
+
+            self.assertTrue(os.path.exists(target_yaml_file))
 
     def test_invalid_data_dependency_loop(self):
 

--- a/sdk/python/kfp/components/structures.py
+++ b/sdk/python/kfp/components/structures.py
@@ -168,7 +168,7 @@ class OutputSpec(base_model.BaseModel):
             ir_artifact_dict (Dict[str, Any]): The ComponentOutputsSpec message in dict format.
 
         Returns:
-            OutputSpec: The InputSpec object.
+            OutputSpec: The OutputSpec object.
         """
         schema_title = ir_artifact_dict['artifactType']['schemaTitle']
         return OutputSpec(type=schema_title.lstrip('system.'))


### PR DESCRIPTION
**Description of your changes:**
This PR fixes component deserialization logic for components with input and output 
artifacts.

Currently, the SDK cannot deserialize components with artifact inputs and does 
not handle inputs and outputs correctly when deserializing v1 component YAML. This 
fix is a requirement for supporting custom artifact types.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. 
[Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
