### PR TITLE
fix(frontend): Disable choosing pipeline version if pipeline is empty.

### DIFF
--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -283,6 +283,7 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
                       id='choosePipelineVersionBtn'
                       onClick={() => this.setStateSafe({ pipelineVersionSelectorOpen: true })}
                       style={{ padding: '3px 5px', margin: 0 }}
+                      disabled={!this.state.pipeline}
                     >
                       Choose
                     </Button>

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -530,6 +530,7 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
           >
             <WithStyles(Button)
               color="secondary"
+              disabled={true}
               id="choosePipelineVersionBtn"
               onClick={[Function]}
               style={
@@ -1051,6 +1052,7 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
           >
             <WithStyles(Button)
               color="secondary"
+              disabled={true}
               id="choosePipelineVersionBtn"
               onClick={[Function]}
               style={
@@ -1590,6 +1592,7 @@ exports[`NewRun changes title and form to default state if the new run is a one-
           >
             <WithStyles(Button)
               color="secondary"
+              disabled={true}
               id="choosePipelineVersionBtn"
               onClick={[Function]}
               style={
@@ -2111,6 +2114,7 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
           >
             <WithStyles(Button)
               color="secondary"
+              disabled={false}
               id="choosePipelineVersionBtn"
               onClick={[Function]}
               style={
@@ -2630,6 +2634,7 @@ exports[`NewRun renders the new run page 1`] = `
           >
             <WithStyles(Button)
               color="secondary"
+              disabled={true}
               id="choosePipelineVersionBtn"
               onClick={[Function]}
               style={
@@ -3151,6 +3156,7 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
           >
             <WithStyles(Button)
               color="secondary"
+              disabled={true}
               id="choosePipelineVersionBtn"
               onClick={[Function]}
               style={
@@ -3690,6 +3696,7 @@ exports[`NewRun updates the run's state with the associated experiment if one is
           >
             <WithStyles(Button)
               color="secondary"
+              disabled={true}
               id="choosePipelineVersionBtn"
               onClick={[Function]}
               style={


### PR DESCRIPTION
The main purpose of this PR is disable users to choose pipeline version if they haven't selected pipeline. (Current UI logic will pop an error message)

Before:

https://user-images.githubusercontent.com/56132941/216479645-ec297c1c-e60b-4326-ac31-301a165e7d56.mov


After:

https://user-images.githubusercontent.com/56132941/216479678-69ed08e6-e6ac-44a3-aa31-4f4358770c69.mov

