### PR TITLE
fix(sdk): make executor output writer more permissive [sdk v2]

### DIFF
--- a/sdk/python/kfp/components/executor.py
+++ b/sdk/python/kfp/components/executor.py
@@ -273,12 +273,11 @@ class Executor():
         write_file = True
 
         CLUSTER_SPEC_ENV_VAR_NAME = 'CLUSTER_SPEC'
-        CHEIF_NODE_LABEL = 'workerpool0'
         cluster_spec_string = os.environ.get(CLUSTER_SPEC_ENV_VAR_NAME)
         if cluster_spec_string:
             cluster_spec = json.loads(cluster_spec_string)
-            chief_node_label = CHEIF_NODE_LABEL
-            write_file = cluster_spec['task']['type'] == chief_node_label
+            CHIEF_NODE_LABELS = {'workerpool0', 'chief', 'master'}
+            write_file = cluster_spec['task']['type'] in CHIEF_NODE_LABELS
 
         if write_file:
             executor_output_path = self._input['outputs']['outputFile']


### PR DESCRIPTION
**Description of your changes:**
Make the executor write `executor_output.json` for more possible chief worker node labels.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title 
convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
