### PR TITLE
chore(sdk): continuation of bumping google-auth dependency

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -24,7 +24,7 @@
 ## Deprecations
 
 ## Bug Fixes and Other Changes
-* Relax required google-auth version from `>=1.6.1,<2` to `>=1.6.1,<3` [#8470](https://github.com/kubeflow/pipelines/pull/8470)
+* Relax required google-auth version from `>=1.6.1,<2` to `>=1.6.1,<3` [#8470](https://github.com/kubeflow/pipelines/pull/8470), [#8473](https://github.com/kubeflow/pipelines/pull/8473)
 
 ## Documentation Updates
 # 1.8.15

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -30,12 +30,12 @@ REQUIRES = [
     'google-api-core>=1.31.5,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0',
     # `Blob.from_string` was introduced in google-cloud-storage 1.20.0
     # https://github.com/googleapis/python-storage/blob/master/CHANGELOG.md#1200
-    'google-cloud-storage>=1.20.0,<2',
+    'google-cloud-storage>=1.20.0,<3',
     'kubernetes>=8.0.0,<19',
     # google-api-python-client v2 doesn't work for private dicovery by default:
     # https://github.com/googleapis/google-api-python-client/issues/1225#issuecomment-791058235
     'google-api-python-client>=1.7.8,<2',
-    'google-auth>=1.6.1,<2',
+    'google-auth>=1.6.1,<3',
     'requests-toolbelt>=0.8.0,<1',
     'cloudpickle>=2.0.0,<3',
     # Update the upper version whenever a new major version of the


### PR DESCRIPTION
**Description of your changes:**
Missed where versions are specified in #8470.

To test these changes:
`pip install -e sdk/python`
`pip show google-auth` should be `2.14.1`

**Checklist:**
- [x] The title for your pull request (PR) should 
follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
