### PR TITLE
chore(sdk): bump kfp-pipeline-spec

### DIFF
--- a/api/v2alpha1/python/setup.py
+++ b/api/v2alpha1/python/setup.py
@@ -14,19 +14,19 @@
 
 import setuptools
 
-NAME = "kfp-pipeline-spec"
-VERSION = "0.2.0"
+NAME = 'kfp-pipeline-spec'
+VERSION = '0.2.0'
 
 setuptools.setup(
     name=NAME,
     version=VERSION,
-    description="Kubeflow Pipelines pipeline spec",
-    author="google",
-    author_email="kubeflow-pipelines@google.com",
-    url="https://github.com/kubeflow/pipelines",
+    description='Kubeflow Pipelines pipeline spec',
+    author='google',
+    author_email='kubeflow-pipelines@google.com',
+    url='https://github.com/kubeflow/pipelines',
     packages=setuptools.find_namespace_packages(include=['kfp.*']),
-    python_requires=">=3.7.0",
-    install_requires=["protobuf>=3.13.0,<4"],
+    python_requires='>=3.7.0',
+    install_requires=['protobuf>=3.13.0,<4'],
     include_package_data=True,
-    license="Apache 2.0",
+    license='Apache 2.0',
 )

--- a/api/v2alpha1/python/setup.py
+++ b/api/v2alpha1/python/setup.py
@@ -15,7 +15,7 @@
 import setuptools
 
 NAME = "kfp-pipeline-spec"
-VERSION = "0.1.17"
+VERSION = "0.2.0"
 
 setuptools.setup(
     name=NAME,


### PR DESCRIPTION
**Description of your changes:**
Bumps `kfp-pipeline-spec` version to `0.2.0`. This is to resolve an error where (in the absence of this change) previous version of the KFP SDK might get "too new" a version of `kfp-pipeline-spec`, write the newer PipelineSpec (IR YAML), and submit to an "older" version of the KFP OSS BE which does not support the new IR YAML.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. 
[Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
