### PR TITLE
bug(sdk): silence root user action warning at component runtime

### DIFF
--- a/sdk/python/kfp/components/component_factory.py
+++ b/sdk/python/kfp/components/component_factory.py
@@ -84,7 +84,8 @@ if ! [ -x "$(command -v pip)" ]; then
 fi
 
 PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet \
-    --no-warn-script-location {index_url_options}{concat_package_list} && "$0" "$@"
+    --no-warn-script-location --root-user-action=ignore \
+    {index_url_options}{concat_package_list} && "$0" "$@"
 '''
 
 

--- a/sdk/python/test_data/components/add_numbers.yaml
+++ b/sdk/python/test_data/components/add_numbers.yaml
@@ -30,8 +30,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/components/component_with_pip_install.yaml
+++ b/sdk/python/test_data/components/component_with_pip_install.yaml
@@ -17,9 +17,9 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location --index-url\
-          \ https://pypi.org/simple --trusted-host https://pypi.org/simple 'yapf'\
-          \ 'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     --index-url https://pypi.org/simple --trusted-host https://pypi.org/simple\
+          \ 'yapf' 'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/components/concat_message.yaml
+++ b/sdk/python/test_data/components/concat_message.yaml
@@ -30,8 +30,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/components/dict_input.yaml
+++ b/sdk/python/test_data/components/dict_input.yaml
@@ -23,8 +23,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/components/identity.yaml
+++ b/sdk/python/test_data/components/identity.yaml
@@ -27,8 +27,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/components/input_artifact.yaml
+++ b/sdk/python/test_data/components/input_artifact.yaml
@@ -25,8 +25,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/components/nested_return.yaml
+++ b/sdk/python/test_data/components/nested_return.yaml
@@ -21,8 +21,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/components/output_metrics.yaml
+++ b/sdk/python/test_data/components/output_metrics.yaml
@@ -26,8 +26,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/components/preprocess.yaml
+++ b/sdk/python/test_data/components/preprocess.yaml
@@ -49,8 +49,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/component_with_optional_inputs.yaml
+++ b/sdk/python/test_data/pipelines/component_with_optional_inputs.yaml
@@ -24,8 +24,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/component_with_pip_index_urls.yaml
+++ b/sdk/python/test_data/pipelines/component_with_pip_index_urls.yaml
@@ -17,9 +17,9 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location --index-url\
-          \ https://pypi.org/simple --trusted-host https://pypi.org/simple 'yapf'\
-          \ 'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     --index-url https://pypi.org/simple --trusted-host https://pypi.org/simple\
+          \ 'yapf' 'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/lightweight_python_functions_pipeline.yaml
+++ b/sdk/python/test_data/pipelines/lightweight_python_functions_pipeline.yaml
@@ -78,8 +78,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -130,8 +130,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/lightweight_python_functions_with_outputs.yaml
+++ b/sdk/python/test_data/pipelines/lightweight_python_functions_with_outputs.yaml
@@ -82,8 +82,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -109,8 +109,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -136,8 +136,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -163,8 +163,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_as_exit_task.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_as_exit_task.yaml
@@ -128,8 +128,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -155,8 +155,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -182,8 +182,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -209,8 +209,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_in_pipeline.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_in_pipeline.yaml
@@ -74,8 +74,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -101,8 +101,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_in_pipeline_complex.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_in_pipeline_complex.yaml
@@ -161,8 +161,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -188,8 +188,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_in_pipeline_loaded_from_yaml.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_in_pipeline_loaded_from_yaml.yaml
@@ -151,8 +151,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -178,8 +178,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.3'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -205,8 +205,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_condition.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_condition.yaml
@@ -89,8 +89,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -117,8 +117,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -145,8 +145,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -172,8 +172,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -199,8 +199,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_dynamic_importer_metadata.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_dynamic_importer_metadata.yaml
@@ -95,8 +95,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_env.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_env.yaml
@@ -38,8 +38,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_exit_handler.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_exit_handler.yaml
@@ -65,8 +65,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -92,8 +92,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -119,8 +119,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_google_artifact_type.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_google_artifact_type.yaml
@@ -56,8 +56,9 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'aiplatform'\
-          \ 'kfp==2.0.0-beta.8' 'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'aiplatform' 'kfp==2.0.0-beta.8' 'kfp==2.0.0-beta.8' && \"$0\" \"\
+          $@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -89,8 +90,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'aiplatform'\
-          \ 'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'aiplatform' 'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_importer.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_importer.yaml
@@ -128,8 +128,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -160,8 +160,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_loops.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_loops.yaml
@@ -171,8 +171,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -198,8 +198,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -224,8 +224,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -250,8 +250,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -276,8 +276,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -302,8 +302,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -328,8 +328,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -354,8 +354,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_loops_and_conditions.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_loops_and_conditions.yaml
@@ -577,8 +577,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -606,8 +606,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -635,8 +635,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -663,8 +663,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -689,8 +689,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -716,8 +716,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -743,8 +743,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -770,8 +770,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -797,8 +797,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -824,8 +824,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -851,8 +851,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -878,8 +878,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -905,8 +905,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_metrics_outputs.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_metrics_outputs.yaml
@@ -61,8 +61,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -90,8 +90,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_multiple_exit_handlers.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_multiple_exit_handlers.yaml
@@ -125,8 +125,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -152,8 +152,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -179,8 +179,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -206,8 +206,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -233,8 +233,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -260,8 +260,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -287,8 +287,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_nested_conditions.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_nested_conditions.yaml
@@ -147,8 +147,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -175,8 +175,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -203,8 +203,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -231,8 +231,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -259,8 +259,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -286,8 +286,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -313,8 +313,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -340,8 +340,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_nested_loops.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_nested_loops.yaml
@@ -138,8 +138,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -165,8 +165,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -192,8 +192,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_outputs.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_outputs.yaml
@@ -104,8 +104,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -131,8 +131,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_parallelfor_parallelism.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_parallelfor_parallelism.yaml
@@ -179,8 +179,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -205,8 +205,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -231,8 +231,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -257,8 +257,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -283,8 +283,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -309,8 +309,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_params_containing_format.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_params_containing_format.yaml
@@ -74,8 +74,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -101,8 +101,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -128,8 +128,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_placeholders.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_placeholders.yaml
@@ -55,8 +55,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -81,8 +81,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -107,8 +107,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -133,8 +133,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -159,8 +159,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_retry.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_retry.yaml
@@ -30,8 +30,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pipeline_with_task_final_status.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_task_final_status.yaml
@@ -67,8 +67,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -98,8 +98,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -125,8 +125,8 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.8'\
-          \ && \"$0\" \"$@\"\n"
+          \ python3 -m pip install --quiet     --no-warn-script-location --root-user-action=ignore\
+          \     'kfp==2.0.0-beta.8' && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)


### PR DESCRIPTION
**Description of your changes:**
Silences the following warning from pip at Python component runtime:

```
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the 
system package manager. It is recommended to use a virtual environment instead: 
https://pip.pypa.io/warnings/venv
```

Users have occasionally cited this as a cause for concern or as a cause of other unrelated bugs.

I'm opting to silence this to avoid this confusion/concern, as this warning is non-actionable and is not particularly meaningful for installations in a containerized environment.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull 
request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
