### PR TITLE
feat(components): add KServe component flag to disable storing CRD status into output parameters

### DIFF
--- a/components/kserve/component.yaml
+++ b/components/kserve/component.yaml
@@ -16,6 +16,7 @@ inputs:
   - {name: Min Replicas,              type: String, default: '-1',         description: 'Minimum number of InferenceService replicas'}
   - {name: Max Replicas,              type: String, default: '-1',         description: 'Maximum number of InferenceService replicas'}
   - {name: Request Timeout,           type: String, default: '60',         description: "Specifies the number of seconds to wait before timing out a request to the component."}
+  - {name: Enable ISVC Status,        type: Bool,   default: 'True',       description: "Specifies whether to store the inference service status as the output parameter"}
 
 outputs:
   - {name: InferenceService Status,   type: String,                        description: 'Status JSON output of InferenceService'}
@@ -40,5 +41,6 @@ implementation:
       --watch-timeout,          {inputValue: Watch Timeout},
       --min-replicas,           {inputValue: Min Replicas},
       --max-replicas,           {inputValue: Max Replicas},
-      --request-timeout,        {inputValue: Request Timeout}
+      --request-timeout,        {inputValue: Request Timeout},
+      --enable-isvc-status,     {inputValue: Enable ISVC Status}
     ]


### PR DESCRIPTION
**Description of your changes:**
Add KServe component flag to disable storing CRD status into output parameters. This way users can choose to not produce the KServe CRD status in case the status is too big or have sensitive information. 

related: #8320
cc @nachogarciam 


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
