### PR TITLE
chore(sdk): pin kfp-pipeline-spec exactly

### DIFF
--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -10,7 +10,8 @@ google-api-core>=1.31.5,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0
 google-auth>=1.6.1,<3
 # https://github.com/googleapis/python-storage/blob/main/CHANGELOG.md#221-2022-03-15
 google-cloud-storage>=2.2.1,<3
-kfp-pipeline-spec>=0.1.17,<0.2.0
+# pin kfp-pipeline-spec to an exact version, since this is the contract between a given KFP SDK version and the BE. we don't want old version of the SDK to write new fields and to have the BE reject the new unsupported field (even if the new field backward compatible from a proto perspective)
+kfp-pipeline-spec==0.2.0
 # Update the upper version whenever a new major version of the
 # kfp-server-api package is released.
 # Update the lower version when kfp sdk depends on new apis/fields in

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -41,7 +41,7 @@ googleapis-common-protos==1.56.4
     # via google-api-core
 idna==3.3
     # via requests
-kfp-pipeline-spec==0.1.17
+kfp-pipeline-spec==0.2.0
     # via -r requirements.in
 kfp-server-api==2.0.0a4
     # via -r requirements.in


### PR DESCRIPTION
**Description of your changes:**
Pins [`kfp-pipeline-spec`](https://pypi.org/project/kfp-pipeline-spec/) to an exact version, since this is the contract between a given KFP SDK version and the BE. We don't want old version of the SDK to write new fields and to have the BE reject the new unsupported field (even if the new field backward compatible from a proto perspective).

Also see https://github.com/kubeflow/pipelines/pull/8744.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
