### PR TITLE
fix(manifests): disable mysql binlog

### DIFF
--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/mysql.yaml
@@ -188,9 +188,9 @@ spec:
           # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin
           # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_authentication_policy
           - --default-authentication-plugin=mysql_native_password
-          # Set binlog expire to 10 days to restore the default behavior in MySQL 5.7.
-          # https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_expire_logs_seconds
-          - --binlog-expire-logs-seconds=864000
+          # Disable binlog as the logs grow fast and eat up all disk spaces eventually. And KFP doesn't currently utilize binlog.
+          # https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#option_mysqld_log-bin
+          - --disable-log-bin
           env:
             - name: MYSQL_ALLOW_EMPTY_PASSWORD
               value: "true"

--- a/manifests/gcp_marketplace/test/snapshot-base.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-base.yaml
@@ -2714,7 +2714,7 @@ metadata:
 spec:
   descriptor:
     type: Kubeflow Pipelines
-    version: 2.0.0-alpha.6
+    version: 2.0.0-beta.0
     description: |-
       Reusable end-to-end ML workflow
     maintainers:

--- a/manifests/gcp_marketplace/test/snapshot-base.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-base.yaml
@@ -2357,9 +2357,9 @@ spec:
           # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin
           # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_authentication_policy
           - --default-authentication-plugin=mysql_native_password
-          # Set binlog expire to 10 days to restore the default behavior in MySQL 5.7.
-          # https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_expire_logs_seconds
-          - --binlog-expire-logs-seconds=864000
+          # Disable binlog as the logs grow fast and eat up all disk spaces eventually. And KFP doesn't currently utilize binlog.
+          # https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#option_mysqld_log-bin
+          - --disable-log-bin
           env:
             - name: MYSQL_ALLOW_EMPTY_PASSWORD
               value: "true"

--- a/manifests/gcp_marketplace/test/snapshot-emissary.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-emissary.yaml
@@ -2714,7 +2714,7 @@ metadata:
 spec:
   descriptor:
     type: Kubeflow Pipelines
-    version: 2.0.0-alpha.6
+    version: 2.0.0-beta.0
     description: |-
       Reusable end-to-end ML workflow
     maintainers:

--- a/manifests/gcp_marketplace/test/snapshot-emissary.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-emissary.yaml
@@ -2357,9 +2357,9 @@ spec:
           # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin
           # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_authentication_policy
           - --default-authentication-plugin=mysql_native_password
-          # Set binlog expire to 10 days to restore the default behavior in MySQL 5.7.
-          # https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_expire_logs_seconds
-          - --binlog-expire-logs-seconds=864000
+          # Disable binlog as the logs grow fast and eat up all disk spaces eventually. And KFP doesn't currently utilize binlog.
+          # https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#option_mysqld_log-bin
+          - --disable-log-bin
           env:
             - name: MYSQL_ALLOW_EMPTY_PASSWORD
               value: "true"

--- a/manifests/gcp_marketplace/test/snapshot-managed-storage-with-db-prefix.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-managed-storage-with-db-prefix.yaml
@@ -2764,7 +2764,7 @@ metadata:
 spec:
   descriptor:
     type: Kubeflow Pipelines
-    version: 2.0.0-alpha.6
+    version: 2.0.0-beta.0
     description: |-
       Reusable end-to-end ML workflow
     maintainers:

--- a/manifests/gcp_marketplace/test/snapshot-managed-storage.yaml
+++ b/manifests/gcp_marketplace/test/snapshot-managed-storage.yaml
@@ -2764,7 +2764,7 @@ metadata:
 spec:
   descriptor:
     type: Kubeflow Pipelines
-    version: 2.0.0-alpha.6
+    version: 2.0.0-beta.0
     description: |-
       Reusable end-to-end ML workflow
     maintainers:

--- a/manifests/kustomize/third-party/mysql/base/mysql-deployment.yaml
+++ b/manifests/kustomize/third-party/mysql/base/mysql-deployment.yaml
@@ -42,9 +42,9 @@ spec:
         # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin
         # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_authentication_policy
         - --default-authentication-plugin=mysql_native_password
-        # Set binlog expire to 10 days to restore the default behavior in MySQL 5.7.
-        # https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_expire_logs_seconds
-        - --binlog-expire-logs-seconds=864000
+        # Disable binlog as the logs grow fast and eat up all disk spaces eventually. And KFP doesn't currently utilize binlog.
+        # https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#option_mysqld_log-bin
+        - --disable-log-bin
         env:
         - name: MYSQL_ALLOW_EMPTY_PASSWORD
           value: "true"


### PR DESCRIPTION
**Description of your changes:**
Follow up on https://github.com/kubeflow/pipelines/pull/8553, the reduction in log expiration appears to be insufficient. Disable binlog as we don't really use it at this moment.
Part of https://github.com/kubeflow/manifests/issues/2402

Manually tested in my own cluster, verified that binlog is disabled after the change:
```shell
mysql> SHOW BINARY LOGS;
ERROR 1381 (HY000): You are not using binary logging
mysql> SHOW MASTER LOGS;
ERROR 1381 (HY000): You are not using binary logging
```

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
