### PR TITLE
refactor(sdk): simplify InputSpec

### DIFF
--- a/sdk/python/kfp/components/base_component.py
+++ b/sdk/python/kfp/components/base_component.py
@@ -73,7 +73,7 @@ class BaseComponent(abc.ABC):
         missing_arguments = [
             input_name for input_name, input_spec in (
                 self.component_spec.inputs or {}).items()
-            if input_name not in task_inputs and not input_spec._optional and
+            if input_name not in task_inputs and not input_spec.optional and
             not type_utils.is_task_final_status_type(input_spec.type)
         ]
         if missing_arguments:

--- a/sdk/python/kfp/components/base_component_test.py
+++ b/sdk/python/kfp/components/base_component_test.py
@@ -50,9 +50,11 @@ component_op = TestComponent(
             'input2':
                 structures.InputSpec(type='Integer'),
             'input3':
-                structures.InputSpec(type='Float', default=3.14),
+                structures.InputSpec(
+                    type='Float', default=3.14, _optional=True),
             'input4':
-                structures.InputSpec(type='Optional[Float]', default=None),
+                structures.InputSpec(
+                    type='Optional[Float]', default=None, _optional=True),
         },
         outputs={
             'output1': structures.OutputSpec(type='String'),

--- a/sdk/python/kfp/components/base_component_test.py
+++ b/sdk/python/kfp/components/base_component_test.py
@@ -50,11 +50,10 @@ component_op = TestComponent(
             'input2':
                 structures.InputSpec(type='Integer'),
             'input3':
-                structures.InputSpec(
-                    type='Float', default=3.14, _optional=True),
+                structures.InputSpec(type='Float', default=3.14, optional=True),
             'input4':
                 structures.InputSpec(
-                    type='Optional[Float]', default=None, _optional=True),
+                    type='Optional[Float]', default=None, optional=True),
         },
         outputs={
             'output1': structures.OutputSpec(type='String'),

--- a/sdk/python/kfp/components/component_factory.py
+++ b/sdk/python/kfp/components/component_factory.py
@@ -229,7 +229,7 @@ def extract_component_interface(
                     input_spec = structures.InputSpec(
                         type=type_struct,
                         default=parameter.default,
-                    )
+                        _optional=True)
                 else:
                     input_spec = structures.InputSpec(type=type_struct,)
 

--- a/sdk/python/kfp/components/component_factory.py
+++ b/sdk/python/kfp/components/component_factory.py
@@ -229,7 +229,7 @@ def extract_component_interface(
                     input_spec = structures.InputSpec(
                         type=type_struct,
                         default=parameter.default,
-                        _optional=True)
+                        optional=True)
                 else:
                     input_spec = structures.InputSpec(type=type_struct,)
 

--- a/sdk/python/kfp/components/structures.py
+++ b/sdk/python/kfp/components/structures.py
@@ -121,7 +121,9 @@ class InputSpec:
         states."""
         # Because None can be the default value, None cannot be used to to indicate no default. This is why we need the optional field. This check prevents users of InputSpec from setting these two values to an inconsistent state, forcing users of InputSpec to be explicit about optionality.
         if self.optional is False and self.default is not None:
-            raise ValueError('')
+            raise ValueError(
+                f'`optional` argument to {self.__class__.__name__} must be True if `default` is not None.'
+            )
 
 
 @dataclasses.dataclass

--- a/sdk/python/kfp/components/structures.py
+++ b/sdk/python/kfp/components/structures.py
@@ -43,11 +43,11 @@ class InputSpec:
     Attributes:
         type: The type of the input.
         default (optional): the default value for the input.
-        _optional: Wether the input is optional. An input is optional when it has an explicit default value.
+        optional: Wether the input is optional. An input is optional when it has an explicit default value.
     """
     type: Union[str, dict]
     default: Optional[Any] = None
-    _optional: Optional[bool] = False
+    optional: Optional[bool] = False
 
     def __post_init__(self) -> None:
         self._validate_type()
@@ -76,7 +76,7 @@ class InputSpec:
             # TODO: write the IR is_optional field to IR when compiling. currently we don't do this, so just set optional to True if default_value is not None.
             optional = default_value is not None
             return InputSpec(
-                type=type_, default=default_value, _optional=optional)
+                type=type_, default=default_value, optional=optional)
 
         else:
             type_ = ir_component_inputs_dict['artifactType']['schemaTitle']
@@ -120,7 +120,7 @@ class InputSpec:
         """Validates that the optional and default properties are in consistent
         states."""
         # Because None can be the default value, None cannot be used to to indicate no default. This is why we need the optional field. This check prevents users of InputSpec from setting these two values to an inconsistent state, forcing users of InputSpec to be explicit about optionality.
-        if self._optional is False and self.default is not None:
+        if self.optional is False and self.default is not None:
             raise ValueError('')
 
 
@@ -642,7 +642,7 @@ class ComponentSpec:
                 inputs[utils.sanitize_input_name(spec['name'])] = InputSpec(
                     type=in_memory_parameter_type_name,
                     default=default,
-                    _optional=optional,
+                    optional=optional,
                 )
                 continue
 
@@ -672,7 +672,7 @@ class ComponentSpec:
                     type=type_utils.create_bundled_artifact_type(
                         schema_title, schema_version),
                     default=default,
-                    _optional=optional,
+                    optional=optional,
                 )
             else:
                 inputs[utils.sanitize_input_name(spec['name'])] = InputSpec(

--- a/sdk/python/kfp/components/structures.py
+++ b/sdk/python/kfp/components/structures.py
@@ -47,7 +47,7 @@ class InputSpec:
     """
     type: Union[str, dict]
     default: Optional[Any] = None
-    optional: Optional[bool] = False
+    optional: bool = False
 
     def __post_init__(self) -> None:
         self._validate_type()

--- a/sdk/python/kfp/components/structures.py
+++ b/sdk/python/kfp/components/structures.py
@@ -16,7 +16,6 @@
 import ast
 import collections
 import dataclasses
-import functools
 import itertools
 import re
 from typing import Any, Dict, List, Mapping, Optional, Union
@@ -38,20 +37,7 @@ import yaml
 
 
 @dataclasses.dataclass
-class InputSpec_:
-    """Component input definitions. (Inner class).
-
-    Attributes:
-        type: The type of the input.
-        default (optional): the default value for the input.
-        description: Optional: the user description of the input.
-    """
-    type: Union[str, dict]
-    default: Optional[Any] = None
-
-
-# Hack to allow access to __init__ arguments for setting _optional value
-class InputSpec(InputSpec_):
+class InputSpec:
     """Component input definitions.
 
     Attributes:
@@ -59,18 +45,13 @@ class InputSpec(InputSpec_):
         default (optional): the default value for the input.
         _optional: Wether the input is optional. An input is optional when it has an explicit default value.
     """
-
-    @functools.wraps(InputSpec_.__init__)
-    def __init__(self, *args, **kwargs) -> None:
-        """InputSpec constructor, which can access the arguments passed to the
-        constructor for setting ._optional value."""
-        if args:
-            raise ValueError('InputSpec does not accept positional arguments.')
-        super().__init__(*args, **kwargs)
-        self._optional = 'default' in kwargs
+    type: Union[str, dict]
+    default: Optional[Any] = None
+    _optional: Optional[bool] = False
 
     def __post_init__(self) -> None:
         self._validate_type()
+        self._validate_usage_of_optional()
 
     @classmethod
     def from_ir_component_inputs_dict(
@@ -92,10 +73,10 @@ class InputSpec(InputSpec_):
             if type_ is None:
                 raise ValueError(f'Unknown type {type_string} found in IR.')
             default_value = ir_component_inputs_dict.get('defaultValue')
+            # TODO: write the IR is_optional field to IR when compiling. currently we don't do this, so just set optional to True if default_value is not None.
+            optional = default_value is not None
             return InputSpec(
-                type=type_,
-                default=default_value,
-            )
+                type=type_, default=default_value, _optional=optional)
 
         else:
             type_ = ir_component_inputs_dict['artifactType']['schemaTitle']
@@ -134,6 +115,13 @@ class InputSpec(InputSpec_):
         # TODO: add transformation logic so that we don't have to transform inputs at every place they are used, including v1 back compat support
         if not spec_type_is_parameter(self.type):
             type_utils.validate_bundled_artifact_type(self.type)
+
+    def _validate_usage_of_optional(self) -> None:
+        """Validates that the optional and default properties are in consistent
+        states."""
+        # Because None can be the default value, None cannot be used to to indicate no default. This is why we need the optional field. This check prevents users of InputSpec from setting these two values to an inconsistent state, forcing users of InputSpec to be explicit about optionality.
+        if self._optional is False and self.default is not None:
+            raise ValueError('')
 
 
 @dataclasses.dataclass
@@ -635,6 +623,8 @@ class ComponentSpec:
         inputs = {}
         for spec in component_dict.get('inputs', []):
             type_ = spec.get('type')
+            optional = spec.get('optional', False) or 'default' in spec
+            default = spec.get('default')
 
             if isinstance(type_, str) and type_ == 'PipelineTaskFinalStatus':
                 inputs[utils.sanitize_input_name(
@@ -652,6 +642,7 @@ class ComponentSpec:
                 inputs[utils.sanitize_input_name(spec['name'])] = InputSpec(
                     type=in_memory_parameter_type_name,
                     default=default,
+                    _optional=optional,
                 )
                 continue
 
@@ -675,12 +666,13 @@ class ComponentSpec:
             else:
                 raise ValueError(f'Unknown input: {type_}')
 
-            if spec.get('optional', False):
+            if optional:
                 # handles a v1 edge-case where a user marks an artifact input as optional with no default value. some of these v1 component YAMLs exist.
                 inputs[utils.sanitize_input_name(spec['name'])] = InputSpec(
                     type=type_utils.create_bundled_artifact_type(
                         schema_title, schema_version),
-                    default=None,
+                    default=default,
+                    _optional=optional,
                 )
             else:
                 inputs[utils.sanitize_input_name(spec['name'])] = InputSpec(

--- a/sdk/python/kfp/components/structures_test.py
+++ b/sdk/python/kfp/components/structures_test.py
@@ -597,6 +597,11 @@ class TestInputSpec(unittest.TestCase):
             artifact_dict)
         self.assertEqual(input_spec.type, 'system.Artifact@0.0.1')
 
+    def test_assert_optional_must_be_true_when_default_is_not_none(self):
+        with self.assertRaisesRegex(ValueError,
+                                    r'must be True if `default` is not None'):
+            input_spec = structures.InputSpec(type='String', default='text')
+
 
 class TestOutputSpec(parameterized.TestCase):
 

--- a/sdk/python/kfp/components/structures_test.py
+++ b/sdk/python/kfp/components/structures_test.py
@@ -539,7 +539,7 @@ class TestInputSpec(unittest.TestCase):
             structures.InputSpec(type='String', default=None))
         self.assertNotEqual(
             structures.InputSpec(type='String', default=None),
-            structures.InputSpec(type='String', default='test'))
+            structures.InputSpec(type='String', default='test', _optional=True))
         self.assertEqual(
             structures.InputSpec(type='List', default=None),
             structures.InputSpec(type='typing.List', default=None))
@@ -551,11 +551,8 @@ class TestInputSpec(unittest.TestCase):
             structures.InputSpec(type='typing.List[typing.Dict[str, str]]'))
 
     def test_optional(self):
-        input_spec = structures.InputSpec(type='String', default='test')
-        self.assertEqual(input_spec.default, 'test')
-        self.assertEqual(input_spec._optional, True)
-
-        input_spec = structures.InputSpec(type='String', default=None)
+        input_spec = structures.InputSpec(
+            type='String', default=None, _optional=True)
         self.assertEqual(input_spec.default, None)
         self.assertEqual(input_spec._optional, True)
 

--- a/sdk/python/kfp/components/structures_test.py
+++ b/sdk/python/kfp/components/structures_test.py
@@ -539,7 +539,7 @@ class TestInputSpec(unittest.TestCase):
             structures.InputSpec(type='String', default=None))
         self.assertNotEqual(
             structures.InputSpec(type='String', default=None),
-            structures.InputSpec(type='String', default='test', _optional=True))
+            structures.InputSpec(type='String', default='test', optional=True))
         self.assertEqual(
             structures.InputSpec(type='List', default=None),
             structures.InputSpec(type='typing.List', default=None))
@@ -552,13 +552,13 @@ class TestInputSpec(unittest.TestCase):
 
     def test_optional(self):
         input_spec = structures.InputSpec(
-            type='String', default=None, _optional=True)
+            type='String', default=None, optional=True)
         self.assertEqual(input_spec.default, None)
-        self.assertEqual(input_spec._optional, True)
+        self.assertEqual(input_spec.optional, True)
 
         input_spec = structures.InputSpec(type='String')
         self.assertEqual(input_spec.default, None)
-        self.assertEqual(input_spec._optional, False)
+        self.assertEqual(input_spec.optional, False)
 
     def test_from_ir_component_inputs_dict(self):
         parameter_dict = {'parameterType': 'STRING'}


### PR DESCRIPTION
**Description of your changes:**
Similar to #8415.

This removes some trickery in the definition and usage of `InputSpec` that was originally 
intended to make deserialization from v1 component YAML turnkey. The v1 backward compatibility 
handling we have added since them makes this no longer helpful and decreases the clarity of the 
code.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more 
about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
