### PR TITLE
refactor(sdk): simplify placeholders and logic

### DIFF
--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -137,59 +137,6 @@ class TestCompilePipeline(parameterized.TestCase):
                 with dsl.Condition(flip.output == 'heads'):
                     flip_coin_graph_component()
 
-    def test_compile_pipeline_with_misused_inputvalue_should_raise_error(self):
-
-        upstream_op = components.load_component_from_text("""
-        name: upstream compoent
-        outputs:
-        - {name: model, type: Model}
-        implementation:
-          container:
-            image: dummy
-            args:
-            - {outputPath: model}
-        """)
-        downstream_op = components.load_component_from_text("""
-        name: compoent with misused placeholder
-        inputs:
-        - {name: model, type: Model}
-        implementation:
-          container:
-            image: dummy
-            args:
-            - {inputValue: model}
-        """)
-
-        with self.assertRaisesRegex(
-                TypeError,
-                ' type "system.Model@0.0.1" cannot be paired with InputValuePlaceholder.'
-        ):
-
-            @dsl.pipeline(name='test-pipeline', pipeline_root='dummy_root')
-            def my_pipeline():
-                downstream_op(model=upstream_op().output)
-
-    def test_compile_pipeline_with_misused_inputpath_should_raise_error(self):
-
-        component_op = components.load_component_from_text("""
-        name: compoent with misused placeholder
-        inputs:
-        - {name: text, type: String}
-        implementation:
-          container:
-            image: dummy
-            args:
-            - {inputPath: text}
-        """)
-
-        with self.assertRaisesRegex(
-                TypeError,
-                ' type "String" cannot be paired with InputPathPlaceholder.'):
-
-            @dsl.pipeline(name='test-pipeline', pipeline_root='dummy_root')
-            def my_pipeline(text: str):
-                component_op(text=text)
-
     def test_compile_pipeline_with_missing_task_should_raise_error(self):
 
         with self.assertRaisesRegex(ValueError,
@@ -198,48 +145,6 @@ class TestCompilePipeline(parameterized.TestCase):
             @dsl.pipeline(name='test-pipeline', pipeline_root='dummy_root')
             def my_pipeline(text: str):
                 pass
-
-    def test_compile_pipeline_with_misused_inputuri_should_raise_error(self):
-
-        component_op = components.load_component_from_text("""
-        name: compoent with misused placeholder
-        inputs:
-        - {name: value, type: Float}
-        implementation:
-          container:
-            image: dummy
-            args:
-            - {inputUri: value}
-        """)
-
-        with self.assertRaisesRegex(
-                TypeError,
-                ' type "Float" cannot be paired with InputUriPlaceholder.'):
-
-            @dsl.pipeline(name='test-pipeline', pipeline_root='dummy_root')
-            def my_pipeline(value: float):
-                component_op(value=value)
-
-    def test_compile_pipeline_with_misused_outputuri_should_raise_error(self):
-
-        component_op = components.load_component_from_text("""
-        name: compoent with misused placeholder
-        outputs:
-        - {name: value, type: Integer}
-        implementation:
-          container:
-            image: dummy
-            args:
-            - {outputUri: value}
-        """)
-
-        with self.assertRaisesRegex(
-                TypeError,
-                ' type "Integer" cannot be paired with OutputUriPlaceholder.'):
-
-            @dsl.pipeline(name='test-pipeline', pipeline_root='dummy_root')
-            def my_pipeline():
-                component_op()
 
     def test_compile_pipeline_with_invalid_name_should_raise_error(self):
 

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -137,6 +137,59 @@ class TestCompilePipeline(parameterized.TestCase):
                 with dsl.Condition(flip.output == 'heads'):
                     flip_coin_graph_component()
 
+    def test_compile_pipeline_with_misused_inputvalue_should_raise_error(self):
+
+        upstream_op = components.load_component_from_text("""
+        name: upstream compoent
+        outputs:
+        - {name: model, type: Model}
+        implementation:
+          container:
+            image: dummy
+            args:
+            - {outputPath: model}
+        """)
+        downstream_op = components.load_component_from_text("""
+        name: compoent with misused placeholder
+        inputs:
+        - {name: model, type: Model}
+        implementation:
+          container:
+            image: dummy
+            args:
+            - {inputValue: model}
+        """)
+
+        with self.assertRaisesRegex(
+                TypeError,
+                ' type "system.Model@0.0.1" cannot be paired with InputValuePlaceholder.'
+        ):
+
+            @dsl.pipeline(name='test-pipeline', pipeline_root='dummy_root')
+            def my_pipeline():
+                downstream_op(model=upstream_op().output)
+
+    def test_compile_pipeline_with_misused_inputpath_should_raise_error(self):
+
+        component_op = components.load_component_from_text("""
+        name: compoent with misused placeholder
+        inputs:
+        - {name: text, type: String}
+        implementation:
+          container:
+            image: dummy
+            args:
+            - {inputPath: text}
+        """)
+
+        with self.assertRaisesRegex(
+                TypeError,
+                ' type "String" cannot be paired with InputPathPlaceholder.'):
+
+            @dsl.pipeline(name='test-pipeline', pipeline_root='dummy_root')
+            def my_pipeline(text: str):
+                component_op(text=text)
+
     def test_compile_pipeline_with_missing_task_should_raise_error(self):
 
         with self.assertRaisesRegex(ValueError,
@@ -145,6 +198,48 @@ class TestCompilePipeline(parameterized.TestCase):
             @dsl.pipeline(name='test-pipeline', pipeline_root='dummy_root')
             def my_pipeline(text: str):
                 pass
+
+    def test_compile_pipeline_with_misused_inputuri_should_raise_error(self):
+
+        component_op = components.load_component_from_text("""
+        name: compoent with misused placeholder
+        inputs:
+        - {name: value, type: Float}
+        implementation:
+          container:
+            image: dummy
+            args:
+            - {inputUri: value}
+        """)
+
+        with self.assertRaisesRegex(
+                TypeError,
+                ' type "Float" cannot be paired with InputUriPlaceholder.'):
+
+            @dsl.pipeline(name='test-pipeline', pipeline_root='dummy_root')
+            def my_pipeline(value: float):
+                component_op(value=value)
+
+    def test_compile_pipeline_with_misused_outputuri_should_raise_error(self):
+
+        component_op = components.load_component_from_text("""
+        name: compoent with misused placeholder
+        outputs:
+        - {name: value, type: Integer}
+        implementation:
+          container:
+            image: dummy
+            args:
+            - {outputUri: value}
+        """)
+
+        with self.assertRaisesRegex(
+                TypeError,
+                ' type "Integer" cannot be paired with OutputUriPlaceholder.'):
+
+            @dsl.pipeline(name='test-pipeline', pipeline_root='dummy_root')
+            def my_pipeline():
+                component_op()
 
     def test_compile_pipeline_with_invalid_name_should_raise_error(self):
 

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -257,7 +257,7 @@ def build_task_spec_for_task(
                                 existing_input_name, additional_input_name))
 
                 additional_input_placeholder = placeholders.InputValuePlaceholder(
-                    additional_input_name)._to_placeholder_string()
+                    additional_input_name).to_string()
                 input_value = input_value.replace(channel.pattern,
                                                   additional_input_placeholder)
 

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -257,7 +257,7 @@ def build_task_spec_for_task(
                                 existing_input_name, additional_input_name))
 
                 additional_input_placeholder = placeholders.InputValuePlaceholder(
-                    additional_input_name).to_string()
+                    additional_input_name)._to_string()
                 input_value = input_value.replace(channel.pattern,
                                                   additional_input_placeholder)
 

--- a/sdk/python/kfp/components/component_decorator_test.py
+++ b/sdk/python/kfp/components/component_decorator_test.py
@@ -106,7 +106,7 @@ class TestComponentDecorator(unittest.TestCase):
 
         component_spec = structures.ComponentSpec.load_from_component_yaml(
             yaml_text)
-        self.assertEqual(component_spec, comp.component_spec)
+        self.assertEqual(component_spec.name, comp.component_spec.name)
 
     def test_output_named_tuple_with_dict(self):
 

--- a/sdk/python/kfp/components/component_factory.py
+++ b/sdk/python/kfp/components/component_factory.py
@@ -365,7 +365,7 @@ def _get_command_and_args_for_containerized_component(
 
     args = [
         '--executor_input',
-        placeholders.ExecutorInputPlaceholder()._to_placeholder_string(),
+        placeholders.ExecutorInputPlaceholder().to_string(),
         '--function_to_execute',
         function_name,
     ]

--- a/sdk/python/kfp/components/component_factory.py
+++ b/sdk/python/kfp/components/component_factory.py
@@ -365,7 +365,7 @@ def _get_command_and_args_for_containerized_component(
 
     args = [
         '--executor_input',
-        placeholders.ExecutorInputPlaceholder().to_string(),
+        placeholders.ExecutorInputPlaceholder()._to_string(),
         '--function_to_execute',
         function_name,
     ]

--- a/sdk/python/kfp/components/container_component_artifact_channel_test.py
+++ b/sdk/python/kfp/components/container_component_artifact_channel_test.py
@@ -25,12 +25,15 @@ class TestContainerComponentArtifactChannel(unittest.TestCase):
             'input', 'my_dataset')
         out_channel = component_factory.ContainerComponentArtifactChannel(
             'output', 'my_result')
-        self.assertEqual(in_channel.uri,
-                         placeholders.InputUriPlaceholder('my_dataset'))
-        self.assertEqual(out_channel.path,
-                         placeholders.OutputPathPlaceholder('my_result'))
-        self.assertEqual(out_channel.metadata,
-                         placeholders.OutputMetadataPlaceholder('my_result'))
+        self.assertEqual(
+            in_channel.uri.to_string(),
+            placeholders.InputUriPlaceholder('my_dataset').to_string())
+        self.assertEqual(
+            out_channel.path.to_string(),
+            placeholders.OutputPathPlaceholder('my_result').to_string())
+        self.assertEqual(
+            out_channel.metadata.to_string(),
+            placeholders.OutputMetadataPlaceholder('my_result').to_string())
         self.assertRaisesRegex(AttributeError,
                                r'Cannot access artifact attribute "name"',
                                lambda: in_channel.name)

--- a/sdk/python/kfp/components/container_component_artifact_channel_test.py
+++ b/sdk/python/kfp/components/container_component_artifact_channel_test.py
@@ -26,14 +26,14 @@ class TestContainerComponentArtifactChannel(unittest.TestCase):
         out_channel = component_factory.ContainerComponentArtifactChannel(
             'output', 'my_result')
         self.assertEqual(
-            in_channel.uri.to_string(),
-            placeholders.InputUriPlaceholder('my_dataset').to_string())
+            in_channel.uri._to_string(),
+            placeholders.InputUriPlaceholder('my_dataset')._to_string())
         self.assertEqual(
-            out_channel.path.to_string(),
-            placeholders.OutputPathPlaceholder('my_result').to_string())
+            out_channel.path._to_string(),
+            placeholders.OutputPathPlaceholder('my_result')._to_string())
         self.assertEqual(
-            out_channel.metadata.to_string(),
-            placeholders.OutputMetadataPlaceholder('my_result').to_string())
+            out_channel.metadata._to_string(),
+            placeholders.OutputMetadataPlaceholder('my_result')._to_string())
         self.assertRaisesRegex(AttributeError,
                                r'Cannot access artifact attribute "name"',
                                lambda: in_channel.name)

--- a/sdk/python/kfp/components/importer_node.py
+++ b/sdk/python/kfp/components/importer_node.py
@@ -85,7 +85,7 @@ def importer(
                 type=d.channel_type)
 
             return placeholders.InputValuePlaceholder(
-                input_name=unique_name)._to_placeholder_string()
+                input_name=unique_name).to_string()
 
         elif isinstance(d, dict):
             # use this instead of list comprehension to ensure compiles are identical across Python versions
@@ -122,7 +122,7 @@ def importer(
         implementation=structures.Implementation(
             importer=structures.ImporterSpec(
                 artifact_uri=placeholders.InputValuePlaceholder(
-                    URI_KEY)._to_placeholder_string(),
+                    URI_KEY).to_string(),
                 schema_title=type_utils.create_bundled_artifact_type(
                     artifact_class.schema_title, artifact_class.schema_version),
                 schema_version=artifact_class.schema_version,

--- a/sdk/python/kfp/components/importer_node.py
+++ b/sdk/python/kfp/components/importer_node.py
@@ -85,7 +85,7 @@ def importer(
                 type=d.channel_type)
 
             return placeholders.InputValuePlaceholder(
-                input_name=unique_name).to_string()
+                input_name=unique_name)._to_string()
 
         elif isinstance(d, dict):
             # use this instead of list comprehension to ensure compiles are identical across Python versions
@@ -122,7 +122,7 @@ def importer(
         implementation=structures.Implementation(
             importer=structures.ImporterSpec(
                 artifact_uri=placeholders.InputValuePlaceholder(
-                    URI_KEY).to_string(),
+                    URI_KEY)._to_string(),
                 schema_title=type_utils.create_bundled_artifact_type(
                     artifact_class.schema_title, artifact_class.schema_version),
                 schema_version=artifact_class.schema_version,

--- a/sdk/python/kfp/components/pipeline_task.py
+++ b/sdk/python/kfp/components/pipeline_task.py
@@ -14,8 +14,9 @@
 """Pipeline task class and operations."""
 
 import copy
+import itertools
 import re
-from typing import Any, List, Mapping, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 from kfp.components import constants
 from kfp.components import pipeline_channel
@@ -128,7 +129,18 @@ class PipelineTask:
         self.container_spec = None
         self.pipeline_spec = None
 
+        def validate_placeholder_types(
+                component_spec: structures.ComponentSpec) -> None:
+            inputs_dict = component_spec.inputs or {}
+            outputs_dict = component_spec.outputs or {}
+            for arg in itertools.chain(
+                (component_spec.implementation.container.command or []),
+                (component_spec.implementation.container.args or [])):
+                check_primitive_placeholder_is_used_for_correct_io_type(
+                    inputs_dict, outputs_dict, arg)
+
         if component_spec.implementation.container is not None:
+            validate_placeholder_types(component_spec)
             self.container_spec = self._extract_container_spec_and_convert_placeholders(
                 component_spec=component_spec)
         elif component_spec.implementation.importer is not None:
@@ -452,3 +464,56 @@ class PipelineTask:
                 )
             self._task_spec.dependent_tasks.append(task.name)
         return self
+
+
+# TODO: this function should ideally be in the function kfp.components.structures.check_placeholder_references_valid_io_name, which does something similar, but this causes the exception to be raised at component definition time, rather than compile time. This would break tests that load v1 component YAML, even though that YAML is invalid.
+def check_primitive_placeholder_is_used_for_correct_io_type(
+    inputs_dict: Dict[str, structures.InputSpec],
+    outputs_dict: Dict[str, structures.OutputSpec],
+    arg: Union[placeholders.Placeholder, Any],
+):
+    """Validates input/output placeholders refer to an input/output with an
+    appropriate type for the placeholder. This should only apply to components
+    loaded from v1 component YAML, where the YAML is authored directly. For v2
+    YAML, this is encapsulated in the DSL logic which does not permit writing
+    incorrect placeholders.
+
+    Args:
+        inputs_dict: The existing input names.
+        outputs_dict: The existing output names.
+        arg: The command line element, which may be a placeholder.
+    """
+
+    if isinstance(arg, placeholders.InputValuePlaceholder):
+        input_name = arg.input_name
+        if not type_utils.is_parameter_type(inputs_dict[input_name].type):
+            raise TypeError(
+                f'Input "{input_name}" with type '
+                f'"{inputs_dict[input_name].type}" cannot be paired with '
+                'InputValuePlaceholder.')
+
+    elif isinstance(
+            arg,
+        (placeholders.InputUriPlaceholder, placeholders.InputPathPlaceholder)):
+        input_name = arg.input_name
+        if type_utils.is_parameter_type(inputs_dict[input_name].type):
+            raise TypeError(
+                f'Input "{input_name}" with type '
+                f'"{inputs_dict[input_name].type}" cannot be paired with '
+                f'{arg.__class__.__name__}.')
+
+    elif isinstance(arg, placeholders.OutputUriPlaceholder):
+        output_name = arg.output_name
+        if type_utils.is_parameter_type(outputs_dict[output_name].type):
+            raise TypeError(
+                f'Output "{output_name}" with type '
+                f'"{outputs_dict[output_name].type}" cannot be paired with '
+                f'{arg.__class__.__name__}.')
+    elif isinstance(arg, placeholders.IfPresentPlaceholder):
+        for arg in itertools.chain(arg.then or [], arg.else_ or []):
+            check_primitive_placeholder_is_used_for_correct_io_type(
+                inputs_dict, outputs_dict, arg)
+    elif isinstance(arg, placeholders.ConcatPlaceholder):
+        for arg in arg.items:
+            check_primitive_placeholder_is_used_for_correct_io_type(
+                inputs_dict, outputs_dict, arg)

--- a/sdk/python/kfp/components/pipeline_task.py
+++ b/sdk/python/kfp/components/pipeline_task.py
@@ -129,10 +129,8 @@ class PipelineTask:
         self.pipeline_spec = None
 
         if component_spec.implementation.container is not None:
-            self.container_spec = self._resolve_command_line_and_arguments(
-                component_spec=component_spec,
-                args=args,
-            )
+            self.container_spec = self._extract_container_spec_and_convert_placeholders(
+                component_spec=component_spec)
         elif component_spec.implementation.importer is not None:
             self.importer_spec = component_spec.implementation.importer
             self.importer_spec.artifact_uri = args['uri']
@@ -208,141 +206,25 @@ class PipelineTask:
         """A list of the dependent task names."""
         return self._task_spec.dependent_tasks
 
-    def _resolve_command_line_and_arguments(
-        self,
-        component_spec: structures.ComponentSpec,
-        args: Mapping[str, str],
+    def _extract_container_spec_and_convert_placeholders(
+        self, component_spec: structures.ComponentSpec
     ) -> structures.ContainerSpecImplementation:
-        """Resolves the command line argument placeholders in a
-        ContainerSpecImplementation.
+        """Extracts a ContainerSpec from a ComponentSpec and converts
+        placeholder objects to strings.
 
         Args:
             component_spec: The component definition.
-            args: The dictionary of component arguments.
         """
-        argument_values = args
-
-        component_inputs = component_spec.inputs or {}
-        inputs_dict = {
-            input_name: input_spec
-            for input_name, input_spec in component_inputs.items()
-        }
-        component_outputs = component_spec.outputs or {}
-        outputs_dict = {
-            output_name: output_spec
-            for output_name, output_spec in component_outputs.items()
-        }
-
-        def check_input_type_and_convert_to_placeholder(
-                arg) -> Union[str, List[str], None]:
-            # TODO: separate input type-checking logic from placeholder-conversion/.to_placeholder() logic
-            if arg is None:
-                return None
-
-            elif isinstance(arg, (str, int, float, bool)):
-                return str(arg)
-
-            elif isinstance(arg, placeholders.InputValuePlaceholder):
-                input_name = arg.input_name
-                if not type_utils.is_parameter_type(
-                        inputs_dict[input_name].type):
-                    raise TypeError(
-                        f'Input "{input_name}" with type '
-                        f'"{inputs_dict[input_name].type}" cannot be paired with '
-                        'InputValuePlaceholder.')
-                if input_name in args or type_utils.is_task_final_status_type(
-                        inputs_dict[input_name].type):
-                    return arg._to_placeholder_string()
-                input_spec = inputs_dict[input_name]
-                if input_spec.default is None:
-                    raise ValueError(
-                        f'No value provided for input: {input_name}.')
-                else:
-                    return arg._to_placeholder_string()
-
-            elif isinstance(arg, placeholders.InputUriPlaceholder):
-                input_name = arg.input_name
-                if type_utils.is_parameter_type(inputs_dict[input_name].type):
-                    raise TypeError(
-                        f'Input "{input_name}" with type '
-                        f'"{inputs_dict[input_name].type}" cannot be paired with '
-                        'InputUriPlaceholder.')
-
-                if input_name in args:
-                    return arg._to_placeholder_string()
-                input_spec = inputs_dict[input_name]
-                if input_spec.default is None:
-                    raise ValueError(
-                        f'No value provided for input: {input_name}.')
-
-                else:
-                    return None
-
-            elif isinstance(arg, placeholders.InputPathPlaceholder):
-                input_name = arg.input_name
-                if type_utils.is_parameter_type(inputs_dict[input_name].type):
-                    raise TypeError(
-                        f'Input "{input_name}" with type '
-                        f'"{inputs_dict[input_name].type}" cannot be paired with '
-                        'InputPathPlaceholder.')
-
-                if input_name in args:
-                    return arg._to_placeholder_string()
-                input_spec = inputs_dict[input_name]
-                if input_spec._optional:
-                    return None
-                else:
-                    raise ValueError(
-                        f'No value provided for input: {input_name}.')
-
-            elif isinstance(arg, placeholders.OutputUriPlaceholder):
-                output_name = arg.output_name
-                if type_utils.is_parameter_type(outputs_dict[output_name].type):
-                    raise TypeError(
-                        f'Onput "{output_name}" with type '
-                        f'"{outputs_dict[output_name].type}" cannot be paired with '
-                        'OutputUriPlaceholder.')
-
-                return arg._to_placeholder_string()
-
-            elif isinstance(arg, (placeholders.OutputPathPlaceholder,
-                                  placeholders.OutputParameterPlaceholder)):
-                output_name = arg.output_name
-                return placeholders.OutputParameterPlaceholder(
-                    arg.output_name)._to_placeholder_string(
-                    ) if type_utils.is_parameter_type(
-                        outputs_dict[output_name].type
-                    ) else placeholders.OutputPathPlaceholder(
-                        arg.output_name)._to_placeholder_string()
-
-            elif isinstance(arg, placeholders.Placeholder):
-                return arg._to_placeholder_string()
-
-            else:
-                raise TypeError(f'Unrecognized argument type: {arg}.')
-
-        def expand_argument_list(argument_list) -> Optional[List[str]]:
-            if argument_list is None:
-                return None
-
-            expanded_list = []
-            for part in argument_list:
-                expanded_part = check_input_type_and_convert_to_placeholder(
-                    part)
-                if expanded_part is not None:
-                    if isinstance(expanded_part, list):
-                        expanded_list.extend(expanded_part)
-                    else:
-                        expanded_list.append(str(expanded_part))
-            return expanded_list
-
-        container_spec = component_spec.implementation.container
-        resolved_container_spec = copy.deepcopy(container_spec)
-        resolved_container_spec.command = expand_argument_list(
-            container_spec.command)
-        resolved_container_spec.args = expand_argument_list(container_spec.args)
-
-        return resolved_container_spec
+        container_spec = copy.deepcopy(component_spec.implementation.container)
+        container_spec.command = [
+            placeholders.convert_command_line_element_to_string(e)
+            for e in container_spec.command or []
+        ]
+        container_spec.args = [
+            placeholders.convert_command_line_element_to_string(e)
+            for e in container_spec.args or []
+        ]
+        return container_spec
 
     def set_caching_options(self, enable_caching: bool) -> 'PipelineTask':
         """Sets caching options for the task.

--- a/sdk/python/kfp/components/pipeline_task.py
+++ b/sdk/python/kfp/components/pipeline_task.py
@@ -228,6 +228,10 @@ class PipelineTask:
             component_spec: The component definition.
         """
         container_spec = copy.deepcopy(component_spec.implementation.container)
+        if container_spec is None:
+            raise ValueError(
+                '_extract_container_spec_and_convert_placeholders used incorrectly. ComponentSpec.implementation.container is None.'
+            )
         container_spec.command = [
             placeholders.convert_command_line_element_to_string(e)
             for e in container_spec.command or []

--- a/sdk/python/kfp/components/pipeline_task_test.py
+++ b/sdk/python/kfp/components/pipeline_task_test.py
@@ -86,9 +86,10 @@ class PipelineTaskTest(parameterized.TestCase):
                     image='alpine',
                     command=['sh', '-c', 'echo "$0" >> "$1"'],
                     args=[
-                        placeholders.InputValuePlaceholder(input_name='input1'),
+                        placeholders.InputValuePlaceholder(
+                            input_name='input1').to_string(),
                         placeholders.OutputPathPlaceholder(
-                            output_name='output1'),
+                            output_name='output1').to_string(),
                     ],
                 )),
             inputs={
@@ -121,15 +122,6 @@ class PipelineTaskTest(parameterized.TestCase):
         self.assertEqual(task._task_spec, expected_task_spec)
         self.assertEqual(task.component_spec, expected_component_spec)
         self.assertEqual(task.container_spec, expected_container_spec)
-
-    def test_create_pipeline_task_invalid_missing_required_input(self):
-        with self.assertRaisesRegex(ValueError,
-                                    'No value provided for input: input1.'):
-            task = pipeline_task.PipelineTask(
-                component_spec=structures.ComponentSpec
-                .load_from_component_yaml(V2_YAML),
-                args={},
-            )
 
     def test_create_pipeline_task_invalid_wrong_input(self):
         with self.assertRaisesRegex(

--- a/sdk/python/kfp/components/pipeline_task_test.py
+++ b/sdk/python/kfp/components/pipeline_task_test.py
@@ -87,9 +87,9 @@ class PipelineTaskTest(parameterized.TestCase):
                     command=['sh', '-c', 'echo "$0" >> "$1"'],
                     args=[
                         placeholders.InputValuePlaceholder(
-                            input_name='input1').to_string(),
+                            input_name='input1')._to_string(),
                         placeholders.OutputPathPlaceholder(
-                            output_name='output1').to_string(),
+                            output_name='output1')._to_string(),
                     ],
                 )),
             inputs={

--- a/sdk/python/kfp/components/placeholders.py
+++ b/sdk/python/kfp/components/placeholders.py
@@ -122,6 +122,9 @@ class ConcatPlaceholder(Placeholder):
     """Placeholder for concatenating multiple strings. May contain other
     placeholders.
 
+    Args:
+        items: Elements to concatenate.
+
     Examples:
       ::
 
@@ -139,7 +142,6 @@ class ConcatPlaceholder(Placeholder):
     """
 
     def __init__(self, items: List['CommandLineElement']) -> None:
-        # """Elements to concatenate."""
         self.items = items
 
     def to_dict(self) -> Dict[str, Any]:
@@ -157,6 +159,11 @@ class ConcatPlaceholder(Placeholder):
 class IfPresentPlaceholder(Placeholder):
     """Placeholder for handling cases where an input may or may not be passed.
     May contain other placeholders.
+
+    Args:
+        input_name: Name of the input/output.
+        then: If the input/output specified in name is present, the command-line argument will be replaced at run-time by the value of then.
+        else_: If the input/output specified in name is not present, the command-line argument will be replaced at run-time by the value of else_.
 
     Examples:
       ::

--- a/sdk/python/kfp/components/placeholders.py
+++ b/sdk/python/kfp/components/placeholders.py
@@ -225,7 +225,7 @@ class IfPresentPlaceholder(Placeholder):
         return json.dumps(self._to_dict())
 
 
-CONTAINER_PLACEHOLDERS = (IfPresentPlaceholder, ConcatPlaceholder)
+_CONTAINER_PLACEHOLDERS = (IfPresentPlaceholder, ConcatPlaceholder)
 PRIMITIVE_INPUT_PLACEHOLDERS = (InputValuePlaceholder, InputPathPlaceholder,
                                 InputUriPlaceholder, InputMetadataPlaceholder)
 PRIMITIVE_OUTPUT_PLACEHOLDERS = (OutputParameterPlaceholder,
@@ -248,7 +248,7 @@ def convert_command_line_element_to_string_or_struct(
         element: Union[Placeholder, Any]) -> Any:
     if isinstance(element, Placeholder):
         return element._to_dict() if isinstance(
-            element, CONTAINER_PLACEHOLDERS) else element._to_string()
+            element, _CONTAINER_PLACEHOLDERS) else element._to_string()
 
     return element
 

--- a/sdk/python/kfp/components/placeholders.py
+++ b/sdk/python/kfp/components/placeholders.py
@@ -26,7 +26,7 @@ from kfp.components.types import type_utils
 class Placeholder(abc.ABC, base_model.BaseModel):
 
     @abc.abstractmethod
-    def to_string(self) -> str:
+    def _to_string(self) -> str:
         raise NotImplementedError
 
     def __str__(self) -> str:
@@ -42,7 +42,7 @@ class Placeholder(abc.ABC, base_model.BaseModel):
 
 class ExecutorInputPlaceholder(Placeholder):
 
-    def to_string(self) -> str:
+    def _to_string(self) -> str:
         return '{{$}}'
 
 
@@ -51,7 +51,7 @@ class InputValuePlaceholder(Placeholder):
     def __init__(self, input_name: str) -> None:
         self.input_name = input_name
 
-    def to_string(self) -> str:
+    def _to_string(self) -> str:
         return f"{{{{$.inputs.parameters['{self.input_name}']}}}}"
 
 
@@ -60,7 +60,7 @@ class InputPathPlaceholder(Placeholder):
     def __init__(self, input_name: str) -> None:
         self.input_name = input_name
 
-    def to_string(self) -> str:
+    def _to_string(self) -> str:
         return f"{{{{$.inputs.artifacts['{self.input_name}'].path}}}}"
 
 
@@ -69,7 +69,7 @@ class InputUriPlaceholder(Placeholder):
     def __init__(self, input_name: str) -> None:
         self.input_name = input_name
 
-    def to_string(self) -> str:
+    def _to_string(self) -> str:
         return f"{{{{$.inputs.artifacts['{self.input_name}'].uri}}}}"
 
 
@@ -78,7 +78,7 @@ class InputMetadataPlaceholder(Placeholder):
     def __init__(self, input_name: str) -> None:
         self.input_name = input_name
 
-    def to_string(self) -> str:
+    def _to_string(self) -> str:
         return f"{{{{$.inputs.artifacts['{self.input_name}'].metadata}}}}"
 
 
@@ -87,7 +87,7 @@ class OutputParameterPlaceholder(Placeholder):
     def __init__(self, output_name: str) -> None:
         self.output_name = output_name
 
-    def to_string(self) -> str:
+    def _to_string(self) -> str:
         return f"{{{{$.outputs.parameters['{self.output_name}'].output_file}}}}"
 
 
@@ -96,7 +96,7 @@ class OutputPathPlaceholder(Placeholder):
     def __init__(self, output_name: str) -> None:
         self.output_name = output_name
 
-    def to_string(self) -> str:
+    def _to_string(self) -> str:
         return f"{{{{$.outputs.artifacts['{self.output_name}'].path}}}}"
 
 
@@ -105,7 +105,7 @@ class OutputUriPlaceholder(Placeholder):
     def __init__(self, output_name: str) -> None:
         self.output_name = output_name
 
-    def to_string(self) -> str:
+    def _to_string(self) -> str:
         return f"{{{{$.outputs.artifacts['{self.output_name}'].uri}}}}"
 
 
@@ -114,7 +114,7 @@ class OutputMetadataPlaceholder(Placeholder):
     def __init__(self, output_name: str) -> None:
         self.output_name = output_name
 
-    def to_string(self) -> str:
+    def _to_string(self) -> str:
         return f"{{{{$.outputs.artifacts['{self.output_name}'].metadata}}}}"
 
 
@@ -144,7 +144,7 @@ class ConcatPlaceholder(Placeholder):
     def __init__(self, items: List['CommandLineElement']) -> None:
         self.items = items
 
-    def to_dict(self) -> Dict[str, Any]:
+    def _to_dict(self) -> Dict[str, Any]:
         return {
             'Concat': [
                 convert_command_line_element_to_string_or_struct(item)
@@ -152,8 +152,8 @@ class ConcatPlaceholder(Placeholder):
             ]
         }
 
-    def to_string(self) -> str:
-        return json.dumps(self.to_dict())
+    def _to_string(self) -> str:
+        return json.dumps(self._to_dict())
 
 
 class IfPresentPlaceholder(Placeholder):
@@ -198,7 +198,7 @@ class IfPresentPlaceholder(Placeholder):
         self.then = then
         self.else_ = else_
 
-    def to_dict(self) -> Dict[str, Any]:
+    def _to_dict(self) -> Dict[str, Any]:
         struct = {
             'IfPresent': {
                 'InputName':
@@ -221,8 +221,8 @@ class IfPresentPlaceholder(Placeholder):
                     self.else_)
         return struct
 
-    def to_string(self) -> str:
-        return json.dumps(self.to_dict())
+    def _to_string(self) -> str:
+        return json.dumps(self._to_dict())
 
 
 CONTAINER_PLACEHOLDERS = (IfPresentPlaceholder, ConcatPlaceholder)
@@ -241,14 +241,14 @@ CommandLineElement = Union[str, IfPresentPlaceholder, ConcatPlaceholder,
 
 def convert_command_line_element_to_string(
         element: Union[str, Placeholder]) -> str:
-    return element.to_string() if isinstance(element, Placeholder) else element
+    return element._to_string() if isinstance(element, Placeholder) else element
 
 
 def convert_command_line_element_to_string_or_struct(
         element: Union[Placeholder, Any]) -> Any:
     if isinstance(element, Placeholder):
-        return element.to_dict() if isinstance(
-            element, CONTAINER_PLACEHOLDERS) else element.to_string()
+        return element._to_dict() if isinstance(
+            element, CONTAINER_PLACEHOLDERS) else element._to_string()
 
     return element
 

--- a/sdk/python/kfp/components/placeholders.py
+++ b/sdk/python/kfp/components/placeholders.py
@@ -15,11 +15,7 @@
 placeholders."""
 
 import abc
-import dataclasses
 import json
-from json.decoder import JSONArray  # type: ignore
-from json.scanner import py_make_scanner
-import re
 from typing import Any, Dict, List, Optional, Union
 
 from kfp.components import base_model
@@ -27,265 +23,102 @@ from kfp.components import utils
 from kfp.components.types import type_utils
 
 
-class Placeholder(abc.ABC):
-    """Abstract base class for Placeholders.
-
-    All placeholders must implement these methods to be handled
-    appropriately downstream.
-    """
-
-    @classmethod
-    @abc.abstractmethod
-    def _from_placeholder_string(cls, placeholder_string: str) -> 'Placeholder':
-        """Converts a placeholder string to the placeholder object that
-        implements this method.
-
-        Args:
-            placeholder_string (str): The placeholder string.
-
-        Returns:
-            Placeholder: The placeholder object that implements this method.
-        """
-        raise NotImplementedError
-
-    @classmethod
-    @abc.abstractmethod
-    def _is_match(cls, placeholder_string: str) -> bool:
-        """Checks if the placeholder string matches the placeholder object that
-        implements this method.
-
-        Args:
-            placeholder_string (str): The placeholder string.
-
-        Returns:
-            bool: Whether the placeholder string matches the placeholder object that implements this method and can be converted to an instance of the placeholder object.
-        """
-        raise NotImplementedError
+class Placeholder(abc.ABC, base_model.BaseModel):
 
     @abc.abstractmethod
-    def _to_placeholder_string(self) -> str:
-        """Converts the placeholder object that implements this to a
-        placeholder string.
-
-        Returns:
-            str: The placeholder string.
-        """
+    def to_string(self) -> str:
         raise NotImplementedError
 
-    @abc.abstractmethod
-    def to_dict(self, by_alias: bool = False) -> Dict[str, Any]:
-        """Converts the placeholder object that implements this to a
-        dictionary. This ensures that this concrete placeholder classes also
-        inherit from kfp.components.base_model.BaseModel.
+    def __str__(self) -> str:
+        """Used for creating readable error messages when a placeholder doesn't
+        refer to an existing input or output."""
+        return self.__class__.__name__
 
-        Args:
-            by_alias (bool, optional): Whether to use attribute name to alias field mapping provided by cls._aliases when converting to dictionary. Defaults to False.
-
-        Returns:
-            Dict[str, Any]: Dictionary representation of the object.
-        """
-        raise NotImplementedError
+    def __eq__(self, other: Any) -> bool:
+        """Used for comparing placeholders in tests."""
+        return isinstance(other,
+                          self.__class__) and self.__dict__ == other.__dict__
 
 
-class RegexPlaceholderSerializationMixin(Placeholder):
-    """Mixin for *Placeholder objects that handles the
-    serialization/deserialization of the placeholder."""
-    _FROM_PLACEHOLDER: Union[re.Pattern, type(NotImplemented)] = NotImplemented
-    _TO_PLACEHOLDER: Union[str, type(NotImplemented)] = NotImplemented
+class ExecutorInputPlaceholder(Placeholder):
 
-    @classmethod
-    def _is_match(cls, placeholder_string: str) -> bool:
-        """Determines if the placeholder_string matches the placeholder pattern
-        using the _FROM_PLACEHOLDER regex.
-
-        Args:
-            placeholder_string (str): The string (often "{{$.inputs/outputs...}}") to check.
-
-        Returns:
-            bool: Determines if the placeholder_string matches the placeholder pattern.
-        """
-        return cls._FROM_PLACEHOLDER.match(placeholder_string) is not None
-
-    @classmethod
-    def _from_placeholder_string(
-            cls,
-            placeholder_string: str) -> 'RegexPlaceholderSerializationMixin':
-        """Converts a placeholder string into a placeholder object.
-
-        Args:
-            placeholder_string (str): The placeholder.
-
-        Returns:
-            PlaceholderSerializationMixin subclass: The placeholder object.
-        """
-        if cls._FROM_PLACEHOLDER == NotImplemented:
-            raise NotImplementedError(
-                f'{cls.__name__} does not support placeholder parsing.')
-        matches = re.search(cls._FROM_PLACEHOLDER, placeholder_string)
-        if matches is None:
-            raise ValueError(
-                f'Could not parse placeholder: {placeholder_string} into {cls.__name__}'
-            )
-        field_names = [field.name for field in dataclasses.fields(cls)]
-        if len(matches.groups()) > len(field_names):
-            raise ValueError(
-                f'Could not parse placeholder string: {placeholder_string}. Expected no more than {len(field_names)} groups matched for fields {field_names}. Got {len(matches.groups())} matched: {matches.groups()}.'
-            )
-        kwargs = {field_name: matches[field_name] for field_name in field_names}
-        return cls(**kwargs)
-
-    def _to_placeholder_string(self) -> str:
-        """Converts a placeholder object into a placeholder string.
-
-        Returns:
-            str: The placeholder string.
-        """
-        if self._TO_PLACEHOLDER == NotImplemented:
-            raise NotImplementedError(
-                f'{self.__class__.__name__} does not support creating placeholder strings.'
-            )
-
-        return self._TO_PLACEHOLDER.format(**self.to_dict())
+    def to_string(self) -> str:
+        return '{{$}}'
 
 
-class ExecutorInputPlaceholder(base_model.BaseModel,
-                               RegexPlaceholderSerializationMixin):
-    """Class that represents executor input placeholder."""
-    _TO_PLACEHOLDER = '{{$}}'
-    _FROM_PLACEHOLDER = re.compile(r'\{\{\$\}\}')
+class InputValuePlaceholder(Placeholder):
 
-    def _to_placeholder_string(self) -> str:
-        return self._TO_PLACEHOLDER
+    def __init__(self, input_name: str) -> None:
+        self.input_name = input_name
 
-
-class InputValuePlaceholder(base_model.BaseModel,
-                            RegexPlaceholderSerializationMixin):
-    """Class that holds an input value placeholder.
-
-    Attributes:
-        input_name: Name of the input.
-    """
-    input_name: str
-    _aliases = {'input_name': 'inputValue'}
-    _TO_PLACEHOLDER = "{{{{$.inputs.parameters['{input_name}']}}}}"
-    _FROM_PLACEHOLDER = re.compile(
-        r"\{\{\$\.inputs\.parameters\[(?:''|'|\")(?P<input_name>.+?)(?:''|'|\")]\}\}"
-    )
+    def to_string(self) -> str:
+        return f"{{{{$.inputs.parameters['{self.input_name}']}}}}"
 
 
-class InputPathPlaceholder(base_model.BaseModel,
-                           RegexPlaceholderSerializationMixin):
-    """Class that holds an input path placeholder.
+class InputPathPlaceholder(Placeholder):
 
-    Attributes:
-        input_name: Name of the input.
-    """
-    input_name: str
-    _aliases = {'input_name': 'inputPath'}
-    _TO_PLACEHOLDER = "{{{{$.inputs.artifacts['{input_name}'].path}}}}"
-    _FROM_PLACEHOLDER = re.compile(
-        r"^\{\{\$\.inputs\.artifacts\[(?:''|'|\")(?P<input_name>.+?)(?:''|'|\")]\.path\}\}$"
-    )
+    def __init__(self, input_name: str) -> None:
+        self.input_name = input_name
+
+    def to_string(self) -> str:
+        return f"{{{{$.inputs.artifacts['{self.input_name}'].path}}}}"
 
 
-class InputUriPlaceholder(base_model.BaseModel,
-                          RegexPlaceholderSerializationMixin):
-    """Class that holds an input uri placeholder.
+class InputUriPlaceholder(Placeholder):
 
-    Attributes:
-        input_name: Name of the input.
-    """
-    input_name: str
-    _aliases = {'input_name': 'inputUri'}
-    _TO_PLACEHOLDER = "{{{{$.inputs.artifacts['{input_name}'].uri}}}}"
-    _FROM_PLACEHOLDER = re.compile(
-        r"^\{\{\$\.inputs\.artifacts\[(?:''|'|\")(?P<input_name>.+?)(?:''|'|\")]\.uri\}\}$"
-    )
+    def __init__(self, input_name: str) -> None:
+        self.input_name = input_name
+
+    def to_string(self) -> str:
+        return f"{{{{$.inputs.artifacts['{self.input_name}'].uri}}}}"
 
 
-class InputMetadataPlaceholder(base_model.BaseModel,
-                               RegexPlaceholderSerializationMixin):
-    """Class that holds an input metadata placeholder.
+class InputMetadataPlaceholder(Placeholder):
 
-    Attributes:
-        input_name: Name of the input.
-    """
-    input_name: str
-    _aliases = {'input_name': 'inputMetadata'}
-    _TO_PLACEHOLDER = "{{{{$.inputs.artifacts['{input_name}'].metadata}}}}"
-    _FROM_PLACEHOLDER = re.compile(
-        r"^\{\{\$\.inputs\.artifacts\[(?:''|'|\")(?P<input_name>.+?)(?:''|'|\")]\.metadata\}\}$"
-    )
+    def __init__(self, input_name: str) -> None:
+        self.input_name = input_name
+
+    def to_string(self) -> str:
+        return f"{{{{$.inputs.artifacts['{self.input_name}'].metadata}}}}"
 
 
-class OutputParameterPlaceholder(base_model.BaseModel,
-                                 RegexPlaceholderSerializationMixin):
-    """Class that holds an output parameter placeholder.
+class OutputParameterPlaceholder(Placeholder):
 
-    Attributes:
-        output_name: Name of the output.
-    """
-    output_name: str
-    _aliases = {'output_name': 'outputPath'}
-    _TO_PLACEHOLDER = "{{{{$.outputs.parameters['{output_name}'].output_file}}}}"
-    _FROM_PLACEHOLDER = re.compile(
-        r"^\{\{\$\.outputs\.parameters\[(?:''|'|\")(?P<output_name>.+?)(?:''|'|\")]\.output_file\}\}$"
-    )
+    def __init__(self, output_name: str) -> None:
+        self.output_name = output_name
+
+    def to_string(self) -> str:
+        return f"{{{{$.outputs.parameters['{self.output_name}'].output_file}}}}"
 
 
-class OutputPathPlaceholder(base_model.BaseModel,
-                            RegexPlaceholderSerializationMixin):
-    """Class that holds an output path placeholder.
+class OutputPathPlaceholder(Placeholder):
 
-    Attributes:
-        output_name: Name of the output.
-    """
-    output_name: str
-    _aliases = {'output_name': 'outputPath'}
-    _TO_PLACEHOLDER = "{{{{$.outputs.artifacts['{output_name}'].path}}}}"
-    _FROM_PLACEHOLDER = re.compile(
-        r"^\{\{\$\.outputs\.artifacts\[(?:''|'|\")(?P<output_name>.+?)(?:''|'|\")]\.path\}\}$"
-    )
+    def __init__(self, output_name: str) -> None:
+        self.output_name = output_name
+
+    def to_string(self) -> str:
+        return f"{{{{$.outputs.artifacts['{self.output_name}'].path}}}}"
 
 
-class OutputUriPlaceholder(base_model.BaseModel,
-                           RegexPlaceholderSerializationMixin):
-    """Class that holds output uri for conditional cases.
+class OutputUriPlaceholder(Placeholder):
 
-    Attributes:
-        output_name: name of the output.
-    """
-    output_name: str
-    _aliases = {'output_name': 'outputUri'}
-    _TO_PLACEHOLDER = "{{{{$.outputs.artifacts['{output_name}'].uri}}}}"
-    _FROM_PLACEHOLDER = re.compile(
-        r"^\{\{\$\.outputs\.artifacts\[(?:''|'|\")(?P<output_name>.+?)(?:''|'|\")]\.uri\}\}$"
-    )
+    def __init__(self, output_name: str) -> None:
+        self.output_name = output_name
+
+    def to_string(self) -> str:
+        return f"{{{{$.outputs.artifacts['{self.output_name}'].uri}}}}"
 
 
-class OutputMetadataPlaceholder(base_model.BaseModel,
-                                RegexPlaceholderSerializationMixin):
-    """Class that holds an output metadata placeholder.
+class OutputMetadataPlaceholder(Placeholder):
 
-    Attributes:
-        output_name: Name of the output.
-    """
-    output_name: str
-    _aliases = {'output_name': 'outputMetadata'}
-    _TO_PLACEHOLDER = "{{{{$.outputs.artifacts['{output_name}'].metadata}}}}"
-    _FROM_PLACEHOLDER = re.compile(
-        r"^\{\{\$\.outputs\.artifacts\[(?:''|'|\")(?P<output_name>.+?)(?:''|'|\")]\.metadata\}\}$"
-    )
+    def __init__(self, output_name: str) -> None:
+        self.output_name = output_name
+
+    def to_string(self) -> str:
+        return f"{{{{$.outputs.artifacts['{self.output_name}'].metadata}}}}"
 
 
-CommandLineElement = Union[str, ExecutorInputPlaceholder, InputValuePlaceholder,
-                           InputPathPlaceholder, InputUriPlaceholder,
-                           OutputParameterPlaceholder, OutputPathPlaceholder,
-                           OutputUriPlaceholder, 'IfPresentPlaceholder',
-                           'ConcatPlaceholder']
-
-
-class ConcatPlaceholder(base_model.BaseModel, Placeholder):
+class ConcatPlaceholder(Placeholder):
     """Placeholder for concatenating multiple strings. May contain other
     placeholders.
 
@@ -304,80 +137,24 @@ class ConcatPlaceholder(base_model.BaseModel, Placeholder):
                 args=['--output_path', output_path]
             )
     """
-    items: List[CommandLineElement]
-    """Elements to concatenate."""
 
-    @classmethod
-    def _split_cel_concat_string(self, string: str) -> List[str]:
-        """Splits a cel string into a list of strings, which may be normal
-        strings or placeholder strings.
+    def __init__(self, items: List['CommandLineElement']) -> None:
+        # """Elements to concatenate."""
+        self.items = items
 
-        Args:
-            cel_string (str): The cel string.
-
-        Returns:
-            List[str]: The list of strings.
-        """
-        concat_char = '+'
-        start_ends = [(match.start(0), match.end(0)) for match in
-                      InputValuePlaceholder._FROM_PLACEHOLDER.finditer(string)]
-
-        items = []
-        if start_ends:
-            start = 0
-            for match_start, match_end in start_ends:
-                leading_string = string[start:match_start]
-                if leading_string and leading_string != concat_char:
-                    items.append(leading_string)
-                items.append(string[match_start:match_end])
-                start = match_end
-            trailing_string = string[match_end:]
-            if trailing_string and trailing_string != concat_char:
-                items.append(trailing_string)
-        return items
-
-    @classmethod
-    def _is_match(cls, placeholder_string: str) -> bool:
-        # 'Concat' is the explicit struct for concatenation
-        # cel splitting handles the cases of {{input}}+{{input}} and {{input}}otherstring
-        return 'Concat' in json_load_nested_placeholder_aware(
-            placeholder_string
-        ) or len(
-            ConcatPlaceholder._split_cel_concat_string(placeholder_string)) > 1
-
-    def _to_placeholder_struct(self) -> Dict[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
         return {
             'Concat': [
-                maybe_convert_placeholder_to_placeholder_string(item)
+                convert_command_line_element_to_string_or_struct(item)
                 for item in self.items
             ]
         }
 
-    def _to_placeholder_string(self) -> str:
-        return json.dumps(self._to_placeholder_struct())
-
-    @classmethod
-    def _from_placeholder_string(
-            cls, placeholder_string: str) -> 'ConcatPlaceholder':
-        placeholder_struct = json_load_nested_placeholder_aware(
-            placeholder_string)
-        if isinstance(placeholder_struct, str):
-            items = [
-                maybe_convert_placeholder_string_to_placeholder(item)
-                for item in cls._split_cel_concat_string(placeholder_struct)
-            ]
-            return cls(items=items)
-        elif isinstance(placeholder_struct, dict):
-            items = [
-                maybe_convert_placeholder_string_to_placeholder(item)
-                for item in placeholder_struct['Concat']
-            ]
-            return ConcatPlaceholder(items=items)
-
-        raise ValueError
+    def to_string(self) -> str:
+        return json.dumps(self.to_dict())
 
 
-class IfPresentPlaceholder(base_model.BaseModel, Placeholder):
+class IfPresentPlaceholder(Placeholder):
     """Placeholder for handling cases where an input may or may not be passed.
     May contain other placeholders.
 
@@ -402,150 +179,76 @@ class IfPresentPlaceholder(base_model.BaseModel, Placeholder):
                     args=['--output_path', output_path]
                 )
     """
-    input_name: str
-    """name of the input/output."""
 
-    then: List[CommandLineElement]
-    """If the input/output specified in name is present, the command-line argument will be replaced at run-time by the expanded value of then."""
+    def __init__(
+        self,
+        input_name: str,
+        then: Union['CommandLineElement', List['CommandLineElement']],
+        else_: Optional[Union['CommandLineElement',
+                              List['CommandLineElement']]] = None,
+    ) -> None:
+        self.input_name = input_name
+        self.then = then
+        self.else_ = else_
 
-    else_: Optional[List[CommandLineElement]] = None
-    """If the input/output specified in name is not present, the command-line argument will be replaced at run-time by the expanded value of otherwise."""
-
-    _aliases = {'input_name': 'inputName', 'else_': 'else'}
-
-    @classmethod
-    def _is_match(cls, string: str) -> bool:
-        try:
-            return 'IfPresent' in json.loads(string)
-        except json.decoder.JSONDecodeError:
-            return False
-
-    def _to_placeholder_struct(self) -> Dict[str, Any]:
-        then = [
-            maybe_convert_placeholder_to_placeholder_string(item)
-            for item in self.then
-        ] if isinstance(self.then, list) else self.then
-        struct = {'IfPresent': {'InputName': self.input_name, 'Then': then}}
+    def to_dict(self) -> Dict[str, Any]:
+        struct = {
+            'IfPresent': {
+                'InputName':
+                    self.input_name,
+                'Then': [
+                    convert_command_line_element_to_string_or_struct(e)
+                    for e in self.then
+                ] if isinstance(self.then, list) else
+                        convert_command_line_element_to_string_or_struct(
+                            self.then)
+            }
+        }
         if self.else_:
-            otherwise = [
-                maybe_convert_placeholder_to_placeholder_string(item)
-                for item in self.else_
-            ] if isinstance(self.else_, list) else self.else_
-            struct['IfPresent']['Else'] = otherwise
+            struct['IfPresent']['Else'] = [
+                convert_command_line_element_to_string_or_struct(e)
+                for e in self.else_
+            ] if isinstance(
+                self.else_,
+                list) else convert_command_line_element_to_string_or_struct(
+                    self.else_)
         return struct
 
-    def _to_placeholder_string(self) -> str:
-        return json.dumps(self._to_placeholder_struct())
-
-    @classmethod
-    def _from_placeholder_string(
-            cks, placeholder_string: str) -> 'IfPresentPlaceholder':
-        struct = json_load_nested_placeholder_aware(placeholder_string)
-        struct_body = struct['IfPresent']
-
-        then = struct_body['Then']
-        then = [
-            maybe_convert_placeholder_string_to_placeholder(item)
-            for item in then
-        ] if isinstance(then, list) else then
-
-        else_ = struct_body.get('Else')
-        else_ = [
-            maybe_convert_placeholder_string_to_placeholder(item)
-            for item in else_
-        ] if isinstance(else_, list) else else_
-        kwargs = {
-            'input_name': struct_body['InputName'],
-            'then': then,
-            'else_': else_
-        }
-        return IfPresentPlaceholder(**kwargs)
-
-    def _transform_else(self) -> None:
-        """Use None instead of empty list for optional."""
-        self.else_ = None if self.else_ == [] else self.else_
+    def to_string(self) -> str:
+        return json.dumps(self.to_dict())
 
 
-class CustomizedDecoder(json.JSONDecoder):
+CONTAINER_PLACEHOLDERS = (IfPresentPlaceholder, ConcatPlaceholder)
+PRIMITIVE_INPUT_PLACEHOLDERS = (InputValuePlaceholder, InputPathPlaceholder,
+                                InputUriPlaceholder, InputMetadataPlaceholder)
+PRIMITIVE_OUTPUT_PLACEHOLDERS = (OutputParameterPlaceholder,
+                                 OutputPathPlaceholder, OutputUriPlaceholder,
+                                 OutputMetadataPlaceholder)
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        def parse_array(*_args, **_kwargs):
-            values, end = JSONArray(*_args, **_kwargs)
-            for i, item in enumerate(values):
-                if isinstance(item, dict):
-                    values[i] = json.dumps(item)
-            return values, end
-
-        self.parse_array = parse_array
-        self.scan_once = py_make_scanner(self)
+CommandLineElement = Union[str, IfPresentPlaceholder, ConcatPlaceholder,
+                           InputValuePlaceholder, InputPathPlaceholder,
+                           InputUriPlaceholder, InputMetadataPlaceholder,
+                           OutputParameterPlaceholder, OutputPathPlaceholder,
+                           OutputUriPlaceholder, OutputMetadataPlaceholder]
 
 
-def json_load_nested_placeholder_aware(
-    placeholder_string: str
-) -> Union[str, Dict[str, Union[str, List[str], dict]]]:
-    try:
-        return json.loads(placeholder_string, cls=CustomizedDecoder)
-    except json.JSONDecodeError:
-        return placeholder_string
+def convert_command_line_element_to_string(
+        element: Union[str, Placeholder]) -> str:
+    return element.to_string() if isinstance(element, Placeholder) else element
 
 
-def maybe_convert_placeholder_string_to_placeholder(
-        placeholder_string: str) -> CommandLineElement:
-    """Infers if a command is a placeholder and converts it to the correct
-    Placeholder object.
+def convert_command_line_element_to_string_or_struct(
+        element: Union[Placeholder, Any]) -> Any:
+    if isinstance(element, Placeholder):
+        return element.to_dict() if isinstance(
+            element, CONTAINER_PLACEHOLDERS) else element.to_string()
 
-    Args:
-        arg (str): The arg or command to possibly convert.
-
-    Returns:
-        CommandLineElement: The converted command or original string.
-    """
-    if not placeholder_string.startswith('{'):
-        return placeholder_string
-
-    # order matters here!
-    from_string_placeholders = [
-        ExecutorInputPlaceholder,
-        IfPresentPlaceholder,
-        ConcatPlaceholder,
-        InputValuePlaceholder,
-        InputPathPlaceholder,
-        InputUriPlaceholder,
-        OutputPathPlaceholder,
-        OutputUriPlaceholder,
-        OutputParameterPlaceholder,
-    ]
-    for placeholder_struct in from_string_placeholders:
-        if placeholder_struct._is_match(placeholder_string):
-            return placeholder_struct._from_placeholder_string(
-                placeholder_string)
-    return placeholder_string
+    return element
 
 
-def maybe_convert_placeholder_to_placeholder_string(
-        placeholder: CommandLineElement) -> str:
-    """Converts a placeholder to a placeholder string if it's a subclass of
-    Placeholder.
-
-    Args:
-        placeholder (Placeholder): The placeholder to convert.
-
-    Returns:
-        str: The placeholder string.
-    """
-    if isinstance(placeholder, Placeholder):
-        return placeholder._to_placeholder_struct() if hasattr(
-            placeholder,
-            '_to_placeholder_struct') else placeholder._to_placeholder_string()
-    return placeholder
-
-
-def maybe_convert_v1_yaml_placeholder_to_v2_placeholder_str(
-    arg: Dict[str, Any],
-    component_dict: Dict[str,
-                         Any]) -> Union[Dict[str, Any], CommandLineElement]:
+def maybe_convert_v1_yaml_placeholder_to_v2_placeholder(
+        arg: Dict[str, Any],
+        component_dict: Dict[str, Any]) -> Union[CommandLineElement, Any]:
     if isinstance(arg, str):
         return arg
 
@@ -563,68 +266,60 @@ def maybe_convert_v1_yaml_placeholder_to_v2_placeholder_str(
     first_value = list(arg.values())[0]
     if first_key == 'inputValue':
         return InputValuePlaceholder(
-            input_name=utils.sanitize_input_name(
-                first_value))._to_placeholder_string()
+            input_name=utils.sanitize_input_name(first_value))
 
     elif first_key == 'inputPath':
         return InputPathPlaceholder(
-            input_name=utils.sanitize_input_name(
-                first_value))._to_placeholder_string()
+            input_name=utils.sanitize_input_name(first_value))
 
     elif first_key == 'inputUri':
         return InputUriPlaceholder(
-            input_name=utils.sanitize_input_name(
-                first_value))._to_placeholder_string()
+            input_name=utils.sanitize_input_name(first_value))
 
     elif first_key == 'outputPath':
         outputs = component_dict['outputs']
         for output in outputs:
             if output['name'] == first_value:
                 type_ = output.get('type')
-                is_parameter = type_ is None or (
-                    isinstance(type_, str) and
-                    type_.lower() in type_utils._PARAMETER_TYPES_MAPPING)
+                is_parameter = type_utils.is_parameter_type(type_)
                 if is_parameter:
                     return OutputParameterPlaceholder(
-                        output_name=utils.sanitize_input_name(
-                            first_value))._to_placeholder_string()
+                        output_name=utils.sanitize_input_name(first_value))
                 else:
                     return OutputPathPlaceholder(
-                        output_name=utils.sanitize_input_name(
-                            first_value))._to_placeholder_string()
+                        output_name=utils.sanitize_input_name(first_value))
         raise ValueError(
             f'{first_value} not found in component outputs. Could not process placeholders. Component spec: {component_dict}.'
         )
 
     elif first_key == 'outputUri':
         return OutputUriPlaceholder(
-            output_name=utils.sanitize_input_name(
-                first_value))._to_placeholder_string()
+            output_name=utils.sanitize_input_name(first_value))
 
     elif first_key == 'ifPresent':
         structure_kwargs = arg['ifPresent']
         structure_kwargs['input_name'] = structure_kwargs.pop('inputName')
         structure_kwargs['otherwise'] = structure_kwargs.pop('else')
         structure_kwargs['then'] = [
-            maybe_convert_v1_yaml_placeholder_to_v2_placeholder_str(
+            maybe_convert_v1_yaml_placeholder_to_v2_placeholder(
                 e, component_dict=component_dict)
             for e in structure_kwargs['then']
         ]
         structure_kwargs['otherwise'] = [
-            maybe_convert_v1_yaml_placeholder_to_v2_placeholder_str(
+            maybe_convert_v1_yaml_placeholder_to_v2_placeholder(
                 e, component_dict=component_dict)
             for e in structure_kwargs['otherwise']
         ]
-        return IfPresentPlaceholder(**structure_kwargs)._to_placeholder_string()
+        return IfPresentPlaceholder(**structure_kwargs)
 
     elif first_key == 'concat':
         return ConcatPlaceholder(items=[
-            maybe_convert_v1_yaml_placeholder_to_v2_placeholder_str(
+            maybe_convert_v1_yaml_placeholder_to_v2_placeholder(
                 e, component_dict=component_dict) for e in arg['concat']
-        ])._to_placeholder_string()
+        ])
 
     elif first_key == 'executorInput':
-        return ExecutorInputPlaceholder()._to_placeholder_string()
+        return ExecutorInputPlaceholder()
 
     elif 'if' in arg:
         if_ = arg['if']
@@ -634,19 +329,19 @@ def maybe_convert_v1_yaml_placeholder_to_v2_placeholder_str(
         return IfPresentPlaceholder(
             input_name=input_name,
             then=[
-                maybe_convert_v1_yaml_placeholder_to_v2_placeholder_str(
+                maybe_convert_v1_yaml_placeholder_to_v2_placeholder(
                     val, component_dict=component_dict) for val in then_
             ],
             else_=[
-                maybe_convert_v1_yaml_placeholder_to_v2_placeholder_str(
+                maybe_convert_v1_yaml_placeholder_to_v2_placeholder(
                     val, component_dict=component_dict) for val in else_
-            ])._to_placeholder_string()
+            ])
 
     elif 'concat' in arg:
 
         return ConcatPlaceholder(items=[
-            maybe_convert_v1_yaml_placeholder_to_v2_placeholder_str(
+            maybe_convert_v1_yaml_placeholder_to_v2_placeholder(
                 val, component_dict=component_dict) for val in arg['concat']
-        ])._to_placeholder_string()
+        ])
     else:
         raise TypeError(f'Unexpected argument {arg} of type {type(arg)}.')

--- a/sdk/python/kfp/components/placeholders_test.py
+++ b/sdk/python/kfp/components/placeholders_test.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Contains tests for kfp.components.placeholders."""
-from typing import List
-import unittest
+from typing import Any
 
 from absl.testing import parameterized
 from kfp.components import placeholders
@@ -21,322 +20,235 @@ from kfp.components import placeholders
 
 class TestExecutorInputPlaceholder(parameterized.TestCase):
 
-    @parameterized.parameters([
-        ('{{$}}', placeholders.ExecutorInputPlaceholder()),
-    ])
-    def test_to_from_placeholder(
-            self, placeholder_string: str,
-            placeholder_obj: placeholders.ExecutorInputPlaceholder):
-        self.assertEqual(
-            placeholders.ExecutorInputPlaceholder._from_placeholder_string(
-                placeholder_string), placeholder_obj)
-        self.assertEqual(placeholder_obj._to_placeholder_string(),
-                         placeholder_string)
+    def test(self):
+        self.assertEqual(placeholders.ExecutorInputPlaceholder().to_string(),
+                         '{{$}}')
 
 
 class TestInputValuePlaceholder(parameterized.TestCase):
 
-    @parameterized.parameters([
-        ("{{$.inputs.parameters['input1']}}",
-         placeholders.InputValuePlaceholder('input1')),
-    ])
-    def test_to_from_placeholder(
-            self, placeholder_string: str,
-            placeholder_obj: placeholders.InputValuePlaceholder):
+    def test(self):
         self.assertEqual(
-            placeholders.InputValuePlaceholder._from_placeholder_string(
-                placeholder_string), placeholder_obj)
-        self.assertEqual(placeholder_obj._to_placeholder_string(),
-                         placeholder_string)
-
-    @parameterized.parameters([
-        ("{{$.inputs.parameters[''input1'']}}",
-         placeholders.InputValuePlaceholder('input1')),
-        ('{{$.inputs.parameters["input1"]}}',
-         placeholders.InputValuePlaceholder('input1')),
-    ])
-    def test_from_placeholder_special_quote_case(
-            self, placeholder_string: str,
-            placeholder_obj: placeholders.InputValuePlaceholder):
-        self.assertEqual(
-            placeholders.InputValuePlaceholder._from_placeholder_string(
-                placeholder_string), placeholder_obj)
+            placeholders.InputValuePlaceholder('input1').to_string(),
+            "{{$.inputs.parameters['input1']}}")
 
 
 class TestInputPathPlaceholder(parameterized.TestCase):
 
-    @parameterized.parameters([
-        ("{{$.inputs.artifacts['input1'].path}}",
-         placeholders.InputPathPlaceholder('input1')),
-    ])
-    def test_to_from_placeholder(
-            self, placeholder_string: str,
-            placeholder_obj: placeholders.InputPathPlaceholder):
+    def test(self):
         self.assertEqual(
-            placeholders.InputPathPlaceholder._from_placeholder_string(
-                placeholder_string), placeholder_obj)
-        self.assertEqual(placeholder_obj._to_placeholder_string(),
-                         placeholder_string)
+            placeholders.InputPathPlaceholder('input1').to_string(),
+            "{{$.inputs.artifacts['input1'].path}}")
 
 
 class TestInputUriPlaceholder(parameterized.TestCase):
 
-    @parameterized.parameters([
-        ("{{$.inputs.artifacts['input1'].uri}}",
-         placeholders.InputUriPlaceholder('input1')),
-    ])
-    def test_to_from_placeholder(
-            self, placeholder_string: str,
-            placeholder_obj: placeholders.InputUriPlaceholder):
+    def test(self):
         self.assertEqual(
-            placeholders.InputUriPlaceholder._from_placeholder_string(
-                placeholder_string), placeholder_obj)
-        self.assertEqual(placeholder_obj._to_placeholder_string(),
-                         placeholder_string)
+            placeholders.InputUriPlaceholder('input1').to_string(),
+            "{{$.inputs.artifacts['input1'].uri}}")
 
 
 class TestInputMetadataPlaceholder(parameterized.TestCase):
 
-    @parameterized.parameters([
-        ("{{$.inputs.artifacts['input1'].metadata}}",
-         placeholders.InputMetadataPlaceholder('input1')),
-    ])
-    def test_to_from_placeholder(
-            self, placeholder_string: str,
-            placeholder_obj: placeholders.InputMetadataPlaceholder):
+    def test(self):
         self.assertEqual(
-            placeholders.InputMetadataPlaceholder._from_placeholder_string(
-                placeholder_string), placeholder_obj)
-        self.assertEqual(placeholder_obj._to_placeholder_string(),
-                         placeholder_string)
+            placeholders.InputMetadataPlaceholder('input1').to_string(),
+            "{{$.inputs.artifacts['input1'].metadata}}")
 
 
 class TestOutputPathPlaceholder(parameterized.TestCase):
 
-    @parameterized.parameters([
-        ("{{$.outputs.artifacts['output1'].path}}",
-         placeholders.OutputPathPlaceholder('output1')),
-    ])
-    def test_to_from_placeholder(
-            self, placeholder_string: str,
-            placeholder_obj: placeholders.OutputPathPlaceholder):
+    def test(self):
         self.assertEqual(
-            placeholders.OutputPathPlaceholder._from_placeholder_string(
-                placeholder_string), placeholder_obj)
-        self.assertEqual(placeholder_obj._to_placeholder_string(),
-                         placeholder_string)
+            placeholders.OutputPathPlaceholder('output1').to_string(),
+            "{{$.outputs.artifacts['output1'].path}}")
 
 
 class TestOutputParameterPlaceholder(parameterized.TestCase):
 
-    @parameterized.parameters([
-        ("{{$.outputs.parameters['output1'].output_file}}",
-         placeholders.OutputParameterPlaceholder('output1')),
-    ])
-    def test_to_from_placeholder(
-            self, placeholder_string: str,
-            placeholder_obj: placeholders.OutputParameterPlaceholder):
+    def test(self):
         self.assertEqual(
-            placeholders.OutputParameterPlaceholder._from_placeholder_string(
-                placeholder_string), placeholder_obj)
-        self.assertEqual(placeholder_obj._to_placeholder_string(),
-                         placeholder_string)
+            placeholders.OutputParameterPlaceholder('output1').to_string(),
+            "{{$.outputs.parameters['output1'].output_file}}")
 
 
 class TestOutputUriPlaceholder(parameterized.TestCase):
 
-    @parameterized.parameters([
-        ("{{$.outputs.artifacts['output1'].uri}}",
-         placeholders.OutputUriPlaceholder('output1')),
-    ])
-    def test_to_from_placeholder(
-            self, placeholder_string: str,
-            placeholder_obj: placeholders.OutputUriPlaceholder):
+    def test(self):
         self.assertEqual(
-            placeholders.OutputUriPlaceholder._from_placeholder_string(
-                placeholder_string), placeholder_obj)
-        self.assertEqual(placeholder_obj._to_placeholder_string(),
-                         placeholder_string)
+            placeholders.OutputUriPlaceholder('output1').to_string(),
+            "{{$.outputs.artifacts['output1'].uri}}")
 
 
 class TestOutputMetadataPlaceholder(parameterized.TestCase):
 
-    @parameterized.parameters([
-        ("{{$.outputs.artifacts['output1'].metadata}}",
-         placeholders.OutputMetadataPlaceholder('output1')),
-    ])
-    def test_to_from_placeholder(
-            self, placeholder_string: str,
-            placeholder_obj: placeholders.OutputMetadataPlaceholder):
+    def test(self):
         self.assertEqual(
-            placeholders.OutputMetadataPlaceholder._from_placeholder_string(
-                placeholder_string), placeholder_obj)
-        self.assertEqual(placeholder_obj._to_placeholder_string(),
-                         placeholder_string)
+            placeholders.OutputMetadataPlaceholder('output1').to_string(),
+            "{{$.outputs.artifacts['output1'].metadata}}")
 
 
 class TestIfPresentPlaceholderStructure(parameterized.TestCase):
 
-    def test_else_transform(self):
-        obj = placeholders.IfPresentPlaceholder(
-            then='then', input_name='input_name', else_=['something'])
-        self.assertEqual(obj.else_, ['something'])
-
-        obj = placeholders.IfPresentPlaceholder(
-            then='then', input_name='input_name', else_=[])
-        self.assertEqual(obj.else_, None)
+    @parameterized.parameters([
+        (placeholders.IfPresentPlaceholder(
+            input_name='input1', then=['then'], else_=['something']),
+         '{"IfPresent": {"InputName": "input1", "Then": ["then"], "Else": ["something"]}}'
+        ),
+        (placeholders.IfPresentPlaceholder(
+            input_name='input1', then='then', else_='something'),
+         '{"IfPresent": {"InputName": "input1", "Then": "then", "Else": "something"}}'
+        ),
+        (placeholders.IfPresentPlaceholder(
+            input_name='input1', then='then', else_=['something']),
+         '{"IfPresent": {"InputName": "input1", "Then": "then", "Else": ["something"]}}'
+        ),
+        (placeholders.IfPresentPlaceholder(
+            input_name='input1', then=['then'], else_='something'),
+         '{"IfPresent": {"InputName": "input1", "Then": ["then"], "Else": "something"}}'
+        ),
+    ])
+    def test_strings_and_lists(
+            self, placeholder_obj: placeholders.IfPresentPlaceholder,
+            placeholder: str):
+        self.assertEqual(placeholder_obj.to_string(), placeholder)
 
     @parameterized.parameters([
-        ('{"IfPresent": {"InputName": "output1", "Then": "then", "Else": "something"}}',
-         placeholders.IfPresentPlaceholder(
-             input_name='output1', then='then', else_='something')),
-        ('{"IfPresent": {"InputName": "output1", "Then": "then"}}',
-         placeholders.IfPresentPlaceholder(input_name='output1', then='then')),
-        ('{"IfPresent": {"InputName": "output1", "Then": "then"}}',
-         placeholders.IfPresentPlaceholder('output1', 'then')),
-        ('{"IfPresent": {"InputName": "output1", "Then": ["then"], "Else": ["something"]}}',
-         placeholders.IfPresentPlaceholder(
-             input_name='output1', then=['then'], else_=['something'])),
-        ('{"IfPresent": {"InputName": "output1", "Then": ["then", {"IfPresent": {"InputName": "output1", "Then": ["then"], "Else": ["something"]}}], "Else": ["something"]}}',
-         placeholders.IfPresentPlaceholder(
-             input_name='output1',
-             then=[
-                 'then',
-                 placeholders.IfPresentPlaceholder(
-                     input_name='output1', then=['then'], else_=['something'])
-             ],
-             else_=['something'])),
+        (placeholders.IfPresentPlaceholder(
+            input_name='input1',
+            then=[
+                '--flag',
+                placeholders.OutputUriPlaceholder(output_name='output1')
+            ],
+            else_=[
+                '--flag',
+                placeholders.OutputMetadataPlaceholder(output_name='output1')
+            ]),
+         """{"IfPresent": {"InputName": "input1", "Then": ["--flag", "{{$.outputs.artifacts['output1'].uri}}"], "Else": ["--flag", "{{$.outputs.artifacts['output1'].metadata}}"]}}"""
+        ),
+        (placeholders.IfPresentPlaceholder(
+            input_name='input1',
+            then=placeholders.InputPathPlaceholder(input_name='input2'),
+            else_=placeholders.InputValuePlaceholder(input_name='input2')),
+         """{"IfPresent": {"InputName": "input1", "Then": "{{$.inputs.artifacts['input2'].path}}", "Else": "{{$.inputs.parameters['input2']}}"}}"""
+        ),
     ])
-    def test_to_from_placeholder(
-            self, placeholder_string: str,
-            placeholder_obj: placeholders.ConcatPlaceholder):
-        self.assertEqual(
-            placeholders.IfPresentPlaceholder._from_placeholder_string(
-                placeholder_string), placeholder_obj)
-        self.assertEqual(placeholder_obj._to_placeholder_string(),
-                         placeholder_string)
+    def test_with_primitive_placeholders(
+            self, placeholder_obj: placeholders.IfPresentPlaceholder,
+            placeholder: str):
+        self.assertEqual(placeholder_obj.to_string(), placeholder)
 
 
 class TestConcatPlaceholder(parameterized.TestCase):
 
     @parameterized.parameters([
-        ('{"Concat": ["a", "b"]}', placeholders.ConcatPlaceholder(['a', 'b'])),
-        ('{"Concat": ["a", {"Concat": ["b", "c"]}]}',
-         placeholders.ConcatPlaceholder(
-             ['a', placeholders.ConcatPlaceholder(['b', 'c'])])),
-        ('{"Concat": ["a", {"Concat": ["b", {"IfPresent": {"InputName": "output1", "Then": ["then"], "Else": ["something"]}}]}]}',
-         placeholders.ConcatPlaceholder([
-             'a',
-             placeholders.ConcatPlaceholder([
-                 'b',
-                 placeholders.IfPresentPlaceholder(
-                     input_name='output1', then=['then'], else_=['something'])
-             ])
-         ]))
+        (placeholders.ConcatPlaceholder(['a']), '{"Concat": ["a"]}'),
+        (placeholders.ConcatPlaceholder(['a', 'b']), '{"Concat": ["a", "b"]}'),
     ])
-    def test_to_from_placeholder(
-            self, placeholder_string: str,
-            placeholder_obj: placeholders.ConcatPlaceholder):
-        self.assertEqual(
-            placeholders.ConcatPlaceholder._from_placeholder_string(
-                placeholder_string), placeholder_obj)
-        self.assertEqual(placeholder_obj._to_placeholder_string(),
-                         placeholder_string)
+    def test_strings(self, placeholder_obj: placeholders.ConcatPlaceholder,
+                     placeholder_string: str):
+        self.assertEqual(placeholder_obj.to_string(), placeholder_string)
 
     @parameterized.parameters([
-        "{{$.inputs.parameters[''input1'']}}+{{$.inputs.parameters[''input2'']}}",
-        '{"Concat": ["a", "b"]}', '{"Concat": ["a", {"Concat": ["b", "c"]}]}',
-        "{{$.inputs.parameters[''input1'']}}something{{$.inputs.parameters[''input2'']}}",
-        "{{$.inputs.parameters[''input_prefix'']}}some value",
-        "some value{{$.inputs.parameters[''input_suffix'']}}",
-        "some value{{$.inputs.parameters[''input_infix'']}}some value"
+        (placeholders.ConcatPlaceholder([
+            'a', placeholders.InputPathPlaceholder(input_name='input2')
+        ]), """{"Concat": ["a", "{{$.inputs.artifacts['input2'].path}}"]}"""),
+        (placeholders.ConcatPlaceholder([
+            placeholders.InputValuePlaceholder(input_name='input2'), 'b'
+        ]), """{"Concat": ["{{$.inputs.parameters['input2']}}", "b"]}"""),
     ])
-    def test_is_match(self, placeholder: str):
-        self.assertTrue(placeholders.ConcatPlaceholder._is_match(placeholder))
+    def test_primitive_placeholders(
+            self, placeholder_obj: placeholders.ConcatPlaceholder,
+            placeholder_string: str):
+        self.assertEqual(placeholder_obj.to_string(), placeholder_string)
+
+
+class TestContainerPlaceholdersTogether(parameterized.TestCase):
 
     @parameterized.parameters([
-        ("{{$.inputs.parameters[''input1'']}}something{{$.inputs.parameters[''input2'']}}",
-         [
-             "{{$.inputs.parameters[''input1'']}}", 'something',
-             "{{$.inputs.parameters[''input2'']}}"
-         ]),
-        ("{{$.inputs.parameters[''input_prefix'']}}some value",
-         ["{{$.inputs.parameters[''input_prefix'']}}", 'some value']),
-        ("some value{{$.inputs.parameters[''input_suffix'']}}",
-         ['some value', "{{$.inputs.parameters[''input_suffix'']}}"]),
-        ("some value{{$.inputs.parameters[''input_infix'']}}some value", [
-            'some value', "{{$.inputs.parameters[''input_infix'']}}",
-            'some value'
+        (placeholders.ConcatPlaceholder([
+            'a', placeholders.ConcatPlaceholder(['b', 'c'])
+        ]), '{"Concat": ["a", {"Concat": ["b", "c"]}]}'),
+        (placeholders.ConcatPlaceholder([
+            'a',
+            placeholders.ConcatPlaceholder([
+                'b',
+                placeholders.ConcatPlaceholder([
+                    'c',
+                    placeholders.InputValuePlaceholder(input_name='input2')
+                ])
+            ])
         ]),
-        ("{{$.inputs.parameters[''input1'']}}+{{$.inputs.parameters[''input2'']}}",
-         [
-             "{{$.inputs.parameters[''input1'']}}",
-             "{{$.inputs.parameters[''input2'']}}"
-         ])
+         """{"Concat": ["a", {"Concat": ["b", {"Concat": ["c", "{{$.inputs.parameters['input2']}}"]}]}]}"""
+        ),
+        # TODO(cjmccarthy): what should be allowed?
+        (placeholders.ConcatPlaceholder([
+            'a',
+            placeholders.ConcatPlaceholder([
+                'b',
+                placeholders.IfPresentPlaceholder(
+                    input_name='output1', then=['then'], else_=['something'])
+            ])
+        ]),
+         '{"Concat": ["a", {"Concat": ["b", {"IfPresent": {"InputName": "output1", "Then": ["then"], "Else": ["something"]}}]}]}'
+        ),
+        (placeholders.ConcatPlaceholder([
+            'a',
+            placeholders.ConcatPlaceholder([
+                'b',
+                placeholders.IfPresentPlaceholder(
+                    input_name='output1', then='then', else_='something')
+            ])
+        ]),
+         '{"Concat": ["a", {"Concat": ["b", {"IfPresent": {"InputName": "output1", "Then": "then", "Else": "something"}}]}]}'
+        ),
+        (placeholders.ConcatPlaceholder([
+            'a',
+            placeholders.IfPresentPlaceholder(
+                input_name='output1',
+                then=placeholders.ConcatPlaceholder([
+                    '--',
+                    'flag',
+                    placeholders.InputPathPlaceholder(input_name='input2'),
+                ]),
+                else_='b'),
+            'c',
+        ]),
+         """{"Concat": ["a", {"IfPresent": {"InputName": "output1", "Then": {"Concat": ["--", "flag", "{{$.inputs.artifacts['input2'].path}}"]}, "Else": "b"}}, "c"]}"""
+        ),
+        (placeholders.ConcatPlaceholder([
+            'a',
+            placeholders.IfPresentPlaceholder(
+                input_name='output1',
+                then=placeholders.ConcatPlaceholder(['--', 'flag']),
+                else_=placeholders.InputPathPlaceholder(input_name='input2')),
+            'c',
+        ]),
+         """{"Concat": ["a", {"IfPresent": {"InputName": "output1", "Then": {"Concat": ["--", "flag"]}, "Else": "{{$.inputs.artifacts['input2'].path}}"}}, "c"]}"""
+        ),
     ])
-    def test_split_cel_concat_string(self, placeholder: str,
-                                     expected: List[str]):
+    def test(self, placeholder_obj: placeholders.IfPresentPlaceholder,
+             placeholder: str):
+        self.assertEqual(placeholder_obj.to_string(), placeholder)
+
+
+class TestConvertCommandLineElementToStringOrStruct(parameterized.TestCase):
+
+    @parameterized.parameters(['a', 'word', 1])
+    def test_pass_through(self, val: Any):
         self.assertEqual(
-            placeholders.ConcatPlaceholder._split_cel_concat_string(
+            placeholders.convert_command_line_element_to_string_or_struct(val),
+            val)
+
+    @parameterized.parameters([
+        (placeholders.ExecutorInputPlaceholder(), '{{$}}'),
+        (placeholders.InputValuePlaceholder('input1'),
+         """{{$.inputs.parameters['input1']}}"""),
+        (placeholders.OutputPathPlaceholder('output1'),
+         """{{$.outputs.artifacts['output1'].path}}"""),
+    ])
+    def test_primitive_placeholder(self, placeholder: Any, expected: str):
+        self.assertEqual(
+            placeholders.convert_command_line_element_to_string_or_struct(
                 placeholder), expected)
-
-
-class TestProcessCommandArg(unittest.TestCase):
-
-    def test_string(self):
-        arg = 'test'
-        struct = placeholders.maybe_convert_placeholder_string_to_placeholder(
-            arg)
-        self.assertEqual(struct, arg)
-
-    def test_input_value_placeholder(self):
-        arg = "{{$.inputs.parameters['input1']}}"
-        actual = placeholders.maybe_convert_placeholder_string_to_placeholder(
-            arg)
-        expected = placeholders.InputValuePlaceholder(input_name='input1')
-        self.assertEqual(actual, expected)
-
-    def test_input_path_placeholder(self):
-        arg = "{{$.inputs.artifacts['input1'].path}}"
-        actual = placeholders.maybe_convert_placeholder_string_to_placeholder(
-            arg)
-        expected = placeholders.InputPathPlaceholder('input1')
-        self.assertEqual(actual, expected)
-
-    def test_input_uri_placeholder(self):
-        arg = "{{$.inputs.artifacts['input1'].uri}}"
-        actual = placeholders.maybe_convert_placeholder_string_to_placeholder(
-            arg)
-        expected = placeholders.InputUriPlaceholder('input1')
-        self.assertEqual(actual, expected)
-
-    def test_output_path_placeholder(self):
-        arg = "{{$.outputs.artifacts['output1'].path}}"
-        actual = placeholders.maybe_convert_placeholder_string_to_placeholder(
-            arg)
-        expected = placeholders.OutputPathPlaceholder('output1')
-        self.assertEqual(actual, expected)
-
-    def test_output_uri_placeholder(self):
-        placeholder = "{{$.outputs.artifacts['output1'].uri}}"
-        actual = placeholders.maybe_convert_placeholder_string_to_placeholder(
-            placeholder)
-        expected = placeholders.OutputUriPlaceholder('output1')
-        self.assertEqual(actual, expected)
-
-    def test_output_parameter_placeholder(self):
-        placeholder = "{{$.outputs.parameters['output1'].output_file}}"
-        actual = placeholders.maybe_convert_placeholder_string_to_placeholder(
-            placeholder)
-        expected = placeholders.OutputParameterPlaceholder('output1')
-        self.assertEqual(actual, expected)
-
-    def test_concat_placeholder(self):
-        placeholder = "{{$.inputs.parameters[''input1'']}}+{{$.inputs.parameters[''input2'']}}"
-        actual = placeholders.maybe_convert_placeholder_string_to_placeholder(
-            placeholder)
-        expected = placeholders.ConcatPlaceholder(items=[
-            placeholders.InputValuePlaceholder(input_name='input1'),
-            placeholders.InputValuePlaceholder(input_name='input2')
-        ])
-        self.assertEqual(actual, expected)

--- a/sdk/python/kfp/components/placeholders_test.py
+++ b/sdk/python/kfp/components/placeholders_test.py
@@ -182,7 +182,6 @@ class TestContainerPlaceholdersTogether(parameterized.TestCase):
         ]),
          """{"Concat": ["a", {"Concat": ["b", {"Concat": ["c", "{{$.inputs.parameters['input2']}}"]}]}]}"""
         ),
-        # TODO(cjmccarthy): what should be allowed?
         (placeholders.ConcatPlaceholder([
             'a',
             placeholders.ConcatPlaceholder([

--- a/sdk/python/kfp/components/placeholders_test.py
+++ b/sdk/python/kfp/components/placeholders_test.py
@@ -21,7 +21,7 @@ from kfp.components import placeholders
 class TestExecutorInputPlaceholder(parameterized.TestCase):
 
     def test(self):
-        self.assertEqual(placeholders.ExecutorInputPlaceholder().to_string(),
+        self.assertEqual(placeholders.ExecutorInputPlaceholder()._to_string(),
                          '{{$}}')
 
 
@@ -29,7 +29,7 @@ class TestInputValuePlaceholder(parameterized.TestCase):
 
     def test(self):
         self.assertEqual(
-            placeholders.InputValuePlaceholder('input1').to_string(),
+            placeholders.InputValuePlaceholder('input1')._to_string(),
             "{{$.inputs.parameters['input1']}}")
 
 
@@ -37,7 +37,7 @@ class TestInputPathPlaceholder(parameterized.TestCase):
 
     def test(self):
         self.assertEqual(
-            placeholders.InputPathPlaceholder('input1').to_string(),
+            placeholders.InputPathPlaceholder('input1')._to_string(),
             "{{$.inputs.artifacts['input1'].path}}")
 
 
@@ -45,7 +45,7 @@ class TestInputUriPlaceholder(parameterized.TestCase):
 
     def test(self):
         self.assertEqual(
-            placeholders.InputUriPlaceholder('input1').to_string(),
+            placeholders.InputUriPlaceholder('input1')._to_string(),
             "{{$.inputs.artifacts['input1'].uri}}")
 
 
@@ -53,7 +53,7 @@ class TestInputMetadataPlaceholder(parameterized.TestCase):
 
     def test(self):
         self.assertEqual(
-            placeholders.InputMetadataPlaceholder('input1').to_string(),
+            placeholders.InputMetadataPlaceholder('input1')._to_string(),
             "{{$.inputs.artifacts['input1'].metadata}}")
 
 
@@ -61,7 +61,7 @@ class TestOutputPathPlaceholder(parameterized.TestCase):
 
     def test(self):
         self.assertEqual(
-            placeholders.OutputPathPlaceholder('output1').to_string(),
+            placeholders.OutputPathPlaceholder('output1')._to_string(),
             "{{$.outputs.artifacts['output1'].path}}")
 
 
@@ -69,7 +69,7 @@ class TestOutputParameterPlaceholder(parameterized.TestCase):
 
     def test(self):
         self.assertEqual(
-            placeholders.OutputParameterPlaceholder('output1').to_string(),
+            placeholders.OutputParameterPlaceholder('output1')._to_string(),
             "{{$.outputs.parameters['output1'].output_file}}")
 
 
@@ -77,7 +77,7 @@ class TestOutputUriPlaceholder(parameterized.TestCase):
 
     def test(self):
         self.assertEqual(
-            placeholders.OutputUriPlaceholder('output1').to_string(),
+            placeholders.OutputUriPlaceholder('output1')._to_string(),
             "{{$.outputs.artifacts['output1'].uri}}")
 
 
@@ -85,7 +85,7 @@ class TestOutputMetadataPlaceholder(parameterized.TestCase):
 
     def test(self):
         self.assertEqual(
-            placeholders.OutputMetadataPlaceholder('output1').to_string(),
+            placeholders.OutputMetadataPlaceholder('output1')._to_string(),
             "{{$.outputs.artifacts['output1'].metadata}}")
 
 
@@ -112,7 +112,7 @@ class TestIfPresentPlaceholderStructure(parameterized.TestCase):
     def test_strings_and_lists(
             self, placeholder_obj: placeholders.IfPresentPlaceholder,
             placeholder: str):
-        self.assertEqual(placeholder_obj.to_string(), placeholder)
+        self.assertEqual(placeholder_obj._to_string(), placeholder)
 
     @parameterized.parameters([
         (placeholders.IfPresentPlaceholder(
@@ -137,7 +137,7 @@ class TestIfPresentPlaceholderStructure(parameterized.TestCase):
     def test_with_primitive_placeholders(
             self, placeholder_obj: placeholders.IfPresentPlaceholder,
             placeholder: str):
-        self.assertEqual(placeholder_obj.to_string(), placeholder)
+        self.assertEqual(placeholder_obj._to_string(), placeholder)
 
 
 class TestConcatPlaceholder(parameterized.TestCase):
@@ -148,7 +148,7 @@ class TestConcatPlaceholder(parameterized.TestCase):
     ])
     def test_strings(self, placeholder_obj: placeholders.ConcatPlaceholder,
                      placeholder_string: str):
-        self.assertEqual(placeholder_obj.to_string(), placeholder_string)
+        self.assertEqual(placeholder_obj._to_string(), placeholder_string)
 
     @parameterized.parameters([
         (placeholders.ConcatPlaceholder([
@@ -161,7 +161,7 @@ class TestConcatPlaceholder(parameterized.TestCase):
     def test_primitive_placeholders(
             self, placeholder_obj: placeholders.ConcatPlaceholder,
             placeholder_string: str):
-        self.assertEqual(placeholder_obj.to_string(), placeholder_string)
+        self.assertEqual(placeholder_obj._to_string(), placeholder_string)
 
 
 class TestContainerPlaceholdersTogether(parameterized.TestCase):
@@ -229,7 +229,7 @@ class TestContainerPlaceholdersTogether(parameterized.TestCase):
     ])
     def test(self, placeholder_obj: placeholders.IfPresentPlaceholder,
              placeholder: str):
-        self.assertEqual(placeholder_obj.to_string(), placeholder)
+        self.assertEqual(placeholder_obj._to_string(), placeholder)
 
 
 class TestConvertCommandLineElementToStringOrStruct(parameterized.TestCase):

--- a/sdk/python/kfp/components/structures.py
+++ b/sdk/python/kfp/components/structures.py
@@ -313,22 +313,11 @@ class ContainerSpecImplementation(base_model.BaseModel):
         Returns:
             ContainerSpecImplementation: The ContainerSpecImplementation instance.
         """
-        args = container_dict.get('args')
-        if args is not None:
-            args = [
-                placeholders.maybe_convert_placeholder_string_to_placeholder(
-                    arg) for arg in args
-            ]
-        command = container_dict.get('command')
-        if command is not None:
-            command = [
-                placeholders.maybe_convert_placeholder_string_to_placeholder(c)
-                for c in command
-            ]
+
         return ContainerSpecImplementation(
             image=container_dict['image'],
-            command=command,
-            args=args,
+            command=container_dict.get('command'),
+            args=container_dict.get('args'),
             env=None,  # can only be set on tasks
             resources=None)  # can only be set on tasks
 
@@ -467,8 +456,47 @@ class Implementation(base_model.BaseModel):
             return Implementation(graph=pipeline_spec)
 
 
-def _check_valid_placeholder_reference(
-        valid_inputs: List[str], valid_outputs: List[str],
+def check_primitive_placeholder_is_used_for_correct_io_type(
+    placeholder: Union[placeholders.Placeholder, Any],
+    inputs_dict: Dict[str, InputSpec],
+    outputs_dict: Dict[str, OutputSpec],
+):
+    if placeholder is None:
+        return None
+
+    elif isinstance(placeholder, (str, int, float, bool)):
+        return str(placeholder)
+
+    elif isinstance(placeholder, placeholders.InputValuePlaceholder):
+        input_name = placeholder.input_name
+        if not type_utils.is_parameter_type(inputs_dict[input_name].type):
+            raise TypeError(
+                f'Input "{input_name}" with type '
+                f'"{inputs_dict[input_name].type}" cannot be paired with '
+                'InputValuePlaceholder.')
+
+    elif isinstance(
+            placeholder,
+        (placeholders.InputUriPlaceholder, placeholders.InputPathPlaceholder)):
+        input_name = placeholder.input_name
+        if type_utils.is_parameter_type(inputs_dict[input_name].type):
+            raise TypeError(
+                f'Input "{input_name}" with type '
+                f'"{inputs_dict[input_name].type}" cannot be paired with '
+                f'{placeholder.__class__.__name__}.')
+
+    elif isinstance(placeholder, placeholders.OutputUriPlaceholder):
+        output_name = placeholder.output_name
+        if type_utils.is_parameter_type(outputs_dict[output_name].type):
+            raise TypeError(
+                f'Output "{output_name}" with type '
+                f'"{outputs_dict[output_name].type}" cannot be paired with '
+                f'{placeholder.__class__.__name__}.')
+
+
+def check_placeholder_references_valid_io_name(
+        valid_inputs: Dict[str, InputSpec], valid_outputs: Dict[str,
+                                                                OutputSpec],
         placeholder: placeholders.CommandLineElement) -> None:
     """Validates input/output placeholders refer to an existing input/output.
 
@@ -478,7 +506,7 @@ def _check_valid_placeholder_reference(
         arg: The placeholder argument for checking.
 
     Raises:
-        ValueError: if any placeholder references a non-existing input or
+        ValueError: if any placeholder references a nonexistant input or
             output.
         TypeError: if any argument is neither a str nor a placeholder
             instance.
@@ -487,49 +515,45 @@ def _check_valid_placeholder_reference(
         raise ValueError(
             'Cannot access artifact by itself in the container definition. Please use .uri or .path instead to access the artifact.'
         )
-    elif isinstance(
-            placeholder,
-        (placeholders.InputValuePlaceholder, placeholders.InputPathPlaceholder,
-         placeholders.InputUriPlaceholder,
-         placeholders.InputMetadataPlaceholder)):
+    elif isinstance(placeholder, placeholders.PRIMITIVE_INPUT_PLACEHOLDERS):
         if placeholder.input_name not in valid_inputs:
             raise ValueError(
-                f'Argument "{placeholder}" references non-existing input.')
-    elif isinstance(
+                f'Argument "{placeholder}" references nonexistant input: "{placeholder.input_name}".'
+            )
+        check_primitive_placeholder_is_used_for_correct_io_type(
             placeholder,
-        (placeholders.OutputParameterPlaceholder,
-         placeholders.OutputPathPlaceholder, placeholders.OutputUriPlaceholder,
-         placeholders.OutputMetadataPlaceholder)):
+            inputs_dict=valid_inputs,
+            outputs_dict=valid_outputs,
+        )
+    elif isinstance(placeholder, placeholders.PRIMITIVE_OUTPUT_PLACEHOLDERS):
         if placeholder.output_name not in valid_outputs:
             raise ValueError(
-                f'Argument "{placeholder}" references non-existing output.')
+                f'Argument "{placeholder}" references nonexistant output: "{placeholder.output_name}".'
+            )
+        check_primitive_placeholder_is_used_for_correct_io_type(
+            placeholder,
+            inputs_dict=valid_inputs,
+            outputs_dict=valid_outputs,
+        )
     elif isinstance(placeholder, placeholders.IfPresentPlaceholder):
         if placeholder.input_name not in valid_inputs:
             raise ValueError(
-                f'Argument "{placeholder}" references non-existing input.')
+                f'Argument "{placeholder}" references nonexistant input: "{placeholder.input_name}".'
+            )
         for placeholder in itertools.chain(placeholder.then or [],
                                            placeholder.else_ or []):
-            _check_valid_placeholder_reference(valid_inputs, valid_outputs,
-                                               placeholder)
+            check_placeholder_references_valid_io_name(valid_inputs,
+                                                       valid_outputs,
+                                                       placeholder)
     elif isinstance(placeholder, placeholders.ConcatPlaceholder):
         for placeholder in placeholder.items:
-            _check_valid_placeholder_reference(valid_inputs, valid_outputs,
-                                               placeholder)
+            check_placeholder_references_valid_io_name(valid_inputs,
+                                                       valid_outputs,
+                                                       placeholder)
     elif not isinstance(placeholder, placeholders.ExecutorInputPlaceholder
                        ) and not isinstance(placeholder, str):
         raise TypeError(
             f'Unexpected argument "{placeholder}" of type {type(placeholder)}.')
-
-
-ValidCommandArgTypes = (str, placeholders.InputValuePlaceholder,
-                        placeholders.InputPathPlaceholder,
-                        placeholders.InputUriPlaceholder,
-                        placeholders.OutputPathPlaceholder,
-                        placeholders.OutputUriPlaceholder,
-                        placeholders.InputMetadataPlaceholder,
-                        placeholders.OutputMetadataPlaceholder,
-                        placeholders.IfPresentPlaceholder,
-                        placeholders.ConcatPlaceholder)
 
 
 class ComponentSpec(base_model.BaseModel):
@@ -567,14 +591,13 @@ class ComponentSpec(base_model.BaseModel):
         if self.implementation.container is None:
             return
 
-        valid_inputs = [] if self.inputs is None else list(self.inputs.keys())
-        valid_outputs = [] if self.outputs is None else list(
-            self.outputs.keys())
-
+        valid_inputs = {} if self.inputs is None else self.inputs
+        valid_outputs = {} if self.outputs is None else self.outputs
         for arg in itertools.chain(
             (self.implementation.container.command or []),
             (self.implementation.container.args or [])):
-            _check_valid_placeholder_reference(valid_inputs, valid_outputs, arg)
+            check_placeholder_references_valid_io_name(valid_inputs,
+                                                       valid_outputs, arg)
 
     @classmethod
     def from_v1_component_spec(
@@ -601,29 +624,27 @@ class ComponentSpec(base_model.BaseModel):
             raise NotImplementedError('Container implementation not found.')
 
         container = component_dict['implementation']['container']
-        container['command'] = [
-            placeholders
-            .maybe_convert_v1_yaml_placeholder_to_v2_placeholder_str(
+        command = [
+            placeholders.maybe_convert_v1_yaml_placeholder_to_v2_placeholder(
                 command, component_dict=component_dict)
             for command in container.get('command', [])
         ]
-        container['args'] = [
-            placeholders
-            .maybe_convert_v1_yaml_placeholder_to_v2_placeholder_str(
+        args = [
+            placeholders.maybe_convert_v1_yaml_placeholder_to_v2_placeholder(
                 command, component_dict=component_dict)
             for command in container.get('args', [])
         ]
-        container['env'] = {
-            key: placeholders
-            .maybe_convert_v1_yaml_placeholder_to_v2_placeholder_str(
+        env = {
+            key:
+            placeholders.maybe_convert_v1_yaml_placeholder_to_v2_placeholder(
                 command, component_dict=component_dict)
             for key, command in container.get('env', {}).items()
         }
         container_spec = ContainerSpecImplementation.from_container_dict({
             'image': container['image'],
-            'command': container['command'],
-            'args': container['args'],
-            'env': container['env']
+            'command': command,
+            'args': args,
+            'env': env
         })
 
         inputs = {}

--- a/sdk/python/kfp/components/structures.py
+++ b/sdk/python/kfp/components/structures.py
@@ -456,51 +456,6 @@ class Implementation(base_model.BaseModel):
             return Implementation(graph=pipeline_spec)
 
 
-def check_primitive_placeholder_is_used_for_correct_io_type(
-    inputs_dict: Dict[str, InputSpec],
-    outputs_dict: Dict[str, OutputSpec],
-    arg: Union[placeholders.Placeholder, Any],
-):
-    """Validates input/output placeholders refer to an input/output with an appropriate type for the placeholder. This should only apply to components loaded from v1 component YAML, where the YAML is authored directly. For v2 YAML, this is encapsulated in the DSL logic which does not permit writing incorrect placeholders.
-
-    Args:
-        inputs_dict: The existing input names.
-        outputs_dict: The existing output names.
-        arg: The command line element, which may be a placeholder.
-    """
-    if arg is None:
-        return None
-
-    elif isinstance(arg, (str, int, float, bool)):
-        return str(arg)
-
-    elif isinstance(arg, placeholders.InputValuePlaceholder):
-        input_name = arg.input_name
-        if not type_utils.is_parameter_type(inputs_dict[input_name].type):
-            raise TypeError(
-                f'Input "{input_name}" with type '
-                f'"{inputs_dict[input_name].type}" cannot be paired with '
-                'InputValuePlaceholder.')
-
-    elif isinstance(
-            arg,
-        (placeholders.InputUriPlaceholder, placeholders.InputPathPlaceholder)):
-        input_name = arg.input_name
-        if type_utils.is_parameter_type(inputs_dict[input_name].type):
-            raise TypeError(
-                f'Input "{input_name}" with type '
-                f'"{inputs_dict[input_name].type}" cannot be paired with '
-                f'{arg.__class__.__name__}.')
-
-    elif isinstance(arg, placeholders.OutputUriPlaceholder):
-        output_name = arg.output_name
-        if type_utils.is_parameter_type(outputs_dict[output_name].type):
-            raise TypeError(
-                f'Output "{output_name}" with type '
-                f'"{outputs_dict[output_name].type}" cannot be paired with '
-                f'{arg.__class__.__name__}.')
-
-
 def check_placeholder_references_valid_io_name(
     inputs_dict: Dict[str, InputSpec],
     outputs_dict: Dict[str, OutputSpec],
@@ -528,21 +483,11 @@ def check_placeholder_references_valid_io_name(
             raise ValueError(
                 f'Argument "{arg}" references nonexistant input: "{arg.input_name}".'
             )
-        check_primitive_placeholder_is_used_for_correct_io_type(
-            inputs_dict=inputs_dict,
-            outputs_dict=outputs_dict,
-            arg=arg,
-        )
     elif isinstance(arg, placeholders.PRIMITIVE_OUTPUT_PLACEHOLDERS):
         if arg.output_name not in outputs_dict:
             raise ValueError(
                 f'Argument "{arg}" references nonexistant output: "{arg.output_name}".'
             )
-        check_primitive_placeholder_is_used_for_correct_io_type(
-            inputs_dict=inputs_dict,
-            outputs_dict=outputs_dict,
-            arg=arg,
-        )
     elif isinstance(arg, placeholders.IfPresentPlaceholder):
         if arg.input_name not in inputs_dict:
             raise ValueError(

--- a/sdk/python/kfp/components/structures.py
+++ b/sdk/python/kfp/components/structures.py
@@ -569,8 +569,8 @@ class ComponentSpec(base_model.BaseModel):
         if component_dict.get('implementation') is None:
             raise ValueError('Implementation field not found')
 
-        if 'container' not in component_dict.get(
-                'implementation'):  # type: ignore
+        if 'implementation' not in component_dict or 'container' not in component_dict[
+                'implementation']:
             raise NotImplementedError('Container implementation not found.')
 
         container = component_dict['implementation']['container']

--- a/sdk/python/kfp/components/structures_test.py
+++ b/sdk/python/kfp/components/structures_test.py
@@ -42,7 +42,7 @@ V1_YAML_IF_PLACEHOLDER = textwrap.dedent("""\
               - {inputUri: optional_input_1}
         image: alpine
     inputs:
-    - {name: optional_input_1, optional: true, type: system.Artifact}
+    - {name: optional_input_1, optional: true, type: String}
     name: component_if
     """)
 
@@ -65,8 +65,7 @@ COMPONENT_SPEC_IF_PLACEHOLDER = structures.ComponentSpec(
                     ])
             ])),
     inputs={
-        'optional_input_1':
-            structures.InputSpec(type='system.Artifact@0.0.1', default=None)
+        'optional_input_1': structures.InputSpec(type='String', default=None)
     },
 )
 

--- a/sdk/python/kfp/components/structures_test.py
+++ b/sdk/python/kfp/components/structures_test.py
@@ -21,7 +21,6 @@ import unittest
 from absl.testing import parameterized
 from google.protobuf import json_format
 from kfp import compiler
-from kfp import components
 from kfp import dsl
 from kfp.components import component_factory
 from kfp.components import placeholders
@@ -957,78 +956,6 @@ class TestRetryPolicy(unittest.TestCase):
         self.assertEqual(retry_policy_struct.backoff_duration, '5s')
         self.assertEqual(retry_policy_struct.backoff_factor, 1.0)
         self.assertEqual(retry_policy_struct.backoff_max_duration, '1s')
-
-
-class TestInvalidV1ComponeneYaml(parameterized.TestCase):
-
-    def test_misused_inputvalueplaceholder(self):
-
-        with self.assertRaisesRegex(
-                TypeError,
-                'Input "model" with type "system.Model@0.0.1" cannot be paired with InputValuePlaceholder.'
-        ):
-            downstream_op = components.load_component_from_text("""
-            name: compoent with misused placeholder
-            inputs:
-            - {name: model, type: Model}
-            implementation:
-              container:
-                image: dummy
-                args:
-                  - {inputValue: model}
-            """)
-
-    def test_misused_inputpathplaceholder(self):
-
-        with self.assertRaisesRegex(
-                TypeError,
-                ' type "String" cannot be paired with InputPathPlaceholder.'):
-            component_op = components.load_component_from_text("""
-            name: compoent with misused placeholder
-            inputs:
-            - {name: text, type: String}
-            implementation:
-              container:
-                image: dummy
-                args:
-                - {inputPath: text}
-            """)
-
-            @dsl.pipeline(name='test-pipeline', pipeline_root='dummy_root')
-            def my_pipeline(text: str):
-                component_op(text=text)
-
-    def test_misused_inputuriplaceholder(self):
-
-        with self.assertRaisesRegex(
-                TypeError,
-                ' type "Float" cannot be paired with InputUriPlaceholder.'):
-            component_op = components.load_component_from_text("""
-            name: compoent with misused placeholder
-            inputs:
-            - {name: value, type: Float}
-            implementation:
-              container:
-                image: dummy
-                args:
-                - {inputUri: value}
-            """)
-
-    def test_misused_outputuriplaceholder(self):
-
-        with self.assertRaisesRegex(
-                TypeError,
-                ' type "Integer" cannot be paired with OutputUriPlaceholder.'):
-            component_op = components.load_component_from_text("""
-            name: compoent with misused placeholder
-            outputs:
-            - {name: value, type: Integer}
-            implementation:
-              container:
-                image: dummy
-                args:
-                - {outputUri: value}
-            """)
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/components/v1_modelbase.py
+++ b/sdk/python/kfp/components/v1_modelbase.py
@@ -361,7 +361,7 @@ class ModelBase:
         return parse_object_from_struct_based_on_class_init(
             cls, struct, serialized_names=cls._serialized_names)
 
-    def to_dict(self) -> Mapping:
+    def to_dict(self) -> Dict[str, Any]:
         return convert_object_to_struct(
             self, serialized_names=self._serialized_names)
 


### PR DESCRIPTION
**Description of your changes:**
This PR simplifies the implementation of in-memory placeholders, as well as simplifies/removes logic rendered unnecesary by the changes to placeholders.

This change is primarily driven the realization that we do not need to deserialize placeholder strings from IR into the placeholder objects that are used for serialization, as they do not offer us anything after the initial serialization due to the immutability of loaded PipelineSpec.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. 
[Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
