### PR TITLE
fix(backend): Fix user cache setting P0D ignored by cache server. Fixes #8366

### DIFF
--- a/backend/src/cache/server/mutation.go
+++ b/backend/src/cache/server/mutation.go
@@ -143,7 +143,7 @@ func MutatePodIfCached(req *v1beta1.AdmissionRequest, clientMgr ClientManagerInt
 	} else {
 		cacheStalenessInSeconds = userCacheStalenessInSeconds
 	}
-	if cacheStalenessInSeconds > maximumCacheStalenessInSeconds {
+	if maximumCacheStalenessInSeconds >= 0 && cacheStalenessInSeconds > maximumCacheStalenessInSeconds {
 		cacheStalenessInSeconds = maximumCacheStalenessInSeconds
 	}
 	log.Printf("cacheStalenessInSeconds: %d", cacheStalenessInSeconds)

--- a/backend/src/cache/server/watcher.go
+++ b/backend/src/cache/server/watcher.go
@@ -81,7 +81,7 @@ func WatchPods(ctx context.Context, namespaceToWatch string, clientManager Clien
 				maximumCacheStalenessInSeconds = stalenessToSeconds(maximumCacheStaleness)
 				log.Printf("maximumCacheStalenessInSeconds: %d", maximumCacheStalenessInSeconds)
 			}
-			if cacheStalenessInSeconds > maximumCacheStalenessInSeconds || cacheStalenessInSeconds < 0 {
+			if maximumCacheStalenessInSeconds >= 0 && cacheStalenessInSeconds > maximumCacheStalenessInSeconds {
 				cacheStalenessInSeconds = maximumCacheStalenessInSeconds
 			}
 			log.Printf("Creating cachedb entry with cacheStalenessInSeconds: %d", cacheStalenessInSeconds)


### PR DESCRIPTION
**Description of your changes:**
A regression introduced by https://github.com/kubeflow/pipelines/pull/8270. 
User cache setting `P0D` (0 in seconds, meaning disable caching) was overridden by the default global cache config (-1 in seconds, meaning infinite caching staleness).

Fixes #8366

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
