### PR TITLE
fix reduce output size kservedeployer.py

### DIFF
--- a/components/kserve/src/kservedeployer.py
+++ b/components/kserve/src/kservedeployer.py
@@ -421,6 +421,7 @@ def main():
                 del model_status['components']['predictor']['latestRolledoutRevision']
                 del model_status['components']['predictor']['url']
                 del model_status['spec']
+                del model_status["status"]["url"]
         except KeyError:
             pass
 


### PR DESCRIPTION
I have an error running kserve custom model. "Termination message is above max allowed size 4096" I need to delete more fields to reduce the output size

**Description of your changes:**


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
