### PR TITLE
fix(sdk): fix NamedTuple output with Dict/List bug

### DIFF
--- a/sdk/python/kfp/components/component_decorator_test.py
+++ b/sdk/python/kfp/components/component_decorator_test.py
@@ -14,6 +14,7 @@
 
 import os
 import tempfile
+from typing import Dict, List, NamedTuple
 import unittest
 
 from kfp.components import python_component
@@ -106,3 +107,46 @@ class TestComponentDecorator(unittest.TestCase):
         component_spec = structures.ComponentSpec.load_from_component_yaml(
             yaml_text)
         self.assertEqual(component_spec, comp.component_spec)
+
+    def test_output_named_tuple_with_dict(self):
+
+        @component
+        def comp(
+                text: str) -> NamedTuple('outputs', [('data', Dict[str, str])]):
+            outputs = NamedTuple('outputs', [('data', Dict[str, str])])
+            return outputs(data={text: text})
+
+        # TODO: ideally should be the canonical type string, rather than the specific annotation as string, but both work
+        self.assertEqual(comp.component_spec.outputs['data'].type,
+                         'typing.Dict[str, str]')
+
+    def test_output_dict(self):
+
+        @component
+        def comp(text: str) -> Dict[str, str]:
+            return {text: text}
+
+        # TODO: ideally should be the canonical type string, rather than the specific annotation as string, but both work
+        self.assertEqual(comp.component_spec.outputs['Output'].type,
+                         'typing.Dict[str, str]')
+
+    def test_output_named_tuple_with_list(self):
+
+        @component
+        def comp(text: str) -> NamedTuple('outputs', [('data', List[str])]):
+            outputs = NamedTuple('outputs', [('data', List[str])])
+            return outputs(data={text: text})
+
+        # TODO: ideally should be the canonical type string, rather than the specific annotation as string, but both work
+        self.assertEqual(comp.component_spec.outputs['data'].type,
+                         'typing.List[str]')
+
+    def test_output_list(self):
+
+        @component
+        def comp(text: str) -> List[str]:
+            return {text: text}
+
+        # TODO: ideally should be the canonical type string, rather than the specific annotation as string, but both work
+        self.assertEqual(comp.component_spec.outputs['Output'].type,
+                         'typing.List[str]')

--- a/sdk/python/kfp/components/component_factory.py
+++ b/sdk/python/kfp/components/component_factory.py
@@ -242,21 +242,17 @@ def extract_component_interface(
                                         None) or getattr(
                                             return_ann, '_field_types', None)
             for field_name in return_ann._fields:
-                type_struct = None
-                if field_annotations:
-                    type_struct = type_utils._annotation_to_type_struct(
-                        field_annotations.get(field_name, None))
-
                 output_name = _maybe_make_unique(field_name, output_names)
                 output_names.add(output_name)
-                if type_struct.lower() in type_utils._PARAMETER_TYPES_MAPPING:
-
-                    output_spec = structures.OutputSpec(type=type_struct)
-                else:
+                annotation = field_annotations.get(field_name)
+                if type_annotations.is_artifact_class(annotation):
                     output_spec = structures.OutputSpec(
                         type=type_utils.create_bundled_artifact_type(
-                            type_struct,
-                            field_annotations.get(field_name).schema_version))
+                            annotation.schema_title, annotation.schema_version))
+                else:
+                    type_struct = type_utils._annotation_to_type_struct(
+                        annotation)
+                    output_spec = structures.OutputSpec(type=type_struct)
                 outputs[output_name] = output_spec
         # Deprecated dict-based way of declaring multiple outputs. Was only used by
         # the @component decorator


### PR DESCRIPTION
**Description of your changes:**
Fixes a bug where a component with a `NamedTuple` output with a `Dict` 
data type would fail to compile.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title 
convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
