### PR TITLE
feat(sdk): add --build-image option to 'kfp components build' to allow users to skip docker build. Fixes #8382 for 1.8

### DIFF
--- a/sdk/python/kfp/cli/components.py
+++ b/sdk/python/kfp/cli/components.py
@@ -369,6 +369,9 @@ def build(components_directory: pathlib.Path = typer.Argument(
               False,
               help="Set this to true to always generate a Dockerfile"
               " as part of the build process"),
+          build_image: bool = typer.Option(
+            True, help="Build the container image."
+          ),
           push_image: bool = typer.Option(
               True, help="Push the built image to its remote repository.")):
     """
@@ -380,11 +383,11 @@ def build(components_directory: pathlib.Path = typer.Argument(
             components_directory))
         raise typer.Exit(1)
 
-    if engine != _Engine.DOCKER:
+    if build_image and (engine != _Engine.DOCKER):
         _error('Currently, only `docker` is supported for --engine.')
         raise typer.Exit(1)
 
-    if engine == _Engine.DOCKER:
+    if build_image and (engine == _Engine.DOCKER):
         if not _DOCKER_IS_PRESENT:
             _error(
                 'The `docker` Python package was not found in the current'
@@ -404,7 +407,9 @@ def build(components_directory: pathlib.Path = typer.Argument(
     builder.maybe_generate_requirements_txt()
     builder.maybe_generate_dockerignore()
     builder.maybe_generate_dockerfile(overwrite_dockerfile=overwrite_dockerfile)
-    builder.build_image(push_image=push_image)
+
+    if build_image:
+        builder.build_image(push_image=push_image)
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/cli/components_test.py
+++ b/sdk/python/kfp/cli/components_test.py
@@ -386,6 +386,20 @@ class Test(unittest.TestCase):
         self._docker_client.api.build.assert_called_once()
         self._docker_client.images.push.assert_not_called()
 
+    def testDockerClientIsNotCalledToBuild(self):
+        component = _make_component(
+            func_name='train', target_image='custom-image')
+        _write_components('components.py', component)
+
+        result = self._runner.invoke(
+            self._app,
+            ['build', str(self._working_dir), '--no-build-image'],
+        )
+        self.assertEqual(result.exit_code, 0)
+
+        self._docker_client.api.build.assert_not_called()
+        self._docker_client.images.push.assert_not_called()
+
     @mock.patch('kfp.__version__', '1.2.3')
     def testDockerfileIsCreatedCorrectly(self):
         component = _make_component(


### PR DESCRIPTION
**Description of your changes:**

Adds a CLI flag to allow the user to skip `docker build` step in `kfp components build`

Addresses #8382 for SDK version 1.8

If accepted, I will recreate the same mechanism in master for SDK version 2

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
