### PR TITLE
fix(backend): when use multi-user model, patchCacheID function in cache-server return error

### DIFF
--- a/backend/src/cache/server/watcher.go
+++ b/backend/src/cache/server/watcher.go
@@ -100,7 +100,7 @@ func WatchPods(ctx context.Context, namespaceToWatch string, clientManager Clien
 				log.Println("Unable to create cache entry.")
 				continue
 			}
-			err = patchCacheID(ctx, k8sCore, pod, namespaceToWatch, cacheEntryCreated.ID)
+			err = patchCacheID(ctx, k8sCore, pod, cacheEntryCreated.ID)
 			if err != nil {
 				log.Printf(err.Error())
 			}
@@ -117,7 +117,7 @@ func isCacheWriten(labels map[string]string) bool {
 	return cacheID != ""
 }
 
-func patchCacheID(ctx context.Context, k8sCore client.KubernetesCoreInterface, podToPatch *corev1.Pod, namespaceToWatch string, id int64) error {
+func patchCacheID(ctx context.Context, k8sCore client.KubernetesCoreInterface, podToPatch *corev1.Pod, id int64) error {
 	labels := podToPatch.ObjectMeta.Labels
 	labels[CacheIDLabelKey] = strconv.FormatInt(id, 10)
 	log.Println(id)
@@ -131,7 +131,7 @@ func patchCacheID(ctx context.Context, k8sCore client.KubernetesCoreInterface, p
 	if err != nil {
 		return fmt.Errorf("Unable to patch cache_id to pod: %s", podToPatch.ObjectMeta.Name)
 	}
-	_, err = k8sCore.PodClient(namespaceToWatch).Patch(ctx, podToPatch.ObjectMeta.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+	_, err = k8sCore.PodClient(podToPatch.Namespace).Patch(ctx, podToPatch.ObjectMeta.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description of your changes:**
when I use multi-user model, I will set params.namespaceToWatch of cache-server to "", and then in patchCacheID function, namespaceToWatch is used to Patch the pod watched, this will return an error. `podToPatch.Namespace` is the correct namespace to Patch the pod.
**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
