### PR TITLE
fix(sdk): make sdk installable with poetry

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -77,7 +77,7 @@ setuptools.setup(
         'all': ['docker'],
     },
     packages=setuptools.find_packages(
-        where=os.path.dirname(__file__), exclude=['*test*']),
+        where='.', exclude=['*test*']),
     classifiers=[
         'Intended Audience :: Developers',
         'Intended Audience :: Education',

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -76,8 +76,7 @@ setuptools.setup(
     extras_require={
         'all': ['docker'],
     },
-    packages=setuptools.find_packages(
-        where='.', exclude=['*test*']),
+    packages=setuptools.find_packages(exclude=['*test*']),
     classifiers=[
         'Intended Audience :: Developers',
         'Intended Audience :: Education',


### PR DESCRIPTION
The poetry package manager executes `setup.py` differently than pip, which means that `__file__` is initialized to just `setup.py`, which means that `where` would be set to the empty string. The proposed change has been tested with both pip and poetry.

**Description of your changes:**


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
