### PR TITLE
fix(sdk): fix bug when referencing component.pipeline_spec in a pipeline body

### DIFF
--- a/sdk/python/kfp/components/base_component.py
+++ b/sdk/python/kfp/components/base_component.py
@@ -111,6 +111,8 @@ class BlockPipelineTaskRegistration:
     google_cloud_pipeline_components compatible with KFP SDK v2.
     """
 
+    # TODO: this handles the special case of a compiled component (when compiled inside a pipeline), which should not have any concept of a default pipeline. Perhaps there is a way to unify component/pipeline compilation concepts to remove this workaround?
+
     def __enter__(self):
         self.task_handler, pipeline_task.PipelineTask._register_task_handler = pipeline_task.PipelineTask._register_task_handler, pipeline_task._register_task_handler
 

--- a/sdk/python/kfp/components/base_component.py
+++ b/sdk/python/kfp/components/base_component.py
@@ -93,9 +93,26 @@ class BaseComponent(abc.ABC):
     @property
     def pipeline_spec(self) -> pipeline_spec_pb2.PipelineSpec:
         """Returns the pipeline spec of the component."""
-        return self.component_spec.to_pipeline_spec()
+        with BlockPipelineTaskRegistration():
+            return self.component_spec.to_pipeline_spec()
 
     @abc.abstractmethod
     def execute(self, **kwargs):
         """Executes the component locally if implemented by the inheriting
         subclass."""
+
+
+class BlockPipelineTaskRegistration:
+    """Temporarily stop registering tasks to the default pipeline.
+
+    Handles special, uncommon functions that decorate and mutate a
+    component, possibly by using the component's .pipeline_spec
+    attribute. This is exhibited in the version of
+    google_cloud_pipeline_components compatible with KFP SDK v2.
+    """
+
+    def __enter__(self):
+        self.task_handler, pipeline_task.PipelineTask._register_task_handler = pipeline_task.PipelineTask._register_task_handler, pipeline_task._register_task_handler
+
+    def __exit__(self, *args):
+        pipeline_task.PipelineTask._register_task_handler = self.task_handler

--- a/sdk/python/kfp/components/base_component_test.py
+++ b/sdk/python/kfp/components/base_component_test.py
@@ -16,6 +16,7 @@
 import unittest
 from unittest.mock import patch
 
+from kfp import dsl
 from kfp.components import base_component
 from kfp.components import pipeline_task
 from kfp.components import placeholders
@@ -117,6 +118,43 @@ class BaseComponentTest(unittest.TestCase):
                 r'component-1\(\) missing 2 required arguments: input1, input2.'
         ):
             component_op()
+
+
+class BlockPipelineTaskRegistration(unittest.TestCase):
+
+    def test_mutating_decorator(self):
+
+        def call_pipeline_spec(component):
+            component.pipeline_spec
+            return component
+
+        @dsl.component
+        def identity(text: str) -> str:
+            return text
+
+        @dsl.pipeline
+        def pipeline_custom_job():
+            modified_identity = call_pipeline_spec(identity)
+            modified_identity(text='text')
+
+        self.assertEqual(len(pipeline_custom_job.pipeline_spec.components), 1)
+        self.assertEqual(
+            len(pipeline_custom_job.pipeline_spec.deployment_spec), 1)
+
+    def test_call_directly_in_pipeline(self):
+
+        @dsl.component
+        def identity(text: str) -> str:
+            return text
+
+        @dsl.pipeline
+        def pipeline_custom_job():
+            identity.pipeline_spec
+            identity(text='text')
+
+        self.assertEqual(len(pipeline_custom_job.pipeline_spec.components), 1)
+        self.assertEqual(
+            len(pipeline_custom_job.pipeline_spec.deployment_spec), 1)
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/components/pipeline_task.py
+++ b/sdk/python/kfp/components/pipeline_task.py
@@ -33,6 +33,10 @@ def create_pipeline_task(
     return PipelineTask(component_spec=component_spec, args=args)
 
 
+_register_task_handler = lambda task: utils.maybe_rename_for_k8s(
+    task.component_spec.name)
+
+
 class PipelineTask:
     """Represents a pipeline task (instantiated component).
 
@@ -57,12 +61,11 @@ class PipelineTask:
             # task is an instance of PipelineTask
             task = identity(message='my string')
     """
+    _register_task_handler = _register_task_handler
 
     # Fallback behavior for compiling a component. This should be overriden by
     # pipeline `register_task_and_generate_id` if compiling a pipeline (more
     # than one component).
-    _register_task_handler = lambda task: utils.maybe_rename_for_k8s(
-        task.component_spec.name)
 
     def __init__(
         self,


### PR DESCRIPTION
**Description of your changes:**
Fixes a KFP SDK v2 behavior that results in broken user code when using KFP SDK v2 with `google_cloud_pipeline_components`.

Specifically, this issue occurs when a component's `.pipeline_spec` method is accessed within a pipeline function. This happens if a user uses 
`create_custom_training_job_op_from_component` within the pipeline function body:

```python
@dsl.component
def print_op(input_text: str = 'test_input_text'):
    print(input_text)
 
@dsl.pipeline
def pipeline_custom_job():
    custom_job_print_op = create_custom_training_job_op_from_component(print_op)
    custom_job_print_op(
      input_text='test_text', project='managed-pipeline-test', display_name='custom_job_v1')
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this 
repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
