### PR TITLE
fix(sdk): new fix for multiple workers writing with gcsfuse bug [KFP SDK v1]

### DIFF
--- a/sdk/python/kfp/v2/components/executor.py
+++ b/sdk/python/kfp/v2/components/executor.py
@@ -253,16 +253,18 @@ class Executor():
                     .format(self._return_annotation))
         import os
         executor_output_path = self._input['outputs']['outputFile']
-        
+
         # This check is to ensure only one worker (in a mirrored, distributed training/compute strategy) attempts to write to the same executor output file at the same time using gcsfuse, which enforces immutability of files.
         write_file = True
-        
-        cluster_spec_string = os.environ.get('CLUSTER_SPEC')
+
+        CLUSTER_SPEC_ENV_VAR_NAME = 'CLUSTER_SPEC'
+        CHEIF_NODE_LABEL = 'workerpool0'
+
+        cluster_spec_string = os.environ.get(CLUSTER_SPEC_ENV_VAR_NAME)
         if cluster_spec_string:
             cluster_spec = json.loads(cluster_spec_string)
-            chief_node_label = 'workerpool0'
-            write_file = cluster_spec['task']['type'] == chief_node_label
-            
+            write_file = cluster_spec['task']['type'] == CHEIF_NODE_LABEL
+
         if write_file:
             os.makedirs(os.path.dirname(executor_output_path), exist_ok=True)
             with open(executor_output_path, 'w') as f:

--- a/sdk/python/kfp/v2/components/executor_test.py
+++ b/sdk/python/kfp/v2/components/executor_test.py
@@ -18,7 +18,7 @@ import os
 import tempfile
 import unittest
 from typing import Callable, Dict, List, NamedTuple, Optional
-
+from unittest import mock
 from kfp.v2.components import executor
 from kfp.v2.components.types import artifact_types
 from kfp.v2.components.types.artifact_types import (Artifact, Dataset, Metrics,
@@ -728,6 +728,38 @@ class ExecutorTest(unittest.TestCase):
                     }
                 },
             })
+
+    @mock.patch.dict(
+        os.environ,
+        {'CLUSTER_SPEC': json.dumps({'task': {
+            'type': 'workerpool0'
+        }})},
+        clear=True)
+    def test_distributed_training_strategy_write(self):
+
+        def test_func(input_parameter: str):
+            self.assertEqual(input_parameter, "Hello, KFP")
+
+        self._get_executor(test_func).execute()
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(self._test_dir, 'output_metadata.json')))
+
+    @mock.patch.dict(
+        os.environ,
+        {'CLUSTER_SPEC': json.dumps({'task': {
+            'type': 'workerpool1'
+        }})},
+        clear=True)
+    def test_distributed_training_strategy_no_write(self):
+
+        def test_func(input_parameter: str):
+            self.assertEqual(input_parameter, "Hello, KFP")
+
+        self._get_executor(test_func).execute()
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(self._test_dir, 'output_metadata.json')))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of your changes:**
#8454 attempted to fix a `FileExistsError` thrown from within KFP SDK code that occurs when multiple workers are writing to the same file in a distributed training strategy.

The previous fix was a probabilistic fix that works most of the time, but not all of the time. This new fix should work all of the time when running pipelines on Vertex Pipelines.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title 
convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
