### PR TITLE
fix(sdk): fix multiple workers writing with gcsfuse bug [KFP SDK v2]

### DIFF
--- a/sdk/python/kfp/components/executor.py
+++ b/sdk/python/kfp/components/executor.py
@@ -265,6 +265,7 @@ class Executor():
                     .format(self._return_annotation))
 
         executor_output_path = self._input['outputs']['outputFile']
+        # This check is to reduce the likelihood that two or more workers (in a distributed training/compute strategy) attempt to write to the same executor output file at the same time using gcsfuse. Do not remove until fixed by gcsfuse.
         if not os.path.exists(executor_output_path):
             os.makedirs(os.path.dirname(executor_output_path), exist_ok=True)
             with open(executor_output_path, 'w') as f:

--- a/sdk/python/kfp/components/executor.py
+++ b/sdk/python/kfp/components/executor.py
@@ -264,12 +264,11 @@ class Executor():
                     ' subclass of `Artifact`, or a NamedTuple collection of these types.'
                     .format(self._return_annotation))
 
-        import os
-        os.makedirs(
-            os.path.dirname(self._input['outputs']['outputFile']),
-            exist_ok=True)
-        with open(self._input['outputs']['outputFile'], 'w') as f:
-            f.write(json.dumps(self._executor_output))
+        executor_output_path = self._input['outputs']['outputFile']
+        if not os.path.exists(executor_output_path):
+            os.makedirs(os.path.dirname(executor_output_path), exist_ok=True)
+            with open(executor_output_path, 'w') as f:
+                f.write(json.dumps(self._executor_output))
 
     def execute(self):
         annotations = inspect.getfullargspec(self._func).annotations


### PR DESCRIPTION
**Description of your changes:**
Fixes a bug where an exception is thrown (non-deterministically) if multiple workers attempt to write to the same file using gcsfuse as the driver. This may or may not be a gcsfuse bug, but either way let's work around it for now in the KFP SDK.

**Checklist:**
- [x] The title for your pull request (PR) should follow our 
title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
