### PR TITLE
chore(sdk): block importing from deprecated

### DIFF
--- a/backend/src/v2/test/components/run_sample.yaml
+++ b/backend/src/v2/test/components/run_sample.yaml
@@ -42,6 +42,7 @@ implementation:
       cp "$backend_compiler_path" /usr/local/bin/kfp-v2-compiler
       # run test sample
       # TODO: remove deprecated dependency
+      export ENV=TEST
       pip install -r sdk/python/requirements-deprecated.txt
       python3 \
         -u \

--- a/backend/src/v2/test/sample-test.sh
+++ b/backend/src/v2/test/sample-test.sh
@@ -25,6 +25,7 @@ source "${DIR}/scripts/ci-env.sh"
 python3 -m pip install --upgrade pip
 
 # TODO: remove deprecated dependency
+export ENV=TEST
 python3 -m pip install -r $source_root/sdk/python/requirements-deprecated.txt
 python3 -m pip install $source_root/sdk/python
 

--- a/sdk/python/kfp/deprecated/__init__.py
+++ b/sdk/python/kfp/deprecated/__init__.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+if os.environ.get('ENV') != 'TEST':
+    raise ImportError("cannot import from 'kfp.deprecated'")
+
 __version__ = '1.8.11'
 
 from . import components

--- a/sdk/python/kfp/test_deprecated.py
+++ b/sdk/python/kfp/test_deprecated.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import unittest
+from unittest import mock
+
+
+class TestImportFromDeprecated(unittest.TestCase):
+
+    def tearDown(self):
+        """Remove deprecated modules from sys.modules.
+
+        Cleans up relevant global state so that tests are independent.
+        """
+
+        modules = [
+            m for m in sys.modules.keys() if m.startswith('kfp.deprecated')
+        ]
+        for m in modules:
+            del sys.modules[m]
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_import_module_fails(self):
+
+        with self.assertRaisesRegex(ImportError,
+                                    "cannot import from 'kfp.deprecated'"):
+            pass
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_import_object_fails(self):
+        with self.assertRaisesRegex(ImportError,
+                                    "cannot import from 'kfp.deprecated'"):
+            pass
+
+    @mock.patch.dict(os.environ, {'ENV': 'TEST'}, clear=True)
+    def test_import_module_succeeds_with_env_var(self):
+        pass
+
+    @mock.patch.dict(os.environ, {'ENV': 'TEST'}, clear=True)
+    def test_import_object_succeeds_with_env_var(self):
+        pass

--- a/test/sample-test/Dockerfile
+++ b/test/sample-test/Dockerfile
@@ -11,6 +11,7 @@ RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
 COPY ./test/sample-test/requirements.txt /python/src/github.com/kubeflow/pipelines/test/sample-test/requirements.txt
 RUN pip3 install -r /python/src/github.com/kubeflow/pipelines/test/sample-test/requirements.txt
 # TODO: remove deprecated dependency
+ENV ENV=TEST
 COPY ./sdk/python/requirements-deprecated.txt /python/src/github.com/kubeflow/pipelines/sdk/python/requirements-deprecated.txt
 RUN pip3 install -r /python/src/github.com/kubeflow/pipelines/sdk/python/requirements-deprecated.txt
 # Install KFP server API from commit.


### PR DESCRIPTION
**Description of your changes:**
Blocks importing from `kfp.deprecated`. Given that we have observed users try to use v1 functionality from the `deprecated` module and 
that the `deprecated` module will eventually be removed, we should block usage.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used 
in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
