### PR TITLE
Test: Update pytest xdist dependency in Sagemaker KFP integration test

### DIFF
--- a/components/aws/sagemaker/tests/integration_tests/environment.yml
+++ b/components/aws/sagemaker/tests/integration_tests/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.7.14
+  - python=3.7.12
   - pip=20.0.*
   - awscli=1.18.141
   - boto3=1.15.0

--- a/components/aws/sagemaker/tests/integration_tests/environment.yml
+++ b/components/aws/sagemaker/tests/integration_tests/environment.yml
@@ -3,11 +3,11 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.7.12
+  - python=3.7.*
   - pip=20.0.*
   - awscli=1.18.141
   - boto3=1.15.0
-  - pytest-xdist=2.1.0
+  - pytest-xdist=3.0.2
   - pyyaml=5.3.*
   - flake8=3.7.*
   - flake8-black=0.1.*

--- a/components/aws/sagemaker/tests/integration_tests/environment.yml
+++ b/components/aws/sagemaker/tests/integration_tests/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.7.*
+  - python=3.7.14
   - pip=20.0.*
   - awscli=1.18.141
   - boto3=1.15.0

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/ack-training-job/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/ack-training-job/config.yaml
@@ -1,6 +1,6 @@
 PipelineDefinition: resources/definition/trainingv2_pipeline.py
 TestName: ack-training-job
-Timeout: 600
+Timeout: 1000
 ExpectedTrainingImage: ((KMEANS_REGISTRY)).dkr.ecr.((REGION)).amazonaws.com/kmeans:1
 Arguments:
   region: ((REGION))


### PR DESCRIPTION
**Description of your changes:**
Conda uses the latest pytest version unless specified in enviorment.yml. The latest pytest version will not work with xdist=2.1.0 because the latest pytest version dropped support for a package that xdist was using(https://docs.pytest.org/en/stable/changelog.html). As a result the integration tests/continuously running tests fail.  

`components/aws/sagemaker/tests/integration_tests/environment.yml` - Update xdist to use the latest version.
`components/aws/sagemaker/tests/integration_tests/resources/config/ack-training-job/config.yaml` - Increase timeout to reduce flakiness in continuously running tests.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
