### PR TITLE
chore(frontend): Regenerate TS client for backend changes on createPipelineVersion

### DIFF
--- a/frontend/src/apisv2beta1/filter/api.ts
+++ b/frontend/src/apisv2beta1/filter/api.ts
@@ -124,7 +124,7 @@ export interface PredicateStringValues {
 }
 
 /**
- * Filter is used to filter resources returned from a ListXXX request.  Example filters: 1) Filter runs with status = 'Running' filter {   predicate {     key: \"status\"     op: EQUALS     string_value: \"Running\"   } }  2) Filter runs that succeeded since Dec 1, 2018 filter {   predicate {     key: \"status\"     op: EQUALS     string_value: \"Succeeded\"   }   predicate {     key: \"created_at\"     op: GREATER_THAN     timestamp_value {       seconds: 1543651200     }   } }  3) Filter runs with one of labels 'label_1' or 'label_2'  filter {   predicate {     key: \"label\"     op: IN     string_values {       value: 'label_1'       value: 'label_2'     }   } }
+ * Filter is used to filter resources returned from a ListXXX request.  Example filters: 1) Filter runs with status = 'Running' filter {   predicate {     key: \"status\"     operation: EQUALS     string_value: \"Running\"   } }  2) Filter runs that succeeded since Dec 1, 2018 filter {   predicate {     key: \"status\"     operation: EQUALS     string_value: \"Succeeded\"   }   predicate {     key: \"created_at\"     operation: GREATER_THAN     timestamp_value {       seconds: 1543651200     }   } }  3) Filter runs with one of labels 'label_1' or 'label_2'  filter {   predicate {     key: \"label\"     operation: IN     string_values {       value: 'label_1'       value: 'label_2'     }   } }
  * @export
  * @interface V2beta1Filter
  */

--- a/frontend/src/apisv2beta1/pipeline/api.ts
+++ b/frontend/src/apisv2beta1/pipeline/api.ts
@@ -363,15 +363,27 @@ export const PipelineServiceApiFetchParamCreator = function(configuration?: Conf
      *
      * @summary Adds a pipeline version to the specified pipeline ID.
      * @param {string} pipeline_id Required input. ID of the parent pipeline.
+     * @param {V2beta1PipelineVersion} body Required input. Pipeline version ID to be created.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    createPipelineVersion(pipeline_id: string, options: any = {}): FetchArgs {
+    createPipelineVersion(
+      pipeline_id: string,
+      body: V2beta1PipelineVersion,
+      options: any = {},
+    ): FetchArgs {
       // verify required parameter 'pipeline_id' is not null or undefined
       if (pipeline_id === null || pipeline_id === undefined) {
         throw new RequiredError(
           'pipeline_id',
           'Required parameter pipeline_id was null or undefined when calling createPipelineVersion.',
+        );
+      }
+      // verify required parameter 'body' is not null or undefined
+      if (body === null || body === undefined) {
+        throw new RequiredError(
+          'body',
+          'Required parameter body was null or undefined when calling createPipelineVersion.',
         );
       }
       const localVarPath = `/apis/v2beta1/pipelines/{pipeline_id}/versions`.replace(
@@ -392,6 +404,8 @@ export const PipelineServiceApiFetchParamCreator = function(configuration?: Conf
         localVarHeaderParameter['authorization'] = localVarApiKeyValue;
       }
 
+      localVarHeaderParameter['Content-Type'] = 'application/json';
+
       localVarUrlObj.query = Object.assign(
         {},
         localVarUrlObj.query,
@@ -401,6 +415,10 @@ export const PipelineServiceApiFetchParamCreator = function(configuration?: Conf
       // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
       delete localVarUrlObj.search;
       localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+      const needsSerialization =
+        <any>'V2beta1PipelineVersion' !== 'string' ||
+        localVarRequestOptions.headers['Content-Type'] === 'application/json';
+      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body || {}) : body || '';
 
       return {
         url: url.format(localVarUrlObj),
@@ -856,16 +874,18 @@ export const PipelineServiceApiFp = function(configuration?: Configuration) {
      *
      * @summary Adds a pipeline version to the specified pipeline ID.
      * @param {string} pipeline_id Required input. ID of the parent pipeline.
+     * @param {V2beta1PipelineVersion} body Required input. Pipeline version ID to be created.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     createPipelineVersion(
       pipeline_id: string,
+      body: V2beta1PipelineVersion,
       options?: any,
     ): (fetch?: FetchAPI, basePath?: string) => Promise<V2beta1PipelineVersion> {
       const localVarFetchArgs = PipelineServiceApiFetchParamCreator(
         configuration,
-      ).createPipelineVersion(pipeline_id, options);
+      ).createPipelineVersion(pipeline_id, body, options);
       return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
         return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then(response => {
           if (response.status >= 200 && response.status < 300) {
@@ -1100,14 +1120,16 @@ export const PipelineServiceApiFactory = function(
      *
      * @summary Adds a pipeline version to the specified pipeline ID.
      * @param {string} pipeline_id Required input. ID of the parent pipeline.
+     * @param {V2beta1PipelineVersion} body Required input. Pipeline version ID to be created.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    createPipelineVersion(pipeline_id: string, options?: any) {
-      return PipelineServiceApiFp(configuration).createPipelineVersion(pipeline_id, options)(
-        fetch,
-        basePath,
-      );
+    createPipelineVersion(pipeline_id: string, body: V2beta1PipelineVersion, options?: any) {
+      return PipelineServiceApiFp(configuration).createPipelineVersion(
+        pipeline_id,
+        body,
+        options,
+      )(fetch, basePath);
     },
     /**
      *
@@ -1262,15 +1284,17 @@ export class PipelineServiceApi extends BaseAPI {
    *
    * @summary Adds a pipeline version to the specified pipeline ID.
    * @param {string} pipeline_id Required input. ID of the parent pipeline.
+   * @param {V2beta1PipelineVersion} body Required input. Pipeline version ID to be created.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof PipelineServiceApi
    */
-  public createPipelineVersion(pipeline_id: string, options?: any) {
-    return PipelineServiceApiFp(this.configuration).createPipelineVersion(pipeline_id, options)(
-      this.fetch,
-      this.basePath,
-    );
+  public createPipelineVersion(pipeline_id: string, body: V2beta1PipelineVersion, options?: any) {
+    return PipelineServiceApiFp(this.configuration).createPipelineVersion(
+      pipeline_id,
+      body,
+      options,
+    )(this.fetch, this.basePath);
   }
 
   /**


### PR DESCRIPTION
Backend add the missing parameters `body` in createPipelineVersion. Frontend then need to regenerate new TS client.