### PR TITLE
feat(backend): Upload namespaced pipeline definitions. Part of #4197

### DIFF
--- a/backend/api/v1beta1/go_http_client/pipeline_upload_client/pipeline_upload_service/upload_pipeline_parameters.go
+++ b/backend/api/v1beta1/go_http_client/pipeline_upload_client/pipeline_upload_service/upload_pipeline_parameters.go
@@ -65,6 +65,8 @@ type UploadPipelineParams struct {
 	Description *string
 	/*Name*/
 	Name *string
+	/*Namespace*/
+	Namespace *string
 	/*Uploadfile
 	  The pipeline to upload. Maximum size of 32MB is supported.
 
@@ -131,6 +133,17 @@ func (o *UploadPipelineParams) SetName(name *string) {
 	o.Name = name
 }
 
+// WithNamespace adds the namespace to the upload pipeline params
+func (o *UploadPipelineParams) WithNamespace(namespace *string) *UploadPipelineParams {
+	o.SetNamespace(namespace)
+	return o
+}
+
+// SetNamespace adds the namespace to the upload pipeline params
+func (o *UploadPipelineParams) SetNamespace(namespace *string) {
+	o.Namespace = namespace
+}
+
 // WithUploadfile adds the uploadfile to the upload pipeline params
 func (o *UploadPipelineParams) WithUploadfile(uploadfile runtime.NamedReadCloser) *UploadPipelineParams {
 	o.SetUploadfile(uploadfile)
@@ -176,6 +189,22 @@ func (o *UploadPipelineParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		qName := qrName
 		if qName != "" {
 			if err := r.SetQueryParam("name", qName); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	if o.Namespace != nil {
+
+		// query param namespace
+		var qrNamespace string
+		if o.Namespace != nil {
+			qrNamespace = *o.Namespace
+		}
+		qNamespace := qrNamespace
+		if qNamespace != "" {
+			if err := r.SetQueryParam("namespace", qNamespace); err != nil {
 				return err
 			}
 		}

--- a/backend/api/v1beta1/go_http_client/pipeline_upload_client/pipeline_upload_service/upload_pipeline_version_parameters.go
+++ b/backend/api/v1beta1/go_http_client/pipeline_upload_client/pipeline_upload_service/upload_pipeline_version_parameters.go
@@ -65,6 +65,8 @@ type UploadPipelineVersionParams struct {
 	Description *string
 	/*Name*/
 	Name *string
+	/*Namespace*/
+	Namespace *string
 	/*Pipelineid*/
 	Pipelineid *string
 	/*Uploadfile
@@ -133,6 +135,17 @@ func (o *UploadPipelineVersionParams) SetName(name *string) {
 	o.Name = name
 }
 
+// WithNamespace adds the namespace to the upload pipeline version params
+func (o *UploadPipelineVersionParams) WithNamespace(namespace *string) *UploadPipelineVersionParams {
+	o.SetNamespace(namespace)
+	return o
+}
+
+// SetNamespace adds the namespace to the upload pipeline version params
+func (o *UploadPipelineVersionParams) SetNamespace(namespace *string) {
+	o.Namespace = namespace
+}
+
 // WithPipelineid adds the pipelineid to the upload pipeline version params
 func (o *UploadPipelineVersionParams) WithPipelineid(pipelineid *string) *UploadPipelineVersionParams {
 	o.SetPipelineid(pipelineid)
@@ -189,6 +202,22 @@ func (o *UploadPipelineVersionParams) WriteToRequest(r runtime.ClientRequest, re
 		qName := qrName
 		if qName != "" {
 			if err := r.SetQueryParam("name", qName); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	if o.Namespace != nil {
+
+		// query param namespace
+		var qrNamespace string
+		if o.Namespace != nil {
+			qrNamespace = *o.Namespace
+		}
+		qNamespace := qrNamespace
+		if qNamespace != "" {
+			if err := r.SetQueryParam("namespace", qNamespace); err != nil {
 				return err
 			}
 		}

--- a/backend/api/v1beta1/swagger/kfp_api_single_file.swagger.json
+++ b/backend/api/v1beta1/swagger/kfp_api_single_file.swagger.json
@@ -1406,6 +1406,12 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "namespace",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [
@@ -1458,6 +1464,12 @@
           },
           {
             "name": "description",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "namespace",
             "in": "query",
             "required": false,
             "type": "string"

--- a/backend/api/v1beta1/swagger/pipeline.upload.swagger.json
+++ b/backend/api/v1beta1/swagger/pipeline.upload.swagger.json
@@ -51,6 +51,12 @@
               "in": "query",
               "required": false,
               "type": "string"
+            },
+            {
+              "name": "namespace",
+              "in": "query",
+              "required": false,
+              "type": "string"
             }
           ],
           "tags": [
@@ -103,6 +109,12 @@
             },
             {
               "name": "description",
+              "in": "query",
+              "required": false,
+              "type": "string"
+            },
+            {
+              "name": "namespace",
               "in": "query",
               "required": false,
               "type": "string"


### PR DESCRIPTION
**Description of your changes:**
This is the backend part pushed by https://github.com/kubeflow/pipelines/pull/8196. See the aforementioned PR and the linked issued for details.

This PR is part of the overarching idea to support namespaced pipeline definitions.
The whole idea is thoroughly analyzed and exposed in this design doc: https://docs.google.com/document/d/1fM4y2L1IVqVj-iiNjYFRRktdCh7FQXgU2XpaYLaqt-A/edit?resourcekey=0-kd5loyP7w3PBD0ug6ECmLQ#

Objective of this PR is to:
1. Fix backend authentication for upload requests in order to properly authenticate users to upload pipeline definitions in specific namespaces
2. Update the swagger definitions accordingly for the upload APIs and generate the code for the relevant clients

Part of #4197

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
