### PR TITLE
feat(sdk): Upload namespaced pipeline definitions. Part of #4197

### DIFF
--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -16,7 +16,7 @@ kfp-pipeline-spec==0.2.0
 # kfp-server-api package is released.
 # Update the lower version when kfp sdk depends on new apis/fields in
 # kfp-server-api.
-kfp-server-api==2.0.0a6
+kfp-server-api==2.0.0b0
 kubernetes>=8.0.0,<24
 protobuf>=3.13.0,<4
 PyYAML>=5.3,<7


### PR DESCRIPTION
**Description of your changes:**
Add a namespace field in the relevant Python wrappers for uploading namespaced pipeline definitions.

This is the SDK part pushed by https://github.com/kubeflow/pipelines/pull/8196. See the aforementioned PR and the linked issued for details.

This PR is part of the overarching idea to support namespaced pipeline definitions.
The whole idea is thoroughly analyzed and exposed in this design doc: https://docs.google.com/document/d/1fM4y2L1IVqVj-iiNjYFRRktdCh7FQXgU2XpaYLaqt-A/edit?resourcekey=0-kd5loyP7w3PBD0ug6ECmLQ#

Objective of this PR is to:
1. Extend the corresponding Python wrappers with a namespace field

Part of #4197
Blocked by #8511 + `kfp-server-api` release

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
