### PR TITLE
feat(sdk): support input list of artifacts in Custom Container Components [lists of artifacts support pt. 4]

### DIFF
--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -380,6 +380,8 @@ def _build_component_spec_from_component_spec_structure(
                 input_name].artifact_type.CopyFrom(
                     type_utils.bundled_artifact_to_artifact_proto(
                         input_spec.type))
+            component_spec.input_definitions.artifacts[
+                input_name].is_artifact_list = input_spec.is_artifact_list
             if input_spec.optional:
                 component_spec.input_definitions.artifacts[
                     input_name].is_optional = True
@@ -395,6 +397,8 @@ def _build_component_spec_from_component_spec_structure(
                 output_name].artifact_type.CopyFrom(
                     type_utils.bundled_artifact_to_artifact_proto(
                         output_spec.type))
+            component_spec.output_definitions.artifacts[
+                output_name].is_artifact_list = output_spec.is_artifact_list
 
     return component_spec
 
@@ -413,7 +417,9 @@ def _connect_dag_outputs(
     """
     if isinstance(output_channel, pipeline_channel.PipelineArtifactChannel):
         if output_name not in component_spec.output_definitions.artifacts:
-            raise ValueError(f'DAG output not defined: {output_name}.')
+            raise ValueError(
+                f'Pipeline or component output not defined: {output_name}. You may be missing a type annotation.'
+            )
         component_spec.dag.outputs.artifacts[
             output_name].artifact_selectors.append(
                 pipeline_spec_pb2.DagOutputsSpec.ArtifactSelectorSpec(
@@ -422,7 +428,9 @@ def _connect_dag_outputs(
                 ))
     elif isinstance(output_channel, pipeline_channel.PipelineParameterChannel):
         if output_name not in component_spec.output_definitions.parameters:
-            raise ValueError(f'Pipeline output not defined: {output_name}.')
+            raise ValueError(
+                f'Pipeline or component output not defined: {output_name}. You may be missing a type annotation.'
+            )
         component_spec.dag.outputs.parameters[
             output_name].value_from_parameter.producer_subtask = output_channel.task_name
         component_spec.dag.outputs.parameters[

--- a/sdk/python/kfp/components/component_factory.py
+++ b/sdk/python/kfp/components/component_factory.py
@@ -17,17 +17,17 @@ import itertools
 import pathlib
 import re
 import textwrap
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple, Type, Union
 import warnings
 
 import docstring_parser
 from kfp.components import container_component
+from kfp.components import container_component_artifact_channel
 from kfp.components import graph_component
 from kfp.components import placeholders
 from kfp.components import python_component
 from kfp.components import structures
-from kfp.components.container_component_artifact_channel import \
-    ContainerComponentArtifactChannel
+from kfp.components.types import artifact_types
 from kfp.components.types import custom_artifact_types
 from kfp.components.types import type_annotations
 from kfp.components.types import type_utils
@@ -477,6 +477,38 @@ def create_component_from_func(
         component_spec=component_spec, python_func=func)
 
 
+def make_input_for_parameterized_container_component_function(
+    name: str, annotation: Union[Type[List[artifact_types.Artifact]],
+                                 Type[artifact_types.Artifact]]
+) -> Union[placeholders.Placeholder, container_component_artifact_channel
+           .ContainerComponentArtifactChannel]:
+    if type_annotations.is_input_artifact(annotation):
+
+        if type_annotations.is_list_of_artifacts(annotation.__origin__):
+            return placeholders.InputListOfArtifactsPlaceholder(name)
+        else:
+            return container_component_artifact_channel.ContainerComponentArtifactChannel(
+                io_type='input', var_name=name)
+
+    elif type_annotations.is_output_artifact(annotation):
+
+        if type_annotations.is_list_of_artifacts(annotation.__origin__):
+            raise ValueError(
+                'Outputting a list of artifacts from a Custom Container Component is not currently supported.'
+            )
+        else:
+            return container_component_artifact_channel.ContainerComponentArtifactChannel(
+                io_type='output', var_name=name)
+
+    elif isinstance(
+            annotation,
+        (type_annotations.OutputAnnotation, type_annotations.OutputPath)):
+        return placeholders.OutputParameterPlaceholder(name)
+
+    else:
+        return placeholders.InputValuePlaceholder(name)
+
+
 def create_container_component_from_func(
         func: Callable) -> container_component.ContainerComponent:
     """Implementation for the @container_component decorator.
@@ -486,27 +518,15 @@ def create_container_component_from_func(
     """
 
     component_spec = extract_component_interface(func, containerized=True)
-    arg_list = []
     signature = inspect.signature(func)
     parameters = list(signature.parameters.values())
+    arg_list = []
     for parameter in parameters:
         parameter_type = type_annotations.maybe_strip_optional_from_annotation(
             parameter.annotation)
-        io_name = parameter.name
-        if type_annotations.is_input_artifact(parameter_type):
-            arg_list.append(
-                ContainerComponentArtifactChannel(
-                    io_type='input', var_name=io_name))
-        elif type_annotations.is_output_artifact(parameter_type):
-            arg_list.append(
-                ContainerComponentArtifactChannel(
-                    io_type='output', var_name=io_name))
-        elif isinstance(
-                parameter_type,
-            (type_annotations.OutputAnnotation, type_annotations.OutputPath)):
-            arg_list.append(placeholders.OutputParameterPlaceholder(io_name))
-        else:  # parameter is an input value
-            arg_list.append(placeholders.InputValuePlaceholder(io_name))
+        arg_list.append(
+            make_input_for_parameterized_container_component_function(
+                parameter.name, parameter_type))
 
     container_spec = func(*arg_list)
     container_spec_implementation = structures.ContainerSpecImplementation.from_container_spec(

--- a/sdk/python/kfp/components/component_factory_test.py
+++ b/sdk/python/kfp/components/component_factory_test.py
@@ -132,20 +132,6 @@ class TestExtractComponentInterfaceListofArtifacts(unittest.TestCase):
                         is_artifact_list=True)
             })
 
-    def test_pipeline_with_named_tuple_fn(self):
-        from typing import NamedTuple
-
-        def comp(
-            i: Input[List[Model]]
-        ) -> NamedTuple('outputs', [('output_list', List[Artifact])]):
-            ...
-
-        with self.assertRaisesRegex(
-                ValueError,
-                r'Cannot use output lists of artifacts in NamedTuple return annotations. Got output list of artifacts annotation for NamedTuple field `output_list`\.'
-        ):
-            component_factory.extract_component_interface(comp)
-
 
 class TestOutputListsOfArtifactsTemporarilyBlocked(unittest.TestCase):
 
@@ -175,6 +161,20 @@ class TestOutputListsOfArtifactsTemporarilyBlocked(unittest.TestCase):
             @dsl.pipeline
             def comp() -> List[Artifact]:
                 ...
+
+    def test_pipeline_with_named_tuple_fn(self):
+        from typing import NamedTuple
+
+        def comp(
+            i: Input[List[Model]]
+        ) -> NamedTuple('outputs', [('output_list', List[Artifact])]):
+            ...
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r'Cannot use output lists of artifacts in NamedTuple return annotations. Got output list of artifacts annotation for NamedTuple field `output_list`\.'
+        ):
+            component_factory.extract_component_interface(comp)
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/components/container_component_artifact_channel_test.py
+++ b/sdk/python/kfp/components/container_component_artifact_channel_test.py
@@ -14,16 +14,16 @@
 
 import unittest
 
-from kfp.components import component_factory
+from kfp.components import container_component_artifact_channel
 from kfp.components import placeholders
 
 
 class TestContainerComponentArtifactChannel(unittest.TestCase):
 
     def test_correct_placeholder_and_attribute_error(self):
-        in_channel = component_factory.ContainerComponentArtifactChannel(
+        in_channel = container_component_artifact_channel.ContainerComponentArtifactChannel(
             'input', 'my_dataset')
-        out_channel = component_factory.ContainerComponentArtifactChannel(
+        out_channel = container_component_artifact_channel.ContainerComponentArtifactChannel(
             'output', 'my_result')
         self.assertEqual(
             in_channel.uri._to_string(),

--- a/sdk/python/kfp/components/placeholders.py
+++ b/sdk/python/kfp/components/placeholders.py
@@ -57,6 +57,28 @@ class InputValuePlaceholder(Placeholder):
         return f"{{{{$.inputs.parameters['{self.input_name}']}}}}"
 
 
+class InputListOfArtifactsPlaceholder(Placeholder):
+
+    def __init__(self, input_name: str) -> None:
+        self.input_name = input_name
+
+    def _to_string(self) -> str:
+        return f"{{{{$.inputs.artifacts['{self.input_name}']}}}}"
+
+    def __getattribute__(self, name: str) -> Any:
+        if name in {'name', 'uri', 'metadata', 'path'}:
+            raise AttributeError(
+                f'Cannot access an attribute on a list of artifacts in a Custom Container Component. Found reference to attribute {name!r} on {self.input_name!r}. Please pass the whole list of artifacts only.'
+            )
+        else:
+            return object.__getattribute__(self, name)
+
+    def __getitem__(self, k: int) -> None:
+        raise KeyError(
+            f'Cannot access individual artifacts in a list of artifacts. Found access to element {k} on {self.input_name!r}. Please pass the whole list of artifacts only.'
+        )
+
+
 class InputPathPlaceholder(Placeholder):
 
     def __init__(self, input_name: str) -> None:
@@ -270,7 +292,8 @@ class IfPresentPlaceholder(Placeholder):
 
 _CONTAINER_PLACEHOLDERS = (IfPresentPlaceholder, ConcatPlaceholder)
 PRIMITIVE_INPUT_PLACEHOLDERS = (InputValuePlaceholder, InputPathPlaceholder,
-                                InputUriPlaceholder, InputMetadataPlaceholder)
+                                InputUriPlaceholder, InputMetadataPlaceholder,
+                                InputListOfArtifactsPlaceholder)
 PRIMITIVE_OUTPUT_PLACEHOLDERS = (OutputParameterPlaceholder,
                                  OutputPathPlaceholder, OutputUriPlaceholder,
                                  OutputMetadataPlaceholder)

--- a/sdk/python/kfp/components/structures.py
+++ b/sdk/python/kfp/components/structures.py
@@ -91,10 +91,13 @@ class InputSpec:
             # TODO: would be better to extract these fields from the proto
             # message, as False default would be preserved
             optional = ir_component_inputs_dict.get('isOptional', False)
+            is_artifact_list = ir_component_inputs_dict.get(
+                'isArtifactList', False)
             return InputSpec(
                 type=type_utils.create_bundled_artifact_type(
                     type_, schema_version),
-                optional=optional)
+                optional=optional,
+                is_artifact_list=is_artifact_list)
 
     def __eq__(self, other: Any) -> bool:
         """Equality comparison for InputSpec. Robust to different type
@@ -177,9 +180,12 @@ class OutputSpec:
             type_ = ir_component_outputs_dict['artifactType']['schemaTitle']
             schema_version = ir_component_outputs_dict['artifactType'][
                 'schemaVersion']
+            is_artifact_list = ir_component_outputs_dict.get(
+                'isArtifactList', False)
             return OutputSpec(
                 type=type_utils.create_bundled_artifact_type(
-                    type_, schema_version))
+                    type_, schema_version),
+                is_artifact_list=is_artifact_list)
 
     def __eq__(self, other: Any) -> bool:
         """Equality comparison for OutputSpec. Robust to different type


### PR DESCRIPTION
**Description of your changes:**
Supports using lists of artifacts in Custom Container Components by enabling writing of placeholders of the form `"{{$.inputs.artifacts['input_name']}}"` via the following syntax:

```python
@dsl.container_component
def comp(input_list: Input[List[Artifact]]):
    return dsl.ContainerSpec(image='alpine', command=['echo'], args=[input_list])
```

Also, write the [`isArtifactList` field](https://github.com/kubeflow/pipelines/blob/1e1a02066ac64cf6ac88d763f16d717219b52576/api/v2alpha1/pipeline_spec.proto#L181) all components types.

Creating output lists of artifacts is not yet supported, but will be supported by https://github.com/kubeflow/pipelines/pull/8808/. This change will also include type checking logic.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the 
pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
