### PR TITLE
fix(backend) : ml-pipeline-ui-artifact fails with NoSuchBucket in multi-user configuration w/ self hosted S3

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/deployment.yaml
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/deployment.yaml
@@ -38,6 +38,24 @@ spec:
             secretKeyRef:
               name: mlpipeline-minio-artifact
               key: secretkey
+        - name: MINIO_SSL
+          valueFrom:
+              configMapKeyRef:
+                optional: true
+                key: minioSSL
+                name: pipeline-install-config
+        - name: MINIO_PORT
+          valueFrom:
+              configMapKeyRef:
+                optional: true
+                key: minioServicePort
+                name: pipeline-install-config
+        - name: MINIO_HOST
+          valueFrom:
+              configMapKeyRef:
+                optional: true
+                key: minioServiceHost
+                name: pipeline-install-config
         volumeMounts:
         - name: hooks
           mountPath: /hooks

--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/sync.py
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/sync.py
@@ -88,7 +88,7 @@ def get_settings_from_env(controller_port=None,
 
     settings["minio_ssl"] = \
         minio_ssl or \
-        os.environ.get("MINIO_SSL") == "true"
+        os.environ.get("MINIO_SSL")
 
     settings["minio_host"] = \
         minio_host or \

--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/sync.py
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/sync.py
@@ -27,7 +27,8 @@ def main():
 def get_settings_from_env(controller_port=None,
                           visualization_server_image=None, frontend_image=None,
                           visualization_server_tag=None, frontend_tag=None, disable_istio_sidecar=None,
-                          minio_access_key=None, minio_secret_key=None, kfp_default_pipeline_root=None):
+                          minio_access_key=None, minio_secret_key=None, kfp_default_pipeline_root=None,
+                          minio_ssl=None, minio_host=None, minio_port=None):
     """
     Returns a dict of settings from environment variables relevant to the controller
 
@@ -43,6 +44,9 @@ def get_settings_from_env(controller_port=None,
         disable_istio_sidecar: Required (no default)
         minio_access_key: Required (no default)
         minio_secret_key: Required (no default)
+        minio_ssl: Required (no default)
+        minio_host: Required (no default)
+        minio_port: Required (no default)
     """
     settings = dict()
     settings["controller_port"] = \
@@ -82,6 +86,18 @@ def get_settings_from_env(controller_port=None,
         minio_secret_key or \
         base64.b64encode(bytes(os.environ.get("MINIO_SECRET_KEY"), 'utf-8')).decode('utf-8')
 
+    settings["minio_ssl"] = \
+        minio_ssl or \
+        os.environ.get("MINIO_SSL") == "true"
+
+    settings["minio_host"] = \
+        minio_host or \
+        os.environ.get("MINIO_HOST")
+
+    settings["minio_port"] = \
+        minio_port or \
+        os.environ.get("MINIO_PORT")
+
     # KFP_DEFAULT_PIPELINE_ROOT is optional
     settings["kfp_default_pipeline_root"] = \
         kfp_default_pipeline_root or \
@@ -93,7 +109,8 @@ def get_settings_from_env(controller_port=None,
 def server_factory(visualization_server_image,
                    visualization_server_tag, frontend_image, frontend_tag,
                    disable_istio_sidecar, minio_access_key,
-                   minio_secret_key, kfp_default_pipeline_root=None,
+                   minio_secret_key, minio_ssl, minio_host, minio_port,
+                   kfp_default_pipeline_root=None,
                    url="", controller_port=8080):
     """
     Returns an HTTPServer populated with Handler with customized settings
@@ -317,6 +334,18 @@ def server_factory(visualization_server_image,
                                                     "name": "mlpipeline-minio-artifact"
                                                 }
                                             }
+                                        },
+                                        {
+                                            "name": "MINIO_SSL",
+                                            "value": minio_ssl
+                                        },
+                                        {
+                                            "name": "MINIO_HOST",
+                                            "value": minio_host
+                                        },
+                                        {
+                                            "name": "MINIO_PORT",
+                                            "value": minio_port
                                         }
                                     ],
                                     "resources": {


### PR DESCRIPTION
**Description of your changes:**

When using the multi-user configuration and a self hosted minio S3 server the **ml-pipeline-ui-artifact** fails to retrieve artifacts from S3 in users' namespaces. This is solved by adding MINIO_SSL, MINIO_HOST, MINIO_PORT environment variables to the **ml-pipeline-ui-artifact**  deployment. The **ml-pipeline-ui-artifact** deployment is handled by the **kubeflow-pipelines-profile-controller** deployment. This PR updates the `sync.py` that serves the the **ml-pipeline-ui-artifact** deployment to be applied in the users namespaces by metacontroller.

When queried the ml-pipeline-ui-artifact pod fails : 
```
GET /pipeline/artifacts/minio/mlpipeline/artifacts/file-passing-pipelines-hfvqp/2022/08/23/file-passing-pipelines-hfvqp-3821772273/main.log
Getting storage artifact at: minio: mlpipeline/artifacts/file-passing-pipelines-hfvqp/2022/08/23/file-passing-pipelines-hfvqp-3821772273/main.log
S3Error: The specified bucket does not exist
    at Object.parseError (/server/node_modules/minio/dist/main/xml-parsers.js:86:11)
    at /server/node_modules/minio/dist/main/transformers.js:156:22
    at DestroyableTransform._flush (/server/node_modules/minio/dist/main/transformers.js:80:10)
    at DestroyableTransform.prefinish (/server/node_modules/readable-stream/lib/_stream_transform.js:138:10)
    at DestroyableTransform.emit (events.js:223:5)
    at prefinish (/server/node_modules/readable-stream/lib/_stream_writable.js:619:14)
    at finishMaybe (/server/node_modules/readable-stream/lib/_stream_writable.js:627:5)
    at endWritable (/server/node_modules/readable-stream/lib/_stream_writable.js:638:3)
    at DestroyableTransform.Writable.end (/server/node_modules/readable-stream/lib/_stream_writable.js:594:41)
    at IncomingMessage.onend (_stream_readable.js:693:10) {
  code: 'NoSuchBucket',
  bucketname: 'mlpipeline',
  resource: '/mlpipeline',
  requestid: '170E44025FFCEBAA',
  hostid: '7c9c4e12-18dd-4559-915a-5293eb6aab81',
  amzRequestid: null,
  amzId2: null,
  amzBucketRegion: null
}
```

Frontend view: 
![image](https://user-images.githubusercontent.com/1567274/186427280-47875481-decd-4f1b-9fec-98ad03c3b704.png)

