### PR TITLE
perf(components): add parent model to ModelUploadOp YAML definition 

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/aiplatform/model/upload_model/component.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/aiplatform/model/upload_model/component.yaml
@@ -14,6 +14,9 @@ description: |
             characters long and can be consist of any UTF-8 characters.
         description (Optional[str]):
             The description of the model.
+        parent_model (Optional[google.VertexModel]): An artifact of a model
+          which to upload a new version to. Only specify this field when
+          uploading a new version.
         unmanaged_container_model (Optional[google.UnmanagedContainerModel]):
             Optional. The unmanaged container model to be uploaded.
 
@@ -199,6 +202,7 @@ inputs:
 - {name: location, type: String, default: "us-central1"}
 - {name: display_name, type: String}
 - {name: description, type: String, optional: true, default: ''}
+- {name: parent_model, type: google.VertexModel, optional: true}
 - {name: unmanaged_container_model, type: google.UnmanagedContainerModel, optional: true}
 - {name: serving_container_image_uri, type: String, optional: true, default: ''}
 - {name: serving_container_command, type: JsonArray, optional: true, default: '[]'}
@@ -254,6 +258,14 @@ implementation:
       ],
       --project, {inputValue: project},
       --location, {inputValue: location},
+      {if: {
+        cond: {isPresent: parent_model},
+        then: '--parent_model_name'
+      }},
+      {if: {
+        cond: {isPresent: parent_model},
+        then: "{{$.inputs.artifacts['parent_model'].metadata['resourceName']}}"
+      }},
       --gcp_resources, {outputPath: gcp_resources},
       --executor_input, "{{$}}",
     ]

--- a/components/google-cloud/google_cloud_pipeline_components/container/v1/model/upload_model/remote_runner.py
+++ b/components/google-cloud/google_cloud_pipeline_components/container/v1/model/upload_model/remote_runner.py
@@ -26,6 +26,7 @@ from google_cloud_pipeline_components.types.artifact_types import VertexModel
 ARTIFACT_PROPERTY_KEY_UNMANAGED_CONTAINER_MODEL = 'unmanaged_container_model'
 API_KEY_PREDICT_SCHEMATA = 'predict_schemata'
 API_KEY_CONTAINER_SPEC = 'container_spec'
+API_KEY_VERSION_ALIASES = 'version_aliases'
 API_KEY_ARTIFACT_URI = 'artifact_uri'
 _LABELS_PAYLOAD_KEY = 'labels'
 
@@ -41,6 +42,9 @@ def append_unmanaged_model_artifact_into_payload(executor_input, model_spec):
     model_spec[
         API_KEY_CONTAINER_SPEC] = json_util.camel_case_to_snake_case_recursive(
             artifact[0].get('metadata', {}).get('containerSpec', {}))
+    model_spec[
+        API_KEY_VERSION_ALIASES] = json_util.camel_case_to_snake_case_recursive(
+            artifact[0].get('metadata', {}).get('versionAliases', ["default"]))
     model_spec[API_KEY_ARTIFACT_URI] = artifact[0].get('uri')
   return model_spec
 

--- a/components/google-cloud/google_cloud_pipeline_components/container/v1/model/upload_model/remote_runner.py
+++ b/components/google-cloud/google_cloud_pipeline_components/container/v1/model/upload_model/remote_runner.py
@@ -85,8 +85,8 @@ def upload_model(
         upload_model_url, json.dumps(upload_model_request), gcp_resources)
     upload_model_lro = remote_runner.poll_lro(lro=upload_model_lro)
     model_resource_name = upload_model_lro['response']['model']
-    if 'model_version_id' in upload_model_lro['response']:
-      model_resource_name += f'@{upload_model_lro["response"]["model_version_id"]}'
+    if 'modelVersionId' in upload_model_lro['response']:
+      model_resource_name += f'@{upload_model_lro["response"]["modelVersionId"]}'
 
     vertex_model = VertexModel('model', vertex_uri_prefix + model_resource_name,
                                model_resource_name)


### PR DESCRIPTION
**Description of your changes:**
In this MR, a new argument `parent_model` is added to the ModelUploadOp component YAML definition. This change is aligned with the definition in [google_cloud_pipeline_components/v1/model/upload_model/component.py](https://github.com/kubeflow/pipelines/blob/master/components/google-cloud/google_cloud_pipeline_components/v1/model/upload_model/component.py)

In addition, a small bug of a wrong response field name of `model version id` is fixed.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
