### PR TITLE
fix(sdk): support accessing `.dsl` attribute on `kfp` module object

### DIFF
--- a/sdk/python/kfp/__init__.py
+++ b/sdk/python/kfp/__init__.py
@@ -20,4 +20,5 @@ __version__ = '2.0.0-beta.13'
 
 TYPE_CHECK = True
 
+from kfp import dsl
 from kfp.client import Client

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -25,6 +25,7 @@ import unittest
 from absl.testing import parameterized
 from click import testing
 from google.protobuf import json_format
+import kfp
 from kfp import components
 from kfp import dsl
 from kfp.cli import cli
@@ -62,6 +63,21 @@ VALID_PRODUCER_COMPONENT_SAMPLE = components.load_component_from_text("""
 
 
 class TestCompilePipeline(parameterized.TestCase):
+
+    def test_can_use_dsl_attribute_on_kfp(self):
+
+        @kfp.dsl.component
+        def identity(string: str) -> str:
+            return string
+
+        @kfp.dsl.pipeline
+        def my_pipeline(string: str = 'string'):
+            op1 = identity(string=string)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            compiler.Compiler().compile(
+                pipeline_func=my_pipeline,
+                package_path=os.path.join(tmpdir, 'pipeline.yaml'))
 
     def test_compile_simple_pipeline(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
**Description of your changes:**
Users should be able to decorate a pipeline via:

```python
@kfp.dsl.pipeline
def p():
    ...
```

Because they can do:
```python
@kfp.v2.dsl.pipeline
def p():
    ...
```

Currently, `kfp.dsl.pipeline` throws an exception. This PR fixes this.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title 
convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
