### PR TITLE
fix(backend): fix backward compatibility in scheduledworkflow

### DIFF
--- a/backend/src/crd/controller/scheduledworkflow/util/scheduled_workflow.go
+++ b/backend/src/crd/controller/scheduledworkflow/util/scheduled_workflow.go
@@ -153,16 +153,11 @@ func (s *ScheduledWorkflow) getWorkflowParametersAsMap() map[string]string {
 func (s *ScheduledWorkflow) NewWorkflow(
 	nextScheduledEpoch int64, nowEpoch int64) (commonutil.ExecutionSpec, error) {
 
-	const (
-		workflowKind       = "Workflow"
-		workflowApiVersion = "argoproj.io/v1alpha1"
-	)
-
 	// Creating the workflow.
 	execSpec, err := commonutil.ScheduleSpecToExecutionSpec(commonutil.ArgoWorkflow, s.Spec.Workflow)
-	typeMeta := execSpec.ExecutionTypeMeta()
-	typeMeta.APIVersion = workflowApiVersion
-	typeMeta.Kind = workflowKind
+	if err != nil {
+		return nil, err
+	}
 
 	uuid, err := s.uuid.NewRandom()
 	if err != nil {

--- a/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1/types.go
+++ b/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1/types.go
@@ -92,7 +92,10 @@ type WorkflowResource struct {
 	Parameters []Parameter `json:"parameters,omitempty"`
 
 	// Specification of the workflow to start.
-	Spec string `json:"spec,omitempty"`
+	// Use interface{} for backward compatibility
+	// TODO: change it to string and avoid type casting
+	//       after several releases
+	Spec interface{} `json:"spec,omitempty"`
 }
 
 type Parameter struct {


### PR DESCRIPTION
**Description of your changes:**
Instead of changing the WorkflowResource.Spec to string, use interface{} to allow backward compatibility.
Add type casting and marshal/unmarshal to properly handle old swf CRs.

I also cleaned up duplicate imports in `workflow.go` 

fixed issue found here: https://github.com/kubeflow/pipelines/pull/8050#issuecomment-1245793840

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
