### PR TITLE
test: install compatible `kfp-server-api` and `kfp` packages

### DIFF
--- a/backend/api/v1beta1/python_http_client/setup.py
+++ b/backend/api/v1beta1/python_http_client/setup.py
@@ -13,7 +13,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "kfp-server-api"
-VERSION = "2.0.0-beta.0"
+VERSION = "2.0.0-alpha.6"
 # To install the library, run the following
 #
 # python setup.py install

--- a/test/sample-test/Dockerfile
+++ b/test/sample-test/Dockerfile
@@ -13,11 +13,9 @@ RUN pip3 install -r /python/src/github.com/kubeflow/pipelines/test/sample-test/r
 # TODO: remove deprecated dependency
 COPY ./sdk/python/requirements-deprecated.txt /python/src/github.com/kubeflow/pipelines/sdk/python/requirements-deprecated.txt
 RUN pip3 install -r /python/src/github.com/kubeflow/pipelines/sdk/python/requirements-deprecated.txt
-# Install KFP server API from commit.
-COPY ./backend/api/v1beta1/python_http_client /python_http_client
 # Install python client, including DSL compiler.
 COPY ./sdk/python /sdk/python
-RUN pip3 install /python_http_client  /sdk/python
+RUN pip3 install /sdk/python
 
 # Copy sample test and samples source code.
 COPY ./test/sample-test /python/src/github.com/kubeflow/pipelines/test/sample-test

--- a/test/sample-test/Dockerfile
+++ b/test/sample-test/Dockerfile
@@ -13,9 +13,11 @@ RUN pip3 install -r /python/src/github.com/kubeflow/pipelines/test/sample-test/r
 # TODO: remove deprecated dependency
 COPY ./sdk/python/requirements-deprecated.txt /python/src/github.com/kubeflow/pipelines/sdk/python/requirements-deprecated.txt
 RUN pip3 install -r /python/src/github.com/kubeflow/pipelines/sdk/python/requirements-deprecated.txt
+# TODO(chensun): Remove install KFP server API from commit once we migrate tests away from using legacy client.
+COPY ./backend/api/v1beta1/python_http_client /python_http_client
 # Install python client, including DSL compiler.
 COPY ./sdk/python /sdk/python
-RUN pip3 install /sdk/python
+RUN pip3 install /python_http_client  /sdk/python
 
 # Copy sample test and samples source code.
 COPY ./test/sample-test /python/src/github.com/kubeflow/pipelines/test/sample-test


### PR DESCRIPTION
**Description of your changes:**
`kfp` (sdk) from HEAD and `kfp-server-api` from HEAD may not always be compatible. This could happen anytime API changes, and SDK may not integrate with API changes at the same time. 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
