### PR TITLE
feature(sdk): Upgrade kubernetes library to v19 to get access to Ephe…

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -10,6 +10,7 @@
 ## Deprecations
 
 ## Bug Fixes and Other Changes
+* Upgrade kubernetes library to v19 to get access to EphemeralVolume [#8526](https://github.com/kubeflow/pipelines/pull/8526) 
 
 ## Documentation Updates
 # 1.8.16

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -14,7 +14,7 @@ uritemplate>=3.0.1,<4
 # kfp.dsl
 PyYAML>=5.3,<6
 jsonschema>=3.0.1,<4
-kubernetes>=8.0.0,<19
+kubernetes>=8.0.0,<20
 
 # kfp.Client
 kfp-server-api>=1.1.2,<2.0.0

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -70,9 +70,9 @@ kfp-pipeline-spec==0.1.16
     # via -r requirements.in
 kfp-server-api==1.8.1
     # via -r requirements.in
-kubernetes==18.20.0
+kubernetes==19.15.0
     # via -r requirements.in
-oauthlib==3.2.0
+oauthlib==3.2.2
     # via requests-oauthlib
 protobuf==3.20.1
     # via
@@ -143,7 +143,7 @@ urllib3==1.26.9
     #   kfp-server-api
     #   kubernetes
     #   requests
-websocket-client==1.3.2
+websocket-client==1.4.2
     # via kubernetes
 wheel==0.37.1
     # via strip-hints


### PR DESCRIPTION
**Description of your changes:**
Upgrade the SDK v1 kubernetes version specification to allow v19. This allows usage of ephemeral volumes (https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1Volume.md > ephemeral) which becomes available with v19.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
