### PR TITLE
chore(frontend): Use v2 filter in listExperiment() v2 API

### DIFF
--- a/frontend/src/components/CustomTable.test.tsx
+++ b/frontend/src/components/CustomTable.test.tsx
@@ -18,7 +18,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import * as React from 'react';
 import CustomTable, { Column, ExpandState, Row, css } from './CustomTable';
 import TestUtils from '../TestUtils';
-import { PredicateOp } from '../apis/filter';
+import { V2beta1PredicateOperation } from '../apisv2beta1/filter';
 import { shallow } from 'enzyme';
 
 const props = {
@@ -721,7 +721,7 @@ describe('CustomTable', () => {
         predicates: [
           {
             key: 'name',
-            op: PredicateOp.ISSUBSTRING,
+            operation: V2beta1PredicateOperation.ISSUBSTRING,
             string_value: 'test filter',
           },
         ],
@@ -759,7 +759,7 @@ describe('CustomTable', () => {
         predicates: [
           {
             key: 'name',
-            op: PredicateOp.ISSUBSTRING,
+            operation: V2beta1PredicateOperation.ISSUBSTRING,
             string_value: 'test filter',
           },
         ],

--- a/frontend/src/components/CustomTable.test.tsx
+++ b/frontend/src/components/CustomTable.test.tsx
@@ -18,7 +18,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import * as React from 'react';
 import CustomTable, { Column, ExpandState, Row, css } from './CustomTable';
 import TestUtils from '../TestUtils';
-import { V2beta1PredicateOperation } from '../apisv2beta1/filter';
+import { PredicateOp } from '../apis/filter';
 import { shallow } from 'enzyme';
 
 const props = {
@@ -721,7 +721,7 @@ describe('CustomTable', () => {
         predicates: [
           {
             key: 'name',
-            operation: V2beta1PredicateOperation.ISSUBSTRING,
+            op: PredicateOp.ISSUBSTRING,
             string_value: 'test filter',
           },
         ],
@@ -759,7 +759,7 @@ describe('CustomTable', () => {
         predicates: [
           {
             key: 'name',
-            operation: V2beta1PredicateOperation.ISSUBSTRING,
+            op: PredicateOp.ISSUBSTRING,
             string_value: 'test filter',
           },
         ],

--- a/frontend/src/components/CustomTable.tsx
+++ b/frontend/src/components/CustomTable.tsx
@@ -33,10 +33,10 @@ import { ListRequest } from '../lib/Apis';
 import { classes, stylesheet } from 'typestyle';
 import { fonts, fontsize, dimension, commonCss, color, padding, zIndex } from '../Css';
 import { logger } from '../lib/Utils';
-import { ApiFilter, PredicateOp } from '../apis/filter/api';
 import { debounce } from 'lodash';
 import { InputAdornment } from '@material-ui/core';
 import { CustomTableRow } from './CustomTableRow';
+import { V2beta1Filter, V2beta1PredicateOperation } from 'src/apisv2beta1/filter';
 
 export enum ExpandState {
   COLLAPSED,
@@ -527,12 +527,12 @@ export default class CustomTable extends React.Component<CustomTableProps, Custo
   }
 
   private _createAndEncodeFilter(filterString: string): string {
-    const filter: ApiFilter = {
+    const filter: V2beta1Filter = {
       predicates: [
         {
           // TODO: remove this hardcoding once more sophisticated filtering is supported
           key: 'name',
-          op: PredicateOp.ISSUBSTRING,
+          operation: V2beta1PredicateOperation.ISSUBSTRING,
           string_value: filterString,
         },
       ],

--- a/frontend/src/components/CustomTable.tsx
+++ b/frontend/src/components/CustomTable.tsx
@@ -33,10 +33,10 @@ import { ListRequest } from '../lib/Apis';
 import { classes, stylesheet } from 'typestyle';
 import { fonts, fontsize, dimension, commonCss, color, padding, zIndex } from '../Css';
 import { logger } from '../lib/Utils';
+import { ApiFilter, PredicateOp } from '../apis/filter/api';
 import { debounce } from 'lodash';
 import { InputAdornment } from '@material-ui/core';
 import { CustomTableRow } from './CustomTableRow';
-import { V2beta1Filter, V2beta1PredicateOperation } from 'src/apisv2beta1/filter';
 
 export enum ExpandState {
   COLLAPSED,
@@ -527,12 +527,12 @@ export default class CustomTable extends React.Component<CustomTableProps, Custo
   }
 
   private _createAndEncodeFilter(filterString: string): string {
-    const filter: V2beta1Filter = {
+    const filter: ApiFilter = {
       predicates: [
         {
           // TODO: remove this hardcoding once more sophisticated filtering is supported
           key: 'name',
-          operation: V2beta1PredicateOperation.ISSUBSTRING,
+          op: PredicateOp.ISSUBSTRING,
           string_value: filterString,
         },
       ],

--- a/frontend/src/pages/ExperimentList.test.tsx
+++ b/frontend/src/pages/ExperimentList.test.tsx
@@ -18,7 +18,6 @@ import * as React from 'react';
 import * as Utils from '../lib/Utils';
 import EnhancedExperimentList, { ExperimentList } from './ExperimentList';
 import TestUtils from '../TestUtils';
-import { ApiFilter, PredicateOp } from '../apis/filter';
 import { ApiRunStorageState } from '../apis/run';
 import { Apis } from '../lib/Apis';
 import { ExpandState } from '../components/CustomTable';

--- a/frontend/src/pages/ExperimentList.test.tsx
+++ b/frontend/src/pages/ExperimentList.test.tsx
@@ -32,6 +32,7 @@ import { NamespaceContext } from 'src/lib/KubeflowClient';
 import { render, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { V2beta1ExperimentStorageState } from '../apisv2beta1/experiment';
+import { V2beta1Filter, V2beta1PredicateOperation } from 'src/apisv2beta1/filter';
 
 // Default arguments for Apis.experimentServiceApi.listExperiment.
 const LIST_EXPERIMENT_DEFAULTS = [
@@ -43,11 +44,11 @@ const LIST_EXPERIMENT_DEFAULTS = [
       predicates: [
         {
           key: 'storage_state',
-          op: PredicateOp.NOTEQUALS,
+          operation: V2beta1PredicateOperation.NOTEQUALS,
           string_value: V2beta1ExperimentStorageState.ARCHIVED.toString(),
         },
       ],
-    } as ApiFilter),
+    } as V2beta1Filter),
   ), // filter
   undefined, // resource_reference_key_type
   undefined, // resource_reference_key_id
@@ -184,11 +185,11 @@ describe('ExperimentList', () => {
           predicates: [
             {
               key: 'storage_state',
-              op: PredicateOp.NOTEQUALS,
+              operation: V2beta1PredicateOperation.NOTEQUALS,
               string_value: ApiRunStorageState.ARCHIVED.toString(),
             },
           ],
-        } as ApiFilter),
+        } as V2beta1Filter),
       ),
     );
     expect(tree.state()).toHaveProperty('displayExperiments', [

--- a/frontend/src/pages/ExperimentList.tsx
+++ b/frontend/src/pages/ExperimentList.tsx
@@ -24,12 +24,12 @@ import CustomTable, {
 } from '../components/CustomTable';
 import RunList from './RunList';
 import produce from 'immer';
-import { ApiFilter, PredicateOp } from '../apis/filter';
 import {
   V2beta1ListExperimentsResponse,
   V2beta1Experiment,
   V2beta1ExperimentStorageState,
 } from 'src/apisv2beta1/experiment';
+import { V2beta1Filter, V2beta1PredicateOperation } from 'src/apisv2beta1/filter';
 import { ApiRun, ApiRunStorageState } from '../apis/run';
 import { Apis, ExperimentSortKeys, ListRequest, RunSortKeys } from '../lib/Apis';
 import { Link } from 'react-router-dom';
@@ -186,11 +186,11 @@ export class ExperimentList extends Page<{ namespace?: string }, ExperimentListS
       // Archived experiments are listed in "Archive" page.
       const filter = JSON.parse(
         decodeURIComponent(request.filter || '{"predicates": []}'),
-      ) as ApiFilter;
+      ) as V2beta1Filter;
       filter.predicates = (filter.predicates || []).concat([
         {
           key: 'storage_state',
-          op: PredicateOp.NOTEQUALS,
+          operation: V2beta1PredicateOperation.NOTEQUALS,
           string_value: V2beta1ExperimentStorageState.ARCHIVED.toString(),
         },
       ]);
@@ -227,11 +227,11 @@ export class ExperimentList extends Page<{ namespace?: string }, ExperimentListS
                 predicates: [
                   {
                     key: 'storage_state',
-                    op: PredicateOp.NOTEQUALS,
+                    operation: V2beta1PredicateOperation.NOTEQUALS,
                     string_value: ApiRunStorageState.ARCHIVED.toString(),
                   },
                 ],
-              } as ApiFilter),
+              } as V2beta1Filter),
             ),
           );
           experiment.last5Runs = listRunsResponse.runs || [];


### PR DESCRIPTION
The main purpose of this PR is change the old filter in listExperiment() v2 API. Also, it can validate the frontend integration tests in https://github.com/kubeflow/pipelines/pull/8939