### PR TITLE
fix(frontend): Surface output artifact of a SubDAG by reading subtask

### DIFF
--- a/frontend/src/components/graph/Constants.ts
+++ b/frontend/src/components/graph/Constants.ts
@@ -33,4 +33,6 @@ export type ExecutionFlowElementData = FlowElementDataBase & {
 
 export type ArtifactFlowElementData = FlowElementDataBase & {
   state?: Artifact.State;
+  producerSubtask?: string;
+  outputArtifactKey?: string;
 };

--- a/frontend/src/lib/v2/DynamicFlow.ts
+++ b/frontend/src/lib/v2/DynamicFlow.ts
@@ -278,7 +278,7 @@ export function updateFlowElementsState(
 
       // Detect whether Artifact is an output of SubDAG, if so, search its source artifact.
       let artifactData = elem.data as ArtifactFlowElementData;
-      if (artifactData.outputArtifactKey && artifactData.producerSubtask) {
+      if (artifactData && artifactData.outputArtifactKey && artifactData.producerSubtask) {
         // SubDAG output artifact has reference to inner subtask and artifact.
         const subArtifactKey = getArtifactNodeKey(
           artifactData.producerSubtask,
@@ -347,7 +347,7 @@ export function getNodeMlmdInfo(
 
     // Detect whether Artifact is an output of SubDAG, if so, search its source artifact.
     let artifactData = elem.data as ArtifactFlowElementData;
-    if (artifactData.outputArtifactKey && artifactData.producerSubtask) {
+    if (artifactData && artifactData.outputArtifactKey && artifactData.producerSubtask) {
       // SubDAG output artifact has reference to inner subtask and artifact.
       const subArtifactKey = getArtifactNodeKey(
         artifactData.producerSubtask,

--- a/frontend/src/lib/v2/DynamicFlow.ts
+++ b/frontend/src/lib/v2/DynamicFlow.ts
@@ -286,7 +286,7 @@ export function updateFlowElementsState(
         );
         linkedArtifact = artifactNodeKeyToArtifact.get(subArtifactKey);
       }
-      
+
       (updatedElem.data as ArtifactFlowElementData).state = linkedArtifact?.artifact?.getState();
       (updatedElem.data as ArtifactFlowElementData).mlmdId = linkedArtifact?.artifact?.getId();
     } else if (NodeTypeNames.SUB_DAG === elem.type) {

--- a/frontend/src/lib/v2/DynamicFlow.ts
+++ b/frontend/src/lib/v2/DynamicFlow.ts
@@ -274,7 +274,19 @@ export function updateFlowElementsState(
         (updatedElem.data as ExecutionFlowElementData).mlmdId = executions[0]?.getId();
       }
     } else if (NodeTypeNames.ARTIFACT === elem.type) {
-      const linkedArtifact = artifactNodeKeyToArtifact.get(elem.id);
+      let linkedArtifact = artifactNodeKeyToArtifact.get(elem.id);
+
+      // Detect whether Artifact is an output of SubDAG, if so, search its source artifact.
+      let artifactData = elem.data as ArtifactFlowElementData;
+      if (artifactData.outputArtifactKey && artifactData.producerSubtask) {
+        // SubDAG output artifact has reference to inner subtask and artifact.
+        const subArtifactKey = getArtifactNodeKey(
+          artifactData.producerSubtask,
+          artifactData.outputArtifactKey,
+        );
+        linkedArtifact = artifactNodeKeyToArtifact.get(subArtifactKey);
+      }
+      
       (updatedElem.data as ArtifactFlowElementData).state = linkedArtifact?.artifact?.getState();
       (updatedElem.data as ArtifactFlowElementData).mlmdId = linkedArtifact?.artifact?.getId();
     } else if (NodeTypeNames.SUB_DAG === elem.type) {
@@ -331,7 +343,19 @@ export function getNodeMlmdInfo(
       ?.filter(exec => exec.getId() === elem.data?.mlmdId);
     return executions ? { execution: executions[0] } : {};
   } else if (NodeTypeNames.ARTIFACT === elem.type) {
-    const linkedArtifact = artifactNodeKeyToArtifact.get(elem.id);
+    let linkedArtifact = artifactNodeKeyToArtifact.get(elem.id);
+
+    // Detect whether Artifact is an output of SubDAG, if so, search its source artifact.
+    let artifactData = elem.data as ArtifactFlowElementData;
+    if (artifactData.outputArtifactKey && artifactData.producerSubtask) {
+      // SubDAG output artifact has reference to inner subtask and artifact.
+      const subArtifactKey = getArtifactNodeKey(
+        artifactData.producerSubtask,
+        artifactData.outputArtifactKey,
+      );
+      linkedArtifact = artifactNodeKeyToArtifact.get(subArtifactKey);
+    }
+
     const executionId = linkedArtifact?.event.getExecutionId();
     const execution = executionId ? executionIdToExectuion.get(executionId) : undefined;
     return { execution, linkedArtifact };


### PR DESCRIPTION
**Description of your changes:**

- PipelineSpec has a `output` field which maps the `outputDefinition` of a DAG to the inner task and artifact.
- If this is an Artifact output from a SubDAG, identify its subtask and artifact so the node status and side panel can find the corresponding Artifact in MLMD.


Before: 
![subDagArtifactBefore](https://user-images.githubusercontent.com/37026441/195405225-06ceb5c4-d2f7-44a6-80bb-c25b45ff4a6d.png)

After:
![subDagArtifactAfter](https://user-images.githubusercontent.com/37026441/195405255-4700480b-4457-4de1-9fb0-8b5aaabfd88f.png)



**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
