### PR TITLE
fix(sdk): fix deserializing v1 component yaml defaults

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -9,6 +9,7 @@
 ## Bug fixes and other changes
 * Fully support optional parameter inputs by witing `isOptional` field to IR [\#8612](https://github.com/kubeflow/pipelines/pull/8612)
 * Add support for optional artifact inputs (toward feature parity with KFP SDK v1) [\#8623](https://github.com/kubeflow/pipelines/pull/8623)
+* Fix bug deserializing v1 component YAML with boolean defaults, struct defaults, and array defaults [\#8639](https://github.com/kubeflow/pipelines/pull/8639)
 
 ## Documentation updates
 # 2.0.0-beta.9

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -539,15 +539,11 @@ def _fill_in_component_input_default_value(
     parameter_type = component_spec.input_definitions.parameters[
         input_name].parameter_type
     if pipeline_spec_pb2.ParameterType.NUMBER_INTEGER == parameter_type:
-        # cast to int to support v1 component YAML where NUMBER_INTEGER defaults are included as strings
-        # for example, input Limit: https://raw.githubusercontent.com/kubeflow/pipelines/60a2612541ec08c6a85c237d2ec7525b12543a43/components/datasets/Chicago_Taxi_Trips/component.yaml
         component_spec.input_definitions.parameters[
-            input_name].default_value.number_value = int(default_value)
-        # cast to int to support v1 component YAML where NUMBER_DOUBLE defaults are included as strings
-        # for example, input learning_rate: https://raw.githubusercontent.com/kubeflow/pipelines/567c04c51ff00a1ee525b3458425b17adbe3df61/components/XGBoost/Train/component.yaml
+            input_name].default_value.number_value = default_value
     elif pipeline_spec_pb2.ParameterType.NUMBER_DOUBLE == parameter_type:
         component_spec.input_definitions.parameters[
-            input_name].default_value.number_value = float(default_value)
+            input_name].default_value.number_value = default_value
     elif pipeline_spec_pb2.ParameterType.STRING == parameter_type:
         component_spec.input_definitions.parameters[
             input_name].default_value.string_value = default_value

--- a/sdk/python/kfp/components/structures.py
+++ b/sdk/python/kfp/components/structures.py
@@ -647,6 +647,8 @@ class ComponentSpec:
             type_ = spec.get('type')
             optional = spec.get('optional', False) or 'default' in spec
             default = spec.get('default')
+            default = type_utils.deserialize_v1_component_yaml_default(
+                type_=type_, default=default)
 
             if isinstance(type_, str) and type_ == 'PipelineTaskFinalStatus':
                 inputs[utils.sanitize_input_name(spec['name'])] = InputSpec(
@@ -655,7 +657,6 @@ class ComponentSpec:
 
             elif isinstance(type_, str) and type_.lower(
             ) in type_utils._PARAMETER_TYPES_MAPPING:
-                default = spec.get('default')
                 type_enum = type_utils._PARAMETER_TYPES_MAPPING[type_.lower()]
                 ir_parameter_type_name = pipeline_spec_pb2.ParameterType.ParameterTypeEnum.Name(
                     type_enum)

--- a/sdk/python/kfp/components/structures_test.py
+++ b/sdk/python/kfp/components/structures_test.py
@@ -921,5 +921,267 @@ class TestRetryPolicy(unittest.TestCase):
         self.assertEqual(retry_policy_proto.backoff_max_duration.seconds, 3600)
 
 
+class TestDeserializeV1ComponentYamlDefaults(unittest.TestCase):
+
+    def test_uppercase_T_True(self):
+        comp_text = textwrap.dedent("""\
+inputs:
+  - { name: val, type: Boolean, default: "True" }
+implementation:
+  container:
+    image: python:3.7
+    command:
+      - sh
+      - -c
+      - |
+        echo $0
+      - { inputValue: val }
+""")
+        comp = components.load_component_from_text(comp_text)
+        self.assertEqual(comp.component_spec.inputs['val'].default, True)
+        self.assertEqual(
+            comp.pipeline_spec.root.input_definitions.parameters['val']
+            .default_value.bool_value, True)
+
+    def test_lowercase_t_true(self):
+        comp_text = textwrap.dedent("""\
+inputs:
+  - { name: val, type: Boolean, default: "true" }
+implementation:
+  container:
+    image: python:3.7
+    command:
+      - sh
+      - -c
+      - |
+        echo $0
+      - { inputValue: val }
+""")
+        comp = components.load_component_from_text(comp_text)
+        self.assertEqual(comp.component_spec.inputs['val'].default, True)
+        self.assertEqual(
+            comp.pipeline_spec.root.input_definitions.parameters['val']
+            .default_value.bool_value, True)
+
+    def test_uppercase_T_True_no_quotes(self):
+        comp_text = textwrap.dedent("""\
+inputs:
+  - { name: val, type: Boolean, default: True }
+implementation:
+  container:
+    image: python:3.7
+    command:
+      - sh
+      - -c
+      - |
+        echo $0
+      - { inputValue: val }
+""")
+        comp = components.load_component_from_text(comp_text)
+        self.assertEqual(comp.component_spec.inputs['val'].default, True)
+        self.assertEqual(
+            comp.pipeline_spec.root.input_definitions.parameters['val']
+            .default_value.bool_value, True)
+
+    def test_lowercase_t_true_no_quotes(self):
+        comp_text = textwrap.dedent("""\
+inputs:
+  - { name: val, type: Boolean, default: true }
+implementation:
+  container:
+    image: python:3.7
+    command:
+      - sh
+      - -c
+      - |
+        echo $0
+      - { inputValue: val }
+""")
+        comp = components.load_component_from_text(comp_text)
+        self.assertEqual(comp.component_spec.inputs['val'].default, True)
+        self.assertEqual(
+            comp.pipeline_spec.root.input_definitions.parameters['val']
+            .default_value.bool_value, True)
+
+    def test_uppercase_F_False(self):
+        comp_text = textwrap.dedent("""\
+inputs:
+  - { name: val, type: Boolean, default: "False" }
+implementation:
+  container:
+    image: python:3.7
+    command:
+      - sh
+      - -c
+      - |
+        echo $0
+      - { inputValue: val }
+""")
+        comp = components.load_component_from_text(comp_text)
+        self.assertEqual(comp.component_spec.inputs['val'].default, False)
+        self.assertEqual(
+            comp.pipeline_spec.root.input_definitions.parameters['val']
+            .default_value.bool_value, False)
+
+    def test_lowercase_f_false(self):
+        comp_text = textwrap.dedent("""\
+inputs:
+  - { name: val, type: Boolean, default: "false" }
+implementation:
+  container:
+    image: python:3.7
+    command:
+      - sh
+      - -c
+      - |
+        echo $0
+      - { inputValue: val }
+""")
+        comp = components.load_component_from_text(comp_text)
+        self.assertEqual(comp.component_spec.inputs['val'].default, False)
+        self.assertEqual(
+            comp.pipeline_spec.root.input_definitions.parameters['val']
+            .default_value.bool_value, False)
+
+    def test_uppercase_F_False_no_quotes(self):
+        comp_text = textwrap.dedent("""\
+inputs:
+  - { name: val, type: Boolean, default: False }
+implementation:
+  container:
+    image: python:3.7
+    command:
+      - sh
+      - -c
+      - |
+        echo $0
+      - { inputValue: val }
+""")
+        comp = components.load_component_from_text(comp_text)
+        self.assertEqual(comp.component_spec.inputs['val'].default, False)
+        self.assertEqual(
+            comp.pipeline_spec.root.input_definitions.parameters['val']
+            .default_value.bool_value, False)
+
+    def test_lowercase_f_false_no_quotes(self):
+        comp_text = textwrap.dedent("""\
+inputs:
+  - { name: val, type: Boolean, default: false }
+implementation:
+  container:
+    image: python:3.7
+    command:
+      - sh
+      - -c
+      - |
+        echo $0
+      - { inputValue: val }
+""")
+        comp = components.load_component_from_text(comp_text)
+        self.assertEqual(comp.component_spec.inputs['val'].default, False)
+        self.assertEqual(
+            comp.pipeline_spec.root.input_definitions.parameters['val']
+            .default_value.bool_value, False)
+
+    def test_int_as_string(self):
+        comp_text = textwrap.dedent("""\
+inputs:
+  - { name: val, type: Integer, default: "1" }
+implementation:
+  container:
+    image: python:3.7
+    command:
+      - sh
+      - -c
+      - |
+        echo $0
+      - { inputValue: val }
+""")
+        comp = components.load_component_from_text(comp_text)
+        self.assertEqual(comp.component_spec.inputs['val'].default, 1)
+        self.assertEqual(
+            comp.pipeline_spec.root.input_definitions.parameters['val']
+            .default_value.number_value, 1.0)
+
+    def test_float_as_string(self):
+        comp_text = textwrap.dedent("""\
+inputs:
+  - { name: val, type: Float, default: "1.0" }
+implementation:
+  container:
+    image: python:3.7
+    command:
+      - sh
+      - -c
+      - |
+        echo $0
+      - { inputValue: val }
+""")
+        comp = components.load_component_from_text(comp_text)
+        self.assertEqual(comp.component_spec.inputs['val'].default, 1.0)
+        self.assertEqual(
+            comp.pipeline_spec.root.input_definitions.parameters['val']
+            .default_value.number_value, 1.0)
+
+    def test_struct(self):
+        comp_text = textwrap.dedent("""\
+inputs:
+  - { name: val, type: JsonObject, default: '{"a": 1.0}' }
+implementation:
+  container:
+    image: python:3.7
+    command:
+      - sh
+      - -c
+      - |
+        echo $0
+      - { inputValue: val }
+""")
+        comp = components.load_component_from_text(comp_text)
+        self.assertEqual(comp.component_spec.inputs['val'].default, {'a': 1.0})
+        self.assertEqual(
+            dict(comp.pipeline_spec.root.input_definitions.parameters['val']
+                 .default_value.struct_value), {'a': 1.0})
+
+    def test_array(self):
+        comp_text = textwrap.dedent("""\
+inputs:
+  - { name: val, type: JsonObject, default: '["a", 1.0]' }
+implementation:
+  container:
+    image: python:3.7
+    command:
+      - sh
+      - -c
+      - |
+        echo $0
+      - { inputValue: val }
+""")
+        comp = components.load_component_from_text(comp_text)
+        self.assertEqual(comp.component_spec.inputs['val'].default, ['a', 1.0])
+        self.assertEqual(
+            list(comp.pipeline_spec.root.input_definitions.parameters['val']
+                 .default_value.list_value), ['a', 1.0])
+
+    def test_artifact_with_dict_type_passes_through(self):
+        comp_text = textwrap.dedent("""\
+inputs:
+  - { name: val, type: {Key: Val}}
+implementation:
+  container:
+    image: python:3.7
+    command:
+      - sh
+      - -c
+      - |
+        echo $0
+      - { inputPath: val }
+""")
+        comp = components.load_component_from_text(comp_text)
+        self.assertFalse(comp.component_spec.inputs['val'].optional)
+        self.assertFalse(comp.pipeline_spec.root.input_definitions
+                         .artifacts['val'].is_optional)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/components/structures_test.py
+++ b/sdk/python/kfp/components/structures_test.py
@@ -923,13 +923,13 @@ class TestRetryPolicy(unittest.TestCase):
 
 class TestDeserializeV1ComponentYamlDefaults(unittest.TestCase):
 
-    def test_uppercase_T_True(self):
+    def test_True(self):
         comp_text = textwrap.dedent("""\
 inputs:
   - { name: val, type: Boolean, default: "True" }
 implementation:
   container:
-    image: python:3.7
+    image: alpine
     command:
       - sh
       - -c
@@ -943,13 +943,13 @@ implementation:
             comp.pipeline_spec.root.input_definitions.parameters['val']
             .default_value.bool_value, True)
 
-    def test_lowercase_t_true(self):
+    def test_true(self):
         comp_text = textwrap.dedent("""\
 inputs:
   - { name: val, type: Boolean, default: "true" }
 implementation:
   container:
-    image: python:3.7
+    image: alpine
     command:
       - sh
       - -c
@@ -963,73 +963,13 @@ implementation:
             comp.pipeline_spec.root.input_definitions.parameters['val']
             .default_value.bool_value, True)
 
-    def test_uppercase_T_True_no_quotes(self):
-        comp_text = textwrap.dedent("""\
-inputs:
-  - { name: val, type: Boolean, default: True }
-implementation:
-  container:
-    image: python:3.7
-    command:
-      - sh
-      - -c
-      - |
-        echo $0
-      - { inputValue: val }
-""")
-        comp = components.load_component_from_text(comp_text)
-        self.assertEqual(comp.component_spec.inputs['val'].default, True)
-        self.assertEqual(
-            comp.pipeline_spec.root.input_definitions.parameters['val']
-            .default_value.bool_value, True)
-
-    def test_lowercase_t_true_no_quotes(self):
-        comp_text = textwrap.dedent("""\
-inputs:
-  - { name: val, type: Boolean, default: true }
-implementation:
-  container:
-    image: python:3.7
-    command:
-      - sh
-      - -c
-      - |
-        echo $0
-      - { inputValue: val }
-""")
-        comp = components.load_component_from_text(comp_text)
-        self.assertEqual(comp.component_spec.inputs['val'].default, True)
-        self.assertEqual(
-            comp.pipeline_spec.root.input_definitions.parameters['val']
-            .default_value.bool_value, True)
-
-    def test_uppercase_F_False(self):
-        comp_text = textwrap.dedent("""\
-inputs:
-  - { name: val, type: Boolean, default: "False" }
-implementation:
-  container:
-    image: python:3.7
-    command:
-      - sh
-      - -c
-      - |
-        echo $0
-      - { inputValue: val }
-""")
-        comp = components.load_component_from_text(comp_text)
-        self.assertEqual(comp.component_spec.inputs['val'].default, False)
-        self.assertEqual(
-            comp.pipeline_spec.root.input_definitions.parameters['val']
-            .default_value.bool_value, False)
-
-    def test_lowercase_f_false(self):
+    def test_false(self):
         comp_text = textwrap.dedent("""\
 inputs:
   - { name: val, type: Boolean, default: "false" }
 implementation:
   container:
-    image: python:3.7
+    image: alpine
     command:
       - sh
       - -c
@@ -1043,13 +983,13 @@ implementation:
             comp.pipeline_spec.root.input_definitions.parameters['val']
             .default_value.bool_value, False)
 
-    def test_uppercase_F_False_no_quotes(self):
+    def test_False(self):
         comp_text = textwrap.dedent("""\
 inputs:
-  - { name: val, type: Boolean, default: False }
+  - { name: val, type: Boolean, default: "False" }
 implementation:
   container:
-    image: python:3.7
+    image: alpine
     command:
       - sh
       - -c
@@ -1063,33 +1003,13 @@ implementation:
             comp.pipeline_spec.root.input_definitions.parameters['val']
             .default_value.bool_value, False)
 
-    def test_lowercase_f_false_no_quotes(self):
-        comp_text = textwrap.dedent("""\
-inputs:
-  - { name: val, type: Boolean, default: false }
-implementation:
-  container:
-    image: python:3.7
-    command:
-      - sh
-      - -c
-      - |
-        echo $0
-      - { inputValue: val }
-""")
-        comp = components.load_component_from_text(comp_text)
-        self.assertEqual(comp.component_spec.inputs['val'].default, False)
-        self.assertEqual(
-            comp.pipeline_spec.root.input_definitions.parameters['val']
-            .default_value.bool_value, False)
-
-    def test_int_as_string(self):
+    def test_int(self):
         comp_text = textwrap.dedent("""\
 inputs:
   - { name: val, type: Integer, default: "1" }
 implementation:
   container:
-    image: python:3.7
+    image: alpine
     command:
       - sh
       - -c
@@ -1103,13 +1023,13 @@ implementation:
             comp.pipeline_spec.root.input_definitions.parameters['val']
             .default_value.number_value, 1.0)
 
-    def test_float_as_string(self):
+    def test_float(self):
         comp_text = textwrap.dedent("""\
 inputs:
   - { name: val, type: Float, default: "1.0" }
 implementation:
   container:
-    image: python:3.7
+    image: alpine
     command:
       - sh
       - -c
@@ -1129,7 +1049,7 @@ inputs:
   - { name: val, type: JsonObject, default: '{"a": 1.0}' }
 implementation:
   container:
-    image: python:3.7
+    image: alpine
     command:
       - sh
       - -c
@@ -1149,7 +1069,7 @@ inputs:
   - { name: val, type: JsonObject, default: '["a", 1.0]' }
 implementation:
   container:
-    image: python:3.7
+    image: alpine
     command:
       - sh
       - -c
@@ -1169,7 +1089,7 @@ inputs:
   - { name: val, type: {Key: Val}}
 implementation:
   container:
-    image: python:3.7
+    image: alpine
     command:
       - sh
       - -c

--- a/sdk/python/kfp/components/types/type_utils.py
+++ b/sdk/python/kfp/components/types/type_utils.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 """Utilities for component I/O type mapping."""
 
+from distutils import util
 import inspect
-from typing import Any, Optional, Type, Union
+import json
+from typing import Any, Callable, Dict, Optional, Type, Union
 import warnings
 
 import kfp
@@ -59,6 +61,52 @@ _PARAMETER_TYPES_MAPPING = {
     'jsonobject': pipeline_spec_pb2.ParameterType.STRUCT,
     'jsonarray': pipeline_spec_pb2.ParameterType.LIST,
 }
+
+
+def bool_cast_fn(default: Union[str, bool]) -> bool:
+    if isinstance(default, str):
+        default = util.strtobool(default) == 1
+    return default
+
+
+def try_loading_json(default: str) -> Union[dict, list]:
+    try:
+        return json.loads(default)
+    except:
+        return default
+
+
+_V1_DEFAULT_DESERIALIZER_MAPPING: Dict[str, Callable] = {
+    'integer': int,
+    'int': int,
+    'double': float,
+    'float': float,
+    'string': str,
+    'str': str,
+    'text': str,
+    'bool': bool_cast_fn,
+    'boolean': bool_cast_fn,
+    'dict': try_loading_json,
+    'list': try_loading_json,
+    'jsonobject': try_loading_json,
+    'jsonarray': try_loading_json,
+}
+
+
+def deserialize_v1_component_yaml_default(type_: str, default: Any) -> Any:
+    """Deserializes v1 default values to correct in-memory types.
+
+    Typecasts for primitive types. Tries to load JSON for arrays and
+    structs.
+    """
+    if default is None:
+        return default
+    if isinstance(type_, str):
+        cast_fn = _V1_DEFAULT_DESERIALIZER_MAPPING.get(type_.lower(),
+                                                       lambda x: x)
+        return cast_fn(default)
+    return default
+
 
 # Mapping primitive types to their IR message field names.
 # This is used in constructing condition strings.

--- a/sdk/python/kfp/components/types/type_utils.py
+++ b/sdk/python/kfp/components/types/type_utils.py
@@ -69,7 +69,7 @@ def bool_cast_fn(default: Union[str, bool]) -> bool:
     return default
 
 
-def try_loading_json(default: str) -> Union[dict, list]:
+def try_loading_json(default: str) -> Union[dict, list, str]:
     try:
         return json.loads(default)
     except:

--- a/sdk/python/kfp/components/types/type_utils_test.py
+++ b/sdk/python/kfp/components/types/type_utils_test.py
@@ -474,5 +474,171 @@ class TestValidateBundledArtifactType(parameterized.TestCase):
             type_utils.validate_bundled_artifact_type(type_)
 
 
+class TestDeserializeV1ComponentYamlDefault(parameterized.TestCase):
+
+    @parameterized.parameters([
+        {
+            'type_': 'String',
+            'default': 'val',
+            'expected_type': str,
+            'expected_val': 'val',
+        },
+        {
+            'type_': 'Boolean',
+            'default': 'True',
+            'expected_type': bool,
+            'expected_val': True,
+        },
+        {
+            'type_': 'Boolean',
+            'default': 'true',
+            'expected_type': bool,
+            'expected_val': True,
+        },
+        {
+            'type_': 'Boolean',
+            'default': 'False',
+            'expected_type': bool,
+            'expected_val': False,
+        },
+        {
+            'type_': 'Boolean',
+            'default': 'false',
+            'expected_type': bool,
+            'expected_val': False,
+        },
+        {
+            'type_': 'Float',
+            'default': '0.0',
+            'expected_type': float,
+            'expected_val': 0.0,
+        },
+        {
+            'type_': 'Float',
+            'default': '1.0',
+            'expected_type': float,
+            'expected_val': 1.0,
+        },
+        {
+            'type_': 'Integer',
+            'default': '0',
+            'expected_type': int,
+            'expected_val': 0,
+        },
+        {
+            'type_': 'JsonObject',
+            'default': '[]',
+            'expected_type': list,
+            'expected_val': [],
+        },
+        {
+            'type_': 'JsonObject',
+            'default': '[1, 1.0, "a", true]',
+            'expected_type': list,
+            'expected_val': [1, 1.0, 'a', True],
+        },
+        {
+            'type_': 'JsonObject',
+            'default': '{}',
+            'expected_type': dict,
+            'expected_val': {},
+        },
+        {
+            'type_': 'JsonObject',
+            'default': '{"a": 1.0, "b": true}',
+            'expected_type': dict,
+            'expected_val': {
+                'a': 1.0,
+                'b': True
+            },
+        },
+    ])
+    def test_for_defaults_as_strings(
+        self,
+        type_: Any,
+        default: str,
+        expected_type: type,
+        expected_val: Any,
+    ):
+        res = type_utils.deserialize_v1_component_yaml_default(type_, default)
+        # check type first since equals check is insufficient since 1.0 == 1
+        self.assertIsInstance(res, expected_type)
+        self.assertEquals(res, expected_val)
+
+    @parameterized.parameters([
+        {
+            'type_': 'Boolean',
+            'default': True,
+            'expected_type': bool,
+            'expected_val': True,
+        },
+        {
+            'type_': 'Boolean',
+            'default': False,
+            'expected_type': bool,
+            'expected_val': False,
+        },
+        {
+            'type_': 'Float',
+            'default': 0.0,
+            'expected_type': float,
+            'expected_val': 0.0,
+        },
+        {
+            'type_': 'Float',
+            'default': 1.0,
+            'expected_type': float,
+            'expected_val': 1.0,
+        },
+        {
+            'type_': 'Integer',
+            'default': 0,
+            'expected_type': int,
+            'expected_val': 0,
+        },
+        {
+            'type_': 'JsonObject',
+            'default': [],
+            'expected_type': list,
+            'expected_val': [],
+        },
+        {
+            'type_': 'JsonObject',
+            'default': [1, 1.0, 'a', True],
+            'expected_type': list,
+            'expected_val': [1, 1.0, 'a', True],
+        },
+        {
+            'type_': 'JsonObject',
+            'default': {},
+            'expected_type': dict,
+            'expected_val': {},
+        },
+        {
+            'type_': 'JsonObject',
+            'default': {
+                'a': 1.0,
+                'b': True
+            },
+            'expected_type': dict,
+            'expected_val': {
+                'a': 1.0,
+                'b': True
+            },
+        },
+    ])
+    def test_robustness_to_literals(
+        self,
+        type_: Any,
+        default: str,
+        expected_type: type,
+        expected_val: Any,
+    ):
+        res = type_utils.deserialize_v1_component_yaml_default(type_, default)
+        # check type first since equals check is insufficient since 1.0 == 1
+        self.assertIsInstance(res, expected_type)
+        self.assertEquals(res, expected_val)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of your changes:**
Fixes two errors related to handling of v1 component YAML defaults:
- Boolean types with defaults as strings (e.g., `"True"`/`"true"`/`"False"`/`"false"`) could be loaded in, but could not be compiled.
- Struct/Array types were loaded in, but not compiled correctly (compiled as a `google.protobuf.Value.string_value` instead of `google.protobuf.Value.struct_value` and `google.protobuf.Value.list_value`, respectively.

This PR fixes both and relocates all v1 component YAML default handling logic to the v1 component YAML deserialization code from v2 IR YAML compilation code.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request 
title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
