### PR TITLE
fix(test): Add frontend integration test manual run

### DIFF
--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -41,6 +41,7 @@ function clean_up {
   ALL_PODS=($(kubectl get pods -o=custom-columns=:metadata.name -n $NAMESPACE))
   for POD_NAME in "${ALL_PODS[@]}"; do
     pod_info_file="$POD_INFO_DIR/$POD_NAME.txt"
+    echo "Saving log of $POD_NAME to $pod_info_file"
     echo "Pod name: $POD_NAME" >> "$pod_info_file"
     echo "Detailed logs:" >> "$pod_info_file"
     echo "https://console.cloud.google.com/logs/viewer?project=$PROJECT&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22$PROJECT%22%0Aresource.labels.location%3D%22us-east1-b%22%0Aresource.labels.cluster_name%3D%22${TEST_CLUSTER}%22%0Aresource.labels.namespace_name%3D%22$NAMESPACE%22%0Aresource.labels.pod_name%3D%22$POD_NAME%22" \
@@ -50,6 +51,11 @@ function clean_up {
     echo "--------" >> "$pod_info_file"
     kubectl get pod $POD_NAME -n $NAMESPACE -o yaml >> "$pod_info_file"
   done
+  
+  echo "Archiving ${ARTIFACTS} into ./${COMMIT_SHA}_logs.tar.gz" 
+  tar -czf ./${COMMIT_SHA}_logs.tar.gz ${ARTIFACTS}
+  echo "Uploading ./${COMMIT_SHA}_logs.tar.gz to ${TEST_RESULTS_GCS_DIR}/logs"
+  gsutil cp ${COMMIT_SHA}_logs.tar.gz "${TEST_RESULTS_GCS_DIR}/logs"
 
   echo "Clean up cluster..."
   if [ $SHOULD_CLEANUP_CLUSTER == true ]; then

--- a/test/frontend-integration-test/README.md
+++ b/test/frontend-integration-test/README.md
@@ -1,0 +1,24 @@
+# Frontend integration test
+
+This test gets triggered by the end-to-end testing workflows.
+
+## Local run
+
+1. Deploy KFP on a k8s cluster and enable port forwarding. Replace the default namespace `kubeflow` below if needed.
+
+    ```bash
+    POD=`kubectl get pods -n kubeflow -l app=ml-pipeline-ui -o jsonpath='{.items[0].metadata.name}'`
+    kubectl port-forward -n kubeflow ${POD} 3000:3000 &
+    ```
+
+1. Build the container with the tests:
+
+    ```bash
+    docker build . -t kfp-frontend-integration-test:local
+    ```
+
+1. Run the test with enabled networking (**this exposes your local networking stack to the testing container**):
+
+    ```bash
+    docker run --net=host kfp-frontend-integration-test:local --remote-run true
+    ```

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -72,10 +72,6 @@ describe('deploy helloworld sample run', () => {
     $('#experimentDescription').setValue(experimentDescription);
 
     $('#createExperimentBtn').click();
-
-    browser.waitUntil(() => {
-      return new URL(browser.getUrl()).hash.startsWith('#/runs/new');
-    }, waitTimeout);
   });
 
   it('creates a new run in the experiment', () => {
@@ -98,7 +94,6 @@ describe('deploy helloworld sample run', () => {
     $('#usePipelineVersionBtn').click();
 
     $('#pipelineVersionSelectorDialog').waitForVisible(waitTimeout, true);
-    browser.pause(1000);
 
     browser.keys(runName);
 
@@ -140,35 +135,31 @@ describe('deploy helloworld sample run', () => {
     assert(attempts, 'waited for 30 seconds but run did not start.');
 
     assert.equal($$('.tableRow').length, 1, 'should only show one run');
-  });
 
-  // Wait for a reasonable amount of time until the run is done
-  // and navigate to the run details page
-  it('waits for run to finish', () => {
-    let attempts = 0;
-    const maxAttempts = 90;
-
-    while (attempts < maxAttempts) {
-      browser.pause(1000);
-      attempts++;
-    }
-
+    // Navigate to details of the deployed run by clicking its anchor element
     browser.execute('document.querySelector(".tableRow a").click()');
-    browser.waitUntil(() => {
-      return new URL(browser.getUrl()).hash.startsWith('#/runs/details');
-    }, waitTimeout);
   });
 
   it('switches to config tab', () => {
-    $('button=Config').waitForVisible();
+    $('button=Config').waitForVisible(waitTimeout);
     $('button=Config').click();
-    browser.pause(waitTimeout);
   });
 
-  it('verifies run status', () => {
-    const status = getValueFromDetailsTable('Status');
-    assert.equal(status.trim(), 'Succeeded',
-      'run has not finished on time. Current status is: ' + status);
+  it('waits for run to finish', () => {
+    let status = getValueFromDetailsTable('Status');
+
+    let attempts = 0;
+    const maxAttempts = 60;
+
+    // Wait for a reasonable amount of time until the run is done
+    while (attempts < maxAttempts && status.trim() !== 'Succeeded') {
+      browser.pause(1000);
+      status = getValueFromDetailsTable('Status');
+      attempts++;
+    }
+
+    assert(attempts < maxAttempts, `waited for ${maxAttempts} seconds but run did not succeed. ` +
+      'Current status is: ' + status);
   });
 
   it('displays run created at date correctly', () => {
@@ -188,7 +179,6 @@ describe('deploy helloworld sample run', () => {
 
   it('has a 4-node graph', () => {
     const nodeSelector = '.graphNode';
-    $(nodeSelector).waitForVisible();
     const nodes = $$(nodeSelector).length;
     assert(nodes === 4, 'should have a 4-node graph, instead has: ' + nodes);
   });
@@ -228,7 +218,6 @@ describe('deploy helloworld sample run', () => {
     $('#usePipelineBtn').click();
 
     $('#pipelineSelectorDialog').waitForVisible(waitTimeout, true);
-    browser.pause(1000);
 
     browser.keys('Tab');
     browser.keys(runWithoutExperimentName);

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -72,6 +72,10 @@ describe('deploy helloworld sample run', () => {
     $('#experimentDescription').setValue(experimentDescription);
 
     $('#createExperimentBtn').click();
+
+    browser.waitUntil(() => {
+      return new URL(browser.getUrl()).hash.startsWith('#/runs/new');
+    }, waitTimeout);
   });
 
   it('creates a new run in the experiment', () => {
@@ -94,6 +98,7 @@ describe('deploy helloworld sample run', () => {
     $('#usePipelineVersionBtn').click();
 
     $('#pipelineVersionSelectorDialog').waitForVisible(waitTimeout, true);
+    browser.pause(1000);
 
     browser.keys(runName);
 
@@ -135,31 +140,35 @@ describe('deploy helloworld sample run', () => {
     assert(attempts, 'waited for 30 seconds but run did not start.');
 
     assert.equal($$('.tableRow').length, 1, 'should only show one run');
-
-    // Navigate to details of the deployed run by clicking its anchor element
-    browser.execute('document.querySelector(".tableRow a").click()');
   });
 
-  it('switches to config tab', () => {
-    $('button=Config').waitForVisible(waitTimeout);
-    $('button=Config').click();
-  });
-
+  // Wait for a reasonable amount of time until the run is done
+  // and navigate to the run details page
   it('waits for run to finish', () => {
-    let status = getValueFromDetailsTable('Status');
-
     let attempts = 0;
-    const maxAttempts = 60;
+    const maxAttempts = 90;
 
-    // Wait for a reasonable amount of time until the run is done
-    while (attempts < maxAttempts && status.trim() !== 'Succeeded') {
+    while (attempts < maxAttempts) {
       browser.pause(1000);
-      status = getValueFromDetailsTable('Status');
       attempts++;
     }
 
-    assert(attempts < maxAttempts, `waited for ${maxAttempts} seconds but run did not succeed. ` +
-      'Current status is: ' + status);
+    browser.execute('document.querySelector(".tableRow a").click()');
+    browser.waitUntil(() => {
+      return new URL(browser.getUrl()).hash.startsWith('#/runs/details');
+    }, waitTimeout);
+  });
+
+  it('switches to config tab', () => {
+    $('button=Config').waitForVisible();
+    $('button=Config').click();
+    browser.pause(waitTimeout);
+  });
+
+  it('verifies run status', () => {
+    const status = getValueFromDetailsTable('Status');
+    assert.equal(status.trim(), 'Succeeded',
+      'run has not finished on time. Current status is: ' + status);
   });
 
   it('displays run created at date correctly', () => {
@@ -179,6 +188,7 @@ describe('deploy helloworld sample run', () => {
 
   it('has a 4-node graph', () => {
     const nodeSelector = '.graphNode';
+    $(nodeSelector).waitForVisible();
     const nodes = $$(nodeSelector).length;
     assert(nodes === 4, 'should have a 4-node graph, instead has: ' + nodes);
   });
@@ -218,6 +228,7 @@ describe('deploy helloworld sample run', () => {
     $('#usePipelineBtn').click();
 
     $('#pipelineSelectorDialog').waitForVisible(waitTimeout, true);
+    browser.pause(1000);
 
     browser.keys('Tab');
     browser.keys(runWithoutExperimentName);


### PR DESCRIPTION
**Description of your changes:**

The goal of this PR is to improve debugging experience for the frontend integration test.

1. Changes the flow of the FE e2e test. The test waits for 90 seconds before opening run details page to verify run's status.
1. Adds local debugging option that would be of a great value for those who face failed tests.
1. Uploads test artifacts to the GCS bucket (this was missing, although artifacts are created).

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
