### PR TITLE
chore(frontend): Support v1 and v2 API request simultaneously in the frontend server

### DIFF
--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -93,7 +93,7 @@ function createUIServer(options: UIConfigs) {
   const currDir = path.resolve(__dirname);
   const basePath = options.server.basePath;
   const apiVersion1Prefix = options.server.apiVersion1Prefix;
-  const apiVersion2Prefix = options.server.apiVersion1Prefix;
+  const apiVersion2Prefix = options.server.apiVersion2Prefix;
   const apiServerAddress = getAddress(options.pipeline);
   const envoyServiceAddress = getAddress(options.metadata.envoyService);
 
@@ -112,6 +112,15 @@ function createUIServer(options: UIConfigs) {
     `/${apiVersion1Prefix}/healthz`,
     getHealthzHandler({
       healthzEndpoint: getHealthzEndpoint(apiServerAddress, apiVersion1Prefix),
+      healthzStats: getBuildMetadata(currDir),
+    }),
+  );
+
+  registerHandler(
+    app.get,
+    `/${apiVersion2Prefix}/healthz`,
+    getHealthzHandler({
+      healthzEndpoint: getHealthzEndpoint(apiServerAddress, apiVersion2Prefix),
       healthzStats: getBuildMetadata(currDir),
     }),
   );

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -92,7 +92,8 @@ export class UIServer {
 function createUIServer(options: UIConfigs) {
   const currDir = path.resolve(__dirname);
   const basePath = options.server.basePath;
-  const apiVersionPrefix = options.server.apiVersionPrefix;
+  const apiVersion1Prefix = options.server.apiVersion1Prefix;
+  const apiVersion2Prefix = options.server.apiVersion1Prefix;
   const apiServerAddress = getAddress(options.pipeline);
   const envoyServiceAddress = getAddress(options.metadata.envoyService);
 
@@ -108,9 +109,9 @@ function createUIServer(options: UIConfigs) {
   /** Healthz */
   registerHandler(
     app.get,
-    `/${apiVersionPrefix}/healthz`,
+    `/${apiVersion1Prefix}/healthz`,
     getHealthzHandler({
-      healthzEndpoint: getHealthzEndpoint(apiServerAddress, apiVersionPrefix),
+      healthzEndpoint: getHealthzEndpoint(apiServerAddress, apiVersion1Prefix),
       healthzStats: getBuildMetadata(currDir),
     }),
   );
@@ -177,7 +178,7 @@ function createUIServer(options: UIConfigs) {
           /** Argo nodeId is just POD name */
           const nodeId = req.query.podname;
           const runId = req.query.runid;
-          return `/${apiVersionPrefix}/runs/${runId}/nodes/${nodeId}/log`;
+          return `/${apiVersion1Prefix}/runs/${runId}/nodes/${nodeId}/log`;
         },
         target: apiServerAddress,
       }),
@@ -218,9 +219,9 @@ function createUIServer(options: UIConfigs) {
     app.use,
     [
       // Original API endpoint is /runs/{run_id}:reportMetrics, but ':reportMetrics' means a url parameter, so we don't use : here.
-      `/${apiVersionPrefix}/runs/*reportMetrics`,
-      `/${apiVersionPrefix}/workflows`,
-      `/${apiVersionPrefix}/scheduledworkflows`,
+      `/${apiVersion1Prefix}/runs/*reportMetrics`,
+      `/${apiVersion1Prefix}/workflows`,
+      `/${apiVersion1Prefix}/scheduledworkflows`,
     ],
     (req, res) => {
       res.status(403).send(`${req.originalUrl} endpoint is not meant for external usage.`);
@@ -229,12 +230,12 @@ function createUIServer(options: UIConfigs) {
 
   // Order matters here, since both handlers can match any proxied request with a referer,
   // and we prioritize the basepath-friendly handler
-  proxyMiddleware(app, `${basePath}/${apiVersionPrefix}`);
-  proxyMiddleware(app, `/${apiVersionPrefix}`);
+  proxyMiddleware(app, `${basePath}/${apiVersion1Prefix}`);
+  proxyMiddleware(app, `/${apiVersion1Prefix}`);
 
   /** Proxy to ml-pipeline api server */
   app.all(
-    `/${apiVersionPrefix}/*`,
+    `/${apiVersion1Prefix}/*`,
     proxy({
       changeOrigin: true,
       onProxyReq: proxyReq => {
@@ -245,7 +246,32 @@ function createUIServer(options: UIConfigs) {
     }),
   );
   app.all(
-    `${basePath}/${apiVersionPrefix}/*`,
+    `/${apiVersion2Prefix}/*`,
+    proxy({
+      changeOrigin: true,
+      onProxyReq: proxyReq => {
+        console.log('Proxied request: ', proxyReq.path);
+      },
+      headers: HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS,
+      target: apiServerAddress,
+    }),
+  );
+
+  app.all(
+    `${basePath}/${apiVersion1Prefix}/*`,
+    proxy({
+      changeOrigin: true,
+      onProxyReq: proxyReq => {
+        console.log('Proxied request: ', proxyReq.path);
+      },
+      headers: HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS,
+      pathRewrite: pathStr =>
+        pathStr.startsWith(basePath) ? pathStr.substr(basePath.length, pathStr.length) : pathStr,
+      target: apiServerAddress,
+    }),
+  );
+  app.all(
+    `${basePath}/${apiVersion2Prefix}/*`,
     proxy({
       changeOrigin: true,
       onProxyReq: proxyReq => {

--- a/frontend/server/configs.ts
+++ b/frontend/server/configs.ts
@@ -17,8 +17,8 @@ import { loadArtifactsProxyConfig, ArtifactsProxyConfig } from './handlers/artif
 export const BASEPATH = '/pipeline';
 export const apiVersion1 = 'v1beta1';
 export const apiVersion1Prefix = `apis/${apiVersion1}`;
-export const apiVersion = 'v1beta1';
-export const apiVersion2Prefix = `apis/${apiVersion1}`;
+export const apiVersion2 = 'v2beta1';
+export const apiVersion2Prefix = `apis/${apiVersion2}`;
 
 export enum Deployments {
   NOT_SPECIFIED = 'NOT_SPECIFIED',

--- a/frontend/server/configs.ts
+++ b/frontend/server/configs.ts
@@ -15,8 +15,10 @@ import * as path from 'path';
 import { loadJSON } from './utils';
 import { loadArtifactsProxyConfig, ArtifactsProxyConfig } from './handlers/artifacts';
 export const BASEPATH = '/pipeline';
+export const apiVersion1 = 'v1beta1';
+export const apiVersion1Prefix = `apis/${apiVersion1}`;
 export const apiVersion = 'v1beta1';
-export const apiVersionPrefix = `apis/${apiVersion}`;
+export const apiVersion2Prefix = `apis/${apiVersion1}`;
 
 export enum Deployments {
   NOT_SPECIFIED = 'NOT_SPECIFIED',
@@ -160,7 +162,8 @@ export function loadConfigs(argv: string[], env: ProcessEnv): UIConfigs {
       port: ML_PIPELINE_SERVICE_PORT,
     },
     server: {
-      apiVersionPrefix,
+      apiVersion1Prefix,
+      apiVersion2Prefix,
       basePath: BASEPATH,
       deployment:
         DEPLOYMENT_STR.toUpperCase() === Deployments.KUBEFLOW
@@ -245,7 +248,8 @@ export interface ServerConfigs {
   basePath: string;
   port: string | number;
   staticDir: string;
-  apiVersionPrefix: string;
+  apiVersion1Prefix: string;
+  apiVersion2Prefix: string;
   deployment: Deployments;
   hideSideNav: boolean;
 }


### PR DESCRIPTION
Currently, the frontend server can only proxy either v1 or v2 API request to backend. The main changes of this PR as follow:

1. Separate v1 and v2 API version and version prefix in `configs.ts`
2. Add additional logic in `app.ts` for proxying v2 API request.


https://user-images.githubusercontent.com/56132941/219529919-ebab5c3f-c982-4fb4-8361-9dc36299d9cf.mov


