### PR TITLE
fix(frontend): Change the pipeline description field as optional.

### DIFF
--- a/frontend/src/pages/NewPipelineVersion.tsx
+++ b/frontend/src/pages/NewPipelineVersion.tsx
@@ -232,7 +232,7 @@ class NewPipelineVersion extends Page<{}, NewPipelineVersionState> {
               <Input
                 id='pipelineDescription'
                 value={pipelineDescription}
-                required={true}
+                required={false}
                 label='Pipeline Description'
                 variant='outlined'
                 inputRef={this._pipelineDescriptionRef}

--- a/frontend/src/pages/__snapshots__/NewPipelineVersion.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewPipelineVersion.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`NewPipelineVersion creating new pipeline renders the new pipeline page 
       }
       label="Pipeline Description"
       onChange={[Function]}
-      required={true}
+      required={false}
       value=""
       variant="outlined"
     />


### PR DESCRIPTION
Current UI incorrectly displays that pipeline description field is required 

Before:
<img width="893" alt="Screenshot 2023-02-03 at 11 24 49 AM" src="https://user-images.githubusercontent.com/56132941/216690509-fbd4d2e6-83fe-4752-9184-46410b9bfd49.png">

After:
<img width="893" alt="Screenshot 2023-02-03 at 11 25 48 AM" src="https://user-images.githubusercontent.com/56132941/216690557-0c9a463d-da1f-4502-8a39-7054b6dea4c3.png">
