### PR TITLE
fix(sdk): fix nested placeholders and block illegal IfPresent form in Concat

### DIFF
--- a/components/test_load_all_components.sh
+++ b/components/test_load_all_components.sh
@@ -35,6 +35,9 @@ SKIP_COMPONENT_FILES = [
   "./contrib/XGBoost/Cross_validation_for_regression/from_CSV/component.yaml",
   "./contrib/XGBoost/Train_regression_and_calculate_metrics/from_CSV/component.yaml",
   "./contrib/XGBoost/Train_and_cross-validate_regression/from_CSV/component.yaml",
+  # TODO: This component uses invalid placeholders. Updated when migrating GCPC to v2.
+  "./google-cloud/google_cloud_pipeline_components/aiplatform/batch_predict_job/component.yaml",
+  "./google-cloud/google_cloud_pipeline_components/v1/batch_predict_job/component.yaml"
 ]
 
 for component_file in sys.stdin:

--- a/sdk/python/kfp/components/pipeline_task.py
+++ b/sdk/python/kfp/components/pipeline_task.py
@@ -474,7 +474,7 @@ class PipelineTask:
 def check_primitive_placeholder_is_used_for_correct_io_type(
     inputs_dict: Dict[str, structures.InputSpec],
     outputs_dict: Dict[str, structures.OutputSpec],
-    arg: Union[placeholders.Placeholder, Any],
+    arg: Union[placeholders.CommandLineElement, Any],
 ):
     """Validates input/output placeholders refer to an input/output with an
     appropriate type for the placeholder. This should only apply to components
@@ -514,7 +514,7 @@ def check_primitive_placeholder_is_used_for_correct_io_type(
                 f'"{outputs_dict[output_name].type}" cannot be paired with '
                 f'{arg.__class__.__name__}.')
     elif isinstance(arg, placeholders.IfPresentPlaceholder):
-        all_normalized_args: List[Union[str, placeholders.Placeholder]] = []
+        all_normalized_args: List[placeholders.CommandLineElement] = []
         if arg.then is None:
             pass
         elif isinstance(arg.then, list):

--- a/sdk/python/kfp/components/pipeline_task.py
+++ b/sdk/python/kfp/components/pipeline_task.py
@@ -514,7 +514,22 @@ def check_primitive_placeholder_is_used_for_correct_io_type(
                 f'"{outputs_dict[output_name].type}" cannot be paired with '
                 f'{arg.__class__.__name__}.')
     elif isinstance(arg, placeholders.IfPresentPlaceholder):
-        for arg in itertools.chain(arg.then or [], arg.else_ or []):
+        all_normalized_args: List[Union[str, placeholders.Placeholder]] = []
+        if arg.then is None:
+            pass
+        elif isinstance(arg.then, list):
+            all_normalized_args.extend(arg.then)
+        else:
+            all_normalized_args.append(arg.then)
+
+        if arg.else_ is None:
+            pass
+        elif isinstance(arg.else_, list):
+            all_normalized_args.extend(arg.else_)
+        else:
+            all_normalized_args.append(arg.else_)
+
+        for arg in all_normalized_args:
             check_primitive_placeholder_is_used_for_correct_io_type(
                 inputs_dict, outputs_dict, arg)
     elif isinstance(arg, placeholders.ConcatPlaceholder):

--- a/sdk/python/kfp/components/placeholders.py
+++ b/sdk/python/kfp/components/placeholders.py
@@ -364,18 +364,31 @@ def maybe_convert_v1_yaml_placeholder_to_v2_placeholder(
     elif 'if' in arg:
         if_ = arg['if']
         input_name = utils.sanitize_input_name(if_['cond']['isPresent'])
-        then_ = if_['then']
-        else_ = if_.get('else', [])
-        return IfPresentPlaceholder(
-            input_name=input_name,
-            then=[
+        then = if_['then']
+        else_ = if_.get('else')
+
+        if isinstance(then, list):
+            then = [
                 maybe_convert_v1_yaml_placeholder_to_v2_placeholder(
-                    val, component_dict=component_dict) for val in then_
-            ],
-            else_=[
+                    val, component_dict=component_dict) for val in then
+            ]
+        else:
+            then = maybe_convert_v1_yaml_placeholder_to_v2_placeholder(
+                then, component_dict=component_dict)
+
+        if else_ is None:
+            pass
+        elif isinstance(else_, list):
+            else_ = [
                 maybe_convert_v1_yaml_placeholder_to_v2_placeholder(
                     val, component_dict=component_dict) for val in else_
-            ])
+            ]
+        else:
+            maybe_convert_v1_yaml_placeholder_to_v2_placeholder(
+                else_, component_dict=component_dict)
+
+        return IfPresentPlaceholder(
+            input_name=input_name, then=then, else_=else_)
 
     elif 'concat' in arg:
 

--- a/sdk/python/kfp/components/placeholders.py
+++ b/sdk/python/kfp/components/placeholders.py
@@ -265,11 +265,7 @@ PRIMITIVE_OUTPUT_PLACEHOLDERS = (OutputParameterPlaceholder,
                                  OutputPathPlaceholder, OutputUriPlaceholder,
                                  OutputMetadataPlaceholder)
 
-CommandLineElement = Union[str, IfPresentPlaceholder, ConcatPlaceholder,
-                           InputValuePlaceholder, InputPathPlaceholder,
-                           InputUriPlaceholder, InputMetadataPlaceholder,
-                           OutputParameterPlaceholder, OutputPathPlaceholder,
-                           OutputUriPlaceholder, OutputMetadataPlaceholder]
+CommandLineElement = Union[str, Placeholder]
 
 
 def convert_command_line_element_to_string(

--- a/sdk/python/kfp/components/placeholders_test.py
+++ b/sdk/python/kfp/components/placeholders_test.py
@@ -15,8 +15,10 @@
 import os
 import tempfile
 from typing import Any
-from kfp import compiler
+
 from absl.testing import parameterized
+from kfp import compiler
+from kfp import dsl
 from kfp.components import placeholders
 
 
@@ -141,7 +143,6 @@ class TestIfPresentPlaceholder(parameterized.TestCase):
             placeholder: str):
         self.assertEqual(placeholder_obj._to_string(), placeholder)
 
-
     def test_if_present_with_single_element_simple_can_be_compiled(self):
 
         @dsl.container_component
@@ -240,16 +241,6 @@ class TestContainerPlaceholdersTogether(parameterized.TestCase):
             placeholders.ConcatPlaceholder([
                 'b',
                 placeholders.IfPresentPlaceholder(
-                    input_name='output1', then=['then'], else_=['something'])
-            ])
-        ]),
-         '{"Concat": ["a", {"Concat": ["b", {"IfPresent": {"InputName": "output1", "Then": ["then"], "Else": ["something"]}}]}]}'
-        ),
-        (placeholders.ConcatPlaceholder([
-            'a',
-            placeholders.ConcatPlaceholder([
-                'b',
-                placeholders.IfPresentPlaceholder(
                     input_name='output1', then='then', else_='something')
             ])
         ]),
@@ -280,9 +271,110 @@ class TestContainerPlaceholdersTogether(parameterized.TestCase):
          """{"Concat": ["a", {"IfPresent": {"InputName": "output1", "Then": {"Concat": ["--", "flag"]}, "Else": "{{$.inputs.artifacts['input2'].path}}"}}, "c"]}"""
         ),
     ])
-    def test(self, placeholder_obj: placeholders.IfPresentPlaceholder,
-             placeholder: str):
+    def test_valid(self, placeholder_obj: placeholders.IfPresentPlaceholder,
+                   placeholder: str):
         self.assertEqual(placeholder_obj._to_string(), placeholder)
+
+    def test_only_single_element_ifpresent_inside_concat_outer(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                f'Please use a single element for `then` and `else_` only\.'):
+            placeholders.ConcatPlaceholder([
+                'b',
+                placeholders.IfPresentPlaceholder(
+                    input_name='output1', then=['then'], else_=['something'])
+            ])
+
+    def test_only_single_element_ifpresent_inside_concat_recursive(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                f'Please use a single element for `then` and `else_` only\.'):
+            placeholders.ConcatPlaceholder([
+                'a',
+                placeholders.ConcatPlaceholder([
+                    'b',
+                    placeholders.IfPresentPlaceholder(
+                        input_name='output1',
+                        then=['then'],
+                        else_=['something'])
+                ])
+            ])
+
+        with self.assertRaisesRegex(
+                ValueError,
+                f'Please use a single element for `then` and `else_` only\.'):
+            placeholders.ConcatPlaceholder([
+                'a',
+                placeholders.ConcatPlaceholder([
+                    'b',
+                    placeholders.IfPresentPlaceholder(
+                        input_name='output1',
+                        then=placeholders.ConcatPlaceholder([
+                            placeholders.IfPresentPlaceholder(
+                                input_name='a', then=['b'])
+                        ]),
+                        else_='something')
+                ])
+            ])
+
+    def test_only_single_element_in_nested_ifpresent_inside_concat(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                f'Please use a single element for `then` and `else_` only\.'):
+            dsl.ConcatPlaceholder([
+                'my-prefix-',
+                dsl.IfPresentPlaceholder(
+                    input_name='input1',
+                    then=[
+                        dsl.IfPresentPlaceholder(
+                            input_name='input1',
+                            then=dsl.ConcatPlaceholder(['infix-', 'value']))
+                    ])
+            ])
+
+    def test_recursive_nested_placeholder_validation_does_not_exit_when_first_valid_then_is_found(
+            self):
+        with self.assertRaisesRegex(
+                ValueError,
+                f'Please use a single element for `then` and `else_` only\.'):
+            dsl.ConcatPlaceholder([
+                'my-prefix-',
+                dsl.IfPresentPlaceholder(
+                    input_name='input1',
+                    then=dsl.IfPresentPlaceholder(
+                        input_name='input1',
+                        then=[dsl.ConcatPlaceholder(['infix-', 'value'])]))
+            ])
+
+    def test_only_single_element_in_nested_ifpresent_inside_concat_with_outer_ifpresent(
+            self):
+        with self.assertRaisesRegex(
+                ValueError,
+                f'Please use a single element for `then` and `else_` only\.'):
+            dsl.IfPresentPlaceholder(
+                input_name='input_1',
+                then=dsl.ConcatPlaceholder([
+                    'my-prefix-',
+                    dsl.IfPresentPlaceholder(
+                        input_name='input1',
+                        then=dsl.IfPresentPlaceholder(
+                            input_name='input1',
+                            then=[dsl.ConcatPlaceholder(['infix-', 'value'])]))
+                ]))
+
+    def test_valid_then_but_invalid_else(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                f'Please use a single element for `then` and `else_` only\.'):
+            dsl.ConcatPlaceholder([
+                'my-prefix-',
+                dsl.IfPresentPlaceholder(
+                    input_name='input1',
+                    then=dsl.IfPresentPlaceholder(
+                        input_name='input1',
+                        then='single-element',
+                        else_=['one', 'two']))
+            ])
 
 
 class TestConvertCommandLineElementToStringOrStruct(parameterized.TestCase):

--- a/sdk/python/kfp/components/structures.py
+++ b/sdk/python/kfp/components/structures.py
@@ -493,7 +493,23 @@ def check_placeholder_references_valid_io_name(
             raise ValueError(
                 f'Argument "{arg}" references nonexistant input: "{arg.input_name}".'
             )
-        for arg in itertools.chain(arg.then or [], arg.else_ or []):
+
+        all_normalized_args: List[Union[str, placeholders.Placeholder]] = []
+        if arg.then is None:
+            pass
+        elif isinstance(arg.then, list):
+            all_normalized_args.extend(arg.then)
+        else:
+            all_normalized_args.append(arg.then)
+
+        if arg.else_ is None:
+            pass
+        elif isinstance(arg.else_, list):
+            all_normalized_args.extend(arg.else_)
+        else:
+            all_normalized_args.append(arg.else_)
+
+        for arg in all_normalized_args:
             check_placeholder_references_valid_io_name(inputs_dict,
                                                        outputs_dict, arg)
     elif isinstance(arg, placeholders.ConcatPlaceholder):

--- a/sdk/python/kfp/components/structures.py
+++ b/sdk/python/kfp/components/structures.py
@@ -494,7 +494,7 @@ def check_placeholder_references_valid_io_name(
                 f'Argument "{arg}" references nonexistant input: "{arg.input_name}".'
             )
 
-        all_normalized_args: List[Union[str, placeholders.Placeholder]] = []
+        all_normalized_args: List[placeholders.CommandLineElement] = []
         if arg.then is None:
             pass
         elif isinstance(arg.then, list):

--- a/sdk/python/kfp/components/structures_test.py
+++ b/sdk/python/kfp/components/structures_test.py
@@ -105,15 +105,8 @@ V1_YAML_NESTED_PLACEHOLDER = textwrap.dedent("""\
             - if:
                 cond:
                     isPresent: input_prefix
-                else:
-                - --arg2
-                - default
-                - concat:
-                    - --arg1
-                    - {inputValue: input_prefix}
-                then:
-                - --arg1
-                - {inputValue: input_prefix}
+                then: {inputValue: input_prefix}
+                else: default
         image: alpine
     inputs:
     - {name: input_prefix, optional: false, type: String}
@@ -129,21 +122,10 @@ COMPONENT_SPEC_NESTED_PLACEHOLDER = structures.ComponentSpec(
                     '--arg1',
                     placeholders.IfPresentPlaceholder(
                         input_name='input_prefix',
-                        then=[
-                            '--arg1',
-                            placeholders.InputValuePlaceholder(
-                                input_name='input_prefix'),
-                        ],
-                        else_=[
-                            '--arg2',
-                            'default',
-                            placeholders.ConcatPlaceholder(items=[
-                                '--arg1',
-                                placeholders.InputValuePlaceholder(
-                                    input_name='input_prefix'),
-                            ]),
-                        ]),
-                ])
+                        then=placeholders.InputValuePlaceholder(
+                            input_name='input_prefix'),
+                        else_='default'),
+                ]),
             ])),
     inputs={'input_prefix': structures.InputSpec(type='String')},
 )


### PR DESCRIPTION
**Description of your changes:**
This PR:

- Adds a check to prevent `then` or `else_` arguments to `IfPresentPlaceholder` from 
being lists if the `IfPresentPlaceholder` is within a `ConcatPlaceholder`.
- Fixes a bug in handling of `then` and `else_` when either is a string element (instead of 
a list of elements)

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more 
about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
