### PR TITLE
fix(sdk): new fix for multiple workers writing with gcsfuse bug [KFP SDK v2]

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -9,7 +9,7 @@
 
 ## Bug fixes and other changes
 * Unblock valid topologies [\#8416](https://github.com/kubeflow/pipelines/pull/8416)
-
+* Fix bug when writing to same file using gcsfuse and distributed training strategy in lightweight/containerized Python components [#8544](https://github.com/kubeflow/pipelines/pull/8544) [alternative fix after [#8455](https://github.com/kubeflow/pipelines/pull/8455) in `kfp==2.0.0b8`]
 
 ## Documentation updates
 # 2.0.0-beta.8

--- a/sdk/python/kfp/components/executor.py
+++ b/sdk/python/kfp/components/executor.py
@@ -260,10 +260,12 @@ class Executor():
         # This check is to ensure only one worker (in a mirrored, distributed training/compute strategy) attempts to write to the same executor output file at the same time using gcsfuse, which enforces immutability of files.
         write_file = True
 
-        cluster_spec_string = os.environ.get('CLUSTER_SPEC')
+        CLUSTER_SPEC_ENV_VAR_NAME = 'CLUSTER_SPEC'
+        CHEIF_NODE_LABEL = 'workerpool0'
+        cluster_spec_string = os.environ.get(CLUSTER_SPEC_ENV_VAR_NAME)
         if cluster_spec_string:
             cluster_spec = json.loads(cluster_spec_string)
-            chief_node_label = 'workerpool0'
+            chief_node_label = CHEIF_NODE_LABEL
             write_file = cluster_spec['task']['type'] == chief_node_label
 
         if write_file:

--- a/sdk/python/kfp/components/executor.py
+++ b/sdk/python/kfp/components/executor.py
@@ -257,9 +257,17 @@ class Executor():
                     f'Unknown return type: {self._return_annotation}. Must be one of `str`, `int`, `float`, a subclass of `Artifact`, or a NamedTuple collection of these types.'
                 )
 
-        executor_output_path = self._input['outputs']['outputFile']
-        # This check is to reduce the likelihood that two or more workers (in a distributed training/compute strategy) attempt to write to the same executor output file at the same time using gcsfuse. Do not remove until fixed by gcsfuse.
-        if not os.path.exists(executor_output_path):
+        # This check is to ensure only one worker (in a mirrored, distributed training/compute strategy) attempts to write to the same executor output file at the same time using gcsfuse, which enforces immutability of files.
+        write_file = True
+
+        cluster_spec_string = os.environ.get('CLUSTER_SPEC')
+        if cluster_spec_string:
+            cluster_spec = json.loads(cluster_spec_string)
+            chief_node_label = 'workerpool0'
+            write_file = cluster_spec['task']['type'] == chief_node_label
+
+        if write_file:
+            executor_output_path = self._input['outputs']['outputFile']
             os.makedirs(os.path.dirname(executor_output_path), exist_ok=True)
             with open(executor_output_path, 'w') as f:
                 f.write(json.dumps(self._executor_output))


### PR DESCRIPTION
**Description of your changes:**
#8455 attempted to fix a FileExistsError thrown from within KFP SDK code that occurs when multiple workers are writing to the same file in a distributed training strategy.

The previous fix was a probabilistic fix that works most of the time, but not all of the time. This new fix should work all of the time when running pipelines on Vertex Pipelines.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
