### PR TITLE
fix(backend): Upgrade mysql to 8.0.26

### DIFF
--- a/.cloudbuild.yaml
+++ b/.cloudbuild.yaml
@@ -186,7 +186,7 @@ steps:
   args: ['pull', 'gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance']
   id:   'pullMinio'
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['pull', 'gcr.io/ml-pipeline/mysql:5.7-debian']
+  args: ['pull', 'gcr.io/ml-pipeline/mysql:8.0-debian']
   id:   'pullMysql'
 - name: 'gcr.io/cloud-builders/docker'
   args: ['pull', 'gcr.io/cloudsql-docker/gce-proxy:1.25.0']

--- a/.cloudbuild.yaml
+++ b/.cloudbuild.yaml
@@ -186,7 +186,7 @@ steps:
   args: ['pull', 'gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance']
   id:   'pullMinio'
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['pull', 'gcr.io/ml-pipeline/mysql:8.0-debian']
+  args: ['pull', 'gcr.io/ml-pipeline/mysql:8.0.26']
   id:   'pullMysql'
 - name: 'gcr.io/cloud-builders/docker'
   args: ['pull', 'gcr.io/cloudsql-docker/gce-proxy:1.25.0']

--- a/.release.cloudbuild.yaml
+++ b/.release.cloudbuild.yaml
@@ -432,14 +432,14 @@ steps:
     docker push gcr.io/ml-pipeline/google/pipelines-test/minio:$(cat /workspace/mm.ver)
 
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['pull', 'gcr.io/ml-pipeline/mysql:8.0-debian']
+  args: ['pull', 'gcr.io/ml-pipeline/mysql:8.0.26']
   id:   'pullMysql'
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/ml-pipeline/mysql:8.0-debian', 'gcr.io/ml-pipeline/google/pipelines/mysql:$TAG_NAME']
+  args: ['tag', 'gcr.io/ml-pipeline/mysql:8.0.26', 'gcr.io/ml-pipeline/google/pipelines/mysql:$TAG_NAME']
   id:   'tagMySqlForMarketplace'
   waitFor: ['pullMysql']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/ml-pipeline/mysql:8.0-debian', 'gcr.io/ml-pipeline/google/pipelines-test/mysql:$TAG_NAME']
+  args: ['tag', 'gcr.io/ml-pipeline/mysql:8.0.26', 'gcr.io/ml-pipeline/google/pipelines-test/mysql:$TAG_NAME']
   id:   'tagMySqlForMarketplaceTest'
   waitFor: ['pullMysql']
 - id:   'tagMySqlForMarketplaceMajorMinor'
@@ -449,8 +449,8 @@ steps:
   args:
   - -ceux
   - |
-    docker tag gcr.io/ml-pipeline/mysql:8.0-debian gcr.io/ml-pipeline/google/pipelines/mysql:$(cat /workspace/mm.ver)
-    docker tag gcr.io/ml-pipeline/mysql:8.0-debian gcr.io/ml-pipeline/google/pipelines-test/mysql:$(cat /workspace/mm.ver)
+    docker tag gcr.io/ml-pipeline/mysql:8.0.26 gcr.io/ml-pipeline/google/pipelines/mysql:$(cat /workspace/mm.ver)
+    docker tag gcr.io/ml-pipeline/mysql:8.0.26 gcr.io/ml-pipeline/google/pipelines-test/mysql:$(cat /workspace/mm.ver)
     docker push gcr.io/ml-pipeline/google/pipelines/mysql:$(cat /workspace/mm.ver)
     docker push gcr.io/ml-pipeline/google/pipelines-test/mysql:$(cat /workspace/mm.ver)
 

--- a/.release.cloudbuild.yaml
+++ b/.release.cloudbuild.yaml
@@ -432,14 +432,14 @@ steps:
     docker push gcr.io/ml-pipeline/google/pipelines-test/minio:$(cat /workspace/mm.ver)
 
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['pull', 'gcr.io/ml-pipeline/mysql:5.7-debian']
+  args: ['pull', 'gcr.io/ml-pipeline/mysql:8.0-debian']
   id:   'pullMysql'
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/ml-pipeline/mysql:5.7-debian', 'gcr.io/ml-pipeline/google/pipelines/mysql:$TAG_NAME']
+  args: ['tag', 'gcr.io/ml-pipeline/mysql:8.0-debian', 'gcr.io/ml-pipeline/google/pipelines/mysql:$TAG_NAME']
   id:   'tagMySqlForMarketplace'
   waitFor: ['pullMysql']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/ml-pipeline/mysql:5.7-debian', 'gcr.io/ml-pipeline/google/pipelines-test/mysql:$TAG_NAME']
+  args: ['tag', 'gcr.io/ml-pipeline/mysql:8.0-debian', 'gcr.io/ml-pipeline/google/pipelines-test/mysql:$TAG_NAME']
   id:   'tagMySqlForMarketplaceTest'
   waitFor: ['pullMysql']
 - id:   'tagMySqlForMarketplaceMajorMinor'
@@ -449,8 +449,8 @@ steps:
   args:
   - -ceux
   - |
-    docker tag gcr.io/ml-pipeline/mysql:5.7-debian gcr.io/ml-pipeline/google/pipelines/mysql:$(cat /workspace/mm.ver)
-    docker tag gcr.io/ml-pipeline/mysql:5.7-debian gcr.io/ml-pipeline/google/pipelines-test/mysql:$(cat /workspace/mm.ver)
+    docker tag gcr.io/ml-pipeline/mysql:8.0-debian gcr.io/ml-pipeline/google/pipelines/mysql:$(cat /workspace/mm.ver)
+    docker tag gcr.io/ml-pipeline/mysql:8.0-debian gcr.io/ml-pipeline/google/pipelines-test/mysql:$(cat /workspace/mm.ver)
     docker push gcr.io/ml-pipeline/google/pipelines/mysql:$(cat /workspace/mm.ver)
     docker push gcr.io/ml-pipeline/google/pipelines-test/mysql:$(cat /workspace/mm.ver)
 

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
@@ -168,8 +168,8 @@ spec:
           # Ext4, Btrfs etc. volumes root directories have a lost+found directory that should not be treated as a database.
           # ignore-db-dir option has been deprecated in mysql v5.7.16.
           #
-          # In order to upgrade MySQL to v8.0 remove /var/lib/mysql/lost+found folder in mysql-pv-claim 
-          # (mysql-persistent-storage):
+          # If upgrading MySQL to v8.0 fails, try removing /var/lib/mysql/lost+found folder in 
+          # mysql-pv-claim (mysql-persistent-storage):
           #
           # kubectl exec -it <mysql-pod-name> -n kubeflow -- bash
           # rm -rf /var/lib/mysql/lost+found
@@ -179,6 +179,14 @@ spec:
           # https://dev.mysql.com/doc/refman/8.0/en/upgrade-docker-mysql.html
           - --datadir
           - /var/lib/mysql
+          # MLMD workloads (metadata-grpc-deployment and metadata-writer) depend on mysql_native_password authentication plugin.
+          # mysql_native_password plugin implements native authentication; that is, authentication based on the password 
+          # hashing method in use from before the introduction of pluggable authentication in MySQL 8.0.
+          #
+          # As default_authentication_plugin option is deprecated in MySQL 8.0.27 this needs to be replaced with
+          # appropriate authentication_policy in the next upgrade. See more details:
+          # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin
+          # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_authentication_policy
           - --default-authentication-plugin=mysql_native_password
           env:
             - name: MYSQL_ALLOW_EMPTY_PASSWORD

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
@@ -166,12 +166,25 @@ spec:
           args:
           # https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_ignore-db-dir
           # Ext4, Btrfs etc. volumes root directories have a lost+found directory that should not be treated as a database.
-          - --ignore-db-dir=lost+found
+          # ignore-db-dir option has been deprecated in mysql v5.7.16.
+          #
+          # In order to upgrade MySQL to v8.0 remove /var/lib/mysql/lost+found folder in mysql-pv-claim 
+          # (mysql-persistent-storage):
+          #
+          # kubectl exec -it <mysql-pod-name> -n kubeflow -- bash
+          # rm -rf /var/lib/mysql/lost+found
+          #
+          # More details on upgrading MySQL can be found here:
+          # https://dev.mysql.com/doc/refman/8.0/en/upgrade-prerequisites.html
+          # https://dev.mysql.com/doc/refman/8.0/en/upgrade-docker-mysql.html
           - --datadir
           - /var/lib/mysql
+          - --default-authentication-plugin=mysql_native_password
           env:
             - name: MYSQL_ALLOW_EMPTY_PASSWORD
               value: "true"
+            - name: MYSQL_ROOT_PASSWORD
+              value: ""
           ports:
             - containerPort: 3306
               name: mysql

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
@@ -183,8 +183,6 @@ spec:
           env:
             - name: MYSQL_ALLOW_EMPTY_PASSWORD
               value: "true"
-            - name: MYSQL_ROOT_PASSWORD
-              value: ""
           ports:
             - containerPort: 3306
               name: mysql

--- a/manifests/gcp_marketplace/test/snapshot-base.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-base.yaml
@@ -2337,8 +2337,8 @@ spec:
           # Ext4, Btrfs etc. volumes root directories have a lost+found directory that should not be treated as a database.
           # ignore-db-dir option has been deprecated in mysql v5.7.16.
           #
-          # In order to upgrade MySQL to v8.0 remove /var/lib/mysql/lost+found folder in mysql-pv-claim 
-          # (mysql-persistent-storage):
+          # If upgrading MySQL to v8.0 fails, try removing /var/lib/mysql/lost+found folder in 
+          # mysql-pv-claim (mysql-persistent-storage):
           #
           # kubectl exec -it <mysql-pod-name> -n kubeflow -- bash
           # rm -rf /var/lib/mysql/lost+found
@@ -2348,6 +2348,14 @@ spec:
           # https://dev.mysql.com/doc/refman/8.0/en/upgrade-docker-mysql.html
           - --datadir
           - /var/lib/mysql
+          # MLMD workloads (metadata-grpc-deployment and metadata-writer) depend on mysql_native_password authentication plugin.
+          # mysql_native_password plugin implements native authentication; that is, authentication based on the password 
+          # hashing method in use from before the introduction of pluggable authentication in MySQL 8.0.
+          #
+          # As default_authentication_plugin option is deprecated in MySQL 8.0.27 this needs to be replaced with
+          # appropriate authentication_policy in the next upgrade. See more details:
+          # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin
+          # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_authentication_policy
           - --default-authentication-plugin=mysql_native_password
           env:
             - name: MYSQL_ALLOW_EMPTY_PASSWORD

--- a/manifests/gcp_marketplace/test/snapshot-base.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-base.yaml
@@ -2352,8 +2352,6 @@ spec:
           env:
             - name: MYSQL_ALLOW_EMPTY_PASSWORD
               value: "true"
-            - name: MYSQL_ROOT_PASSWORD
-              value: ""
           ports:
             - containerPort: 3306
               name: mysql

--- a/manifests/gcp_marketplace/test/snapshot-base.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-base.yaml
@@ -2335,12 +2335,25 @@ spec:
           args:
           # https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_ignore-db-dir
           # Ext4, Btrfs etc. volumes root directories have a lost+found directory that should not be treated as a database.
-          - --ignore-db-dir=lost+found
+          # ignore-db-dir option has been deprecated in mysql v5.7.16.
+          #
+          # In order to upgrade MySQL to v8.0 remove /var/lib/mysql/lost+found folder in mysql-pv-claim 
+          # (mysql-persistent-storage):
+          #
+          # kubectl exec -it <mysql-pod-name> -n kubeflow -- bash
+          # rm -rf /var/lib/mysql/lost+found
+          #
+          # More details on upgrading MySQL can be found here:
+          # https://dev.mysql.com/doc/refman/8.0/en/upgrade-prerequisites.html
+          # https://dev.mysql.com/doc/refman/8.0/en/upgrade-docker-mysql.html
           - --datadir
           - /var/lib/mysql
+          - --default-authentication-plugin=mysql_native_password
           env:
             - name: MYSQL_ALLOW_EMPTY_PASSWORD
               value: "true"
+            - name: MYSQL_ROOT_PASSWORD
+              value: ""
           ports:
             - containerPort: 3306
               name: mysql
@@ -2692,7 +2705,7 @@ metadata:
 spec:
   descriptor:
     type: Kubeflow Pipelines
-    version: 2.0.0-alpha.3
+    version: 2.0.0-alpha.5
     description: |-
       Reusable end-to-end ML workflow
     maintainers:

--- a/manifests/gcp_marketplace/test/snapshot-emissary.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-emissary.yaml
@@ -2337,8 +2337,8 @@ spec:
           # Ext4, Btrfs etc. volumes root directories have a lost+found directory that should not be treated as a database.
           # ignore-db-dir option has been deprecated in mysql v5.7.16.
           #
-          # In order to upgrade MySQL to v8.0 remove /var/lib/mysql/lost+found folder in mysql-pv-claim 
-          # (mysql-persistent-storage):
+          # If upgrading MySQL to v8.0 fails, try removing /var/lib/mysql/lost+found folder in 
+          # mysql-pv-claim (mysql-persistent-storage):
           #
           # kubectl exec -it <mysql-pod-name> -n kubeflow -- bash
           # rm -rf /var/lib/mysql/lost+found
@@ -2348,6 +2348,14 @@ spec:
           # https://dev.mysql.com/doc/refman/8.0/en/upgrade-docker-mysql.html
           - --datadir
           - /var/lib/mysql
+          # MLMD workloads (metadata-grpc-deployment and metadata-writer) depend on mysql_native_password authentication plugin.
+          # mysql_native_password plugin implements native authentication; that is, authentication based on the password 
+          # hashing method in use from before the introduction of pluggable authentication in MySQL 8.0.
+          #
+          # As default_authentication_plugin option is deprecated in MySQL 8.0.27 this needs to be replaced with
+          # appropriate authentication_policy in the next upgrade. See more details:
+          # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin
+          # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_authentication_policy
           - --default-authentication-plugin=mysql_native_password
           env:
             - name: MYSQL_ALLOW_EMPTY_PASSWORD

--- a/manifests/gcp_marketplace/test/snapshot-emissary.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-emissary.yaml
@@ -2352,8 +2352,6 @@ spec:
           env:
             - name: MYSQL_ALLOW_EMPTY_PASSWORD
               value: "true"
-            - name: MYSQL_ROOT_PASSWORD
-              value: ""
           ports:
             - containerPort: 3306
               name: mysql

--- a/manifests/gcp_marketplace/test/snapshot-emissary.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-emissary.yaml
@@ -2335,12 +2335,25 @@ spec:
           args:
           # https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_ignore-db-dir
           # Ext4, Btrfs etc. volumes root directories have a lost+found directory that should not be treated as a database.
-          - --ignore-db-dir=lost+found
+          # ignore-db-dir option has been deprecated in mysql v5.7.16.
+          #
+          # In order to upgrade MySQL to v8.0 remove /var/lib/mysql/lost+found folder in mysql-pv-claim 
+          # (mysql-persistent-storage):
+          #
+          # kubectl exec -it <mysql-pod-name> -n kubeflow -- bash
+          # rm -rf /var/lib/mysql/lost+found
+          #
+          # More details on upgrading MySQL can be found here:
+          # https://dev.mysql.com/doc/refman/8.0/en/upgrade-prerequisites.html
+          # https://dev.mysql.com/doc/refman/8.0/en/upgrade-docker-mysql.html
           - --datadir
           - /var/lib/mysql
+          - --default-authentication-plugin=mysql_native_password
           env:
             - name: MYSQL_ALLOW_EMPTY_PASSWORD
               value: "true"
+            - name: MYSQL_ROOT_PASSWORD
+              value: ""
           ports:
             - containerPort: 3306
               name: mysql
@@ -2692,7 +2705,7 @@ metadata:
 spec:
   descriptor:
     type: Kubeflow Pipelines
-    version: 2.0.0-alpha.3
+    version: 2.0.0-alpha.5
     description: |-
       Reusable end-to-end ML workflow
     maintainers:

--- a/manifests/gcp_marketplace/test/snapshot-managed-storage-with-db-prefix.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-managed-storage-with-db-prefix.yaml
@@ -2764,7 +2764,7 @@ metadata:
 spec:
   descriptor:
     type: Kubeflow Pipelines
-    version: 2.0.0-alpha.3
+    version: 2.0.0-alpha.5
     description: |-
       Reusable end-to-end ML workflow
     maintainers:

--- a/manifests/gcp_marketplace/test/snapshot-managed-storage.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-managed-storage.yaml
@@ -2764,7 +2764,7 @@ metadata:
 spec:
   descriptor:
     type: Kubeflow Pipelines
-    version: 2.0.0-alpha.3
+    version: 2.0.0-alpha.5
     description: |-
       Reusable end-to-end ML workflow
     maintainers:

--- a/manifests/kustomize/third-party/mysql/base/mysql-deployment.yaml
+++ b/manifests/kustomize/third-party/mysql/base/mysql-deployment.yaml
@@ -37,8 +37,6 @@ spec:
         env:
         - name: MYSQL_ALLOW_EMPTY_PASSWORD
           value: "true"
-        - name: MYSQL_ROOT_PASSWORD
-          value: ""
         image: gcr.io/ml-pipeline/mysql:8.0.26
         name: mysql
         ports:

--- a/manifests/kustomize/third-party/mysql/base/mysql-deployment.yaml
+++ b/manifests/kustomize/third-party/mysql/base/mysql-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
         - name: MYSQL_ALLOW_EMPTY_PASSWORD
           value: "true"
-        image: gcr.io/ml-pipeline/mysql:5.7-debian
+        image: gcr.io/ml-pipeline/mysql:8.0-debian
         name: mysql
         ports:
         - containerPort: 3306

--- a/manifests/kustomize/third-party/mysql/base/mysql-deployment.yaml
+++ b/manifests/kustomize/third-party/mysql/base/mysql-deployment.yaml
@@ -17,22 +17,30 @@ spec:
     spec:
       serviceAccountName: mysql
       containers:
-      # https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_ignore-db-dir
-      # Ext4, Btrfs etc. volumes root directories have a lost+found directory that should not be treated as a database.
-      # ignore-db-dir option has been deprecated in mysql v5.7.16.
-      #
-      # In order to upgrade MySQL to v8.0 remove /var/lib/mysql/lost+found folder in mysql-pv-claim 
-      # (mysql-persistent-storage):
-      #
-      # kubectl exec -it <mysql-pod-name> -n kubeflow -- bash
-      # rm -rf /var/lib/mysql/lost+found
-      #
-      # More details on upgrading MySQL can be found here:
-      # https://dev.mysql.com/doc/refman/8.0/en/upgrade-prerequisites.html
-      # https://dev.mysql.com/doc/refman/8.0/en/upgrade-docker-mysql.html
       - args:
+        # https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_ignore-db-dir
+        # Ext4, Btrfs etc. volumes root directories have a lost+found directory that should not be treated as a database.
+        # ignore-db-dir option has been deprecated in mysql v5.7.16.
+        #
+        # If upgrading MySQL to v8.0 fails, try removing /var/lib/mysql/lost+found folder in 
+        # mysql-pv-claim (mysql-persistent-storage):
+        #
+        # kubectl exec -it <mysql-pod-name> -n kubeflow -- bash
+        # rm -rf /var/lib/mysql/lost+found
+        #
+        # More details on upgrading MySQL can be found here:
+        # https://dev.mysql.com/doc/refman/8.0/en/upgrade-prerequisites.html
+        # https://dev.mysql.com/doc/refman/8.0/en/upgrade-docker-mysql.html
         - --datadir
         - /var/lib/mysql
+        # MLMD workloads (metadata-grpc-deployment and metadata-writer) depend on mysql_native_password authentication plugin.
+        # mysql_native_password plugin implements native authentication; that is, authentication based on the password 
+        # hashing method in use from before the introduction of pluggable authentication in MySQL 8.0.
+        #
+        # As default_authentication_plugin option is deprecated in MySQL 8.0.27 this needs to be replaced with
+        # appropriate authentication_policy in the next upgrade. See more details:
+        # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin
+        # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_authentication_policy
         - --default-authentication-plugin=mysql_native_password
         env:
         - name: MYSQL_ALLOW_EMPTY_PASSWORD

--- a/manifests/kustomize/third-party/mysql/base/mysql-deployment.yaml
+++ b/manifests/kustomize/third-party/mysql/base/mysql-deployment.yaml
@@ -19,14 +19,27 @@ spec:
       containers:
       # https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_ignore-db-dir
       # Ext4, Btrfs etc. volumes root directories have a lost+found directory that should not be treated as a database.
+      # ignore-db-dir option has been deprecated in mysql v5.7.16.
+      #
+      # In order to upgrade MySQL to v8.0 remove /var/lib/mysql/lost+found folder in mysql-pv-claim 
+      # (mysql-persistent-storage):
+      #
+      # kubectl exec -it <mysql-pod-name> -n kubeflow -- bash
+      # rm -rf /var/lib/mysql/lost+found
+      #
+      # More details on upgrading MySQL can be found here:
+      # https://dev.mysql.com/doc/refman/8.0/en/upgrade-prerequisites.html
+      # https://dev.mysql.com/doc/refman/8.0/en/upgrade-docker-mysql.html
       - args:
-        - --ignore-db-dir=lost+found
         - --datadir
         - /var/lib/mysql
+        - --default-authentication-plugin=mysql_native_password
         env:
         - name: MYSQL_ALLOW_EMPTY_PASSWORD
           value: "true"
-        image: gcr.io/ml-pipeline/mysql:8.0-debian
+        - name: MYSQL_ROOT_PASSWORD
+          value: ""
+        image: gcr.io/ml-pipeline/mysql:8.0.26
         name: mysql
         ports:
         - containerPort: 3306

--- a/test/tag_for_hosted.sh
+++ b/test/tag_for_hosted.sh
@@ -110,8 +110,8 @@ docker tag gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z-license-complia
 docker push gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/minio:$SEM_VER
 docker push gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/minio:$MM_VER
 
-docker tag gcr.io/ml-pipeline/mysql:8.0-debian gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$SEM_VER
-docker tag gcr.io/ml-pipeline/mysql:8.0-debian gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$MM_VER
+docker tag gcr.io/ml-pipeline/mysql:8.0.26 gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$SEM_VER
+docker tag gcr.io/ml-pipeline/mysql:8.0.26 gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$MM_VER
 docker push gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$SEM_VER
 docker push gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$MM_VER
 

--- a/test/tag_for_hosted.sh
+++ b/test/tag_for_hosted.sh
@@ -110,8 +110,8 @@ docker tag gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z-license-complia
 docker push gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/minio:$SEM_VER
 docker push gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/minio:$MM_VER
 
-docker tag gcr.io/ml-pipeline/mysql:5.7-debian gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$SEM_VER
-docker tag gcr.io/ml-pipeline/mysql:5.7-debian gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$MM_VER
+docker tag gcr.io/ml-pipeline/mysql:8.0-debian gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$SEM_VER
+docker tag gcr.io/ml-pipeline/mysql:8.0-debian gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$MM_VER
 docker push gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$SEM_VER
 docker push gcr.io/$PROJECT_ID/hosted/$COMMIT_SHA/mysql:$MM_VER
 


### PR DESCRIPTION
**Description of your changes:**
Upgrading MySQL to 8.0-debian. Reasons:
- Current MySQL 5.7 has several critical vulnerabilities:
   - [CVE-2020-35527 ](https://security-tracker.debian.org/tracker/CVE-2020-35527)
  - [CVE-2022-37434 ](https://security-tracker.debian.org/tracker/CVE-2022-37434)
  - [CVE-2021-20223 ](https://security-tracker.debian.org/tracker/CVE-2021-20223)
- KFP already offers support for MySQL 8.0 via managed storage options (e.g. on [GCP](https://github.com/GoogleCloudPlatform/kubeflow-distribution/blob/master/kubeflow/apps/pipelines/kustomization.yaml#L24)). This has been already tested.
- Other Kubeflow components already support MySQL 8.0 (e.g. [katib](https://github.com/kubeflow/katib/blob/7bf39225f7235ee4ba6cf285ecc2c455c6471234/manifests/v1beta1/components/mysql/mysql.yaml#L25)).
- MySQL 8.0 is a default version for many platforms (e.g. [GCP](https://cloud.google.com/sql/docs/mysql/db-versions))

This issue is related to GoogleCloudPlatform/kubeflow-distribution/issues/391.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
