### PR TITLE
fix(sdk): print max_attempts instead of sleep_duration

### DIFF
--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -407,7 +407,7 @@ class Client:
             sleep_duration: Time in seconds between retries.
 
         Returns:
-            JSON response from the healtz endpoint.
+            JSON response from the healthz endpoint.
         """
         count = 0
         response = None
@@ -427,7 +427,7 @@ class Client:
             except kfp_server_api.ApiException:
                 # logging.exception also logs detailed info about the ApiException
                 logging.exception(
-                    f'Failed to get healthz info attempt {count} of {sleep_duration}.'
+                    f'Failed to get healthz info attempt {count} of {max_attempts}.'
                 )
                 time.sleep(sleep_duration)
 


### PR DESCRIPTION
**Description of your changes:**
This PR fixes the print statement in the retry logic of `get_kfp_healthz` to properly specify `max_attempts` instead of `sleep_duration`.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
