### PR TITLE
fix(frontend): Show pipeline details for an existing recurring run without pipeline / pipeline version.

### DIFF
--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -72,6 +72,7 @@ export enum QUERY_PARAMS {
   pipelineId = 'pipelineId',
   pipelineVersionId = 'pipelineVersionId',
   fromRunId = 'fromRun',
+  fromRecurringRunId = 'fromRecurringRun',
   runlist = 'runlist',
   view = 'view',
 }

--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -82,6 +82,7 @@ export enum RouteParams {
   pipelineId = 'pid',
   pipelineVersionId = 'vid',
   runId = 'rid',
+  recurringRunId = 'rrid',
   // TODO: create one of these for artifact and execution?
   ID = 'id',
   executionId = 'executionid',
@@ -115,7 +116,7 @@ export const RoutePage = {
   RUN_DETAILS: `/runs/details/:${RouteParams.runId}`,
   RUN_DETAILS_WITH_EXECUTION: `/runs/details/:${RouteParams.runId}/execution/:${RouteParams.executionId}`,
   RECURRING_RUNS: '/recurringruns',
-  RECURRING_RUN_DETAILS: `/recurringrun/details/:${RouteParams.runId}`,
+  RECURRING_RUN_DETAILS: `/recurringrun/details/:${RouteParams.recurringRunId}`,
   START: '/start',
   FRONTEND_FEATURES: '/frontend_features',
 };

--- a/frontend/src/components/__snapshots__/Router.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Router.test.tsx.snap
@@ -113,7 +113,7 @@ exports[`Router initial render 1`] = `
     <Route
       exact={true}
       key="17"
-      path="/recurringrun/details/:rid"
+      path="/recurringrun/details/:rrid"
       render={[Function]}
     />
     <Route

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -394,7 +394,7 @@ function NewRunV2(props: NewRunV2Props) {
           setIsStartingNewRun(false);
           if (data.id) {
             props.history.push(
-              RoutePage.RECURRING_RUN_DETAILS.replace(':' + RouteParams.runId, data.id),
+              RoutePage.RECURRING_RUN_DETAILS.replace(':' + RouteParams.recurringRunId, data.id),
             );
           } else {
             props.history.push(RoutePage.RECURRING_RUNS);

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -144,7 +144,7 @@ function getPipelineDetailsUrl(
     ? RoutePage.PIPELINE_DETAILS.replace(
         ':' + RouteParams.pipelineId + '/version/:' + RouteParams.pipelineVersionId + '?',
         '',
-      ) + urlParser.build({ [QUERY_PARAMS.cloneFromRecurringRun]: originalRecurringRunId })
+      ) + urlParser.build({ [QUERY_PARAMS.fromRecurringRunId]: originalRecurringRunId })
     : '';
 
   return isRecurring ? pipelineDetailsUrlfromRecurringRun : pipelineDetailsUrlfromRun;
@@ -431,7 +431,7 @@ function NewRunV2(props: NewRunV2Props) {
             </div>
             <div className={classes(padding(10, 't'))}>
               {/* TODO(jlyaoyuli): View pipelineDetails from existing recurring run*/}
-              {apiRun && (
+              {cloneOrigin.isClone && (
                 <Link
                   className={classes(commonCss.link)}
                   to={getPipelineDetailsUrl(

--- a/frontend/src/pages/PipelineDetails.test.tsx
+++ b/frontend/src/pages/PipelineDetails.test.tsx
@@ -29,6 +29,7 @@ import TestUtils from '../TestUtils';
 import * as WorkflowUtils from 'src/lib/v2/WorkflowUtils';
 import { PageProps } from './Page';
 import PipelineDetails from './PipelineDetails';
+import { ApiJob } from '../apis/job';
 
 describe('PipelineDetails', () => {
   const updateBannerSpy = jest.fn();
@@ -40,6 +41,7 @@ describe('PipelineDetails', () => {
   const getPipelineVersionSpy = jest.spyOn(Apis.pipelineServiceApi, 'getPipelineVersion');
   const listPipelineVersionsSpy = jest.spyOn(Apis.pipelineServiceApi, 'listPipelineVersions');
   const getRunSpy = jest.spyOn(Apis.runServiceApi, 'getRun');
+  const getRecurringRunSpy = jest.spyOn(Apis.jobServiceApi, 'getJob');
   const getExperimentSpy = jest.spyOn(Apis.experimentServiceApi, 'getExperiment');
   const deletePipelineVersionSpy = jest.spyOn(Apis.pipelineServiceApi, 'deletePipelineVersion');
   const getPipelineVersionTemplateSpy = jest.spyOn(
@@ -52,21 +54,32 @@ describe('PipelineDetails', () => {
   let testPipeline: ApiPipeline = {};
   let testPipelineVersion: ApiPipelineVersion = {};
   let testRun: ApiRunDetail = {};
+  let testRecurringRun: ApiJob = {};
 
-  function generateProps(fromRunSpec = false): PageProps {
+  function generateProps(fromRunSpec = false, fromRecurringRunSpec = false): PageProps {
+    let params = {};
+    if (!fromRunSpec && !fromRecurringRunSpec) {
+      params = {
+        [RouteParams.pipelineId]: testPipeline.id,
+        [RouteParams.pipelineVersionId]:
+          (testPipeline.default_version && testPipeline.default_version!.id) || '',
+      };
+    }
+
+    let search = '';
+    if (fromRunSpec) {
+      search = `?${QUERY_PARAMS.fromRunId}=test-run-id`;
+    } else if (fromRecurringRunSpec) {
+      search = `?${QUERY_PARAMS.fromRecurringRunId}=test-recurring-run-id`;
+    }
+
     const match = {
       isExact: true,
-      params: fromRunSpec
-        ? {}
-        : {
-            [RouteParams.pipelineId]: testPipeline.id,
-            [RouteParams.pipelineVersionId]:
-              (testPipeline.default_version && testPipeline.default_version!.id) || '',
-          },
+      params: params,
       path: '',
       url: '',
     };
-    const location = { search: fromRunSpec ? `?${QUERY_PARAMS.fromRunId}=test-run-id` : '' } as any;
+    const location = { search } as any;
     const pageProps = TestUtils.generatePageProps(
       PipelineDetails,
       location,
@@ -112,12 +125,21 @@ describe('PipelineDetails', () => {
       },
     };
 
+    testRecurringRun = {
+      id: 'test-recurring-run-id',
+      name: 'test recurring run',
+      pipeline_spec: {
+        pipeline_id: 'run-pipeline-id',
+      },
+    };
+
     getPipelineSpy.mockImplementation(() => Promise.resolve(testPipeline));
     getPipelineVersionSpy.mockImplementation(() => Promise.resolve(testPipelineVersion));
     listPipelineVersionsSpy.mockImplementation(() =>
       Promise.resolve({ versions: [testPipelineVersion] }),
     );
     getRunSpy.mockImplementation(() => Promise.resolve(testRun));
+    getRecurringRunSpy.mockImplementation(() => Promise.resolve(testRecurringRun));
     getExperimentSpy.mockImplementation(() =>
       Promise.resolve({ id: 'test-experiment-id', name: 'test experiment' } as ApiExperiment),
     );
@@ -226,6 +248,21 @@ describe('PipelineDetails', () => {
     };
 
     tree = shallow(<PipelineDetails {...generateProps(true)} />);
+    await TestUtils.flushPromises();
+
+    expect(tree.state('templateString')).toBe(
+      'spec:\n  arguments:\n    parameters:\n      - name: output\n',
+    );
+  });
+
+  it('directly uses pipeline manifest from recurring run as template string (v2)', async () => {
+    testRecurringRun.pipeline_spec = {
+      pipeline_id: 'run-pipeline-id',
+      workflow_manifest: '{"spec": {"arguments": {"parameters": [{"name": "output"}]}}}',
+      pipeline_manifest: 'spec:\n  arguments:\n    parameters:\n      - name: output\n',
+    };
+
+    tree = shallow(<PipelineDetails {...generateProps(false, true)} />);
     await TestUtils.flushPromises();
 
     expect(tree.state('templateString')).toBe(

--- a/frontend/src/pages/PipelineDetails.test.tsx
+++ b/frontend/src/pages/PipelineDetails.test.tsx
@@ -58,6 +58,8 @@ describe('PipelineDetails', () => {
 
   function generateProps(fromRunSpec = false, fromRecurringRunSpec = false): PageProps {
     let params = {};
+    // If no fromXXX parameter is provided, it means KFP UI expects to
+    // show Pipeline detail with pipeline version ID
     if (!fromRunSpec && !fromRecurringRunSpec) {
       params = {
         [RouteParams.pipelineId]: testPipeline.id,
@@ -194,6 +196,32 @@ describe('PipelineDetails', () => {
 
   it(
     'shows all runs breadcrumbs, and "Pipeline details" as page title when the pipeline ' +
+      'comes from a recurring run spec that does not have an experiment',
+    async () => {
+      tree = shallow(<PipelineDetails {...generateProps(false, true)} />);
+      await getRecurringRunSpy;
+      await getPipelineVersionTemplateSpy;
+      await TestUtils.flushPromises();
+      expect(updateToolbarSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          breadcrumbs: [
+            { displayName: 'All recurring runs', href: RoutePage.RECURRING_RUNS },
+            {
+              displayName: testRecurringRun.name,
+              href: RoutePage.RECURRING_RUN_DETAILS.replace(
+                ':' + RouteParams.recurringRunId,
+                testRecurringRun.id!,
+              ),
+            },
+          ],
+          pageTitle: 'Pipeline details',
+        }),
+      );
+    },
+  );
+
+  it(
+    'shows all runs breadcrumbs, and "Pipeline details" as page title when the pipeline ' +
       'comes from a run spec that has an experiment',
     async () => {
       testRun.run!.resource_references = [
@@ -218,6 +246,43 @@ describe('PipelineDetails', () => {
             {
               displayName: testRun.run!.name,
               href: RoutePage.RUN_DETAILS.replace(':' + RouteParams.runId, testRun.run!.id!),
+            },
+          ],
+          pageTitle: 'Pipeline details',
+        }),
+      );
+    },
+  );
+
+  it(
+    'shows all runs breadcrumbs, and "Pipeline details" as page title when the pipeline ' +
+      'comes from a recurring run spec that has an experiment',
+    async () => {
+      testRecurringRun.resource_references = [
+        { key: { id: 'test-experiment-id', type: ApiResourceType.EXPERIMENT } },
+      ];
+      tree = shallow(<PipelineDetails {...generateProps(false, true)} />);
+      await getRecurringRunSpy;
+      await getExperimentSpy;
+      await getPipelineVersionTemplateSpy;
+      await TestUtils.flushPromises();
+      expect(updateToolbarSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          breadcrumbs: [
+            { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
+            {
+              displayName: 'test experiment',
+              href: RoutePage.EXPERIMENT_DETAILS.replace(
+                ':' + RouteParams.experimentId,
+                'test-experiment-id',
+              ),
+            },
+            {
+              displayName: testRecurringRun.name,
+              href: RoutePage.RECURRING_RUN_DETAILS.replace(
+                ':' + RouteParams.recurringRunId,
+                testRecurringRun.id!,
+              ),
             },
           ],
           pageTitle: 'Pipeline details',

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -233,14 +233,13 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
 
     // If fromRunId or fromRecurringRunId is specified, load the run and get the pipeline template from it
     if (origin) {
-      const errorTextAdjective = origin.isRecurring ? 'recurring ' : '';
+      const msgRunOrRecurringRun = origin.isRecurring ? 'recurring ' : '';
       try {
-        origin.recurringRun = origin.isRecurring
-          ? await Apis.jobServiceApi.getJob(origin.recurringRunId!)
-          : undefined;
-        origin.run = origin.isRecurring
-          ? undefined
-          : await Apis.runServiceApi.getRun(origin.runId!);
+        if (origin.isRecurring) {
+          origin.recurringRun = await Apis.jobServiceApi.getJob(origin.recurringRunId!);
+        } else {
+          origin.run = await Apis.runServiceApi.getRun(origin.runId!);
+        }
         const pipelineManifest = origin.isRecurring
           ? origin.recurringRun!.pipeline_spec?.pipeline_manifest
           : origin.run!.run?.pipeline_spec?.pipeline_manifest;
@@ -262,13 +261,13 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
                 : JsYaml.safeDump(workflowManifest);
             } catch (err) {
               await this.showPageError(
-                `Failed to parse pipeline spec from ${errorTextAdjective}run with ID: ${
+                `Failed to parse pipeline spec from ${msgRunOrRecurringRun}run with ID: ${
                   origin.isRecurring ? origin.recurringRun!.id : origin.run!.run!.id
                 }.`,
                 err,
               );
               logger.error(
-                `Failed to convert pipeline spec YAML from ${errorTextAdjective}run with ID: ${
+                `Failed to convert pipeline spec YAML from ${msgRunOrRecurringRun}run with ID: ${
                   origin.isRecurring ? origin.recurringRun!.id : origin.run!.run!.id
                 }.`,
                 err,
@@ -276,13 +275,13 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
             }
           } catch (err) {
             await this.showPageError(
-              `Failed to parse pipeline spec from ${errorTextAdjective}run with ID: ${
+              `Failed to parse pipeline spec from ${msgRunOrRecurringRun}run with ID: ${
                 origin.isRecurring ? origin.recurringRun!.id : origin.run!.run!.id
               }.`,
               err,
             );
             logger.error(
-              `Failed to parse pipeline spec JSON from ${errorTextAdjective}run with ID: ${
+              `Failed to parse pipeline spec JSON from ${msgRunOrRecurringRun}run with ID: ${
                 origin.isRecurring ? origin.recurringRun!.id : origin.run!.run!.id
               }.`,
               err,
@@ -312,7 +311,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
           );
         } else {
           breadcrumbs.push({
-            displayName: `All ${errorTextAdjective}runs`,
+            displayName: `All ${msgRunOrRecurringRun}runs`,
             href: origin.isRecurring ? RoutePage.RECURRING_RUNS : RoutePage.RUNS,
           });
         }
@@ -327,8 +326,8 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
         });
         pageTitle = 'Pipeline details';
       } catch (err) {
-        await this.showPageError(`Cannot retrieve ${errorTextAdjective}run details.`, err);
-        logger.error(`Cannot retrieve ${errorTextAdjective}run details.`, err);
+        await this.showPageError(`Cannot retrieve ${msgRunOrRecurringRun}run details.`, err);
+        logger.error(`Cannot retrieve ${msgRunOrRecurringRun}run details.`, err);
         return;
       }
     } else {

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -46,6 +46,8 @@ import { logger } from '../lib/Utils';
 import { Page } from './Page';
 import PipelineDetailsV1 from './PipelineDetailsV1';
 import PipelineDetailsV2 from './PipelineDetailsV2';
+import { ApiRunDetail } from 'src/apis/run';
+import { ApiJob } from 'src/apis/job';
 
 interface PipelineDetailsState {
   graph: dagre.graphlib.Graph | null;
@@ -58,6 +60,12 @@ interface PipelineDetailsState {
   templateString?: string;
   versions: ApiPipelineVersion[];
 }
+
+type origin = {
+  isRecurring: boolean;
+  run?: ApiRunDetail;
+  recurringRun?: ApiJob;
+};
 
 class PipelineDetails extends Page<{}, PipelineDetailsState> {
   constructor(props: any) {
@@ -186,15 +194,38 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
     return this.load();
   }
 
-  /*
-  private buildBreadCumb() {
-    
+  private buildBreadCumb(
+    breadcrumbs: Array<{ displayName: string; href: string }>,
+    origin: origin,
+    runId: string,
+    experiment?: ApiExperiment,
+  ) {
+    // Build the breadcrumbs, by adding experiment and run names
+    if (experiment) {
+      breadcrumbs.push(
+        { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
+        {
+          displayName: experiment.name!,
+          href: RoutePage.EXPERIMENT_DETAILS.replace(
+            ':' + RouteParams.experimentId,
+            experiment.id!,
+          ),
+        },
+      );
+    } else {
+      breadcrumbs.push({ displayName: 'All runs', href: RoutePage.RUNS });
+    }
+    breadcrumbs.push({
+      displayName: origin.isRecurring ? origin.recurringRun!.name! : origin.run!.run?.name!,
+      href: RoutePage.RUN_DETAILS.replace(':' + RouteParams.runId, runId),
+    });
   }
-  */
 
   public async load(): Promise<void> {
     this.clearBanner();
-    const fromRunId = new URLParser(this.props).get(QUERY_PARAMS.fromRunId);
+    const urlParser = new URLParser(this.props);
+    const fromRunId = urlParser.get(QUERY_PARAMS.fromRunId);
+    const fromRecurringRunId = urlParser.get(QUERY_PARAMS.fromRecurringRunId);
 
     let pipeline: ApiPipeline | null = null;
     let version: ApiPipelineVersion | null = null;
@@ -204,11 +235,16 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
     let pageTitle = '';
     let selectedVersion: ApiPipelineVersion | undefined;
     let versions: ApiPipelineVersion[] = [];
+    let origin: origin;
 
     // If fromRunId is specified, load the run and get the pipeline template from it
     if (fromRunId) {
       try {
         const runDetails = await Apis.runServiceApi.getRun(fromRunId);
+        origin = {
+          isRecurring: false,
+          run: runDetails,
+        };
 
         // V1: Convert the run's pipeline spec to YAML to be displayed as the pipeline's source.
         // V2: Use the pipeline spec string directly because it can be translated in JSON format.
@@ -254,34 +290,72 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
         if (relatedExperimentId) {
           experiment = await Apis.experimentServiceApi.getExperiment(relatedExperimentId);
         }
-
-        // Build the breadcrumbs, by adding experiment and run names
-        if (experiment) {
-          breadcrumbs.push(
-            { displayName: 'Experiments', href: RoutePage.EXPERIMENTS },
-            {
-              displayName: experiment.name!,
-              href: RoutePage.EXPERIMENT_DETAILS.replace(
-                ':' + RouteParams.experimentId,
-                experiment.id!,
-              ),
-            },
-          );
-        } else {
-          breadcrumbs.push({ displayName: 'All runs', href: RoutePage.RUNS });
-        }
-        breadcrumbs.push({
-          displayName: runDetails.run!.name!,
-          href: RoutePage.RUN_DETAILS.replace(':' + RouteParams.runId, fromRunId),
-        });
+        this.buildBreadCumb(breadcrumbs, origin, fromRunId, experiment);
         pageTitle = 'Pipeline details';
       } catch (err) {
         await this.showPageError('Cannot retrieve run details.', err);
         logger.error('Cannot retrieve run details.', err);
         return;
       }
+    } else if (fromRecurringRunId) {
+      try {
+        const recurringRunDetails = await Apis.jobServiceApi.getJob(fromRecurringRunId);
+        origin = {
+          isRecurring: true,
+          recurringRun: recurringRunDetails,
+        };
+
+        if (
+          isFeatureEnabled(FeatureKey.V2_ALPHA) &&
+          recurringRunDetails.pipeline_spec?.pipeline_manifest
+        ) {
+          templateString = recurringRunDetails.pipeline_spec.pipeline_manifest;
+        } else {
+          try {
+            const workflowManifestString = RunUtils.getWorkflowManifest(recurringRunDetails) || '';
+            const workflowManifest = JSON.parse(workflowManifestString || '{}');
+            try {
+              if (WorkflowUtils.isPipelineSpec(workflowManifestString)) {
+                templateString = workflowManifestString;
+              } else {
+                templateString = JsYaml.safeDump(workflowManifest);
+              }
+            } catch (err) {
+              await this.showPageError(
+                `Failed to parse pipeline spec from run with ID: ${recurringRunDetails.id}.`,
+                err,
+              );
+              logger.error(
+                `Failed to convert pipeline spec YAML from run with ID: ${recurringRunDetails.id}.`,
+                err,
+              );
+            }
+          } catch (err) {
+            await this.showPageError(
+              `Failed to parse pipeline spec from run with ID: ${recurringRunDetails.id}.`,
+              err,
+            );
+            logger.error(
+              `Failed to parse pipeline spec JSON from run with ID: ${recurringRunDetails.id}.`,
+              err,
+            );
+          }
+        }
+
+        const relatedExperimentId = RunUtils.getFirstExperimentReferenceId(recurringRunDetails);
+        let experiment: ApiExperiment | undefined;
+        if (relatedExperimentId) {
+          experiment = await Apis.experimentServiceApi.getExperiment(relatedExperimentId);
+        }
+        this.buildBreadCumb(breadcrumbs, origin, fromRecurringRunId, experiment);
+        pageTitle = 'Pipeline details';
+      } catch (err) {
+        await this.showPageError('Cannot retrieve recurring run details.', err);
+        logger.error('Cannot retrieve recurring run details.', err);
+        return;
+      }
     } else {
-      // if fromRunId is not specified, then we have a full pipeline
+      // if fromRunId or fromRecurringRunId is not specified, then we have a full pipeline
       const pipelineId = this.props.match.params[RouteParams.pipelineId];
 
       try {

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -186,6 +186,12 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
     return this.load();
   }
 
+  /*
+  private buildBreadCumb() {
+    
+  }
+  */
+
   public async load(): Promise<void> {
     this.clearBanner();
     const fromRunId = new URLParser(this.props).get(QUERY_PARAMS.fromRunId);

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -233,7 +233,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
 
     // If fromRunId or fromRecurringRunId is specified, load the run and get the pipeline template from it
     if (origin) {
-      const msgRunOrRecurringRun = origin.isRecurring ? 'recurring ' : '';
+      const msgRunOrRecurringRun = origin.isRecurring ? 'recurring run' : 'run';
       try {
         if (origin.isRecurring) {
           origin.recurringRun = await Apis.jobServiceApi.getJob(origin.recurringRunId!);
@@ -261,13 +261,13 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
                 : JsYaml.safeDump(workflowManifest);
             } catch (err) {
               await this.showPageError(
-                `Failed to parse pipeline spec from ${msgRunOrRecurringRun}run with ID: ${
+                `Failed to parse pipeline spec from ${msgRunOrRecurringRun} with ID: ${
                   origin.isRecurring ? origin.recurringRun!.id : origin.run!.run!.id
                 }.`,
                 err,
               );
               logger.error(
-                `Failed to convert pipeline spec YAML from ${msgRunOrRecurringRun}run with ID: ${
+                `Failed to convert pipeline spec YAML from ${msgRunOrRecurringRun} with ID: ${
                   origin.isRecurring ? origin.recurringRun!.id : origin.run!.run!.id
                 }.`,
                 err,
@@ -275,13 +275,13 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
             }
           } catch (err) {
             await this.showPageError(
-              `Failed to parse pipeline spec from ${msgRunOrRecurringRun}run with ID: ${
+              `Failed to parse pipeline spec from ${msgRunOrRecurringRun} with ID: ${
                 origin.isRecurring ? origin.recurringRun!.id : origin.run!.run!.id
               }.`,
               err,
             );
             logger.error(
-              `Failed to parse pipeline spec JSON from ${msgRunOrRecurringRun}run with ID: ${
+              `Failed to parse pipeline spec JSON from ${msgRunOrRecurringRun} with ID: ${
                 origin.isRecurring ? origin.recurringRun!.id : origin.run!.run!.id
               }.`,
               err,
@@ -311,7 +311,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
           );
         } else {
           breadcrumbs.push({
-            displayName: `All ${msgRunOrRecurringRun}runs`,
+            displayName: `All ${msgRunOrRecurringRun}s`,
             href: origin.isRecurring ? RoutePage.RECURRING_RUNS : RoutePage.RUNS,
           });
         }
@@ -326,8 +326,8 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
         });
         pageTitle = 'Pipeline details';
       } catch (err) {
-        await this.showPageError(`Cannot retrieve ${msgRunOrRecurringRun}run details.`, err);
-        logger.error(`Cannot retrieve ${msgRunOrRecurringRun}run details.`, err);
+        await this.showPageError(`Cannot retrieve ${msgRunOrRecurringRun} details.`, err);
+        logger.error(`Cannot retrieve ${msgRunOrRecurringRun} details.`, err);
         return;
       }
     } else {

--- a/frontend/src/pages/RecurringRunDetails.test.tsx
+++ b/frontend/src/pages/RecurringRunDetails.test.tsx
@@ -43,7 +43,7 @@ describe('RecurringRunDetails', () => {
   function generateProps(): PageProps {
     const match = {
       isExact: true,
-      params: { [RouteParams.runId]: fullTestJob.id },
+      params: { [RouteParams.recurringRunId]: fullTestJob.id },
       path: '',
       url: '',
     };

--- a/frontend/src/pages/RecurringRunDetails.tsx
+++ b/frontend/src/pages/RecurringRunDetails.tsx
@@ -137,7 +137,7 @@ class RecurringRunDetails extends Page<{}, RecurringRunConfigState> {
 
   public async load(): Promise<void> {
     this.clearBanner();
-    const runId = this.props.match.params[RouteParams.runId];
+    const runId = this.props.match.params[RouteParams.recurringRunId];
 
     let run: ApiJob;
     try {

--- a/frontend/src/pages/RecurringRunList.tsx
+++ b/frontend/src/pages/RecurringRunList.tsx
@@ -156,7 +156,7 @@ class RecurringRunList extends React.PureComponent<RecurringRunListProps, Recurr
         <Link
           className={commonCss.link}
           onClick={e => e.stopPropagation()}
-          to={RoutePage.RECURRING_RUN_DETAILS.replace(':' + RouteParams.runId, props.id)}
+          to={RoutePage.RECURRING_RUN_DETAILS.replace(':' + RouteParams.recurringRunId, props.id)}
         >
           {props.value}
         </Link>

--- a/frontend/src/pages/RecurringRunsManager.tsx
+++ b/frontend/src/pages/RecurringRunsManager.tsx
@@ -107,7 +107,7 @@ class RecurringRunsManager extends React.Component<RecurringRunListProps, Recurr
     return (
       <Link
         className={commonCss.link}
-        to={RoutePage.RECURRING_RUN_DETAILS.replace(':' + RouteParams.runId, props.id)}
+        to={RoutePage.RECURRING_RUN_DETAILS.replace(':' + RouteParams.recurringRunId, props.id)}
       >
         {props.value}
       </Link>

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -274,7 +274,7 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
       return <div>-</div>;
     }
     const url = RoutePage.RECURRING_RUN_DETAILS.replace(
-      ':' + RouteParams.runId,
+      ':' + RouteParams.recurringRunId,
       props.value.id || '',
     );
     return (

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -34,6 +34,7 @@ interface PipelineVersionInfo {
   displayName?: string;
   versionId?: string;
   runId?: string;
+  recurringRunId?: string;
   pipelineId?: string;
   usePlaceholder: boolean;
 }
@@ -235,7 +236,10 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
     if (!props.value || (!props.value.usePlaceholder && !props.value.pipelineId)) {
       return <div>-</div>;
     }
-    const search = new URLParser(this.props).build({ [QUERY_PARAMS.fromRunId]: props.id });
+    const urlParser = new URLParser(this.props);
+    const search = props.value.recurringRunId
+      ? urlParser.build({ [QUERY_PARAMS.fromRecurringRunId]: props.value.recurringRunId })
+      : urlParser.build({ [QUERY_PARAMS.fromRunId]: props.id });
     const url = props.value.usePlaceholder
       ? RoutePage.PIPELINE_DETAILS_NO_VERSION.replace(':' + RouteParams.pipelineId + '?', '') +
         search
@@ -507,7 +511,9 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
       !!RunUtils.getWorkflowManifest(displayRun.run) ||
       displayRun.run.pipeline_spec?.pipeline_manifest
     ) {
-      displayRun.pipelineVersion = { usePlaceholder: true };
+      displayRun.pipelineVersion = displayRun.recurringRun?.id
+        ? { usePlaceholder: true, recurringRunId: displayRun.recurringRun.id }
+        : { usePlaceholder: true };
     }
   }
 


### PR DESCRIPTION
Enable pipeline details logic to retrieve `template string` from pipeline manifest in recurring run and then using it to configure DAG in pipeline details page.

Before:

https://user-images.githubusercontent.com/56132941/213337299-b7570a94-0768-42b5-afd4-8827e6544956.mov


After:

https://user-images.githubusercontent.com/56132941/213337382-1d71f6fe-a40b-41b6-a337-a75f680b85c5.mov

