### PR TITLE
feat(frontend): Conditionally enable to override the existing pipeline name with the name of uploaded file

### DIFF
--- a/frontend/src/pages/NewPipelineVersion.test.tsx
+++ b/frontend/src/pages/NewPipelineVersion.test.tsx
@@ -355,12 +355,36 @@ describe('NewPipelineVersion', () => {
 
       expect(tree.state('importMethod')).toBe(ImportMethod.LOCAL);
       expect(uploadPipelineSpy).toHaveBeenLastCalledWith(
-        'file_name',
+        'test pipeline name',
         'test pipeline description',
         file,
       );
       expect(createPipelineSpy).not.toHaveBeenCalled();
     });
+
+    it('replaces the pipeline name with uploaded file name if override checkbox is checked', async () => {
+      // tree = shallow(<NewPipelineVersion {...generateProps()} />);
+      
+      render(<NewPipelineVersion {...generateProps()}/>)
+
+      const pipelineNameInput = await screen.findByLabelText(/Pipeline name/);
+      fireEvent.change(pipelineNameInput, { target: { value: 'test-pipeline-name' } });
+
+      const uploadFileBtn = await screen.findByText('Upload a file');
+      fireEvent.click(uploadFileBtn);
+
+      const overrideNameBox = await screen.findByText('Overide pipeline name')
+      fireEvent.click(overrideNameBox);
+
+      const file = new File(['file contents'], 'file_name', { type: 'text/plain' });
+
+      // mock drop file from local.
+
+
+
+
+
+    })
 
     it('allows updating pipeline version name', async () => {
       render(

--- a/frontend/src/pages/NewPipelineVersion.test.tsx
+++ b/frontend/src/pages/NewPipelineVersion.test.tsx
@@ -363,17 +363,15 @@ describe('NewPipelineVersion', () => {
     });
 
     it('replaces the pipeline name with uploaded file name if override checkbox is checked', async () => {
-      // tree = shallow(<NewPipelineVersion {...generateProps()} />);
-
       render(<NewPipelineVersion {...generateProps()} />);
 
-      const pipelineNameInput = await screen.findByLabelText(/Pipeline Name/);
+      const pipelineNameInput = screen.getAllByLabelText(/Pipeline Name/)[0];
       fireEvent.change(pipelineNameInput, { target: { value: 'test-pipeline-name' } });
 
       const uploadFileBtn = await screen.findByText('Upload a file');
       fireEvent.click(uploadFileBtn);
 
-      const overrideNameBox = await screen.findByText('Override pipeline name');
+      const overrideNameBox = await screen.findByText('Override Pipeline Name');
       fireEvent.click(overrideNameBox);
 
       // mock drop file from local.
@@ -408,7 +406,7 @@ describe('NewPipelineVersion', () => {
       );
       const formCtlLabel = screen.getByLabelText('Create a new pipeline');
       fireEvent.click(formCtlLabel);
-      const pipelineNameInput = await screen.findByLabelText(/Pipeline Name/);
+      const pipelineNameInput = screen.getAllByLabelText(/Pipeline Name/)[0];
       fireEvent.change(pipelineNameInput, { target: { value: 'new pipeline name?' } });
       expect(pipelineNameInput.closest('input')?.value).toBe('new pipeline name?');
 

--- a/frontend/src/pages/NewPipelineVersion.test.tsx
+++ b/frontend/src/pages/NewPipelineVersion.test.tsx
@@ -364,27 +364,30 @@ describe('NewPipelineVersion', () => {
 
     it('replaces the pipeline name with uploaded file name if override checkbox is checked', async () => {
       // tree = shallow(<NewPipelineVersion {...generateProps()} />);
-      
-      render(<NewPipelineVersion {...generateProps()}/>)
 
-      const pipelineNameInput = await screen.findByLabelText(/Pipeline name/);
+      render(<NewPipelineVersion {...generateProps()} />);
+
+      const pipelineNameInput = await screen.findByLabelText(/Pipeline Name/);
       fireEvent.change(pipelineNameInput, { target: { value: 'test-pipeline-name' } });
 
       const uploadFileBtn = await screen.findByText('Upload a file');
       fireEvent.click(uploadFileBtn);
 
-      const overrideNameBox = await screen.findByText('Overide pipeline name')
+      const overrideNameBox = await screen.findByText('Override pipeline name');
       fireEvent.click(overrideNameBox);
 
-      const file = new File(['file contents'], 'file_name', { type: 'text/plain' });
-
       // mock drop file from local.
+      const uploadFile = await screen.findByText(/File/);
+      const file = new File(['file contents'], 'new-file-name', { type: 'text/plain' });
+      Object.defineProperty(uploadFile, 'files', {
+        value: [file],
+      });
+      fireEvent.drop(uploadFile);
 
-
-
-
-
-    })
+      const createBtn = await screen.findByText('Create');
+      fireEvent.click(createBtn);
+      expect(uploadPipelineSpy).toHaveBeenLastCalledWith('new-file-name', '', file);
+    });
 
     it('allows updating pipeline version name', async () => {
       render(

--- a/frontend/src/pages/NewPipelineVersion.test.tsx
+++ b/frontend/src/pages/NewPipelineVersion.test.tsx
@@ -355,7 +355,7 @@ describe('NewPipelineVersion', () => {
 
       expect(tree.state('importMethod')).toBe(ImportMethod.LOCAL);
       expect(uploadPipelineSpy).toHaveBeenLastCalledWith(
-        'test pipeline name',
+        'file_name',
         'test pipeline description',
         file,
       );

--- a/frontend/src/pages/NewPipelineVersion.tsx
+++ b/frontend/src/pages/NewPipelineVersion.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import Button from '@material-ui/core/Button';
+import { Button, Checkbox, FormControlLabel, InputAdornment} from '@material-ui/core';
+// import { Checkbox } from '@material-ui/core';
+// import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import InputAdornment from '@material-ui/core/InputAdornment';
+// import FormControlLabel from '@material-ui/core/FormControlLabel';
+// import InputAdornment from '@material-ui/core/InputAdornment';
 import Radio from '@material-ui/core/Radio';
 import { TextFieldProps } from '@material-ui/core/TextField';
 import * as React from 'react';
@@ -413,10 +415,30 @@ class NewPipelineVersion extends Page<{}, NewPipelineVersionState> {
                   style: {
                     maxWidth: 2000,
                     width: 455,
+                    // width: 290,
                   },
                 }}
               />
             </Dropzone>
+            {/* </div>
+            <div> */}
+            <FormControlLabel
+            // style={{ padding: '0px 120px', margin: 0, whiteSpace: 'nowrap' }}
+              // style={{adding: '3px 5px'}}
+              label='Override pipeline name'
+              control={
+                <Checkbox
+                  color='primary'
+                  // checked={customPipelineRootChecked}
+                  onChange={(event, checked) => {
+                    // setCustomPipelineRootChecked(checked);
+                    if (!checked) {
+                      // not overrid the pipeline names
+                    }
+                  }}
+                />
+              }
+            />
           </div>
           <div className={classes(commonCss.flex, padding(10, 'b'))}>
             <FormControlLabel

--- a/frontend/src/pages/NewPipelineVersion.tsx
+++ b/frontend/src/pages/NewPipelineVersion.tsx
@@ -414,14 +414,11 @@ class NewPipelineVersion extends Page<{}, NewPipelineVersionState> {
                   readOnly: true,
                   style: {
                     maxWidth: 2000,
-                    width: 455,
-                    // width: 290,
+                    width: 290,
                   },
                 }}
               />
             </Dropzone>
-            {/* </div>
-            <div> */}
             <FormControlLabel
             // style={{ padding: '0px 120px', margin: 0, whiteSpace: 'nowrap' }}
               // style={{adding: '3px 5px'}}
@@ -459,7 +456,7 @@ class NewPipelineVersion extends Page<{}, NewPipelineVersionState> {
               // Find a better to align this input box with others
               style={{
                 maxWidth: 2000,
-                width: 465,
+                width: 470,
               }}
             />
           </div>

--- a/frontend/src/pages/NewPipelineVersion.tsx
+++ b/frontend/src/pages/NewPipelineVersion.tsx
@@ -419,7 +419,7 @@ class NewPipelineVersion extends Page<{}, NewPipelineVersionState> {
               />
             </Dropzone>
             <FormControlLabel
-              label='Override pipeline name'
+              label='Override Pipeline Name'
               control={
                 <Checkbox
                   disabled={importMethod === ImportMethod.URL}

--- a/frontend/src/pages/NewPipelineVersion.tsx
+++ b/frontend/src/pages/NewPipelineVersion.tsx
@@ -699,7 +699,9 @@ class NewPipelineVersion extends Page<{}, NewPipelineVersionState> {
         dropzoneActive: false,
         file: files[0],
         fileName: files[0].name,
-        pipelineName: this.state.pipelineName || files[0].name.split('.')[0],
+        pipelineName: this.state.newPipeline
+          ? files[0].name.split('.')[0]
+          : this.state.pipelineName || files[0].name.split('.')[0],
       },
       () => {
         this._validate();

--- a/frontend/src/pages/NewPipelineVersion.tsx
+++ b/frontend/src/pages/NewPipelineVersion.tsx
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-import { Button, Checkbox, FormControlLabel, InputAdornment} from '@material-ui/core';
-// import { Checkbox } from '@material-ui/core';
-// import Button from '@material-ui/core/Button';
+import { Button, Checkbox, FormControlLabel, InputAdornment } from '@material-ui/core';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
-// import FormControlLabel from '@material-ui/core/FormControlLabel';
-// import InputAdornment from '@material-ui/core/InputAdornment';
 import Radio from '@material-ui/core/Radio';
 import { TextFieldProps } from '@material-ui/core/TextField';
 import * as React from 'react';
@@ -52,6 +48,7 @@ interface NewPipelineVersionState {
   pipelineDescription: string;
   pipelineId?: string;
   pipelineName?: string;
+  overridePipeineName: boolean;
   pipelineVersionName: string;
   pipelineVersionDescription: string;
   pipeline?: ApiPipeline;
@@ -140,6 +137,7 @@ class NewPipelineVersion extends Page<{}, NewPipelineVersionState> {
       isbeingCreated: false,
       newPipeline: pipelineId ? false : true,
       packageUrl: '',
+      overridePipeineName: false,
       pipelineDescription: '',
       pipelineId: '',
       pipelineName: '',
@@ -162,6 +160,7 @@ class NewPipelineVersion extends Page<{}, NewPipelineVersionState> {
     const {
       packageUrl,
       pipelineName,
+      overridePipeineName,
       pipelineVersionName,
       pipelineVersionDescription,
       isbeingCreated,
@@ -420,18 +419,14 @@ class NewPipelineVersion extends Page<{}, NewPipelineVersionState> {
               />
             </Dropzone>
             <FormControlLabel
-            // style={{ padding: '0px 120px', margin: 0, whiteSpace: 'nowrap' }}
-              // style={{adding: '3px 5px'}}
               label='Override pipeline name'
               control={
                 <Checkbox
+                  disabled={importMethod === ImportMethod.URL}
                   color='primary'
-                  // checked={customPipelineRootChecked}
+                  checked={overridePipeineName}
                   onChange={(event, checked) => {
-                    // setCustomPipelineRootChecked(checked);
-                    if (!checked) {
-                      // not overrid the pipeline names
-                    }
+                    this.setState({ overridePipeineName: checked });
                   }}
                 />
               }
@@ -718,7 +713,7 @@ class NewPipelineVersion extends Page<{}, NewPipelineVersionState> {
         dropzoneActive: false,
         file: files[0],
         fileName: files[0].name,
-        pipelineName: this.state.newPipeline
+        pipelineName: this.state.overridePipeineName
           ? files[0].name.split('.')[0]
           : this.state.pipelineName || files[0].name.split('.')[0],
       },

--- a/frontend/src/pages/__snapshots__/NewPipelineVersion.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewPipelineVersion.test.tsx.snap
@@ -134,7 +134,7 @@ exports[`NewPipelineVersion creating new pipeline renders the new pipeline page 
               "readOnly": true,
               "style": Object {
                 "maxWidth": 2000,
-                "width": 455,
+                "width": 290,
               },
             }
           }
@@ -146,6 +146,16 @@ exports[`NewPipelineVersion creating new pipeline renders the new pipeline page 
           variant="outlined"
         />
       </n>
+      <WithStyles(WithFormControlContext(FormControlLabel))
+        control={
+          <WithStyles(Checkbox)
+            checked={false}
+            color="primary"
+            onChange={[Function]}
+          />
+        }
+        label="Override pipeline name"
+      />
     </div>
     <div
       className="flex"
@@ -170,7 +180,7 @@ exports[`NewPipelineVersion creating new pipeline renders the new pipeline page 
         style={
           Object {
             "maxWidth": 2000,
-            "width": 465,
+            "width": 470,
           }
         }
         value=""

--- a/frontend/src/pages/__snapshots__/NewPipelineVersion.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewPipelineVersion.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`NewPipelineVersion creating new pipeline renders the new pipeline page 
             onChange={[Function]}
           />
         }
-        label="Override pipeline name"
+        label="Override Pipeline Name"
       />
     </div>
     <div

--- a/frontend/src/pages/__snapshots__/NewPipelineVersion.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewPipelineVersion.test.tsx.snap
@@ -151,6 +151,7 @@ exports[`NewPipelineVersion creating new pipeline renders the new pipeline page 
           <WithStyles(Checkbox)
             checked={false}
             color="primary"
+            disabled={true}
             onChange={[Function]}
           />
         }


### PR DESCRIPTION
The main purpose of this PR is adding a checkbox to determine if the existing pipeline name is replaced with the name of uploaded file.

Before:

https://user-images.githubusercontent.com/56132941/216728770-c9b185a7-fd81-44fa-8a45-1b14ba2ea080.mov


After:

https://user-images.githubusercontent.com/56132941/217395164-050bd86c-fa0f-40ff-ade5-9ff509ba2f12.mov


