### PR TITLE
fix(sdk): Replace OOB authentication with loopback flow

### DIFF
--- a/sdk/python/kfp/client/auth.py
+++ b/sdk/python/kfp/client/auth.py
@@ -431,8 +431,11 @@ class RedirectWSGIApp:
         self.last_request_uri = None
         self._success_message = success_message
 
-    def __call__(self, environ: Dict[str, Any],
-                 start_response: Callable[str, list]) -> Iterable[bytes]:
+    def __call__(
+        self, environ: Dict[str, Any], start_response: Callable[[str, list],
+                                                                Callable[...,
+                                                                         None]]
+    ) -> Iterable[bytes]:
         """WSGI Callable. Updates environment dictionary with parameters
         required for WSGI and returns it.
 

--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -259,9 +259,8 @@ class Client:
             token = existing_token
             self._is_refresh_token = False
         elif client_id:
-            token = auth.get_auth_token(client_id, other_client_id,
-                                        other_client_secret)
-            self._is_refresh_token = True
+            token, self._is_refresh_token = auth.get_auth_token(
+                client_id, other_client_id, other_client_secret)
         elif self._is_inverse_proxy_host(host):
             token = auth.get_gcp_access_token()
             self._is_refresh_token = False
@@ -477,13 +476,13 @@ class Client:
                 resource_references=resource_references)
             experiment = self._experiment_api.create_experiment(body=experiment)
 
-        link = f"{self._get_url_prefix()}/#/experiments/details/{experiment.id}"
+        link = f'{self._get_url_prefix()}/#/experiments/details/{experiment.id}'
         if self._is_ipython():
             import IPython
             html = f'<a href="{link}" target="_blank" >Experiment details</a>.'
             IPython.display.display(IPython.display.HTML(html))
         else:
-            print(f"Experiment details: {link}")
+            print(f'Experiment details: {link}')
 
         return experiment
 
@@ -784,13 +783,13 @@ class Client:
 
         response = self._run_api.create_run(body=run_body)
 
-        link = f"{self._get_url_prefix()}/#/runs/details/{response.run.id}"
+        link = f'{self._get_url_prefix()}/#/runs/details/{response.run.id}'
         if self._is_ipython():
             import IPython
             html = (f'<a href="{link}" target="_blank" >Run details</a>.')
             IPython.display.display(IPython.display.HTML(html))
         else:
-            print(f"Run details: {link}")
+            print(f'Run details: {link}')
 
         return response.run
 
@@ -1377,13 +1376,13 @@ class Client:
         validate_pipeline_resource_name(pipeline_name)
         response = self._upload_api.upload_pipeline(
             pipeline_package_path, name=pipeline_name, description=description)
-        link = f"{self._get_url_prefix()}/#/pipelines/details/{response.id}"
+        link = f'{self._get_url_prefix()}/#/pipelines/details/{response.id}'
         if self._is_ipython():
             import IPython
             html = f'<a href="{link}" target="_blank" >Pipeline details</a>.'
             IPython.display.display(IPython.display.HTML(html))
         else:
-            print(f"Pipeline details: {link}")
+            print(f'Pipeline details: {link}')
 
         return response
 
@@ -1426,13 +1425,13 @@ class Client:
         response = self._upload_api.upload_pipeline_version(
             pipeline_package_path, **kwargs)
 
-        link = f"{self._get_url_prefix()}/#/pipelines/details/{response.id}"
+        link = f'{self._get_url_prefix()}/#/pipelines/details/{response.id}'
         if self._is_ipython():
             import IPython
             html = f'<a href="{link}" target="_blank" >Pipeline details</a>.'
             IPython.display.display(IPython.display.HTML(html))
         else:
-            print(f"Pipeline details: {link}")
+            print(f'Pipeline details: {link}')
 
         return response
 


### PR DESCRIPTION
On February 16 2022, Google [announced](https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html) plans to make Google OAuth interactions safer by using more secure OAuth flows. The migration guide is available [here](https://developers.google.com/identity/protocols/oauth2/resources/oob-migration). The issue was previously reported in #7474.

The proposed solution is based on the loopback flow and it fetches an authentication code from the response url. This method has been deprecated for mobile apps, but it is still the recommended workaround for desktop apps. Although we might need to change this in the future, I propose to include this change in the next release to unblock Kubeflow users. A similar solution was proposed in #7526.

There are two scenarios:
1. SSH connection is detected: specific instructions on what a user will need to manually copy into a terminal dialog are provided with an option to fall back to a local web-server (CTRL+C)
2. No SSH detected and a **default** option with a local web-server is triggered. An option to manually copy-paste a response URL is provided too. 

This implementation will require adding `http://localhost:9999` to the corresponding [OAuth 2.0 Client IDs](https://console.cloud.google.com/apis/credentials/).

**Description of the changes:**

- Replaced OOB redirect_uri with http://localhost:9999 (loopback ip).
- Added a local web-server that listens to http://localhost:9999 and fetches authentication code as recommended for [desktop apps](https://developers.google.com/identity/protocols/oauth2/native-app#redirect-uri_loopback).
- Formatted auth.py and added docstrings.
- Users will need to add `http://localhost:9999` to the Authorized redirect URIs of their [OAuth 2.0 Client IDs](https://console.cloud.google.com/apis/credentials/). Docs need to be updated.
- Although this doesn't change anything for users, I proposed to add instructions to Kubeflow docs on how to handle certain errors: 
  - expired access/refresh tokens,
  - 9999 port being occupied,
  - corrupted credentials.json,
  - reference to OAuth errors.
- Some handling of frequent errors is provided.
- No dependencies added.
- Manually tested on Kubeflow v1.6.0 on GCP.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
