### PR TITLE
feat(sdk): add --build-image option to 'kfp components build' to allow users to skip docker build. Fixes #8382 for 2.0

### DIFF
--- a/sdk/python/kfp/cli/component.py
+++ b/sdk/python/kfp/cli/component.py
@@ -378,7 +378,7 @@ def build(components_directory: str, component_filepattern: str, engine: str,
           build_image: bool, push_image: bool):
     """Builds containers for KFP v2 Python-based components."""
 
-    if not build_image and engine != 'docker':
+    if build_image and engine != 'docker':
         warnings.warn(
             'The --engine option is deprecated and does not need to be passed. Only Docker engine is supported and will be used by default.',
             DeprecationWarning,
@@ -393,7 +393,7 @@ def build(components_directory: str, component_filepattern: str, engine: str,
             f'{components_directory} does not seem to be a valid directory.')
         raise sys.exit(1)
 
-    if not build_image and not _DOCKER_IS_PRESENT:
+    if build_image and not _DOCKER_IS_PRESENT:
         logging.error(
             'The `docker` Python package was not found in the current'
             ' environment. Please run `pip install docker` to install it.'

--- a/sdk/python/kfp/cli/component_test.py
+++ b/sdk/python/kfp/cli/component_test.py
@@ -386,6 +386,20 @@ class Test(unittest.TestCase):
         self._docker_client.images.push.assert_called_once_with(
             'custom-image', stream=True, decode=True)
 
+    def test_docker_client_is_not_called_to_build_or_push(self):
+        component = _make_component(
+            func_name='train', target_image='custom-image')
+        _write_components('components.py', component)
+
+        result = self.runner.invoke(
+            self.cli,
+            ['build', str(self._working_dir), '--no-build-image'],
+        )
+        self.assertEqual(result.exit_code, 0)
+
+        self._docker_client.api.build.assert_not_called()
+        self._docker_client.images.push.assert_not_called()
+
     def test_docker_client_is_called_to_build_but_skips_pushing(self):
         component = _make_component(
             func_name='train', target_image='custom-image')


### PR DESCRIPTION
**Description of your changes:**

Adds a CLI flag to allow the user to skip docker build step in `kfp component build`

Addresses https://github.com/kubeflow/pipelines/issues/8382 for SDK version 2.0

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
