### PR TITLE
fix(sdk): fix unknown artifact string in dsl.OutputPath/dsl.InputPath

### DIFF
--- a/sdk/python/kfp/components/component_factory_test.py
+++ b/sdk/python/kfp/components/component_factory_test.py
@@ -19,7 +19,11 @@ from kfp import dsl
 from kfp.components import component_factory
 from kfp.components import structures
 from kfp.components.component_decorator import component
+from kfp.components.types.artifact_types import Artifact
+from kfp.components.types.artifact_types import Model
 from kfp.components.types.type_annotations import OutputPath
+from kfp.dsl import Input
+from kfp.dsl import Output
 
 
 class TestGetPackagesToInstallCommand(unittest.TestCase):
@@ -70,12 +74,6 @@ class TestInvalidParameterName(unittest.TestCase):
             @component
             def comp(Output: OutputPath(str), text: str) -> str:
                 pass
-
-
-from kfp.components.types.artifact_types import Artifact
-from kfp.components.types.artifact_types import Model
-from kfp.dsl import Input
-from kfp.dsl import Output
 
 
 class TestExtractComponentInterfaceListofArtifacts(unittest.TestCase):
@@ -131,6 +129,41 @@ class TestExtractComponentInterfaceListofArtifacts(unittest.TestCase):
                         default=None,
                         is_artifact_list=True)
             })
+
+
+class TestArtifactStringInInputpathOutputpath(unittest.TestCase):
+
+    def test_unknown(self):
+
+        @dsl.component
+        def comp(
+                i: dsl.InputPath('MyCustomType'),
+                o: dsl.OutputPath('MyCustomType'),
+        ):
+            ...
+
+        self.assertEqual(comp.component_spec.outputs['o'].type,
+                         'system.Artifact@0.0.1')
+        self.assertFalse(comp.component_spec.outputs['o'].is_artifact_list)
+        self.assertEqual(comp.component_spec.inputs['i'].type,
+                         'system.Artifact@0.0.1')
+        self.assertFalse(comp.component_spec.inputs['i'].is_artifact_list)
+
+    def test_known_v1_back_compat(self):
+
+        @dsl.component
+        def comp(
+                i: dsl.InputPath('Dataset'),
+                o: dsl.OutputPath('Dataset'),
+        ):
+            ...
+
+        self.assertEqual(comp.component_spec.outputs['o'].type,
+                         'system.Dataset@0.0.1')
+        self.assertFalse(comp.component_spec.outputs['o'].is_artifact_list)
+        self.assertEqual(comp.component_spec.inputs['i'].type,
+                         'system.Dataset@0.0.1')
+        self.assertFalse(comp.component_spec.inputs['i'].is_artifact_list)
 
 
 class TestOutputListsOfArtifactsTemporarilyBlocked(unittest.TestCase):

--- a/sdk/python/kfp/components/types/type_annotations.py
+++ b/sdk/python/kfp/components/types/type_annotations.py
@@ -106,11 +106,15 @@ def construct_type_for_inputpath_or_outputpath(
     elif isinstance(
             type_,
             str) and type_.lower() in type_utils._ARTIFACT_CLASSES_MAPPING:
-        # v1 artifact backward compat
+        # v1 artifact backward compat, e.g. dsl.OutputPath('Dataset')
         return type_utils.create_bundled_artifact_type(
             type_utils._ARTIFACT_CLASSES_MAPPING[type_.lower()].schema_title)
-    else:
+    elif type_utils.get_parameter_type(type_):
         return type_
+    else:
+        # v1 unknown type dsl.OutputPath('MyCustomType')
+        return type_utils.create_bundled_artifact_type(
+            artifact_types.Artifact.schema_title)
 
 
 class InputAnnotation:


### PR DESCRIPTION
**Description of your changes:**
Fixes a regression since `2.0.0b4` where use of `dsl.OutputPath('MyCustomType')` cannot be compiled. Same for `dsl.InputPath`. With this fix the input/output type is represented as a `system.Artifact`, consistent with the last working implementation.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about 
the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
