### PR TITLE
feat(frontend): Support namespaced pipelines from the UI. Closes #5084

### DIFF
--- a/frontend/src/atoms/MD2Tabs.tsx
+++ b/frontend/src/atoms/MD2Tabs.tsx
@@ -16,6 +16,7 @@
 
 import * as React from 'react';
 import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
 import Separator from './Separator';
 import { color, fontsize } from '../Css';
 import { classes, stylesheet } from 'typestyle';
@@ -24,7 +25,7 @@ import { logger } from '../lib/Utils';
 interface MD2TabsProps {
   onSwitch?: (tab: number) => void;
   selectedTab: number;
-  tabs: string[];
+  tabs: (string | { header: string; tooltip: string })[];
 }
 
 const css = stylesheet({
@@ -74,22 +75,30 @@ class MD2Tabs extends React.Component<MD2TabsProps, any> {
   public render(): JSX.Element {
     const selected = this._getSelectedIndex();
     const switchHandler = this.props.onSwitch || (() => null);
+    const tabs = this.props.tabs.map(tab => {
+      if (typeof tab === 'string') {
+        return { header: tab, tooltip: '' };
+      }
+      return tab;
+    });
     return (
       <div className={css.tabs} ref={this._rootRef}>
         <div className={css.indicator} ref={this._indicatorRef} />
         <Separator units={20} />
-        {this.props.tabs.map((tab, i) => (
-          <Button
-            className={classes(css.button, i === selected ? css.active : '')}
-            key={i}
-            onClick={() => {
-              if (i !== selected) {
-                switchHandler(i);
-              }
-            }}
-          >
-            <span ref={this._tabRefs[i]}>{tab}</span>
-          </Button>
+        {tabs.map((tab, i) => (
+          <Tooltip title={tab.tooltip} placement='top-start' key={i}>
+            <Button
+              className={classes(css.button, i === selected ? css.active : '')}
+              key={i}
+              onClick={() => {
+                if (i !== selected) {
+                  switchHandler(i);
+                }
+              }}
+            >
+              <span ref={this._tabRefs[i]}>{tab.header}</span>
+            </Button>
+          </Tooltip>
         ))}
       </div>
     );

--- a/frontend/src/atoms/__snapshots__/MD2Tabs.test.tsx.snap
+++ b/frontend/src/atoms/__snapshots__/MD2Tabs.test.tsx.snap
@@ -29,292 +29,1174 @@ exports[`Input gracefully handles an out of bound selectedTab value 1`] = `
         }
       />
     </Separator>
-    <WithStyles(Button)
-      className="button active"
+    <WithStyles(Tooltip)
       key="0"
-      onClick={[Function]}
+      placement="top-start"
+      title=""
     >
-      <Button
-        className="button active"
+      <Tooltip
+        TransitionComponent={[Function]}
         classes={
           Object {
-            "colorInherit": "MuiButton-colorInherit-22",
-            "contained": "MuiButton-contained-12",
-            "containedPrimary": "MuiButton-containedPrimary-13",
-            "containedSecondary": "MuiButton-containedSecondary-14",
-            "disabled": "MuiButton-disabled-21",
-            "extendedFab": "MuiButton-extendedFab-19",
-            "fab": "MuiButton-fab-18",
-            "flat": "MuiButton-flat-6",
-            "flatPrimary": "MuiButton-flatPrimary-7",
-            "flatSecondary": "MuiButton-flatSecondary-8",
-            "focusVisible": "MuiButton-focusVisible-20",
-            "fullWidth": "MuiButton-fullWidth-26",
-            "label": "MuiButton-label-2",
-            "mini": "MuiButton-mini-23",
-            "outlined": "MuiButton-outlined-9",
-            "outlinedPrimary": "MuiButton-outlinedPrimary-10",
-            "outlinedSecondary": "MuiButton-outlinedSecondary-11",
-            "raised": "MuiButton-raised-15",
-            "raisedPrimary": "MuiButton-raisedPrimary-16",
-            "raisedSecondary": "MuiButton-raisedSecondary-17",
-            "root": "MuiButton-root-1",
-            "sizeLarge": "MuiButton-sizeLarge-25",
-            "sizeSmall": "MuiButton-sizeSmall-24",
-            "text": "MuiButton-text-3",
-            "textPrimary": "MuiButton-textPrimary-4",
-            "textSecondary": "MuiButton-textSecondary-5",
+            "popper": "MuiTooltip-popper-1",
+            "popperInteractive": "MuiTooltip-popperInteractive-2",
+            "tooltip": "MuiTooltip-tooltip-3",
+            "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-8",
+            "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-5",
+            "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-6",
+            "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-7",
+            "touch": "MuiTooltip-touch-4",
           }
         }
-        color="default"
-        component="button"
-        disableFocusRipple={false}
-        disabled={false}
-        fullWidth={false}
-        mini={false}
-        onClick={[Function]}
-        size="medium"
-        type="button"
-        variant="text"
+        disableFocusListener={false}
+        disableHoverListener={false}
+        disableTouchListener={false}
+        enterDelay={0}
+        enterTouchDelay={1000}
+        interactive={false}
+        leaveDelay={0}
+        leaveTouchDelay={1500}
+        placement="top-start"
+        theme={
+          Object {
+            "breakpoints": Object {
+              "between": [Function],
+              "down": [Function],
+              "keys": Array [
+                "xs",
+                "sm",
+                "md",
+                "lg",
+                "xl",
+              ],
+              "only": [Function],
+              "up": [Function],
+              "values": Object {
+                "lg": 1280,
+                "md": 960,
+                "sm": 600,
+                "xl": 1920,
+                "xs": 0,
+              },
+              "width": [Function],
+            },
+            "direction": "ltr",
+            "mixins": Object {
+              "gutters": [Function],
+              "toolbar": Object {
+                "@media (min-width:0px) and (orientation: landscape)": Object {
+                  "minHeight": 48,
+                },
+                "@media (min-width:600px)": Object {
+                  "minHeight": 64,
+                },
+                "minHeight": 56,
+              },
+            },
+            "overrides": Object {},
+            "palette": Object {
+              "action": Object {
+                "active": "rgba(0, 0, 0, 0.54)",
+                "disabled": "rgba(0, 0, 0, 0.26)",
+                "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                "hover": "rgba(0, 0, 0, 0.08)",
+                "hoverOpacity": 0.08,
+                "selected": "rgba(0, 0, 0, 0.14)",
+              },
+              "augmentColor": [Function],
+              "background": Object {
+                "default": "#fafafa",
+                "paper": "#fff",
+              },
+              "common": Object {
+                "black": "#000",
+                "white": "#fff",
+              },
+              "contrastThreshold": 3,
+              "divider": "rgba(0, 0, 0, 0.12)",
+              "error": Object {
+                "contrastText": "#fff",
+                "dark": "#d32f2f",
+                "light": "#e57373",
+                "main": "#f44336",
+              },
+              "getContrastText": [Function],
+              "grey": Object {
+                "100": "#f5f5f5",
+                "200": "#eeeeee",
+                "300": "#e0e0e0",
+                "400": "#bdbdbd",
+                "50": "#fafafa",
+                "500": "#9e9e9e",
+                "600": "#757575",
+                "700": "#616161",
+                "800": "#424242",
+                "900": "#212121",
+                "A100": "#d5d5d5",
+                "A200": "#aaaaaa",
+                "A400": "#303030",
+                "A700": "#616161",
+              },
+              "primary": Object {
+                "contrastText": "#fff",
+                "dark": "#303f9f",
+                "light": "#7986cb",
+                "main": "#3f51b5",
+              },
+              "secondary": Object {
+                "contrastText": "#fff",
+                "dark": "#c51162",
+                "light": "#ff4081",
+                "main": "#f50057",
+              },
+              "text": Object {
+                "disabled": "rgba(0, 0, 0, 0.38)",
+                "hint": "rgba(0, 0, 0, 0.38)",
+                "primary": "rgba(0, 0, 0, 0.87)",
+                "secondary": "rgba(0, 0, 0, 0.54)",
+              },
+              "tonalOffset": 0.2,
+              "type": "light",
+            },
+            "props": Object {},
+            "shadows": Array [
+              "none",
+              "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+              "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+              "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+              "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+              "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+              "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+              "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+              "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+              "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+              "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+              "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+              "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+              "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+              "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+              "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+              "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+              "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+              "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+              "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+              "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+              "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+              "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+              "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+              "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+            ],
+            "shape": Object {
+              "borderRadius": 4,
+            },
+            "spacing": Object {
+              "unit": 8,
+            },
+            "transitions": Object {
+              "create": [Function],
+              "duration": Object {
+                "complex": 375,
+                "enteringScreen": 225,
+                "leavingScreen": 195,
+                "short": 250,
+                "shorter": 200,
+                "shortest": 150,
+                "standard": 300,
+              },
+              "easing": Object {
+                "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+              },
+              "getAutoHeightDuration": [Function],
+            },
+            "typography": Object {
+              "body1": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.875rem",
+                "fontWeight": 400,
+                "lineHeight": "1.46429em",
+              },
+              "body1Next": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 400,
+                "letterSpacing": "0.00938em",
+                "lineHeight": 1.5,
+              },
+              "body2": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.875rem",
+                "fontWeight": 500,
+                "lineHeight": "1.71429em",
+              },
+              "body2Next": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.875rem",
+                "fontWeight": 400,
+                "letterSpacing": "0.01071em",
+                "lineHeight": 1.5,
+              },
+              "button": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.875rem",
+                "fontWeight": 500,
+                "textTransform": "uppercase",
+              },
+              "buttonNext": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.875rem",
+                "fontWeight": 500,
+                "letterSpacing": "0.02857em",
+                "lineHeight": 1.75,
+                "textTransform": "uppercase",
+              },
+              "caption": Object {
+                "color": "rgba(0, 0, 0, 0.54)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+                "lineHeight": "1.375em",
+              },
+              "captionNext": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+                "letterSpacing": "0.03333em",
+                "lineHeight": 1.66,
+              },
+              "display1": Object {
+                "color": "rgba(0, 0, 0, 0.54)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "2.125rem",
+                "fontWeight": 400,
+                "lineHeight": "1.20588em",
+              },
+              "display2": Object {
+                "color": "rgba(0, 0, 0, 0.54)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "2.8125rem",
+                "fontWeight": 400,
+                "lineHeight": "1.13333em",
+                "marginLeft": "-.02em",
+              },
+              "display3": Object {
+                "color": "rgba(0, 0, 0, 0.54)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "3.5rem",
+                "fontWeight": 400,
+                "letterSpacing": "-.02em",
+                "lineHeight": "1.30357em",
+                "marginLeft": "-.02em",
+              },
+              "display4": Object {
+                "color": "rgba(0, 0, 0, 0.54)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "7rem",
+                "fontWeight": 300,
+                "letterSpacing": "-.04em",
+                "lineHeight": "1.14286em",
+                "marginLeft": "-.04em",
+              },
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": 14,
+              "fontWeightLight": 300,
+              "fontWeightMedium": 500,
+              "fontWeightRegular": 400,
+              "h1": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "6rem",
+                "fontWeight": 300,
+                "letterSpacing": "-0.01562em",
+                "lineHeight": 1,
+              },
+              "h2": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "3.75rem",
+                "fontWeight": 300,
+                "letterSpacing": "-0.00833em",
+                "lineHeight": 1,
+              },
+              "h3": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "3rem",
+                "fontWeight": 400,
+                "letterSpacing": "0em",
+                "lineHeight": 1.04,
+              },
+              "h4": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "2.125rem",
+                "fontWeight": 400,
+                "letterSpacing": "0.00735em",
+                "lineHeight": 1.17,
+              },
+              "h5": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "1.5rem",
+                "fontWeight": 400,
+                "letterSpacing": "0em",
+                "lineHeight": 1.33,
+              },
+              "h6": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "1.25rem",
+                "fontWeight": 500,
+                "letterSpacing": "0.0075em",
+                "lineHeight": 1.6,
+              },
+              "headline": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "1.5rem",
+                "fontWeight": 400,
+                "lineHeight": "1.35417em",
+              },
+              "overline": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+                "letterSpacing": "0.08333em",
+                "lineHeight": 2.66,
+                "textTransform": "uppercase",
+              },
+              "pxToRem": [Function],
+              "round": [Function],
+              "subheading": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 400,
+                "lineHeight": "1.5em",
+              },
+              "subtitle1": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 400,
+                "letterSpacing": "0.00938em",
+                "lineHeight": 1.75,
+              },
+              "subtitle2": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.875rem",
+                "fontWeight": 500,
+                "letterSpacing": "0.00714em",
+                "lineHeight": 1.57,
+              },
+              "title": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "1.3125rem",
+                "fontWeight": 500,
+                "lineHeight": "1.16667em",
+              },
+              "useNextVariants": false,
+            },
+            "zIndex": Object {
+              "appBar": 1100,
+              "drawer": 1200,
+              "mobileStepper": 1000,
+              "modal": 1300,
+              "snackbar": 1400,
+              "tooltip": 1500,
+            },
+          }
+        }
+        title=""
       >
-        <WithStyles(ButtonBase)
-          className="MuiButton-root-1 MuiButton-text-3 MuiButton-flat-6 button active"
-          component="button"
-          disabled={false}
-          focusRipple={true}
-          focusVisibleClassName="MuiButton-focusVisible-20"
-          onClick={[Function]}
-          type="button"
+        <RootRef
+          rootRef={[Function]}
         >
-          <ButtonBase
-            centerRipple={false}
-            className="MuiButton-root-1 MuiButton-text-3 MuiButton-flat-6 button active"
-            classes={
-              Object {
-                "disabled": "MuiButtonBase-disabled-28",
-                "focusVisible": "MuiButtonBase-focusVisible-29",
-                "root": "MuiButtonBase-root-27",
-              }
-            }
-            component="button"
-            disableRipple={false}
-            disableTouchRipple={false}
-            disabled={false}
-            focusRipple={true}
-            focusVisibleClassName="MuiButton-focusVisible-20"
+          <WithStyles(Button)
+            aria-describedby={null}
+            className="button active"
+            key="0"
+            onBlur={[Function]}
             onClick={[Function]}
-            tabIndex="0"
-            type="button"
+            onFocus={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+            title=""
           >
-            <button
-              className="MuiButtonBase-root-27 MuiButton-root-1 MuiButton-text-3 MuiButton-flat-6 button active"
+            <Button
+              aria-describedby={null}
+              className="button active"
+              classes={
+                Object {
+                  "colorInherit": "MuiButton-colorInherit-30",
+                  "contained": "MuiButton-contained-20",
+                  "containedPrimary": "MuiButton-containedPrimary-21",
+                  "containedSecondary": "MuiButton-containedSecondary-22",
+                  "disabled": "MuiButton-disabled-29",
+                  "extendedFab": "MuiButton-extendedFab-27",
+                  "fab": "MuiButton-fab-26",
+                  "flat": "MuiButton-flat-14",
+                  "flatPrimary": "MuiButton-flatPrimary-15",
+                  "flatSecondary": "MuiButton-flatSecondary-16",
+                  "focusVisible": "MuiButton-focusVisible-28",
+                  "fullWidth": "MuiButton-fullWidth-34",
+                  "label": "MuiButton-label-10",
+                  "mini": "MuiButton-mini-31",
+                  "outlined": "MuiButton-outlined-17",
+                  "outlinedPrimary": "MuiButton-outlinedPrimary-18",
+                  "outlinedSecondary": "MuiButton-outlinedSecondary-19",
+                  "raised": "MuiButton-raised-23",
+                  "raisedPrimary": "MuiButton-raisedPrimary-24",
+                  "raisedSecondary": "MuiButton-raisedSecondary-25",
+                  "root": "MuiButton-root-9",
+                  "sizeLarge": "MuiButton-sizeLarge-33",
+                  "sizeSmall": "MuiButton-sizeSmall-32",
+                  "text": "MuiButton-text-11",
+                  "textPrimary": "MuiButton-textPrimary-12",
+                  "textSecondary": "MuiButton-textSecondary-13",
+                }
+              }
+              color="default"
+              component="button"
+              disableFocusRipple={false}
               disabled={false}
+              fullWidth={false}
+              mini={false}
               onBlur={[Function]}
               onClick={[Function]}
-              onContextMenu={[Function]}
               onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
               onMouseLeave={[Function]}
-              onMouseUp={[Function]}
+              onMouseOver={[Function]}
               onTouchEnd={[Function]}
-              onTouchMove={[Function]}
               onTouchStart={[Function]}
-              tabIndex="0"
+              size="medium"
+              title=""
               type="button"
+              variant="text"
             >
-              <span
-                className="MuiButton-label-2"
+              <WithStyles(ButtonBase)
+                aria-describedby={null}
+                className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button active"
+                component="button"
+                disabled={false}
+                focusRipple={true}
+                focusVisibleClassName="MuiButton-focusVisible-28"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title=""
+                type="button"
               >
-                <span>
-                  tab1
-                </span>
-              </span>
-              <NoSsr
-                defer={false}
-                fallback={null}
-              >
-                <WithStyles(TouchRipple)
-                  center={false}
-                  innerRef={[Function]}
-                >
-                  <TouchRipple
-                    center={false}
-                    classes={
-                      Object {
-                        "child": "MuiTouchRipple-child-34",
-                        "childLeaving": "MuiTouchRipple-childLeaving-35",
-                        "childPulsate": "MuiTouchRipple-childPulsate-36",
-                        "ripple": "MuiTouchRipple-ripple-31",
-                        "ripplePulsate": "MuiTouchRipple-ripplePulsate-33",
-                        "rippleVisible": "MuiTouchRipple-rippleVisible-32",
-                        "root": "MuiTouchRipple-root-30",
-                      }
+                <ButtonBase
+                  aria-describedby={null}
+                  centerRipple={false}
+                  className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button active"
+                  classes={
+                    Object {
+                      "disabled": "MuiButtonBase-disabled-36",
+                      "focusVisible": "MuiButtonBase-focusVisible-37",
+                      "root": "MuiButtonBase-root-35",
                     }
+                  }
+                  component="button"
+                  disableRipple={false}
+                  disableTouchRipple={false}
+                  disabled={false}
+                  focusRipple={true}
+                  focusVisibleClassName="MuiButton-focusVisible-28"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex="0"
+                  title=""
+                  type="button"
+                >
+                  <button
+                    aria-describedby={null}
+                    className="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button active"
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onContextMenu={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    tabIndex="0"
+                    title=""
+                    type="button"
                   >
-                    <TransitionGroup
-                      childFactory={[Function]}
-                      className="MuiTouchRipple-root-30"
-                      component="span"
-                      enter={true}
-                      exit={true}
+                    <span
+                      className="MuiButton-label-10"
                     >
-                      <span
-                        className="MuiTouchRipple-root-30"
-                      />
-                    </TransitionGroup>
-                  </TouchRipple>
-                </WithStyles(TouchRipple)>
-              </NoSsr>
-            </button>
-          </ButtonBase>
-        </WithStyles(ButtonBase)>
-      </Button>
-    </WithStyles(Button)>
-    <WithStyles(Button)
-      className="button"
+                      <span>
+                        tab1
+                      </span>
+                    </span>
+                    <NoSsr
+                      defer={false}
+                      fallback={null}
+                    >
+                      <WithStyles(TouchRipple)
+                        center={false}
+                        innerRef={[Function]}
+                      >
+                        <TouchRipple
+                          center={false}
+                          classes={
+                            Object {
+                              "child": "MuiTouchRipple-child-42",
+                              "childLeaving": "MuiTouchRipple-childLeaving-43",
+                              "childPulsate": "MuiTouchRipple-childPulsate-44",
+                              "ripple": "MuiTouchRipple-ripple-39",
+                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-41",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-40",
+                              "root": "MuiTouchRipple-root-38",
+                            }
+                          }
+                        >
+                          <TransitionGroup
+                            childFactory={[Function]}
+                            className="MuiTouchRipple-root-38"
+                            component="span"
+                            enter={true}
+                            exit={true}
+                          >
+                            <span
+                              className="MuiTouchRipple-root-38"
+                            />
+                          </TransitionGroup>
+                        </TouchRipple>
+                      </WithStyles(TouchRipple)>
+                    </NoSsr>
+                  </button>
+                </ButtonBase>
+              </WithStyles(ButtonBase)>
+            </Button>
+          </WithStyles(Button)>
+        </RootRef>
+        <Popper
+          className="MuiTooltip-popper-1"
+          disablePortal={false}
+          id={null}
+          open={false}
+          placement="top-start"
+          transition={true}
+        />
+      </Tooltip>
+    </WithStyles(Tooltip)>
+    <WithStyles(Tooltip)
       key="1"
-      onClick={[Function]}
+      placement="top-start"
+      title=""
     >
-      <Button
-        className="button"
+      <Tooltip
+        TransitionComponent={[Function]}
         classes={
           Object {
-            "colorInherit": "MuiButton-colorInherit-22",
-            "contained": "MuiButton-contained-12",
-            "containedPrimary": "MuiButton-containedPrimary-13",
-            "containedSecondary": "MuiButton-containedSecondary-14",
-            "disabled": "MuiButton-disabled-21",
-            "extendedFab": "MuiButton-extendedFab-19",
-            "fab": "MuiButton-fab-18",
-            "flat": "MuiButton-flat-6",
-            "flatPrimary": "MuiButton-flatPrimary-7",
-            "flatSecondary": "MuiButton-flatSecondary-8",
-            "focusVisible": "MuiButton-focusVisible-20",
-            "fullWidth": "MuiButton-fullWidth-26",
-            "label": "MuiButton-label-2",
-            "mini": "MuiButton-mini-23",
-            "outlined": "MuiButton-outlined-9",
-            "outlinedPrimary": "MuiButton-outlinedPrimary-10",
-            "outlinedSecondary": "MuiButton-outlinedSecondary-11",
-            "raised": "MuiButton-raised-15",
-            "raisedPrimary": "MuiButton-raisedPrimary-16",
-            "raisedSecondary": "MuiButton-raisedSecondary-17",
-            "root": "MuiButton-root-1",
-            "sizeLarge": "MuiButton-sizeLarge-25",
-            "sizeSmall": "MuiButton-sizeSmall-24",
-            "text": "MuiButton-text-3",
-            "textPrimary": "MuiButton-textPrimary-4",
-            "textSecondary": "MuiButton-textSecondary-5",
+            "popper": "MuiTooltip-popper-1",
+            "popperInteractive": "MuiTooltip-popperInteractive-2",
+            "tooltip": "MuiTooltip-tooltip-3",
+            "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-8",
+            "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-5",
+            "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-6",
+            "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-7",
+            "touch": "MuiTooltip-touch-4",
           }
         }
-        color="default"
-        component="button"
-        disableFocusRipple={false}
-        disabled={false}
-        fullWidth={false}
-        mini={false}
-        onClick={[Function]}
-        size="medium"
-        type="button"
-        variant="text"
+        disableFocusListener={false}
+        disableHoverListener={false}
+        disableTouchListener={false}
+        enterDelay={0}
+        enterTouchDelay={1000}
+        interactive={false}
+        leaveDelay={0}
+        leaveTouchDelay={1500}
+        placement="top-start"
+        theme={
+          Object {
+            "breakpoints": Object {
+              "between": [Function],
+              "down": [Function],
+              "keys": Array [
+                "xs",
+                "sm",
+                "md",
+                "lg",
+                "xl",
+              ],
+              "only": [Function],
+              "up": [Function],
+              "values": Object {
+                "lg": 1280,
+                "md": 960,
+                "sm": 600,
+                "xl": 1920,
+                "xs": 0,
+              },
+              "width": [Function],
+            },
+            "direction": "ltr",
+            "mixins": Object {
+              "gutters": [Function],
+              "toolbar": Object {
+                "@media (min-width:0px) and (orientation: landscape)": Object {
+                  "minHeight": 48,
+                },
+                "@media (min-width:600px)": Object {
+                  "minHeight": 64,
+                },
+                "minHeight": 56,
+              },
+            },
+            "overrides": Object {},
+            "palette": Object {
+              "action": Object {
+                "active": "rgba(0, 0, 0, 0.54)",
+                "disabled": "rgba(0, 0, 0, 0.26)",
+                "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                "hover": "rgba(0, 0, 0, 0.08)",
+                "hoverOpacity": 0.08,
+                "selected": "rgba(0, 0, 0, 0.14)",
+              },
+              "augmentColor": [Function],
+              "background": Object {
+                "default": "#fafafa",
+                "paper": "#fff",
+              },
+              "common": Object {
+                "black": "#000",
+                "white": "#fff",
+              },
+              "contrastThreshold": 3,
+              "divider": "rgba(0, 0, 0, 0.12)",
+              "error": Object {
+                "contrastText": "#fff",
+                "dark": "#d32f2f",
+                "light": "#e57373",
+                "main": "#f44336",
+              },
+              "getContrastText": [Function],
+              "grey": Object {
+                "100": "#f5f5f5",
+                "200": "#eeeeee",
+                "300": "#e0e0e0",
+                "400": "#bdbdbd",
+                "50": "#fafafa",
+                "500": "#9e9e9e",
+                "600": "#757575",
+                "700": "#616161",
+                "800": "#424242",
+                "900": "#212121",
+                "A100": "#d5d5d5",
+                "A200": "#aaaaaa",
+                "A400": "#303030",
+                "A700": "#616161",
+              },
+              "primary": Object {
+                "contrastText": "#fff",
+                "dark": "#303f9f",
+                "light": "#7986cb",
+                "main": "#3f51b5",
+              },
+              "secondary": Object {
+                "contrastText": "#fff",
+                "dark": "#c51162",
+                "light": "#ff4081",
+                "main": "#f50057",
+              },
+              "text": Object {
+                "disabled": "rgba(0, 0, 0, 0.38)",
+                "hint": "rgba(0, 0, 0, 0.38)",
+                "primary": "rgba(0, 0, 0, 0.87)",
+                "secondary": "rgba(0, 0, 0, 0.54)",
+              },
+              "tonalOffset": 0.2,
+              "type": "light",
+            },
+            "props": Object {},
+            "shadows": Array [
+              "none",
+              "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+              "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+              "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+              "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+              "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+              "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+              "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+              "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+              "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+              "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+              "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+              "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+              "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+              "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+              "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+              "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+              "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+              "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+              "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+              "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+              "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+              "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+              "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+              "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+            ],
+            "shape": Object {
+              "borderRadius": 4,
+            },
+            "spacing": Object {
+              "unit": 8,
+            },
+            "transitions": Object {
+              "create": [Function],
+              "duration": Object {
+                "complex": 375,
+                "enteringScreen": 225,
+                "leavingScreen": 195,
+                "short": 250,
+                "shorter": 200,
+                "shortest": 150,
+                "standard": 300,
+              },
+              "easing": Object {
+                "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+              },
+              "getAutoHeightDuration": [Function],
+            },
+            "typography": Object {
+              "body1": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.875rem",
+                "fontWeight": 400,
+                "lineHeight": "1.46429em",
+              },
+              "body1Next": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 400,
+                "letterSpacing": "0.00938em",
+                "lineHeight": 1.5,
+              },
+              "body2": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.875rem",
+                "fontWeight": 500,
+                "lineHeight": "1.71429em",
+              },
+              "body2Next": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.875rem",
+                "fontWeight": 400,
+                "letterSpacing": "0.01071em",
+                "lineHeight": 1.5,
+              },
+              "button": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.875rem",
+                "fontWeight": 500,
+                "textTransform": "uppercase",
+              },
+              "buttonNext": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.875rem",
+                "fontWeight": 500,
+                "letterSpacing": "0.02857em",
+                "lineHeight": 1.75,
+                "textTransform": "uppercase",
+              },
+              "caption": Object {
+                "color": "rgba(0, 0, 0, 0.54)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+                "lineHeight": "1.375em",
+              },
+              "captionNext": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+                "letterSpacing": "0.03333em",
+                "lineHeight": 1.66,
+              },
+              "display1": Object {
+                "color": "rgba(0, 0, 0, 0.54)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "2.125rem",
+                "fontWeight": 400,
+                "lineHeight": "1.20588em",
+              },
+              "display2": Object {
+                "color": "rgba(0, 0, 0, 0.54)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "2.8125rem",
+                "fontWeight": 400,
+                "lineHeight": "1.13333em",
+                "marginLeft": "-.02em",
+              },
+              "display3": Object {
+                "color": "rgba(0, 0, 0, 0.54)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "3.5rem",
+                "fontWeight": 400,
+                "letterSpacing": "-.02em",
+                "lineHeight": "1.30357em",
+                "marginLeft": "-.02em",
+              },
+              "display4": Object {
+                "color": "rgba(0, 0, 0, 0.54)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "7rem",
+                "fontWeight": 300,
+                "letterSpacing": "-.04em",
+                "lineHeight": "1.14286em",
+                "marginLeft": "-.04em",
+              },
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": 14,
+              "fontWeightLight": 300,
+              "fontWeightMedium": 500,
+              "fontWeightRegular": 400,
+              "h1": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "6rem",
+                "fontWeight": 300,
+                "letterSpacing": "-0.01562em",
+                "lineHeight": 1,
+              },
+              "h2": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "3.75rem",
+                "fontWeight": 300,
+                "letterSpacing": "-0.00833em",
+                "lineHeight": 1,
+              },
+              "h3": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "3rem",
+                "fontWeight": 400,
+                "letterSpacing": "0em",
+                "lineHeight": 1.04,
+              },
+              "h4": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "2.125rem",
+                "fontWeight": 400,
+                "letterSpacing": "0.00735em",
+                "lineHeight": 1.17,
+              },
+              "h5": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "1.5rem",
+                "fontWeight": 400,
+                "letterSpacing": "0em",
+                "lineHeight": 1.33,
+              },
+              "h6": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "1.25rem",
+                "fontWeight": 500,
+                "letterSpacing": "0.0075em",
+                "lineHeight": 1.6,
+              },
+              "headline": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "1.5rem",
+                "fontWeight": 400,
+                "lineHeight": "1.35417em",
+              },
+              "overline": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.75rem",
+                "fontWeight": 400,
+                "letterSpacing": "0.08333em",
+                "lineHeight": 2.66,
+                "textTransform": "uppercase",
+              },
+              "pxToRem": [Function],
+              "round": [Function],
+              "subheading": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 400,
+                "lineHeight": "1.5em",
+              },
+              "subtitle1": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "1rem",
+                "fontWeight": 400,
+                "letterSpacing": "0.00938em",
+                "lineHeight": 1.75,
+              },
+              "subtitle2": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "0.875rem",
+                "fontWeight": 500,
+                "letterSpacing": "0.00714em",
+                "lineHeight": 1.57,
+              },
+              "title": Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": "1.3125rem",
+                "fontWeight": 500,
+                "lineHeight": "1.16667em",
+              },
+              "useNextVariants": false,
+            },
+            "zIndex": Object {
+              "appBar": 1100,
+              "drawer": 1200,
+              "mobileStepper": 1000,
+              "modal": 1300,
+              "snackbar": 1400,
+              "tooltip": 1500,
+            },
+          }
+        }
+        title=""
       >
-        <WithStyles(ButtonBase)
-          className="MuiButton-root-1 MuiButton-text-3 MuiButton-flat-6 button"
-          component="button"
-          disabled={false}
-          focusRipple={true}
-          focusVisibleClassName="MuiButton-focusVisible-20"
-          onClick={[Function]}
-          type="button"
+        <RootRef
+          rootRef={[Function]}
         >
-          <ButtonBase
-            centerRipple={false}
-            className="MuiButton-root-1 MuiButton-text-3 MuiButton-flat-6 button"
-            classes={
-              Object {
-                "disabled": "MuiButtonBase-disabled-28",
-                "focusVisible": "MuiButtonBase-focusVisible-29",
-                "root": "MuiButtonBase-root-27",
-              }
-            }
-            component="button"
-            disableRipple={false}
-            disableTouchRipple={false}
-            disabled={false}
-            focusRipple={true}
-            focusVisibleClassName="MuiButton-focusVisible-20"
+          <WithStyles(Button)
+            aria-describedby={null}
+            className="button"
+            key="1"
+            onBlur={[Function]}
             onClick={[Function]}
-            tabIndex="0"
-            type="button"
+            onFocus={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+            title=""
           >
-            <button
-              className="MuiButtonBase-root-27 MuiButton-root-1 MuiButton-text-3 MuiButton-flat-6 button"
+            <Button
+              aria-describedby={null}
+              className="button"
+              classes={
+                Object {
+                  "colorInherit": "MuiButton-colorInherit-30",
+                  "contained": "MuiButton-contained-20",
+                  "containedPrimary": "MuiButton-containedPrimary-21",
+                  "containedSecondary": "MuiButton-containedSecondary-22",
+                  "disabled": "MuiButton-disabled-29",
+                  "extendedFab": "MuiButton-extendedFab-27",
+                  "fab": "MuiButton-fab-26",
+                  "flat": "MuiButton-flat-14",
+                  "flatPrimary": "MuiButton-flatPrimary-15",
+                  "flatSecondary": "MuiButton-flatSecondary-16",
+                  "focusVisible": "MuiButton-focusVisible-28",
+                  "fullWidth": "MuiButton-fullWidth-34",
+                  "label": "MuiButton-label-10",
+                  "mini": "MuiButton-mini-31",
+                  "outlined": "MuiButton-outlined-17",
+                  "outlinedPrimary": "MuiButton-outlinedPrimary-18",
+                  "outlinedSecondary": "MuiButton-outlinedSecondary-19",
+                  "raised": "MuiButton-raised-23",
+                  "raisedPrimary": "MuiButton-raisedPrimary-24",
+                  "raisedSecondary": "MuiButton-raisedSecondary-25",
+                  "root": "MuiButton-root-9",
+                  "sizeLarge": "MuiButton-sizeLarge-33",
+                  "sizeSmall": "MuiButton-sizeSmall-32",
+                  "text": "MuiButton-text-11",
+                  "textPrimary": "MuiButton-textPrimary-12",
+                  "textSecondary": "MuiButton-textSecondary-13",
+                }
+              }
+              color="default"
+              component="button"
+              disableFocusRipple={false}
               disabled={false}
+              fullWidth={false}
+              mini={false}
               onBlur={[Function]}
               onClick={[Function]}
-              onContextMenu={[Function]}
               onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
               onMouseLeave={[Function]}
-              onMouseUp={[Function]}
+              onMouseOver={[Function]}
               onTouchEnd={[Function]}
-              onTouchMove={[Function]}
               onTouchStart={[Function]}
-              tabIndex="0"
+              size="medium"
+              title=""
               type="button"
+              variant="text"
             >
-              <span
-                className="MuiButton-label-2"
+              <WithStyles(ButtonBase)
+                aria-describedby={null}
+                className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                component="button"
+                disabled={false}
+                focusRipple={true}
+                focusVisibleClassName="MuiButton-focusVisible-28"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title=""
+                type="button"
               >
-                <span>
-                  tab2
-                </span>
-              </span>
-              <NoSsr
-                defer={false}
-                fallback={null}
-              >
-                <WithStyles(TouchRipple)
-                  center={false}
-                  innerRef={[Function]}
-                >
-                  <TouchRipple
-                    center={false}
-                    classes={
-                      Object {
-                        "child": "MuiTouchRipple-child-34",
-                        "childLeaving": "MuiTouchRipple-childLeaving-35",
-                        "childPulsate": "MuiTouchRipple-childPulsate-36",
-                        "ripple": "MuiTouchRipple-ripple-31",
-                        "ripplePulsate": "MuiTouchRipple-ripplePulsate-33",
-                        "rippleVisible": "MuiTouchRipple-rippleVisible-32",
-                        "root": "MuiTouchRipple-root-30",
-                      }
+                <ButtonBase
+                  aria-describedby={null}
+                  centerRipple={false}
+                  className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                  classes={
+                    Object {
+                      "disabled": "MuiButtonBase-disabled-36",
+                      "focusVisible": "MuiButtonBase-focusVisible-37",
+                      "root": "MuiButtonBase-root-35",
                     }
+                  }
+                  component="button"
+                  disableRipple={false}
+                  disableTouchRipple={false}
+                  disabled={false}
+                  focusRipple={true}
+                  focusVisibleClassName="MuiButton-focusVisible-28"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex="0"
+                  title=""
+                  type="button"
+                >
+                  <button
+                    aria-describedby={null}
+                    className="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onContextMenu={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    tabIndex="0"
+                    title=""
+                    type="button"
                   >
-                    <TransitionGroup
-                      childFactory={[Function]}
-                      className="MuiTouchRipple-root-30"
-                      component="span"
-                      enter={true}
-                      exit={true}
+                    <span
+                      className="MuiButton-label-10"
                     >
-                      <span
-                        className="MuiTouchRipple-root-30"
-                      />
-                    </TransitionGroup>
-                  </TouchRipple>
-                </WithStyles(TouchRipple)>
-              </NoSsr>
-            </button>
-          </ButtonBase>
-        </WithStyles(ButtonBase)>
-      </Button>
-    </WithStyles(Button)>
+                      <span>
+                        tab2
+                      </span>
+                    </span>
+                    <NoSsr
+                      defer={false}
+                      fallback={null}
+                    >
+                      <WithStyles(TouchRipple)
+                        center={false}
+                        innerRef={[Function]}
+                      >
+                        <TouchRipple
+                          center={false}
+                          classes={
+                            Object {
+                              "child": "MuiTouchRipple-child-42",
+                              "childLeaving": "MuiTouchRipple-childLeaving-43",
+                              "childPulsate": "MuiTouchRipple-childPulsate-44",
+                              "ripple": "MuiTouchRipple-ripple-39",
+                              "ripplePulsate": "MuiTouchRipple-ripplePulsate-41",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-40",
+                              "root": "MuiTouchRipple-root-38",
+                            }
+                          }
+                        >
+                          <TransitionGroup
+                            childFactory={[Function]}
+                            className="MuiTouchRipple-root-38"
+                            component="span"
+                            enter={true}
+                            exit={true}
+                          >
+                            <span
+                              className="MuiTouchRipple-root-38"
+                            />
+                          </TransitionGroup>
+                        </TouchRipple>
+                      </WithStyles(TouchRipple)>
+                    </NoSsr>
+                  </button>
+                </ButtonBase>
+              </WithStyles(ButtonBase)>
+            </Button>
+          </WithStyles(Button)>
+        </RootRef>
+        <Popper
+          className="MuiTooltip-popper-1"
+          disablePortal={false}
+          id={null}
+          open={false}
+          placement="top-start"
+          transition={true}
+        />
+      </Tooltip>
+    </WithStyles(Tooltip)>
   </div>
 </MD2Tabs>
 `;
@@ -329,23 +1211,35 @@ exports[`Input renders with the right styles by default 1`] = `
   <Separator
     units={20}
   />
-  <WithStyles(Button)
-    className="button active"
+  <WithStyles(Tooltip)
     key="0"
-    onClick={[Function]}
+    placement="top-start"
+    title=""
   >
-    <span>
-      tab1
-    </span>
-  </WithStyles(Button)>
-  <WithStyles(Button)
-    className="button"
+    <WithStyles(Button)
+      className="button active"
+      key="0"
+      onClick={[Function]}
+    >
+      <span>
+        tab1
+      </span>
+    </WithStyles(Button)>
+  </WithStyles(Tooltip)>
+  <WithStyles(Tooltip)
     key="1"
-    onClick={[Function]}
+    placement="top-start"
+    title=""
   >
-    <span>
-      tab2
-    </span>
-  </WithStyles(Button)>
+    <WithStyles(Button)
+      className="button"
+      key="1"
+      onClick={[Function]}
+    >
+      <span>
+        tab2
+      </span>
+    </WithStyles(Button)>
+  </WithStyles(Tooltip)>
 </div>
 `;

--- a/frontend/src/components/PipelinesDialog.test.tsx
+++ b/frontend/src/components/PipelinesDialog.test.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import PipelinesDialog, { PipelinesDialogProps } from './PipelinesDialog';
+import { PageProps } from '../pages/Page';
+import { Apis, PipelineSortKeys } from '../lib/Apis';
+import { ApiListPipelinesResponse, ApiPipeline } from '../apis/pipeline';
+import TestUtils from '../TestUtils';
+import { BuildInfoContext } from '../lib/BuildInfo';
+
+function generateProps(): PipelinesDialogProps {
+  return {
+    ...generatePageProps(),
+    open: true,
+    selectorDialog: '',
+    onClose: jest.fn(),
+    namespace: 'ns',
+    pipelineSelectorColumns: [
+      {
+        flex: 1,
+        label: 'Pipeline name',
+        sortKey: PipelineSortKeys.NAME,
+      },
+      { label: 'Description', flex: 2 },
+      { label: 'Uploaded on', flex: 1, sortKey: PipelineSortKeys.CREATED_AT },
+    ],
+  };
+}
+
+function generatePageProps(): PageProps {
+  return {
+    history: {} as any,
+    location: '' as any,
+    match: {} as any,
+    toolbarProps: {} as any,
+    updateBanner: jest.fn(),
+    updateDialog: jest.fn(),
+    updateSnackbar: jest.fn(),
+    updateToolbar: jest.fn(),
+  };
+}
+
+const oldPipeline = newMockPipeline();
+const newPipeline = newMockPipeline();
+
+function newMockPipeline(): ApiPipeline {
+  return {
+    id: 'run-pipeline-id',
+    name: 'mock pipeline name',
+    parameters: [],
+    default_version: {
+      id: 'run-pipeline-version-id',
+      name: 'mock pipeline version name',
+    },
+  };
+}
+
+describe('PipelinesDialog', () => {
+  let listPipelineSpy: jest.SpyInstance<{}>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    listPipelineSpy = jest
+      .spyOn(Apis.pipelineServiceApi, 'listPipelines')
+      .mockImplementation((...args) => {
+        const response: ApiListPipelinesResponse = {
+          pipelines: [oldPipeline, newPipeline],
+          total_size: 2,
+        };
+        return Promise.resolve(response);
+      });
+  });
+
+  afterEach(async () => {
+    jest.resetAllMocks();
+  });
+
+  it('it renders correctly in multi user mode', async () => {
+    const tree = render(
+      <BuildInfoContext.Provider value={{ apiServerMultiUser: true }}>
+        <PipelinesDialog {...generateProps()} />
+      </BuildInfoContext.Provider>,
+    );
+    await TestUtils.flushPromises();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('it renders correctly in single user mode', async () => {
+    const tree = render(
+      <BuildInfoContext.Provider value={{ apiServerMultiUser: false }}>
+        <PipelinesDialog {...generateProps()} />
+      </BuildInfoContext.Provider>,
+    );
+    await TestUtils.flushPromises();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/frontend/src/components/PipelinesDialog.tsx
+++ b/frontend/src/components/PipelinesDialog.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2023 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import { classes } from 'typestyle';
+import { padding, commonCss } from '../Css';
+import DialogContent from '@material-ui/core/DialogContent';
+import ResourceSelector from '../pages/ResourceSelector';
+import { Apis, PipelineSortKeys } from '../lib/Apis';
+import { Column } from './CustomTable';
+import { ApiPipeline } from '../apis/pipeline';
+import Buttons from '../lib/Buttons';
+import { PageProps } from '../pages/Page';
+import MD2Tabs from '../atoms/MD2Tabs';
+import Toolbar, { ToolbarActionMap } from '../components/Toolbar';
+import { PipelineTabsHeaders, PipelineTabsTooltips } from '../pages/PrivateAndSharedPipelines';
+import { BuildInfoContext } from 'src/lib/BuildInfo';
+
+enum NamespacedAndSharedTab {
+  NAMESPACED = 0,
+  SHARED = 1,
+}
+
+export interface PipelinesDialogProps extends PageProps {
+  open: boolean;
+  selectorDialog: string;
+  onClose: (confirmed: boolean, selectedPipeline?: ApiPipeline) => void;
+  namespace: string | undefined; // use context or make it optional?
+  pipelineSelectorColumns: Column[];
+  toolbarActionMap?: ToolbarActionMap;
+}
+
+const PipelinesDialog: React.FC<PipelinesDialogProps> = (props): JSX.Element | null => {
+  const buildInfo = React.useContext(BuildInfoContext);
+  const [view, setView] = React.useState(NamespacedAndSharedTab.NAMESPACED);
+  const [unconfirmedSelectedPipeline, setUnconfirmedSelectedPipeline] = React.useState<
+    ApiPipeline
+  >();
+
+  function getPipelinesList(): JSX.Element {
+    return (
+      <ResourceSelector
+        {...props}
+        filterLabel='Filter pipelines'
+        listApi={async (...args) => {
+          if (buildInfo?.apiServerMultiUser && view === NamespacedAndSharedTab.NAMESPACED) {
+            args.push('NAMESPACE');
+            args.push(props.namespace);
+          }
+          const response = await Apis.pipelineServiceApi.listPipelines(...args);
+          return {
+            nextPageToken: response.next_page_token || '',
+            resources: response.pipelines || [],
+          };
+        }}
+        columns={props.pipelineSelectorColumns}
+        emptyMessage='No pipelines found. Upload a pipeline and then try again.'
+        initialSortColumn={PipelineSortKeys.CREATED_AT}
+        selectionChanged={(selectedPipeline: ApiPipeline) => {
+          setUnconfirmedSelectedPipeline(selectedPipeline);
+        }}
+      />
+    );
+  }
+
+  function getTabs(): JSX.Element | null {
+    if (!buildInfo?.apiServerMultiUser) {
+      return null;
+    }
+
+    return (
+      <MD2Tabs
+        tabs={[
+          {
+            header: PipelineTabsHeaders.PRIVATE,
+            tooltip: PipelineTabsTooltips.PRIVATE,
+          },
+          {
+            header: PipelineTabsHeaders.SHARED,
+            tooltip: PipelineTabsTooltips.SHARED,
+          },
+        ]}
+        selectedTab={view}
+        onSwitch={tabSwitched}
+      />
+    );
+  }
+
+  function tabSwitched(newTab: NamespacedAndSharedTab): void {
+    setUnconfirmedSelectedPipeline(undefined);
+    setView(newTab);
+  }
+
+  function closeAndResetState(): void {
+    props.onClose(false);
+    setUnconfirmedSelectedPipeline(undefined);
+    setView(NamespacedAndSharedTab.NAMESPACED);
+  }
+
+  const getToolbar = (): JSX.Element => {
+    let actions = new Buttons(props, () => {}).getToolbarActionMap();
+    if (props.toolbarActionMap) {
+      actions = props.toolbarActionMap;
+    }
+    return <Toolbar actions={actions} breadcrumbs={[]} pageTitle={'Choose a pipeline'} />;
+  };
+
+  return (
+    <Dialog
+      open={props.open}
+      classes={{ paper: props.selectorDialog }}
+      onClose={() => closeAndResetState()}
+      PaperProps={{ id: 'pipelineSelectorDialog' }}
+    >
+      <DialogContent>
+        {getToolbar()}
+        <div className={classes(commonCss.page, padding(20, 't'))}>
+          {getTabs()}
+
+          {view === NamespacedAndSharedTab.NAMESPACED && getPipelinesList()}
+          {view === NamespacedAndSharedTab.SHARED && getPipelinesList()}
+        </div>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          id='cancelPipelineSelectionBtn'
+          onClick={() => closeAndResetState()}
+          color='secondary'
+        >
+          Cancel
+        </Button>
+        <Button
+          id='usePipelineBtn'
+          onClick={() => props.onClose(true, unconfirmedSelectedPipeline)}
+          color='secondary'
+          disabled={!unconfirmedSelectedPipeline}
+        >
+          Use this pipeline
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default PipelinesDialog;

--- a/frontend/src/components/PrivateSharedSelector.test.tsx
+++ b/frontend/src/components/PrivateSharedSelector.test.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BuildInfoContext } from '../lib/BuildInfo';
+import PrivateSharedSelector, { PrivateSharedSelectorProps } from './PrivateSharedSelector';
+import { PipelineTabsHeaders } from '../pages/PrivateAndSharedPipelines';
+
+function generateProps(): PrivateSharedSelectorProps {
+  return {
+    onChange: jest.fn(),
+  };
+}
+
+describe('PrivateSharedSelector', () => {
+  it('it renders correctly', async () => {
+    const tree = render(<PrivateSharedSelector {...generateProps()} />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('it changes checked input on click', async () => {
+    render(
+      <BuildInfoContext.Provider value={{ apiServerMultiUser: true }}>
+        <PrivateSharedSelector {...generateProps()} />
+      </BuildInfoContext.Provider>,
+    );
+
+    const privateInput = screen.getByLabelText(PipelineTabsHeaders.PRIVATE) as HTMLInputElement;
+    const sharedInput = screen.getByLabelText(PipelineTabsHeaders.SHARED) as HTMLInputElement;
+    expect(privateInput.checked).toBe(true);
+    expect(sharedInput.checked).toBe(false);
+
+    fireEvent.click(sharedInput);
+
+    expect(privateInput.checked).toBe(false);
+    expect(sharedInput.checked).toBe(true);
+  });
+});

--- a/frontend/src/components/PrivateSharedSelector.tsx
+++ b/frontend/src/components/PrivateSharedSelector.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import { classes } from 'typestyle';
+import Radio from '@material-ui/core/Radio';
+import Tooltip from '@material-ui/core/Tooltip';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import { commonCss, padding } from '../Css';
+import { PipelineTabsHeaders } from '../pages/PrivateAndSharedPipelines';
+
+export interface PrivateSharedSelectorProps {
+  onChange: (isPrivate: boolean) => void;
+}
+
+export enum PipelineButtonTooltips {
+  PRIVATE = 'Only people who have access to this namespace will be able to view and use this pipeline.',
+  SHARED = 'Everyone in your organization will be able to view and use this pipeline.',
+}
+
+const PrivateSharedSelector: React.FC<PrivateSharedSelectorProps> = (props): JSX.Element | null => {
+  const [namespacedPipeline, setNamespacedPipeline] = React.useState(true);
+
+  React.useEffect(() => {
+    props.onChange(namespacedPipeline);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [namespacedPipeline]);
+
+  return (
+    <React.Fragment>
+      <div>Select if the new pipeline will be private or shared.</div>
+      <div className={classes(commonCss.flex, padding(10, 'b'))}>
+        <Tooltip title={PipelineButtonTooltips.PRIVATE} placement='top-start'>
+          <FormControlLabel
+            id='createNewPrivatePipelineBtn'
+            label={PipelineTabsHeaders.PRIVATE}
+            checked={namespacedPipeline === true}
+            control={<Radio color='primary' />}
+            onChange={() => {
+              setNamespacedPipeline(true);
+            }}
+          />
+        </Tooltip>
+        <Tooltip title={PipelineButtonTooltips.SHARED} placement='top-start'>
+          <FormControlLabel
+            id='createNewSharedPipelineBtn'
+            label={PipelineTabsHeaders.SHARED}
+            checked={namespacedPipeline === false}
+            control={<Radio color='primary' />}
+            onChange={() => {
+              setNamespacedPipeline(false);
+            }}
+          />
+        </Tooltip>
+      </div>
+    </React.Fragment>
+  );
+};
+
+export default PrivateSharedSelector;

--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -45,10 +45,11 @@ import NewExperiment from '../pages/NewExperiment';
 import NewPipelineVersion from '../pages/NewPipelineVersion';
 import NewRunSwitcher from '../pages/NewRunSwitcher';
 import PipelineDetails from '../pages/PipelineDetails';
-import PipelineList from '../pages/PipelineList';
+import PrivateAndSharedPipelines, { PrivateAndSharedTab } from '../pages/PrivateAndSharedPipelines';
 import RecurringRunDetails from '../pages/RecurringRunDetails';
 import SideNav from './SideNav';
 import Toolbar, { ToolbarProps } from './Toolbar';
+import { BuildInfoContext } from 'src/lib/BuildInfo';
 
 export type RouteConfig = {
   path: string;
@@ -110,6 +111,7 @@ export const RoutePage = {
   NEW_PIPELINE_VERSION: '/pipeline_versions/new',
   NEW_RUN: '/runs/new',
   PIPELINES: '/pipelines',
+  PIPELINES_SHARED: '/shared/pipelines',
   PIPELINE_DETAILS: `/pipelines/details/:${RouteParams.pipelineId}/version/:${RouteParams.pipelineVersionId}?`,
   PIPELINE_DETAILS_NO_VERSION: `/pipelines/details/:${RouteParams.pipelineId}?`, // pipelineId is optional
   RUNS: '/runs',
@@ -164,7 +166,9 @@ const DEFAULT_ROUTE =
 
 // This component is made as a wrapper to separate toolbar state for different pages.
 const Router: React.FC<RouterProps> = ({ configs }) => {
-  const routes: RouteConfig[] = configs || [
+  const buildInfo = React.useContext(BuildInfoContext);
+
+  let routes: RouteConfig[] = configs || [
     { path: RoutePage.START, Component: GettingStarted },
     {
       Component: AllRunsAndArchive,
@@ -189,7 +193,16 @@ const Router: React.FC<RouterProps> = ({ configs }) => {
     { path: RoutePage.NEW_EXPERIMENT, Component: NewExperiment },
     { path: RoutePage.NEW_PIPELINE_VERSION, Component: NewPipelineVersion },
     { path: RoutePage.NEW_RUN, Component: NewRunSwitcher },
-    { path: RoutePage.PIPELINES, Component: PipelineList },
+    {
+      path: RoutePage.PIPELINES,
+      Component: PrivateAndSharedPipelines,
+      view: PrivateAndSharedTab.PRIVATE,
+    },
+    {
+      path: RoutePage.PIPELINES_SHARED,
+      Component: PrivateAndSharedPipelines,
+      view: PrivateAndSharedTab.SHARED,
+    },
     { path: RoutePage.PIPELINE_DETAILS, Component: PipelineDetails },
     { path: RoutePage.PIPELINE_DETAILS_NO_VERSION, Component: PipelineDetails },
     { path: RoutePage.RUNS, Component: AllRunsAndArchive, view: AllRunsAndArchiveTab.RUNS },
@@ -200,6 +213,10 @@ const Router: React.FC<RouterProps> = ({ configs }) => {
     { path: RoutePage.COMPARE, Component: Compare },
     { path: RoutePage.FRONTEND_FEATURES, Component: FrontendFeatures },
   ];
+
+  if (!buildInfo?.apiServerMultiUser) {
+    routes = routes.filter(r => r.path !== RoutePage.PIPELINES_SHARED);
+  }
 
   return (
     // There will be only one instance of SideNav, throughout UI usage.

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -33,12 +33,12 @@ import { commonCss, fontsize } from '../Css';
 import ExperimentsIcon from '../icons/experiments';
 import GitHubIcon from '../icons/GitHub-Mark-120px-plus.png';
 import PipelinesIcon from '../icons/pipelines';
-import { Apis } from '../lib/Apis';
+import { BuildInfo } from '../lib/Apis';
 import { Deployments, KFP_FLAGS } from '../lib/Flags';
 import { LocalStorage, LocalStorageKey } from '../lib/LocalStorage';
-import { logger } from '../lib/Utils';
 import { GkeMetadataContext, GkeMetadata } from 'src/lib/GkeMetadata';
 import { Alarm } from '@material-ui/icons';
+import { BuildInfoContext } from 'src/lib/BuildInfo';
 
 export const tailwindcss = {
   sideNavItem: 'flex flex-row flex-shrink-0',
@@ -194,10 +194,10 @@ interface SideNavProps extends RouterProps {
 
 interface SideNavInternalProps extends SideNavProps {
   gkeMetadata: GkeMetadata;
+  buildInfo: BuildInfo | undefined;
 }
 
 interface SideNavState {
-  displayBuildInfo?: DisplayBuildInfo;
   collapsed: boolean;
   jupyterHubAvailable: boolean;
   manualCollapseState: boolean;
@@ -224,28 +224,6 @@ export class SideNav extends React.Component<SideNavInternalProps, SideNavState>
   public async componentDidMount(): Promise<void> {
     window.addEventListener('resize', this._maybeResize.bind(this));
     this._maybeResize();
-
-    async function fetchBuildInfo() {
-      const buildInfo = await Apis.getBuildInfo();
-      const commitHash = buildInfo.apiServerCommitHash || buildInfo.frontendCommitHash || '';
-      const tagName = buildInfo.apiServerTagName || buildInfo.frontendTagName || '';
-      return {
-        tagName: tagName || 'unknown',
-        commitHash: commitHash ? commitHash.substring(0, 7) : 'unknown',
-        commitUrl:
-          'https://www.github.com/kubeflow/pipelines' +
-          (commitHash && commitHash !== 'unknown' ? `/commit/${commitHash}` : ''),
-        date: buildInfo.buildDate
-          ? new Date(buildInfo.buildDate).toLocaleDateString('en-US')
-          : 'unknown',
-      };
-    }
-    const displayBuildInfo = await fetchBuildInfo().catch(err => {
-      logger.error('Failed to retrieve build info', err);
-      return undefined;
-    });
-
-    this.setStateSafe({ displayBuildInfo });
   }
 
   public componentWillUnmount(): void {
@@ -254,7 +232,8 @@ export class SideNav extends React.Component<SideNavInternalProps, SideNavState>
 
   public render(): JSX.Element | null {
     const page = this.props.page;
-    const { collapsed, displayBuildInfo } = this.state;
+    const displayBuildInfo: DisplayBuildInfo = this._getBuildInfo();
+    const { collapsed } = this.state;
     const { gkeMetadata } = this.props;
     const iconColor = {
       active: sideNavColors.fgActive,
@@ -620,6 +599,22 @@ export class SideNav extends React.Component<SideNavInternalProps, SideNavState>
     );
   }
 
+  private _getBuildInfo(buildInfo = this.props.buildInfo): DisplayBuildInfo {
+    const commitHash = buildInfo?.apiServerCommitHash || buildInfo?.frontendCommitHash || '';
+    const tagName = buildInfo?.apiServerTagName || buildInfo?.frontendTagName || '';
+
+    return {
+      tagName: tagName || 'unknown',
+      commitHash: commitHash ? commitHash.substring(0, 7) : 'unknown',
+      commitUrl:
+        'https://www.github.com/kubeflow/pipelines' +
+        (commitHash && commitHash !== 'unknown' ? `/commit/${commitHash}` : ''),
+      date: buildInfo?.buildDate
+        ? new Date(buildInfo?.buildDate).toLocaleDateString('en-US')
+        : 'unknown',
+    };
+  }
+
   private _highlightExperimentsButton(page: string): boolean {
     return page.startsWith(RoutePage.EXPERIMENTS) || page === RoutePage.ARCHIVED_EXPERIMENTS;
   }
@@ -705,6 +700,7 @@ const ExternalUri: React.FC<ExternalUriProps> = ({ title, to, collapsed, icon })
 
 const EnhancedSideNav: React.FC<SideNavProps> = props => {
   const gkeMetadata = React.useContext(GkeMetadataContext);
-  return <SideNav {...props} gkeMetadata={gkeMetadata} />;
+  const buildInfo = React.useContext(BuildInfoContext);
+  return <SideNav {...props} gkeMetadata={gkeMetadata} buildInfo={buildInfo} />;
 };
 export default EnhancedSideNav;

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -293,7 +293,7 @@ export class SideNav extends React.Component<SideNavInternalProps, SideNavState>
           <div
             className={classes(
               css.indicator,
-              !page.startsWith(RoutePage.PIPELINES) && css.indicatorHidden,
+              !this._highlightPipelinesButton(page) && css.indicatorHidden,
             )}
           />
           <Tooltip
@@ -308,7 +308,7 @@ export class SideNav extends React.Component<SideNavInternalProps, SideNavState>
               <Button
                 className={classes(
                   css.button,
-                  page.startsWith(RoutePage.PIPELINES) && css.active,
+                  this._highlightPipelinesButton(page) && css.active,
                   collapsed && css.collapsedButton,
                 )}
               >
@@ -316,7 +316,7 @@ export class SideNav extends React.Component<SideNavInternalProps, SideNavState>
                   <div className={classes({ alignItems: 'stretch' })}>
                     <PipelinesIcon
                       color={
-                        page.startsWith(RoutePage.PIPELINES) ? iconColor.active : iconColor.inactive
+                        this._highlightPipelinesButton(page) ? iconColor.active : iconColor.inactive
                       }
                     />
                   </div>
@@ -613,6 +613,10 @@ export class SideNav extends React.Component<SideNavInternalProps, SideNavState>
         ? new Date(buildInfo?.buildDate).toLocaleDateString('en-US')
         : 'unknown',
     };
+  }
+
+  private _highlightPipelinesButton(page: string): boolean {
+    return page.startsWith(RoutePage.PIPELINES) || page.startsWith(RoutePage.PIPELINES_SHARED);
   }
 
   private _highlightExperimentsButton(page: string): boolean {

--- a/frontend/src/components/UploadPipelineDialog.test.tsx
+++ b/frontend/src/components/UploadPipelineDialog.test.tsx
@@ -60,14 +60,14 @@ describe('UploadPipelineDialog', () => {
     const spy = jest.fn();
     tree = shallow(<UploadPipelineDialog open={false} onClose={spy} />);
     tree.find('#cancelUploadBtn').simulate('click');
-    expect(spy).toHaveBeenCalledWith(false, '', null, '', ImportMethod.LOCAL, '');
+    expect(spy).toHaveBeenCalledWith(false, '', null, '', ImportMethod.LOCAL, true, '');
   });
 
   it('calls close callback with null and empty string when dialog is closed', () => {
     const spy = jest.fn();
     tree = shallow(<UploadPipelineDialog open={false} onClose={spy} />);
     tree.find('WithStyles(Dialog)').simulate('close');
-    expect(spy).toHaveBeenCalledWith(false, '', null, '', ImportMethod.LOCAL, '');
+    expect(spy).toHaveBeenCalledWith(false, '', null, '', ImportMethod.LOCAL, true, '');
   });
 
   it('calls close callback with file name, file object, and description when confirmed', () => {
@@ -78,7 +78,7 @@ describe('UploadPipelineDialog', () => {
       target: { value: 'test name' },
     });
     tree.find('#confirmUploadBtn').simulate('click');
-    expect(spy).toHaveBeenLastCalledWith(true, 'test name', null, '', ImportMethod.LOCAL, '');
+    expect(spy).toHaveBeenLastCalledWith(true, 'test name', null, '', ImportMethod.LOCAL, true, '');
   });
 
   it('calls close callback with trimmed file url and pipeline name when confirmed', () => {
@@ -99,6 +99,7 @@ describe('UploadPipelineDialog', () => {
       null,
       'https://www.google.com/test-file.txt',
       ImportMethod.URL,
+      true,
       '',
     );
   });

--- a/frontend/src/components/UploadPipelineDialog.tsx
+++ b/frontend/src/components/UploadPipelineDialog.tsx
@@ -29,6 +29,8 @@ import { TextFieldProps } from '@material-ui/core/TextField';
 import { padding, commonCss, zIndex, color } from '../Css';
 import { stylesheet, classes } from 'typestyle';
 import { ExternalLink } from '../atoms/ExternalLink';
+import PrivateSharedSelector from './PrivateSharedSelector';
+import { BuildInfoContext } from 'src/lib/BuildInfo';
 
 const css = stylesheet({
   dropOverlay: {
@@ -61,6 +63,7 @@ interface UploadPipelineDialogProps {
     file: File | null,
     url: string,
     method: ImportMethod,
+    isPrivatePipeline: boolean,
     description?: string,
   ) => Promise<boolean>;
 }
@@ -74,12 +77,14 @@ interface UploadPipelineDialogState {
   importMethod: ImportMethod;
   uploadPipelineDescription: string;
   uploadPipelineName: string;
+  isPrivatePipeline: boolean;
 }
 
 class UploadPipelineDialog extends React.Component<
   UploadPipelineDialogProps,
   UploadPipelineDialogState
 > {
+  static contextType = BuildInfoContext;
   private _dropzoneRef = React.createRef<Dropzone & HTMLDivElement>();
 
   constructor(props: any) {
@@ -94,6 +99,7 @@ class UploadPipelineDialog extends React.Component<
       importMethod: ImportMethod.LOCAL,
       uploadPipelineDescription: '',
       uploadPipelineName: '',
+      isPrivatePipeline: true,
     };
   }
 
@@ -116,8 +122,19 @@ class UploadPipelineDialog extends React.Component<
         classes={{ paper: css.root }}
       >
         <DialogTitle>Upload and name your pipeline</DialogTitle>
-
         <div className={padding(20, 'lr')}>
+          {this.context?.apiServerMultiUser && (
+            <PrivateSharedSelector
+              onChange={val => {
+                this.setState({
+                  isPrivatePipeline: val,
+                });
+              }}
+            ></PrivateSharedSelector>
+          )}
+
+          <div>Upload a pipeline package file from your computer or import one using a URL.</div>
+
           <div className={classes(commonCss.flex, padding(10, 'b'))}>
             <FormControlLabel
               id='uploadLocalFileBtn'
@@ -149,12 +166,7 @@ class UploadPipelineDialog extends React.Component<
               >
                 {dropzoneActive && <div className={css.dropOverlay}>Drop files..</div>}
 
-                <div className={padding(10, 'b')}>
-                  Choose a pipeline package file from your computer, and give the pipeline a unique
-                  name.
-                  <br />
-                  You can also drag and drop the file here.
-                </div>
+                <div className={padding(10, 'b')}>You can also drag and drop the file here.</div>
                 <DocumentationCompilePipeline />
                 <Input
                   onChange={this.handleChange('fileName')}
@@ -259,6 +271,7 @@ class UploadPipelineDialog extends React.Component<
         this.state.file,
         this.state.fileUrl.trim(),
         this.state.importMethod,
+        this.state.isPrivatePipeline,
         this.state.uploadPipelineDescription,
       );
       if (success) {

--- a/frontend/src/components/__snapshots__/PipelinesDialog.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/PipelinesDialog.test.tsx.snap
@@ -1,0 +1,1087 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PipelinesDialog it renders correctly in multi user mode 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body
+    style="overflow: hidden; padding-right: 0px;"
+  >
+    <div
+      aria-hidden="true"
+    />
+    <div
+      class="MuiModal-root-15 MuiDialog-root-1"
+      role="dialog"
+    >
+      <div
+        aria-hidden="true"
+        class="MuiBackdrop-root-17"
+        style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      />
+      <div
+        class="MuiDialog-container-4 MuiDialog-scrollPaper-2"
+        role="document"
+        style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+        tabindex="-1"
+      >
+        <div
+          class="MuiPaper-root-19 MuiPaper-elevation24-45 MuiPaper-rounded-20 MuiDialog-paper-5 MuiDialog-paperScrollPaper-6 MuiDialog-paperWidthSm-9"
+          id="pipelineSelectorDialog"
+        >
+          <div
+            class="MuiDialogContent-root-46"
+          >
+            <div
+              class="root topLevelToolbar"
+            >
+              <div
+                style="min-width: 100px;"
+              >
+                <div
+                  class="breadcrumbs flex"
+                />
+                <div
+                  class="flex"
+                >
+                  <span
+                    class="pageName ellipsis"
+                    data-testid="page-title"
+                  >
+                    Choose a pipeline
+                  </span>
+                </div>
+              </div>
+              <div
+                class="actions"
+              />
+            </div>
+            <div
+              class="page"
+            >
+              <div
+                class="tabs"
+              >
+                <div
+                  class="indicator"
+                />
+                <span
+                  style="display: inline-block; min-width: 20px; width: 20px;"
+                />
+                <button
+                  class="MuiButtonBase-root-81 MuiButton-root-55 MuiButton-text-57 MuiButton-flat-60 button active"
+                  tabindex="0"
+                  title="Only people who have access to this namespace will be able to view and use these pipelines."
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label-56"
+                  >
+                    <span>
+                      Private
+                    </span>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-187"
+                  />
+                </button>
+                <button
+                  class="MuiButtonBase-root-81 MuiButton-root-55 MuiButton-text-57 MuiButton-flat-60 button"
+                  tabindex="0"
+                  title="Everyone in your organization will be able to view and use these pipelines."
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label-56"
+                  >
+                    <span>
+                      Shared
+                    </span>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-187"
+                  />
+                </button>
+              </div>
+              <div
+                class="pageOverflowHidden"
+              >
+                <div>
+                  <div
+                    class="MuiFormControl-root-84 filterBox"
+                    spellcheck="false"
+                    style="height: 48px; max-width: 100%; width: 100%;"
+                  >
+                    <label
+                      class="MuiFormLabel-root-99 MuiInputLabel-root-88 noMargin MuiInputLabel-formControl-93 MuiInputLabel-animated-96 MuiInputLabel-shrink-95 MuiInputLabel-outlined-98"
+                      data-shrink="true"
+                      for="tableFilterBox"
+                    >
+                      Filter pipelines
+                    </label>
+                    <div
+                      class="MuiInputBase-root-119 MuiOutlinedInput-root-106 noLeftPadding MuiInputBase-formControl-120 MuiInputBase-adornedStart-123 MuiOutlinedInput-adornedStart-109"
+                    >
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiPrivateNotchedOutline-root-136 MuiOutlinedInput-notchedOutline-113 filterBorderRadius"
+                        style="padding-left: 8px;"
+                      >
+                        <legend
+                          class="MuiPrivateNotchedOutline-legend-137"
+                          style="width: 0px;"
+                        >
+                          <span>
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                      <div
+                        class="MuiInputAdornment-root-138 MuiInputAdornment-positionEnd-141"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-143"
+                          focusable="false"
+                          role="presentation"
+                          style="color: rgb(128, 134, 139); padding-right: 16px;"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+                          />
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                        </svg>
+                      </div>
+                      <input
+                        aria-invalid="false"
+                        class="MuiInputBase-input-129 MuiOutlinedInput-input-114 MuiInputBase-inputAdornedStart-134 MuiOutlinedInput-inputAdornedStart-117"
+                        id="tableFilterBox"
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="header"
+                >
+                  <div
+                    class="columnName cell selectionToggle"
+                  >
+                    <span
+                      style="display: inline-block; min-width: 42px; width: 42px;"
+                    />
+                  </div>
+                  <div
+                    class="columnName"
+                    style="width: 25%;"
+                    title="Pipeline name"
+                  >
+                    <span
+                      class="MuiButtonBase-root-81 MuiTableSortLabel-root-152 ellipsis"
+                      role="button"
+                      tabindex="0"
+                      title="Sort"
+                    >
+                      Pipeline name
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-143 MuiTableSortLabel-icon-154 MuiTableSortLabel-iconDirectionDesc-155"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                  <div
+                    class="columnName"
+                    style="width: 50%;"
+                    title="Description"
+                  >
+                    <span
+                      class="MuiButtonBase-root-81 MuiTableSortLabel-root-152 ellipsis"
+                      role="button"
+                      tabindex="0"
+                      title="Cannot sort by this column"
+                    >
+                      Description
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-143 MuiTableSortLabel-icon-154 MuiTableSortLabel-iconDirectionDesc-155"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                  <div
+                    class="columnName"
+                    style="width: 25%;"
+                    title="Uploaded on"
+                  >
+                    <span
+                      class="MuiButtonBase-root-81 MuiTableSortLabel-root-152 MuiTableSortLabel-active-153 ellipsis"
+                      role="button"
+                      tabindex="0"
+                      title="Sort"
+                    >
+                      Uploaded on
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-143 MuiTableSortLabel-icon-154 MuiTableSortLabel-iconDirectionDesc-155"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                </div>
+                <div
+                  class="scrollContainer"
+                  style="min-height: 60px;"
+                >
+                  <div
+                    class="expandableContainer"
+                  >
+                    <div
+                      aria-checked="false"
+                      class="tableRow row"
+                      role="checkbox"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="cell selectionToggle"
+                      >
+                        <span
+                          class="MuiButtonBase-root-81 MuiIconButton-root-179 MuiPrivateSwitchBase-root-209 MuiRadio-root-204 MuiRadio-colorPrimary-207"
+                        >
+                          <span
+                            class="MuiIconButton-label-184"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root-143"
+                              focusable="false"
+                              role="presentation"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                              />
+                            </svg>
+                            <input
+                              class="MuiPrivateSwitchBase-input-212"
+                              type="radio"
+                              value=""
+                            />
+                          </span>
+                          <span
+                            class="MuiTouchRipple-root-187"
+                          />
+                        </span>
+                      </div>
+                      <div
+                        class="cell"
+                        style="width: 25%;"
+                      >
+                        mock pipeline name
+                      </div>
+                      <div
+                        class="cell"
+                        style="width: 50%;"
+                      />
+                      <div
+                        class="cell"
+                        style="width: 25%;"
+                      >
+                        -
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="expandableContainer"
+                  >
+                    <div
+                      aria-checked="false"
+                      class="tableRow row"
+                      role="checkbox"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="cell selectionToggle"
+                      >
+                        <span
+                          class="MuiButtonBase-root-81 MuiIconButton-root-179 MuiPrivateSwitchBase-root-209 MuiRadio-root-204 MuiRadio-colorPrimary-207"
+                        >
+                          <span
+                            class="MuiIconButton-label-184"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root-143"
+                              focusable="false"
+                              role="presentation"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                              />
+                            </svg>
+                            <input
+                              class="MuiPrivateSwitchBase-input-212"
+                              type="radio"
+                              value=""
+                            />
+                          </span>
+                          <span
+                            class="MuiTouchRipple-root-187"
+                          />
+                        </span>
+                      </div>
+                      <div
+                        class="cell"
+                        style="width: 25%;"
+                      >
+                        mock pipeline name
+                      </div>
+                      <div
+                        class="cell"
+                        style="width: 50%;"
+                      />
+                      <div
+                        class="cell"
+                        style="width: 25%;"
+                      >
+                        -
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="footer"
+                >
+                  <span
+                    class=""
+                  >
+                    Rows per page:
+                  </span>
+                  <div
+                    class="MuiFormControl-root-84 verticalAlignInitial rowsPerPage"
+                  >
+                    <div
+                      class="MuiInputBase-root-119 MuiInput-root-164 MuiInputBase-formControl-120 MuiInput-formControl-165"
+                    >
+                      <div
+                        class="MuiSelect-root-157"
+                      >
+                        <div
+                          aria-haspopup="true"
+                          aria-pressed="false"
+                          class="MuiSelect-select-158 MuiSelect-selectMenu-161 MuiInputBase-input-129 MuiInput-input-172"
+                          role="button"
+                          tabindex="0"
+                        >
+                          10
+                        </div>
+                        <input
+                          type="hidden"
+                          value="10"
+                        />
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-143 MuiSelect-icon-163"
+                          focusable="false"
+                          role="presentation"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M7 10l5 5 5-5z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <button
+                    class="MuiButtonBase-root-81 MuiButtonBase-disabled-82 MuiIconButton-root-179 MuiIconButton-disabled-183"
+                    disabled=""
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <span
+                      class="MuiIconButton-label-184"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-143"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                        />
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                  <button
+                    class="MuiButtonBase-root-81 MuiButtonBase-disabled-82 MuiIconButton-root-179 MuiIconButton-disabled-183"
+                    disabled=""
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <span
+                      class="MuiIconButton-label-184"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-143"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                        />
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiDialogActions-root-185"
+          >
+            <button
+              class="MuiButtonBase-root-81 MuiButton-root-55 MuiButton-text-57 MuiButton-textSecondary-59 MuiButton-flat-60 MuiButton-flatSecondary-62 MuiDialogActions-action-186"
+              id="cancelPipelineSelectionBtn"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label-56"
+              >
+                Cancel
+              </span>
+              <span
+                class="MuiTouchRipple-root-187"
+              />
+            </button>
+            <button
+              class="MuiButtonBase-root-81 MuiButtonBase-disabled-82 MuiButton-root-55 MuiButton-text-57 MuiButton-textSecondary-59 MuiButton-flat-60 MuiButton-flatSecondary-62 MuiButton-disabled-75 MuiDialogActions-action-186"
+              disabled=""
+              id="usePipelineBtn"
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                class="MuiButton-label-56"
+              >
+                Use this pipeline
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div
+    aria-hidden="true"
+  />,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`PipelinesDialog it renders correctly in single user mode 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body
+    style="padding-right: 0px; overflow: hidden;"
+  >
+    <div
+      aria-hidden="true"
+    />
+    <div
+      class="MuiModal-root-227 MuiDialog-root-213"
+      role="dialog"
+    >
+      <div
+        aria-hidden="true"
+        class="MuiBackdrop-root-229"
+        style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      />
+      <div
+        class="MuiDialog-container-216 MuiDialog-scrollPaper-214"
+        role="document"
+        style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+        tabindex="-1"
+      >
+        <div
+          class="MuiPaper-root-231 MuiPaper-elevation24-257 MuiPaper-rounded-232 MuiDialog-paper-217 MuiDialog-paperScrollPaper-218 MuiDialog-paperWidthSm-221"
+          id="pipelineSelectorDialog"
+        >
+          <div
+            class="MuiDialogContent-root-258"
+          >
+            <div
+              class="root topLevelToolbar"
+            >
+              <div
+                style="min-width: 100px;"
+              >
+                <div
+                  class="breadcrumbs flex"
+                />
+                <div
+                  class="flex"
+                >
+                  <span
+                    class="pageName ellipsis"
+                    data-testid="page-title"
+                  >
+                    Choose a pipeline
+                  </span>
+                </div>
+              </div>
+              <div
+                class="actions"
+              />
+            </div>
+            <div
+              class="page"
+            >
+              <div
+                class="pageOverflowHidden"
+              >
+                <div>
+                  <div
+                    class="MuiFormControl-root-259 filterBox"
+                    spellcheck="false"
+                    style="height: 48px; max-width: 100%; width: 100%;"
+                  >
+                    <label
+                      class="MuiFormLabel-root-274 MuiInputLabel-root-263 noMargin MuiInputLabel-formControl-268 MuiInputLabel-animated-271 MuiInputLabel-shrink-270 MuiInputLabel-outlined-273"
+                      data-shrink="true"
+                      for="tableFilterBox"
+                    >
+                      Filter pipelines
+                    </label>
+                    <div
+                      class="MuiInputBase-root-294 MuiOutlinedInput-root-281 noLeftPadding MuiInputBase-formControl-295 MuiInputBase-adornedStart-298 MuiOutlinedInput-adornedStart-284"
+                    >
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiPrivateNotchedOutline-root-311 MuiOutlinedInput-notchedOutline-288 filterBorderRadius"
+                        style="padding-left: 8px;"
+                      >
+                        <legend
+                          class="MuiPrivateNotchedOutline-legend-312"
+                          style="width: 0px;"
+                        >
+                          <span>
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                      <div
+                        class="MuiInputAdornment-root-313 MuiInputAdornment-positionEnd-316"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-318"
+                          focusable="false"
+                          role="presentation"
+                          style="color: rgb(128, 134, 139); padding-right: 16px;"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+                          />
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                        </svg>
+                      </div>
+                      <input
+                        aria-invalid="false"
+                        class="MuiInputBase-input-304 MuiOutlinedInput-input-289 MuiInputBase-inputAdornedStart-309 MuiOutlinedInput-inputAdornedStart-292"
+                        id="tableFilterBox"
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="header"
+                >
+                  <div
+                    class="columnName cell selectionToggle"
+                  >
+                    <span
+                      style="display: inline-block; min-width: 42px; width: 42px;"
+                    />
+                  </div>
+                  <div
+                    class="columnName"
+                    style="width: 25%;"
+                    title="Pipeline name"
+                  >
+                    <span
+                      class="MuiButtonBase-root-340 MuiTableSortLabel-root-335 ellipsis"
+                      role="button"
+                      tabindex="0"
+                      title="Sort"
+                    >
+                      Pipeline name
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-318 MuiTableSortLabel-icon-337 MuiTableSortLabel-iconDirectionDesc-338"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                  <div
+                    class="columnName"
+                    style="width: 50%;"
+                    title="Description"
+                  >
+                    <span
+                      class="MuiButtonBase-root-340 MuiTableSortLabel-root-335 ellipsis"
+                      role="button"
+                      tabindex="0"
+                      title="Cannot sort by this column"
+                    >
+                      Description
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-318 MuiTableSortLabel-icon-337 MuiTableSortLabel-iconDirectionDesc-338"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                  <div
+                    class="columnName"
+                    style="width: 25%;"
+                    title="Uploaded on"
+                  >
+                    <span
+                      class="MuiButtonBase-root-340 MuiTableSortLabel-root-335 MuiTableSortLabel-active-336 ellipsis"
+                      role="button"
+                      tabindex="0"
+                      title="Sort"
+                    >
+                      Uploaded on
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-318 MuiTableSortLabel-icon-337 MuiTableSortLabel-iconDirectionDesc-338"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                </div>
+                <div
+                  class="scrollContainer"
+                  style="min-height: 60px;"
+                >
+                  <div
+                    class="expandableContainer"
+                  >
+                    <div
+                      aria-checked="false"
+                      class="tableRow row"
+                      role="checkbox"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="cell selectionToggle"
+                      >
+                        <span
+                          class="MuiButtonBase-root-340 MuiIconButton-root-365 MuiPrivateSwitchBase-root-421 MuiRadio-root-416 MuiRadio-colorPrimary-419"
+                        >
+                          <span
+                            class="MuiIconButton-label-370"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root-318"
+                              focusable="false"
+                              role="presentation"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                              />
+                            </svg>
+                            <input
+                              class="MuiPrivateSwitchBase-input-424"
+                              type="radio"
+                              value=""
+                            />
+                          </span>
+                          <span
+                            class="MuiTouchRipple-root-409"
+                          />
+                        </span>
+                      </div>
+                      <div
+                        class="cell"
+                        style="width: 25%;"
+                      >
+                        mock pipeline name
+                      </div>
+                      <div
+                        class="cell"
+                        style="width: 50%;"
+                      />
+                      <div
+                        class="cell"
+                        style="width: 25%;"
+                      >
+                        -
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="expandableContainer"
+                  >
+                    <div
+                      aria-checked="false"
+                      class="tableRow row"
+                      role="checkbox"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="cell selectionToggle"
+                      >
+                        <span
+                          class="MuiButtonBase-root-340 MuiIconButton-root-365 MuiPrivateSwitchBase-root-421 MuiRadio-root-416 MuiRadio-colorPrimary-419"
+                        >
+                          <span
+                            class="MuiIconButton-label-370"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root-318"
+                              focusable="false"
+                              role="presentation"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                              />
+                            </svg>
+                            <input
+                              class="MuiPrivateSwitchBase-input-424"
+                              type="radio"
+                              value=""
+                            />
+                          </span>
+                          <span
+                            class="MuiTouchRipple-root-409"
+                          />
+                        </span>
+                      </div>
+                      <div
+                        class="cell"
+                        style="width: 25%;"
+                      >
+                        mock pipeline name
+                      </div>
+                      <div
+                        class="cell"
+                        style="width: 50%;"
+                      />
+                      <div
+                        class="cell"
+                        style="width: 25%;"
+                      >
+                        -
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="footer"
+                >
+                  <span
+                    class=""
+                  >
+                    Rows per page:
+                  </span>
+                  <div
+                    class="MuiFormControl-root-259 verticalAlignInitial rowsPerPage"
+                  >
+                    <div
+                      class="MuiInputBase-root-294 MuiInput-root-350 MuiInputBase-formControl-295 MuiInput-formControl-351"
+                    >
+                      <div
+                        class="MuiSelect-root-343"
+                      >
+                        <div
+                          aria-haspopup="true"
+                          aria-pressed="false"
+                          class="MuiSelect-select-344 MuiSelect-selectMenu-347 MuiInputBase-input-304 MuiInput-input-358"
+                          role="button"
+                          tabindex="0"
+                        >
+                          10
+                        </div>
+                        <input
+                          type="hidden"
+                          value="10"
+                        />
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-318 MuiSelect-icon-349"
+                          focusable="false"
+                          role="presentation"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M7 10l5 5 5-5z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <button
+                    class="MuiButtonBase-root-340 MuiButtonBase-disabled-341 MuiIconButton-root-365 MuiIconButton-disabled-369"
+                    disabled=""
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <span
+                      class="MuiIconButton-label-370"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-318"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                        />
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                  <button
+                    class="MuiButtonBase-root-340 MuiButtonBase-disabled-341 MuiIconButton-root-365 MuiIconButton-disabled-369"
+                    disabled=""
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <span
+                      class="MuiIconButton-label-370"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-318"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                        />
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiDialogActions-root-371"
+          >
+            <button
+              class="MuiButtonBase-root-340 MuiButton-root-373 MuiButton-text-375 MuiButton-textSecondary-377 MuiButton-flat-378 MuiButton-flatSecondary-380 MuiDialogActions-action-372"
+              id="cancelPipelineSelectionBtn"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label-374"
+              >
+                Cancel
+              </span>
+              <span
+                class="MuiTouchRipple-root-409"
+              />
+            </button>
+            <button
+              class="MuiButtonBase-root-340 MuiButtonBase-disabled-341 MuiButton-root-373 MuiButton-text-375 MuiButton-textSecondary-377 MuiButton-flat-378 MuiButton-flatSecondary-380 MuiButton-disabled-393 MuiDialogActions-action-372"
+              disabled=""
+              id="usePipelineBtn"
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                class="MuiButton-label-374"
+              >
+                Use this pipeline
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div
+    aria-hidden="true"
+  />,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/frontend/src/components/__snapshots__/PrivateSharedSelector.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/PrivateSharedSelector.test.tsx.snap
@@ -1,0 +1,232 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PrivateSharedSelector it renders correctly 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div>
+        Select if the new pipeline will be private or shared.
+      </div>
+      <div
+        class="flex"
+      >
+        <label
+          class="MuiFormControlLabel-root-9"
+          id="createNewPrivatePipelineBtn"
+          title="Only people who have access to this namespace will be able to view and use this pipeline."
+        >
+          <span
+            class="MuiButtonBase-root-30 MuiIconButton-root-24 MuiPrivateSwitchBase-root-20 MuiRadio-root-15 MuiRadio-colorPrimary-18 MuiPrivateSwitchBase-checked-21 MuiRadio-checked-16"
+          >
+            <span
+              class="MuiIconButton-label-29"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root-33"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zm0-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <input
+                checked=""
+                class="MuiPrivateSwitchBase-input-23"
+                type="radio"
+                value=""
+              />
+            </span>
+            <span
+              class="MuiTouchRipple-root-78"
+            />
+          </span>
+          <span
+            class="MuiTypography-root-42 MuiTypography-body1-51 MuiFormControlLabel-label-14"
+          >
+            Private
+          </span>
+        </label>
+        <label
+          class="MuiFormControlLabel-root-9"
+          id="createNewSharedPipelineBtn"
+          title="Everyone in your organization will be able to view and use this pipeline."
+        >
+          <span
+            class="MuiButtonBase-root-30 MuiIconButton-root-24 MuiPrivateSwitchBase-root-20 MuiRadio-root-15 MuiRadio-colorPrimary-18"
+          >
+            <span
+              class="MuiIconButton-label-29"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root-33"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <input
+                class="MuiPrivateSwitchBase-input-23"
+                type="radio"
+                value=""
+              />
+            </span>
+            <span
+              class="MuiTouchRipple-root-78"
+            />
+          </span>
+          <span
+            class="MuiTypography-root-42 MuiTypography-body1-51 MuiFormControlLabel-label-14"
+          >
+            Shared
+          </span>
+        </label>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div>
+      Select if the new pipeline will be private or shared.
+    </div>
+    <div
+      class="flex"
+    >
+      <label
+        class="MuiFormControlLabel-root-9"
+        id="createNewPrivatePipelineBtn"
+        title="Only people who have access to this namespace will be able to view and use this pipeline."
+      >
+        <span
+          class="MuiButtonBase-root-30 MuiIconButton-root-24 MuiPrivateSwitchBase-root-20 MuiRadio-root-15 MuiRadio-colorPrimary-18 MuiPrivateSwitchBase-checked-21 MuiRadio-checked-16"
+        >
+          <span
+            class="MuiIconButton-label-29"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root-33"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zm0-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+              />
+            </svg>
+            <input
+              checked=""
+              class="MuiPrivateSwitchBase-input-23"
+              type="radio"
+              value=""
+            />
+          </span>
+          <span
+            class="MuiTouchRipple-root-78"
+          />
+        </span>
+        <span
+          class="MuiTypography-root-42 MuiTypography-body1-51 MuiFormControlLabel-label-14"
+        >
+          Private
+        </span>
+      </label>
+      <label
+        class="MuiFormControlLabel-root-9"
+        id="createNewSharedPipelineBtn"
+        title="Everyone in your organization will be able to view and use this pipeline."
+      >
+        <span
+          class="MuiButtonBase-root-30 MuiIconButton-root-24 MuiPrivateSwitchBase-root-20 MuiRadio-root-15 MuiRadio-colorPrimary-18"
+        >
+          <span
+            class="MuiIconButton-label-29"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root-33"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+              />
+            </svg>
+            <input
+              class="MuiPrivateSwitchBase-input-23"
+              type="radio"
+              value=""
+            />
+          </span>
+          <span
+            class="MuiTouchRipple-root-78"
+          />
+        </span>
+        <span
+          class="MuiTypography-root-42 MuiTypography-body1-51 MuiFormControlLabel-label-14"
+        >
+          Shared
+        </span>
+      </label>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
@@ -1,6 +1,13467 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SideNav populates the display build information using the response from the healthz endpoint 1`] = `
+exports[`SideNav display the correct GKE metadata 1`] = `
+<SideNav
+  buildInfo={Object {}}
+  gkeMetadata={
+    Object {
+      "clusterName": "some-cluster-name",
+      "projectId": "some-project-id",
+    }
+  }
+  history={Object {}}
+  page="/pipelines"
+>
+  <div
+    className="root flexColumn noShrink"
+    id="sideNav"
+  >
+    <div
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+    >
+      <div
+        className="indicator"
+      />
+      <WithStyles(Tooltip)
+        disableFocusListener={true}
+        disableHoverListener={true}
+        disableTouchListener={true}
+        enterDelay={300}
+        placement="right-start"
+        title="Pipeline List"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-60",
+              "popperInteractive": "MuiTooltip-popperInteractive-61",
+              "tooltip": "MuiTooltip-tooltip-62",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-67",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-64",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-65",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-66",
+              "touch": "MuiTooltip-touch-63",
+            }
+          }
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="right-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Pipeline List"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <Link
+              aria-describedby={null}
+              className="unstyled"
+              id="pipelinesBtn"
+              replace={false}
+              title={null}
+              to="/pipelines"
+            >
+              <a
+                aria-describedby={null}
+                className="unstyled"
+                href="/pipelines"
+                id="pipelinesBtn"
+                onClick={[Function]}
+                title={null}
+              >
+                <WithStyles(Button)
+                  className="button active"
+                >
+                  <Button
+                    className="button active"
+                    classes={
+                      Object {
+                        "colorInherit": "MuiButton-colorInherit-89",
+                        "contained": "MuiButton-contained-79",
+                        "containedPrimary": "MuiButton-containedPrimary-80",
+                        "containedSecondary": "MuiButton-containedSecondary-81",
+                        "disabled": "MuiButton-disabled-88",
+                        "extendedFab": "MuiButton-extendedFab-86",
+                        "fab": "MuiButton-fab-85",
+                        "flat": "MuiButton-flat-73",
+                        "flatPrimary": "MuiButton-flatPrimary-74",
+                        "flatSecondary": "MuiButton-flatSecondary-75",
+                        "focusVisible": "MuiButton-focusVisible-87",
+                        "fullWidth": "MuiButton-fullWidth-93",
+                        "label": "MuiButton-label-69",
+                        "mini": "MuiButton-mini-90",
+                        "outlined": "MuiButton-outlined-76",
+                        "outlinedPrimary": "MuiButton-outlinedPrimary-77",
+                        "outlinedSecondary": "MuiButton-outlinedSecondary-78",
+                        "raised": "MuiButton-raised-82",
+                        "raisedPrimary": "MuiButton-raisedPrimary-83",
+                        "raisedSecondary": "MuiButton-raisedSecondary-84",
+                        "root": "MuiButton-root-68",
+                        "sizeLarge": "MuiButton-sizeLarge-92",
+                        "sizeSmall": "MuiButton-sizeSmall-91",
+                        "text": "MuiButton-text-70",
+                        "textPrimary": "MuiButton-textPrimary-71",
+                        "textSecondary": "MuiButton-textSecondary-72",
+                      }
+                    }
+                    color="default"
+                    component="button"
+                    disableFocusRipple={false}
+                    disabled={false}
+                    fullWidth={false}
+                    mini={false}
+                    size="medium"
+                    type="button"
+                    variant="text"
+                  >
+                    <WithStyles(ButtonBase)
+                      className="MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button active"
+                      component="button"
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-87"
+                      type="button"
+                    >
+                      <ButtonBase
+                        centerRipple={false}
+                        className="MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button active"
+                        classes={
+                          Object {
+                            "disabled": "MuiButtonBase-disabled-95",
+                            "focusVisible": "MuiButtonBase-focusVisible-96",
+                            "root": "MuiButtonBase-root-94",
+                          }
+                        }
+                        component="button"
+                        disableRipple={false}
+                        disableTouchRipple={false}
+                        disabled={false}
+                        focusRipple={true}
+                        focusVisibleClassName="MuiButton-focusVisible-87"
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <button
+                          className="MuiButtonBase-root-94 MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button active"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onContextMenu={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          tabIndex="0"
+                          type="button"
+                        >
+                          <span
+                            className="MuiButton-label-69"
+                          >
+                            <div
+                              className="flex flex-row flex-shrink-0"
+                            >
+                              <div
+                                className="alignItems"
+                              >
+                                <PipelinesIcon
+                                  color="#0d6de7"
+                                >
+                                  <svg
+                                    height="20px"
+                                    version="1.1"
+                                    viewBox="0 0 20 20"
+                                    width="20px"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                                  >
+                                    <g
+                                      fill="none"
+                                      fillRule="evenodd"
+                                      id="Symbols"
+                                      stroke="none"
+                                      strokeWidth="1"
+                                    >
+                                      <g
+                                        transform="translate(-2.000000, -4.000000)"
+                                      >
+                                        <polygon
+                                          id="Shape"
+                                          points="0 0 24 0 24 24 0 24"
+                                        />
+                                        <path
+                                          d="M12.7244079,9.74960425 L17.4807112,9.74960425 C17.7675226,9.74960425 18,9.51894323 18,9.23437272 L18,4.51523153 C18,4.23066102 17.7675226,4 17.4807112,4 L12.7244079,4 C12.4375965,4 12.2051191,4.23066102 12.2051191,4.51523153 L12.2051191,6.06125154 L9.98218019,6.06125154 C9.52936032,6.06125154 9.16225043,6.42549311 9.16225043,6.87477501 L9.16225043,11.2135669 L7.05995053,11.2135669 C6.71661861,10.189612 5.74374462,9.45093267 4.59644424,9.45093267 C3.16249641,9.45093267 2,10.6043462 2,12.0270903 C2,13.4498886 3.16249641,14.603248 4.59644424,14.603248 C5.74379928,14.603248 6.71661861,13.8645687 7.06000519,12.8406138 L9.16225043,12.8406138 L9.16225043,17.1794057 C9.16225043,17.6286875 9.52936032,17.9929291 9.98218019,17.9929291 L12.2051191,17.9929291 L12.2051191,19.4847685 C12.2051191,19.769339 12.4375965,20 12.7244079,20 L17.4807112,20 C17.7675226,20 18,19.769339 18,19.4847685 L18,14.7656273 C18,14.4810568 17.7675226,14.2503957 17.4807112,14.2503957 L12.7244079,14.2503957 C12.4375965,14.2503957 12.2051191,14.4810568 12.2051191,14.7656273 L12.2051191,16.3658822 L10.80211,16.3658822 L10.80211,7.68829848 L12.2051191,7.68829848 L12.2051191,9.23437272 C12.2051191,9.51894323 12.4375965,9.74960425 12.7244079,9.74960425 Z"
+                                          fill="#0d6de7"
+                                          id="Path"
+                                        />
+                                      </g>
+                                    </g>
+                                  </svg>
+                                </PipelinesIcon>
+                              </div>
+                              <span
+                                className="label"
+                              >
+                                Pipelines
+                              </span>
+                            </div>
+                          </span>
+                          <NoSsr
+                            defer={false}
+                            fallback={null}
+                          >
+                            <WithStyles(TouchRipple)
+                              center={false}
+                              innerRef={[Function]}
+                            >
+                              <TouchRipple
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "MuiTouchRipple-child-116",
+                                    "childLeaving": "MuiTouchRipple-childLeaving-117",
+                                    "childPulsate": "MuiTouchRipple-childPulsate-118",
+                                    "ripple": "MuiTouchRipple-ripple-113",
+                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate-115",
+                                    "rippleVisible": "MuiTouchRipple-rippleVisible-114",
+                                    "root": "MuiTouchRipple-root-112",
+                                  }
+                                }
+                              >
+                                <TransitionGroup
+                                  childFactory={[Function]}
+                                  className="MuiTouchRipple-root-112"
+                                  component="span"
+                                  enter={true}
+                                  exit={true}
+                                >
+                                  <span
+                                    className="MuiTouchRipple-root-112"
+                                  />
+                                </TransitionGroup>
+                              </TouchRipple>
+                            </WithStyles(TouchRipple)>
+                          </NoSsr>
+                        </button>
+                      </ButtonBase>
+                    </WithStyles(ButtonBase)>
+                  </Button>
+                </WithStyles(Button)>
+              </a>
+            </Link>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <a
+                class="unstyled"
+                href="/pipelines"
+                id="pipelinesBtn"
+              >
+                <button
+                  class="MuiButtonBase-root-94 MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button active"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label-69"
+                  >
+                    <div
+                      class="flex flex-row flex-shrink-0"
+                    >
+                      <div
+                        class="alignItems"
+                      >
+                        <svg
+                          height="20px"
+                          version="1.1"
+                          viewBox="0 0 20 20"
+                          width="20px"
+                          xmlns="http://www.w3.org/2000/svg"
+                          xmlns:xlink="http://www.w3.org/1999/xlink"
+                        >
+                          <g
+                            fill="none"
+                            fill-rule="evenodd"
+                            id="Symbols"
+                            stroke="none"
+                            stroke-width="1"
+                          >
+                            <g
+                              transform="translate(-2.000000, -4.000000)"
+                            >
+                              <polygon
+                                id="Shape"
+                                points="0 0 24 0 24 24 0 24"
+                              />
+                              <path
+                                d="M12.7244079,9.74960425 L17.4807112,9.74960425 C17.7675226,9.74960425 18,9.51894323 18,9.23437272 L18,4.51523153 C18,4.23066102 17.7675226,4 17.4807112,4 L12.7244079,4 C12.4375965,4 12.2051191,4.23066102 12.2051191,4.51523153 L12.2051191,6.06125154 L9.98218019,6.06125154 C9.52936032,6.06125154 9.16225043,6.42549311 9.16225043,6.87477501 L9.16225043,11.2135669 L7.05995053,11.2135669 C6.71661861,10.189612 5.74374462,9.45093267 4.59644424,9.45093267 C3.16249641,9.45093267 2,10.6043462 2,12.0270903 C2,13.4498886 3.16249641,14.603248 4.59644424,14.603248 C5.74379928,14.603248 6.71661861,13.8645687 7.06000519,12.8406138 L9.16225043,12.8406138 L9.16225043,17.1794057 C9.16225043,17.6286875 9.52936032,17.9929291 9.98218019,17.9929291 L12.2051191,17.9929291 L12.2051191,19.4847685 C12.2051191,19.769339 12.4375965,20 12.7244079,20 L17.4807112,20 C17.7675226,20 18,19.769339 18,19.4847685 L18,14.7656273 C18,14.4810568 17.7675226,14.2503957 17.4807112,14.2503957 L12.7244079,14.2503957 C12.4375965,14.2503957 12.2051191,14.4810568 12.2051191,14.7656273 L12.2051191,16.3658822 L10.80211,16.3658822 L10.80211,7.68829848 L12.2051191,7.68829848 L12.2051191,9.23437272 C12.2051191,9.51894323 12.4375965,9.74960425 12.7244079,9.74960425 Z"
+                                fill="#0d6de7"
+                                id="Path"
+                              />
+                            </g>
+                          </g>
+                        </svg>
+                      </div>
+                      <span
+                        class="label"
+                      >
+                        Pipelines
+                      </span>
+                    </div>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-112"
+                  />
+                </button>
+              </a>
+            }
+            className="MuiTooltip-popper-60"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="right-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+      <div
+        className="indicator indicatorHidden"
+      />
+      <WithStyles(Tooltip)
+        disableFocusListener={true}
+        disableHoverListener={true}
+        disableTouchListener={true}
+        enterDelay={300}
+        placement="right-start"
+        title="Experiment List"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-60",
+              "popperInteractive": "MuiTooltip-popperInteractive-61",
+              "tooltip": "MuiTooltip-tooltip-62",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-67",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-64",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-65",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-66",
+              "touch": "MuiTooltip-touch-63",
+            }
+          }
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="right-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Experiment List"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <Link
+              aria-describedby={null}
+              className="unstyled"
+              id="experimentsBtn"
+              replace={false}
+              title={null}
+              to="/experiments"
+            >
+              <a
+                aria-describedby={null}
+                className="unstyled"
+                href="/experiments"
+                id="experimentsBtn"
+                onClick={[Function]}
+                title={null}
+              >
+                <WithStyles(Button)
+                  className="button"
+                >
+                  <Button
+                    className="button"
+                    classes={
+                      Object {
+                        "colorInherit": "MuiButton-colorInherit-89",
+                        "contained": "MuiButton-contained-79",
+                        "containedPrimary": "MuiButton-containedPrimary-80",
+                        "containedSecondary": "MuiButton-containedSecondary-81",
+                        "disabled": "MuiButton-disabled-88",
+                        "extendedFab": "MuiButton-extendedFab-86",
+                        "fab": "MuiButton-fab-85",
+                        "flat": "MuiButton-flat-73",
+                        "flatPrimary": "MuiButton-flatPrimary-74",
+                        "flatSecondary": "MuiButton-flatSecondary-75",
+                        "focusVisible": "MuiButton-focusVisible-87",
+                        "fullWidth": "MuiButton-fullWidth-93",
+                        "label": "MuiButton-label-69",
+                        "mini": "MuiButton-mini-90",
+                        "outlined": "MuiButton-outlined-76",
+                        "outlinedPrimary": "MuiButton-outlinedPrimary-77",
+                        "outlinedSecondary": "MuiButton-outlinedSecondary-78",
+                        "raised": "MuiButton-raised-82",
+                        "raisedPrimary": "MuiButton-raisedPrimary-83",
+                        "raisedSecondary": "MuiButton-raisedSecondary-84",
+                        "root": "MuiButton-root-68",
+                        "sizeLarge": "MuiButton-sizeLarge-92",
+                        "sizeSmall": "MuiButton-sizeSmall-91",
+                        "text": "MuiButton-text-70",
+                        "textPrimary": "MuiButton-textPrimary-71",
+                        "textSecondary": "MuiButton-textSecondary-72",
+                      }
+                    }
+                    color="default"
+                    component="button"
+                    disableFocusRipple={false}
+                    disabled={false}
+                    fullWidth={false}
+                    mini={false}
+                    size="medium"
+                    type="button"
+                    variant="text"
+                  >
+                    <WithStyles(ButtonBase)
+                      className="MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                      component="button"
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-87"
+                      type="button"
+                    >
+                      <ButtonBase
+                        centerRipple={false}
+                        className="MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                        classes={
+                          Object {
+                            "disabled": "MuiButtonBase-disabled-95",
+                            "focusVisible": "MuiButtonBase-focusVisible-96",
+                            "root": "MuiButtonBase-root-94",
+                          }
+                        }
+                        component="button"
+                        disableRipple={false}
+                        disableTouchRipple={false}
+                        disabled={false}
+                        focusRipple={true}
+                        focusVisibleClassName="MuiButton-focusVisible-87"
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <button
+                          className="MuiButtonBase-root-94 MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onContextMenu={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          tabIndex="0"
+                          type="button"
+                        >
+                          <span
+                            className="MuiButton-label-69"
+                          >
+                            <div
+                              className="flex flex-row flex-shrink-0"
+                            >
+                              <div
+                                className="alignItems"
+                              >
+                                <ExperimentsIcon
+                                  color="#9aa0a6"
+                                >
+                                  <svg
+                                    height="20"
+                                    viewBox="0 0 20 12"
+                                    width="20"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <g
+                                      fill="none"
+                                      fillRule="evenodd"
+                                      id="Symbols"
+                                    >
+                                      <g
+                                        transform="translate(-26 -72)"
+                                      >
+                                        <g
+                                          transform="translate(0 12)"
+                                        >
+                                          <g
+                                            transform="translate(0 44)"
+                                          >
+                                            <g
+                                              id="Group-3"
+                                            >
+                                              <g
+                                                transform="translate(26 12)"
+                                              >
+                                                <polygon
+                                                  points="0 0 20 0 20 20 0 20"
+                                                />
+                                                <path
+                                                  d="M15,5.83333333 L13.825,4.65833333 L8.54166667,9.94166667 L9.71666667,11.1166667 L15,5.83333333 Z M18.5333333,4.65833333 L9.71666667,13.475 L6.23333333,10 L5.05833333,11.175 L9.71666667,15.8333333 L19.7166667,5.83333333 L18.5333333,4.65833333 Z M0.341666667,11.175 L5,15.8333333 L6.175,14.6583333 L1.525,10 L0.341666667,11.175 Z"
+                                                  fill="#9aa0a6"
+                                                  fillRule="nonzero"
+                                                />
+                                              </g>
+                                            </g>
+                                          </g>
+                                        </g>
+                                      </g>
+                                    </g>
+                                  </svg>
+                                </ExperimentsIcon>
+                              </div>
+                              <span
+                                className="label"
+                              >
+                                Experiments
+                              </span>
+                            </div>
+                          </span>
+                          <NoSsr
+                            defer={false}
+                            fallback={null}
+                          >
+                            <WithStyles(TouchRipple)
+                              center={false}
+                              innerRef={[Function]}
+                            >
+                              <TouchRipple
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "MuiTouchRipple-child-116",
+                                    "childLeaving": "MuiTouchRipple-childLeaving-117",
+                                    "childPulsate": "MuiTouchRipple-childPulsate-118",
+                                    "ripple": "MuiTouchRipple-ripple-113",
+                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate-115",
+                                    "rippleVisible": "MuiTouchRipple-rippleVisible-114",
+                                    "root": "MuiTouchRipple-root-112",
+                                  }
+                                }
+                              >
+                                <TransitionGroup
+                                  childFactory={[Function]}
+                                  className="MuiTouchRipple-root-112"
+                                  component="span"
+                                  enter={true}
+                                  exit={true}
+                                >
+                                  <span
+                                    className="MuiTouchRipple-root-112"
+                                  />
+                                </TransitionGroup>
+                              </TouchRipple>
+                            </WithStyles(TouchRipple)>
+                          </NoSsr>
+                        </button>
+                      </ButtonBase>
+                    </WithStyles(ButtonBase)>
+                  </Button>
+                </WithStyles(Button)>
+              </a>
+            </Link>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <a
+                class="unstyled"
+                href="/experiments"
+                id="experimentsBtn"
+              >
+                <button
+                  class="MuiButtonBase-root-94 MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label-69"
+                  >
+                    <div
+                      class="flex flex-row flex-shrink-0"
+                    >
+                      <div
+                        class="alignItems"
+                      >
+                        <svg
+                          height="20"
+                          viewBox="0 0 20 12"
+                          width="20"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <g
+                            fill="none"
+                            fill-rule="evenodd"
+                            id="Symbols"
+                          >
+                            <g
+                              transform="translate(-26 -72)"
+                            >
+                              <g
+                                transform="translate(0 12)"
+                              >
+                                <g
+                                  transform="translate(0 44)"
+                                >
+                                  <g
+                                    id="Group-3"
+                                  >
+                                    <g
+                                      transform="translate(26 12)"
+                                    >
+                                      <polygon
+                                        points="0 0 20 0 20 20 0 20"
+                                      />
+                                      <path
+                                        d="M15,5.83333333 L13.825,4.65833333 L8.54166667,9.94166667 L9.71666667,11.1166667 L15,5.83333333 Z M18.5333333,4.65833333 L9.71666667,13.475 L6.23333333,10 L5.05833333,11.175 L9.71666667,15.8333333 L19.7166667,5.83333333 L18.5333333,4.65833333 Z M0.341666667,11.175 L5,15.8333333 L6.175,14.6583333 L1.525,10 L0.341666667,11.175 Z"
+                                        fill="#9aa0a6"
+                                        fill-rule="nonzero"
+                                      />
+                                    </g>
+                                  </g>
+                                </g>
+                              </g>
+                            </g>
+                          </g>
+                        </svg>
+                      </div>
+                      <span
+                        class="label"
+                      >
+                        Experiments
+                      </span>
+                    </div>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-112"
+                  />
+                </button>
+              </a>
+            }
+            className="MuiTooltip-popper-60"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="right-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+      <div
+        className="indicator indicatorHidden"
+      />
+      <WithStyles(Tooltip)
+        disableFocusListener={true}
+        disableHoverListener={true}
+        disableTouchListener={true}
+        enterDelay={300}
+        placement="right-start"
+        title="Runs List"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-60",
+              "popperInteractive": "MuiTooltip-popperInteractive-61",
+              "tooltip": "MuiTooltip-tooltip-62",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-67",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-64",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-65",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-66",
+              "touch": "MuiTooltip-touch-63",
+            }
+          }
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="right-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Runs List"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <Link
+              aria-describedby={null}
+              className="unstyled"
+              id="runsBtn"
+              replace={false}
+              title={null}
+              to="/runs"
+            >
+              <a
+                aria-describedby={null}
+                className="unstyled"
+                href="/runs"
+                id="runsBtn"
+                onClick={[Function]}
+                title={null}
+              >
+                <WithStyles(Button)
+                  className="button"
+                >
+                  <Button
+                    className="button"
+                    classes={
+                      Object {
+                        "colorInherit": "MuiButton-colorInherit-89",
+                        "contained": "MuiButton-contained-79",
+                        "containedPrimary": "MuiButton-containedPrimary-80",
+                        "containedSecondary": "MuiButton-containedSecondary-81",
+                        "disabled": "MuiButton-disabled-88",
+                        "extendedFab": "MuiButton-extendedFab-86",
+                        "fab": "MuiButton-fab-85",
+                        "flat": "MuiButton-flat-73",
+                        "flatPrimary": "MuiButton-flatPrimary-74",
+                        "flatSecondary": "MuiButton-flatSecondary-75",
+                        "focusVisible": "MuiButton-focusVisible-87",
+                        "fullWidth": "MuiButton-fullWidth-93",
+                        "label": "MuiButton-label-69",
+                        "mini": "MuiButton-mini-90",
+                        "outlined": "MuiButton-outlined-76",
+                        "outlinedPrimary": "MuiButton-outlinedPrimary-77",
+                        "outlinedSecondary": "MuiButton-outlinedSecondary-78",
+                        "raised": "MuiButton-raised-82",
+                        "raisedPrimary": "MuiButton-raisedPrimary-83",
+                        "raisedSecondary": "MuiButton-raisedSecondary-84",
+                        "root": "MuiButton-root-68",
+                        "sizeLarge": "MuiButton-sizeLarge-92",
+                        "sizeSmall": "MuiButton-sizeSmall-91",
+                        "text": "MuiButton-text-70",
+                        "textPrimary": "MuiButton-textPrimary-71",
+                        "textSecondary": "MuiButton-textSecondary-72",
+                      }
+                    }
+                    color="default"
+                    component="button"
+                    disableFocusRipple={false}
+                    disabled={false}
+                    fullWidth={false}
+                    mini={false}
+                    size="medium"
+                    type="button"
+                    variant="text"
+                  >
+                    <WithStyles(ButtonBase)
+                      className="MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                      component="button"
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-87"
+                      type="button"
+                    >
+                      <ButtonBase
+                        centerRipple={false}
+                        className="MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                        classes={
+                          Object {
+                            "disabled": "MuiButtonBase-disabled-95",
+                            "focusVisible": "MuiButtonBase-focusVisible-96",
+                            "root": "MuiButtonBase-root-94",
+                          }
+                        }
+                        component="button"
+                        disableRipple={false}
+                        disableTouchRipple={false}
+                        disabled={false}
+                        focusRipple={true}
+                        focusVisibleClassName="MuiButton-focusVisible-87"
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <button
+                          className="MuiButtonBase-root-94 MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onContextMenu={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          tabIndex="0"
+                          type="button"
+                        >
+                          <span
+                            className="MuiButton-label-69"
+                          >
+                            <div
+                              className="flex flex-row flex-shrink-0"
+                            >
+                              <pure(DirectionsRunIcon)>
+                                <DirectionsRunIcon>
+                                  <WithStyles(SvgIcon)>
+                                    <SvgIcon
+                                      classes={
+                                        Object {
+                                          "colorAction": "MuiSvgIcon-colorAction-100",
+                                          "colorDisabled": "MuiSvgIcon-colorDisabled-102",
+                                          "colorError": "MuiSvgIcon-colorError-101",
+                                          "colorPrimary": "MuiSvgIcon-colorPrimary-98",
+                                          "colorSecondary": "MuiSvgIcon-colorSecondary-99",
+                                          "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-103",
+                                          "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-105",
+                                          "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-104",
+                                          "root": "MuiSvgIcon-root-97",
+                                        }
+                                      }
+                                      color="inherit"
+                                      component="svg"
+                                      fontSize="default"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        className="MuiSvgIcon-root-97"
+                                        focusable="false"
+                                        role="presentation"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                          fill="none"
+                                        />
+                                        <path
+                                          d="M13.49 5.48c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm-3.6 13.9l1-4.4 2.1 2v6h2v-7.5l-2.1-2 .6-3c1.3 1.5 3.3 2.5 5.5 2.5v-2c-1.9 0-3.5-1-4.3-2.4l-1-1.6c-.4-.6-1-1-1.7-1-.3 0-.5.1-.8.1l-5.2 2.2v4.7h2v-3.4l1.8-.7-1.6 8.1-4.9-1-.4 2 7 1.4z"
+                                        />
+                                      </svg>
+                                    </SvgIcon>
+                                  </WithStyles(SvgIcon)>
+                                </DirectionsRunIcon>
+                              </pure(DirectionsRunIcon)>
+                              <span
+                                className="label"
+                              >
+                                Runs
+                              </span>
+                            </div>
+                          </span>
+                          <NoSsr
+                            defer={false}
+                            fallback={null}
+                          >
+                            <WithStyles(TouchRipple)
+                              center={false}
+                              innerRef={[Function]}
+                            >
+                              <TouchRipple
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "MuiTouchRipple-child-116",
+                                    "childLeaving": "MuiTouchRipple-childLeaving-117",
+                                    "childPulsate": "MuiTouchRipple-childPulsate-118",
+                                    "ripple": "MuiTouchRipple-ripple-113",
+                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate-115",
+                                    "rippleVisible": "MuiTouchRipple-rippleVisible-114",
+                                    "root": "MuiTouchRipple-root-112",
+                                  }
+                                }
+                              >
+                                <TransitionGroup
+                                  childFactory={[Function]}
+                                  className="MuiTouchRipple-root-112"
+                                  component="span"
+                                  enter={true}
+                                  exit={true}
+                                >
+                                  <span
+                                    className="MuiTouchRipple-root-112"
+                                  />
+                                </TransitionGroup>
+                              </TouchRipple>
+                            </WithStyles(TouchRipple)>
+                          </NoSsr>
+                        </button>
+                      </ButtonBase>
+                    </WithStyles(ButtonBase)>
+                  </Button>
+                </WithStyles(Button)>
+              </a>
+            </Link>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <a
+                class="unstyled"
+                href="/runs"
+                id="runsBtn"
+              >
+                <button
+                  class="MuiButtonBase-root-94 MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label-69"
+                  >
+                    <div
+                      class="flex flex-row flex-shrink-0"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-97"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                        <path
+                          d="M13.49 5.48c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm-3.6 13.9l1-4.4 2.1 2v6h2v-7.5l-2.1-2 .6-3c1.3 1.5 3.3 2.5 5.5 2.5v-2c-1.9 0-3.5-1-4.3-2.4l-1-1.6c-.4-.6-1-1-1.7-1-.3 0-.5.1-.8.1l-5.2 2.2v4.7h2v-3.4l1.8-.7-1.6 8.1-4.9-1-.4 2 7 1.4z"
+                        />
+                      </svg>
+                      <span
+                        class="label"
+                      >
+                        Runs
+                      </span>
+                    </div>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-112"
+                  />
+                </button>
+              </a>
+            }
+            className="MuiTooltip-popper-60"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="right-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+      <div
+        className="indicator indicatorHidden"
+      />
+      <WithStyles(Tooltip)
+        disableFocusListener={true}
+        disableHoverListener={true}
+        disableTouchListener={true}
+        enterDelay={300}
+        placement="right-start"
+        title="Recurring Runs List"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-60",
+              "popperInteractive": "MuiTooltip-popperInteractive-61",
+              "tooltip": "MuiTooltip-tooltip-62",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-67",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-64",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-65",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-66",
+              "touch": "MuiTooltip-touch-63",
+            }
+          }
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="right-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Recurring Runs List"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <Link
+              aria-describedby={null}
+              className="unstyled"
+              id="recurringRunsBtn"
+              replace={false}
+              title={null}
+              to="/recurringruns"
+            >
+              <a
+                aria-describedby={null}
+                className="unstyled"
+                href="/recurringruns"
+                id="recurringRunsBtn"
+                onClick={[Function]}
+                title={null}
+              >
+                <WithStyles(Button)
+                  className="button"
+                >
+                  <Button
+                    className="button"
+                    classes={
+                      Object {
+                        "colorInherit": "MuiButton-colorInherit-89",
+                        "contained": "MuiButton-contained-79",
+                        "containedPrimary": "MuiButton-containedPrimary-80",
+                        "containedSecondary": "MuiButton-containedSecondary-81",
+                        "disabled": "MuiButton-disabled-88",
+                        "extendedFab": "MuiButton-extendedFab-86",
+                        "fab": "MuiButton-fab-85",
+                        "flat": "MuiButton-flat-73",
+                        "flatPrimary": "MuiButton-flatPrimary-74",
+                        "flatSecondary": "MuiButton-flatSecondary-75",
+                        "focusVisible": "MuiButton-focusVisible-87",
+                        "fullWidth": "MuiButton-fullWidth-93",
+                        "label": "MuiButton-label-69",
+                        "mini": "MuiButton-mini-90",
+                        "outlined": "MuiButton-outlined-76",
+                        "outlinedPrimary": "MuiButton-outlinedPrimary-77",
+                        "outlinedSecondary": "MuiButton-outlinedSecondary-78",
+                        "raised": "MuiButton-raised-82",
+                        "raisedPrimary": "MuiButton-raisedPrimary-83",
+                        "raisedSecondary": "MuiButton-raisedSecondary-84",
+                        "root": "MuiButton-root-68",
+                        "sizeLarge": "MuiButton-sizeLarge-92",
+                        "sizeSmall": "MuiButton-sizeSmall-91",
+                        "text": "MuiButton-text-70",
+                        "textPrimary": "MuiButton-textPrimary-71",
+                        "textSecondary": "MuiButton-textSecondary-72",
+                      }
+                    }
+                    color="default"
+                    component="button"
+                    disableFocusRipple={false}
+                    disabled={false}
+                    fullWidth={false}
+                    mini={false}
+                    size="medium"
+                    type="button"
+                    variant="text"
+                  >
+                    <WithStyles(ButtonBase)
+                      className="MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                      component="button"
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-87"
+                      type="button"
+                    >
+                      <ButtonBase
+                        centerRipple={false}
+                        className="MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                        classes={
+                          Object {
+                            "disabled": "MuiButtonBase-disabled-95",
+                            "focusVisible": "MuiButtonBase-focusVisible-96",
+                            "root": "MuiButtonBase-root-94",
+                          }
+                        }
+                        component="button"
+                        disableRipple={false}
+                        disableTouchRipple={false}
+                        disabled={false}
+                        focusRipple={true}
+                        focusVisibleClassName="MuiButton-focusVisible-87"
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <button
+                          className="MuiButtonBase-root-94 MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onContextMenu={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          tabIndex="0"
+                          type="button"
+                        >
+                          <span
+                            className="MuiButton-label-69"
+                          >
+                            <div
+                              className="flex flex-row flex-shrink-0"
+                            >
+                              <pure(AlarmIcon)>
+                                <AlarmIcon>
+                                  <WithStyles(SvgIcon)>
+                                    <SvgIcon
+                                      classes={
+                                        Object {
+                                          "colorAction": "MuiSvgIcon-colorAction-100",
+                                          "colorDisabled": "MuiSvgIcon-colorDisabled-102",
+                                          "colorError": "MuiSvgIcon-colorError-101",
+                                          "colorPrimary": "MuiSvgIcon-colorPrimary-98",
+                                          "colorSecondary": "MuiSvgIcon-colorSecondary-99",
+                                          "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-103",
+                                          "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-105",
+                                          "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-104",
+                                          "root": "MuiSvgIcon-root-97",
+                                        }
+                                      }
+                                      color="inherit"
+                                      component="svg"
+                                      fontSize="default"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        className="MuiSvgIcon-root-97"
+                                        focusable="false"
+                                        role="presentation"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                          fill="none"
+                                        />
+                                        <path
+                                          d="M22 5.72l-4.6-3.86-1.29 1.53 4.6 3.86L22 5.72zM7.88 3.39L6.6 1.86 2 5.71l1.29 1.53 4.59-3.85zM12.5 8H11v6l4.75 2.85.75-1.23-4-2.37V8zM12 4c-4.97 0-9 4.03-9 9s4.02 9 9 9c4.97 0 9-4.03 9-9s-4.03-9-9-9zm0 16c-3.87 0-7-3.13-7-7s3.13-7 7-7 7 3.13 7 7-3.13 7-7 7z"
+                                        />
+                                      </svg>
+                                    </SvgIcon>
+                                  </WithStyles(SvgIcon)>
+                                </AlarmIcon>
+                              </pure(AlarmIcon)>
+                              <span
+                                className="label"
+                              >
+                                Recurring Runs
+                              </span>
+                            </div>
+                          </span>
+                          <NoSsr
+                            defer={false}
+                            fallback={null}
+                          >
+                            <WithStyles(TouchRipple)
+                              center={false}
+                              innerRef={[Function]}
+                            >
+                              <TouchRipple
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "MuiTouchRipple-child-116",
+                                    "childLeaving": "MuiTouchRipple-childLeaving-117",
+                                    "childPulsate": "MuiTouchRipple-childPulsate-118",
+                                    "ripple": "MuiTouchRipple-ripple-113",
+                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate-115",
+                                    "rippleVisible": "MuiTouchRipple-rippleVisible-114",
+                                    "root": "MuiTouchRipple-root-112",
+                                  }
+                                }
+                              >
+                                <TransitionGroup
+                                  childFactory={[Function]}
+                                  className="MuiTouchRipple-root-112"
+                                  component="span"
+                                  enter={true}
+                                  exit={true}
+                                >
+                                  <span
+                                    className="MuiTouchRipple-root-112"
+                                  />
+                                </TransitionGroup>
+                              </TouchRipple>
+                            </WithStyles(TouchRipple)>
+                          </NoSsr>
+                        </button>
+                      </ButtonBase>
+                    </WithStyles(ButtonBase)>
+                  </Button>
+                </WithStyles(Button)>
+              </a>
+            </Link>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <a
+                class="unstyled"
+                href="/recurringruns"
+                id="recurringRunsBtn"
+              >
+                <button
+                  class="MuiButtonBase-root-94 MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label-69"
+                  >
+                    <div
+                      class="flex flex-row flex-shrink-0"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-97"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                        <path
+                          d="M22 5.72l-4.6-3.86-1.29 1.53 4.6 3.86L22 5.72zM7.88 3.39L6.6 1.86 2 5.71l1.29 1.53 4.59-3.85zM12.5 8H11v6l4.75 2.85.75-1.23-4-2.37V8zM12 4c-4.97 0-9 4.03-9 9s4.02 9 9 9c4.97 0 9-4.03 9-9s-4.03-9-9-9zm0 16c-3.87 0-7-3.13-7-7s3.13-7 7-7 7 3.13 7 7-3.13 7-7 7z"
+                        />
+                      </svg>
+                      <span
+                        class="label"
+                      >
+                        Recurring Runs
+                      </span>
+                    </div>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-112"
+                  />
+                </button>
+              </a>
+            }
+            className="MuiTooltip-popper-60"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="right-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+      <div
+        className="indicator indicatorHidden"
+      />
+      <WithStyles(Tooltip)
+        disableFocusListener={true}
+        disableHoverListener={true}
+        disableTouchListener={true}
+        enterDelay={300}
+        placement="right-start"
+        title="Artifacts List"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-60",
+              "popperInteractive": "MuiTooltip-popperInteractive-61",
+              "tooltip": "MuiTooltip-tooltip-62",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-67",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-64",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-65",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-66",
+              "touch": "MuiTooltip-touch-63",
+            }
+          }
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="right-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Artifacts List"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <Link
+              aria-describedby={null}
+              className="unstyled"
+              id="artifactsBtn"
+              replace={false}
+              title={null}
+              to="/artifacts"
+            >
+              <a
+                aria-describedby={null}
+                className="unstyled"
+                href="/artifacts"
+                id="artifactsBtn"
+                onClick={[Function]}
+                title={null}
+              >
+                <WithStyles(Button)
+                  className="button"
+                >
+                  <Button
+                    className="button"
+                    classes={
+                      Object {
+                        "colorInherit": "MuiButton-colorInherit-89",
+                        "contained": "MuiButton-contained-79",
+                        "containedPrimary": "MuiButton-containedPrimary-80",
+                        "containedSecondary": "MuiButton-containedSecondary-81",
+                        "disabled": "MuiButton-disabled-88",
+                        "extendedFab": "MuiButton-extendedFab-86",
+                        "fab": "MuiButton-fab-85",
+                        "flat": "MuiButton-flat-73",
+                        "flatPrimary": "MuiButton-flatPrimary-74",
+                        "flatSecondary": "MuiButton-flatSecondary-75",
+                        "focusVisible": "MuiButton-focusVisible-87",
+                        "fullWidth": "MuiButton-fullWidth-93",
+                        "label": "MuiButton-label-69",
+                        "mini": "MuiButton-mini-90",
+                        "outlined": "MuiButton-outlined-76",
+                        "outlinedPrimary": "MuiButton-outlinedPrimary-77",
+                        "outlinedSecondary": "MuiButton-outlinedSecondary-78",
+                        "raised": "MuiButton-raised-82",
+                        "raisedPrimary": "MuiButton-raisedPrimary-83",
+                        "raisedSecondary": "MuiButton-raisedSecondary-84",
+                        "root": "MuiButton-root-68",
+                        "sizeLarge": "MuiButton-sizeLarge-92",
+                        "sizeSmall": "MuiButton-sizeSmall-91",
+                        "text": "MuiButton-text-70",
+                        "textPrimary": "MuiButton-textPrimary-71",
+                        "textSecondary": "MuiButton-textSecondary-72",
+                      }
+                    }
+                    color="default"
+                    component="button"
+                    disableFocusRipple={false}
+                    disabled={false}
+                    fullWidth={false}
+                    mini={false}
+                    size="medium"
+                    type="button"
+                    variant="text"
+                  >
+                    <WithStyles(ButtonBase)
+                      className="MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                      component="button"
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-87"
+                      type="button"
+                    >
+                      <ButtonBase
+                        centerRipple={false}
+                        className="MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                        classes={
+                          Object {
+                            "disabled": "MuiButtonBase-disabled-95",
+                            "focusVisible": "MuiButtonBase-focusVisible-96",
+                            "root": "MuiButtonBase-root-94",
+                          }
+                        }
+                        component="button"
+                        disableRipple={false}
+                        disableTouchRipple={false}
+                        disabled={false}
+                        focusRipple={true}
+                        focusVisibleClassName="MuiButton-focusVisible-87"
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <button
+                          className="MuiButtonBase-root-94 MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onContextMenu={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          tabIndex="0"
+                          type="button"
+                        >
+                          <span
+                            className="MuiButton-label-69"
+                          >
+                            <div
+                              className="flex flex-row flex-shrink-0"
+                            >
+                              <pure(BubbleChartIcon)>
+                                <BubbleChartIcon>
+                                  <WithStyles(SvgIcon)>
+                                    <SvgIcon
+                                      classes={
+                                        Object {
+                                          "colorAction": "MuiSvgIcon-colorAction-100",
+                                          "colorDisabled": "MuiSvgIcon-colorDisabled-102",
+                                          "colorError": "MuiSvgIcon-colorError-101",
+                                          "colorPrimary": "MuiSvgIcon-colorPrimary-98",
+                                          "colorSecondary": "MuiSvgIcon-colorSecondary-99",
+                                          "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-103",
+                                          "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-105",
+                                          "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-104",
+                                          "root": "MuiSvgIcon-root-97",
+                                        }
+                                      }
+                                      color="inherit"
+                                      component="svg"
+                                      fontSize="default"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        className="MuiSvgIcon-root-97"
+                                        focusable="false"
+                                        role="presentation"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                          fill="none"
+                                        />
+                                        <circle
+                                          cx="7.2"
+                                          cy="14.4"
+                                          r="3.2"
+                                        />
+                                        <circle
+                                          cx="14.8"
+                                          cy="18"
+                                          r="2"
+                                        />
+                                        <circle
+                                          cx="15.2"
+                                          cy="8.8"
+                                          r="4.8"
+                                        />
+                                      </svg>
+                                    </SvgIcon>
+                                  </WithStyles(SvgIcon)>
+                                </BubbleChartIcon>
+                              </pure(BubbleChartIcon)>
+                              <span
+                                className="label"
+                              >
+                                Artifacts
+                              </span>
+                            </div>
+                          </span>
+                          <NoSsr
+                            defer={false}
+                            fallback={null}
+                          >
+                            <WithStyles(TouchRipple)
+                              center={false}
+                              innerRef={[Function]}
+                            >
+                              <TouchRipple
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "MuiTouchRipple-child-116",
+                                    "childLeaving": "MuiTouchRipple-childLeaving-117",
+                                    "childPulsate": "MuiTouchRipple-childPulsate-118",
+                                    "ripple": "MuiTouchRipple-ripple-113",
+                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate-115",
+                                    "rippleVisible": "MuiTouchRipple-rippleVisible-114",
+                                    "root": "MuiTouchRipple-root-112",
+                                  }
+                                }
+                              >
+                                <TransitionGroup
+                                  childFactory={[Function]}
+                                  className="MuiTouchRipple-root-112"
+                                  component="span"
+                                  enter={true}
+                                  exit={true}
+                                >
+                                  <span
+                                    className="MuiTouchRipple-root-112"
+                                  />
+                                </TransitionGroup>
+                              </TouchRipple>
+                            </WithStyles(TouchRipple)>
+                          </NoSsr>
+                        </button>
+                      </ButtonBase>
+                    </WithStyles(ButtonBase)>
+                  </Button>
+                </WithStyles(Button)>
+              </a>
+            </Link>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <a
+                class="unstyled"
+                href="/artifacts"
+                id="artifactsBtn"
+              >
+                <button
+                  class="MuiButtonBase-root-94 MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label-69"
+                  >
+                    <div
+                      class="flex flex-row flex-shrink-0"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-97"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                        <circle
+                          cx="7.2"
+                          cy="14.4"
+                          r="3.2"
+                        />
+                        <circle
+                          cx="14.8"
+                          cy="18"
+                          r="2"
+                        />
+                        <circle
+                          cx="15.2"
+                          cy="8.8"
+                          r="4.8"
+                        />
+                      </svg>
+                      <span
+                        class="label"
+                      >
+                        Artifacts
+                      </span>
+                    </div>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-112"
+                  />
+                </button>
+              </a>
+            }
+            className="MuiTooltip-popper-60"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="right-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+      <div
+        className="indicator indicatorHidden"
+      />
+      <WithStyles(Tooltip)
+        disableFocusListener={true}
+        disableHoverListener={true}
+        disableTouchListener={true}
+        enterDelay={300}
+        placement="right-start"
+        title="Executions List"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-60",
+              "popperInteractive": "MuiTooltip-popperInteractive-61",
+              "tooltip": "MuiTooltip-tooltip-62",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-67",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-64",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-65",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-66",
+              "touch": "MuiTooltip-touch-63",
+            }
+          }
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="right-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Executions List"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <Link
+              aria-describedby={null}
+              className="unstyled"
+              id="executionsBtn"
+              replace={false}
+              title={null}
+              to="/executions"
+            >
+              <a
+                aria-describedby={null}
+                className="unstyled"
+                href="/executions"
+                id="executionsBtn"
+                onClick={[Function]}
+                title={null}
+              >
+                <WithStyles(Button)
+                  className="button"
+                >
+                  <Button
+                    className="button"
+                    classes={
+                      Object {
+                        "colorInherit": "MuiButton-colorInherit-89",
+                        "contained": "MuiButton-contained-79",
+                        "containedPrimary": "MuiButton-containedPrimary-80",
+                        "containedSecondary": "MuiButton-containedSecondary-81",
+                        "disabled": "MuiButton-disabled-88",
+                        "extendedFab": "MuiButton-extendedFab-86",
+                        "fab": "MuiButton-fab-85",
+                        "flat": "MuiButton-flat-73",
+                        "flatPrimary": "MuiButton-flatPrimary-74",
+                        "flatSecondary": "MuiButton-flatSecondary-75",
+                        "focusVisible": "MuiButton-focusVisible-87",
+                        "fullWidth": "MuiButton-fullWidth-93",
+                        "label": "MuiButton-label-69",
+                        "mini": "MuiButton-mini-90",
+                        "outlined": "MuiButton-outlined-76",
+                        "outlinedPrimary": "MuiButton-outlinedPrimary-77",
+                        "outlinedSecondary": "MuiButton-outlinedSecondary-78",
+                        "raised": "MuiButton-raised-82",
+                        "raisedPrimary": "MuiButton-raisedPrimary-83",
+                        "raisedSecondary": "MuiButton-raisedSecondary-84",
+                        "root": "MuiButton-root-68",
+                        "sizeLarge": "MuiButton-sizeLarge-92",
+                        "sizeSmall": "MuiButton-sizeSmall-91",
+                        "text": "MuiButton-text-70",
+                        "textPrimary": "MuiButton-textPrimary-71",
+                        "textSecondary": "MuiButton-textSecondary-72",
+                      }
+                    }
+                    color="default"
+                    component="button"
+                    disableFocusRipple={false}
+                    disabled={false}
+                    fullWidth={false}
+                    mini={false}
+                    size="medium"
+                    type="button"
+                    variant="text"
+                  >
+                    <WithStyles(ButtonBase)
+                      className="MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                      component="button"
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-87"
+                      type="button"
+                    >
+                      <ButtonBase
+                        centerRipple={false}
+                        className="MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                        classes={
+                          Object {
+                            "disabled": "MuiButtonBase-disabled-95",
+                            "focusVisible": "MuiButtonBase-focusVisible-96",
+                            "root": "MuiButtonBase-root-94",
+                          }
+                        }
+                        component="button"
+                        disableRipple={false}
+                        disableTouchRipple={false}
+                        disabled={false}
+                        focusRipple={true}
+                        focusVisibleClassName="MuiButton-focusVisible-87"
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <button
+                          className="MuiButtonBase-root-94 MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onContextMenu={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          tabIndex="0"
+                          type="button"
+                        >
+                          <span
+                            className="MuiButton-label-69"
+                          >
+                            <div
+                              className="flex flex-row flex-shrink-0"
+                            >
+                              <pure(PlayArrowIcon)>
+                                <PlayArrowIcon>
+                                  <WithStyles(SvgIcon)>
+                                    <SvgIcon
+                                      classes={
+                                        Object {
+                                          "colorAction": "MuiSvgIcon-colorAction-100",
+                                          "colorDisabled": "MuiSvgIcon-colorDisabled-102",
+                                          "colorError": "MuiSvgIcon-colorError-101",
+                                          "colorPrimary": "MuiSvgIcon-colorPrimary-98",
+                                          "colorSecondary": "MuiSvgIcon-colorSecondary-99",
+                                          "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-103",
+                                          "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-105",
+                                          "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-104",
+                                          "root": "MuiSvgIcon-root-97",
+                                        }
+                                      }
+                                      color="inherit"
+                                      component="svg"
+                                      fontSize="default"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        className="MuiSvgIcon-root-97"
+                                        focusable="false"
+                                        role="presentation"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M8 5v14l11-7z"
+                                        />
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                          fill="none"
+                                        />
+                                      </svg>
+                                    </SvgIcon>
+                                  </WithStyles(SvgIcon)>
+                                </PlayArrowIcon>
+                              </pure(PlayArrowIcon)>
+                              <span
+                                className="label"
+                              >
+                                Executions
+                              </span>
+                            </div>
+                          </span>
+                          <NoSsr
+                            defer={false}
+                            fallback={null}
+                          >
+                            <WithStyles(TouchRipple)
+                              center={false}
+                              innerRef={[Function]}
+                            >
+                              <TouchRipple
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "MuiTouchRipple-child-116",
+                                    "childLeaving": "MuiTouchRipple-childLeaving-117",
+                                    "childPulsate": "MuiTouchRipple-childPulsate-118",
+                                    "ripple": "MuiTouchRipple-ripple-113",
+                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate-115",
+                                    "rippleVisible": "MuiTouchRipple-rippleVisible-114",
+                                    "root": "MuiTouchRipple-root-112",
+                                  }
+                                }
+                              >
+                                <TransitionGroup
+                                  childFactory={[Function]}
+                                  className="MuiTouchRipple-root-112"
+                                  component="span"
+                                  enter={true}
+                                  exit={true}
+                                >
+                                  <span
+                                    className="MuiTouchRipple-root-112"
+                                  />
+                                </TransitionGroup>
+                              </TouchRipple>
+                            </WithStyles(TouchRipple)>
+                          </NoSsr>
+                        </button>
+                      </ButtonBase>
+                    </WithStyles(ButtonBase)>
+                  </Button>
+                </WithStyles(Button)>
+              </a>
+            </Link>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <a
+                class="unstyled"
+                href="/executions"
+                id="executionsBtn"
+              >
+                <button
+                  class="MuiButtonBase-root-94 MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label-69"
+                  >
+                    <div
+                      class="flex flex-row flex-shrink-0"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-97"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M8 5v14l11-7z"
+                        />
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                      </svg>
+                      <span
+                        class="label"
+                      >
+                        Executions
+                      </span>
+                    </div>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-112"
+                  />
+                </button>
+              </a>
+            }
+            className="MuiTooltip-popper-60"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="right-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+      <hr
+        className="separator"
+      />
+      <ExternalUri
+        collapsed={false}
+        icon={[Function]}
+        title="Documentation"
+        to="https://www.kubeflow.org/docs/pipelines/"
+      >
+        <WithStyles(Tooltip)
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          enterDelay={300}
+          placement="right-start"
+          title="Documentation"
+        >
+          <Tooltip
+            TransitionComponent={[Function]}
+            classes={
+              Object {
+                "popper": "MuiTooltip-popper-60",
+                "popperInteractive": "MuiTooltip-popperInteractive-61",
+                "tooltip": "MuiTooltip-tooltip-62",
+                "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-67",
+                "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-64",
+                "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-65",
+                "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-66",
+                "touch": "MuiTooltip-touch-63",
+              }
+            }
+            disableFocusListener={true}
+            disableHoverListener={true}
+            disableTouchListener={true}
+            enterDelay={300}
+            enterTouchDelay={1000}
+            interactive={false}
+            leaveDelay={0}
+            leaveTouchDelay={1500}
+            placement="right-start"
+            theme={
+              Object {
+                "breakpoints": Object {
+                  "between": [Function],
+                  "down": [Function],
+                  "keys": Array [
+                    "xs",
+                    "sm",
+                    "md",
+                    "lg",
+                    "xl",
+                  ],
+                  "only": [Function],
+                  "up": [Function],
+                  "values": Object {
+                    "lg": 1280,
+                    "md": 960,
+                    "sm": 600,
+                    "xl": 1920,
+                    "xs": 0,
+                  },
+                  "width": [Function],
+                },
+                "direction": "ltr",
+                "mixins": Object {
+                  "gutters": [Function],
+                  "toolbar": Object {
+                    "@media (min-width:0px) and (orientation: landscape)": Object {
+                      "minHeight": 48,
+                    },
+                    "@media (min-width:600px)": Object {
+                      "minHeight": 64,
+                    },
+                    "minHeight": 56,
+                  },
+                },
+                "overrides": Object {},
+                "palette": Object {
+                  "action": Object {
+                    "active": "rgba(0, 0, 0, 0.54)",
+                    "disabled": "rgba(0, 0, 0, 0.26)",
+                    "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                    "hover": "rgba(0, 0, 0, 0.08)",
+                    "hoverOpacity": 0.08,
+                    "selected": "rgba(0, 0, 0, 0.14)",
+                  },
+                  "augmentColor": [Function],
+                  "background": Object {
+                    "default": "#fafafa",
+                    "paper": "#fff",
+                  },
+                  "common": Object {
+                    "black": "#000",
+                    "white": "#fff",
+                  },
+                  "contrastThreshold": 3,
+                  "divider": "rgba(0, 0, 0, 0.12)",
+                  "error": Object {
+                    "contrastText": "#fff",
+                    "dark": "#d32f2f",
+                    "light": "#e57373",
+                    "main": "#f44336",
+                  },
+                  "getContrastText": [Function],
+                  "grey": Object {
+                    "100": "#f5f5f5",
+                    "200": "#eeeeee",
+                    "300": "#e0e0e0",
+                    "400": "#bdbdbd",
+                    "50": "#fafafa",
+                    "500": "#9e9e9e",
+                    "600": "#757575",
+                    "700": "#616161",
+                    "800": "#424242",
+                    "900": "#212121",
+                    "A100": "#d5d5d5",
+                    "A200": "#aaaaaa",
+                    "A400": "#303030",
+                    "A700": "#616161",
+                  },
+                  "primary": Object {
+                    "contrastText": "#fff",
+                    "dark": "#303f9f",
+                    "light": "#7986cb",
+                    "main": "#3f51b5",
+                  },
+                  "secondary": Object {
+                    "contrastText": "#fff",
+                    "dark": "#c51162",
+                    "light": "#ff4081",
+                    "main": "#f50057",
+                  },
+                  "text": Object {
+                    "disabled": "rgba(0, 0, 0, 0.38)",
+                    "hint": "rgba(0, 0, 0, 0.38)",
+                    "primary": "rgba(0, 0, 0, 0.87)",
+                    "secondary": "rgba(0, 0, 0, 0.54)",
+                  },
+                  "tonalOffset": 0.2,
+                  "type": "light",
+                },
+                "props": Object {},
+                "shadows": Array [
+                  "none",
+                  "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                  "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                  "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                  "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                  "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                  "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                  "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                  "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                  "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                  "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                  "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                  "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                  "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                  "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                  "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                  "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                  "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                  "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                  "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                  "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                  "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                  "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                  "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                  "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+                ],
+                "shape": Object {
+                  "borderRadius": 4,
+                },
+                "spacing": Object {
+                  "unit": 8,
+                },
+                "transitions": Object {
+                  "create": [Function],
+                  "duration": Object {
+                    "complex": 375,
+                    "enteringScreen": 225,
+                    "leavingScreen": 195,
+                    "short": 250,
+                    "shorter": 200,
+                    "shortest": 150,
+                    "standard": 300,
+                  },
+                  "easing": Object {
+                    "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                    "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                    "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                    "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                  },
+                  "getAutoHeightDuration": [Function],
+                },
+                "typography": Object {
+                  "body1": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.46429em",
+                  },
+                  "body1Next": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.00938em",
+                    "lineHeight": 1.5,
+                  },
+                  "body2": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                    "lineHeight": "1.71429em",
+                  },
+                  "body2Next": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.01071em",
+                    "lineHeight": 1.5,
+                  },
+                  "button": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                    "textTransform": "uppercase",
+                  },
+                  "buttonNext": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                    "letterSpacing": "0.02857em",
+                    "lineHeight": 1.75,
+                    "textTransform": "uppercase",
+                  },
+                  "caption": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.375em",
+                  },
+                  "captionNext": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.03333em",
+                    "lineHeight": 1.66,
+                  },
+                  "display1": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "2.125rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.20588em",
+                  },
+                  "display2": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "2.8125rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.13333em",
+                    "marginLeft": "-.02em",
+                  },
+                  "display3": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "3.5rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "-.02em",
+                    "lineHeight": "1.30357em",
+                    "marginLeft": "-.02em",
+                  },
+                  "display4": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "7rem",
+                    "fontWeight": 300,
+                    "letterSpacing": "-.04em",
+                    "lineHeight": "1.14286em",
+                    "marginLeft": "-.04em",
+                  },
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": 14,
+                  "fontWeightLight": 300,
+                  "fontWeightMedium": 500,
+                  "fontWeightRegular": 400,
+                  "h1": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "6rem",
+                    "fontWeight": 300,
+                    "letterSpacing": "-0.01562em",
+                    "lineHeight": 1,
+                  },
+                  "h2": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "3.75rem",
+                    "fontWeight": 300,
+                    "letterSpacing": "-0.00833em",
+                    "lineHeight": 1,
+                  },
+                  "h3": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "3rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0em",
+                    "lineHeight": 1.04,
+                  },
+                  "h4": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "2.125rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.00735em",
+                    "lineHeight": 1.17,
+                  },
+                  "h5": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0em",
+                    "lineHeight": 1.33,
+                  },
+                  "h6": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1.25rem",
+                    "fontWeight": 500,
+                    "letterSpacing": "0.0075em",
+                    "lineHeight": 1.6,
+                  },
+                  "headline": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.35417em",
+                  },
+                  "overline": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.08333em",
+                    "lineHeight": 2.66,
+                    "textTransform": "uppercase",
+                  },
+                  "pxToRem": [Function],
+                  "round": [Function],
+                  "subheading": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.5em",
+                  },
+                  "subtitle1": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.00938em",
+                    "lineHeight": 1.75,
+                  },
+                  "subtitle2": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                    "letterSpacing": "0.00714em",
+                    "lineHeight": 1.57,
+                  },
+                  "title": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1.3125rem",
+                    "fontWeight": 500,
+                    "lineHeight": "1.16667em",
+                  },
+                  "useNextVariants": false,
+                },
+                "zIndex": Object {
+                  "appBar": 1100,
+                  "drawer": 1200,
+                  "mobileStepper": 1000,
+                  "modal": 1300,
+                  "snackbar": 1400,
+                  "tooltip": 1500,
+                },
+              }
+            }
+            title="Documentation"
+          >
+            <RootRef
+              rootRef={[Function]}
+            >
+              <a
+                aria-describedby={null}
+                className="unstyled"
+                href="https://www.kubeflow.org/docs/pipelines/"
+                rel="noopener noreferrer"
+                target="_blank"
+                title={null}
+              >
+                <WithStyles(Button)
+                  className="button"
+                >
+                  <Button
+                    className="button"
+                    classes={
+                      Object {
+                        "colorInherit": "MuiButton-colorInherit-89",
+                        "contained": "MuiButton-contained-79",
+                        "containedPrimary": "MuiButton-containedPrimary-80",
+                        "containedSecondary": "MuiButton-containedSecondary-81",
+                        "disabled": "MuiButton-disabled-88",
+                        "extendedFab": "MuiButton-extendedFab-86",
+                        "fab": "MuiButton-fab-85",
+                        "flat": "MuiButton-flat-73",
+                        "flatPrimary": "MuiButton-flatPrimary-74",
+                        "flatSecondary": "MuiButton-flatSecondary-75",
+                        "focusVisible": "MuiButton-focusVisible-87",
+                        "fullWidth": "MuiButton-fullWidth-93",
+                        "label": "MuiButton-label-69",
+                        "mini": "MuiButton-mini-90",
+                        "outlined": "MuiButton-outlined-76",
+                        "outlinedPrimary": "MuiButton-outlinedPrimary-77",
+                        "outlinedSecondary": "MuiButton-outlinedSecondary-78",
+                        "raised": "MuiButton-raised-82",
+                        "raisedPrimary": "MuiButton-raisedPrimary-83",
+                        "raisedSecondary": "MuiButton-raisedSecondary-84",
+                        "root": "MuiButton-root-68",
+                        "sizeLarge": "MuiButton-sizeLarge-92",
+                        "sizeSmall": "MuiButton-sizeSmall-91",
+                        "text": "MuiButton-text-70",
+                        "textPrimary": "MuiButton-textPrimary-71",
+                        "textSecondary": "MuiButton-textSecondary-72",
+                      }
+                    }
+                    color="default"
+                    component="button"
+                    disableFocusRipple={false}
+                    disabled={false}
+                    fullWidth={false}
+                    mini={false}
+                    size="medium"
+                    type="button"
+                    variant="text"
+                  >
+                    <WithStyles(ButtonBase)
+                      className="MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                      component="button"
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-87"
+                      type="button"
+                    >
+                      <ButtonBase
+                        centerRipple={false}
+                        className="MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                        classes={
+                          Object {
+                            "disabled": "MuiButtonBase-disabled-95",
+                            "focusVisible": "MuiButtonBase-focusVisible-96",
+                            "root": "MuiButtonBase-root-94",
+                          }
+                        }
+                        component="button"
+                        disableRipple={false}
+                        disableTouchRipple={false}
+                        disabled={false}
+                        focusRipple={true}
+                        focusVisibleClassName="MuiButton-focusVisible-87"
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <button
+                          className="MuiButtonBase-root-94 MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onContextMenu={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          tabIndex="0"
+                          type="button"
+                        >
+                          <span
+                            className="MuiButton-label-69"
+                          >
+                            <div
+                              className="flex flex-row flex-shrink-0"
+                            >
+                              <pure(DescriptionIcon)
+                                className="icon"
+                              >
+                                <DescriptionIcon
+                                  className="icon"
+                                >
+                                  <WithStyles(SvgIcon)
+                                    className="icon"
+                                  >
+                                    <SvgIcon
+                                      className="icon"
+                                      classes={
+                                        Object {
+                                          "colorAction": "MuiSvgIcon-colorAction-100",
+                                          "colorDisabled": "MuiSvgIcon-colorDisabled-102",
+                                          "colorError": "MuiSvgIcon-colorError-101",
+                                          "colorPrimary": "MuiSvgIcon-colorPrimary-98",
+                                          "colorSecondary": "MuiSvgIcon-colorSecondary-99",
+                                          "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-103",
+                                          "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-105",
+                                          "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-104",
+                                          "root": "MuiSvgIcon-root-97",
+                                        }
+                                      }
+                                      color="inherit"
+                                      component="svg"
+                                      fontSize="default"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        className="MuiSvgIcon-root-97 icon"
+                                        focusable="false"
+                                        role="presentation"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                          fill="none"
+                                        />
+                                        <path
+                                          d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+                                        />
+                                      </svg>
+                                    </SvgIcon>
+                                  </WithStyles(SvgIcon)>
+                                </DescriptionIcon>
+                              </pure(DescriptionIcon)>
+                              <span
+                                className="label"
+                              >
+                                Documentation
+                              </span>
+                              <pure(OpenInNewIcon)
+                                className="openInNewTabIcon"
+                              >
+                                <OpenInNewIcon
+                                  className="openInNewTabIcon"
+                                >
+                                  <WithStyles(SvgIcon)
+                                    className="openInNewTabIcon"
+                                  >
+                                    <SvgIcon
+                                      className="openInNewTabIcon"
+                                      classes={
+                                        Object {
+                                          "colorAction": "MuiSvgIcon-colorAction-100",
+                                          "colorDisabled": "MuiSvgIcon-colorDisabled-102",
+                                          "colorError": "MuiSvgIcon-colorError-101",
+                                          "colorPrimary": "MuiSvgIcon-colorPrimary-98",
+                                          "colorSecondary": "MuiSvgIcon-colorSecondary-99",
+                                          "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-103",
+                                          "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-105",
+                                          "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-104",
+                                          "root": "MuiSvgIcon-root-97",
+                                        }
+                                      }
+                                      color="inherit"
+                                      component="svg"
+                                      fontSize="default"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        className="MuiSvgIcon-root-97 openInNewTabIcon"
+                                        focusable="false"
+                                        role="presentation"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                          fill="none"
+                                        />
+                                        <path
+                                          d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                                        />
+                                      </svg>
+                                    </SvgIcon>
+                                  </WithStyles(SvgIcon)>
+                                </OpenInNewIcon>
+                              </pure(OpenInNewIcon)>
+                            </div>
+                          </span>
+                          <NoSsr
+                            defer={false}
+                            fallback={null}
+                          >
+                            <WithStyles(TouchRipple)
+                              center={false}
+                              innerRef={[Function]}
+                            >
+                              <TouchRipple
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "MuiTouchRipple-child-116",
+                                    "childLeaving": "MuiTouchRipple-childLeaving-117",
+                                    "childPulsate": "MuiTouchRipple-childPulsate-118",
+                                    "ripple": "MuiTouchRipple-ripple-113",
+                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate-115",
+                                    "rippleVisible": "MuiTouchRipple-rippleVisible-114",
+                                    "root": "MuiTouchRipple-root-112",
+                                  }
+                                }
+                              >
+                                <TransitionGroup
+                                  childFactory={[Function]}
+                                  className="MuiTouchRipple-root-112"
+                                  component="span"
+                                  enter={true}
+                                  exit={true}
+                                >
+                                  <span
+                                    className="MuiTouchRipple-root-112"
+                                  />
+                                </TransitionGroup>
+                              </TouchRipple>
+                            </WithStyles(TouchRipple)>
+                          </NoSsr>
+                        </button>
+                      </ButtonBase>
+                    </WithStyles(ButtonBase)>
+                  </Button>
+                </WithStyles(Button)>
+              </a>
+            </RootRef>
+            <Popper
+              anchorEl={
+                <a
+                  class="unstyled"
+                  href="https://www.kubeflow.org/docs/pipelines/"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <button
+                    class="MuiButtonBase-root-94 MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiButton-label-69"
+                    >
+                      <div
+                        class="flex flex-row flex-shrink-0"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-97 icon"
+                          focusable="false"
+                          role="presentation"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                          <path
+                            d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+                          />
+                        </svg>
+                        <span
+                          class="label"
+                        >
+                          Documentation
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-97 openInNewTabIcon"
+                          focusable="false"
+                          role="presentation"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                          <path
+                            d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root-112"
+                    />
+                  </button>
+                </a>
+              }
+              className="MuiTooltip-popper-60"
+              disablePortal={false}
+              id={null}
+              open={false}
+              placement="right-start"
+              transition={true}
+            />
+          </Tooltip>
+        </WithStyles(Tooltip)>
+      </ExternalUri>
+      <ExternalUri
+        collapsed={false}
+        icon={[Function]}
+        title="Github Repo"
+        to="https://github.com/kubeflow/pipelines"
+      >
+        <WithStyles(Tooltip)
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          enterDelay={300}
+          placement="right-start"
+          title="Github Repo"
+        >
+          <Tooltip
+            TransitionComponent={[Function]}
+            classes={
+              Object {
+                "popper": "MuiTooltip-popper-60",
+                "popperInteractive": "MuiTooltip-popperInteractive-61",
+                "tooltip": "MuiTooltip-tooltip-62",
+                "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-67",
+                "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-64",
+                "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-65",
+                "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-66",
+                "touch": "MuiTooltip-touch-63",
+              }
+            }
+            disableFocusListener={true}
+            disableHoverListener={true}
+            disableTouchListener={true}
+            enterDelay={300}
+            enterTouchDelay={1000}
+            interactive={false}
+            leaveDelay={0}
+            leaveTouchDelay={1500}
+            placement="right-start"
+            theme={
+              Object {
+                "breakpoints": Object {
+                  "between": [Function],
+                  "down": [Function],
+                  "keys": Array [
+                    "xs",
+                    "sm",
+                    "md",
+                    "lg",
+                    "xl",
+                  ],
+                  "only": [Function],
+                  "up": [Function],
+                  "values": Object {
+                    "lg": 1280,
+                    "md": 960,
+                    "sm": 600,
+                    "xl": 1920,
+                    "xs": 0,
+                  },
+                  "width": [Function],
+                },
+                "direction": "ltr",
+                "mixins": Object {
+                  "gutters": [Function],
+                  "toolbar": Object {
+                    "@media (min-width:0px) and (orientation: landscape)": Object {
+                      "minHeight": 48,
+                    },
+                    "@media (min-width:600px)": Object {
+                      "minHeight": 64,
+                    },
+                    "minHeight": 56,
+                  },
+                },
+                "overrides": Object {},
+                "palette": Object {
+                  "action": Object {
+                    "active": "rgba(0, 0, 0, 0.54)",
+                    "disabled": "rgba(0, 0, 0, 0.26)",
+                    "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                    "hover": "rgba(0, 0, 0, 0.08)",
+                    "hoverOpacity": 0.08,
+                    "selected": "rgba(0, 0, 0, 0.14)",
+                  },
+                  "augmentColor": [Function],
+                  "background": Object {
+                    "default": "#fafafa",
+                    "paper": "#fff",
+                  },
+                  "common": Object {
+                    "black": "#000",
+                    "white": "#fff",
+                  },
+                  "contrastThreshold": 3,
+                  "divider": "rgba(0, 0, 0, 0.12)",
+                  "error": Object {
+                    "contrastText": "#fff",
+                    "dark": "#d32f2f",
+                    "light": "#e57373",
+                    "main": "#f44336",
+                  },
+                  "getContrastText": [Function],
+                  "grey": Object {
+                    "100": "#f5f5f5",
+                    "200": "#eeeeee",
+                    "300": "#e0e0e0",
+                    "400": "#bdbdbd",
+                    "50": "#fafafa",
+                    "500": "#9e9e9e",
+                    "600": "#757575",
+                    "700": "#616161",
+                    "800": "#424242",
+                    "900": "#212121",
+                    "A100": "#d5d5d5",
+                    "A200": "#aaaaaa",
+                    "A400": "#303030",
+                    "A700": "#616161",
+                  },
+                  "primary": Object {
+                    "contrastText": "#fff",
+                    "dark": "#303f9f",
+                    "light": "#7986cb",
+                    "main": "#3f51b5",
+                  },
+                  "secondary": Object {
+                    "contrastText": "#fff",
+                    "dark": "#c51162",
+                    "light": "#ff4081",
+                    "main": "#f50057",
+                  },
+                  "text": Object {
+                    "disabled": "rgba(0, 0, 0, 0.38)",
+                    "hint": "rgba(0, 0, 0, 0.38)",
+                    "primary": "rgba(0, 0, 0, 0.87)",
+                    "secondary": "rgba(0, 0, 0, 0.54)",
+                  },
+                  "tonalOffset": 0.2,
+                  "type": "light",
+                },
+                "props": Object {},
+                "shadows": Array [
+                  "none",
+                  "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                  "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                  "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                  "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                  "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                  "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                  "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                  "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                  "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                  "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                  "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                  "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                  "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                  "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                  "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                  "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                  "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                  "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                  "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                  "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                  "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                  "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                  "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                  "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+                ],
+                "shape": Object {
+                  "borderRadius": 4,
+                },
+                "spacing": Object {
+                  "unit": 8,
+                },
+                "transitions": Object {
+                  "create": [Function],
+                  "duration": Object {
+                    "complex": 375,
+                    "enteringScreen": 225,
+                    "leavingScreen": 195,
+                    "short": 250,
+                    "shorter": 200,
+                    "shortest": 150,
+                    "standard": 300,
+                  },
+                  "easing": Object {
+                    "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                    "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                    "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                    "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                  },
+                  "getAutoHeightDuration": [Function],
+                },
+                "typography": Object {
+                  "body1": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.46429em",
+                  },
+                  "body1Next": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.00938em",
+                    "lineHeight": 1.5,
+                  },
+                  "body2": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                    "lineHeight": "1.71429em",
+                  },
+                  "body2Next": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.01071em",
+                    "lineHeight": 1.5,
+                  },
+                  "button": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                    "textTransform": "uppercase",
+                  },
+                  "buttonNext": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                    "letterSpacing": "0.02857em",
+                    "lineHeight": 1.75,
+                    "textTransform": "uppercase",
+                  },
+                  "caption": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.375em",
+                  },
+                  "captionNext": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.03333em",
+                    "lineHeight": 1.66,
+                  },
+                  "display1": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "2.125rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.20588em",
+                  },
+                  "display2": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "2.8125rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.13333em",
+                    "marginLeft": "-.02em",
+                  },
+                  "display3": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "3.5rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "-.02em",
+                    "lineHeight": "1.30357em",
+                    "marginLeft": "-.02em",
+                  },
+                  "display4": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "7rem",
+                    "fontWeight": 300,
+                    "letterSpacing": "-.04em",
+                    "lineHeight": "1.14286em",
+                    "marginLeft": "-.04em",
+                  },
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": 14,
+                  "fontWeightLight": 300,
+                  "fontWeightMedium": 500,
+                  "fontWeightRegular": 400,
+                  "h1": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "6rem",
+                    "fontWeight": 300,
+                    "letterSpacing": "-0.01562em",
+                    "lineHeight": 1,
+                  },
+                  "h2": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "3.75rem",
+                    "fontWeight": 300,
+                    "letterSpacing": "-0.00833em",
+                    "lineHeight": 1,
+                  },
+                  "h3": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "3rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0em",
+                    "lineHeight": 1.04,
+                  },
+                  "h4": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "2.125rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.00735em",
+                    "lineHeight": 1.17,
+                  },
+                  "h5": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0em",
+                    "lineHeight": 1.33,
+                  },
+                  "h6": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1.25rem",
+                    "fontWeight": 500,
+                    "letterSpacing": "0.0075em",
+                    "lineHeight": 1.6,
+                  },
+                  "headline": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.35417em",
+                  },
+                  "overline": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.08333em",
+                    "lineHeight": 2.66,
+                    "textTransform": "uppercase",
+                  },
+                  "pxToRem": [Function],
+                  "round": [Function],
+                  "subheading": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.5em",
+                  },
+                  "subtitle1": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.00938em",
+                    "lineHeight": 1.75,
+                  },
+                  "subtitle2": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                    "letterSpacing": "0.00714em",
+                    "lineHeight": 1.57,
+                  },
+                  "title": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1.3125rem",
+                    "fontWeight": 500,
+                    "lineHeight": "1.16667em",
+                  },
+                  "useNextVariants": false,
+                },
+                "zIndex": Object {
+                  "appBar": 1100,
+                  "drawer": 1200,
+                  "mobileStepper": 1000,
+                  "modal": 1300,
+                  "snackbar": 1400,
+                  "tooltip": 1500,
+                },
+              }
+            }
+            title="Github Repo"
+          >
+            <RootRef
+              rootRef={[Function]}
+            >
+              <a
+                aria-describedby={null}
+                className="unstyled"
+                href="https://github.com/kubeflow/pipelines"
+                rel="noopener noreferrer"
+                target="_blank"
+                title={null}
+              >
+                <WithStyles(Button)
+                  className="button"
+                >
+                  <Button
+                    className="button"
+                    classes={
+                      Object {
+                        "colorInherit": "MuiButton-colorInherit-89",
+                        "contained": "MuiButton-contained-79",
+                        "containedPrimary": "MuiButton-containedPrimary-80",
+                        "containedSecondary": "MuiButton-containedSecondary-81",
+                        "disabled": "MuiButton-disabled-88",
+                        "extendedFab": "MuiButton-extendedFab-86",
+                        "fab": "MuiButton-fab-85",
+                        "flat": "MuiButton-flat-73",
+                        "flatPrimary": "MuiButton-flatPrimary-74",
+                        "flatSecondary": "MuiButton-flatSecondary-75",
+                        "focusVisible": "MuiButton-focusVisible-87",
+                        "fullWidth": "MuiButton-fullWidth-93",
+                        "label": "MuiButton-label-69",
+                        "mini": "MuiButton-mini-90",
+                        "outlined": "MuiButton-outlined-76",
+                        "outlinedPrimary": "MuiButton-outlinedPrimary-77",
+                        "outlinedSecondary": "MuiButton-outlinedSecondary-78",
+                        "raised": "MuiButton-raised-82",
+                        "raisedPrimary": "MuiButton-raisedPrimary-83",
+                        "raisedSecondary": "MuiButton-raisedSecondary-84",
+                        "root": "MuiButton-root-68",
+                        "sizeLarge": "MuiButton-sizeLarge-92",
+                        "sizeSmall": "MuiButton-sizeSmall-91",
+                        "text": "MuiButton-text-70",
+                        "textPrimary": "MuiButton-textPrimary-71",
+                        "textSecondary": "MuiButton-textSecondary-72",
+                      }
+                    }
+                    color="default"
+                    component="button"
+                    disableFocusRipple={false}
+                    disabled={false}
+                    fullWidth={false}
+                    mini={false}
+                    size="medium"
+                    type="button"
+                    variant="text"
+                  >
+                    <WithStyles(ButtonBase)
+                      className="MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                      component="button"
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-87"
+                      type="button"
+                    >
+                      <ButtonBase
+                        centerRipple={false}
+                        className="MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                        classes={
+                          Object {
+                            "disabled": "MuiButtonBase-disabled-95",
+                            "focusVisible": "MuiButtonBase-focusVisible-96",
+                            "root": "MuiButtonBase-root-94",
+                          }
+                        }
+                        component="button"
+                        disableRipple={false}
+                        disableTouchRipple={false}
+                        disabled={false}
+                        focusRipple={true}
+                        focusVisibleClassName="MuiButton-focusVisible-87"
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <button
+                          className="MuiButtonBase-root-94 MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onContextMenu={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          tabIndex="0"
+                          type="button"
+                        >
+                          <span
+                            className="MuiButton-label-69"
+                          >
+                            <div
+                              className="flex flex-row flex-shrink-0"
+                            >
+                              <img
+                                alt="Github"
+                                className="icon iconImage"
+                                src="GitHub-Mark-120px-plus.png"
+                              />
+                              <span
+                                className="label"
+                              >
+                                Github Repo
+                              </span>
+                              <pure(OpenInNewIcon)
+                                className="openInNewTabIcon"
+                              >
+                                <OpenInNewIcon
+                                  className="openInNewTabIcon"
+                                >
+                                  <WithStyles(SvgIcon)
+                                    className="openInNewTabIcon"
+                                  >
+                                    <SvgIcon
+                                      className="openInNewTabIcon"
+                                      classes={
+                                        Object {
+                                          "colorAction": "MuiSvgIcon-colorAction-100",
+                                          "colorDisabled": "MuiSvgIcon-colorDisabled-102",
+                                          "colorError": "MuiSvgIcon-colorError-101",
+                                          "colorPrimary": "MuiSvgIcon-colorPrimary-98",
+                                          "colorSecondary": "MuiSvgIcon-colorSecondary-99",
+                                          "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-103",
+                                          "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-105",
+                                          "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-104",
+                                          "root": "MuiSvgIcon-root-97",
+                                        }
+                                      }
+                                      color="inherit"
+                                      component="svg"
+                                      fontSize="default"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        className="MuiSvgIcon-root-97 openInNewTabIcon"
+                                        focusable="false"
+                                        role="presentation"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                          fill="none"
+                                        />
+                                        <path
+                                          d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                                        />
+                                      </svg>
+                                    </SvgIcon>
+                                  </WithStyles(SvgIcon)>
+                                </OpenInNewIcon>
+                              </pure(OpenInNewIcon)>
+                            </div>
+                          </span>
+                          <NoSsr
+                            defer={false}
+                            fallback={null}
+                          >
+                            <WithStyles(TouchRipple)
+                              center={false}
+                              innerRef={[Function]}
+                            >
+                              <TouchRipple
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "MuiTouchRipple-child-116",
+                                    "childLeaving": "MuiTouchRipple-childLeaving-117",
+                                    "childPulsate": "MuiTouchRipple-childPulsate-118",
+                                    "ripple": "MuiTouchRipple-ripple-113",
+                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate-115",
+                                    "rippleVisible": "MuiTouchRipple-rippleVisible-114",
+                                    "root": "MuiTouchRipple-root-112",
+                                  }
+                                }
+                              >
+                                <TransitionGroup
+                                  childFactory={[Function]}
+                                  className="MuiTouchRipple-root-112"
+                                  component="span"
+                                  enter={true}
+                                  exit={true}
+                                >
+                                  <span
+                                    className="MuiTouchRipple-root-112"
+                                  />
+                                </TransitionGroup>
+                              </TouchRipple>
+                            </WithStyles(TouchRipple)>
+                          </NoSsr>
+                        </button>
+                      </ButtonBase>
+                    </WithStyles(ButtonBase)>
+                  </Button>
+                </WithStyles(Button)>
+              </a>
+            </RootRef>
+            <Popper
+              anchorEl={
+                <a
+                  class="unstyled"
+                  href="https://github.com/kubeflow/pipelines"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <button
+                    class="MuiButtonBase-root-94 MuiButton-root-68 MuiButton-text-70 MuiButton-flat-73 button"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiButton-label-69"
+                    >
+                      <div
+                        class="flex flex-row flex-shrink-0"
+                      >
+                        <img
+                          alt="Github"
+                          class="icon iconImage"
+                          src="GitHub-Mark-120px-plus.png"
+                        />
+                        <span
+                          class="label"
+                        >
+                          Github Repo
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-97 openInNewTabIcon"
+                          focusable="false"
+                          role="presentation"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                          <path
+                            d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root-112"
+                    />
+                  </button>
+                </a>
+              }
+              className="MuiTooltip-popper-60"
+              disablePortal={false}
+              id={null}
+              open={false}
+              placement="right-start"
+              transition={true}
+            />
+          </Tooltip>
+        </WithStyles(Tooltip)>
+      </ExternalUri>
+      <hr
+        className="separator"
+      />
+      <WithStyles(IconButton)
+        className="chevron"
+        onClick={[Function]}
+      >
+        <IconButton
+          className="chevron"
+          classes={
+            Object {
+              "colorInherit": "MuiIconButton-colorInherit-107",
+              "colorPrimary": "MuiIconButton-colorPrimary-108",
+              "colorSecondary": "MuiIconButton-colorSecondary-109",
+              "disabled": "MuiIconButton-disabled-110",
+              "label": "MuiIconButton-label-111",
+              "root": "MuiIconButton-root-106",
+            }
+          }
+          color="default"
+          disabled={false}
+          onClick={[Function]}
+        >
+          <WithStyles(ButtonBase)
+            centerRipple={true}
+            className="MuiIconButton-root-106 chevron"
+            disabled={false}
+            focusRipple={true}
+            onClick={[Function]}
+          >
+            <ButtonBase
+              centerRipple={true}
+              className="MuiIconButton-root-106 chevron"
+              classes={
+                Object {
+                  "disabled": "MuiButtonBase-disabled-95",
+                  "focusVisible": "MuiButtonBase-focusVisible-96",
+                  "root": "MuiButtonBase-root-94",
+                }
+              }
+              component="button"
+              disableRipple={false}
+              disableTouchRipple={false}
+              disabled={false}
+              focusRipple={true}
+              onClick={[Function]}
+              tabIndex="0"
+              type="button"
+            >
+              <button
+                className="MuiButtonBase-root-94 MuiIconButton-root-106 chevron"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                tabIndex="0"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label-111"
+                >
+                  <pure(ChevronLeftIcon)>
+                    <ChevronLeftIcon>
+                      <WithStyles(SvgIcon)>
+                        <SvgIcon
+                          classes={
+                            Object {
+                              "colorAction": "MuiSvgIcon-colorAction-100",
+                              "colorDisabled": "MuiSvgIcon-colorDisabled-102",
+                              "colorError": "MuiSvgIcon-colorError-101",
+                              "colorPrimary": "MuiSvgIcon-colorPrimary-98",
+                              "colorSecondary": "MuiSvgIcon-colorSecondary-99",
+                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-103",
+                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-105",
+                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-104",
+                              "root": "MuiSvgIcon-root-97",
+                            }
+                          }
+                          color="inherit"
+                          component="svg"
+                          fontSize="default"
+                          viewBox="0 0 24 24"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="MuiSvgIcon-root-97"
+                            focusable="false"
+                            role="presentation"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                            />
+                            <path
+                              d="M0 0h24v24H0z"
+                              fill="none"
+                            />
+                          </svg>
+                        </SvgIcon>
+                      </WithStyles(SvgIcon)>
+                    </ChevronLeftIcon>
+                  </pure(ChevronLeftIcon)>
+                </span>
+                <NoSsr
+                  defer={false}
+                  fallback={null}
+                >
+                  <WithStyles(TouchRipple)
+                    center={true}
+                    innerRef={[Function]}
+                  >
+                    <TouchRipple
+                      center={true}
+                      classes={
+                        Object {
+                          "child": "MuiTouchRipple-child-116",
+                          "childLeaving": "MuiTouchRipple-childLeaving-117",
+                          "childPulsate": "MuiTouchRipple-childPulsate-118",
+                          "ripple": "MuiTouchRipple-ripple-113",
+                          "ripplePulsate": "MuiTouchRipple-ripplePulsate-115",
+                          "rippleVisible": "MuiTouchRipple-rippleVisible-114",
+                          "root": "MuiTouchRipple-root-112",
+                        }
+                      }
+                    >
+                      <TransitionGroup
+                        childFactory={[Function]}
+                        className="MuiTouchRipple-root-112"
+                        component="span"
+                        enter={true}
+                        exit={true}
+                      >
+                        <span
+                          className="MuiTouchRipple-root-112"
+                        />
+                      </TransitionGroup>
+                    </TouchRipple>
+                  </WithStyles(TouchRipple)>
+                </NoSsr>
+              </button>
+            </ButtonBase>
+          </WithStyles(ButtonBase)>
+        </IconButton>
+      </WithStyles(IconButton)>
+    </div>
+    <div
+      className="infoVisible"
+    >
+      <WithStyles(Tooltip)
+        enterDelay={300}
+        placement="top-start"
+        title="Cluster name: some-cluster-name, Project ID: some-project-id"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-60",
+              "popperInteractive": "MuiTooltip-popperInteractive-61",
+              "tooltip": "MuiTooltip-tooltip-62",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-67",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-64",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-65",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-66",
+              "touch": "MuiTooltip-touch-63",
+            }
+          }
+          disableFocusListener={false}
+          disableHoverListener={false}
+          disableTouchListener={false}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="top-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Cluster name: some-cluster-name, Project ID: some-project-id"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <div
+              aria-describedby={null}
+              className="envMetadata"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseLeave={[Function]}
+              onMouseOver={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              title="Cluster name: some-cluster-name, Project ID: some-project-id"
+            >
+              <span>
+                Cluster name: 
+              </span>
+              <a
+                className="link unstyled"
+                href="https://console.cloud.google.com/kubernetes/list?project=some-project-id&filter=name:some-cluster-name"
+                rel="noopener"
+                target="_blank"
+              >
+                some-cluster-name
+              </a>
+            </div>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <div
+                class="envMetadata"
+                title="Cluster name: some-cluster-name, Project ID: some-project-id"
+              >
+                <span>
+                  Cluster name: 
+                </span>
+                <a
+                  class="link unstyled"
+                  href="https://console.cloud.google.com/kubernetes/list?project=some-project-id&filter=name:some-cluster-name"
+                  rel="noopener"
+                  target="_blank"
+                >
+                  some-cluster-name
+                </a>
+              </div>
+            }
+            className="MuiTooltip-popper-60"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="top-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+      <WithStyles(Tooltip)
+        enterDelay={300}
+        placement="top-start"
+        title="Build date: unknown, Commit hash: unknown"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-60",
+              "popperInteractive": "MuiTooltip-popperInteractive-61",
+              "tooltip": "MuiTooltip-tooltip-62",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-67",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-64",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-65",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-66",
+              "touch": "MuiTooltip-touch-63",
+            }
+          }
+          disableFocusListener={false}
+          disableHoverListener={false}
+          disableTouchListener={false}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="top-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Build date: unknown, Commit hash: unknown"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <div
+              aria-describedby={null}
+              className="envMetadata"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseLeave={[Function]}
+              onMouseOver={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              title="Build date: unknown, Commit hash: unknown"
+            >
+              <span>
+                Version: 
+              </span>
+              <a
+                className="link unstyled"
+                href="https://www.github.com/kubeflow/pipelines"
+                rel="noopener"
+                target="_blank"
+              >
+                unknown
+              </a>
+            </div>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <div
+                class="envMetadata"
+                title="Build date: unknown, Commit hash: unknown"
+              >
+                <span>
+                  Version: 
+                </span>
+                <a
+                  class="link unstyled"
+                  href="https://www.github.com/kubeflow/pipelines"
+                  rel="noopener"
+                  target="_blank"
+                >
+                  unknown
+                </a>
+              </div>
+            }
+            className="MuiTooltip-popper-60"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="top-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+      <WithStyles(Tooltip)
+        enterDelay={300}
+        placement="top-start"
+        title="Report an Issue"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-60",
+              "popperInteractive": "MuiTooltip-popperInteractive-61",
+              "tooltip": "MuiTooltip-tooltip-62",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-67",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-64",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-65",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-66",
+              "touch": "MuiTooltip-touch-63",
+            }
+          }
+          disableFocusListener={false}
+          disableHoverListener={false}
+          disableTouchListener={false}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="top-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Report an Issue"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <div
+              aria-describedby={null}
+              className="envMetadata"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseLeave={[Function]}
+              onMouseOver={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              title="Report an Issue"
+            >
+              <a
+                className="link unstyled"
+                href="https://github.com/kubeflow/pipelines/issues/new/choose"
+                rel="noopener"
+                target="_blank"
+              >
+                Report an Issue
+              </a>
+            </div>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <div
+                class="envMetadata"
+                title="Report an Issue"
+              >
+                <a
+                  class="link unstyled"
+                  href="https://github.com/kubeflow/pipelines/issues/new/choose"
+                  rel="noopener"
+                  target="_blank"
+                >
+                  Report an Issue
+                </a>
+              </div>
+            }
+            className="MuiTooltip-popper-60"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="top-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+    </div>
+  </div>
+</SideNav>
+`;
+
+exports[`SideNav populates the display build information using the default props 1`] = `
+<SideNav
+  buildInfo={
+    Object {
+      "apiServerCommitHash": "0a7b9e38f2b9bcdef4bbf3234d971e1635b50cd5",
+      "apiServerReady": true,
+      "apiServerTagName": "1.0.0",
+      "buildDate": "Tue Oct 23 14:23:53 UTC 2018",
+      "frontendCommitHash": "302e93ce99099173f387c7e0635476fe1b69ea98",
+      "frontendTagName": "1.0.0-rc1",
+    }
+  }
+  gkeMetadata={Object {}}
+  history={Object {}}
+  page="/pipelines"
+>
+  <div
+    className="root flexColumn noShrink"
+    id="sideNav"
+  >
+    <div
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+    >
+      <div
+        className="indicator"
+      />
+      <WithStyles(Tooltip)
+        disableFocusListener={true}
+        disableHoverListener={true}
+        disableTouchListener={true}
+        enterDelay={300}
+        placement="right-start"
+        title="Pipeline List"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-1",
+              "popperInteractive": "MuiTooltip-popperInteractive-2",
+              "tooltip": "MuiTooltip-tooltip-3",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-8",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-5",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-6",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-7",
+              "touch": "MuiTooltip-touch-4",
+            }
+          }
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="right-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Pipeline List"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <Link
+              aria-describedby={null}
+              className="unstyled"
+              id="pipelinesBtn"
+              replace={false}
+              title={null}
+              to="/pipelines"
+            >
+              <a
+                aria-describedby={null}
+                className="unstyled"
+                href="/pipelines"
+                id="pipelinesBtn"
+                onClick={[Function]}
+                title={null}
+              >
+                <WithStyles(Button)
+                  className="button active"
+                >
+                  <Button
+                    className="button active"
+                    classes={
+                      Object {
+                        "colorInherit": "MuiButton-colorInherit-30",
+                        "contained": "MuiButton-contained-20",
+                        "containedPrimary": "MuiButton-containedPrimary-21",
+                        "containedSecondary": "MuiButton-containedSecondary-22",
+                        "disabled": "MuiButton-disabled-29",
+                        "extendedFab": "MuiButton-extendedFab-27",
+                        "fab": "MuiButton-fab-26",
+                        "flat": "MuiButton-flat-14",
+                        "flatPrimary": "MuiButton-flatPrimary-15",
+                        "flatSecondary": "MuiButton-flatSecondary-16",
+                        "focusVisible": "MuiButton-focusVisible-28",
+                        "fullWidth": "MuiButton-fullWidth-34",
+                        "label": "MuiButton-label-10",
+                        "mini": "MuiButton-mini-31",
+                        "outlined": "MuiButton-outlined-17",
+                        "outlinedPrimary": "MuiButton-outlinedPrimary-18",
+                        "outlinedSecondary": "MuiButton-outlinedSecondary-19",
+                        "raised": "MuiButton-raised-23",
+                        "raisedPrimary": "MuiButton-raisedPrimary-24",
+                        "raisedSecondary": "MuiButton-raisedSecondary-25",
+                        "root": "MuiButton-root-9",
+                        "sizeLarge": "MuiButton-sizeLarge-33",
+                        "sizeSmall": "MuiButton-sizeSmall-32",
+                        "text": "MuiButton-text-11",
+                        "textPrimary": "MuiButton-textPrimary-12",
+                        "textSecondary": "MuiButton-textSecondary-13",
+                      }
+                    }
+                    color="default"
+                    component="button"
+                    disableFocusRipple={false}
+                    disabled={false}
+                    fullWidth={false}
+                    mini={false}
+                    size="medium"
+                    type="button"
+                    variant="text"
+                  >
+                    <WithStyles(ButtonBase)
+                      className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button active"
+                      component="button"
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-28"
+                      type="button"
+                    >
+                      <ButtonBase
+                        centerRipple={false}
+                        className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button active"
+                        classes={
+                          Object {
+                            "disabled": "MuiButtonBase-disabled-36",
+                            "focusVisible": "MuiButtonBase-focusVisible-37",
+                            "root": "MuiButtonBase-root-35",
+                          }
+                        }
+                        component="button"
+                        disableRipple={false}
+                        disableTouchRipple={false}
+                        disabled={false}
+                        focusRipple={true}
+                        focusVisibleClassName="MuiButton-focusVisible-28"
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <button
+                          className="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button active"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onContextMenu={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          tabIndex="0"
+                          type="button"
+                        >
+                          <span
+                            className="MuiButton-label-10"
+                          >
+                            <div
+                              className="flex flex-row flex-shrink-0"
+                            >
+                              <div
+                                className="alignItems"
+                              >
+                                <PipelinesIcon
+                                  color="#0d6de7"
+                                >
+                                  <svg
+                                    height="20px"
+                                    version="1.1"
+                                    viewBox="0 0 20 20"
+                                    width="20px"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                                  >
+                                    <g
+                                      fill="none"
+                                      fillRule="evenodd"
+                                      id="Symbols"
+                                      stroke="none"
+                                      strokeWidth="1"
+                                    >
+                                      <g
+                                        transform="translate(-2.000000, -4.000000)"
+                                      >
+                                        <polygon
+                                          id="Shape"
+                                          points="0 0 24 0 24 24 0 24"
+                                        />
+                                        <path
+                                          d="M12.7244079,9.74960425 L17.4807112,9.74960425 C17.7675226,9.74960425 18,9.51894323 18,9.23437272 L18,4.51523153 C18,4.23066102 17.7675226,4 17.4807112,4 L12.7244079,4 C12.4375965,4 12.2051191,4.23066102 12.2051191,4.51523153 L12.2051191,6.06125154 L9.98218019,6.06125154 C9.52936032,6.06125154 9.16225043,6.42549311 9.16225043,6.87477501 L9.16225043,11.2135669 L7.05995053,11.2135669 C6.71661861,10.189612 5.74374462,9.45093267 4.59644424,9.45093267 C3.16249641,9.45093267 2,10.6043462 2,12.0270903 C2,13.4498886 3.16249641,14.603248 4.59644424,14.603248 C5.74379928,14.603248 6.71661861,13.8645687 7.06000519,12.8406138 L9.16225043,12.8406138 L9.16225043,17.1794057 C9.16225043,17.6286875 9.52936032,17.9929291 9.98218019,17.9929291 L12.2051191,17.9929291 L12.2051191,19.4847685 C12.2051191,19.769339 12.4375965,20 12.7244079,20 L17.4807112,20 C17.7675226,20 18,19.769339 18,19.4847685 L18,14.7656273 C18,14.4810568 17.7675226,14.2503957 17.4807112,14.2503957 L12.7244079,14.2503957 C12.4375965,14.2503957 12.2051191,14.4810568 12.2051191,14.7656273 L12.2051191,16.3658822 L10.80211,16.3658822 L10.80211,7.68829848 L12.2051191,7.68829848 L12.2051191,9.23437272 C12.2051191,9.51894323 12.4375965,9.74960425 12.7244079,9.74960425 Z"
+                                          fill="#0d6de7"
+                                          id="Path"
+                                        />
+                                      </g>
+                                    </g>
+                                  </svg>
+                                </PipelinesIcon>
+                              </div>
+                              <span
+                                className="label"
+                              >
+                                Pipelines
+                              </span>
+                            </div>
+                          </span>
+                          <NoSsr
+                            defer={false}
+                            fallback={null}
+                          >
+                            <WithStyles(TouchRipple)
+                              center={false}
+                              innerRef={[Function]}
+                            >
+                              <TouchRipple
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "MuiTouchRipple-child-57",
+                                    "childLeaving": "MuiTouchRipple-childLeaving-58",
+                                    "childPulsate": "MuiTouchRipple-childPulsate-59",
+                                    "ripple": "MuiTouchRipple-ripple-54",
+                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate-56",
+                                    "rippleVisible": "MuiTouchRipple-rippleVisible-55",
+                                    "root": "MuiTouchRipple-root-53",
+                                  }
+                                }
+                              >
+                                <TransitionGroup
+                                  childFactory={[Function]}
+                                  className="MuiTouchRipple-root-53"
+                                  component="span"
+                                  enter={true}
+                                  exit={true}
+                                >
+                                  <span
+                                    className="MuiTouchRipple-root-53"
+                                  />
+                                </TransitionGroup>
+                              </TouchRipple>
+                            </WithStyles(TouchRipple)>
+                          </NoSsr>
+                        </button>
+                      </ButtonBase>
+                    </WithStyles(ButtonBase)>
+                  </Button>
+                </WithStyles(Button)>
+              </a>
+            </Link>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <a
+                class="unstyled"
+                href="/pipelines"
+                id="pipelinesBtn"
+              >
+                <button
+                  class="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button active"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label-10"
+                  >
+                    <div
+                      class="flex flex-row flex-shrink-0"
+                    >
+                      <div
+                        class="alignItems"
+                      >
+                        <svg
+                          height="20px"
+                          version="1.1"
+                          viewBox="0 0 20 20"
+                          width="20px"
+                          xmlns="http://www.w3.org/2000/svg"
+                          xmlns:xlink="http://www.w3.org/1999/xlink"
+                        >
+                          <g
+                            fill="none"
+                            fill-rule="evenodd"
+                            id="Symbols"
+                            stroke="none"
+                            stroke-width="1"
+                          >
+                            <g
+                              transform="translate(-2.000000, -4.000000)"
+                            >
+                              <polygon
+                                id="Shape"
+                                points="0 0 24 0 24 24 0 24"
+                              />
+                              <path
+                                d="M12.7244079,9.74960425 L17.4807112,9.74960425 C17.7675226,9.74960425 18,9.51894323 18,9.23437272 L18,4.51523153 C18,4.23066102 17.7675226,4 17.4807112,4 L12.7244079,4 C12.4375965,4 12.2051191,4.23066102 12.2051191,4.51523153 L12.2051191,6.06125154 L9.98218019,6.06125154 C9.52936032,6.06125154 9.16225043,6.42549311 9.16225043,6.87477501 L9.16225043,11.2135669 L7.05995053,11.2135669 C6.71661861,10.189612 5.74374462,9.45093267 4.59644424,9.45093267 C3.16249641,9.45093267 2,10.6043462 2,12.0270903 C2,13.4498886 3.16249641,14.603248 4.59644424,14.603248 C5.74379928,14.603248 6.71661861,13.8645687 7.06000519,12.8406138 L9.16225043,12.8406138 L9.16225043,17.1794057 C9.16225043,17.6286875 9.52936032,17.9929291 9.98218019,17.9929291 L12.2051191,17.9929291 L12.2051191,19.4847685 C12.2051191,19.769339 12.4375965,20 12.7244079,20 L17.4807112,20 C17.7675226,20 18,19.769339 18,19.4847685 L18,14.7656273 C18,14.4810568 17.7675226,14.2503957 17.4807112,14.2503957 L12.7244079,14.2503957 C12.4375965,14.2503957 12.2051191,14.4810568 12.2051191,14.7656273 L12.2051191,16.3658822 L10.80211,16.3658822 L10.80211,7.68829848 L12.2051191,7.68829848 L12.2051191,9.23437272 C12.2051191,9.51894323 12.4375965,9.74960425 12.7244079,9.74960425 Z"
+                                fill="#0d6de7"
+                                id="Path"
+                              />
+                            </g>
+                          </g>
+                        </svg>
+                      </div>
+                      <span
+                        class="label"
+                      >
+                        Pipelines
+                      </span>
+                    </div>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-53"
+                  />
+                </button>
+              </a>
+            }
+            className="MuiTooltip-popper-1"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="right-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+      <div
+        className="indicator indicatorHidden"
+      />
+      <WithStyles(Tooltip)
+        disableFocusListener={true}
+        disableHoverListener={true}
+        disableTouchListener={true}
+        enterDelay={300}
+        placement="right-start"
+        title="Experiment List"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-1",
+              "popperInteractive": "MuiTooltip-popperInteractive-2",
+              "tooltip": "MuiTooltip-tooltip-3",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-8",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-5",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-6",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-7",
+              "touch": "MuiTooltip-touch-4",
+            }
+          }
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="right-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Experiment List"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <Link
+              aria-describedby={null}
+              className="unstyled"
+              id="experimentsBtn"
+              replace={false}
+              title={null}
+              to="/experiments"
+            >
+              <a
+                aria-describedby={null}
+                className="unstyled"
+                href="/experiments"
+                id="experimentsBtn"
+                onClick={[Function]}
+                title={null}
+              >
+                <WithStyles(Button)
+                  className="button"
+                >
+                  <Button
+                    className="button"
+                    classes={
+                      Object {
+                        "colorInherit": "MuiButton-colorInherit-30",
+                        "contained": "MuiButton-contained-20",
+                        "containedPrimary": "MuiButton-containedPrimary-21",
+                        "containedSecondary": "MuiButton-containedSecondary-22",
+                        "disabled": "MuiButton-disabled-29",
+                        "extendedFab": "MuiButton-extendedFab-27",
+                        "fab": "MuiButton-fab-26",
+                        "flat": "MuiButton-flat-14",
+                        "flatPrimary": "MuiButton-flatPrimary-15",
+                        "flatSecondary": "MuiButton-flatSecondary-16",
+                        "focusVisible": "MuiButton-focusVisible-28",
+                        "fullWidth": "MuiButton-fullWidth-34",
+                        "label": "MuiButton-label-10",
+                        "mini": "MuiButton-mini-31",
+                        "outlined": "MuiButton-outlined-17",
+                        "outlinedPrimary": "MuiButton-outlinedPrimary-18",
+                        "outlinedSecondary": "MuiButton-outlinedSecondary-19",
+                        "raised": "MuiButton-raised-23",
+                        "raisedPrimary": "MuiButton-raisedPrimary-24",
+                        "raisedSecondary": "MuiButton-raisedSecondary-25",
+                        "root": "MuiButton-root-9",
+                        "sizeLarge": "MuiButton-sizeLarge-33",
+                        "sizeSmall": "MuiButton-sizeSmall-32",
+                        "text": "MuiButton-text-11",
+                        "textPrimary": "MuiButton-textPrimary-12",
+                        "textSecondary": "MuiButton-textSecondary-13",
+                      }
+                    }
+                    color="default"
+                    component="button"
+                    disableFocusRipple={false}
+                    disabled={false}
+                    fullWidth={false}
+                    mini={false}
+                    size="medium"
+                    type="button"
+                    variant="text"
+                  >
+                    <WithStyles(ButtonBase)
+                      className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                      component="button"
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-28"
+                      type="button"
+                    >
+                      <ButtonBase
+                        centerRipple={false}
+                        className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                        classes={
+                          Object {
+                            "disabled": "MuiButtonBase-disabled-36",
+                            "focusVisible": "MuiButtonBase-focusVisible-37",
+                            "root": "MuiButtonBase-root-35",
+                          }
+                        }
+                        component="button"
+                        disableRipple={false}
+                        disableTouchRipple={false}
+                        disabled={false}
+                        focusRipple={true}
+                        focusVisibleClassName="MuiButton-focusVisible-28"
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <button
+                          className="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onContextMenu={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          tabIndex="0"
+                          type="button"
+                        >
+                          <span
+                            className="MuiButton-label-10"
+                          >
+                            <div
+                              className="flex flex-row flex-shrink-0"
+                            >
+                              <div
+                                className="alignItems"
+                              >
+                                <ExperimentsIcon
+                                  color="#9aa0a6"
+                                >
+                                  <svg
+                                    height="20"
+                                    viewBox="0 0 20 12"
+                                    width="20"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <g
+                                      fill="none"
+                                      fillRule="evenodd"
+                                      id="Symbols"
+                                    >
+                                      <g
+                                        transform="translate(-26 -72)"
+                                      >
+                                        <g
+                                          transform="translate(0 12)"
+                                        >
+                                          <g
+                                            transform="translate(0 44)"
+                                          >
+                                            <g
+                                              id="Group-3"
+                                            >
+                                              <g
+                                                transform="translate(26 12)"
+                                              >
+                                                <polygon
+                                                  points="0 0 20 0 20 20 0 20"
+                                                />
+                                                <path
+                                                  d="M15,5.83333333 L13.825,4.65833333 L8.54166667,9.94166667 L9.71666667,11.1166667 L15,5.83333333 Z M18.5333333,4.65833333 L9.71666667,13.475 L6.23333333,10 L5.05833333,11.175 L9.71666667,15.8333333 L19.7166667,5.83333333 L18.5333333,4.65833333 Z M0.341666667,11.175 L5,15.8333333 L6.175,14.6583333 L1.525,10 L0.341666667,11.175 Z"
+                                                  fill="#9aa0a6"
+                                                  fillRule="nonzero"
+                                                />
+                                              </g>
+                                            </g>
+                                          </g>
+                                        </g>
+                                      </g>
+                                    </g>
+                                  </svg>
+                                </ExperimentsIcon>
+                              </div>
+                              <span
+                                className="label"
+                              >
+                                Experiments
+                              </span>
+                            </div>
+                          </span>
+                          <NoSsr
+                            defer={false}
+                            fallback={null}
+                          >
+                            <WithStyles(TouchRipple)
+                              center={false}
+                              innerRef={[Function]}
+                            >
+                              <TouchRipple
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "MuiTouchRipple-child-57",
+                                    "childLeaving": "MuiTouchRipple-childLeaving-58",
+                                    "childPulsate": "MuiTouchRipple-childPulsate-59",
+                                    "ripple": "MuiTouchRipple-ripple-54",
+                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate-56",
+                                    "rippleVisible": "MuiTouchRipple-rippleVisible-55",
+                                    "root": "MuiTouchRipple-root-53",
+                                  }
+                                }
+                              >
+                                <TransitionGroup
+                                  childFactory={[Function]}
+                                  className="MuiTouchRipple-root-53"
+                                  component="span"
+                                  enter={true}
+                                  exit={true}
+                                >
+                                  <span
+                                    className="MuiTouchRipple-root-53"
+                                  />
+                                </TransitionGroup>
+                              </TouchRipple>
+                            </WithStyles(TouchRipple)>
+                          </NoSsr>
+                        </button>
+                      </ButtonBase>
+                    </WithStyles(ButtonBase)>
+                  </Button>
+                </WithStyles(Button)>
+              </a>
+            </Link>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <a
+                class="unstyled"
+                href="/experiments"
+                id="experimentsBtn"
+              >
+                <button
+                  class="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label-10"
+                  >
+                    <div
+                      class="flex flex-row flex-shrink-0"
+                    >
+                      <div
+                        class="alignItems"
+                      >
+                        <svg
+                          height="20"
+                          viewBox="0 0 20 12"
+                          width="20"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <g
+                            fill="none"
+                            fill-rule="evenodd"
+                            id="Symbols"
+                          >
+                            <g
+                              transform="translate(-26 -72)"
+                            >
+                              <g
+                                transform="translate(0 12)"
+                              >
+                                <g
+                                  transform="translate(0 44)"
+                                >
+                                  <g
+                                    id="Group-3"
+                                  >
+                                    <g
+                                      transform="translate(26 12)"
+                                    >
+                                      <polygon
+                                        points="0 0 20 0 20 20 0 20"
+                                      />
+                                      <path
+                                        d="M15,5.83333333 L13.825,4.65833333 L8.54166667,9.94166667 L9.71666667,11.1166667 L15,5.83333333 Z M18.5333333,4.65833333 L9.71666667,13.475 L6.23333333,10 L5.05833333,11.175 L9.71666667,15.8333333 L19.7166667,5.83333333 L18.5333333,4.65833333 Z M0.341666667,11.175 L5,15.8333333 L6.175,14.6583333 L1.525,10 L0.341666667,11.175 Z"
+                                        fill="#9aa0a6"
+                                        fill-rule="nonzero"
+                                      />
+                                    </g>
+                                  </g>
+                                </g>
+                              </g>
+                            </g>
+                          </g>
+                        </svg>
+                      </div>
+                      <span
+                        class="label"
+                      >
+                        Experiments
+                      </span>
+                    </div>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-53"
+                  />
+                </button>
+              </a>
+            }
+            className="MuiTooltip-popper-1"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="right-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+      <div
+        className="indicator indicatorHidden"
+      />
+      <WithStyles(Tooltip)
+        disableFocusListener={true}
+        disableHoverListener={true}
+        disableTouchListener={true}
+        enterDelay={300}
+        placement="right-start"
+        title="Runs List"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-1",
+              "popperInteractive": "MuiTooltip-popperInteractive-2",
+              "tooltip": "MuiTooltip-tooltip-3",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-8",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-5",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-6",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-7",
+              "touch": "MuiTooltip-touch-4",
+            }
+          }
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="right-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Runs List"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <Link
+              aria-describedby={null}
+              className="unstyled"
+              id="runsBtn"
+              replace={false}
+              title={null}
+              to="/runs"
+            >
+              <a
+                aria-describedby={null}
+                className="unstyled"
+                href="/runs"
+                id="runsBtn"
+                onClick={[Function]}
+                title={null}
+              >
+                <WithStyles(Button)
+                  className="button"
+                >
+                  <Button
+                    className="button"
+                    classes={
+                      Object {
+                        "colorInherit": "MuiButton-colorInherit-30",
+                        "contained": "MuiButton-contained-20",
+                        "containedPrimary": "MuiButton-containedPrimary-21",
+                        "containedSecondary": "MuiButton-containedSecondary-22",
+                        "disabled": "MuiButton-disabled-29",
+                        "extendedFab": "MuiButton-extendedFab-27",
+                        "fab": "MuiButton-fab-26",
+                        "flat": "MuiButton-flat-14",
+                        "flatPrimary": "MuiButton-flatPrimary-15",
+                        "flatSecondary": "MuiButton-flatSecondary-16",
+                        "focusVisible": "MuiButton-focusVisible-28",
+                        "fullWidth": "MuiButton-fullWidth-34",
+                        "label": "MuiButton-label-10",
+                        "mini": "MuiButton-mini-31",
+                        "outlined": "MuiButton-outlined-17",
+                        "outlinedPrimary": "MuiButton-outlinedPrimary-18",
+                        "outlinedSecondary": "MuiButton-outlinedSecondary-19",
+                        "raised": "MuiButton-raised-23",
+                        "raisedPrimary": "MuiButton-raisedPrimary-24",
+                        "raisedSecondary": "MuiButton-raisedSecondary-25",
+                        "root": "MuiButton-root-9",
+                        "sizeLarge": "MuiButton-sizeLarge-33",
+                        "sizeSmall": "MuiButton-sizeSmall-32",
+                        "text": "MuiButton-text-11",
+                        "textPrimary": "MuiButton-textPrimary-12",
+                        "textSecondary": "MuiButton-textSecondary-13",
+                      }
+                    }
+                    color="default"
+                    component="button"
+                    disableFocusRipple={false}
+                    disabled={false}
+                    fullWidth={false}
+                    mini={false}
+                    size="medium"
+                    type="button"
+                    variant="text"
+                  >
+                    <WithStyles(ButtonBase)
+                      className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                      component="button"
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-28"
+                      type="button"
+                    >
+                      <ButtonBase
+                        centerRipple={false}
+                        className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                        classes={
+                          Object {
+                            "disabled": "MuiButtonBase-disabled-36",
+                            "focusVisible": "MuiButtonBase-focusVisible-37",
+                            "root": "MuiButtonBase-root-35",
+                          }
+                        }
+                        component="button"
+                        disableRipple={false}
+                        disableTouchRipple={false}
+                        disabled={false}
+                        focusRipple={true}
+                        focusVisibleClassName="MuiButton-focusVisible-28"
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <button
+                          className="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onContextMenu={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          tabIndex="0"
+                          type="button"
+                        >
+                          <span
+                            className="MuiButton-label-10"
+                          >
+                            <div
+                              className="flex flex-row flex-shrink-0"
+                            >
+                              <pure(DirectionsRunIcon)>
+                                <DirectionsRunIcon>
+                                  <WithStyles(SvgIcon)>
+                                    <SvgIcon
+                                      classes={
+                                        Object {
+                                          "colorAction": "MuiSvgIcon-colorAction-41",
+                                          "colorDisabled": "MuiSvgIcon-colorDisabled-43",
+                                          "colorError": "MuiSvgIcon-colorError-42",
+                                          "colorPrimary": "MuiSvgIcon-colorPrimary-39",
+                                          "colorSecondary": "MuiSvgIcon-colorSecondary-40",
+                                          "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-44",
+                                          "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-46",
+                                          "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-45",
+                                          "root": "MuiSvgIcon-root-38",
+                                        }
+                                      }
+                                      color="inherit"
+                                      component="svg"
+                                      fontSize="default"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        className="MuiSvgIcon-root-38"
+                                        focusable="false"
+                                        role="presentation"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                          fill="none"
+                                        />
+                                        <path
+                                          d="M13.49 5.48c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm-3.6 13.9l1-4.4 2.1 2v6h2v-7.5l-2.1-2 .6-3c1.3 1.5 3.3 2.5 5.5 2.5v-2c-1.9 0-3.5-1-4.3-2.4l-1-1.6c-.4-.6-1-1-1.7-1-.3 0-.5.1-.8.1l-5.2 2.2v4.7h2v-3.4l1.8-.7-1.6 8.1-4.9-1-.4 2 7 1.4z"
+                                        />
+                                      </svg>
+                                    </SvgIcon>
+                                  </WithStyles(SvgIcon)>
+                                </DirectionsRunIcon>
+                              </pure(DirectionsRunIcon)>
+                              <span
+                                className="label"
+                              >
+                                Runs
+                              </span>
+                            </div>
+                          </span>
+                          <NoSsr
+                            defer={false}
+                            fallback={null}
+                          >
+                            <WithStyles(TouchRipple)
+                              center={false}
+                              innerRef={[Function]}
+                            >
+                              <TouchRipple
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "MuiTouchRipple-child-57",
+                                    "childLeaving": "MuiTouchRipple-childLeaving-58",
+                                    "childPulsate": "MuiTouchRipple-childPulsate-59",
+                                    "ripple": "MuiTouchRipple-ripple-54",
+                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate-56",
+                                    "rippleVisible": "MuiTouchRipple-rippleVisible-55",
+                                    "root": "MuiTouchRipple-root-53",
+                                  }
+                                }
+                              >
+                                <TransitionGroup
+                                  childFactory={[Function]}
+                                  className="MuiTouchRipple-root-53"
+                                  component="span"
+                                  enter={true}
+                                  exit={true}
+                                >
+                                  <span
+                                    className="MuiTouchRipple-root-53"
+                                  />
+                                </TransitionGroup>
+                              </TouchRipple>
+                            </WithStyles(TouchRipple)>
+                          </NoSsr>
+                        </button>
+                      </ButtonBase>
+                    </WithStyles(ButtonBase)>
+                  </Button>
+                </WithStyles(Button)>
+              </a>
+            </Link>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <a
+                class="unstyled"
+                href="/runs"
+                id="runsBtn"
+              >
+                <button
+                  class="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label-10"
+                  >
+                    <div
+                      class="flex flex-row flex-shrink-0"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-38"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                        <path
+                          d="M13.49 5.48c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm-3.6 13.9l1-4.4 2.1 2v6h2v-7.5l-2.1-2 .6-3c1.3 1.5 3.3 2.5 5.5 2.5v-2c-1.9 0-3.5-1-4.3-2.4l-1-1.6c-.4-.6-1-1-1.7-1-.3 0-.5.1-.8.1l-5.2 2.2v4.7h2v-3.4l1.8-.7-1.6 8.1-4.9-1-.4 2 7 1.4z"
+                        />
+                      </svg>
+                      <span
+                        class="label"
+                      >
+                        Runs
+                      </span>
+                    </div>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-53"
+                  />
+                </button>
+              </a>
+            }
+            className="MuiTooltip-popper-1"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="right-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+      <div
+        className="indicator indicatorHidden"
+      />
+      <WithStyles(Tooltip)
+        disableFocusListener={true}
+        disableHoverListener={true}
+        disableTouchListener={true}
+        enterDelay={300}
+        placement="right-start"
+        title="Recurring Runs List"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-1",
+              "popperInteractive": "MuiTooltip-popperInteractive-2",
+              "tooltip": "MuiTooltip-tooltip-3",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-8",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-5",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-6",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-7",
+              "touch": "MuiTooltip-touch-4",
+            }
+          }
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="right-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Recurring Runs List"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <Link
+              aria-describedby={null}
+              className="unstyled"
+              id="recurringRunsBtn"
+              replace={false}
+              title={null}
+              to="/recurringruns"
+            >
+              <a
+                aria-describedby={null}
+                className="unstyled"
+                href="/recurringruns"
+                id="recurringRunsBtn"
+                onClick={[Function]}
+                title={null}
+              >
+                <WithStyles(Button)
+                  className="button"
+                >
+                  <Button
+                    className="button"
+                    classes={
+                      Object {
+                        "colorInherit": "MuiButton-colorInherit-30",
+                        "contained": "MuiButton-contained-20",
+                        "containedPrimary": "MuiButton-containedPrimary-21",
+                        "containedSecondary": "MuiButton-containedSecondary-22",
+                        "disabled": "MuiButton-disabled-29",
+                        "extendedFab": "MuiButton-extendedFab-27",
+                        "fab": "MuiButton-fab-26",
+                        "flat": "MuiButton-flat-14",
+                        "flatPrimary": "MuiButton-flatPrimary-15",
+                        "flatSecondary": "MuiButton-flatSecondary-16",
+                        "focusVisible": "MuiButton-focusVisible-28",
+                        "fullWidth": "MuiButton-fullWidth-34",
+                        "label": "MuiButton-label-10",
+                        "mini": "MuiButton-mini-31",
+                        "outlined": "MuiButton-outlined-17",
+                        "outlinedPrimary": "MuiButton-outlinedPrimary-18",
+                        "outlinedSecondary": "MuiButton-outlinedSecondary-19",
+                        "raised": "MuiButton-raised-23",
+                        "raisedPrimary": "MuiButton-raisedPrimary-24",
+                        "raisedSecondary": "MuiButton-raisedSecondary-25",
+                        "root": "MuiButton-root-9",
+                        "sizeLarge": "MuiButton-sizeLarge-33",
+                        "sizeSmall": "MuiButton-sizeSmall-32",
+                        "text": "MuiButton-text-11",
+                        "textPrimary": "MuiButton-textPrimary-12",
+                        "textSecondary": "MuiButton-textSecondary-13",
+                      }
+                    }
+                    color="default"
+                    component="button"
+                    disableFocusRipple={false}
+                    disabled={false}
+                    fullWidth={false}
+                    mini={false}
+                    size="medium"
+                    type="button"
+                    variant="text"
+                  >
+                    <WithStyles(ButtonBase)
+                      className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                      component="button"
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-28"
+                      type="button"
+                    >
+                      <ButtonBase
+                        centerRipple={false}
+                        className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                        classes={
+                          Object {
+                            "disabled": "MuiButtonBase-disabled-36",
+                            "focusVisible": "MuiButtonBase-focusVisible-37",
+                            "root": "MuiButtonBase-root-35",
+                          }
+                        }
+                        component="button"
+                        disableRipple={false}
+                        disableTouchRipple={false}
+                        disabled={false}
+                        focusRipple={true}
+                        focusVisibleClassName="MuiButton-focusVisible-28"
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <button
+                          className="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onContextMenu={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          tabIndex="0"
+                          type="button"
+                        >
+                          <span
+                            className="MuiButton-label-10"
+                          >
+                            <div
+                              className="flex flex-row flex-shrink-0"
+                            >
+                              <pure(AlarmIcon)>
+                                <AlarmIcon>
+                                  <WithStyles(SvgIcon)>
+                                    <SvgIcon
+                                      classes={
+                                        Object {
+                                          "colorAction": "MuiSvgIcon-colorAction-41",
+                                          "colorDisabled": "MuiSvgIcon-colorDisabled-43",
+                                          "colorError": "MuiSvgIcon-colorError-42",
+                                          "colorPrimary": "MuiSvgIcon-colorPrimary-39",
+                                          "colorSecondary": "MuiSvgIcon-colorSecondary-40",
+                                          "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-44",
+                                          "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-46",
+                                          "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-45",
+                                          "root": "MuiSvgIcon-root-38",
+                                        }
+                                      }
+                                      color="inherit"
+                                      component="svg"
+                                      fontSize="default"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        className="MuiSvgIcon-root-38"
+                                        focusable="false"
+                                        role="presentation"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                          fill="none"
+                                        />
+                                        <path
+                                          d="M22 5.72l-4.6-3.86-1.29 1.53 4.6 3.86L22 5.72zM7.88 3.39L6.6 1.86 2 5.71l1.29 1.53 4.59-3.85zM12.5 8H11v6l4.75 2.85.75-1.23-4-2.37V8zM12 4c-4.97 0-9 4.03-9 9s4.02 9 9 9c4.97 0 9-4.03 9-9s-4.03-9-9-9zm0 16c-3.87 0-7-3.13-7-7s3.13-7 7-7 7 3.13 7 7-3.13 7-7 7z"
+                                        />
+                                      </svg>
+                                    </SvgIcon>
+                                  </WithStyles(SvgIcon)>
+                                </AlarmIcon>
+                              </pure(AlarmIcon)>
+                              <span
+                                className="label"
+                              >
+                                Recurring Runs
+                              </span>
+                            </div>
+                          </span>
+                          <NoSsr
+                            defer={false}
+                            fallback={null}
+                          >
+                            <WithStyles(TouchRipple)
+                              center={false}
+                              innerRef={[Function]}
+                            >
+                              <TouchRipple
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "MuiTouchRipple-child-57",
+                                    "childLeaving": "MuiTouchRipple-childLeaving-58",
+                                    "childPulsate": "MuiTouchRipple-childPulsate-59",
+                                    "ripple": "MuiTouchRipple-ripple-54",
+                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate-56",
+                                    "rippleVisible": "MuiTouchRipple-rippleVisible-55",
+                                    "root": "MuiTouchRipple-root-53",
+                                  }
+                                }
+                              >
+                                <TransitionGroup
+                                  childFactory={[Function]}
+                                  className="MuiTouchRipple-root-53"
+                                  component="span"
+                                  enter={true}
+                                  exit={true}
+                                >
+                                  <span
+                                    className="MuiTouchRipple-root-53"
+                                  />
+                                </TransitionGroup>
+                              </TouchRipple>
+                            </WithStyles(TouchRipple)>
+                          </NoSsr>
+                        </button>
+                      </ButtonBase>
+                    </WithStyles(ButtonBase)>
+                  </Button>
+                </WithStyles(Button)>
+              </a>
+            </Link>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <a
+                class="unstyled"
+                href="/recurringruns"
+                id="recurringRunsBtn"
+              >
+                <button
+                  class="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label-10"
+                  >
+                    <div
+                      class="flex flex-row flex-shrink-0"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-38"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                        <path
+                          d="M22 5.72l-4.6-3.86-1.29 1.53 4.6 3.86L22 5.72zM7.88 3.39L6.6 1.86 2 5.71l1.29 1.53 4.59-3.85zM12.5 8H11v6l4.75 2.85.75-1.23-4-2.37V8zM12 4c-4.97 0-9 4.03-9 9s4.02 9 9 9c4.97 0 9-4.03 9-9s-4.03-9-9-9zm0 16c-3.87 0-7-3.13-7-7s3.13-7 7-7 7 3.13 7 7-3.13 7-7 7z"
+                        />
+                      </svg>
+                      <span
+                        class="label"
+                      >
+                        Recurring Runs
+                      </span>
+                    </div>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-53"
+                  />
+                </button>
+              </a>
+            }
+            className="MuiTooltip-popper-1"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="right-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+      <div
+        className="indicator indicatorHidden"
+      />
+      <WithStyles(Tooltip)
+        disableFocusListener={true}
+        disableHoverListener={true}
+        disableTouchListener={true}
+        enterDelay={300}
+        placement="right-start"
+        title="Artifacts List"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-1",
+              "popperInteractive": "MuiTooltip-popperInteractive-2",
+              "tooltip": "MuiTooltip-tooltip-3",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-8",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-5",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-6",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-7",
+              "touch": "MuiTooltip-touch-4",
+            }
+          }
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="right-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Artifacts List"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <Link
+              aria-describedby={null}
+              className="unstyled"
+              id="artifactsBtn"
+              replace={false}
+              title={null}
+              to="/artifacts"
+            >
+              <a
+                aria-describedby={null}
+                className="unstyled"
+                href="/artifacts"
+                id="artifactsBtn"
+                onClick={[Function]}
+                title={null}
+              >
+                <WithStyles(Button)
+                  className="button"
+                >
+                  <Button
+                    className="button"
+                    classes={
+                      Object {
+                        "colorInherit": "MuiButton-colorInherit-30",
+                        "contained": "MuiButton-contained-20",
+                        "containedPrimary": "MuiButton-containedPrimary-21",
+                        "containedSecondary": "MuiButton-containedSecondary-22",
+                        "disabled": "MuiButton-disabled-29",
+                        "extendedFab": "MuiButton-extendedFab-27",
+                        "fab": "MuiButton-fab-26",
+                        "flat": "MuiButton-flat-14",
+                        "flatPrimary": "MuiButton-flatPrimary-15",
+                        "flatSecondary": "MuiButton-flatSecondary-16",
+                        "focusVisible": "MuiButton-focusVisible-28",
+                        "fullWidth": "MuiButton-fullWidth-34",
+                        "label": "MuiButton-label-10",
+                        "mini": "MuiButton-mini-31",
+                        "outlined": "MuiButton-outlined-17",
+                        "outlinedPrimary": "MuiButton-outlinedPrimary-18",
+                        "outlinedSecondary": "MuiButton-outlinedSecondary-19",
+                        "raised": "MuiButton-raised-23",
+                        "raisedPrimary": "MuiButton-raisedPrimary-24",
+                        "raisedSecondary": "MuiButton-raisedSecondary-25",
+                        "root": "MuiButton-root-9",
+                        "sizeLarge": "MuiButton-sizeLarge-33",
+                        "sizeSmall": "MuiButton-sizeSmall-32",
+                        "text": "MuiButton-text-11",
+                        "textPrimary": "MuiButton-textPrimary-12",
+                        "textSecondary": "MuiButton-textSecondary-13",
+                      }
+                    }
+                    color="default"
+                    component="button"
+                    disableFocusRipple={false}
+                    disabled={false}
+                    fullWidth={false}
+                    mini={false}
+                    size="medium"
+                    type="button"
+                    variant="text"
+                  >
+                    <WithStyles(ButtonBase)
+                      className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                      component="button"
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-28"
+                      type="button"
+                    >
+                      <ButtonBase
+                        centerRipple={false}
+                        className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                        classes={
+                          Object {
+                            "disabled": "MuiButtonBase-disabled-36",
+                            "focusVisible": "MuiButtonBase-focusVisible-37",
+                            "root": "MuiButtonBase-root-35",
+                          }
+                        }
+                        component="button"
+                        disableRipple={false}
+                        disableTouchRipple={false}
+                        disabled={false}
+                        focusRipple={true}
+                        focusVisibleClassName="MuiButton-focusVisible-28"
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <button
+                          className="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onContextMenu={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          tabIndex="0"
+                          type="button"
+                        >
+                          <span
+                            className="MuiButton-label-10"
+                          >
+                            <div
+                              className="flex flex-row flex-shrink-0"
+                            >
+                              <pure(BubbleChartIcon)>
+                                <BubbleChartIcon>
+                                  <WithStyles(SvgIcon)>
+                                    <SvgIcon
+                                      classes={
+                                        Object {
+                                          "colorAction": "MuiSvgIcon-colorAction-41",
+                                          "colorDisabled": "MuiSvgIcon-colorDisabled-43",
+                                          "colorError": "MuiSvgIcon-colorError-42",
+                                          "colorPrimary": "MuiSvgIcon-colorPrimary-39",
+                                          "colorSecondary": "MuiSvgIcon-colorSecondary-40",
+                                          "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-44",
+                                          "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-46",
+                                          "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-45",
+                                          "root": "MuiSvgIcon-root-38",
+                                        }
+                                      }
+                                      color="inherit"
+                                      component="svg"
+                                      fontSize="default"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        className="MuiSvgIcon-root-38"
+                                        focusable="false"
+                                        role="presentation"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                          fill="none"
+                                        />
+                                        <circle
+                                          cx="7.2"
+                                          cy="14.4"
+                                          r="3.2"
+                                        />
+                                        <circle
+                                          cx="14.8"
+                                          cy="18"
+                                          r="2"
+                                        />
+                                        <circle
+                                          cx="15.2"
+                                          cy="8.8"
+                                          r="4.8"
+                                        />
+                                      </svg>
+                                    </SvgIcon>
+                                  </WithStyles(SvgIcon)>
+                                </BubbleChartIcon>
+                              </pure(BubbleChartIcon)>
+                              <span
+                                className="label"
+                              >
+                                Artifacts
+                              </span>
+                            </div>
+                          </span>
+                          <NoSsr
+                            defer={false}
+                            fallback={null}
+                          >
+                            <WithStyles(TouchRipple)
+                              center={false}
+                              innerRef={[Function]}
+                            >
+                              <TouchRipple
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "MuiTouchRipple-child-57",
+                                    "childLeaving": "MuiTouchRipple-childLeaving-58",
+                                    "childPulsate": "MuiTouchRipple-childPulsate-59",
+                                    "ripple": "MuiTouchRipple-ripple-54",
+                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate-56",
+                                    "rippleVisible": "MuiTouchRipple-rippleVisible-55",
+                                    "root": "MuiTouchRipple-root-53",
+                                  }
+                                }
+                              >
+                                <TransitionGroup
+                                  childFactory={[Function]}
+                                  className="MuiTouchRipple-root-53"
+                                  component="span"
+                                  enter={true}
+                                  exit={true}
+                                >
+                                  <span
+                                    className="MuiTouchRipple-root-53"
+                                  />
+                                </TransitionGroup>
+                              </TouchRipple>
+                            </WithStyles(TouchRipple)>
+                          </NoSsr>
+                        </button>
+                      </ButtonBase>
+                    </WithStyles(ButtonBase)>
+                  </Button>
+                </WithStyles(Button)>
+              </a>
+            </Link>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <a
+                class="unstyled"
+                href="/artifacts"
+                id="artifactsBtn"
+              >
+                <button
+                  class="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label-10"
+                  >
+                    <div
+                      class="flex flex-row flex-shrink-0"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-38"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                        <circle
+                          cx="7.2"
+                          cy="14.4"
+                          r="3.2"
+                        />
+                        <circle
+                          cx="14.8"
+                          cy="18"
+                          r="2"
+                        />
+                        <circle
+                          cx="15.2"
+                          cy="8.8"
+                          r="4.8"
+                        />
+                      </svg>
+                      <span
+                        class="label"
+                      >
+                        Artifacts
+                      </span>
+                    </div>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-53"
+                  />
+                </button>
+              </a>
+            }
+            className="MuiTooltip-popper-1"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="right-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+      <div
+        className="indicator indicatorHidden"
+      />
+      <WithStyles(Tooltip)
+        disableFocusListener={true}
+        disableHoverListener={true}
+        disableTouchListener={true}
+        enterDelay={300}
+        placement="right-start"
+        title="Executions List"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-1",
+              "popperInteractive": "MuiTooltip-popperInteractive-2",
+              "tooltip": "MuiTooltip-tooltip-3",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-8",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-5",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-6",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-7",
+              "touch": "MuiTooltip-touch-4",
+            }
+          }
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="right-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Executions List"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <Link
+              aria-describedby={null}
+              className="unstyled"
+              id="executionsBtn"
+              replace={false}
+              title={null}
+              to="/executions"
+            >
+              <a
+                aria-describedby={null}
+                className="unstyled"
+                href="/executions"
+                id="executionsBtn"
+                onClick={[Function]}
+                title={null}
+              >
+                <WithStyles(Button)
+                  className="button"
+                >
+                  <Button
+                    className="button"
+                    classes={
+                      Object {
+                        "colorInherit": "MuiButton-colorInherit-30",
+                        "contained": "MuiButton-contained-20",
+                        "containedPrimary": "MuiButton-containedPrimary-21",
+                        "containedSecondary": "MuiButton-containedSecondary-22",
+                        "disabled": "MuiButton-disabled-29",
+                        "extendedFab": "MuiButton-extendedFab-27",
+                        "fab": "MuiButton-fab-26",
+                        "flat": "MuiButton-flat-14",
+                        "flatPrimary": "MuiButton-flatPrimary-15",
+                        "flatSecondary": "MuiButton-flatSecondary-16",
+                        "focusVisible": "MuiButton-focusVisible-28",
+                        "fullWidth": "MuiButton-fullWidth-34",
+                        "label": "MuiButton-label-10",
+                        "mini": "MuiButton-mini-31",
+                        "outlined": "MuiButton-outlined-17",
+                        "outlinedPrimary": "MuiButton-outlinedPrimary-18",
+                        "outlinedSecondary": "MuiButton-outlinedSecondary-19",
+                        "raised": "MuiButton-raised-23",
+                        "raisedPrimary": "MuiButton-raisedPrimary-24",
+                        "raisedSecondary": "MuiButton-raisedSecondary-25",
+                        "root": "MuiButton-root-9",
+                        "sizeLarge": "MuiButton-sizeLarge-33",
+                        "sizeSmall": "MuiButton-sizeSmall-32",
+                        "text": "MuiButton-text-11",
+                        "textPrimary": "MuiButton-textPrimary-12",
+                        "textSecondary": "MuiButton-textSecondary-13",
+                      }
+                    }
+                    color="default"
+                    component="button"
+                    disableFocusRipple={false}
+                    disabled={false}
+                    fullWidth={false}
+                    mini={false}
+                    size="medium"
+                    type="button"
+                    variant="text"
+                  >
+                    <WithStyles(ButtonBase)
+                      className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                      component="button"
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-28"
+                      type="button"
+                    >
+                      <ButtonBase
+                        centerRipple={false}
+                        className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                        classes={
+                          Object {
+                            "disabled": "MuiButtonBase-disabled-36",
+                            "focusVisible": "MuiButtonBase-focusVisible-37",
+                            "root": "MuiButtonBase-root-35",
+                          }
+                        }
+                        component="button"
+                        disableRipple={false}
+                        disableTouchRipple={false}
+                        disabled={false}
+                        focusRipple={true}
+                        focusVisibleClassName="MuiButton-focusVisible-28"
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <button
+                          className="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onContextMenu={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          tabIndex="0"
+                          type="button"
+                        >
+                          <span
+                            className="MuiButton-label-10"
+                          >
+                            <div
+                              className="flex flex-row flex-shrink-0"
+                            >
+                              <pure(PlayArrowIcon)>
+                                <PlayArrowIcon>
+                                  <WithStyles(SvgIcon)>
+                                    <SvgIcon
+                                      classes={
+                                        Object {
+                                          "colorAction": "MuiSvgIcon-colorAction-41",
+                                          "colorDisabled": "MuiSvgIcon-colorDisabled-43",
+                                          "colorError": "MuiSvgIcon-colorError-42",
+                                          "colorPrimary": "MuiSvgIcon-colorPrimary-39",
+                                          "colorSecondary": "MuiSvgIcon-colorSecondary-40",
+                                          "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-44",
+                                          "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-46",
+                                          "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-45",
+                                          "root": "MuiSvgIcon-root-38",
+                                        }
+                                      }
+                                      color="inherit"
+                                      component="svg"
+                                      fontSize="default"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        className="MuiSvgIcon-root-38"
+                                        focusable="false"
+                                        role="presentation"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M8 5v14l11-7z"
+                                        />
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                          fill="none"
+                                        />
+                                      </svg>
+                                    </SvgIcon>
+                                  </WithStyles(SvgIcon)>
+                                </PlayArrowIcon>
+                              </pure(PlayArrowIcon)>
+                              <span
+                                className="label"
+                              >
+                                Executions
+                              </span>
+                            </div>
+                          </span>
+                          <NoSsr
+                            defer={false}
+                            fallback={null}
+                          >
+                            <WithStyles(TouchRipple)
+                              center={false}
+                              innerRef={[Function]}
+                            >
+                              <TouchRipple
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "MuiTouchRipple-child-57",
+                                    "childLeaving": "MuiTouchRipple-childLeaving-58",
+                                    "childPulsate": "MuiTouchRipple-childPulsate-59",
+                                    "ripple": "MuiTouchRipple-ripple-54",
+                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate-56",
+                                    "rippleVisible": "MuiTouchRipple-rippleVisible-55",
+                                    "root": "MuiTouchRipple-root-53",
+                                  }
+                                }
+                              >
+                                <TransitionGroup
+                                  childFactory={[Function]}
+                                  className="MuiTouchRipple-root-53"
+                                  component="span"
+                                  enter={true}
+                                  exit={true}
+                                >
+                                  <span
+                                    className="MuiTouchRipple-root-53"
+                                  />
+                                </TransitionGroup>
+                              </TouchRipple>
+                            </WithStyles(TouchRipple)>
+                          </NoSsr>
+                        </button>
+                      </ButtonBase>
+                    </WithStyles(ButtonBase)>
+                  </Button>
+                </WithStyles(Button)>
+              </a>
+            </Link>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <a
+                class="unstyled"
+                href="/executions"
+                id="executionsBtn"
+              >
+                <button
+                  class="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label-10"
+                  >
+                    <div
+                      class="flex flex-row flex-shrink-0"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-38"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M8 5v14l11-7z"
+                        />
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                      </svg>
+                      <span
+                        class="label"
+                      >
+                        Executions
+                      </span>
+                    </div>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-53"
+                  />
+                </button>
+              </a>
+            }
+            className="MuiTooltip-popper-1"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="right-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+      <hr
+        className="separator"
+      />
+      <ExternalUri
+        collapsed={false}
+        icon={[Function]}
+        title="Documentation"
+        to="https://www.kubeflow.org/docs/pipelines/"
+      >
+        <WithStyles(Tooltip)
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          enterDelay={300}
+          placement="right-start"
+          title="Documentation"
+        >
+          <Tooltip
+            TransitionComponent={[Function]}
+            classes={
+              Object {
+                "popper": "MuiTooltip-popper-1",
+                "popperInteractive": "MuiTooltip-popperInteractive-2",
+                "tooltip": "MuiTooltip-tooltip-3",
+                "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-8",
+                "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-5",
+                "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-6",
+                "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-7",
+                "touch": "MuiTooltip-touch-4",
+              }
+            }
+            disableFocusListener={true}
+            disableHoverListener={true}
+            disableTouchListener={true}
+            enterDelay={300}
+            enterTouchDelay={1000}
+            interactive={false}
+            leaveDelay={0}
+            leaveTouchDelay={1500}
+            placement="right-start"
+            theme={
+              Object {
+                "breakpoints": Object {
+                  "between": [Function],
+                  "down": [Function],
+                  "keys": Array [
+                    "xs",
+                    "sm",
+                    "md",
+                    "lg",
+                    "xl",
+                  ],
+                  "only": [Function],
+                  "up": [Function],
+                  "values": Object {
+                    "lg": 1280,
+                    "md": 960,
+                    "sm": 600,
+                    "xl": 1920,
+                    "xs": 0,
+                  },
+                  "width": [Function],
+                },
+                "direction": "ltr",
+                "mixins": Object {
+                  "gutters": [Function],
+                  "toolbar": Object {
+                    "@media (min-width:0px) and (orientation: landscape)": Object {
+                      "minHeight": 48,
+                    },
+                    "@media (min-width:600px)": Object {
+                      "minHeight": 64,
+                    },
+                    "minHeight": 56,
+                  },
+                },
+                "overrides": Object {},
+                "palette": Object {
+                  "action": Object {
+                    "active": "rgba(0, 0, 0, 0.54)",
+                    "disabled": "rgba(0, 0, 0, 0.26)",
+                    "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                    "hover": "rgba(0, 0, 0, 0.08)",
+                    "hoverOpacity": 0.08,
+                    "selected": "rgba(0, 0, 0, 0.14)",
+                  },
+                  "augmentColor": [Function],
+                  "background": Object {
+                    "default": "#fafafa",
+                    "paper": "#fff",
+                  },
+                  "common": Object {
+                    "black": "#000",
+                    "white": "#fff",
+                  },
+                  "contrastThreshold": 3,
+                  "divider": "rgba(0, 0, 0, 0.12)",
+                  "error": Object {
+                    "contrastText": "#fff",
+                    "dark": "#d32f2f",
+                    "light": "#e57373",
+                    "main": "#f44336",
+                  },
+                  "getContrastText": [Function],
+                  "grey": Object {
+                    "100": "#f5f5f5",
+                    "200": "#eeeeee",
+                    "300": "#e0e0e0",
+                    "400": "#bdbdbd",
+                    "50": "#fafafa",
+                    "500": "#9e9e9e",
+                    "600": "#757575",
+                    "700": "#616161",
+                    "800": "#424242",
+                    "900": "#212121",
+                    "A100": "#d5d5d5",
+                    "A200": "#aaaaaa",
+                    "A400": "#303030",
+                    "A700": "#616161",
+                  },
+                  "primary": Object {
+                    "contrastText": "#fff",
+                    "dark": "#303f9f",
+                    "light": "#7986cb",
+                    "main": "#3f51b5",
+                  },
+                  "secondary": Object {
+                    "contrastText": "#fff",
+                    "dark": "#c51162",
+                    "light": "#ff4081",
+                    "main": "#f50057",
+                  },
+                  "text": Object {
+                    "disabled": "rgba(0, 0, 0, 0.38)",
+                    "hint": "rgba(0, 0, 0, 0.38)",
+                    "primary": "rgba(0, 0, 0, 0.87)",
+                    "secondary": "rgba(0, 0, 0, 0.54)",
+                  },
+                  "tonalOffset": 0.2,
+                  "type": "light",
+                },
+                "props": Object {},
+                "shadows": Array [
+                  "none",
+                  "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                  "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                  "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                  "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                  "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                  "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                  "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                  "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                  "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                  "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                  "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                  "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                  "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                  "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                  "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                  "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                  "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                  "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                  "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                  "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                  "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                  "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                  "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                  "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+                ],
+                "shape": Object {
+                  "borderRadius": 4,
+                },
+                "spacing": Object {
+                  "unit": 8,
+                },
+                "transitions": Object {
+                  "create": [Function],
+                  "duration": Object {
+                    "complex": 375,
+                    "enteringScreen": 225,
+                    "leavingScreen": 195,
+                    "short": 250,
+                    "shorter": 200,
+                    "shortest": 150,
+                    "standard": 300,
+                  },
+                  "easing": Object {
+                    "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                    "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                    "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                    "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                  },
+                  "getAutoHeightDuration": [Function],
+                },
+                "typography": Object {
+                  "body1": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.46429em",
+                  },
+                  "body1Next": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.00938em",
+                    "lineHeight": 1.5,
+                  },
+                  "body2": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                    "lineHeight": "1.71429em",
+                  },
+                  "body2Next": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.01071em",
+                    "lineHeight": 1.5,
+                  },
+                  "button": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                    "textTransform": "uppercase",
+                  },
+                  "buttonNext": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                    "letterSpacing": "0.02857em",
+                    "lineHeight": 1.75,
+                    "textTransform": "uppercase",
+                  },
+                  "caption": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.375em",
+                  },
+                  "captionNext": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.03333em",
+                    "lineHeight": 1.66,
+                  },
+                  "display1": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "2.125rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.20588em",
+                  },
+                  "display2": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "2.8125rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.13333em",
+                    "marginLeft": "-.02em",
+                  },
+                  "display3": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "3.5rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "-.02em",
+                    "lineHeight": "1.30357em",
+                    "marginLeft": "-.02em",
+                  },
+                  "display4": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "7rem",
+                    "fontWeight": 300,
+                    "letterSpacing": "-.04em",
+                    "lineHeight": "1.14286em",
+                    "marginLeft": "-.04em",
+                  },
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": 14,
+                  "fontWeightLight": 300,
+                  "fontWeightMedium": 500,
+                  "fontWeightRegular": 400,
+                  "h1": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "6rem",
+                    "fontWeight": 300,
+                    "letterSpacing": "-0.01562em",
+                    "lineHeight": 1,
+                  },
+                  "h2": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "3.75rem",
+                    "fontWeight": 300,
+                    "letterSpacing": "-0.00833em",
+                    "lineHeight": 1,
+                  },
+                  "h3": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "3rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0em",
+                    "lineHeight": 1.04,
+                  },
+                  "h4": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "2.125rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.00735em",
+                    "lineHeight": 1.17,
+                  },
+                  "h5": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0em",
+                    "lineHeight": 1.33,
+                  },
+                  "h6": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1.25rem",
+                    "fontWeight": 500,
+                    "letterSpacing": "0.0075em",
+                    "lineHeight": 1.6,
+                  },
+                  "headline": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.35417em",
+                  },
+                  "overline": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.08333em",
+                    "lineHeight": 2.66,
+                    "textTransform": "uppercase",
+                  },
+                  "pxToRem": [Function],
+                  "round": [Function],
+                  "subheading": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.5em",
+                  },
+                  "subtitle1": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.00938em",
+                    "lineHeight": 1.75,
+                  },
+                  "subtitle2": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                    "letterSpacing": "0.00714em",
+                    "lineHeight": 1.57,
+                  },
+                  "title": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1.3125rem",
+                    "fontWeight": 500,
+                    "lineHeight": "1.16667em",
+                  },
+                  "useNextVariants": false,
+                },
+                "zIndex": Object {
+                  "appBar": 1100,
+                  "drawer": 1200,
+                  "mobileStepper": 1000,
+                  "modal": 1300,
+                  "snackbar": 1400,
+                  "tooltip": 1500,
+                },
+              }
+            }
+            title="Documentation"
+          >
+            <RootRef
+              rootRef={[Function]}
+            >
+              <a
+                aria-describedby={null}
+                className="unstyled"
+                href="https://www.kubeflow.org/docs/pipelines/"
+                rel="noopener noreferrer"
+                target="_blank"
+                title={null}
+              >
+                <WithStyles(Button)
+                  className="button"
+                >
+                  <Button
+                    className="button"
+                    classes={
+                      Object {
+                        "colorInherit": "MuiButton-colorInherit-30",
+                        "contained": "MuiButton-contained-20",
+                        "containedPrimary": "MuiButton-containedPrimary-21",
+                        "containedSecondary": "MuiButton-containedSecondary-22",
+                        "disabled": "MuiButton-disabled-29",
+                        "extendedFab": "MuiButton-extendedFab-27",
+                        "fab": "MuiButton-fab-26",
+                        "flat": "MuiButton-flat-14",
+                        "flatPrimary": "MuiButton-flatPrimary-15",
+                        "flatSecondary": "MuiButton-flatSecondary-16",
+                        "focusVisible": "MuiButton-focusVisible-28",
+                        "fullWidth": "MuiButton-fullWidth-34",
+                        "label": "MuiButton-label-10",
+                        "mini": "MuiButton-mini-31",
+                        "outlined": "MuiButton-outlined-17",
+                        "outlinedPrimary": "MuiButton-outlinedPrimary-18",
+                        "outlinedSecondary": "MuiButton-outlinedSecondary-19",
+                        "raised": "MuiButton-raised-23",
+                        "raisedPrimary": "MuiButton-raisedPrimary-24",
+                        "raisedSecondary": "MuiButton-raisedSecondary-25",
+                        "root": "MuiButton-root-9",
+                        "sizeLarge": "MuiButton-sizeLarge-33",
+                        "sizeSmall": "MuiButton-sizeSmall-32",
+                        "text": "MuiButton-text-11",
+                        "textPrimary": "MuiButton-textPrimary-12",
+                        "textSecondary": "MuiButton-textSecondary-13",
+                      }
+                    }
+                    color="default"
+                    component="button"
+                    disableFocusRipple={false}
+                    disabled={false}
+                    fullWidth={false}
+                    mini={false}
+                    size="medium"
+                    type="button"
+                    variant="text"
+                  >
+                    <WithStyles(ButtonBase)
+                      className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                      component="button"
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-28"
+                      type="button"
+                    >
+                      <ButtonBase
+                        centerRipple={false}
+                        className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                        classes={
+                          Object {
+                            "disabled": "MuiButtonBase-disabled-36",
+                            "focusVisible": "MuiButtonBase-focusVisible-37",
+                            "root": "MuiButtonBase-root-35",
+                          }
+                        }
+                        component="button"
+                        disableRipple={false}
+                        disableTouchRipple={false}
+                        disabled={false}
+                        focusRipple={true}
+                        focusVisibleClassName="MuiButton-focusVisible-28"
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <button
+                          className="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onContextMenu={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          tabIndex="0"
+                          type="button"
+                        >
+                          <span
+                            className="MuiButton-label-10"
+                          >
+                            <div
+                              className="flex flex-row flex-shrink-0"
+                            >
+                              <pure(DescriptionIcon)
+                                className="icon"
+                              >
+                                <DescriptionIcon
+                                  className="icon"
+                                >
+                                  <WithStyles(SvgIcon)
+                                    className="icon"
+                                  >
+                                    <SvgIcon
+                                      className="icon"
+                                      classes={
+                                        Object {
+                                          "colorAction": "MuiSvgIcon-colorAction-41",
+                                          "colorDisabled": "MuiSvgIcon-colorDisabled-43",
+                                          "colorError": "MuiSvgIcon-colorError-42",
+                                          "colorPrimary": "MuiSvgIcon-colorPrimary-39",
+                                          "colorSecondary": "MuiSvgIcon-colorSecondary-40",
+                                          "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-44",
+                                          "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-46",
+                                          "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-45",
+                                          "root": "MuiSvgIcon-root-38",
+                                        }
+                                      }
+                                      color="inherit"
+                                      component="svg"
+                                      fontSize="default"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        className="MuiSvgIcon-root-38 icon"
+                                        focusable="false"
+                                        role="presentation"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                          fill="none"
+                                        />
+                                        <path
+                                          d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+                                        />
+                                      </svg>
+                                    </SvgIcon>
+                                  </WithStyles(SvgIcon)>
+                                </DescriptionIcon>
+                              </pure(DescriptionIcon)>
+                              <span
+                                className="label"
+                              >
+                                Documentation
+                              </span>
+                              <pure(OpenInNewIcon)
+                                className="openInNewTabIcon"
+                              >
+                                <OpenInNewIcon
+                                  className="openInNewTabIcon"
+                                >
+                                  <WithStyles(SvgIcon)
+                                    className="openInNewTabIcon"
+                                  >
+                                    <SvgIcon
+                                      className="openInNewTabIcon"
+                                      classes={
+                                        Object {
+                                          "colorAction": "MuiSvgIcon-colorAction-41",
+                                          "colorDisabled": "MuiSvgIcon-colorDisabled-43",
+                                          "colorError": "MuiSvgIcon-colorError-42",
+                                          "colorPrimary": "MuiSvgIcon-colorPrimary-39",
+                                          "colorSecondary": "MuiSvgIcon-colorSecondary-40",
+                                          "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-44",
+                                          "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-46",
+                                          "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-45",
+                                          "root": "MuiSvgIcon-root-38",
+                                        }
+                                      }
+                                      color="inherit"
+                                      component="svg"
+                                      fontSize="default"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        className="MuiSvgIcon-root-38 openInNewTabIcon"
+                                        focusable="false"
+                                        role="presentation"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                          fill="none"
+                                        />
+                                        <path
+                                          d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                                        />
+                                      </svg>
+                                    </SvgIcon>
+                                  </WithStyles(SvgIcon)>
+                                </OpenInNewIcon>
+                              </pure(OpenInNewIcon)>
+                            </div>
+                          </span>
+                          <NoSsr
+                            defer={false}
+                            fallback={null}
+                          >
+                            <WithStyles(TouchRipple)
+                              center={false}
+                              innerRef={[Function]}
+                            >
+                              <TouchRipple
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "MuiTouchRipple-child-57",
+                                    "childLeaving": "MuiTouchRipple-childLeaving-58",
+                                    "childPulsate": "MuiTouchRipple-childPulsate-59",
+                                    "ripple": "MuiTouchRipple-ripple-54",
+                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate-56",
+                                    "rippleVisible": "MuiTouchRipple-rippleVisible-55",
+                                    "root": "MuiTouchRipple-root-53",
+                                  }
+                                }
+                              >
+                                <TransitionGroup
+                                  childFactory={[Function]}
+                                  className="MuiTouchRipple-root-53"
+                                  component="span"
+                                  enter={true}
+                                  exit={true}
+                                >
+                                  <span
+                                    className="MuiTouchRipple-root-53"
+                                  />
+                                </TransitionGroup>
+                              </TouchRipple>
+                            </WithStyles(TouchRipple)>
+                          </NoSsr>
+                        </button>
+                      </ButtonBase>
+                    </WithStyles(ButtonBase)>
+                  </Button>
+                </WithStyles(Button)>
+              </a>
+            </RootRef>
+            <Popper
+              anchorEl={
+                <a
+                  class="unstyled"
+                  href="https://www.kubeflow.org/docs/pipelines/"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <button
+                    class="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiButton-label-10"
+                    >
+                      <div
+                        class="flex flex-row flex-shrink-0"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-38 icon"
+                          focusable="false"
+                          role="presentation"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                          <path
+                            d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+                          />
+                        </svg>
+                        <span
+                          class="label"
+                        >
+                          Documentation
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-38 openInNewTabIcon"
+                          focusable="false"
+                          role="presentation"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                          <path
+                            d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root-53"
+                    />
+                  </button>
+                </a>
+              }
+              className="MuiTooltip-popper-1"
+              disablePortal={false}
+              id={null}
+              open={false}
+              placement="right-start"
+              transition={true}
+            />
+          </Tooltip>
+        </WithStyles(Tooltip)>
+      </ExternalUri>
+      <ExternalUri
+        collapsed={false}
+        icon={[Function]}
+        title="Github Repo"
+        to="https://github.com/kubeflow/pipelines"
+      >
+        <WithStyles(Tooltip)
+          disableFocusListener={true}
+          disableHoverListener={true}
+          disableTouchListener={true}
+          enterDelay={300}
+          placement="right-start"
+          title="Github Repo"
+        >
+          <Tooltip
+            TransitionComponent={[Function]}
+            classes={
+              Object {
+                "popper": "MuiTooltip-popper-1",
+                "popperInteractive": "MuiTooltip-popperInteractive-2",
+                "tooltip": "MuiTooltip-tooltip-3",
+                "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-8",
+                "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-5",
+                "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-6",
+                "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-7",
+                "touch": "MuiTooltip-touch-4",
+              }
+            }
+            disableFocusListener={true}
+            disableHoverListener={true}
+            disableTouchListener={true}
+            enterDelay={300}
+            enterTouchDelay={1000}
+            interactive={false}
+            leaveDelay={0}
+            leaveTouchDelay={1500}
+            placement="right-start"
+            theme={
+              Object {
+                "breakpoints": Object {
+                  "between": [Function],
+                  "down": [Function],
+                  "keys": Array [
+                    "xs",
+                    "sm",
+                    "md",
+                    "lg",
+                    "xl",
+                  ],
+                  "only": [Function],
+                  "up": [Function],
+                  "values": Object {
+                    "lg": 1280,
+                    "md": 960,
+                    "sm": 600,
+                    "xl": 1920,
+                    "xs": 0,
+                  },
+                  "width": [Function],
+                },
+                "direction": "ltr",
+                "mixins": Object {
+                  "gutters": [Function],
+                  "toolbar": Object {
+                    "@media (min-width:0px) and (orientation: landscape)": Object {
+                      "minHeight": 48,
+                    },
+                    "@media (min-width:600px)": Object {
+                      "minHeight": 64,
+                    },
+                    "minHeight": 56,
+                  },
+                },
+                "overrides": Object {},
+                "palette": Object {
+                  "action": Object {
+                    "active": "rgba(0, 0, 0, 0.54)",
+                    "disabled": "rgba(0, 0, 0, 0.26)",
+                    "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                    "hover": "rgba(0, 0, 0, 0.08)",
+                    "hoverOpacity": 0.08,
+                    "selected": "rgba(0, 0, 0, 0.14)",
+                  },
+                  "augmentColor": [Function],
+                  "background": Object {
+                    "default": "#fafafa",
+                    "paper": "#fff",
+                  },
+                  "common": Object {
+                    "black": "#000",
+                    "white": "#fff",
+                  },
+                  "contrastThreshold": 3,
+                  "divider": "rgba(0, 0, 0, 0.12)",
+                  "error": Object {
+                    "contrastText": "#fff",
+                    "dark": "#d32f2f",
+                    "light": "#e57373",
+                    "main": "#f44336",
+                  },
+                  "getContrastText": [Function],
+                  "grey": Object {
+                    "100": "#f5f5f5",
+                    "200": "#eeeeee",
+                    "300": "#e0e0e0",
+                    "400": "#bdbdbd",
+                    "50": "#fafafa",
+                    "500": "#9e9e9e",
+                    "600": "#757575",
+                    "700": "#616161",
+                    "800": "#424242",
+                    "900": "#212121",
+                    "A100": "#d5d5d5",
+                    "A200": "#aaaaaa",
+                    "A400": "#303030",
+                    "A700": "#616161",
+                  },
+                  "primary": Object {
+                    "contrastText": "#fff",
+                    "dark": "#303f9f",
+                    "light": "#7986cb",
+                    "main": "#3f51b5",
+                  },
+                  "secondary": Object {
+                    "contrastText": "#fff",
+                    "dark": "#c51162",
+                    "light": "#ff4081",
+                    "main": "#f50057",
+                  },
+                  "text": Object {
+                    "disabled": "rgba(0, 0, 0, 0.38)",
+                    "hint": "rgba(0, 0, 0, 0.38)",
+                    "primary": "rgba(0, 0, 0, 0.87)",
+                    "secondary": "rgba(0, 0, 0, 0.54)",
+                  },
+                  "tonalOffset": 0.2,
+                  "type": "light",
+                },
+                "props": Object {},
+                "shadows": Array [
+                  "none",
+                  "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                  "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                  "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                  "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                  "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                  "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                  "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                  "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                  "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                  "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                  "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                  "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                  "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                  "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                  "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                  "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                  "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                  "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                  "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                  "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                  "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                  "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                  "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                  "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+                ],
+                "shape": Object {
+                  "borderRadius": 4,
+                },
+                "spacing": Object {
+                  "unit": 8,
+                },
+                "transitions": Object {
+                  "create": [Function],
+                  "duration": Object {
+                    "complex": 375,
+                    "enteringScreen": 225,
+                    "leavingScreen": 195,
+                    "short": 250,
+                    "shorter": 200,
+                    "shortest": 150,
+                    "standard": 300,
+                  },
+                  "easing": Object {
+                    "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                    "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                    "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                    "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                  },
+                  "getAutoHeightDuration": [Function],
+                },
+                "typography": Object {
+                  "body1": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.46429em",
+                  },
+                  "body1Next": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.00938em",
+                    "lineHeight": 1.5,
+                  },
+                  "body2": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                    "lineHeight": "1.71429em",
+                  },
+                  "body2Next": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.01071em",
+                    "lineHeight": 1.5,
+                  },
+                  "button": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                    "textTransform": "uppercase",
+                  },
+                  "buttonNext": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                    "letterSpacing": "0.02857em",
+                    "lineHeight": 1.75,
+                    "textTransform": "uppercase",
+                  },
+                  "caption": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.375em",
+                  },
+                  "captionNext": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.03333em",
+                    "lineHeight": 1.66,
+                  },
+                  "display1": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "2.125rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.20588em",
+                  },
+                  "display2": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "2.8125rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.13333em",
+                    "marginLeft": "-.02em",
+                  },
+                  "display3": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "3.5rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "-.02em",
+                    "lineHeight": "1.30357em",
+                    "marginLeft": "-.02em",
+                  },
+                  "display4": Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "7rem",
+                    "fontWeight": 300,
+                    "letterSpacing": "-.04em",
+                    "lineHeight": "1.14286em",
+                    "marginLeft": "-.04em",
+                  },
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": 14,
+                  "fontWeightLight": 300,
+                  "fontWeightMedium": 500,
+                  "fontWeightRegular": 400,
+                  "h1": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "6rem",
+                    "fontWeight": 300,
+                    "letterSpacing": "-0.01562em",
+                    "lineHeight": 1,
+                  },
+                  "h2": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "3.75rem",
+                    "fontWeight": 300,
+                    "letterSpacing": "-0.00833em",
+                    "lineHeight": 1,
+                  },
+                  "h3": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "3rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0em",
+                    "lineHeight": 1.04,
+                  },
+                  "h4": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "2.125rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.00735em",
+                    "lineHeight": 1.17,
+                  },
+                  "h5": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0em",
+                    "lineHeight": 1.33,
+                  },
+                  "h6": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1.25rem",
+                    "fontWeight": 500,
+                    "letterSpacing": "0.0075em",
+                    "lineHeight": 1.6,
+                  },
+                  "headline": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1.5rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.35417em",
+                  },
+                  "overline": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.75rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.08333em",
+                    "lineHeight": 2.66,
+                    "textTransform": "uppercase",
+                  },
+                  "pxToRem": [Function],
+                  "round": [Function],
+                  "subheading": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1rem",
+                    "fontWeight": 400,
+                    "lineHeight": "1.5em",
+                  },
+                  "subtitle1": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1rem",
+                    "fontWeight": 400,
+                    "letterSpacing": "0.00938em",
+                    "lineHeight": 1.75,
+                  },
+                  "subtitle2": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "0.875rem",
+                    "fontWeight": 500,
+                    "letterSpacing": "0.00714em",
+                    "lineHeight": 1.57,
+                  },
+                  "title": Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                    "fontSize": "1.3125rem",
+                    "fontWeight": 500,
+                    "lineHeight": "1.16667em",
+                  },
+                  "useNextVariants": false,
+                },
+                "zIndex": Object {
+                  "appBar": 1100,
+                  "drawer": 1200,
+                  "mobileStepper": 1000,
+                  "modal": 1300,
+                  "snackbar": 1400,
+                  "tooltip": 1500,
+                },
+              }
+            }
+            title="Github Repo"
+          >
+            <RootRef
+              rootRef={[Function]}
+            >
+              <a
+                aria-describedby={null}
+                className="unstyled"
+                href="https://github.com/kubeflow/pipelines"
+                rel="noopener noreferrer"
+                target="_blank"
+                title={null}
+              >
+                <WithStyles(Button)
+                  className="button"
+                >
+                  <Button
+                    className="button"
+                    classes={
+                      Object {
+                        "colorInherit": "MuiButton-colorInherit-30",
+                        "contained": "MuiButton-contained-20",
+                        "containedPrimary": "MuiButton-containedPrimary-21",
+                        "containedSecondary": "MuiButton-containedSecondary-22",
+                        "disabled": "MuiButton-disabled-29",
+                        "extendedFab": "MuiButton-extendedFab-27",
+                        "fab": "MuiButton-fab-26",
+                        "flat": "MuiButton-flat-14",
+                        "flatPrimary": "MuiButton-flatPrimary-15",
+                        "flatSecondary": "MuiButton-flatSecondary-16",
+                        "focusVisible": "MuiButton-focusVisible-28",
+                        "fullWidth": "MuiButton-fullWidth-34",
+                        "label": "MuiButton-label-10",
+                        "mini": "MuiButton-mini-31",
+                        "outlined": "MuiButton-outlined-17",
+                        "outlinedPrimary": "MuiButton-outlinedPrimary-18",
+                        "outlinedSecondary": "MuiButton-outlinedSecondary-19",
+                        "raised": "MuiButton-raised-23",
+                        "raisedPrimary": "MuiButton-raisedPrimary-24",
+                        "raisedSecondary": "MuiButton-raisedSecondary-25",
+                        "root": "MuiButton-root-9",
+                        "sizeLarge": "MuiButton-sizeLarge-33",
+                        "sizeSmall": "MuiButton-sizeSmall-32",
+                        "text": "MuiButton-text-11",
+                        "textPrimary": "MuiButton-textPrimary-12",
+                        "textSecondary": "MuiButton-textSecondary-13",
+                      }
+                    }
+                    color="default"
+                    component="button"
+                    disableFocusRipple={false}
+                    disabled={false}
+                    fullWidth={false}
+                    mini={false}
+                    size="medium"
+                    type="button"
+                    variant="text"
+                  >
+                    <WithStyles(ButtonBase)
+                      className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                      component="button"
+                      disabled={false}
+                      focusRipple={true}
+                      focusVisibleClassName="MuiButton-focusVisible-28"
+                      type="button"
+                    >
+                      <ButtonBase
+                        centerRipple={false}
+                        className="MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                        classes={
+                          Object {
+                            "disabled": "MuiButtonBase-disabled-36",
+                            "focusVisible": "MuiButtonBase-focusVisible-37",
+                            "root": "MuiButtonBase-root-35",
+                          }
+                        }
+                        component="button"
+                        disableRipple={false}
+                        disableTouchRipple={false}
+                        disabled={false}
+                        focusRipple={true}
+                        focusVisibleClassName="MuiButton-focusVisible-28"
+                        tabIndex="0"
+                        type="button"
+                      >
+                        <button
+                          className="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onContextMenu={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          tabIndex="0"
+                          type="button"
+                        >
+                          <span
+                            className="MuiButton-label-10"
+                          >
+                            <div
+                              className="flex flex-row flex-shrink-0"
+                            >
+                              <img
+                                alt="Github"
+                                className="icon iconImage"
+                                src="GitHub-Mark-120px-plus.png"
+                              />
+                              <span
+                                className="label"
+                              >
+                                Github Repo
+                              </span>
+                              <pure(OpenInNewIcon)
+                                className="openInNewTabIcon"
+                              >
+                                <OpenInNewIcon
+                                  className="openInNewTabIcon"
+                                >
+                                  <WithStyles(SvgIcon)
+                                    className="openInNewTabIcon"
+                                  >
+                                    <SvgIcon
+                                      className="openInNewTabIcon"
+                                      classes={
+                                        Object {
+                                          "colorAction": "MuiSvgIcon-colorAction-41",
+                                          "colorDisabled": "MuiSvgIcon-colorDisabled-43",
+                                          "colorError": "MuiSvgIcon-colorError-42",
+                                          "colorPrimary": "MuiSvgIcon-colorPrimary-39",
+                                          "colorSecondary": "MuiSvgIcon-colorSecondary-40",
+                                          "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-44",
+                                          "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-46",
+                                          "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-45",
+                                          "root": "MuiSvgIcon-root-38",
+                                        }
+                                      }
+                                      color="inherit"
+                                      component="svg"
+                                      fontSize="default"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        className="MuiSvgIcon-root-38 openInNewTabIcon"
+                                        focusable="false"
+                                        role="presentation"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                          fill="none"
+                                        />
+                                        <path
+                                          d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                                        />
+                                      </svg>
+                                    </SvgIcon>
+                                  </WithStyles(SvgIcon)>
+                                </OpenInNewIcon>
+                              </pure(OpenInNewIcon)>
+                            </div>
+                          </span>
+                          <NoSsr
+                            defer={false}
+                            fallback={null}
+                          >
+                            <WithStyles(TouchRipple)
+                              center={false}
+                              innerRef={[Function]}
+                            >
+                              <TouchRipple
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "MuiTouchRipple-child-57",
+                                    "childLeaving": "MuiTouchRipple-childLeaving-58",
+                                    "childPulsate": "MuiTouchRipple-childPulsate-59",
+                                    "ripple": "MuiTouchRipple-ripple-54",
+                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate-56",
+                                    "rippleVisible": "MuiTouchRipple-rippleVisible-55",
+                                    "root": "MuiTouchRipple-root-53",
+                                  }
+                                }
+                              >
+                                <TransitionGroup
+                                  childFactory={[Function]}
+                                  className="MuiTouchRipple-root-53"
+                                  component="span"
+                                  enter={true}
+                                  exit={true}
+                                >
+                                  <span
+                                    className="MuiTouchRipple-root-53"
+                                  />
+                                </TransitionGroup>
+                              </TouchRipple>
+                            </WithStyles(TouchRipple)>
+                          </NoSsr>
+                        </button>
+                      </ButtonBase>
+                    </WithStyles(ButtonBase)>
+                  </Button>
+                </WithStyles(Button)>
+              </a>
+            </RootRef>
+            <Popper
+              anchorEl={
+                <a
+                  class="unstyled"
+                  href="https://github.com/kubeflow/pipelines"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <button
+                    class="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiButton-label-10"
+                    >
+                      <div
+                        class="flex flex-row flex-shrink-0"
+                      >
+                        <img
+                          alt="Github"
+                          class="icon iconImage"
+                          src="GitHub-Mark-120px-plus.png"
+                        />
+                        <span
+                          class="label"
+                        >
+                          Github Repo
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-38 openInNewTabIcon"
+                          focusable="false"
+                          role="presentation"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                          <path
+                            d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root-53"
+                    />
+                  </button>
+                </a>
+              }
+              className="MuiTooltip-popper-1"
+              disablePortal={false}
+              id={null}
+              open={false}
+              placement="right-start"
+              transition={true}
+            />
+          </Tooltip>
+        </WithStyles(Tooltip)>
+      </ExternalUri>
+      <hr
+        className="separator"
+      />
+      <WithStyles(IconButton)
+        className="chevron"
+        onClick={[Function]}
+      >
+        <IconButton
+          className="chevron"
+          classes={
+            Object {
+              "colorInherit": "MuiIconButton-colorInherit-48",
+              "colorPrimary": "MuiIconButton-colorPrimary-49",
+              "colorSecondary": "MuiIconButton-colorSecondary-50",
+              "disabled": "MuiIconButton-disabled-51",
+              "label": "MuiIconButton-label-52",
+              "root": "MuiIconButton-root-47",
+            }
+          }
+          color="default"
+          disabled={false}
+          onClick={[Function]}
+        >
+          <WithStyles(ButtonBase)
+            centerRipple={true}
+            className="MuiIconButton-root-47 chevron"
+            disabled={false}
+            focusRipple={true}
+            onClick={[Function]}
+          >
+            <ButtonBase
+              centerRipple={true}
+              className="MuiIconButton-root-47 chevron"
+              classes={
+                Object {
+                  "disabled": "MuiButtonBase-disabled-36",
+                  "focusVisible": "MuiButtonBase-focusVisible-37",
+                  "root": "MuiButtonBase-root-35",
+                }
+              }
+              component="button"
+              disableRipple={false}
+              disableTouchRipple={false}
+              disabled={false}
+              focusRipple={true}
+              onClick={[Function]}
+              tabIndex="0"
+              type="button"
+            >
+              <button
+                className="MuiButtonBase-root-35 MuiIconButton-root-47 chevron"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                tabIndex="0"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label-52"
+                >
+                  <pure(ChevronLeftIcon)>
+                    <ChevronLeftIcon>
+                      <WithStyles(SvgIcon)>
+                        <SvgIcon
+                          classes={
+                            Object {
+                              "colorAction": "MuiSvgIcon-colorAction-41",
+                              "colorDisabled": "MuiSvgIcon-colorDisabled-43",
+                              "colorError": "MuiSvgIcon-colorError-42",
+                              "colorPrimary": "MuiSvgIcon-colorPrimary-39",
+                              "colorSecondary": "MuiSvgIcon-colorSecondary-40",
+                              "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-44",
+                              "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-46",
+                              "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-45",
+                              "root": "MuiSvgIcon-root-38",
+                            }
+                          }
+                          color="inherit"
+                          component="svg"
+                          fontSize="default"
+                          viewBox="0 0 24 24"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="MuiSvgIcon-root-38"
+                            focusable="false"
+                            role="presentation"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                            />
+                            <path
+                              d="M0 0h24v24H0z"
+                              fill="none"
+                            />
+                          </svg>
+                        </SvgIcon>
+                      </WithStyles(SvgIcon)>
+                    </ChevronLeftIcon>
+                  </pure(ChevronLeftIcon)>
+                </span>
+                <NoSsr
+                  defer={false}
+                  fallback={null}
+                >
+                  <WithStyles(TouchRipple)
+                    center={true}
+                    innerRef={[Function]}
+                  >
+                    <TouchRipple
+                      center={true}
+                      classes={
+                        Object {
+                          "child": "MuiTouchRipple-child-57",
+                          "childLeaving": "MuiTouchRipple-childLeaving-58",
+                          "childPulsate": "MuiTouchRipple-childPulsate-59",
+                          "ripple": "MuiTouchRipple-ripple-54",
+                          "ripplePulsate": "MuiTouchRipple-ripplePulsate-56",
+                          "rippleVisible": "MuiTouchRipple-rippleVisible-55",
+                          "root": "MuiTouchRipple-root-53",
+                        }
+                      }
+                    >
+                      <TransitionGroup
+                        childFactory={[Function]}
+                        className="MuiTouchRipple-root-53"
+                        component="span"
+                        enter={true}
+                        exit={true}
+                      >
+                        <span
+                          className="MuiTouchRipple-root-53"
+                        />
+                      </TransitionGroup>
+                    </TouchRipple>
+                  </WithStyles(TouchRipple)>
+                </NoSsr>
+              </button>
+            </ButtonBase>
+          </WithStyles(ButtonBase)>
+        </IconButton>
+      </WithStyles(IconButton)>
+    </div>
+    <div
+      className="infoVisible"
+    >
+      <WithStyles(Tooltip)
+        enterDelay={300}
+        placement="top-start"
+        title="Build date: 10/23/2018, Commit hash: 0a7b9e3"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-1",
+              "popperInteractive": "MuiTooltip-popperInteractive-2",
+              "tooltip": "MuiTooltip-tooltip-3",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-8",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-5",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-6",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-7",
+              "touch": "MuiTooltip-touch-4",
+            }
+          }
+          disableFocusListener={false}
+          disableHoverListener={false}
+          disableTouchListener={false}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="top-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Build date: 10/23/2018, Commit hash: 0a7b9e3"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <div
+              aria-describedby={null}
+              className="envMetadata"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseLeave={[Function]}
+              onMouseOver={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              title="Build date: 10/23/2018, Commit hash: 0a7b9e3"
+            >
+              <span>
+                Version: 
+              </span>
+              <a
+                className="link unstyled"
+                href="https://www.github.com/kubeflow/pipelines/commit/0a7b9e38f2b9bcdef4bbf3234d971e1635b50cd5"
+                rel="noopener"
+                target="_blank"
+              >
+                1.0.0
+              </a>
+            </div>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <div
+                class="envMetadata"
+                title="Build date: 10/23/2018, Commit hash: 0a7b9e3"
+              >
+                <span>
+                  Version: 
+                </span>
+                <a
+                  class="link unstyled"
+                  href="https://www.github.com/kubeflow/pipelines/commit/0a7b9e38f2b9bcdef4bbf3234d971e1635b50cd5"
+                  rel="noopener"
+                  target="_blank"
+                >
+                  1.0.0
+                </a>
+              </div>
+            }
+            className="MuiTooltip-popper-1"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="top-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+      <WithStyles(Tooltip)
+        enterDelay={300}
+        placement="top-start"
+        title="Report an Issue"
+      >
+        <Tooltip
+          TransitionComponent={[Function]}
+          classes={
+            Object {
+              "popper": "MuiTooltip-popper-1",
+              "popperInteractive": "MuiTooltip-popperInteractive-2",
+              "tooltip": "MuiTooltip-tooltip-3",
+              "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom-8",
+              "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft-5",
+              "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight-6",
+              "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop-7",
+              "touch": "MuiTooltip-touch-4",
+            }
+          }
+          disableFocusListener={false}
+          disableHoverListener={false}
+          disableTouchListener={false}
+          enterDelay={300}
+          enterTouchDelay={1000}
+          interactive={false}
+          leaveDelay={0}
+          leaveTouchDelay={1500}
+          placement="top-start"
+          theme={
+            Object {
+              "breakpoints": Object {
+                "between": [Function],
+                "down": [Function],
+                "keys": Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ],
+                "only": [Function],
+                "up": [Function],
+                "values": Object {
+                  "lg": 1280,
+                  "md": 960,
+                  "sm": 600,
+                  "xl": 1920,
+                  "xs": 0,
+                },
+                "width": [Function],
+              },
+              "direction": "ltr",
+              "mixins": Object {
+                "gutters": [Function],
+                "toolbar": Object {
+                  "@media (min-width:0px) and (orientation: landscape)": Object {
+                    "minHeight": 48,
+                  },
+                  "@media (min-width:600px)": Object {
+                    "minHeight": 64,
+                  },
+                  "minHeight": 56,
+                },
+              },
+              "overrides": Object {},
+              "palette": Object {
+                "action": Object {
+                  "active": "rgba(0, 0, 0, 0.54)",
+                  "disabled": "rgba(0, 0, 0, 0.26)",
+                  "disabledBackground": "rgba(0, 0, 0, 0.12)",
+                  "hover": "rgba(0, 0, 0, 0.08)",
+                  "hoverOpacity": 0.08,
+                  "selected": "rgba(0, 0, 0, 0.14)",
+                },
+                "augmentColor": [Function],
+                "background": Object {
+                  "default": "#fafafa",
+                  "paper": "#fff",
+                },
+                "common": Object {
+                  "black": "#000",
+                  "white": "#fff",
+                },
+                "contrastThreshold": 3,
+                "divider": "rgba(0, 0, 0, 0.12)",
+                "error": Object {
+                  "contrastText": "#fff",
+                  "dark": "#d32f2f",
+                  "light": "#e57373",
+                  "main": "#f44336",
+                },
+                "getContrastText": [Function],
+                "grey": Object {
+                  "100": "#f5f5f5",
+                  "200": "#eeeeee",
+                  "300": "#e0e0e0",
+                  "400": "#bdbdbd",
+                  "50": "#fafafa",
+                  "500": "#9e9e9e",
+                  "600": "#757575",
+                  "700": "#616161",
+                  "800": "#424242",
+                  "900": "#212121",
+                  "A100": "#d5d5d5",
+                  "A200": "#aaaaaa",
+                  "A400": "#303030",
+                  "A700": "#616161",
+                },
+                "primary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#303f9f",
+                  "light": "#7986cb",
+                  "main": "#3f51b5",
+                },
+                "secondary": Object {
+                  "contrastText": "#fff",
+                  "dark": "#c51162",
+                  "light": "#ff4081",
+                  "main": "#f50057",
+                },
+                "text": Object {
+                  "disabled": "rgba(0, 0, 0, 0.38)",
+                  "hint": "rgba(0, 0, 0, 0.38)",
+                  "primary": "rgba(0, 0, 0, 0.87)",
+                  "secondary": "rgba(0, 0, 0, 0.54)",
+                },
+                "tonalOffset": 0.2,
+                "type": "light",
+              },
+              "props": Object {},
+              "shadows": Array [
+                "none",
+                "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+                "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+                "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+                "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+                "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+                "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+                "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+                "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+                "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+                "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+                "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+                "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+                "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+                "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+                "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+                "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+                "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+                "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+                "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+                "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+              ],
+              "shape": Object {
+                "borderRadius": 4,
+              },
+              "spacing": Object {
+                "unit": 8,
+              },
+              "transitions": Object {
+                "create": [Function],
+                "duration": Object {
+                  "complex": 375,
+                  "enteringScreen": 225,
+                  "leavingScreen": 195,
+                  "short": 250,
+                  "shorter": 200,
+                  "shortest": 150,
+                  "standard": 300,
+                },
+                "easing": Object {
+                  "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+                  "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+                  "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+                  "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+                },
+                "getAutoHeightDuration": [Function],
+              },
+              "typography": Object {
+                "body1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.46429em",
+                },
+                "body1Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.5,
+                },
+                "body2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.71429em",
+                },
+                "body2Next": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.01071em",
+                  "lineHeight": 1.5,
+                },
+                "button": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "textTransform": "uppercase",
+                },
+                "buttonNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.02857em",
+                  "lineHeight": 1.75,
+                  "textTransform": "uppercase",
+                },
+                "caption": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.375em",
+                },
+                "captionNext": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.03333em",
+                  "lineHeight": 1.66,
+                },
+                "display1": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.20588em",
+                },
+                "display2": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.8125rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.13333em",
+                  "marginLeft": "-.02em",
+                },
+                "display3": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "-.02em",
+                  "lineHeight": "1.30357em",
+                  "marginLeft": "-.02em",
+                },
+                "display4": Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "7rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-.04em",
+                  "lineHeight": "1.14286em",
+                  "marginLeft": "-.04em",
+                },
+                "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                "fontSize": 14,
+                "fontWeightLight": 300,
+                "fontWeightMedium": 500,
+                "fontWeightRegular": 400,
+                "h1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "6rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.01562em",
+                  "lineHeight": 1,
+                },
+                "h2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3.75rem",
+                  "fontWeight": 300,
+                  "letterSpacing": "-0.00833em",
+                  "lineHeight": 1,
+                },
+                "h3": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "3rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.04,
+                },
+                "h4": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "2.125rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00735em",
+                  "lineHeight": 1.17,
+                },
+                "h5": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0em",
+                  "lineHeight": 1.33,
+                },
+                "h6": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.25rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.0075em",
+                  "lineHeight": 1.6,
+                },
+                "headline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.5rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.35417em",
+                },
+                "overline": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.75rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.08333em",
+                  "lineHeight": 2.66,
+                  "textTransform": "uppercase",
+                },
+                "pxToRem": [Function],
+                "round": [Function],
+                "subheading": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "lineHeight": "1.5em",
+                },
+                "subtitle1": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1rem",
+                  "fontWeight": 400,
+                  "letterSpacing": "0.00938em",
+                  "lineHeight": 1.75,
+                },
+                "subtitle2": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "0.875rem",
+                  "fontWeight": 500,
+                  "letterSpacing": "0.00714em",
+                  "lineHeight": 1.57,
+                },
+                "title": Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+                  "fontSize": "1.3125rem",
+                  "fontWeight": 500,
+                  "lineHeight": "1.16667em",
+                },
+                "useNextVariants": false,
+              },
+              "zIndex": Object {
+                "appBar": 1100,
+                "drawer": 1200,
+                "mobileStepper": 1000,
+                "modal": 1300,
+                "snackbar": 1400,
+                "tooltip": 1500,
+              },
+            }
+          }
+          title="Report an Issue"
+        >
+          <RootRef
+            rootRef={[Function]}
+          >
+            <div
+              aria-describedby={null}
+              className="envMetadata"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseLeave={[Function]}
+              onMouseOver={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              title="Report an Issue"
+            >
+              <a
+                className="link unstyled"
+                href="https://github.com/kubeflow/pipelines/issues/new/choose"
+                rel="noopener"
+                target="_blank"
+              >
+                Report an Issue
+              </a>
+            </div>
+          </RootRef>
+          <Popper
+            anchorEl={
+              <div
+                class="envMetadata"
+                title="Report an Issue"
+              >
+                <a
+                  class="link unstyled"
+                  href="https://github.com/kubeflow/pipelines/issues/new/choose"
+                  rel="noopener"
+                  target="_blank"
+                >
+                  Report an Issue
+                </a>
+              </div>
+            }
+            className="MuiTooltip-popper-1"
+            disablePortal={false}
+            id={null}
+            open={false}
+            placement="top-start"
+            transition={true}
+          />
+        </Tooltip>
+      </WithStyles(Tooltip)>
+    </div>
+  </div>
+</SideNav>
+`;
+
+exports[`SideNav renders Pipelines as active page 1`] = `
 <div
   className="root flexColumn noShrink"
   id="sideNav"
@@ -293,7 +13754,7 @@ exports[`SideNav populates the display build information using the response from
 </div>
 `;
 
-exports[`SideNav renders Pipelines as active page 1`] = `
+exports[`SideNav renders Pipelines as active when on PipelineDetails page 1`] = `
 <div
   className="root flexColumn noShrink"
   id="sideNav"
@@ -546,275 +14007,24 @@ exports[`SideNav renders Pipelines as active page 1`] = `
     <WithStyles(Tooltip)
       enterDelay={300}
       placement="top-start"
-      title="Report an Issue"
+      title="Build date: 10/23/2018, Commit hash: 0a7b9e3"
     >
       <div
         className="envMetadata"
       >
+        <span>
+          Version: 
+        </span>
         <a
           className="link unstyled"
-          href="https://github.com/kubeflow/pipelines/issues/new/choose"
+          href="https://www.github.com/kubeflow/pipelines/commit/0a7b9e38f2b9bcdef4bbf3234d971e1635b50cd5"
           rel="noopener"
           target="_blank"
         >
-          Report an Issue
+          1.0.0
         </a>
       </div>
     </WithStyles(Tooltip)>
-  </div>
-</div>
-`;
-
-exports[`SideNav renders Pipelines as active when on PipelineDetails page 1`] = `
-<div
-  className="root flexColumn noShrink"
-  id="sideNav"
->
-  <div
-    style={
-      Object {
-        "flexGrow": 1,
-      }
-    }
-  >
-    <div
-      className="indicator"
-    />
-    <WithStyles(Tooltip)
-      disableFocusListener={true}
-      disableHoverListener={true}
-      disableTouchListener={true}
-      enterDelay={300}
-      placement="right-start"
-      title="Pipeline List"
-    >
-      <Link
-        className="unstyled"
-        id="pipelinesBtn"
-        replace={false}
-        to="/pipelines"
-      >
-        <WithStyles(Button)
-          className="button active"
-        >
-          <div
-            className="flex flex-row flex-shrink-0"
-          >
-            <div
-              className="alignItems"
-            >
-              <PipelinesIcon
-                color="#0d6de7"
-              />
-            </div>
-            <span
-              className="label"
-            >
-              Pipelines
-            </span>
-          </div>
-        </WithStyles(Button)>
-      </Link>
-    </WithStyles(Tooltip)>
-    <div
-      className="indicator indicatorHidden"
-    />
-    <WithStyles(Tooltip)
-      disableFocusListener={true}
-      disableHoverListener={true}
-      disableTouchListener={true}
-      enterDelay={300}
-      placement="right-start"
-      title="Experiment List"
-    >
-      <Link
-        className="unstyled"
-        id="experimentsBtn"
-        replace={false}
-        to="/experiments"
-      >
-        <WithStyles(Button)
-          className="button"
-        >
-          <div
-            className="flex flex-row flex-shrink-0"
-          >
-            <div
-              className="alignItems"
-            >
-              <ExperimentsIcon
-                color="#9aa0a6"
-              />
-            </div>
-            <span
-              className="label"
-            >
-              Experiments
-            </span>
-          </div>
-        </WithStyles(Button)>
-      </Link>
-    </WithStyles(Tooltip)>
-    <div
-      className="indicator indicatorHidden"
-    />
-    <WithStyles(Tooltip)
-      disableFocusListener={true}
-      disableHoverListener={true}
-      disableTouchListener={true}
-      enterDelay={300}
-      placement="right-start"
-      title="Runs List"
-    >
-      <Link
-        className="unstyled"
-        id="runsBtn"
-        replace={false}
-        to="/runs"
-      >
-        <WithStyles(Button)
-          className="button"
-        >
-          <div
-            className="flex flex-row flex-shrink-0"
-          >
-            <pure(DirectionsRunIcon) />
-            <span
-              className="label"
-            >
-              Runs
-            </span>
-          </div>
-        </WithStyles(Button)>
-      </Link>
-    </WithStyles(Tooltip)>
-    <div
-      className="indicator indicatorHidden"
-    />
-    <WithStyles(Tooltip)
-      disableFocusListener={true}
-      disableHoverListener={true}
-      disableTouchListener={true}
-      enterDelay={300}
-      placement="right-start"
-      title="Recurring Runs List"
-    >
-      <Link
-        className="unstyled"
-        id="recurringRunsBtn"
-        replace={false}
-        to="/recurringruns"
-      >
-        <WithStyles(Button)
-          className="button"
-        >
-          <div
-            className="flex flex-row flex-shrink-0"
-          >
-            <pure(AlarmIcon) />
-            <span
-              className="label"
-            >
-              Recurring Runs
-            </span>
-          </div>
-        </WithStyles(Button)>
-      </Link>
-    </WithStyles(Tooltip)>
-    <div
-      className="indicator indicatorHidden"
-    />
-    <WithStyles(Tooltip)
-      disableFocusListener={true}
-      disableHoverListener={true}
-      disableTouchListener={true}
-      enterDelay={300}
-      placement="right-start"
-      title="Artifacts List"
-    >
-      <Link
-        className="unstyled"
-        id="artifactsBtn"
-        replace={false}
-        to="/artifacts"
-      >
-        <WithStyles(Button)
-          className="button"
-        >
-          <div
-            className="flex flex-row flex-shrink-0"
-          >
-            <pure(BubbleChartIcon) />
-            <span
-              className="label"
-            >
-              Artifacts
-            </span>
-          </div>
-        </WithStyles(Button)>
-      </Link>
-    </WithStyles(Tooltip)>
-    <div
-      className="indicator indicatorHidden"
-    />
-    <WithStyles(Tooltip)
-      disableFocusListener={true}
-      disableHoverListener={true}
-      disableTouchListener={true}
-      enterDelay={300}
-      placement="right-start"
-      title="Executions List"
-    >
-      <Link
-        className="unstyled"
-        id="executionsBtn"
-        replace={false}
-        to="/executions"
-      >
-        <WithStyles(Button)
-          className="button"
-        >
-          <div
-            className="flex flex-row flex-shrink-0"
-          >
-            <pure(PlayArrowIcon) />
-            <span
-              className="label"
-            >
-              Executions
-            </span>
-          </div>
-        </WithStyles(Button)>
-      </Link>
-    </WithStyles(Tooltip)>
-    <hr
-      className="separator"
-    />
-    <ExternalUri
-      collapsed={false}
-      icon={[Function]}
-      title="Documentation"
-      to="https://www.kubeflow.org/docs/pipelines/"
-    />
-    <ExternalUri
-      collapsed={false}
-      icon={[Function]}
-      title="Github Repo"
-      to="https://github.com/kubeflow/pipelines"
-    />
-    <hr
-      className="separator"
-    />
-    <WithStyles(IconButton)
-      className="chevron"
-      onClick={[Function]}
-    >
-      <pure(ChevronLeftIcon) />
-    </WithStyles(IconButton)>
-  </div>
-  <div
-    className="infoVisible"
-  >
     <WithStyles(Tooltip)
       enterDelay={300}
       placement="top-start"
@@ -1090,6 +14300,27 @@ exports[`SideNav renders collapsed state 1`] = `
     <WithStyles(Tooltip)
       enterDelay={300}
       placement="top-start"
+      title="Build date: 10/23/2018, Commit hash: 0a7b9e3"
+    >
+      <div
+        className="envMetadata"
+      >
+        <span>
+          Version: 
+        </span>
+        <a
+          className="link unstyled"
+          href="https://www.github.com/kubeflow/pipelines/commit/0a7b9e38f2b9bcdef4bbf3234d971e1635b50cd5"
+          rel="noopener"
+          target="_blank"
+        >
+          1.0.0
+        </a>
+      </div>
+    </WithStyles(Tooltip)>
+    <WithStyles(Tooltip)
+      enterDelay={300}
+      placement="top-start"
       title="Report an Issue"
     >
       <div
@@ -1359,6 +14590,27 @@ exports[`SideNav renders expanded state 1`] = `
   <div
     className="infoVisible"
   >
+    <WithStyles(Tooltip)
+      enterDelay={300}
+      placement="top-start"
+      title="Build date: 10/23/2018, Commit hash: 0a7b9e3"
+    >
+      <div
+        className="envMetadata"
+      >
+        <span>
+          Version: 
+        </span>
+        <a
+          className="link unstyled"
+          href="https://www.github.com/kubeflow/pipelines/commit/0a7b9e38f2b9bcdef4bbf3234d971e1635b50cd5"
+          rel="noopener"
+          target="_blank"
+        >
+          1.0.0
+        </a>
+      </div>
+    </WithStyles(Tooltip)>
     <WithStyles(Tooltip)
       enterDelay={300}
       placement="top-start"
@@ -1634,6 +14886,27 @@ exports[`SideNav renders experiments as active page 1`] = `
     <WithStyles(Tooltip)
       enterDelay={300}
       placement="top-start"
+      title="Build date: 10/23/2018, Commit hash: 0a7b9e3"
+    >
+      <div
+        className="envMetadata"
+      >
+        <span>
+          Version: 
+        </span>
+        <a
+          className="link unstyled"
+          href="https://www.github.com/kubeflow/pipelines/commit/0a7b9e38f2b9bcdef4bbf3234d971e1635b50cd5"
+          rel="noopener"
+          target="_blank"
+        >
+          1.0.0
+        </a>
+      </div>
+    </WithStyles(Tooltip)>
+    <WithStyles(Tooltip)
+      enterDelay={300}
+      placement="top-start"
       title="Report an Issue"
     >
       <div
@@ -1903,6 +15176,27 @@ exports[`SideNav renders experiments as active page when on AllRuns page 1`] = `
   <div
     className="infoVisible"
   >
+    <WithStyles(Tooltip)
+      enterDelay={300}
+      placement="top-start"
+      title="Build date: 10/23/2018, Commit hash: 0a7b9e3"
+    >
+      <div
+        className="envMetadata"
+      >
+        <span>
+          Version: 
+        </span>
+        <a
+          className="link unstyled"
+          href="https://www.github.com/kubeflow/pipelines/commit/0a7b9e38f2b9bcdef4bbf3234d971e1635b50cd5"
+          rel="noopener"
+          target="_blank"
+        >
+          1.0.0
+        </a>
+      </div>
+    </WithStyles(Tooltip)>
     <WithStyles(Tooltip)
       enterDelay={300}
       placement="top-start"
@@ -2178,6 +15472,27 @@ exports[`SideNav renders experiments as active page when on Compare page 1`] = `
     <WithStyles(Tooltip)
       enterDelay={300}
       placement="top-start"
+      title="Build date: 10/23/2018, Commit hash: 0a7b9e3"
+    >
+      <div
+        className="envMetadata"
+      >
+        <span>
+          Version: 
+        </span>
+        <a
+          className="link unstyled"
+          href="https://www.github.com/kubeflow/pipelines/commit/0a7b9e38f2b9bcdef4bbf3234d971e1635b50cd5"
+          rel="noopener"
+          target="_blank"
+        >
+          1.0.0
+        </a>
+      </div>
+    </WithStyles(Tooltip)>
+    <WithStyles(Tooltip)
+      enterDelay={300}
+      placement="top-start"
       title="Report an Issue"
     >
       <div
@@ -2447,6 +15762,27 @@ exports[`SideNav renders experiments as active page when on NewExperiment page 1
   <div
     className="infoVisible"
   >
+    <WithStyles(Tooltip)
+      enterDelay={300}
+      placement="top-start"
+      title="Build date: 10/23/2018, Commit hash: 0a7b9e3"
+    >
+      <div
+        className="envMetadata"
+      >
+        <span>
+          Version: 
+        </span>
+        <a
+          className="link unstyled"
+          href="https://www.github.com/kubeflow/pipelines/commit/0a7b9e38f2b9bcdef4bbf3234d971e1635b50cd5"
+          rel="noopener"
+          target="_blank"
+        >
+          1.0.0
+        </a>
+      </div>
+    </WithStyles(Tooltip)>
     <WithStyles(Tooltip)
       enterDelay={300}
       placement="top-start"
@@ -2722,6 +16058,27 @@ exports[`SideNav renders experiments as active page when on NewRun page 1`] = `
     <WithStyles(Tooltip)
       enterDelay={300}
       placement="top-start"
+      title="Build date: 10/23/2018, Commit hash: 0a7b9e3"
+    >
+      <div
+        className="envMetadata"
+      >
+        <span>
+          Version: 
+        </span>
+        <a
+          className="link unstyled"
+          href="https://www.github.com/kubeflow/pipelines/commit/0a7b9e38f2b9bcdef4bbf3234d971e1635b50cd5"
+          rel="noopener"
+          target="_blank"
+        >
+          1.0.0
+        </a>
+      </div>
+    </WithStyles(Tooltip)>
+    <WithStyles(Tooltip)
+      enterDelay={300}
+      placement="top-start"
       title="Report an Issue"
     >
       <div
@@ -2991,6 +16348,27 @@ exports[`SideNav renders experiments as active page when on RecurringRunDetails 
   <div
     className="infoVisible"
   >
+    <WithStyles(Tooltip)
+      enterDelay={300}
+      placement="top-start"
+      title="Build date: 10/23/2018, Commit hash: 0a7b9e3"
+    >
+      <div
+        className="envMetadata"
+      >
+        <span>
+          Version: 
+        </span>
+        <a
+          className="link unstyled"
+          href="https://www.github.com/kubeflow/pipelines/commit/0a7b9e38f2b9bcdef4bbf3234d971e1635b50cd5"
+          rel="noopener"
+          target="_blank"
+        >
+          1.0.0
+        </a>
+      </div>
+    </WithStyles(Tooltip)>
     <WithStyles(Tooltip)
       enterDelay={300}
       placement="top-start"
@@ -3266,6 +16644,27 @@ exports[`SideNav renders experiments as active page when on RunDetails page 1`] 
     <WithStyles(Tooltip)
       enterDelay={300}
       placement="top-start"
+      title="Build date: 10/23/2018, Commit hash: 0a7b9e3"
+    >
+      <div
+        className="envMetadata"
+      >
+        <span>
+          Version: 
+        </span>
+        <a
+          className="link unstyled"
+          href="https://www.github.com/kubeflow/pipelines/commit/0a7b9e38f2b9bcdef4bbf3234d971e1635b50cd5"
+          rel="noopener"
+          target="_blank"
+        >
+          1.0.0
+        </a>
+      </div>
+    </WithStyles(Tooltip)>
+    <WithStyles(Tooltip)
+      enterDelay={300}
+      placement="top-start"
       title="Report an Issue"
     >
       <div
@@ -3535,6 +16934,27 @@ exports[`SideNav renders experiments as active when on ExperimentDetails page 1`
   <div
     className="infoVisible"
   >
+    <WithStyles(Tooltip)
+      enterDelay={300}
+      placement="top-start"
+      title="Build date: 10/23/2018, Commit hash: 0a7b9e3"
+    >
+      <div
+        className="envMetadata"
+      >
+        <span>
+          Version: 
+        </span>
+        <a
+          className="link unstyled"
+          href="https://www.github.com/kubeflow/pipelines/commit/0a7b9e38f2b9bcdef4bbf3234d971e1635b50cd5"
+          rel="noopener"
+          target="_blank"
+        >
+          1.0.0
+        </a>
+      </div>
+    </WithStyles(Tooltip)>
     <WithStyles(Tooltip)
       enterDelay={300}
       placement="top-start"
@@ -3848,6 +17268,27 @@ exports[`SideNav show jupyterhub link if accessible 1`] = `
   <div
     className="infoVisible"
   >
+    <WithStyles(Tooltip)
+      enterDelay={300}
+      placement="top-start"
+      title="Build date: 10/23/2018, Commit hash: 0a7b9e3"
+    >
+      <div
+        className="envMetadata"
+      >
+        <span>
+          Version: 
+        </span>
+        <a
+          className="link unstyled"
+          href="https://www.github.com/kubeflow/pipelines/commit/0a7b9e38f2b9bcdef4bbf3234d971e1635b50cd5"
+          rel="noopener"
+          target="_blank"
+        >
+          1.0.0
+        </a>
+      </div>
+    </WithStyles(Tooltip)>
     <WithStyles(Tooltip)
       enterDelay={300}
       placement="top-start"

--- a/frontend/src/components/__snapshots__/UploadPipelineDialog.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/UploadPipelineDialog.test.tsx.snap
@@ -17,6 +17,9 @@ exports[`UploadPipelineDialog renders alternate UI for uploading via URL 1`] = `
   <div
     className=""
   >
+    <div>
+      Upload a pipeline package file from your computer or import one using a URL.
+    </div>
     <div
       className="flex"
     >
@@ -100,6 +103,9 @@ exports[`UploadPipelineDialog renders an active dropzone 1`] = `
   <div
     className=""
   >
+    <div>
+      Upload a pipeline package file from your computer or import one using a URL.
+    </div>
     <div
       className="flex"
     >
@@ -158,8 +164,6 @@ exports[`UploadPipelineDialog renders an active dropzone 1`] = `
       <div
         className=""
       >
-        Choose a pipeline package file from your computer, and give the pipeline a unique name.
-        <br />
         You can also drag and drop the file here.
       </div>
       <DocumentationCompilePipeline />
@@ -237,6 +241,9 @@ exports[`UploadPipelineDialog renders closed 1`] = `
   <div
     className=""
   >
+    <div>
+      Upload a pipeline package file from your computer or import one using a URL.
+    </div>
     <div
       className="flex"
     >
@@ -290,8 +297,6 @@ exports[`UploadPipelineDialog renders closed 1`] = `
       <div
         className=""
       >
-        Choose a pipeline package file from your computer, and give the pipeline a unique name.
-        <br />
         You can also drag and drop the file here.
       </div>
       <DocumentationCompilePipeline />
@@ -369,6 +374,9 @@ exports[`UploadPipelineDialog renders open 1`] = `
   <div
     className=""
   >
+    <div>
+      Upload a pipeline package file from your computer or import one using a URL.
+    </div>
     <div
       className="flex"
     >
@@ -422,8 +430,6 @@ exports[`UploadPipelineDialog renders open 1`] = `
       <div
         className=""
       >
-        Choose a pipeline package file from your computer, and give the pipeline a unique name.
-        <br />
         You can also drag and drop the file here.
       </div>
       <DocumentationCompilePipeline />
@@ -501,6 +507,9 @@ exports[`UploadPipelineDialog renders with a selected file to upload 1`] = `
   <div
     className=""
   >
+    <div>
+      Upload a pipeline package file from your computer or import one using a URL.
+    </div>
     <div
       className="flex"
     >
@@ -554,8 +563,6 @@ exports[`UploadPipelineDialog renders with a selected file to upload 1`] = `
       <div
         className=""
       >
-        Choose a pipeline package file from your computer, and give the pipeline a unique name.
-        <br />
         You can also drag and drop the file here.
       </div>
       <DocumentationCompilePipeline />

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -32,6 +32,7 @@ import {
   NamespaceContext,
   NamespaceContextProvider,
 } from './lib/KubeflowClient';
+import { BuildInfoProvider } from './lib/BuildInfo';
 // import { ReactQueryDevtools } from 'react-query/devtools';
 
 // TODO: license headers
@@ -56,11 +57,13 @@ export const queryClient = new QueryClient();
 const app = (
   <QueryClientProvider client={queryClient}>
     <MuiThemeProvider theme={theme}>
-      <GkeMetadataProvider>
-        <HashRouter>
-          <Router />
-        </HashRouter>
-      </GkeMetadataProvider>
+      <BuildInfoProvider>
+        <GkeMetadataProvider>
+          <HashRouter>
+            <Router />
+          </HashRouter>
+        </GkeMetadataProvider>
+      </BuildInfoProvider>
     </MuiThemeProvider>
     {/* <ReactQueryDevtools initialIsOpen={false} /> */}
   </QueryClientProvider>

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -38,6 +38,7 @@ export interface BuildInfo {
   apiServerCommitHash?: string;
   apiServerTagName?: string;
   apiServerReady?: boolean;
+  apiServerMultiUser?: boolean;
   buildDate?: string;
   frontendCommitHash?: string;
   frontendTagName?: string;

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -325,21 +325,23 @@ export class Apis {
     pipelineName: string,
     pipelineDescription: string,
     pipelineData: File,
+    namespace?: string,
   ): Promise<ApiPipeline> {
     const fd = new FormData();
     fd.append('uploadfile', pipelineData, pipelineData.name);
-    return await this._fetchAndParse<ApiPipeline>(
-      '/pipelines/upload',
-      v1beta1Prefix,
-      `name=${encodeURIComponent(pipelineName)}&description=${encodeURIComponent(
-        pipelineDescription,
-      )}`,
-      {
-        body: fd,
-        cache: 'no-cache',
-        method: 'POST',
-      },
-    );
+    let query = `name=${encodeURIComponent(pipelineName)}&description=${encodeURIComponent(
+      pipelineDescription,
+    )}`;
+
+    if (namespace) {
+      query = `${query}&namespace=${encodeURIComponent(namespace)}`;
+    }
+
+    return await this._fetchAndParse<ApiPipeline>('/pipelines/upload', v1beta1Prefix, query, {
+      body: fd,
+      cache: 'no-cache',
+      method: 'POST',
+    });
   }
 
   public static async uploadPipelineVersion(

--- a/frontend/src/lib/BuildInfo.tsx
+++ b/frontend/src/lib/BuildInfo.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2022 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Apis, BuildInfo } from '../lib/Apis';
+import { logger } from './Utils';
+
+interface BuildInfoProviderState {
+  buildInfo: BuildInfo | undefined;
+}
+
+export const BuildInfoContext = React.createContext<BuildInfo | undefined>(undefined);
+export class BuildInfoProvider extends React.Component<{}, BuildInfoProviderState> {
+  state = {
+    buildInfo: undefined,
+  };
+  async componentDidMount() {
+    try {
+      const buildInfo = await Apis.getBuildInfo();
+      this.setState({ buildInfo });
+    } catch (err) {
+      logger.error('Failed to retrieve build info', err);
+    }
+  }
+  render() {
+    return <BuildInfoContext.Provider value={this.state.buildInfo} {...this.props} />;
+  }
+}

--- a/frontend/src/lib/BuildInfo.tsx
+++ b/frontend/src/lib/BuildInfo.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 The Kubeflow Authors
+ * Copyright 2023 The Kubeflow Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -58,6 +58,7 @@ import { errorToMessage, logger, mergeApiParametersByNames } from '../lib/Utils'
 import { Workflow } from '../third_party/mlmd/argo_template';
 import { Page } from './Page';
 import ResourceSelector from './ResourceSelector';
+import PipelinesDialog from '../components/PipelinesDialog';
 
 interface NewRunState {
   description: string;
@@ -222,6 +223,12 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
 
     const buttons = new Buttons(this.props, this.refresh.bind(this));
 
+    const dialogToolbarActionMap = new Buttons(this.props, () => {})
+      .upload(() => {
+        this.setStateSafe({ pipelineSelectorOpen: false, uploadDialogOpen: true });
+      })
+      .getToolbarActionMap();
+
     return (
       <div className={classes(commonCss.page, padding(20, 'lr'))}>
         <div className={commonCss.scrollContainer}>
@@ -283,7 +290,7 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
                       id='choosePipelineVersionBtn'
                       onClick={() => this.setStateSafe({ pipelineVersionSelectorOpen: true })}
                       style={{ padding: '3px 5px', margin: 0 }}
-                      disabled={!this.state.pipeline}
+                      disabled={!unconfirmedSelectedPipeline}
                     >
                       Choose
                     </Button>
@@ -295,55 +302,19 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
           )}
 
           {/* Pipeline selector dialog */}
-          <Dialog
+          <PipelinesDialog
+            {...this.props}
             open={pipelineSelectorOpen}
-            classes={{ paper: css.selectorDialog }}
-            onClose={() => this._pipelineSelectorClosed(false)}
-            PaperProps={{ id: 'pipelineSelectorDialog' }}
-          >
-            <DialogContent>
-              <ResourceSelector
-                {...this.props}
-                title='Choose a pipeline'
-                filterLabel='Filter pipelines'
-                listApi={async (...args) => {
-                  const response = await Apis.pipelineServiceApi.listPipelines(...args);
-                  return {
-                    nextPageToken: response.next_page_token || '',
-                    resources: response.pipelines || [],
-                  };
-                }}
-                columns={this.pipelineSelectorColumns}
-                emptyMessage='No pipelines found. Upload a pipeline and then try again.'
-                initialSortColumn={PipelineSortKeys.CREATED_AT}
-                selectionChanged={(selectedPipeline: ApiPipeline) =>
-                  this.setStateSafe({ unconfirmedSelectedPipeline: selectedPipeline })
-                }
-                toolbarActionMap={buttons
-                  .upload(() =>
-                    this.setStateSafe({ pipelineSelectorOpen: false, uploadDialogOpen: true }),
-                  )
-                  .getToolbarActionMap()}
-              />
-            </DialogContent>
-            <DialogActions>
-              <Button
-                id='cancelPipelineSelectionBtn'
-                onClick={() => this._pipelineSelectorClosed(false)}
-                color='secondary'
-              >
-                Cancel
-              </Button>
-              <Button
-                id='usePipelineBtn'
-                onClick={() => this._pipelineSelectorClosed(true)}
-                color='secondary'
-                disabled={!unconfirmedSelectedPipeline}
-              >
-                Use this pipeline
-              </Button>
-            </DialogActions>
-          </Dialog>
+            selectorDialog={css.selectorDialog}
+            onClose={(confirmed, selectedPipeline?: ApiPipeline) => {
+              this.setStateSafe({ unconfirmedSelectedPipeline: selectedPipeline }, () => {
+                this._pipelineSelectorClosed(confirmed);
+              });
+            }}
+            toolbarActionMap={dialogToolbarActionMap}
+            namespace={this.props.namespace}
+            pipelineSelectorColumns={this.pipelineSelectorColumns}
+          ></PipelinesDialog>
 
           {/* Pipeline version selector dialog */}
           <Dialog
@@ -707,10 +678,12 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
       if (possiblePipelineId) {
         try {
           const pipeline = await Apis.pipelineServiceApi.getPipeline(possiblePipelineId);
+          const pipelineName = (pipeline && pipeline.name) || '';
           this.setStateSafe({
             parameters: pipeline.parameters || [],
             pipeline,
-            pipelineName: (pipeline && pipeline.name) || '',
+            pipelineName,
+            unconfirmedSelectedPipeline: pipeline,
           });
           const possiblePipelineVersionId =
             this.props.existingPipelineVersionId ||

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -935,6 +935,7 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
     file: File | null,
     url: string,
     method: ImportMethod,
+    isPrivatePipeline: boolean,
     description?: string,
   ): Promise<boolean> {
     if (
@@ -949,7 +950,12 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
     try {
       const uploadedPipeline =
         method === ImportMethod.LOCAL
-          ? await Apis.uploadPipeline(name, description || '', file!)
+          ? await Apis.uploadPipeline(
+              name,
+              description || '',
+              file!,
+              isPrivatePipeline ? this.props.namespace : undefined,
+            )
           : await Apis.pipelineServiceApi.createPipeline({ name, url: { pipeline_url: url } });
       this.setStateSafe(
         {

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -56,6 +56,7 @@ import { convertYamlToV2PipelineSpec } from 'src/lib/v2/WorkflowUtils';
 import { classes, stylesheet } from 'typestyle';
 import { PageProps } from './Page';
 import ResourceSelector from './ResourceSelector';
+import PipelinesDialog from 'src/components/PipelinesDialog';
 
 const css = stylesheet({
   nonEditableInput: {
@@ -704,7 +705,6 @@ type PipelineSelectorProps = PageProps & PipelineSelectorSpecificProps;
 
 function PipelineSelector(props: PipelineSelectorProps) {
   const [pipelineSelectorOpen, setPipelineSelectorOpen] = useState(false);
-  const [pendingPipeline, setPendingPipeline] = useState<ApiPipeline>();
 
   return (
     <>
@@ -733,56 +733,20 @@ function PipelineSelector(props: PipelineSelectorProps) {
       />
 
       {/* Pipeline selector dialog */}
-      <Dialog
+      <PipelinesDialog
+        {...props}
         open={pipelineSelectorOpen}
-        classes={{ paper: css.selectorDialog }}
-        onClose={() => setPipelineSelectorOpen(false)}
-        PaperProps={{ id: 'pipelineSelectorDialog' }}
-      >
-        <DialogContent>
-          <ResourceSelector
-            {...props}
-            title='Choose a pipeline'
-            filterLabel='Filter pipelines'
-            listApi={async (...args) => {
-              const response = await Apis.pipelineServiceApi.listPipelines(...args);
-              return {
-                nextPageToken: response.next_page_token || '',
-                resources: response.pipelines || [],
-              };
-            }}
-            columns={PIPELINE_SELECTOR_COLUMNS}
-            emptyMessage='No pipelines found. Upload a pipeline and then try again.'
-            initialSortColumn={PipelineSortKeys.CREATED_AT}
-            selectionChanged={(selectedPipeline: ApiPipeline) =>
-              setPendingPipeline(selectedPipeline)
-            }
-            // TODO(jlyaoyuli): enable pipeline upload function in the selector dialog
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button
-            id='cancelPipelineSelectionBtn'
-            onClick={() => setPipelineSelectorOpen(false)}
-            color='secondary'
-          >
-            Cancel
-          </Button>
-          <Button
-            id='usePipelineBtn'
-            onClick={() => {
-              if (pendingPipeline) {
-                props.handlePipelineChange(pendingPipeline);
-              }
-              setPipelineSelectorOpen(false);
-            }}
-            color='secondary'
-            disabled={!pendingPipeline}
-          >
-            Use this pipeline
-          </Button>
-        </DialogActions>
-      </Dialog>
+        selectorDialog={css.selectorDialog}
+        onClose={(confirmed, selectedPipeline?: ApiPipeline) => {
+          if (confirmed && selectedPipeline) {
+            props.handlePipelineChange(selectedPipeline);
+          }
+          setPipelineSelectorOpen(false);
+        }}
+        namespace={props.namespace}
+        pipelineSelectorColumns={PIPELINE_SELECTOR_COLUMNS}
+        // TODO(jlyaoyuli): enable pipeline upload function in the selector dialog
+      ></PipelinesDialog>
     </>
   );
 }

--- a/frontend/src/pages/PipelineList.test.tsx
+++ b/frontend/src/pages/PipelineList.test.tsx
@@ -71,7 +71,7 @@ describe('PipelineList', () => {
         },
       })),
     }));
-    tree = TestUtils.mountWithRouter(<PipelineList {...generateProps()} />);
+    tree = TestUtils.mountWithRouter(<PipelineList {...generateProps()} namespace='test-ns' />);
     await listPipelinesSpy;
     await TestUtils.flushPromises();
     tree.update(); // Make sure the tree is updated before returning it
@@ -144,9 +144,16 @@ describe('PipelineList', () => {
 
   it('calls Apis to list pipelines, sorted by creation time in descending order', async () => {
     listPipelinesSpy.mockImplementationOnce(() => ({ pipelines: [{ name: 'pipeline1' }] }));
-    tree = TestUtils.mountWithRouter(<PipelineList {...generateProps()} />);
+    tree = TestUtils.mountWithRouter(<PipelineList {...generateProps()} namespace='test-ns' />);
     await listPipelinesSpy;
-    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '');
+    expect(listPipelinesSpy).toHaveBeenLastCalledWith(
+      '',
+      10,
+      'created_at desc',
+      '',
+      'NAMESPACE',
+      'test-ns',
+    );
     expect(tree.state()).toHaveProperty('displayPipelines', [
       { expandState: 0, name: 'pipeline1' },
     ]);
@@ -160,7 +167,14 @@ describe('PipelineList', () => {
     expect(refreshBtn).toBeDefined();
     await refreshBtn!.action();
     expect(listPipelinesSpy.mock.calls.length).toBe(2);
-    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '');
+    expect(listPipelinesSpy).toHaveBeenLastCalledWith(
+      '',
+      10,
+      'created_at desc',
+      '',
+      'NAMESPACE',
+      'test-ns',
+    );
     expect(updateBannerSpy).toHaveBeenLastCalledWith({});
   });
 
@@ -186,7 +200,14 @@ describe('PipelineList', () => {
     TestUtils.makeErrorResponseOnce(listPipelinesSpy, 'bad stuff happened');
     await refreshBtn!.action();
     expect(listPipelinesSpy.mock.calls.length).toBe(2);
-    expect(listPipelinesSpy).toHaveBeenLastCalledWith('', 10, 'created_at desc', '');
+    expect(listPipelinesSpy).toHaveBeenLastCalledWith(
+      '',
+      10,
+      'created_at desc',
+      '',
+      undefined,
+      undefined,
+    );
     expect(updateBannerSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
         additionalInfo: 'bad stuff happened',

--- a/frontend/src/pages/PipelineList.tsx
+++ b/frontend/src/pages/PipelineList.tsx
@@ -57,7 +57,7 @@ const descriptionCustomRenderer: React.FC<CustomRendererProps<string>> = (
   return <Description description={props.value || ''} forceInline={true} />;
 };
 
-class PipelineList extends Page<{}, PipelineListState> {
+class PipelineList extends Page<{ namespace?: string }, PipelineListState> {
   private _tableRef = React.createRef<CustomTable>();
 
   constructor(props: any) {
@@ -176,6 +176,8 @@ class PipelineList extends Page<{}, PipelineListState> {
         request.pageSize,
         request.sortBy,
         request.filter,
+        this.props.namespace ? 'NAMESPACE' : undefined,
+        this.props.namespace || undefined,
       );
       displayPipelines = response.pipelines || [];
       displayPipelines.forEach(exp => (exp.expandState = ExpandState.COLLAPSED));

--- a/frontend/src/pages/PipelineList.tsx
+++ b/frontend/src/pages/PipelineList.tsx
@@ -29,11 +29,10 @@ import CustomTable, {
 import { Description } from '../components/Description';
 import { RoutePage, RouteParams } from '../components/Router';
 import { ToolbarProps } from '../components/Toolbar';
-import UploadPipelineDialog, { ImportMethod } from '../components/UploadPipelineDialog';
 import { commonCss, padding } from '../Css';
 import { Apis, ListRequest, PipelineSortKeys } from '../lib/Apis';
 import Buttons, { ButtonKeys } from '../lib/Buttons';
-import { errorToMessage, formatDateString } from '../lib/Utils';
+import { formatDateString } from '../lib/Utils';
 import { Page } from './Page';
 import PipelineVersionList from './PipelineVersionList';
 
@@ -44,7 +43,6 @@ interface DisplayPipeline extends ApiPipeline {
 interface PipelineListState {
   displayPipelines: DisplayPipeline[];
   selectedIds: string[];
-  uploadDialogOpen: boolean;
 
   // selectedVersionIds is a map from string to string array.
   // For each pipeline, there is a list of selected version ids.
@@ -66,8 +64,6 @@ class PipelineList extends Page<{ namespace?: string }, PipelineListState> {
     this.state = {
       displayPipelines: [],
       selectedIds: [],
-      uploadDialogOpen: false,
-
       selectedVersionIds: {},
     };
   }
@@ -124,11 +120,6 @@ class PipelineList extends Page<{ namespace?: string }, PipelineListState> {
           getExpandComponent={this._getExpandedPipelineComponent.bind(this)}
           filterLabel='Filter pipelines'
           emptyMessage='No pipelines found. Click "Upload pipeline" to start.'
-        />
-
-        <UploadPipelineDialog
-          open={this.state.uploadDialogOpen}
-          onClose={this._uploadDialogClosed.bind(this)}
         />
       </div>
     );
@@ -227,37 +218,6 @@ class PipelineList extends Page<{ namespace?: string }, PipelineListState> {
       const actions = this.props.toolbarProps.actions;
       actions[ButtonKeys.DELETE_RUN].disabled = selectedIds.length < 1 && selectedVersionIdsCt < 1;
       this.props.updateToolbar({ actions });
-    }
-  }
-
-  private async _uploadDialogClosed(
-    confirmed: boolean,
-    name: string,
-    file: File | null,
-    url: string,
-    method: ImportMethod,
-    description?: string,
-  ): Promise<boolean> {
-    if (
-      !confirmed ||
-      (method === ImportMethod.LOCAL && !file) ||
-      (method === ImportMethod.URL && !url)
-    ) {
-      this.setStateSafe({ uploadDialogOpen: false });
-      return false;
-    }
-
-    try {
-      method === ImportMethod.LOCAL
-        ? await Apis.uploadPipeline(name, description || '', file!)
-        : await Apis.pipelineServiceApi.createPipeline({ name, url: { pipeline_url: url } });
-      this.setStateSafe({ uploadDialogOpen: false });
-      this.refresh();
-      return true;
-    } catch (err) {
-      const errorMessage = await errorToMessage(err);
-      this.showErrorDialog('Failed to upload pipeline', errorMessage);
-      return false;
     }
   }
 

--- a/frontend/src/pages/PrivateAndSharedPipelines.test.tsx
+++ b/frontend/src/pages/PrivateAndSharedPipelines.test.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { PageProps } from './Page';
+import { Apis } from '../lib/Apis';
+import { ApiListPipelinesResponse, ApiPipeline } from '../apis/pipeline';
+import TestUtils from '../TestUtils';
+import { BuildInfoContext } from '../lib/BuildInfo';
+import PrivateAndSharedPipelines, {
+  PrivateAndSharedProps,
+  PrivateAndSharedTab,
+} from './PrivateAndSharedPipelines';
+import { Router } from 'react-router-dom';
+import { NamespaceContext } from '../lib/KubeflowClient';
+
+function generateProps(): PrivateAndSharedProps {
+  return {
+    ...generatePageProps(),
+    view: PrivateAndSharedTab.PRIVATE,
+  };
+}
+
+function generatePageProps(): PageProps {
+  return {
+    history: {} as any,
+    location: '' as any,
+    match: {} as any,
+    toolbarProps: {} as any,
+    updateBanner: jest.fn(),
+    updateDialog: jest.fn(),
+    updateSnackbar: jest.fn(),
+    updateToolbar: jest.fn(),
+  };
+}
+
+const oldPipeline = newMockPipeline();
+const newPipeline = newMockPipeline();
+
+function newMockPipeline(): ApiPipeline {
+  return {
+    id: 'run-pipeline-id',
+    name: 'mock pipeline name',
+    parameters: [],
+    default_version: {
+      id: 'run-pipeline-version-id',
+      name: 'mock pipeline version name',
+    },
+    created_at: new Date('2022-09-21T13:53:59Z'),
+    description: 'mock pipeline description',
+  };
+}
+
+describe('PrivateAndSharedPipelines', () => {
+  const history = createMemoryHistory({
+    initialEntries: ['/does-not-matter'],
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
+    let listPipelineSpy = jest.spyOn(Apis.pipelineServiceApi, 'listPipelines');
+    listPipelineSpy.mockImplementation((...args) => {
+      const response: ApiListPipelinesResponse = {
+        pipelines: [oldPipeline, newPipeline],
+        total_size: 2,
+      };
+      return Promise.resolve(response);
+    });
+  });
+
+  afterEach(async () => {
+    jest.resetAllMocks();
+  });
+
+  it('it renders correctly in multi user mode', async () => {
+    const tree = render(
+      <Router history={history}>
+        <BuildInfoContext.Provider value={{ apiServerMultiUser: true }}>
+          <NamespaceContext.Provider value={'ns'}>
+            <PrivateAndSharedPipelines {...generateProps()} />
+          </NamespaceContext.Provider>
+        </BuildInfoContext.Provider>
+      </Router>,
+    );
+    await TestUtils.flushPromises();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('it renders correctly in single user mode', async () => {
+    const tree = render(
+      <Router history={history}>
+        <BuildInfoContext.Provider value={{ apiServerMultiUser: false }}>
+          <NamespaceContext.Provider value={undefined}>
+            <PrivateAndSharedPipelines {...generateProps()} />
+          </NamespaceContext.Provider>
+        </BuildInfoContext.Provider>
+      </Router>,
+    );
+    await TestUtils.flushPromises();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/frontend/src/pages/PrivateAndSharedPipelines.tsx
+++ b/frontend/src/pages/PrivateAndSharedPipelines.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import { classes } from 'typestyle';
+import MD2Tabs from '../atoms/MD2Tabs';
+import { PageProps } from './Page';
+import PipelineList from './PipelineList';
+import { RoutePage } from '../components/Router';
+import { NamespaceContext } from '../lib/KubeflowClient';
+import { commonCss, padding } from '../Css';
+import { BuildInfoContext } from 'src/lib/BuildInfo';
+
+export enum PrivateAndSharedTab {
+  PRIVATE = 0,
+  SHARED = 1,
+}
+
+export interface PrivateAndSharedProps extends PageProps {
+  view: PrivateAndSharedTab;
+}
+
+const PrivatePipelineList: React.FC<PageProps> = props => {
+  const namespace = React.useContext(NamespaceContext);
+  return <PipelineList {...props} namespace={namespace} />;
+};
+
+export enum PipelineTabsHeaders {
+  PRIVATE = 'Private',
+  SHARED = 'Shared',
+}
+
+export enum PipelineTabsTooltips {
+  PRIVATE = 'Only people who have access to this namespace will be able to view and use these pipelines.',
+  SHARED = 'Everyone in your organization will be able to view and use these pipelines.',
+}
+
+const PrivateAndSharedPipelines: React.FC<PrivateAndSharedProps> = props => {
+  const buildInfo = React.useContext(BuildInfoContext);
+
+  const tabSwitched = (newTab: PrivateAndSharedTab): void => {
+    props.history.push(
+      newTab === PrivateAndSharedTab.PRIVATE ? RoutePage.PIPELINES : RoutePage.PIPELINES_SHARED,
+    );
+  };
+
+  if (!buildInfo?.apiServerMultiUser) {
+    return <PipelineList {...props} />;
+  }
+  return (
+    <div className={classes(commonCss.page, padding(20, 't'))}>
+      <MD2Tabs
+        tabs={[
+          {
+            header: PipelineTabsHeaders.PRIVATE,
+            tooltip: PipelineTabsTooltips.PRIVATE,
+          },
+          {
+            header: PipelineTabsHeaders.SHARED,
+            tooltip: PipelineTabsTooltips.SHARED,
+          },
+        ]}
+        selectedTab={props.view}
+        onSwitch={tabSwitched}
+      />
+
+      {props.view === PrivateAndSharedTab.PRIVATE && <PrivatePipelineList {...props} />}
+
+      {props.view === PrivateAndSharedTab.SHARED && <PipelineList {...props} />}
+    </div>
+  );
+};
+
+export default PrivateAndSharedPipelines;

--- a/frontend/src/pages/ResourceSelector.tsx
+++ b/frontend/src/pages/ResourceSelector.tsx
@@ -42,7 +42,7 @@ export interface ResourceSelectorProps extends RouteComponentProps {
   filterLabel: string;
   initialSortColumn: any;
   selectionChanged: (resource: BaseResource) => void;
-  title: string;
+  title?: string;
   toolbarActionMap?: ToolbarActionMap;
   updateDialog: (dialogProps: DialogProps) => void;
 }
@@ -74,7 +74,8 @@ class ResourceSelector extends React.Component<ResourceSelectorProps, ResourceSe
 
     return (
       <React.Fragment>
-        <Toolbar actions={toolbarActionMap} breadcrumbs={[]} pageTitle={title} />
+        {title && <Toolbar actions={toolbarActionMap} breadcrumbs={[]} pageTitle={title} />}
+
         <CustomTable
           columns={columns}
           rows={rows}

--- a/frontend/src/pages/__snapshots__/NewPipelineVersion.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewPipelineVersion.test.tsx.snap
@@ -8,6 +8,11 @@ exports[`NewPipelineVersion creating new pipeline renders the new pipeline page 
     className="scrollContainer"
   >
     <div
+      className=""
+    >
+      Upload pipeline or pipeline version.
+    </div>
+    <div
       className="flex"
     >
       <WithStyles(WithFormControlContext(FormControlLabel))
@@ -33,9 +38,7 @@ exports[`NewPipelineVersion creating new pipeline renders the new pipeline page 
         onChange={[Function]}
       />
     </div>
-    <div
-      className="explanation"
-    >
+    <div>
       Upload pipeline with the specified package.
     </div>
     <Input
@@ -138,6 +141,7 @@ exports[`NewPipelineVersion creating new pipeline renders the new pipeline page 
               },
             }
           }
+          data-testid="uploadFileInput"
           disabled={true}
           label="File"
           onChange={[Function]}

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -30,112 +30,75 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
         </Link>
       </div>
     </div>
-    <WithStyles(Dialog)
-      PaperProps={
+    <PipelinesDialog
+      history={
         Object {
-          "id": "pipelineSelectorDialog",
+          "push": [MockFunction],
+          "replace": [MockFunction],
         }
       }
-      classes={
+      location={
         Object {
-          "paper": "selectorDialog",
+          "pathname": "/runs/new",
+          "search": "?fromRun=some-mock-run-id",
         }
       }
+      match=""
       onClose={[Function]}
       open={false}
-    >
-      <WithStyles(DialogContent)>
-        <ResourceSelector
-          columns={
-            Array [
-              Object {
-                "customRenderer": [Function],
-                "flex": 1,
-                "label": "Pipeline name",
-                "sortKey": "name",
-              },
-              Object {
-                "customRenderer": [Function],
-                "flex": 2,
-                "label": "Description",
-              },
-              Object {
-                "flex": 1,
-                "label": "Uploaded on",
-                "sortKey": "created_at",
-              },
-            ]
-          }
-          emptyMessage="No pipelines found. Upload a pipeline and then try again."
-          filterLabel="Filter pipelines"
-          history={
+      pipelineSelectorColumns={
+        Array [
+          Object {
+            "customRenderer": [Function],
+            "flex": 1,
+            "label": "Pipeline name",
+            "sortKey": "name",
+          },
+          Object {
+            "customRenderer": [Function],
+            "flex": 2,
+            "label": "Description",
+          },
+          Object {
+            "flex": 1,
+            "label": "Uploaded on",
+            "sortKey": "created_at",
+          },
+        ]
+      }
+      selectorDialog="selectorDialog"
+      toolbarActionMap={
+        Object {
+          "uploadPipeline": Object {
+            "action": [Function],
+            "icon": [Function],
+            "id": "uploadBtn",
+            "outlined": true,
+            "style": Object {
+              "minWidth": 160,
+            },
+            "title": "Upload pipeline",
+            "tooltip": "Upload pipeline",
+          },
+        }
+      }
+      toolbarProps={
+        Object {
+          "actions": Object {},
+          "breadcrumbs": Array [
             Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            }
-          }
-          initialSortColumn="created_at"
-          listApi={[Function]}
-          location={
-            Object {
-              "pathname": "/runs/new",
-              "search": "?fromRun=some-mock-run-id",
-            }
-          }
-          match=""
-          selectionChanged={[Function]}
-          title="Choose a pipeline"
-          toolbarActionMap={
-            Object {
-              "uploadPipeline": Object {
-                "action": [Function],
-                "icon": [Function],
-                "id": "uploadBtn",
-                "outlined": true,
-                "style": Object {
-                  "minWidth": 160,
-                },
-                "title": "Upload pipeline",
-                "tooltip": "Upload pipeline",
-              },
-            }
-          }
-          toolbarProps={
-            Object {
-              "actions": Object {},
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-              ],
-              "pageTitle": "Start a new run",
-            }
-          }
-          updateBanner={[MockFunction]}
-          updateDialog={[MockFunction]}
-          updateSnackbar={[MockFunction]}
-          updateToolbar={[MockFunction]}
-        />
-      </WithStyles(DialogContent)>
-      <WithStyles(DialogActions)>
-        <WithStyles(Button)
-          color="secondary"
-          id="cancelPipelineSelectionBtn"
-          onClick={[Function]}
-        >
-          Cancel
-        </WithStyles(Button)>
-        <WithStyles(Button)
-          color="secondary"
-          disabled={true}
-          id="usePipelineBtn"
-          onClick={[Function]}
-        >
-          Use this pipeline
-        </WithStyles(Button)>
-      </WithStyles(DialogActions)>
-    </WithStyles(Dialog)>
+              "displayName": "Experiments",
+              "href": "/experiments",
+            },
+          ],
+          "pageTitle": "Start a new run",
+        }
+      }
+      updateBanner={[MockFunction]}
+      updateDialog={[MockFunction]}
+      updateSnackbar={[MockFunction]}
+      updateToolbar={[MockFunction]}
+    />
     <WithStyles(Dialog)
       PaperProps={
         Object {
@@ -552,112 +515,75 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
       value=""
       variant="outlined"
     />
-    <WithStyles(Dialog)
-      PaperProps={
+    <PipelinesDialog
+      history={
         Object {
-          "id": "pipelineSelectorDialog",
+          "push": [MockFunction],
+          "replace": [MockFunction],
         }
       }
-      classes={
+      location={
         Object {
-          "paper": "selectorDialog",
+          "pathname": "/runs/new",
+          "search": "?experimentId=some-mock-experiment-id&firstRunInExperiment=1",
         }
       }
+      match=""
       onClose={[Function]}
       open={false}
-    >
-      <WithStyles(DialogContent)>
-        <ResourceSelector
-          columns={
-            Array [
-              Object {
-                "customRenderer": [Function],
-                "flex": 1,
-                "label": "Pipeline name",
-                "sortKey": "name",
-              },
-              Object {
-                "customRenderer": [Function],
-                "flex": 2,
-                "label": "Description",
-              },
-              Object {
-                "flex": 1,
-                "label": "Uploaded on",
-                "sortKey": "created_at",
-              },
-            ]
-          }
-          emptyMessage="No pipelines found. Upload a pipeline and then try again."
-          filterLabel="Filter pipelines"
-          history={
+      pipelineSelectorColumns={
+        Array [
+          Object {
+            "customRenderer": [Function],
+            "flex": 1,
+            "label": "Pipeline name",
+            "sortKey": "name",
+          },
+          Object {
+            "customRenderer": [Function],
+            "flex": 2,
+            "label": "Description",
+          },
+          Object {
+            "flex": 1,
+            "label": "Uploaded on",
+            "sortKey": "created_at",
+          },
+        ]
+      }
+      selectorDialog="selectorDialog"
+      toolbarActionMap={
+        Object {
+          "uploadPipeline": Object {
+            "action": [Function],
+            "icon": [Function],
+            "id": "uploadBtn",
+            "outlined": true,
+            "style": Object {
+              "minWidth": 160,
+            },
+            "title": "Upload pipeline",
+            "tooltip": "Upload pipeline",
+          },
+        }
+      }
+      toolbarProps={
+        Object {
+          "actions": Object {},
+          "breadcrumbs": Array [
             Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            }
-          }
-          initialSortColumn="created_at"
-          listApi={[Function]}
-          location={
-            Object {
-              "pathname": "/runs/new",
-              "search": "?experimentId=some-mock-experiment-id&firstRunInExperiment=1",
-            }
-          }
-          match=""
-          selectionChanged={[Function]}
-          title="Choose a pipeline"
-          toolbarActionMap={
-            Object {
-              "uploadPipeline": Object {
-                "action": [Function],
-                "icon": [Function],
-                "id": "uploadBtn",
-                "outlined": true,
-                "style": Object {
-                  "minWidth": 160,
-                },
-                "title": "Upload pipeline",
-                "tooltip": "Upload pipeline",
-              },
-            }
-          }
-          toolbarProps={
-            Object {
-              "actions": Object {},
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-              ],
-              "pageTitle": "Start a new run",
-            }
-          }
-          updateBanner={[MockFunction]}
-          updateDialog={[MockFunction]}
-          updateSnackbar={[MockFunction]}
-          updateToolbar={[MockFunction]}
-        />
-      </WithStyles(DialogContent)>
-      <WithStyles(DialogActions)>
-        <WithStyles(Button)
-          color="secondary"
-          id="cancelPipelineSelectionBtn"
-          onClick={[Function]}
-        >
-          Cancel
-        </WithStyles(Button)>
-        <WithStyles(Button)
-          color="secondary"
-          disabled={true}
-          id="usePipelineBtn"
-          onClick={[Function]}
-        >
-          Use this pipeline
-        </WithStyles(Button)>
-      </WithStyles(DialogActions)>
-    </WithStyles(Dialog)>
+              "displayName": "Experiments",
+              "href": "/experiments",
+            },
+          ],
+          "pageTitle": "Start a new run",
+        }
+      }
+      updateBanner={[MockFunction]}
+      updateDialog={[MockFunction]}
+      updateSnackbar={[MockFunction]}
+      updateToolbar={[MockFunction]}
+    />
     <WithStyles(Dialog)
       PaperProps={
         Object {
@@ -1074,112 +1000,75 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
       value=""
       variant="outlined"
     />
-    <WithStyles(Dialog)
-      PaperProps={
+    <PipelinesDialog
+      history={
         Object {
-          "id": "pipelineSelectorDialog",
+          "push": [MockFunction],
+          "replace": [MockFunction],
         }
       }
-      classes={
+      location={
         Object {
-          "paper": "selectorDialog",
+          "pathname": "/runs/new",
+          "search": "?experimentId=some-mock-experiment-id",
         }
       }
+      match=""
       onClose={[Function]}
       open={false}
-    >
-      <WithStyles(DialogContent)>
-        <ResourceSelector
-          columns={
-            Array [
-              Object {
-                "customRenderer": [Function],
-                "flex": 1,
-                "label": "Pipeline name",
-                "sortKey": "name",
-              },
-              Object {
-                "customRenderer": [Function],
-                "flex": 2,
-                "label": "Description",
-              },
-              Object {
-                "flex": 1,
-                "label": "Uploaded on",
-                "sortKey": "created_at",
-              },
-            ]
-          }
-          emptyMessage="No pipelines found. Upload a pipeline and then try again."
-          filterLabel="Filter pipelines"
-          history={
+      pipelineSelectorColumns={
+        Array [
+          Object {
+            "customRenderer": [Function],
+            "flex": 1,
+            "label": "Pipeline name",
+            "sortKey": "name",
+          },
+          Object {
+            "customRenderer": [Function],
+            "flex": 2,
+            "label": "Description",
+          },
+          Object {
+            "flex": 1,
+            "label": "Uploaded on",
+            "sortKey": "created_at",
+          },
+        ]
+      }
+      selectorDialog="selectorDialog"
+      toolbarActionMap={
+        Object {
+          "uploadPipeline": Object {
+            "action": [Function],
+            "icon": [Function],
+            "id": "uploadBtn",
+            "outlined": true,
+            "style": Object {
+              "minWidth": 160,
+            },
+            "title": "Upload pipeline",
+            "tooltip": "Upload pipeline",
+          },
+        }
+      }
+      toolbarProps={
+        Object {
+          "actions": Object {},
+          "breadcrumbs": Array [
             Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            }
-          }
-          initialSortColumn="created_at"
-          listApi={[Function]}
-          location={
-            Object {
-              "pathname": "/runs/new",
-              "search": "?experimentId=some-mock-experiment-id",
-            }
-          }
-          match=""
-          selectionChanged={[Function]}
-          title="Choose a pipeline"
-          toolbarActionMap={
-            Object {
-              "uploadPipeline": Object {
-                "action": [Function],
-                "icon": [Function],
-                "id": "uploadBtn",
-                "outlined": true,
-                "style": Object {
-                  "minWidth": 160,
-                },
-                "title": "Upload pipeline",
-                "tooltip": "Upload pipeline",
-              },
-            }
-          }
-          toolbarProps={
-            Object {
-              "actions": Object {},
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-              ],
-              "pageTitle": "Start a new run",
-            }
-          }
-          updateBanner={[MockFunction]}
-          updateDialog={[MockFunction]}
-          updateSnackbar={[MockFunction]}
-          updateToolbar={[MockFunction]}
-        />
-      </WithStyles(DialogContent)>
-      <WithStyles(DialogActions)>
-        <WithStyles(Button)
-          color="secondary"
-          id="cancelPipelineSelectionBtn"
-          onClick={[Function]}
-        >
-          Cancel
-        </WithStyles(Button)>
-        <WithStyles(Button)
-          color="secondary"
-          disabled={true}
-          id="usePipelineBtn"
-          onClick={[Function]}
-        >
-          Use this pipeline
-        </WithStyles(Button)>
-      </WithStyles(DialogActions)>
-    </WithStyles(Dialog)>
+              "displayName": "Experiments",
+              "href": "/experiments",
+            },
+          ],
+          "pageTitle": "Start a new run",
+        }
+      }
+      updateBanner={[MockFunction]}
+      updateDialog={[MockFunction]}
+      updateSnackbar={[MockFunction]}
+      updateToolbar={[MockFunction]}
+    />
     <WithStyles(Dialog)
       PaperProps={
         Object {
@@ -1614,112 +1503,75 @@ exports[`NewRun changes title and form to default state if the new run is a one-
       value=""
       variant="outlined"
     />
-    <WithStyles(Dialog)
-      PaperProps={
+    <PipelinesDialog
+      history={
         Object {
-          "id": "pipelineSelectorDialog",
+          "push": [MockFunction],
+          "replace": [MockFunction],
         }
       }
-      classes={
+      location={
         Object {
-          "paper": "selectorDialog",
+          "pathname": "/runs/new",
+          "search": "?recurring=1",
         }
       }
+      match=""
       onClose={[Function]}
       open={false}
-    >
-      <WithStyles(DialogContent)>
-        <ResourceSelector
-          columns={
-            Array [
-              Object {
-                "customRenderer": [Function],
-                "flex": 1,
-                "label": "Pipeline name",
-                "sortKey": "name",
-              },
-              Object {
-                "customRenderer": [Function],
-                "flex": 2,
-                "label": "Description",
-              },
-              Object {
-                "flex": 1,
-                "label": "Uploaded on",
-                "sortKey": "created_at",
-              },
-            ]
-          }
-          emptyMessage="No pipelines found. Upload a pipeline and then try again."
-          filterLabel="Filter pipelines"
-          history={
+      pipelineSelectorColumns={
+        Array [
+          Object {
+            "customRenderer": [Function],
+            "flex": 1,
+            "label": "Pipeline name",
+            "sortKey": "name",
+          },
+          Object {
+            "customRenderer": [Function],
+            "flex": 2,
+            "label": "Description",
+          },
+          Object {
+            "flex": 1,
+            "label": "Uploaded on",
+            "sortKey": "created_at",
+          },
+        ]
+      }
+      selectorDialog="selectorDialog"
+      toolbarActionMap={
+        Object {
+          "uploadPipeline": Object {
+            "action": [Function],
+            "icon": [Function],
+            "id": "uploadBtn",
+            "outlined": true,
+            "style": Object {
+              "minWidth": 160,
+            },
+            "title": "Upload pipeline",
+            "tooltip": "Upload pipeline",
+          },
+        }
+      }
+      toolbarProps={
+        Object {
+          "actions": Object {},
+          "breadcrumbs": Array [
             Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            }
-          }
-          initialSortColumn="created_at"
-          listApi={[Function]}
-          location={
-            Object {
-              "pathname": "/runs/new",
-              "search": "?recurring=1",
-            }
-          }
-          match=""
-          selectionChanged={[Function]}
-          title="Choose a pipeline"
-          toolbarActionMap={
-            Object {
-              "uploadPipeline": Object {
-                "action": [Function],
-                "icon": [Function],
-                "id": "uploadBtn",
-                "outlined": true,
-                "style": Object {
-                  "minWidth": 160,
-                },
-                "title": "Upload pipeline",
-                "tooltip": "Upload pipeline",
-              },
-            }
-          }
-          toolbarProps={
-            Object {
-              "actions": Object {},
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-              ],
-              "pageTitle": "Start a new run",
-            }
-          }
-          updateBanner={[MockFunction]}
-          updateDialog={[MockFunction]}
-          updateSnackbar={[MockFunction]}
-          updateToolbar={[MockFunction]}
-        />
-      </WithStyles(DialogContent)>
-      <WithStyles(DialogActions)>
-        <WithStyles(Button)
-          color="secondary"
-          id="cancelPipelineSelectionBtn"
-          onClick={[Function]}
-        >
-          Cancel
-        </WithStyles(Button)>
-        <WithStyles(Button)
-          color="secondary"
-          disabled={true}
-          id="usePipelineBtn"
-          onClick={[Function]}
-        >
-          Use this pipeline
-        </WithStyles(Button)>
-      </WithStyles(DialogActions)>
-    </WithStyles(Dialog)>
+              "displayName": "Experiments",
+              "href": "/experiments",
+            },
+          ],
+          "pageTitle": "Start a new run",
+        }
+      }
+      updateBanner={[MockFunction]}
+      updateDialog={[MockFunction]}
+      updateSnackbar={[MockFunction]}
+      updateToolbar={[MockFunction]}
+    />
     <WithStyles(Dialog)
       PaperProps={
         Object {
@@ -2136,112 +1988,75 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
       value="original mock pipeline version name"
       variant="outlined"
     />
-    <WithStyles(Dialog)
-      PaperProps={
+    <PipelinesDialog
+      history={
         Object {
-          "id": "pipelineSelectorDialog",
+          "push": [MockFunction],
+          "replace": [MockFunction],
         }
       }
-      classes={
+      location={
         Object {
-          "paper": "selectorDialog",
+          "pathname": "/runs/new",
+          "search": "?pipelineId=original-run-pipeline-id&pipelineVersionId=original-run-pipeline-version-id",
         }
       }
+      match=""
       onClose={[Function]}
       open={false}
-    >
-      <WithStyles(DialogContent)>
-        <ResourceSelector
-          columns={
-            Array [
-              Object {
-                "customRenderer": [Function],
-                "flex": 1,
-                "label": "Pipeline name",
-                "sortKey": "name",
-              },
-              Object {
-                "customRenderer": [Function],
-                "flex": 2,
-                "label": "Description",
-              },
-              Object {
-                "flex": 1,
-                "label": "Uploaded on",
-                "sortKey": "created_at",
-              },
-            ]
-          }
-          emptyMessage="No pipelines found. Upload a pipeline and then try again."
-          filterLabel="Filter pipelines"
-          history={
+      pipelineSelectorColumns={
+        Array [
+          Object {
+            "customRenderer": [Function],
+            "flex": 1,
+            "label": "Pipeline name",
+            "sortKey": "name",
+          },
+          Object {
+            "customRenderer": [Function],
+            "flex": 2,
+            "label": "Description",
+          },
+          Object {
+            "flex": 1,
+            "label": "Uploaded on",
+            "sortKey": "created_at",
+          },
+        ]
+      }
+      selectorDialog="selectorDialog"
+      toolbarActionMap={
+        Object {
+          "uploadPipeline": Object {
+            "action": [Function],
+            "icon": [Function],
+            "id": "uploadBtn",
+            "outlined": true,
+            "style": Object {
+              "minWidth": 160,
+            },
+            "title": "Upload pipeline",
+            "tooltip": "Upload pipeline",
+          },
+        }
+      }
+      toolbarProps={
+        Object {
+          "actions": Object {},
+          "breadcrumbs": Array [
             Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            }
-          }
-          initialSortColumn="created_at"
-          listApi={[Function]}
-          location={
-            Object {
-              "pathname": "/runs/new",
-              "search": "?pipelineId=original-run-pipeline-id&pipelineVersionId=original-run-pipeline-version-id",
-            }
-          }
-          match=""
-          selectionChanged={[Function]}
-          title="Choose a pipeline"
-          toolbarActionMap={
-            Object {
-              "uploadPipeline": Object {
-                "action": [Function],
-                "icon": [Function],
-                "id": "uploadBtn",
-                "outlined": true,
-                "style": Object {
-                  "minWidth": 160,
-                },
-                "title": "Upload pipeline",
-                "tooltip": "Upload pipeline",
-              },
-            }
-          }
-          toolbarProps={
-            Object {
-              "actions": Object {},
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-              ],
-              "pageTitle": "Start a new run",
-            }
-          }
-          updateBanner={[MockFunction]}
-          updateDialog={[MockFunction]}
-          updateSnackbar={[MockFunction]}
-          updateToolbar={[MockFunction]}
-        />
-      </WithStyles(DialogContent)>
-      <WithStyles(DialogActions)>
-        <WithStyles(Button)
-          color="secondary"
-          id="cancelPipelineSelectionBtn"
-          onClick={[Function]}
-        >
-          Cancel
-        </WithStyles(Button)>
-        <WithStyles(Button)
-          color="secondary"
-          disabled={true}
-          id="usePipelineBtn"
-          onClick={[Function]}
-        >
-          Use this pipeline
-        </WithStyles(Button)>
-      </WithStyles(DialogActions)>
-    </WithStyles(Dialog)>
+              "displayName": "Experiments",
+              "href": "/experiments",
+            },
+          ],
+          "pageTitle": "Start a new run",
+        }
+      }
+      updateBanner={[MockFunction]}
+      updateDialog={[MockFunction]}
+      updateSnackbar={[MockFunction]}
+      updateToolbar={[MockFunction]}
+    />
     <WithStyles(Dialog)
       PaperProps={
         Object {
@@ -2656,112 +2471,75 @@ exports[`NewRun renders the new run page 1`] = `
       value=""
       variant="outlined"
     />
-    <WithStyles(Dialog)
-      PaperProps={
+    <PipelinesDialog
+      history={
         Object {
-          "id": "pipelineSelectorDialog",
+          "push": [MockFunction],
+          "replace": [MockFunction],
         }
       }
-      classes={
+      location={
         Object {
-          "paper": "selectorDialog",
+          "pathname": "/runs/new",
+          "search": "?experimentId=some-mock-experiment-id",
         }
       }
+      match=""
       onClose={[Function]}
       open={false}
-    >
-      <WithStyles(DialogContent)>
-        <ResourceSelector
-          columns={
-            Array [
-              Object {
-                "customRenderer": [Function],
-                "flex": 1,
-                "label": "Pipeline name",
-                "sortKey": "name",
-              },
-              Object {
-                "customRenderer": [Function],
-                "flex": 2,
-                "label": "Description",
-              },
-              Object {
-                "flex": 1,
-                "label": "Uploaded on",
-                "sortKey": "created_at",
-              },
-            ]
-          }
-          emptyMessage="No pipelines found. Upload a pipeline and then try again."
-          filterLabel="Filter pipelines"
-          history={
+      pipelineSelectorColumns={
+        Array [
+          Object {
+            "customRenderer": [Function],
+            "flex": 1,
+            "label": "Pipeline name",
+            "sortKey": "name",
+          },
+          Object {
+            "customRenderer": [Function],
+            "flex": 2,
+            "label": "Description",
+          },
+          Object {
+            "flex": 1,
+            "label": "Uploaded on",
+            "sortKey": "created_at",
+          },
+        ]
+      }
+      selectorDialog="selectorDialog"
+      toolbarActionMap={
+        Object {
+          "uploadPipeline": Object {
+            "action": [Function],
+            "icon": [Function],
+            "id": "uploadBtn",
+            "outlined": true,
+            "style": Object {
+              "minWidth": 160,
+            },
+            "title": "Upload pipeline",
+            "tooltip": "Upload pipeline",
+          },
+        }
+      }
+      toolbarProps={
+        Object {
+          "actions": Object {},
+          "breadcrumbs": Array [
             Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            }
-          }
-          initialSortColumn="created_at"
-          listApi={[Function]}
-          location={
-            Object {
-              "pathname": "/runs/new",
-              "search": "?experimentId=some-mock-experiment-id",
-            }
-          }
-          match=""
-          selectionChanged={[Function]}
-          title="Choose a pipeline"
-          toolbarActionMap={
-            Object {
-              "uploadPipeline": Object {
-                "action": [Function],
-                "icon": [Function],
-                "id": "uploadBtn",
-                "outlined": true,
-                "style": Object {
-                  "minWidth": 160,
-                },
-                "title": "Upload pipeline",
-                "tooltip": "Upload pipeline",
-              },
-            }
-          }
-          toolbarProps={
-            Object {
-              "actions": Object {},
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-              ],
-              "pageTitle": "Start a new run",
-            }
-          }
-          updateBanner={[MockFunction]}
-          updateDialog={[MockFunction]}
-          updateSnackbar={[MockFunction]}
-          updateToolbar={[MockFunction]}
-        />
-      </WithStyles(DialogContent)>
-      <WithStyles(DialogActions)>
-        <WithStyles(Button)
-          color="secondary"
-          id="cancelPipelineSelectionBtn"
-          onClick={[Function]}
-        >
-          Cancel
-        </WithStyles(Button)>
-        <WithStyles(Button)
-          color="secondary"
-          disabled={true}
-          id="usePipelineBtn"
-          onClick={[Function]}
-        >
-          Use this pipeline
-        </WithStyles(Button)>
-      </WithStyles(DialogActions)>
-    </WithStyles(Dialog)>
+              "displayName": "Experiments",
+              "href": "/experiments",
+            },
+          ],
+          "pageTitle": "Start a new run",
+        }
+      }
+      updateBanner={[MockFunction]}
+      updateDialog={[MockFunction]}
+      updateSnackbar={[MockFunction]}
+      updateToolbar={[MockFunction]}
+    />
     <WithStyles(Dialog)
       PaperProps={
         Object {
@@ -3178,112 +2956,75 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
       value=""
       variant="outlined"
     />
-    <WithStyles(Dialog)
-      PaperProps={
+    <PipelinesDialog
+      history={
         Object {
-          "id": "pipelineSelectorDialog",
+          "push": [MockFunction],
+          "replace": [MockFunction],
         }
       }
-      classes={
+      location={
         Object {
-          "paper": "selectorDialog",
+          "pathname": "/runs/new",
+          "search": "?recurring=1",
         }
       }
+      match=""
       onClose={[Function]}
       open={false}
-    >
-      <WithStyles(DialogContent)>
-        <ResourceSelector
-          columns={
-            Array [
-              Object {
-                "customRenderer": [Function],
-                "flex": 1,
-                "label": "Pipeline name",
-                "sortKey": "name",
-              },
-              Object {
-                "customRenderer": [Function],
-                "flex": 2,
-                "label": "Description",
-              },
-              Object {
-                "flex": 1,
-                "label": "Uploaded on",
-                "sortKey": "created_at",
-              },
-            ]
-          }
-          emptyMessage="No pipelines found. Upload a pipeline and then try again."
-          filterLabel="Filter pipelines"
-          history={
+      pipelineSelectorColumns={
+        Array [
+          Object {
+            "customRenderer": [Function],
+            "flex": 1,
+            "label": "Pipeline name",
+            "sortKey": "name",
+          },
+          Object {
+            "customRenderer": [Function],
+            "flex": 2,
+            "label": "Description",
+          },
+          Object {
+            "flex": 1,
+            "label": "Uploaded on",
+            "sortKey": "created_at",
+          },
+        ]
+      }
+      selectorDialog="selectorDialog"
+      toolbarActionMap={
+        Object {
+          "uploadPipeline": Object {
+            "action": [Function],
+            "icon": [Function],
+            "id": "uploadBtn",
+            "outlined": true,
+            "style": Object {
+              "minWidth": 160,
+            },
+            "title": "Upload pipeline",
+            "tooltip": "Upload pipeline",
+          },
+        }
+      }
+      toolbarProps={
+        Object {
+          "actions": Object {},
+          "breadcrumbs": Array [
             Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            }
-          }
-          initialSortColumn="created_at"
-          listApi={[Function]}
-          location={
-            Object {
-              "pathname": "/runs/new",
-              "search": "?recurring=1",
-            }
-          }
-          match=""
-          selectionChanged={[Function]}
-          title="Choose a pipeline"
-          toolbarActionMap={
-            Object {
-              "uploadPipeline": Object {
-                "action": [Function],
-                "icon": [Function],
-                "id": "uploadBtn",
-                "outlined": true,
-                "style": Object {
-                  "minWidth": 160,
-                },
-                "title": "Upload pipeline",
-                "tooltip": "Upload pipeline",
-              },
-            }
-          }
-          toolbarProps={
-            Object {
-              "actions": Object {},
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-              ],
-              "pageTitle": "Start a new run",
-            }
-          }
-          updateBanner={[MockFunction]}
-          updateDialog={[MockFunction]}
-          updateSnackbar={[MockFunction]}
-          updateToolbar={[MockFunction]}
-        />
-      </WithStyles(DialogContent)>
-      <WithStyles(DialogActions)>
-        <WithStyles(Button)
-          color="secondary"
-          id="cancelPipelineSelectionBtn"
-          onClick={[Function]}
-        >
-          Cancel
-        </WithStyles(Button)>
-        <WithStyles(Button)
-          color="secondary"
-          disabled={true}
-          id="usePipelineBtn"
-          onClick={[Function]}
-        >
-          Use this pipeline
-        </WithStyles(Button)>
-      </WithStyles(DialogActions)>
-    </WithStyles(Dialog)>
+              "displayName": "Experiments",
+              "href": "/experiments",
+            },
+          ],
+          "pageTitle": "Start a new run",
+        }
+      }
+      updateBanner={[MockFunction]}
+      updateDialog={[MockFunction]}
+      updateSnackbar={[MockFunction]}
+      updateToolbar={[MockFunction]}
+    />
     <WithStyles(Dialog)
       PaperProps={
         Object {
@@ -3718,112 +3459,75 @@ exports[`NewRun updates the run's state with the associated experiment if one is
       value=""
       variant="outlined"
     />
-    <WithStyles(Dialog)
-      PaperProps={
+    <PipelinesDialog
+      history={
         Object {
-          "id": "pipelineSelectorDialog",
+          "push": [MockFunction],
+          "replace": [MockFunction],
         }
       }
-      classes={
+      location={
         Object {
-          "paper": "selectorDialog",
+          "pathname": "/runs/new",
+          "search": "?experimentId=some-mock-experiment-id",
         }
       }
+      match=""
       onClose={[Function]}
       open={false}
-    >
-      <WithStyles(DialogContent)>
-        <ResourceSelector
-          columns={
-            Array [
-              Object {
-                "customRenderer": [Function],
-                "flex": 1,
-                "label": "Pipeline name",
-                "sortKey": "name",
-              },
-              Object {
-                "customRenderer": [Function],
-                "flex": 2,
-                "label": "Description",
-              },
-              Object {
-                "flex": 1,
-                "label": "Uploaded on",
-                "sortKey": "created_at",
-              },
-            ]
-          }
-          emptyMessage="No pipelines found. Upload a pipeline and then try again."
-          filterLabel="Filter pipelines"
-          history={
+      pipelineSelectorColumns={
+        Array [
+          Object {
+            "customRenderer": [Function],
+            "flex": 1,
+            "label": "Pipeline name",
+            "sortKey": "name",
+          },
+          Object {
+            "customRenderer": [Function],
+            "flex": 2,
+            "label": "Description",
+          },
+          Object {
+            "flex": 1,
+            "label": "Uploaded on",
+            "sortKey": "created_at",
+          },
+        ]
+      }
+      selectorDialog="selectorDialog"
+      toolbarActionMap={
+        Object {
+          "uploadPipeline": Object {
+            "action": [Function],
+            "icon": [Function],
+            "id": "uploadBtn",
+            "outlined": true,
+            "style": Object {
+              "minWidth": 160,
+            },
+            "title": "Upload pipeline",
+            "tooltip": "Upload pipeline",
+          },
+        }
+      }
+      toolbarProps={
+        Object {
+          "actions": Object {},
+          "breadcrumbs": Array [
             Object {
-              "push": [MockFunction],
-              "replace": [MockFunction],
-            }
-          }
-          initialSortColumn="created_at"
-          listApi={[Function]}
-          location={
-            Object {
-              "pathname": "/runs/new",
-              "search": "?experimentId=some-mock-experiment-id",
-            }
-          }
-          match=""
-          selectionChanged={[Function]}
-          title="Choose a pipeline"
-          toolbarActionMap={
-            Object {
-              "uploadPipeline": Object {
-                "action": [Function],
-                "icon": [Function],
-                "id": "uploadBtn",
-                "outlined": true,
-                "style": Object {
-                  "minWidth": 160,
-                },
-                "title": "Upload pipeline",
-                "tooltip": "Upload pipeline",
-              },
-            }
-          }
-          toolbarProps={
-            Object {
-              "actions": Object {},
-              "breadcrumbs": Array [
-                Object {
-                  "displayName": "Experiments",
-                  "href": "/experiments",
-                },
-              ],
-              "pageTitle": "Start a new run",
-            }
-          }
-          updateBanner={[MockFunction]}
-          updateDialog={[MockFunction]}
-          updateSnackbar={[MockFunction]}
-          updateToolbar={[MockFunction]}
-        />
-      </WithStyles(DialogContent)>
-      <WithStyles(DialogActions)>
-        <WithStyles(Button)
-          color="secondary"
-          id="cancelPipelineSelectionBtn"
-          onClick={[Function]}
-        >
-          Cancel
-        </WithStyles(Button)>
-        <WithStyles(Button)
-          color="secondary"
-          disabled={true}
-          id="usePipelineBtn"
-          onClick={[Function]}
-        >
-          Use this pipeline
-        </WithStyles(Button)>
-      </WithStyles(DialogActions)>
-    </WithStyles(Dialog)>
+              "displayName": "Experiments",
+              "href": "/experiments",
+            },
+          ],
+          "pageTitle": "Start a new run",
+        }
+      }
+      updateBanner={[MockFunction]}
+      updateDialog={[MockFunction]}
+      updateSnackbar={[MockFunction]}
+      updateToolbar={[MockFunction]}
+    />
     <WithStyles(Dialog)
       PaperProps={
         Object {

--- a/frontend/src/pages/__snapshots__/PipelineList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/PipelineList.test.tsx.snap
@@ -47,10 +47,6 @@ exports[`PipelineList renders a list of one pipeline 1`] = `
     toggleExpansion={[Function]}
     updateSelection={[Function]}
   />
-  <UploadPipelineDialog
-    onClose={[Function]}
-    open={false}
-  />
 </div>
 `;
 
@@ -100,10 +96,6 @@ exports[`PipelineList renders a list of one pipeline with error 1`] = `
     selectedIds={Array []}
     toggleExpansion={[Function]}
     updateSelection={[Function]}
-  />
-  <UploadPipelineDialog
-    onClose={[Function]}
-    open={false}
   />
 </div>
 `;
@@ -155,10 +147,6 @@ exports[`PipelineList renders a list of one pipeline with no description or crea
     toggleExpansion={[Function]}
     updateSelection={[Function]}
   />
-  <UploadPipelineDialog
-    onClose={[Function]}
-    open={false}
-  />
 </div>
 `;
 
@@ -196,10 +184,6 @@ exports[`PipelineList renders an empty list with empty state message 1`] = `
     selectedIds={Array []}
     toggleExpansion={[Function]}
     updateSelection={[Function]}
-  />
-  <UploadPipelineDialog
-    onClose={[Function]}
-    open={false}
   />
 </div>
 `;

--- a/frontend/src/pages/__snapshots__/PrivateAndSharedPipelines.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/PrivateAndSharedPipelines.test.tsx.snap
@@ -1,0 +1,2143 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PrivateAndSharedPipelines it renders correctly in multi user mode 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="page"
+      >
+        <div
+          class="tabs"
+        >
+          <div
+            class="indicator"
+          />
+          <span
+            style="display: inline-block; min-width: 20px; width: 20px;"
+          />
+          <button
+            class="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button active"
+            tabindex="0"
+            title="Only people who have access to this namespace will be able to view and use these pipelines."
+            type="button"
+          >
+            <span
+              class="MuiButton-label-10"
+            >
+              <span>
+                Private
+              </span>
+            </span>
+            <span
+              class="MuiTouchRipple-root-151"
+            />
+          </button>
+          <button
+            class="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+            tabindex="0"
+            title="Everyone in your organization will be able to view and use these pipelines."
+            type="button"
+          >
+            <span
+              class="MuiButton-label-10"
+            >
+              <span>
+                Shared
+              </span>
+            </span>
+            <span
+              class="MuiTouchRipple-root-151"
+            />
+          </button>
+        </div>
+        <div
+          class="page"
+        >
+          <div
+            class="pageOverflowHidden"
+          >
+            <div>
+              <div
+                class="MuiFormControl-root-38 filterBox"
+                spellcheck="false"
+                style="height: 48px; max-width: 100%; width: 100%;"
+              >
+                <label
+                  class="MuiFormLabel-root-53 MuiInputLabel-root-42 noMargin MuiInputLabel-formControl-47 MuiInputLabel-animated-50 MuiInputLabel-shrink-49 MuiInputLabel-outlined-52"
+                  data-shrink="true"
+                  for="tableFilterBox"
+                >
+                  Filter pipelines
+                </label>
+                <div
+                  class="MuiInputBase-root-73 MuiOutlinedInput-root-60 noLeftPadding MuiInputBase-formControl-74 MuiInputBase-adornedStart-77 MuiOutlinedInput-adornedStart-63"
+                >
+                  <fieldset
+                    aria-hidden="true"
+                    class="MuiPrivateNotchedOutline-root-90 MuiOutlinedInput-notchedOutline-67 filterBorderRadius"
+                    style="padding-left: 8px;"
+                  >
+                    <legend
+                      class="MuiPrivateNotchedOutline-legend-91"
+                      style="width: 0px;"
+                    >
+                      <span>
+                        ​
+                      </span>
+                    </legend>
+                  </fieldset>
+                  <div
+                    class="MuiInputAdornment-root-92 MuiInputAdornment-positionEnd-95"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-97"
+                      focusable="false"
+                      role="presentation"
+                      style="color: rgb(128, 134, 139); padding-right: 16px;"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+                      />
+                      <path
+                        d="M0 0h24v24H0z"
+                        fill="none"
+                      />
+                    </svg>
+                  </div>
+                  <input
+                    aria-invalid="false"
+                    class="MuiInputBase-input-83 MuiOutlinedInput-input-68 MuiInputBase-inputAdornedStart-88 MuiOutlinedInput-inputAdornedStart-71"
+                    id="tableFilterBox"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="header"
+            >
+              <div
+                class="columnName cell selectionToggle"
+              >
+                <span
+                  class="MuiButtonBase-root-35 MuiIconButton-root-116 MuiPrivateSwitchBase-root-112 MuiCheckbox-root-106 MuiCheckbox-colorPrimary-110"
+                >
+                  <span
+                    class="MuiIconButton-label-121"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-97"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                      />
+                    </svg>
+                    <input
+                      class="MuiPrivateSwitchBase-input-115"
+                      data-indeterminate="false"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-151"
+                  />
+                </span>
+                <span
+                  style="display: inline-block; min-width: 40px; width: 40px;"
+                />
+              </div>
+              <div
+                class="columnName"
+                style="width: 20%;"
+                title="Pipeline name"
+              >
+                <span
+                  class="MuiButtonBase-root-35 MuiTableSortLabel-root-122 ellipsis"
+                  role="button"
+                  tabindex="0"
+                  title="Sort"
+                >
+                  Pipeline name
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root-97 MuiTableSortLabel-icon-124 MuiTableSortLabel-iconDirectionDesc-125"
+                    focusable="false"
+                    role="presentation"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                class="columnName"
+                style="width: 60%;"
+                title="Description"
+              >
+                <span
+                  class="MuiButtonBase-root-35 MuiTableSortLabel-root-122 ellipsis"
+                  role="button"
+                  tabindex="0"
+                  title="Cannot sort by this column"
+                >
+                  Description
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root-97 MuiTableSortLabel-icon-124 MuiTableSortLabel-iconDirectionDesc-125"
+                    focusable="false"
+                    role="presentation"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                class="columnName"
+                style="width: 20%;"
+                title="Uploaded on"
+              >
+                <span
+                  class="MuiButtonBase-root-35 MuiTableSortLabel-root-122 MuiTableSortLabel-active-123 ellipsis"
+                  role="button"
+                  tabindex="0"
+                  title="Sort"
+                >
+                  Uploaded on
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root-97 MuiTableSortLabel-icon-124 MuiTableSortLabel-iconDirectionDesc-125"
+                    focusable="false"
+                    role="presentation"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </div>
+            <div
+              class="scrollContainer"
+              style="min-height: 60px;"
+            >
+              <div
+                class="expandableContainer"
+              >
+                <div
+                  aria-checked="false"
+                  class="tableRow row"
+                  role="checkbox"
+                  tabindex="-1"
+                >
+                  <div
+                    class="cell selectionToggle"
+                  >
+                    <span
+                      class="MuiButtonBase-root-35 MuiIconButton-root-116 MuiPrivateSwitchBase-root-112 MuiCheckbox-root-106 MuiCheckbox-colorPrimary-110"
+                    >
+                      <span
+                        class="MuiIconButton-label-121"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-97"
+                          focusable="false"
+                          role="presentation"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                          />
+                        </svg>
+                        <input
+                          class="MuiPrivateSwitchBase-input-115"
+                          data-indeterminate="false"
+                          type="checkbox"
+                          value=""
+                        />
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root-151"
+                      />
+                    </span>
+                    <button
+                      aria-label="Expand"
+                      class="MuiButtonBase-root-35 MuiIconButton-root-116 expandButton"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiIconButton-label-121"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-97"
+                          focusable="false"
+                          role="presentation"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M10 17l5-5-5-5v10z"
+                          />
+                          <path
+                            d="M0 24V0h24v24H0z"
+                            fill="none"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root-151"
+                      />
+                    </button>
+                  </div>
+                  <div
+                    class="cell"
+                    style="width: 20%;"
+                  >
+                    <a
+                      class="link"
+                      href="/pipelines/details/run-pipeline-id"
+                      title="mock pipeline name"
+                    >
+                      mock pipeline name
+                    </a>
+                  </div>
+                  <div
+                    class="cell"
+                    style="width: 60%;"
+                  >
+                    <span>
+                      mock pipeline description
+                    </span>
+                  </div>
+                  <div
+                    class="cell"
+                    style="width: 20%;"
+                  >
+                    9/21/2022, 1:53:59 PM
+                  </div>
+                </div>
+              </div>
+              <div
+                class="expandableContainer"
+              >
+                <div
+                  aria-checked="false"
+                  class="tableRow row"
+                  role="checkbox"
+                  tabindex="-1"
+                >
+                  <div
+                    class="cell selectionToggle"
+                  >
+                    <span
+                      class="MuiButtonBase-root-35 MuiIconButton-root-116 MuiPrivateSwitchBase-root-112 MuiCheckbox-root-106 MuiCheckbox-colorPrimary-110"
+                    >
+                      <span
+                        class="MuiIconButton-label-121"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-97"
+                          focusable="false"
+                          role="presentation"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                          />
+                        </svg>
+                        <input
+                          class="MuiPrivateSwitchBase-input-115"
+                          data-indeterminate="false"
+                          type="checkbox"
+                          value=""
+                        />
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root-151"
+                      />
+                    </span>
+                    <button
+                      aria-label="Expand"
+                      class="MuiButtonBase-root-35 MuiIconButton-root-116 expandButton"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiIconButton-label-121"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-97"
+                          focusable="false"
+                          role="presentation"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M10 17l5-5-5-5v10z"
+                          />
+                          <path
+                            d="M0 24V0h24v24H0z"
+                            fill="none"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root-151"
+                      />
+                    </button>
+                  </div>
+                  <div
+                    class="cell"
+                    style="width: 20%;"
+                  >
+                    <a
+                      class="link"
+                      href="/pipelines/details/run-pipeline-id"
+                      title="mock pipeline name"
+                    >
+                      mock pipeline name
+                    </a>
+                  </div>
+                  <div
+                    class="cell"
+                    style="width: 60%;"
+                  >
+                    <span>
+                      mock pipeline description
+                    </span>
+                  </div>
+                  <div
+                    class="cell"
+                    style="width: 20%;"
+                  >
+                    9/21/2022, 1:53:59 PM
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="footer"
+            >
+              <span
+                class=""
+              >
+                Rows per page:
+              </span>
+              <div
+                class="MuiFormControl-root-38 verticalAlignInitial rowsPerPage"
+              >
+                <div
+                  class="MuiInputBase-root-73 MuiInput-root-134 MuiInputBase-formControl-74 MuiInput-formControl-135"
+                >
+                  <div
+                    class="MuiSelect-root-127"
+                  >
+                    <div
+                      aria-haspopup="true"
+                      aria-pressed="false"
+                      class="MuiSelect-select-128 MuiSelect-selectMenu-131 MuiInputBase-input-83 MuiInput-input-142"
+                      role="button"
+                      tabindex="0"
+                    >
+                      10
+                    </div>
+                    <input
+                      type="hidden"
+                      value="10"
+                    />
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-97 MuiSelect-icon-133"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7 10l5 5 5-5z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <button
+                class="MuiButtonBase-root-35 MuiButtonBase-disabled-36 MuiIconButton-root-116 MuiIconButton-disabled-120"
+                disabled=""
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  class="MuiIconButton-label-121"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root-97"
+                    focusable="false"
+                    role="presentation"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                    />
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                class="MuiButtonBase-root-35 MuiButtonBase-disabled-36 MuiIconButton-root-116 MuiIconButton-disabled-120"
+                disabled=""
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  class="MuiIconButton-label-121"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root-97"
+                    focusable="false"
+                    role="presentation"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                    />
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="page"
+    >
+      <div
+        class="tabs"
+      >
+        <div
+          class="indicator"
+        />
+        <span
+          style="display: inline-block; min-width: 20px; width: 20px;"
+        />
+        <button
+          class="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button active"
+          tabindex="0"
+          title="Only people who have access to this namespace will be able to view and use these pipelines."
+          type="button"
+        >
+          <span
+            class="MuiButton-label-10"
+          >
+            <span>
+              Private
+            </span>
+          </span>
+          <span
+            class="MuiTouchRipple-root-151"
+          />
+        </button>
+        <button
+          class="MuiButtonBase-root-35 MuiButton-root-9 MuiButton-text-11 MuiButton-flat-14 button"
+          tabindex="0"
+          title="Everyone in your organization will be able to view and use these pipelines."
+          type="button"
+        >
+          <span
+            class="MuiButton-label-10"
+          >
+            <span>
+              Shared
+            </span>
+          </span>
+          <span
+            class="MuiTouchRipple-root-151"
+          />
+        </button>
+      </div>
+      <div
+        class="page"
+      >
+        <div
+          class="pageOverflowHidden"
+        >
+          <div>
+            <div
+              class="MuiFormControl-root-38 filterBox"
+              spellcheck="false"
+              style="height: 48px; max-width: 100%; width: 100%;"
+            >
+              <label
+                class="MuiFormLabel-root-53 MuiInputLabel-root-42 noMargin MuiInputLabel-formControl-47 MuiInputLabel-animated-50 MuiInputLabel-shrink-49 MuiInputLabel-outlined-52"
+                data-shrink="true"
+                for="tableFilterBox"
+              >
+                Filter pipelines
+              </label>
+              <div
+                class="MuiInputBase-root-73 MuiOutlinedInput-root-60 noLeftPadding MuiInputBase-formControl-74 MuiInputBase-adornedStart-77 MuiOutlinedInput-adornedStart-63"
+              >
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiPrivateNotchedOutline-root-90 MuiOutlinedInput-notchedOutline-67 filterBorderRadius"
+                  style="padding-left: 8px;"
+                >
+                  <legend
+                    class="MuiPrivateNotchedOutline-legend-91"
+                    style="width: 0px;"
+                  >
+                    <span>
+                      ​
+                    </span>
+                  </legend>
+                </fieldset>
+                <div
+                  class="MuiInputAdornment-root-92 MuiInputAdornment-positionEnd-95"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root-97"
+                    focusable="false"
+                    role="presentation"
+                    style="color: rgb(128, 134, 139); padding-right: 16px;"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+                    />
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                  </svg>
+                </div>
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input-83 MuiOutlinedInput-input-68 MuiInputBase-inputAdornedStart-88 MuiOutlinedInput-inputAdornedStart-71"
+                  id="tableFilterBox"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="header"
+          >
+            <div
+              class="columnName cell selectionToggle"
+            >
+              <span
+                class="MuiButtonBase-root-35 MuiIconButton-root-116 MuiPrivateSwitchBase-root-112 MuiCheckbox-root-106 MuiCheckbox-colorPrimary-110"
+              >
+                <span
+                  class="MuiIconButton-label-121"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root-97"
+                    focusable="false"
+                    role="presentation"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                    />
+                  </svg>
+                  <input
+                    class="MuiPrivateSwitchBase-input-115"
+                    data-indeterminate="false"
+                    type="checkbox"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="MuiTouchRipple-root-151"
+                />
+              </span>
+              <span
+                style="display: inline-block; min-width: 40px; width: 40px;"
+              />
+            </div>
+            <div
+              class="columnName"
+              style="width: 20%;"
+              title="Pipeline name"
+            >
+              <span
+                class="MuiButtonBase-root-35 MuiTableSortLabel-root-122 ellipsis"
+                role="button"
+                tabindex="0"
+                title="Sort"
+              >
+                Pipeline name
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root-97 MuiTableSortLabel-icon-124 MuiTableSortLabel-iconDirectionDesc-125"
+                  focusable="false"
+                  role="presentation"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              class="columnName"
+              style="width: 60%;"
+              title="Description"
+            >
+              <span
+                class="MuiButtonBase-root-35 MuiTableSortLabel-root-122 ellipsis"
+                role="button"
+                tabindex="0"
+                title="Cannot sort by this column"
+              >
+                Description
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root-97 MuiTableSortLabel-icon-124 MuiTableSortLabel-iconDirectionDesc-125"
+                  focusable="false"
+                  role="presentation"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              class="columnName"
+              style="width: 20%;"
+              title="Uploaded on"
+            >
+              <span
+                class="MuiButtonBase-root-35 MuiTableSortLabel-root-122 MuiTableSortLabel-active-123 ellipsis"
+                role="button"
+                tabindex="0"
+                title="Sort"
+              >
+                Uploaded on
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root-97 MuiTableSortLabel-icon-124 MuiTableSortLabel-iconDirectionDesc-125"
+                  focusable="false"
+                  role="presentation"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+          <div
+            class="scrollContainer"
+            style="min-height: 60px;"
+          >
+            <div
+              class="expandableContainer"
+            >
+              <div
+                aria-checked="false"
+                class="tableRow row"
+                role="checkbox"
+                tabindex="-1"
+              >
+                <div
+                  class="cell selectionToggle"
+                >
+                  <span
+                    class="MuiButtonBase-root-35 MuiIconButton-root-116 MuiPrivateSwitchBase-root-112 MuiCheckbox-root-106 MuiCheckbox-colorPrimary-110"
+                  >
+                    <span
+                      class="MuiIconButton-label-121"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-97"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                      <input
+                        class="MuiPrivateSwitchBase-input-115"
+                        data-indeterminate="false"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root-151"
+                    />
+                  </span>
+                  <button
+                    aria-label="Expand"
+                    class="MuiButtonBase-root-35 MuiIconButton-root-116 expandButton"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiIconButton-label-121"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-97"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M10 17l5-5-5-5v10z"
+                        />
+                        <path
+                          d="M0 24V0h24v24H0z"
+                          fill="none"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root-151"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="cell"
+                  style="width: 20%;"
+                >
+                  <a
+                    class="link"
+                    href="/pipelines/details/run-pipeline-id"
+                    title="mock pipeline name"
+                  >
+                    mock pipeline name
+                  </a>
+                </div>
+                <div
+                  class="cell"
+                  style="width: 60%;"
+                >
+                  <span>
+                    mock pipeline description
+                  </span>
+                </div>
+                <div
+                  class="cell"
+                  style="width: 20%;"
+                >
+                  9/21/2022, 1:53:59 PM
+                </div>
+              </div>
+            </div>
+            <div
+              class="expandableContainer"
+            >
+              <div
+                aria-checked="false"
+                class="tableRow row"
+                role="checkbox"
+                tabindex="-1"
+              >
+                <div
+                  class="cell selectionToggle"
+                >
+                  <span
+                    class="MuiButtonBase-root-35 MuiIconButton-root-116 MuiPrivateSwitchBase-root-112 MuiCheckbox-root-106 MuiCheckbox-colorPrimary-110"
+                  >
+                    <span
+                      class="MuiIconButton-label-121"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-97"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                      <input
+                        class="MuiPrivateSwitchBase-input-115"
+                        data-indeterminate="false"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root-151"
+                    />
+                  </span>
+                  <button
+                    aria-label="Expand"
+                    class="MuiButtonBase-root-35 MuiIconButton-root-116 expandButton"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiIconButton-label-121"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-97"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M10 17l5-5-5-5v10z"
+                        />
+                        <path
+                          d="M0 24V0h24v24H0z"
+                          fill="none"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root-151"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="cell"
+                  style="width: 20%;"
+                >
+                  <a
+                    class="link"
+                    href="/pipelines/details/run-pipeline-id"
+                    title="mock pipeline name"
+                  >
+                    mock pipeline name
+                  </a>
+                </div>
+                <div
+                  class="cell"
+                  style="width: 60%;"
+                >
+                  <span>
+                    mock pipeline description
+                  </span>
+                </div>
+                <div
+                  class="cell"
+                  style="width: 20%;"
+                >
+                  9/21/2022, 1:53:59 PM
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="footer"
+          >
+            <span
+              class=""
+            >
+              Rows per page:
+            </span>
+            <div
+              class="MuiFormControl-root-38 verticalAlignInitial rowsPerPage"
+            >
+              <div
+                class="MuiInputBase-root-73 MuiInput-root-134 MuiInputBase-formControl-74 MuiInput-formControl-135"
+              >
+                <div
+                  class="MuiSelect-root-127"
+                >
+                  <div
+                    aria-haspopup="true"
+                    aria-pressed="false"
+                    class="MuiSelect-select-128 MuiSelect-selectMenu-131 MuiInputBase-input-83 MuiInput-input-142"
+                    role="button"
+                    tabindex="0"
+                  >
+                    10
+                  </div>
+                  <input
+                    type="hidden"
+                    value="10"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root-97 MuiSelect-icon-133"
+                    focusable="false"
+                    role="presentation"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 10l5 5 5-5z"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root-35 MuiButtonBase-disabled-36 MuiIconButton-root-116 MuiIconButton-disabled-120"
+              disabled=""
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                class="MuiIconButton-label-121"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root-97"
+                  focusable="false"
+                  role="presentation"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                  />
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                </svg>
+              </span>
+            </button>
+            <button
+              class="MuiButtonBase-root-35 MuiButtonBase-disabled-36 MuiIconButton-root-116 MuiIconButton-disabled-120"
+              disabled=""
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                class="MuiIconButton-label-121"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root-97"
+                  focusable="false"
+                  role="presentation"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                  />
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`PrivateAndSharedPipelines it renders correctly in single user mode 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="page"
+      >
+        <div
+          class="pageOverflowHidden"
+        >
+          <div>
+            <div
+              class="MuiFormControl-root-168 filterBox"
+              spellcheck="false"
+              style="height: 48px; max-width: 100%; width: 100%;"
+            >
+              <label
+                class="MuiFormLabel-root-183 MuiInputLabel-root-172 noMargin MuiInputLabel-formControl-177 MuiInputLabel-animated-180 MuiInputLabel-shrink-179 MuiInputLabel-outlined-182"
+                data-shrink="true"
+                for="tableFilterBox"
+              >
+                Filter pipelines
+              </label>
+              <div
+                class="MuiInputBase-root-203 MuiOutlinedInput-root-190 noLeftPadding MuiInputBase-formControl-204 MuiInputBase-adornedStart-207 MuiOutlinedInput-adornedStart-193"
+              >
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiPrivateNotchedOutline-root-220 MuiOutlinedInput-notchedOutline-197 filterBorderRadius"
+                  style="padding-left: 8px;"
+                >
+                  <legend
+                    class="MuiPrivateNotchedOutline-legend-221"
+                    style="width: 0px;"
+                  >
+                    <span>
+                      ​
+                    </span>
+                  </legend>
+                </fieldset>
+                <div
+                  class="MuiInputAdornment-root-222 MuiInputAdornment-positionEnd-225"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root-227"
+                    focusable="false"
+                    role="presentation"
+                    style="color: rgb(128, 134, 139); padding-right: 16px;"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+                    />
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                  </svg>
+                </div>
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input-213 MuiOutlinedInput-input-198 MuiInputBase-inputAdornedStart-218 MuiOutlinedInput-inputAdornedStart-201"
+                  id="tableFilterBox"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="header"
+          >
+            <div
+              class="columnName cell selectionToggle"
+            >
+              <span
+                class="MuiButtonBase-root-252 MuiIconButton-root-246 MuiPrivateSwitchBase-root-242 MuiCheckbox-root-236 MuiCheckbox-colorPrimary-240"
+              >
+                <span
+                  class="MuiIconButton-label-251"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root-227"
+                    focusable="false"
+                    role="presentation"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                    />
+                  </svg>
+                  <input
+                    class="MuiPrivateSwitchBase-input-245"
+                    data-indeterminate="false"
+                    type="checkbox"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="MuiTouchRipple-root-292"
+                />
+              </span>
+              <span
+                style="display: inline-block; min-width: 40px; width: 40px;"
+              />
+            </div>
+            <div
+              class="columnName"
+              style="width: 20%;"
+              title="Pipeline name"
+            >
+              <span
+                class="MuiButtonBase-root-252 MuiTableSortLabel-root-263 ellipsis"
+                role="button"
+                tabindex="0"
+                title="Sort"
+              >
+                Pipeline name
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root-227 MuiTableSortLabel-icon-265 MuiTableSortLabel-iconDirectionDesc-266"
+                  focusable="false"
+                  role="presentation"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              class="columnName"
+              style="width: 60%;"
+              title="Description"
+            >
+              <span
+                class="MuiButtonBase-root-252 MuiTableSortLabel-root-263 ellipsis"
+                role="button"
+                tabindex="0"
+                title="Cannot sort by this column"
+              >
+                Description
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root-227 MuiTableSortLabel-icon-265 MuiTableSortLabel-iconDirectionDesc-266"
+                  focusable="false"
+                  role="presentation"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              class="columnName"
+              style="width: 20%;"
+              title="Uploaded on"
+            >
+              <span
+                class="MuiButtonBase-root-252 MuiTableSortLabel-root-263 MuiTableSortLabel-active-264 ellipsis"
+                role="button"
+                tabindex="0"
+                title="Sort"
+              >
+                Uploaded on
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root-227 MuiTableSortLabel-icon-265 MuiTableSortLabel-iconDirectionDesc-266"
+                  focusable="false"
+                  role="presentation"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+          <div
+            class="scrollContainer"
+            style="min-height: 60px;"
+          >
+            <div
+              class="expandableContainer"
+            >
+              <div
+                aria-checked="false"
+                class="tableRow row"
+                role="checkbox"
+                tabindex="-1"
+              >
+                <div
+                  class="cell selectionToggle"
+                >
+                  <span
+                    class="MuiButtonBase-root-252 MuiIconButton-root-246 MuiPrivateSwitchBase-root-242 MuiCheckbox-root-236 MuiCheckbox-colorPrimary-240"
+                  >
+                    <span
+                      class="MuiIconButton-label-251"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-227"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                      <input
+                        class="MuiPrivateSwitchBase-input-245"
+                        data-indeterminate="false"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root-292"
+                    />
+                  </span>
+                  <button
+                    aria-label="Expand"
+                    class="MuiButtonBase-root-252 MuiIconButton-root-246 expandButton"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiIconButton-label-251"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-227"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M10 17l5-5-5-5v10z"
+                        />
+                        <path
+                          d="M0 24V0h24v24H0z"
+                          fill="none"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root-292"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="cell"
+                  style="width: 20%;"
+                >
+                  <a
+                    class="link"
+                    href="/pipelines/details/run-pipeline-id"
+                    title="mock pipeline name"
+                  >
+                    mock pipeline name
+                  </a>
+                </div>
+                <div
+                  class="cell"
+                  style="width: 60%;"
+                >
+                  <span>
+                    mock pipeline description
+                  </span>
+                </div>
+                <div
+                  class="cell"
+                  style="width: 20%;"
+                >
+                  9/21/2022, 1:53:59 PM
+                </div>
+              </div>
+            </div>
+            <div
+              class="expandableContainer"
+            >
+              <div
+                aria-checked="false"
+                class="tableRow row"
+                role="checkbox"
+                tabindex="-1"
+              >
+                <div
+                  class="cell selectionToggle"
+                >
+                  <span
+                    class="MuiButtonBase-root-252 MuiIconButton-root-246 MuiPrivateSwitchBase-root-242 MuiCheckbox-root-236 MuiCheckbox-colorPrimary-240"
+                  >
+                    <span
+                      class="MuiIconButton-label-251"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-227"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                      <input
+                        class="MuiPrivateSwitchBase-input-245"
+                        data-indeterminate="false"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root-292"
+                    />
+                  </span>
+                  <button
+                    aria-label="Expand"
+                    class="MuiButtonBase-root-252 MuiIconButton-root-246 expandButton"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiIconButton-label-251"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-227"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M10 17l5-5-5-5v10z"
+                        />
+                        <path
+                          d="M0 24V0h24v24H0z"
+                          fill="none"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root-292"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="cell"
+                  style="width: 20%;"
+                >
+                  <a
+                    class="link"
+                    href="/pipelines/details/run-pipeline-id"
+                    title="mock pipeline name"
+                  >
+                    mock pipeline name
+                  </a>
+                </div>
+                <div
+                  class="cell"
+                  style="width: 60%;"
+                >
+                  <span>
+                    mock pipeline description
+                  </span>
+                </div>
+                <div
+                  class="cell"
+                  style="width: 20%;"
+                >
+                  9/21/2022, 1:53:59 PM
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="footer"
+          >
+            <span
+              class=""
+            >
+              Rows per page:
+            </span>
+            <div
+              class="MuiFormControl-root-168 verticalAlignInitial rowsPerPage"
+            >
+              <div
+                class="MuiInputBase-root-203 MuiInput-root-275 MuiInputBase-formControl-204 MuiInput-formControl-276"
+              >
+                <div
+                  class="MuiSelect-root-268"
+                >
+                  <div
+                    aria-haspopup="true"
+                    aria-pressed="false"
+                    class="MuiSelect-select-269 MuiSelect-selectMenu-272 MuiInputBase-input-213 MuiInput-input-283"
+                    role="button"
+                    tabindex="0"
+                  >
+                    10
+                  </div>
+                  <input
+                    type="hidden"
+                    value="10"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root-227 MuiSelect-icon-274"
+                    focusable="false"
+                    role="presentation"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 10l5 5 5-5z"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root-252 MuiButtonBase-disabled-253 MuiIconButton-root-246 MuiIconButton-disabled-250"
+              disabled=""
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                class="MuiIconButton-label-251"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root-227"
+                  focusable="false"
+                  role="presentation"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                  />
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                </svg>
+              </span>
+            </button>
+            <button
+              class="MuiButtonBase-root-252 MuiButtonBase-disabled-253 MuiIconButton-root-246 MuiIconButton-disabled-250"
+              disabled=""
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                class="MuiIconButton-label-251"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root-227"
+                  focusable="false"
+                  role="presentation"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                  />
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="page"
+    >
+      <div
+        class="pageOverflowHidden"
+      >
+        <div>
+          <div
+            class="MuiFormControl-root-168 filterBox"
+            spellcheck="false"
+            style="height: 48px; max-width: 100%; width: 100%;"
+          >
+            <label
+              class="MuiFormLabel-root-183 MuiInputLabel-root-172 noMargin MuiInputLabel-formControl-177 MuiInputLabel-animated-180 MuiInputLabel-shrink-179 MuiInputLabel-outlined-182"
+              data-shrink="true"
+              for="tableFilterBox"
+            >
+              Filter pipelines
+            </label>
+            <div
+              class="MuiInputBase-root-203 MuiOutlinedInput-root-190 noLeftPadding MuiInputBase-formControl-204 MuiInputBase-adornedStart-207 MuiOutlinedInput-adornedStart-193"
+            >
+              <fieldset
+                aria-hidden="true"
+                class="MuiPrivateNotchedOutline-root-220 MuiOutlinedInput-notchedOutline-197 filterBorderRadius"
+                style="padding-left: 8px;"
+              >
+                <legend
+                  class="MuiPrivateNotchedOutline-legend-221"
+                  style="width: 0px;"
+                >
+                  <span>
+                    ​
+                  </span>
+                </legend>
+              </fieldset>
+              <div
+                class="MuiInputAdornment-root-222 MuiInputAdornment-positionEnd-225"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root-227"
+                  focusable="false"
+                  role="presentation"
+                  style="color: rgb(128, 134, 139); padding-right: 16px;"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+                  />
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input-213 MuiOutlinedInput-input-198 MuiInputBase-inputAdornedStart-218 MuiOutlinedInput-inputAdornedStart-201"
+                id="tableFilterBox"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="header"
+        >
+          <div
+            class="columnName cell selectionToggle"
+          >
+            <span
+              class="MuiButtonBase-root-252 MuiIconButton-root-246 MuiPrivateSwitchBase-root-242 MuiCheckbox-root-236 MuiCheckbox-colorPrimary-240"
+            >
+              <span
+                class="MuiIconButton-label-251"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root-227"
+                  focusable="false"
+                  role="presentation"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                  />
+                </svg>
+                <input
+                  class="MuiPrivateSwitchBase-input-245"
+                  data-indeterminate="false"
+                  type="checkbox"
+                  value=""
+                />
+              </span>
+              <span
+                class="MuiTouchRipple-root-292"
+              />
+            </span>
+            <span
+              style="display: inline-block; min-width: 40px; width: 40px;"
+            />
+          </div>
+          <div
+            class="columnName"
+            style="width: 20%;"
+            title="Pipeline name"
+          >
+            <span
+              class="MuiButtonBase-root-252 MuiTableSortLabel-root-263 ellipsis"
+              role="button"
+              tabindex="0"
+              title="Sort"
+            >
+              Pipeline name
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root-227 MuiTableSortLabel-icon-265 MuiTableSortLabel-iconDirectionDesc-266"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="columnName"
+            style="width: 60%;"
+            title="Description"
+          >
+            <span
+              class="MuiButtonBase-root-252 MuiTableSortLabel-root-263 ellipsis"
+              role="button"
+              tabindex="0"
+              title="Cannot sort by this column"
+            >
+              Description
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root-227 MuiTableSortLabel-icon-265 MuiTableSortLabel-iconDirectionDesc-266"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="columnName"
+            style="width: 20%;"
+            title="Uploaded on"
+          >
+            <span
+              class="MuiButtonBase-root-252 MuiTableSortLabel-root-263 MuiTableSortLabel-active-264 ellipsis"
+              role="button"
+              tabindex="0"
+              title="Sort"
+            >
+              Uploaded on
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root-227 MuiTableSortLabel-icon-265 MuiTableSortLabel-iconDirectionDesc-266"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                />
+              </svg>
+            </span>
+          </div>
+        </div>
+        <div
+          class="scrollContainer"
+          style="min-height: 60px;"
+        >
+          <div
+            class="expandableContainer"
+          >
+            <div
+              aria-checked="false"
+              class="tableRow row"
+              role="checkbox"
+              tabindex="-1"
+            >
+              <div
+                class="cell selectionToggle"
+              >
+                <span
+                  class="MuiButtonBase-root-252 MuiIconButton-root-246 MuiPrivateSwitchBase-root-242 MuiCheckbox-root-236 MuiCheckbox-colorPrimary-240"
+                >
+                  <span
+                    class="MuiIconButton-label-251"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-227"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                      />
+                    </svg>
+                    <input
+                      class="MuiPrivateSwitchBase-input-245"
+                      data-indeterminate="false"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-292"
+                  />
+                </span>
+                <button
+                  aria-label="Expand"
+                  class="MuiButtonBase-root-252 MuiIconButton-root-246 expandButton"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label-251"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-227"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M10 17l5-5-5-5v10z"
+                      />
+                      <path
+                        d="M0 24V0h24v24H0z"
+                        fill="none"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-292"
+                  />
+                </button>
+              </div>
+              <div
+                class="cell"
+                style="width: 20%;"
+              >
+                <a
+                  class="link"
+                  href="/pipelines/details/run-pipeline-id"
+                  title="mock pipeline name"
+                >
+                  mock pipeline name
+                </a>
+              </div>
+              <div
+                class="cell"
+                style="width: 60%;"
+              >
+                <span>
+                  mock pipeline description
+                </span>
+              </div>
+              <div
+                class="cell"
+                style="width: 20%;"
+              >
+                9/21/2022, 1:53:59 PM
+              </div>
+            </div>
+          </div>
+          <div
+            class="expandableContainer"
+          >
+            <div
+              aria-checked="false"
+              class="tableRow row"
+              role="checkbox"
+              tabindex="-1"
+            >
+              <div
+                class="cell selectionToggle"
+              >
+                <span
+                  class="MuiButtonBase-root-252 MuiIconButton-root-246 MuiPrivateSwitchBase-root-242 MuiCheckbox-root-236 MuiCheckbox-colorPrimary-240"
+                >
+                  <span
+                    class="MuiIconButton-label-251"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-227"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                      />
+                    </svg>
+                    <input
+                      class="MuiPrivateSwitchBase-input-245"
+                      data-indeterminate="false"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-292"
+                  />
+                </span>
+                <button
+                  aria-label="Expand"
+                  class="MuiButtonBase-root-252 MuiIconButton-root-246 expandButton"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label-251"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-227"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M10 17l5-5-5-5v10z"
+                      />
+                      <path
+                        d="M0 24V0h24v24H0z"
+                        fill="none"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root-292"
+                  />
+                </button>
+              </div>
+              <div
+                class="cell"
+                style="width: 20%;"
+              >
+                <a
+                  class="link"
+                  href="/pipelines/details/run-pipeline-id"
+                  title="mock pipeline name"
+                >
+                  mock pipeline name
+                </a>
+              </div>
+              <div
+                class="cell"
+                style="width: 60%;"
+              >
+                <span>
+                  mock pipeline description
+                </span>
+              </div>
+              <div
+                class="cell"
+                style="width: 20%;"
+              >
+                9/21/2022, 1:53:59 PM
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="footer"
+        >
+          <span
+            class=""
+          >
+            Rows per page:
+          </span>
+          <div
+            class="MuiFormControl-root-168 verticalAlignInitial rowsPerPage"
+          >
+            <div
+              class="MuiInputBase-root-203 MuiInput-root-275 MuiInputBase-formControl-204 MuiInput-formControl-276"
+            >
+              <div
+                class="MuiSelect-root-268"
+              >
+                <div
+                  aria-haspopup="true"
+                  aria-pressed="false"
+                  class="MuiSelect-select-269 MuiSelect-selectMenu-272 MuiInputBase-input-213 MuiInput-input-283"
+                  role="button"
+                  tabindex="0"
+                >
+                  10
+                </div>
+                <input
+                  type="hidden"
+                  value="10"
+                />
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root-227 MuiSelect-icon-274"
+                  focusable="false"
+                  role="presentation"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M7 10l5 5 5-5z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+          <button
+            class="MuiButtonBase-root-252 MuiButtonBase-disabled-253 MuiIconButton-root-246 MuiIconButton-disabled-250"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label-251"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root-227"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                />
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+              </svg>
+            </span>
+          </button>
+          <button
+            class="MuiButtonBase-root-252 MuiButtonBase-disabled-253 MuiIconButton-root-246 MuiIconButton-disabled-250"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            <span
+              class="MuiIconButton-label-251"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root-227"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                />
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;


### PR DESCRIPTION
The purpose of this PR is to introduce namespaced pipelines in the pipelines frontend.
Design doc: https://docs.google.com/document/d/1fM4y2L1IVqVj-iiNjYFRRktdCh7FQXgU2XpaYLaqt-A/edit?resourcekey=0-kd5loyP7w3PBD0ug6ECmLQ#heading=h.x9snb54sjlu9

The pipelines list page now has two tabs, one that displays the private pipelines and one for shared.

![Screenshot from 2023-02-09 12-31-07](https://user-images.githubusercontent.com/3420211/217833591-72eb206d-0251-4b3f-8732-ff1dae1de0c3.png)

![Screenshot from 2023-02-09 12-31-38](https://user-images.githubusercontent.com/3420211/217833599-d3e74ae6-dad0-4ea7-b649-eff2a78938d2.png)

The new run page now includes radio buttons that help create a private or shared pipeline.

![Screenshot from 2023-02-09 12-32-17](https://user-images.githubusercontent.com/3420211/217833804-3f7e00c2-6df0-458c-a13a-ad63748dcd6f.png)

![Screenshot from 2023-02-09 12-32-41](https://user-images.githubusercontent.com/3420211/217833839-5272a036-c1eb-4cd8-8375-7dba6d64918f.png)

Similar to the pipelines list, the choose pipeline dialog has two tabs.

![Screenshot from 2023-02-09 12-33-07](https://user-images.githubusercontent.com/3420211/217834018-253c356b-a257-405c-ba84-769ec5f82be9.png)

![Screenshot from 2023-02-09 12-33-34](https://user-images.githubusercontent.com/3420211/217834025-0ffbf6ab-ba2b-41ac-b631-52200f3589d1.png)


Finally, the upload pipeline dialog includes radio buttons for a private and shared pipeline.

![Screenshot from 2023-02-09 12-33-56](https://user-images.githubusercontent.com/3420211/217834097-cadcd4e4-2082-49f0-9410-b0ce0214c9f2.png)

In single-user mode, the pipelines list page and the choose pipeline dialog have no tabs. The radio buttons should also be hidden.

Part of #4197
Closes #5084

/cc @jlyaoyuli @zijianjoy @chensun @StefanoFioravanzo @elikatsis