### PR TITLE
feat(backend): add support for "finished_at" and others in filter. Fixes #8654

### DIFF
--- a/backend/src/apiserver/list/list_test.go
+++ b/backend/src/apiserver/list/list_test.go
@@ -5,18 +5,17 @@ import (
 	"strings"
 	"testing"
 
-	"google.golang.org/protobuf/testing/protocmp"
-
+	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/filter"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
-	"github.com/stretchr/testify/assert"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 type fakeMetric struct {
@@ -494,6 +493,55 @@ func TestNewOptions_InvalidFilter(t *testing.T) {
 	got, err := NewOptions(&fakeListable{}, 10, "timestamp", protoFilter)
 	if err == nil {
 		t.Errorf("NewOptions(protoFilter=%+v) =\nGot: %+v, <nil>\nWant error", protoFilter, got)
+	}
+}
+
+func TestNewOptions_ModelFilter(t *testing.T) {
+	protoFilter := &api.Filter{
+		Predicates: []*api.Predicate{
+			&api.Predicate{
+				Key:   "finished_at",
+				Op:    api.Predicate_GREATER_THAN,
+				Value: &api.Predicate_StringValue{StringValue: "SomeTime"},
+			},
+		},
+	}
+
+	protoFilterWithRightKeyNames := &api.Filter{
+		Predicates: []*api.Predicate{
+			&api.Predicate{
+				Key:   "FinishedAtInSec",
+				Op:    api.Predicate_GREATER_THAN,
+				Value: &api.Predicate_StringValue{StringValue: "SomeTime"},
+			},
+		},
+	}
+
+	f, err := filter.New(protoFilterWithRightKeyNames)
+	if err != nil {
+		t.Fatalf("failed to parse filter proto %+v: %v", protoFilter, err)
+	}
+
+	got, err := NewOptions(&model.Run{}, 10, "name", protoFilter)
+	want := &Options{
+		PageSize: 10,
+		token: &token{
+			KeyFieldName:    "UUID",
+			SortByFieldName: "DisplayName",
+			IsDesc:          false,
+			Filter:          f,
+		},
+	}
+
+	opts := []cmp.Option{
+		cmpopts.EquateEmpty(), protocmp.Transform(),
+		cmp.AllowUnexported(Options{}),
+		cmp.AllowUnexported(filter.Filter{}),
+	}
+
+	if !cmp.Equal(got, want, opts...) || err != nil {
+		t.Errorf("NewOptions(protoFilter=%+v) =\nGot: %+v, %v\nWant: %+v, nil\nDiff:\n%s",
+			protoFilter, got, err, want, cmp.Diff(got, want, opts...))
 	}
 }
 

--- a/backend/src/apiserver/model/job.go
+++ b/backend/src/apiserver/model/job.go
@@ -89,10 +89,15 @@ func (j *Job) DefaultSortField() string {
 }
 
 var jobAPIToModelFieldMap = map[string]string{
-	"id":         "UUID",
-	"name":       "DisplayName",
-	"created_at": "CreatedAtInSec",
-	"package_id": "PipelineId",
+	"id":            "UUID",
+	"name":          "DisplayName",
+	"created_at":    "CreatedAtInSec",
+	"package_id":    "PipelineId",
+	"finished_at":   "FinishedAtInSec",
+	"scheduled_at":  "ScheduledAtInSec",
+	"storage_state": "StorageState",
+	"status":        "Conditions",
+	"description":   "Description",
 }
 
 // APIToModelFieldMap returns a map from API names to field names for model Job.

--- a/backend/src/apiserver/model/job.go
+++ b/backend/src/apiserver/model/job.go
@@ -89,15 +89,11 @@ func (j *Job) DefaultSortField() string {
 }
 
 var jobAPIToModelFieldMap = map[string]string{
-	"id":            "UUID",
-	"name":          "DisplayName",
-	"created_at":    "CreatedAtInSec",
-	"package_id":    "PipelineId",
-	"finished_at":   "FinishedAtInSec",
-	"scheduled_at":  "ScheduledAtInSec",
-	"storage_state": "StorageState",
-	"status":        "Conditions",
-	"description":   "Description",
+	"id":          "UUID",
+	"name":        "DisplayName",
+	"created_at":  "CreatedAtInSec",
+	"updated_at":  "UpdatedAtInSec",
+	"description": "Description",
 }
 
 // APIToModelFieldMap returns a map from API names to field names for model Job.

--- a/backend/src/apiserver/model/run.go
+++ b/backend/src/apiserver/model/run.go
@@ -86,6 +86,7 @@ var runAPIToModelFieldMap = map[string]string{
 	"scheduled_at":  "ScheduledAtInSec",
 	"storage_state": "StorageState",
 	"status":        "Conditions",
+	"finished_at":   "FinishedAtInSec",
 }
 
 // APIToModelFieldMap returns a map from API names to field names for model Run.

--- a/backend/src/apiserver/server/list_request_util.go
+++ b/backend/src/apiserver/server/list_request_util.go
@@ -138,7 +138,7 @@ func parseAPIFilter(encoded string) (*api.Filter, error) {
 	}
 
 	errorF := func(err error) (*api.Filter, error) {
-		return nil, util.NewInvalidInputError("failed to parse valid filter from %q: %v", encoded, err)
+		return nil, util.NewInvalidInputError("failed to parse valid filter from %q: %v, decoded value: %q", encoded, err, decoded)
 	}
 
 	decoded, err := url.QueryUnescape(encoded)

--- a/backend/src/apiserver/server/list_request_util.go
+++ b/backend/src/apiserver/server/list_request_util.go
@@ -138,7 +138,7 @@ func parseAPIFilter(encoded string) (*api.Filter, error) {
 	}
 
 	errorF := func(err error) (*api.Filter, error) {
-		return nil, util.NewInvalidInputError("failed to parse valid filter from %q: %v, decoded value: %q", encoded, err, decoded)
+		return nil, util.NewInvalidInputError("failed to parse valid filter from %q: %v", encoded, err)
 	}
 
 	decoded, err := url.QueryUnescape(encoded)

--- a/backend/test/integration/job_api_test.go
+++ b/backend/test/integration/job_api_test.go
@@ -337,11 +337,11 @@ func (s *JobApiTestSuite) TestJobApis() {
 		if err != nil {
 			return err
 		}
-		if len(runs) != 1 {
-			return fmt.Errorf("expected runs to be length 1, got: %v", len(runs))
+		if len(runs) != 2 {
+			return fmt.Errorf("expected runs to be length 2, got: %v", len(runs))
 		}
-		if totalSize != 1 {
-			return fmt.Errorf("expected total size 1, got: %v", totalSize)
+		if totalSize != 2 {
+			return fmt.Errorf("expected total size 2, got: %v", totalSize)
 		}
 		argParamsRun := runs[0]
 		return s.checkArgParamsRun(argParamsRun, argParamsExperiment.ID, argParamsExperiment.Name, argParamsJob.ID, argParamsJob.Name)

--- a/backend/test/integration/job_api_test.go
+++ b/backend/test/integration/job_api_test.go
@@ -300,7 +300,7 @@ func (s *JobApiTestSuite) TestJobApis() {
 	jobs, totalSize, _, err = test.ListJobs(
 		s.jobClient,
 		&jobparams.ListJobsParams{
-			Filter: util.StringPointer(`predicates { key: "created_at" op: LESS_THAN_EQUALS long_value: ` + fmt.Sprint(filterTime) + ` }`)},
+			Filter: util.StringPointer(`{"predicates": [{"key": "created_at", "op": 6, "string_value": "` + fmt.Sprint(filterTime) + `"}]}`)},
 		s.resourceNamespace)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(jobs))

--- a/backend/test/integration/job_api_test.go
+++ b/backend/test/integration/job_api_test.go
@@ -288,6 +288,17 @@ func (s *JobApiTestSuite) TestJobApis() {
 	assert.Equal(t, 1, totalSize)
 	assert.Equal(t, "hello world", jobs[0].Name)
 
+	/* ---------- List the jobs, filtered by created_at, only return the previous two jobs ---------- */
+	filterTime := time.Now().Unix()
+	_, err = s.jobClient.Create(createJobRequest)
+	assert.Nil(t, err)
+	jobs, _, _, err = test.ListJobs(
+		s.jobClient,
+		&jobparams.ListJobsParams{
+			Filter: util.StringPointer(`predicates { key: "created_at" op: LESS_THAN_EQUALS long_value: ` + fmt.Sprint(filterTime) + ` }`)},
+		s.resourceNamespace)
+	assert.Equal(t, 2, len(jobs))
+
 	// The scheduledWorkflow CRD would create the run and it synced to the DB by persistent agent.
 	// This could take a few seconds to finish.
 

--- a/backend/test/integration/job_api_test.go
+++ b/backend/test/integration/job_api_test.go
@@ -291,13 +291,20 @@ func (s *JobApiTestSuite) TestJobApis() {
 	/* ---------- List the jobs, filtered by created_at, only return the previous two jobs ---------- */
 	filterTime := time.Now().Unix()
 	_, err = s.jobClient.Create(createJobRequest)
+	// Check total number of jobs to be 3
+	jobs, totalSize, _, err = test.ListAllJobs(s.jobClient, s.resourceNamespace)
 	assert.Nil(t, err)
-	jobs, _, _, err = test.ListJobs(
+	assert.Equal(t, 3, totalSize)
+	assert.Equal(t, 3, len(jobs))
+	// Check number of filtered jobs finished before filterTime to be 2
+	jobs, totalSize, _, err = test.ListJobs(
 		s.jobClient,
 		&jobparams.ListJobsParams{
 			Filter: util.StringPointer(`predicates { key: "created_at" op: LESS_THAN_EQUALS long_value: ` + fmt.Sprint(filterTime) + ` }`)},
 		s.resourceNamespace)
+	assert.Nil(t, err)
 	assert.Equal(t, 2, len(jobs))
+	assert.Equal(t, 2, totalSize)
 
 	// The scheduledWorkflow CRD would create the run and it synced to the DB by persistent agent.
 	// This could take a few seconds to finish.

--- a/backend/test/integration/job_api_test.go
+++ b/backend/test/integration/job_api_test.go
@@ -289,7 +289,9 @@ func (s *JobApiTestSuite) TestJobApis() {
 	assert.Equal(t, "hello world", jobs[0].Name)
 
 	/* ---------- List the jobs, filtered by created_at, only return the previous two jobs ---------- */
+	time.Sleep(5 * time.Second) // Sleep for 5 seconds to make sure the previous jobs are created at a different timestamp
 	filterTime := time.Now().Unix()
+	time.Sleep(5 * time.Second)
 	_, err = s.jobClient.Create(createJobRequest)
 	// Check total number of jobs to be 3
 	jobs, totalSize, _, err = test.ListAllJobs(s.jobClient, s.resourceNamespace)

--- a/backend/test/integration/run_api_test.go
+++ b/backend/test/integration/run_api_test.go
@@ -253,19 +253,27 @@ func (s *RunApiTestSuite) TestRunApis() {
 
 	/* ---------- List the runs, filtered by finished_at, only return the previous two runs ---------- */
 	// Wait for the runs to finish
-	time.Sleep(120 * time.Second)
+	time.Sleep(300 * time.Second)
 	filterTime := time.Now().Unix()
 	// Create a new run
 	_, _, err = s.runClient.Create(createRunRequest)
 	assert.Nil(t, err)
 	// Wait for the new run to finish
-	time.Sleep(120 * time.Second)
-	runs, _, _, err = test.ListRuns(
+	time.Sleep(300 * time.Second)
+	// Check total number of runs is 3
+	runs, totalSize, _, err = test.ListAllRuns(s.runClient, s.resourceNamespace)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(runs))
+	assert.Equal(t, 3, totalSize)
+	// Check number of filtered runs finished before filterTime to be 2
+	runs, totalSize, _, err = test.ListRuns(
 		s.runClient,
 		&runparams.ListRunsV1Params{
 			Filter: util.StringPointer(`predicates { key: "finished_at" op: LESS_THAN_EQUALS long_value: ` + fmt.Sprint(filterTime) + ` }`)},
 		s.resourceNamespace)
+	assert.Nil(t, err)
 	assert.Equal(t, 2, len(runs))
+	assert.Equal(t, 2, totalSize)
 
 	/* ---------- Archive a run ------------*/
 	err = s.runClient.Archive(&runparams.ArchiveRunV1Params{

--- a/backend/test/integration/run_api_test.go
+++ b/backend/test/integration/run_api_test.go
@@ -251,25 +251,21 @@ func (s *RunApiTestSuite) TestRunApis() {
 	assert.Equal(t, 1, totalSize)
 	assert.Equal(t, "hello world", runs[0].Name)
 
-	/* ---------- List the runs, filtered by finished_at, only return the previous two runs ---------- */
-	// Wait for the runs to finish
-	time.Sleep(300 * time.Second)
+	/* ---------- List the runs, filtered by created_at, only return the previous two runs ---------- */
 	filterTime := time.Now().Unix()
 	// Create a new run
 	_, _, err = s.runClient.Create(createRunRequest)
 	assert.Nil(t, err)
-	// Wait for the new run to finish
-	time.Sleep(300 * time.Second)
 	// Check total number of runs is 3
 	runs, totalSize, _, err = test.ListAllRuns(s.runClient, s.resourceNamespace)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(runs))
 	assert.Equal(t, 3, totalSize)
-	// Check number of filtered runs finished before filterTime to be 2
+	// Check number of filtered runs created before filterTime to be 2
 	runs, totalSize, _, err = test.ListRuns(
 		s.runClient,
 		&runparams.ListRunsV1Params{
-			Filter: util.StringPointer(`predicates { key: "finished_at" op: LESS_THAN_EQUALS long_value: ` + fmt.Sprint(filterTime) + ` }`)},
+			Filter: util.StringPointer(`{"predicates": [{"key": "created_at", "op": 6, "string_value": "` + fmt.Sprint(filterTime) + `"}]}`)},
 		s.resourceNamespace)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(runs))

--- a/backend/test/integration/run_api_test.go
+++ b/backend/test/integration/run_api_test.go
@@ -252,7 +252,9 @@ func (s *RunApiTestSuite) TestRunApis() {
 	assert.Equal(t, "hello world", runs[0].Name)
 
 	/* ---------- List the runs, filtered by created_at, only return the previous two runs ---------- */
+	time.Sleep(5 * time.Second) // Sleep for 5 seconds to make sure the previous runs are created at a different timestamp
 	filterTime := time.Now().Unix()
+	time.Sleep(5 * time.Second)
 	// Create a new run
 	_, _, err = s.runClient.Create(createRunRequest)
 	assert.Nil(t, err)

--- a/backend/test/integration/run_api_test.go
+++ b/backend/test/integration/run_api_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"fmt"
 	"io/ioutil"
 	"sort"
 	"testing"
@@ -249,6 +250,22 @@ func (s *RunApiTestSuite) TestRunApis() {
 	assert.Equal(t, 1, len(runs))
 	assert.Equal(t, 1, totalSize)
 	assert.Equal(t, "hello world", runs[0].Name)
+
+	/* ---------- List the runs, filtered by finished_at, only return the previous two runs ---------- */
+	// Wait for the runs to finish
+	time.Sleep(120 * time.Second)
+	filterTime := time.Now().Unix()
+	// Create a new run
+	_, _, err = s.runClient.Create(createRunRequest)
+	assert.Nil(t, err)
+	// Wait for the new run to finish
+	time.Sleep(120 * time.Second)
+	runs, _, _, err = test.ListRuns(
+		s.runClient,
+		&runparams.ListRunsV1Params{
+			Filter: util.StringPointer(`predicates { key: "finished_at" op: LESS_THAN_EQUALS long_value: ` + fmt.Sprint(filterTime) + ` }`)},
+		s.resourceNamespace)
+	assert.Equal(t, 2, len(runs))
 
 	/* ---------- Archive a run ------------*/
 	err = s.runClient.Archive(&runparams.ArchiveRunV1Params{


### PR DESCRIPTION
**Description of your changes:**
Fixes #8654.
With this PR, users can now filter runs with `finished_at`; Additionally, users can filter recurring runs (f.k.a. jobs) using 	`updated_at` and `description`, similar to what we now have with runs.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
