### PR TITLE
feat(resources/storage): allow ephemeral storage to be set from pipeline parameters

### DIFF
--- a/sdk/python/kfp/deprecated/compiler/_op_to_template.py
+++ b/sdk/python/kfp/deprecated/compiler/_op_to_template.py
@@ -315,7 +315,7 @@ def _op_to_template(op: BaseOp):
     if isinstance(op, dsl.ContainerOp) and ('resources' in op.container.keys()):
         for setting, val in op.container['resources'].items():
             for resource, param in val.items():
-                if (resource in ['cpu', 'memory', 'amd.com/gpu', 'nvidia.com/gpu'] or re.match('^{{inputs.parameters.*}}$', resource))\
+                if (resource in ['cpu', 'memory', 'amd.com/gpu', 'nvidia.com/gpu', 'ephemeral-storage'] or re.match('^{{inputs.parameters.*}}$', resource))\
                     and re.match('^{{inputs.parameters.*}}$', str(param)):
                     if not 'containers' in podSpecPatch:
                         podSpecPatch['containers'] = [{

--- a/sdk/python/kfp/deprecated/dsl/_container_op.py
+++ b/sdk/python/kfp/deprecated/dsl/_container_op.py
@@ -347,20 +347,22 @@ class Container(V1Container):
         """Set ephemeral-storage request (minimum) for this operator.
 
         Args:
-          size: a string which can be a number or a number followed by one of
+          size(Union[str, PipelineParam]): A string which can be a number or a number followed by one of
             "E", "P", "T", "G", "M", "K".
         """
-        self._validate_size_string(size)
+        if not isinstance(size, _pipeline_param.PipelineParam):
+            self._validate_size_string(size)
         return self.add_resource_request('ephemeral-storage', size)
 
     def set_ephemeral_storage_limit(self, size) -> 'Container':
         """Set ephemeral-storage request (maximum) for this operator.
 
         Args:
-          size: a string which can be a number or a number followed by one of
+          size(Union[str, PipelineParam]): A string which can be a number or a number followed by one of
             "E", "P", "T", "G", "M", "K".
         """
-        self._validate_size_string(size)
+        if not isinstance(size, _pipeline_param.PipelineParam):
+            self._validate_size_string(size)
         return self.add_resource_limit('ephemeral-storage', size)
 
     def set_cpu_request(


### PR DESCRIPTION
Just like we can do it for cpu, memory and gpu this commit enable ephemeral storage resource to be set from pipeline step parameters.

**Description of your changes:**


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
