### PR TITLE
test: Update frontend-integration-test image

### DIFF
--- a/test/frontend-integration-test/Dockerfile
+++ b/test/frontend-integration-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/ml-pipeline-test/selenium-standalone-chrome-gcloud-nodejs:v20230201-2.0.0b11-74-g395719cab-dirty-9bed65
+FROM gcr.io/ml-pipeline-test/selenium-standalone-chrome-gcloud-nodejs:v20230322-2.0.0b11-144-g87e1c5fcf-dirty-2ca4f7
 #To build this image: cd selenium-standalone-chrome-gcloud-nodejs.Docker && make push
 
 COPY --chown=seluser . /src

--- a/test/frontend-integration-test/selenium-standalone-chrome-gcloud-nodejs.Docker/Dockerfile
+++ b/test/frontend-integration-test/selenium-standalone-chrome-gcloud-nodejs.Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/standalone-chrome:109.0.5414.119-chromedriver-109.0.5414.74-20230131
+FROM selenium/standalone-chrome:110.0.5481.177-chromedriver-110.0.5481.77
 
 USER root
 
@@ -25,7 +25,7 @@ RUN apt-get update -qqy && apt-get install -qqy \
     rm -rf /var/lib/apt/lists/* /tmp/* /usr/share/locale/* /usr/share/i18n/locales/*
 
 
-RUN curl --silent --show-error --location https://deb.nodesource.com/setup_14.x | bash - && \
+RUN curl --silent --show-error --location https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get install -y nodejs
 
 USER seluser


### PR DESCRIPTION
**Description of your changes:**

Suspect [the frontend-integration-test failure](https://oss.gprow.dev/view/gs/oss-prow/pr-logs/pull/kubeflow_pipelines/9024/kubeflow-pipeline-e2e-test/1638628723034951680) was due to using old version of node.
[@wdio/junit-reporter@8.6.6](https://www.npmjs.com/package/@wdio/junit-reporter/v/8.6.6) was released 2 days ago, likely explains why the test started failing [since March 20](https://oss.gprow.dev/job-history/gs/oss-prow/pr-logs/directory/kubeflow-pipeline-e2e-test?buildId=) without any related code change from our side.

Update node to v16, also update `standalone-chrome` to latest.

Logs from failed test:
```
integration-test-w7g2d-805499231: npm WARN notsup Unsupported engine for @wdio/junit-reporter@8.6.6: wanted: {"node":"^16.13 || >=18"} (current: {"node":"14.21.2","npm":"6.14.17"})
integration-test-w7g2d-805499231: npm WARN notsup Not compatible with your version of node/npm: @wdio/junit-reporter@8.6.6
integration-test-w7g2d-805499231: npm WARN notsup Unsupported engine for @wdio/local-runner@8.6.7: wanted: {"node":"^16.13 || >=18"} (current: {"node":"14.21.2","npm":"6.14.17"})
integration-test-w7g2d-805499231: npm WARN notsup Not compatible with your version of node/npm: @wdio/local-runner@8.6.7
integration-test-w7g2d-805499231: npm WARN notsup Unsupported engine for @wdio/mocha-framework@8.6.6: wanted: {"node":"^16.13 || >=18"} (current: {"node":"14.21.2","npm":"6.14.17"})
```

```
integration-test-w7g2d-805499231: (node:182) UnhandledPromiseRejectionWarning: TypeError: Object.hasOwn is not a function
integration-test-w7g2d-805499231:     at file:///src/node_modules/deepmerge-ts/dist/node/index.mjs:240:51
integration-test-w7g2d-805499231:     at Array.filter (<anonymous>)
integration-test-w7g2d-805499231:     at getUtils (file:///src/node_modules/deepmerge-ts/dist/node/index.mjs:240:18)
integration-test-w7g2d-805499231:     at deepmergeCustom (file:///src/node_modules/deepmerge-ts/dist/node/index.mjs:220:19)
integration-test-w7g2d-805499231:     at file:///src/node_modules/webdriver/build/utils.js:10:19
integration-test-w7g2d-805499231:     at <anonymous> (<anonymous>)
integration-test-w7g2d-805499231: (Use `node --trace-warnings ...` to show where the warning was created)
integration-test-w7g2d-805499231: (node:182) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
integration-test-w7g2d-805499231: (node:182) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->

