### PR TITLE
fix(sdk): fix loading non-canonical type strings from v1 component YAML

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -9,6 +9,7 @@
 
 ## Bug fixes and other changes
 * Support python 3.11 [\#8907](https://github.com/kubeflow/pipelines/pull/8907)
+* Fix loading non-canonical generic type strings from v1 component YAML (e.g., `List[str]`, `typing.List[str]`, `Dict[str]`, `typing.Dict[str, str]` [\#9041](https://github.com/kubeflow/pipelines/pull/9041)
 
 ## Documentation updates
 # 2.0.0-beta.13

--- a/sdk/python/kfp/components/structures.py
+++ b/sdk/python/kfp/components/structures.py
@@ -651,6 +651,9 @@ class ComponentSpec:
             default = type_utils.deserialize_v1_component_yaml_default(
                 type_=type_, default=default)
 
+            if isinstance(type_, str):
+                type_ = type_utils.get_canonical_name_for_outer_generic(type_)
+
             if isinstance(type_, str) and type_ == 'PipelineTaskFinalStatus':
                 inputs[utils.sanitize_input_name(spec['name'])] = InputSpec(
                     type=type_, optional=True)
@@ -706,6 +709,8 @@ class ComponentSpec:
         outputs = {}
         for spec in component_dict.get('outputs', []):
             type_ = spec.get('type')
+            if isinstance(type_, str):
+                type_ = type_utils.get_canonical_name_for_outer_generic(type_)
 
             if isinstance(type_, str) and type_.lower(
             ) in type_utils._PARAMETER_TYPES_MAPPING:

--- a/sdk/python/kfp/components/structures_test.py
+++ b/sdk/python/kfp/components/structures_test.py
@@ -166,6 +166,23 @@ COMPONENT_SPEC_EXECUTOR_INPUT_PLACEHOLDER = structures.ComponentSpec(
     inputs={'input': structures.InputSpec(type='String')},
 )
 
+V1_NONCANONICAL_GENERIC_TYPES_COMPONENT_SPEC = textwrap.dedent("""\
+    name: generic_types_test
+    inputs:
+    - {name: input1, type: "List[str]"}
+    - {name: input2, type: "typing.List[str]"}
+    - {name: input3, type: "Dict[str, str]"}
+    - {name: input4, type: "typing.Dict[str, str]"}
+    outputs:
+    - {name: output1, type: "List[str]"}
+    - {name: output2, type: "typing.List[str]"}
+    - {name: output3, type: "Dict[str, str]"}
+    - {name: output4, type: "typing.Dict[str, str]"}
+    implementation:
+      container:
+        image: alpine
+    """)
+
 
 class StructuresTest(parameterized.TestCase):
 
@@ -1079,6 +1096,21 @@ implementation:
         self.assertFalse(comp.component_spec.inputs['val'].optional)
         self.assertFalse(comp.pipeline_spec.root.input_definitions
                          .artifacts['val'].is_optional)
+
+    def test_load_noncanonical_v1_generic_types(self):
+        loaded_comp = components.load_component_from_text(
+            V1_NONCANONICAL_GENERIC_TYPES_COMPONENT_SPEC)
+        inputs = loaded_comp.component_spec.inputs
+        outputs = loaded_comp.component_spec.outputs
+        self.assertEqual(inputs['input1'].type, 'List')
+        self.assertEqual(inputs['input2'].type, 'List')
+        self.assertEqual(inputs['input3'].type, 'Dict')
+        self.assertEqual(inputs['input4'].type, 'Dict')
+
+        self.assertEqual(outputs['output1'].type, 'List')
+        self.assertEqual(outputs['output2'].type, 'List')
+        self.assertEqual(outputs['output3'].type, 'Dict')
+        self.assertEqual(outputs['output4'].type, 'Dict')
 
 
 class TestLoadDocumentsFromYAML(unittest.TestCase):

--- a/sdk/python/kfp/components/types/type_utils.py
+++ b/sdk/python/kfp/components/types/type_utils.py
@@ -465,10 +465,18 @@ def get_canonical_name_for_outer_generic(type_name: Any) -> str:
     Returns:
         str: The canonical type.
     """
-    if not isinstance(type_name, str) or not type_name.startswith('typing.'):
+    if not isinstance(type_name, str):
         return type_name
 
-    return type_name.lstrip('typing.').split('[')[0]
+    if type_name.startswith('typing.'):
+        type_name = type_name.lstrip('typing.')
+
+    if type_name.lower().startswith('list') or type_name.lower().startswith(
+            'dict'):
+        return type_name.split('[')[0]
+
+    else:
+        return type_name
 
 
 def create_bundled_artifact_type(schema_title: str,


### PR DESCRIPTION
**Description of your changes:**
Fixes a bug where non-canonical representations of v1 component YAML 
generic types were loaded as artifacts. These types include:  
`List[str]`, `typing.List[str]`, `Dict[str]`, `typing.Dict[str, str]`

**Checklist:**
- [x] The title for your pull request (PR) should follow our title 
convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
