### PR TITLE
chore(frontend): Regenerate Typescript API client after adding pipeline_id into run and recurring run

### DIFF
--- a/frontend/src/apisv2beta1/pipeline/api.ts
+++ b/frontend/src/apisv2beta1/pipeline/api.ts
@@ -269,13 +269,19 @@ export interface V2beta1PipelineVersion {
    */
   created_at?: Date;
   /**
-   * Required input field. Pipeline version package url. When calling CreatePipelineVersion, one needs to provide  one package file location.
+   * Input. Required. The URL to the source of the pipeline version. This is required when creating the pipeine version through CreatePipelineVersion API.
    * @type {V2beta1Url}
    * @memberof V2beta1PipelineVersion
    */
   package_url?: V2beta1Url;
   /**
-   * Required input field. Specifies the pipeline spec for the pipeline version.
+   * Input. Optional. The URL to the code source of the pipeline version. The code is usually the Python definition of the pipeline and potentially related the component definitions. This allows users to trace back to how the pipeline YAML was created.
+   * @type {string}
+   * @memberof V2beta1PipelineVersion
+   */
+  code_source_url?: string;
+  /**
+   * Output. The pipeline spec for the pipeline version.
    * @type {any}
    * @memberof V2beta1PipelineVersion
    */

--- a/frontend/src/apisv2beta1/recurringrun/api.ts
+++ b/frontend/src/apisv2beta1/recurringrun/api.ts
@@ -226,6 +226,26 @@ export interface V2beta1PeriodicSchedule {
 }
 
 /**
+ * Reference to an existing pipeline version.
+ * @export
+ * @interface V2beta1PipelineVersionReference
+ */
+export interface V2beta1PipelineVersionReference {
+  /**
+   * Input. Required. Unique ID of the parent pipeline.
+   * @type {string}
+   * @memberof V2beta1PipelineVersionReference
+   */
+  pipeline_id?: string;
+  /**
+   * Input. Required. Unique ID of an existing pipeline version.
+   * @type {string}
+   * @memberof V2beta1PipelineVersionReference
+   */
+  pipeline_version_id?: string;
+}
+
+/**
  *
  * @export
  * @interface V2beta1RecurringRun
@@ -261,6 +281,12 @@ export interface V2beta1RecurringRun {
    * @memberof V2beta1RecurringRun
    */
   pipeline_spec?: any;
+  /**
+   * Reference to a pipeline version containing pipeline_id and pipeline_version_id.
+   * @type {V2beta1PipelineVersionReference}
+   * @memberof V2beta1RecurringRun
+   */
+  pipeline_version_reference?: V2beta1PipelineVersionReference;
   /**
    * Runtime config of the pipeline.
    * @type {V2beta1RuntimeConfig}

--- a/frontend/src/apisv2beta1/run/api.ts
+++ b/frontend/src/apisv2beta1/run/api.ts
@@ -333,6 +333,26 @@ export interface V2beta1PipelineTaskExecutorDetail {
 }
 
 /**
+ * Reference to an existing pipeline version.
+ * @export
+ * @interface V2beta1PipelineVersionReference
+ */
+export interface V2beta1PipelineVersionReference {
+  /**
+   * Input. Required. Unique ID of the parent pipeline.
+   * @type {string}
+   * @memberof V2beta1PipelineVersionReference
+   */
+  pipeline_id?: string;
+  /**
+   * Input. Required. Unique ID of an existing pipeline version.
+   * @type {string}
+   * @memberof V2beta1PipelineVersionReference
+   */
+  pipeline_version_id?: string;
+}
+
+/**
  *
  * @export
  * @interface V2beta1ReadArtifactResponse
@@ -394,6 +414,12 @@ export interface V2beta1Run {
    * @memberof V2beta1Run
    */
   pipeline_spec?: any;
+  /**
+   * Reference to a pipeline version containing pipeline_id and pipeline_version_id.
+   * @type {V2beta1PipelineVersionReference}
+   * @memberof V2beta1Run
+   */
+  pipeline_version_reference?: V2beta1PipelineVersionReference;
   /**
    * Required input. Runtime config of the run.
    * @type {V2beta1RuntimeConfig}


### PR DESCRIPTION
This is the corresponding change to match the backend fix on missing pipeline id in run and recurring run