### PR TITLE
fix(frontend): Use browser-compatible atob instead of Buffer for frontend graph decompression. Fixes #7655

### DIFF
--- a/frontend/src/lib/Utils.tsx
+++ b/frontend/src/lib/Utils.tsx
@@ -388,7 +388,11 @@ export function buildQuery(queriesMap: { [key: string]: string | number | undefi
 
 export async function decodeCompressedNodes(compressedNodes: string): Promise<object> {
   return new Promise<object>((resolve, reject) => {
-    const compressedBuffer = Buffer.from(compressedNodes, 'base64');
+    const compressedBuffer = Uint8Array.from(
+      atob(compressedNodes)
+        .split('')
+        .map(char => char.charCodeAt(0)),
+    );
     try {
       const result = pako.ungzip(compressedBuffer, { to: 'string' });
       const nodes = JSON.parse(result);


### PR DESCRIPTION
**Description of your changes:**

As already remarked by @jlyaoyuli in https://github.com/kubeflow/pipelines/issues/7655 , `Buffer` is not available in the browser, hence the error occurs.
I could reproduce the error with a large graph which triggers the compressed transfer. Changing the decompression as in this PR resolved the issue for my test.