### PR TITLE
fix(sdk): fix upload_pipeline when no pipeline name is provided

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -7,6 +7,7 @@
 ## Deprecations
 
 ## Bug fixes and other changes
+* Fix upload_pipeline method on client when no name is provided [\#8695](https://github.com/kubeflow/pipelines/pull/8695)
 
 ## Documentation updates
 # 2.0.0-beta.11

--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -1372,9 +1372,8 @@ class Client:
             ``ApiPipeline`` object.
         """
         if pipeline_name is None:
-            pipeline_name = os.path.splitext(
-                os.path.basename('something/file.txt'))[0]
-
+            pipeline_yaml = self._extract_pipeline_yaml(pipeline_package_path)
+            pipeline_name = pipeline_yaml['pipelineInfo']['name']
         validate_pipeline_resource_name(pipeline_name)
         response = self._upload_api.upload_pipeline(
             pipeline_package_path, name=pipeline_name, description=description)


### PR DESCRIPTION
**Description of your changes:**
This PR fixes a bug where pipelines submitted through the client using `upload_pipeline` that don't have a name passed to the method are not named correctly.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
