### PR TITLE
chore: address kubectl dry-run deprecation

### DIFF
--- a/backend/src/cache/deployer/webhook-create-signed-cert.sh
+++ b/backend/src/cache/deployer/webhook-create-signed-cert.sh
@@ -149,5 +149,5 @@ echo ${serverCert} > ${cert_output_path}
 kubectl create secret generic ${secret} \
         --from-file=key.pem=${tmpdir}/server-key.pem \
         --from-file=cert.pem=${tmpdir}/server-cert.pem \
-        --dry-run -o yaml |
+        --dry-run=client -o yaml |
     kubectl -n ${namespace} apply -f -

--- a/manifests/gcp_marketplace/guide.md
+++ b/manifests/gcp_marketplace/guide.md
@@ -80,7 +80,7 @@ gcloud iam service-accounts keys create application_default_credentials.json --i
 # Attempt to create a k8s secret. If already exists, override.
 kubectl create secret generic user-gcp-sa \
   --from-file=user-gcp-sa.json=application_default_credentials.json \
-  -n $NAMESPACE --dry-run -o yaml  |  kubectl apply -f -
+  -n $NAMESPACE --dry-run=client -o yaml  |  kubectl apply -f -
 ```
 Remove the private key file if needed
 ```

--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -91,7 +91,7 @@ gcloud container clusters get-credentials ${TEST_CLUSTER}
 # when we reuse a cluster when debugging, clean up its kfp installation first
 # this does nothing with a new cluster
 kubectl delete namespace ${NAMESPACE} --wait || echo "No need to delete ${NAMESPACE} namespace. It doesn't exist."
-kubectl create namespace ${NAMESPACE} --dry-run -o yaml | kubectl apply -f -
+kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
 
 if [ "$ENABLE_WORKLOAD_IDENTITY" != true ]; then
   if [ -z $SA_KEY_FILE ]; then
@@ -103,5 +103,5 @@ if [ "$ENABLE_WORKLOAD_IDENTITY" != true ]; then
     # Because there's a limit of 10 keys per service account, we are reusing the same key stored in the following bucket.
     gsutil cp "gs://ml-pipeline-test-keys/ml-pipeline-test-sa-key.json" $SA_KEY_FILE
   fi
-  kubectl create secret -n ${NAMESPACE} generic user-gcp-sa --from-file=user-gcp-sa.json=$SA_KEY_FILE --dry-run -o yaml | kubectl apply -f -
+  kubectl create secret -n ${NAMESPACE} generic user-gcp-sa --from-file=user-gcp-sa.json=$SA_KEY_FILE --dry-run=client -o yaml | kubectl apply -f -
 fi

--- a/test/install-argo.sh
+++ b/test/install-argo.sh
@@ -22,22 +22,18 @@ ENABLE_WORKLOAD_IDENTITY=${ENABLE_WORKLOAD_IDENTITY:-false}
 kubectl config set-context $(kubectl config current-context) --namespace=default
 echo "Add necessary cluster role bindings"
 ACCOUNT=$(gcloud info --format='value(config.account)')
-kubectl create clusterrolebinding PROW_BINDING --clusterrole=cluster-admin --user=$ACCOUNT --dry-run -o yaml | kubectl apply -f -
-kubectl create clusterrolebinding DEFAULT_BINDING --clusterrole=cluster-admin --serviceaccount=default:default --dry-run -o yaml | kubectl apply -f -
+kubectl create clusterrolebinding PROW_BINDING --clusterrole=cluster-admin --user=$ACCOUNT --dry-run=client -o yaml | kubectl apply -f -
+kubectl create clusterrolebinding DEFAULT_BINDING --clusterrole=cluster-admin --serviceaccount=default:default --dry-run=client -o yaml | kubectl apply -f -
 
 "${DIR}/install-argo-cli.sh"
-
-# No need to install here, it comes with kfp lite deployment
-# kubectl create ns argo --dry-run -o yaml | kubectl apply -f -
-# kubectl apply -n argo -f https://raw.githubusercontent.com/argoproj/argo-workflows/$ARGO_VERSION/manifests/install.yaml
 
 ARGO_KSA="test-runner"
 
 # Some workflows are deployed to the non-default namespace where the GCP credential secret is stored
 # In this case, the default service account in that namespace doesn't have enough permission
 echo "add service account for running the test workflow"
-kubectl create serviceaccount ${ARGO_KSA} -n ${NAMESPACE} --dry-run -o yaml | kubectl apply -f -
-kubectl create clusterrolebinding test-admin-binding --clusterrole=cluster-admin --serviceaccount=${NAMESPACE}:${ARGO_KSA} --dry-run -o yaml | kubectl apply -f -
+kubectl create serviceaccount ${ARGO_KSA} -n ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
+kubectl create clusterrolebinding test-admin-binding --clusterrole=cluster-admin --serviceaccount=${NAMESPACE}:${ARGO_KSA} --dry-run=client -o yaml | kubectl apply -f -
 
 if [ "$ENABLE_WORKLOAD_IDENTITY" = true ]; then
   ARGO_GSA="test-argo"


### PR DESCRIPTION
**Description of your changes:**

Fixes warning:
> W0103 18:48:39.397850     482 helpers.go:553] --dry-run is deprecated and can be replaced with --dry-run=client.

`--dry-run=true` were deprecated in 1.18, and is subject to to removed in 2 releases per:
https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/576-dry-run/README.md#kubectl

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
