### PR TITLE
fix(frontend): Change the prompt and error message of parameter field into more readable text

### DIFF
--- a/frontend/src/components/NewRunParametersV2.test.tsx
+++ b/frontend/src/components/NewRunParametersV2.test.tsx
@@ -463,7 +463,7 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const structParam = screen.getByLabelText('structParam - map / dict');
+    const structParam = screen.getByLabelText('structParam - dict');
     fireEvent.change(structParam, { target: { value: '{"A":1,"B":2}' } });
     expect(handleParameterChangeSpy).toHaveBeenCalledTimes(1);
     expect(handleParameterChangeSpy).toHaveBeenLastCalledWith({
@@ -488,7 +488,7 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const structParam = screen.getByLabelText('structParam - map / dict');
+    const structParam = screen.getByLabelText('structParam - dict');
     fireEvent.change(structParam, { target: { value: '"A":1,"B":2' } });
     expect(handleParameterChangeSpy).toHaveBeenCalledTimes(1);
     expect(handleParameterChangeSpy).toHaveBeenLastCalledWith({
@@ -732,12 +732,12 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const structParam = screen.getByLabelText('structParam - map / dict');
+    const structParam = screen.getByLabelText('structParam - dict');
     fireEvent.change(structParam, { target: { value: '123' } });
     expect(setIsValidInputSpy).toHaveBeenCalledTimes(2);
     expect(setIsValidInputSpy).toHaveBeenLastCalledWith(false);
     screen.getByDisplayValue('123');
-    screen.getByText('Invalid input. This parameter should be in map / dict type');
+    screen.getByText('Invalid input. This parameter should be in dict type');
   });
 
   it('show error message for invalid struct input', () => {
@@ -757,12 +757,12 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const structParam = screen.getByLabelText('structParam - map / dict');
+    const structParam = screen.getByLabelText('structParam - dict');
     fireEvent.change(structParam, { target: { value: '[1,2,3]' } });
     expect(setIsValidInputSpy).toHaveBeenCalledTimes(2);
     expect(setIsValidInputSpy).toHaveBeenLastCalledWith(false);
     screen.getByDisplayValue('[1,2,3]');
-    screen.getByText('Invalid input. This parameter should be in map / dict type');
+    screen.getByText('Invalid input. This parameter should be in dict type');
   });
 
   it('set input as valid type with valid struct input', () => {
@@ -782,7 +782,7 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const structParam = screen.getByLabelText('structParam - map / dict');
+    const structParam = screen.getByLabelText('structParam - dict');
     fireEvent.change(structParam, { target: { value: '{"A":1,"B":2}' } });
     expect(setIsValidInputSpy).toHaveBeenCalledTimes(2);
     expect(setIsValidInputSpy).toHaveBeenLastCalledWith(true);

--- a/frontend/src/components/NewRunParametersV2.test.tsx
+++ b/frontend/src/components/NewRunParametersV2.test.tsx
@@ -48,11 +48,11 @@ describe('NewRunParametersV2', () => {
 
     screen.getByText('Run parameters');
     screen.getByText('Specify parameters required by the pipeline');
-    screen.getByText('strParam - STRING');
+    screen.getByText('strParam - string');
     screen.getByDisplayValue('string value');
-    screen.getByText('boolParam - BOOLEAN');
+    screen.getByText('boolParam - boolean');
     screen.getByDisplayValue('true');
-    screen.getByText('intParam - NUMBER_INTEGER');
+    screen.getByText('intParam - integer');
     screen.getByDisplayValue('123');
   });
 
@@ -133,7 +133,7 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const strParam = screen.getByLabelText('strParam - STRING');
+    const strParam = screen.getByLabelText('strParam - string');
     fireEvent.change(strParam, { target: { value: 'new string' } });
     expect(handleParameterChangeSpy).toHaveBeenCalledTimes(1);
     expect(handleParameterChangeSpy).toHaveBeenLastCalledWith({
@@ -184,7 +184,7 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const boolParam = screen.getByLabelText('boolParam - BOOLEAN');
+    const boolParam = screen.getByLabelText('boolParam - boolean');
     fireEvent.change(boolParam, { target: { value: 'true' } });
     expect(handleParameterChangeSpy).toHaveBeenCalledTimes(1);
     expect(handleParameterChangeSpy).toHaveBeenLastCalledWith({
@@ -209,7 +209,7 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const boolParam = screen.getByLabelText('boolParam - BOOLEAN');
+    const boolParam = screen.getByLabelText('boolParam - boolean');
     fireEvent.change(boolParam, { target: { value: 'True' } });
     expect(handleParameterChangeSpy).toHaveBeenCalledTimes(1);
     expect(handleParameterChangeSpy).toHaveBeenLastCalledWith({
@@ -260,7 +260,7 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const intParam = screen.getByLabelText('intParam - NUMBER_INTEGER');
+    const intParam = screen.getByLabelText('intParam - integer');
     fireEvent.change(intParam, { target: { value: '789' } });
     expect(handleParameterChangeSpy).toHaveBeenCalledTimes(1);
     expect(handleParameterChangeSpy).toHaveBeenLastCalledWith({
@@ -285,7 +285,7 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const intParam = screen.getByLabelText('intParam - NUMBER_INTEGER');
+    const intParam = screen.getByLabelText('intParam - integer');
     fireEvent.change(intParam, { target: { value: '7.89' } });
     expect(handleParameterChangeSpy).toHaveBeenCalledTimes(1);
     expect(handleParameterChangeSpy).toHaveBeenLastCalledWith({
@@ -336,7 +336,7 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const doubleParam = screen.getByLabelText('doubleParam - NUMBER_DOUBLE');
+    const doubleParam = screen.getByLabelText('doubleParam - double');
     fireEvent.change(doubleParam, { target: { value: '7.89' } });
     expect(handleParameterChangeSpy).toHaveBeenCalledTimes(1);
     expect(handleParameterChangeSpy).toHaveBeenLastCalledWith({
@@ -387,7 +387,7 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const listParam = screen.getByLabelText('listParam - LIST');
+    const listParam = screen.getByLabelText('listParam - list');
     fireEvent.change(listParam, { target: { value: '[4,5,6]' } });
     expect(handleParameterChangeSpy).toHaveBeenCalledTimes(1);
     expect(handleParameterChangeSpy).toHaveBeenLastCalledWith({
@@ -412,7 +412,7 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const listParam = screen.getByLabelText('listParam - LIST');
+    const listParam = screen.getByLabelText('listParam - list');
     fireEvent.change(listParam, { target: { value: '[4,5,6' } });
     expect(handleParameterChangeSpy).toHaveBeenCalledTimes(1);
     expect(handleParameterChangeSpy).toHaveBeenLastCalledWith({
@@ -463,7 +463,7 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const structParam = screen.getByLabelText('structParam - STRUCT');
+    const structParam = screen.getByLabelText('structParam - map / dict');
     fireEvent.change(structParam, { target: { value: '{"A":1,"B":2}' } });
     expect(handleParameterChangeSpy).toHaveBeenCalledTimes(1);
     expect(handleParameterChangeSpy).toHaveBeenLastCalledWith({
@@ -488,7 +488,7 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const structParam = screen.getByLabelText('structParam - STRUCT');
+    const structParam = screen.getByLabelText('structParam - map / dict');
     fireEvent.change(structParam, { target: { value: '"A":1,"B":2' } });
     expect(handleParameterChangeSpy).toHaveBeenCalledTimes(1);
     expect(handleParameterChangeSpy).toHaveBeenLastCalledWith({
@@ -558,12 +558,12 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const intParam = screen.getByLabelText('intParam - NUMBER_INTEGER');
+    const intParam = screen.getByLabelText('intParam - integer');
     fireEvent.change(intParam, { target: { value: '123b' } });
     expect(setIsValidInputSpy).toHaveBeenCalledTimes(2);
     expect(setIsValidInputSpy).toHaveBeenLastCalledWith(false);
     screen.getByDisplayValue('123b');
-    screen.getByText('Invalid input. This parameter should be in NUMBER_INTEGER type');
+    screen.getByText('Invalid input. This parameter should be in integer type');
   });
 
   it('show error message for missing integer input', () => {
@@ -608,12 +608,12 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const boolParam = screen.getByLabelText('boolParam - BOOLEAN');
+    const boolParam = screen.getByLabelText('boolParam - boolean');
     fireEvent.change(boolParam, { target: { value: '123' } });
     expect(setIsValidInputSpy).toHaveBeenCalledTimes(2);
     expect(setIsValidInputSpy).toHaveBeenLastCalledWith(false);
     screen.getByDisplayValue('123');
-    screen.getByText('Invalid input. This parameter should be in BOOLEAN type');
+    screen.getByText('Invalid input. This parameter should be in boolean type');
   });
 
   it('set input as valid type with valid boolean input', () => {
@@ -633,7 +633,7 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const boolParam = screen.getByLabelText('boolParam - BOOLEAN');
+    const boolParam = screen.getByLabelText('boolParam - boolean');
     fireEvent.change(boolParam, { target: { value: 'true' } });
     expect(setIsValidInputSpy).toHaveBeenCalledTimes(2);
     expect(setIsValidInputSpy).toHaveBeenLastCalledWith(true);
@@ -657,12 +657,12 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const doubleParam = screen.getByLabelText('doubleParam - NUMBER_DOUBLE');
+    const doubleParam = screen.getByLabelText('doubleParam - double');
     fireEvent.change(doubleParam, { target: { value: '123b' } });
     expect(setIsValidInputSpy).toHaveBeenCalledTimes(2);
     expect(setIsValidInputSpy).toHaveBeenLastCalledWith(false);
     screen.getByDisplayValue('123b');
-    screen.getByText('Invalid input. This parameter should be in NUMBER_DOUBLE type');
+    screen.getByText('Invalid input. This parameter should be in double type');
   });
 
   it('show error message for invalid list input', () => {
@@ -682,12 +682,12 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const listParam = screen.getByLabelText('listParam - LIST');
+    const listParam = screen.getByLabelText('listParam - list');
     fireEvent.change(listParam, { target: { value: '123' } });
     expect(setIsValidInputSpy).toHaveBeenCalledTimes(2);
     expect(setIsValidInputSpy).toHaveBeenLastCalledWith(false);
     screen.getByDisplayValue('123');
-    screen.getByText('Invalid input. This parameter should be in LIST type');
+    screen.getByText('Invalid input. This parameter should be in list type');
   });
 
   it('show error message for invalid list input', () => {
@@ -707,12 +707,12 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const listParam = screen.getByLabelText('listParam - LIST');
+    const listParam = screen.getByLabelText('listParam - list');
     fireEvent.change(listParam, { target: { value: '[1,2,3' } });
     expect(setIsValidInputSpy).toHaveBeenCalledTimes(2);
     expect(setIsValidInputSpy).toHaveBeenLastCalledWith(false);
     screen.getByDisplayValue('[1,2,3');
-    screen.getByText('Invalid input. This parameter should be in LIST type');
+    screen.getByText('Invalid input. This parameter should be in list type');
   });
 
   it('show error message for invalid struct input', () => {
@@ -732,12 +732,12 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const structParam = screen.getByLabelText('structParam - STRUCT');
+    const structParam = screen.getByLabelText('structParam - map / dict');
     fireEvent.change(structParam, { target: { value: '123' } });
     expect(setIsValidInputSpy).toHaveBeenCalledTimes(2);
     expect(setIsValidInputSpy).toHaveBeenLastCalledWith(false);
     screen.getByDisplayValue('123');
-    screen.getByText('Invalid input. This parameter should be in STRUCT type');
+    screen.getByText('Invalid input. This parameter should be in map / dict type');
   });
 
   it('show error message for invalid struct input', () => {
@@ -757,12 +757,12 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const structParam = screen.getByLabelText('structParam - STRUCT');
+    const structParam = screen.getByLabelText('structParam - map / dict');
     fireEvent.change(structParam, { target: { value: '[1,2,3]' } });
     expect(setIsValidInputSpy).toHaveBeenCalledTimes(2);
     expect(setIsValidInputSpy).toHaveBeenLastCalledWith(false);
     screen.getByDisplayValue('[1,2,3]');
-    screen.getByText('Invalid input. This parameter should be in STRUCT type');
+    screen.getByText('Invalid input. This parameter should be in map / dict type');
   });
 
   it('set input as valid type with valid struct input', () => {
@@ -782,7 +782,7 @@ describe('NewRunParametersV2', () => {
     };
     render(<NewRunParametersV2 {...props} />);
 
-    const structParam = screen.getByLabelText('structParam - STRUCT');
+    const structParam = screen.getByLabelText('structParam - map / dict');
     fireEvent.change(structParam, { target: { value: '{"A":1,"B":2}' } });
     expect(setIsValidInputSpy).toHaveBeenCalledTimes(2);
     expect(setIsValidInputSpy).toHaveBeenLastCalledWith(true);

--- a/frontend/src/components/NewRunParametersV2.tsx
+++ b/frontend/src/components/NewRunParametersV2.tsx
@@ -60,6 +60,15 @@ interface NewRunParametersProps {
   setIsValidInput?: (isValid: boolean) => void;
 }
 
+const protoMap = new Map<string, string>([
+  ['NUMBER_DOUBLE', 'float/double'],
+  ['NUMBER_INTEGER', 'integer'],
+  ['STRING', 'string'],
+  ['BOOLEAN', 'boolean'],
+  ['LIST', 'list'],
+  ['STRUCT', 'map/dict'],
+]);
+
 function convertInput(paramStr: string, paramType: ParameterType_ParameterTypeEnum): any {
   // TBD (jlyaoyuli): Currently, empty string is not allowed.
   if (paramStr === '') {
@@ -122,7 +131,7 @@ function generateInputValidationErrMsg(
     case null:
       errorMessage =
         'Invalid input. This parameter should be in ' +
-        ParameterType_ParameterTypeEnum[paramType] +
+        protoMap.get(ParameterType_ParameterTypeEnum[paramType]) +
         ' type';
       break;
     default:

--- a/frontend/src/components/NewRunParametersV2.tsx
+++ b/frontend/src/components/NewRunParametersV2.tsx
@@ -61,7 +61,7 @@ interface NewRunParametersProps {
 }
 
 const protoMap = new Map<string, string>([
-  ['NUMBER_DOUBLE', 'float / double'],
+  ['NUMBER_DOUBLE', 'double'],
   ['NUMBER_INTEGER', 'integer'],
   ['STRING', 'string'],
   ['BOOLEAN', 'boolean'],

--- a/frontend/src/components/NewRunParametersV2.tsx
+++ b/frontend/src/components/NewRunParametersV2.tsx
@@ -61,12 +61,12 @@ interface NewRunParametersProps {
 }
 
 const protoMap = new Map<string, string>([
-  ['NUMBER_DOUBLE', 'float/double'],
+  ['NUMBER_DOUBLE', 'float / double'],
   ['NUMBER_INTEGER', 'integer'],
   ['STRING', 'string'],
   ['BOOLEAN', 'boolean'],
   ['LIST', 'list'],
-  ['STRUCT', 'map/dict'],
+  ['STRUCT', 'map / dict'],
 ]);
 
 function convertInput(paramStr: string, paramType: ParameterType_ParameterTypeEnum): any {
@@ -268,7 +268,7 @@ function NewRunParametersV2(props: NewRunParametersProps) {
         <div>
           {Object.entries(specParameters).map(([k, v]) => {
             const param = {
-              key: `${k} - ${ParameterType_ParameterTypeEnum[v.parameterType]}`,
+              key: `${k} - ${protoMap.get(ParameterType_ParameterTypeEnum[v.parameterType])}`,
               value: updatedParameters[k],
               type: v.parameterType,
               errorMsg: errorMessages[k],

--- a/frontend/src/components/NewRunParametersV2.tsx
+++ b/frontend/src/components/NewRunParametersV2.tsx
@@ -66,7 +66,7 @@ const protoMap = new Map<string, string>([
   ['STRING', 'string'],
   ['BOOLEAN', 'boolean'],
   ['LIST', 'list'],
-  ['STRUCT', 'map / dict'],
+  ['STRUCT', 'dict'],
 ]);
 
 function convertInput(paramStr: string, paramType: ParameterType_ParameterTypeEnum): any {


### PR DESCRIPTION
Previously, KFP directly use proto type as error message of parameter field. The main purpose of this change is change the type in the text more readable, which aligns with MP's design.

The changes as follow:
```
NUMBER_INTEGER -> integer
NUMBER_DOUBLE -> double
BOOLEAN -> boolean
STRING -> string
LIST -> list
STRUCT -> map / dict
```

Before:
![Screenshot 2023-02-08 at 11 36 02 AM](https://user-images.githubusercontent.com/56132941/217633945-1c93e9d5-c71b-4353-a66b-04b1adf79f29.png)

After:
![Screenshot 2023-02-08 at 11 37 39 AM](https://user-images.githubusercontent.com/56132941/217633977-004f8707-f155-4d49-8ba4-797a90f2c4f8.png)


