### PR TITLE
fix: support setting task dependencies via kfp.kubernetes.mount_pvc

### DIFF
--- a/kubernetes_platform/python/test/snapshot/data/create_mount_delete_dynamic_pvc.yaml
+++ b/kubernetes_platform/python/test/snapshot/data/create_mount_delete_dynamic_pvc.yaml
@@ -109,6 +109,8 @@ root:
           enableCache: true
         componentRef:
           name: comp-comp
+        dependentTasks:
+        - createpvc
         taskInfo:
           name: comp
       comp-2:
@@ -118,6 +120,7 @@ root:
           name: comp-comp-2
         dependentTasks:
         - comp
+        - createpvc
         taskInfo:
           name: comp-2
       createpvc:

--- a/kubernetes_platform/python/test/snapshot/data/create_mount_delete_existing_pvc.yaml
+++ b/kubernetes_platform/python/test/snapshot/data/create_mount_delete_existing_pvc.yaml
@@ -81,6 +81,8 @@ root:
           enableCache: true
         componentRef:
           name: comp-comp
+        dependentTasks:
+        - createpvc
         taskInfo:
           name: comp
       createpvc:

--- a/kubernetes_platform/python/test/snapshot/data/create_mount_delete_existing_pvc_from_task_output.yaml
+++ b/kubernetes_platform/python/test/snapshot/data/create_mount_delete_existing_pvc_from_task_output.yaml
@@ -113,6 +113,8 @@ root:
           enableCache: true
         componentRef:
           name: comp-comp
+        dependentTasks:
+        - createpvc
         taskInfo:
           name: comp
       createpvc:

--- a/sdk/python/kfp/components/pipeline_channel.py
+++ b/sdk/python/kfp/components/pipeline_channel.py
@@ -97,6 +97,14 @@ class PipelineChannel(abc.ABC):
         # so that serialization and unserialization remain consistent
         # (i.e. None => '' => None)
         self.task_name = task_name or None
+        from kfp.components import pipeline_context
+
+        default_pipeline = pipeline_context.Pipeline.get_default_pipeline()
+        if self.task_name is not None and default_pipeline is not None and default_pipeline.tasks:
+            self.task = pipeline_context.Pipeline.get_default_pipeline().tasks[
+                self.task_name]
+        else:
+            self.task = None
 
     @property
     def full_name(self) -> str:

--- a/sdk/python/kfp/components/pipeline_channel_test.py
+++ b/sdk/python/kfp/components/pipeline_channel_test.py
@@ -16,6 +16,7 @@
 import unittest
 
 from absl.testing import parameterized
+from kfp import dsl
 from kfp.components import pipeline_channel
 
 
@@ -153,6 +154,20 @@ class PipelineChannelTest(parameterized.TestCase):
         ]
         params = pipeline_channel.extract_pipeline_channels_from_any(payload)
         self.assertListEqual([p1, p2, p3], params)
+
+
+class TestCanAccessTask(unittest.TestCase):
+
+    def test(self):
+
+        @dsl.component
+        def comp() -> str:
+            return 'text'
+
+        @dsl.pipeline
+        def my_pipeline():
+            op1 = comp()
+            self.assertEqual(op1.output.task, op1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of your changes:**
Fixes a bug where `kfp.kubernetes.mount_pvc` doesn't set task dependencies when `pvc_name` is produced by an upstream task.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request 
title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
