### PR TITLE
feat(sdk): Ignore upstream failure

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -16,6 +16,8 @@
 ## Features
 * Support fanning-in parameter outputs from a task in a `dsl.ParellelFor` context using `dsl.Collected` [\#8631](https://github.com/kubeflow/pipelines/pull/8631)
 
+* Introduces a new syntax for pipeline tasks to consume outputs from the upstream task while at the same time ignoring if the upstream tasks succeeds or not. [\#8838](https://github.com/kubeflow/pipelines/pull/8838)
+
 ## Breaking changes
 
 ## Deprecations

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -2913,9 +2913,9 @@ class TestValidIgnoreUpstreamTaskSyntax(unittest.TestCase):
         self.assertEqual(
             my_pipeline.pipeline_spec.root.dag.tasks['print-op'].trigger_policy
             .strategy, 2)
-        self.assertNotEqual(
+        self.assertEqual(
             my_pipeline.pipeline_spec.root.dag.tasks['fail-op'].trigger_policy
-            .strategy, 2)
+            .strategy, 0)
 
     def test_component_with_no_input_permitted(self):
 
@@ -2938,9 +2938,9 @@ class TestValidIgnoreUpstreamTaskSyntax(unittest.TestCase):
         self.assertEqual(
             my_pipeline.pipeline_spec.root.dag.tasks['print-op'].trigger_policy
             .strategy, 2)
-        self.assertNotEqual(
+        self.assertEqual(
             my_pipeline.pipeline_spec.root.dag.tasks['fail-op'].trigger_policy
-            .strategy, 2)
+            .strategy, 0)
 
     def test_clean_up_on_wrapped_pipeline_permitted(self):
 
@@ -2974,9 +2974,9 @@ class TestValidIgnoreUpstreamTaskSyntax(unittest.TestCase):
         self.assertEqual(
             my_pipeline.pipeline_spec.root.dag.tasks['print-op'].trigger_policy
             .strategy, 2)
-        self.assertNotEqual(
+        self.assertEqual(
             my_pipeline.pipeline_spec.root.dag.tasks['fail-op'].trigger_policy
-            .strategy, 2)
+            .strategy, 0)
 
     def test_clean_up_task_with_no_default_value_for_upstream_input_blocked(
             self):
@@ -2993,8 +2993,7 @@ class TestValidIgnoreUpstreamTaskSyntax(unittest.TestCase):
             print(message)
 
         with self.assertRaisesRegex(
-                ValueError,
-                r'requires a default value to make sure it never fails.'):
+                ValueError, r'Tasks can only use .ignore_upstream_failure()'):
 
             @dsl.pipeline()
             def my_pipeline(sample_input1: str = 'message'):
@@ -3025,9 +3024,9 @@ class TestValidIgnoreUpstreamTaskSyntax(unittest.TestCase):
         self.assertEqual(
             my_pipeline.pipeline_spec.root.dag.tasks['print-op'].trigger_policy
             .strategy, 2)
-        self.assertNotEqual(
+        self.assertEqual(
             my_pipeline.pipeline_spec.root.dag.tasks['fail-op'].trigger_policy
-            .strategy, 2)
+            .strategy, 0)
 
     def test_clean_up_task_with_no_default_value_for_constant_permitted(self):
 
@@ -3050,9 +3049,9 @@ class TestValidIgnoreUpstreamTaskSyntax(unittest.TestCase):
         self.assertEqual(
             my_pipeline.pipeline_spec.root.dag.tasks['print-op'].trigger_policy
             .strategy, 2)
-        self.assertNotEqual(
+        self.assertEqual(
             my_pipeline.pipeline_spec.root.dag.tasks['fail-op'].trigger_policy
-            .strategy, 2)
+            .strategy, 0)
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -300,6 +300,11 @@ def build_task_spec_for_task(
                 'str, int, float, bool, dict, and list.'
                 f'Got {input_value} of type {type(input_value)}.')
 
+        if task.ignore_upstream_failure_tag:
+            pipeline_task_spec.trigger_policy.strategy = (
+                pipeline_spec_pb2.PipelineTaskSpec.TriggerPolicy.TriggerStrategy
+                .ALL_UPSTREAM_TASKS_COMPLETED)
+
     return pipeline_task_spec
 
 

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -300,10 +300,11 @@ def build_task_spec_for_task(
                 'str, int, float, bool, dict, and list.'
                 f'Got {input_value} of type {type(input_value)}.')
 
-        if task.ignore_upstream_failure_tag:
-            pipeline_task_spec.trigger_policy.strategy = (
-                pipeline_spec_pb2.PipelineTaskSpec.TriggerPolicy.TriggerStrategy
-                .ALL_UPSTREAM_TASKS_COMPLETED)
+    if task._ignore_upstream_failure_tag:
+        print('hereee')
+        pipeline_task_spec.trigger_policy.strategy = (
+            pipeline_spec_pb2.PipelineTaskSpec.TriggerPolicy.TriggerStrategy
+            .ALL_UPSTREAM_TASKS_COMPLETED)
 
     return pipeline_task_spec
 

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -301,7 +301,6 @@ def build_task_spec_for_task(
                 f'Got {input_value} of type {type(input_value)}.')
 
     if task._ignore_upstream_failure_tag:
-        print('hereee')
         pipeline_task_spec.trigger_policy.strategy = (
             pipeline_spec_pb2.PipelineTaskSpec.TriggerPolicy.TriggerStrategy
             .ALL_UPSTREAM_TASKS_COMPLETED)

--- a/sdk/python/kfp/components/pipeline_task.py
+++ b/sdk/python/kfp/components/pipeline_task.py
@@ -482,7 +482,7 @@ class PipelineTask:
         This method effectively turns the caller task into an exit task
         if the caller task has upstream dependencies.
 
-        "If the task has no upstream tasks, either via data exchange or an explicit dependency via .after(), this method has no effect."
+        If the task has no upstream tasks, either via data exchange or an explicit dependency via .after(), this method has no effect.
 
         Returns:
             Self return to allow chained setting calls.
@@ -491,8 +491,8 @@ class PipelineTask:
           ::
 
             @dsl.pipeline()
-            def my_pipeline(sample_input1: str = 'message'):
-                task = fail_op(message=sample_input1)
+            def my_pipeline(text: str = 'message'):
+                task = fail_op(message=text)
                 clean_up_task = print_op(
                     message=task.output).ignore_upstream_failure()
         """
@@ -504,7 +504,7 @@ class PipelineTask:
                ) and (not input_spec.optional) and (argument_value.task_name
                                                     is not None):
                 raise ValueError(
-                    f' Task {self.name} requires a default value to make sure it never fails.'
+                    f'Tasks can only use .ignore_upstream_failure() if all input parameters that accept arguments created by an upstream task have a default value, \n\tin case the upstream task fails to produce its output. Input parameter task {self.name}`s {input_spec_name!r} argument is an output of an upstream task {argument_value.task_name}, but {input_spec_name} has no default value.'
                 )
 
         self._ignore_upstream_failure_tag = True

--- a/sdk/python/kfp/components/pipeline_task.py
+++ b/sdk/python/kfp/components/pipeline_task.py
@@ -504,7 +504,7 @@ class PipelineTask:
                ) and (not input_spec.optional) and (argument_value.task_name
                                                     is not None):
                 raise ValueError(
-                    f'Tasks can only use .ignore_upstream_failure() if all input parameters that accept arguments created by an upstream task have a default value, \n\tin case the upstream task fails to produce its output. Input parameter task {self.name}`s {input_spec_name!r} argument is an output of an upstream task {argument_value.task_name}, but {input_spec_name} has no default value.'
+                    f'Tasks can only use .ignore_upstream_failure() if all input parameters that accept arguments created by an upstream task have a default value, in case the upstream task fails to produce its output. Input parameter task {self.name!r}`s {input_spec_name!r} argument is an output of an upstream task {argument_value.task_name!r}, but {input_spec_name!r} has no default value.'
                 )
 
         self._ignore_upstream_failure_tag = True

--- a/sdk/python/test_data/pipelines/pipeline_with_task_using_ignore_upstream_failure.py
+++ b/sdk/python/test_data/pipelines/pipeline_with_task_using_ignore_upstream_failure.py
@@ -1,0 +1,43 @@
+# Copyright 2023 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kfp import compiler
+from kfp import dsl
+
+
+@dsl.component
+def fail_op(message: str) -> str:
+    """Fails."""
+    import sys
+    print(message)
+    sys.exit(1)
+    return message
+
+
+@dsl.component
+def print_op(message: str = 'default'):
+    """Prints a message."""
+    print(message)
+
+
+@dsl.pipeline()
+def my_pipeline(sample_input: str = 'message'):
+    task = fail_op(message=sample_input)
+    clean_up_task = print_op(message=task.output).ignore_upstream_failure()
+
+
+if __name__ == '__main__':
+    compiler.Compiler().compile(
+        pipeline_func=my_pipeline,
+        package_path=__file__.replace('.py', '.yaml'))

--- a/sdk/python/test_data/pipelines/pipeline_with_task_using_ignore_upstream_failure.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_task_using_ignore_upstream_failure.yaml
@@ -74,7 +74,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_op(message: str = \"default\"):\n    \"\"\"Prints a message.\"\
+          \ *\n\ndef print_op(message: str = 'default'):\n    \"\"\"Prints a message.\"\
           \"\"\n    print(message)\n\n"
         image: python:3.7
 pipelineInfo:

--- a/sdk/python/test_data/pipelines/pipeline_with_task_using_ignore_upstream_failure.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_task_using_ignore_upstream_failure.yaml
@@ -1,0 +1,120 @@
+# PIPELINE DEFINITION
+# Name: my-pipeline
+# Inputs:
+#    sample_input: str [Default: 'message']
+components:
+  comp-fail-op:
+    executorLabel: exec-fail-op
+    inputDefinitions:
+      parameters:
+        message:
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        Output:
+          parameterType: STRING
+  comp-print-op:
+    executorLabel: exec-print-op
+    inputDefinitions:
+      parameters:
+        message:
+          defaultValue: default
+          isOptional: true
+          parameterType: STRING
+deploymentSpec:
+  executors:
+    exec-fail-op:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - fail_op
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.12'\
+          \ && \"$0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef fail_op(message: str) -> str:\n    \"\"\"Fails.\"\"\"\n    import\
+          \ sys\n    print(message)\n    sys.exit(1)\n    return message\n\n"
+        image: python:3.7
+    exec-print-op:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - print_op
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-beta.12'\
+          \ && \"$0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef print_op(message: str = \"default\"):\n    \"\"\"Prints a message.\"\
+          \"\"\n    print(message)\n\n"
+        image: python:3.7
+pipelineInfo:
+  name: my-pipeline
+root:
+  dag:
+    tasks:
+      fail-op:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-fail-op
+        inputs:
+          parameters:
+            message:
+              componentInputParameter: sample_input
+        taskInfo:
+          name: fail-op
+      print-op:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-print-op
+        dependentTasks:
+        - fail-op
+        inputs:
+          parameters:
+            message:
+              taskOutputParameter:
+                outputParameterKey: Output
+                producerTask: fail-op
+        taskInfo:
+          name: print-op
+        triggerPolicy:
+          strategy: ALL_UPSTREAM_TASKS_COMPLETED
+  inputDefinitions:
+    parameters:
+      sample_input:
+        defaultValue: message
+        isOptional: true
+        parameterType: STRING
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.0.0-beta.12

--- a/sdk/python/test_data/test_data_config.yaml
+++ b/sdk/python/test_data/test_data_config.yaml
@@ -156,6 +156,9 @@ pipelines:
     - module: parallelfor_fan_in/conditional_producer_and_consumers
       name: math_pipeline
       execute: false
+    - module: pipeline_with_task_using_ignore_upstream_failure
+      name: my_pipeline
+      execute: false
 components:
   test_data_dir: sdk/python/test_data/components
   read: true


### PR DESCRIPTION
Introduces a new syntax for pipeline tasks to consume outputs from the upstream task while at the same time ignoring if the upstream tasks succeeds or not. Similar to an exit handler but with the included ability to parse inputs to the exit task.

sample syntax
```
@dsl.pipeline()
def my_pipeline(sample_input1: str = 'message'):
    task = fail_op(message=sample_input1)
    clean_up = print_op(message=task.output).ignore_upstream_failure()
```


**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
