### PR TITLE
chore(frontend): Change pipeline_version_id field in run / recurring run

### DIFF
--- a/frontend/src/pages/NewRunSwitcher.tsx
+++ b/frontend/src/pages/NewRunSwitcher.tsx
@@ -92,8 +92,8 @@ function NewRunSwitcher(props: PageProps) {
   const pipelineVersionId =
     pipelineVersionIdParam ||
     apiPipeline?.default_version?.id ||
-    v2Run?.pipeline_version_id ||
-    recurringRun?.pipeline_version_id;
+    v2Run?.pipeline_version_reference?.pipeline_version_id ||
+    recurringRun?.pipeline_version_reference?.pipeline_version_id;
 
   const { isFetching: pipelineVersionIsFetching, data: apiPipelineVersion } = useQuery<
     ApiPipelineVersion,

--- a/frontend/src/pages/NewRunV2.test.tsx
+++ b/frontend/src/pages/NewRunV2.test.tsx
@@ -103,7 +103,10 @@ describe('NewRunV2', () => {
     finished_at: new Date('2021-05-18T21:01:23.000Z'),
     run_id: TEST_RUN_ID,
     display_name: 'Run of v2-xgboost-ilbo',
-    pipeline_version_id: ORIGINAL_TEST_PIPELINE_VERSION_ID,
+    pipeline_version_reference: {
+      pipeline_id: ORIGINAL_TEST_PIPELINE_ID,
+      pipeline_version_id: ORIGINAL_TEST_PIPELINE_VERSION_ID,
+    },
     runtime_config: { parameters: { intParam: 123 } },
     scheduled_at: new Date('2021-05-17T20:58:23.000Z'),
     state: V2beta1RuntimeState.SUCCEEDED,
@@ -116,7 +119,10 @@ describe('NewRunV2', () => {
     finished_at: new Date('2022-08-12T21:01:23.000Z'),
     run_id: 'test-clone-ui-run-id',
     display_name: 'Clone of Run of v2-xgboost-ilbo',
-    pipeline_version_id: NEW_TEST_PIPELINE_VERSION_ID,
+    pipeline_version_reference: {
+      pipeline_id: NEW_TEST_PIPELINE_ID,
+      pipeline_version_id: ORIGINAL_TEST_PIPELINE_VERSION_ID,
+    },
     runtime_config: { parameters: { intParam: 123 } },
     scheduled_at: new Date('2022-08-12T20:58:23.000Z'),
     state: V2beta1RuntimeState.SUCCEEDED,
@@ -152,7 +158,10 @@ describe('NewRunV2', () => {
     created_at: new Date('2021-05-17T20:58:23.000Z'),
     description: 'V2 xgboost',
     display_name: 'Run of v2-xgboost-ilbo',
-    pipeline_version_id: ORIGINAL_TEST_PIPELINE_VERSION_ID,
+    pipeline_version_reference: {
+      pipeline_id: ORIGINAL_TEST_PIPELINE_ID,
+      pipeline_version_id: ORIGINAL_TEST_PIPELINE_VERSION_ID,
+    },
     recurring_run_id: TEST_RECURRING_RUN_ID,
     runtime_config: { parameters: { intParam: 123 } },
     trigger: {
@@ -165,7 +174,10 @@ describe('NewRunV2', () => {
     created_at: new Date('2023-01-04T20:58:23.000Z'),
     description: 'V2 xgboost',
     display_name: 'Clone of Run of v2-xgboost-ilbo',
-    pipeline_version_id: NEW_TEST_PIPELINE_VERSION_ID,
+    pipeline_version_reference: {
+      pipeline_id: NEW_TEST_PIPELINE_ID,
+      pipeline_version_id: NEW_TEST_PIPELINE_VERSION_ID,
+    },
     recurring_run_id: 'test-clone-ui-recurring-run-id',
     runtime_config: { parameters: { intParam: 123 } },
     trigger: {
@@ -443,7 +455,10 @@ describe('NewRunV2', () => {
         expect(createRunSpy).toHaveBeenCalledWith(
           expect.objectContaining({
             description: '',
-            pipeline_version_id: ORIGINAL_TEST_PIPELINE_VERSION_ID,
+            pipeline_version_reference: {
+              pipeline_id: ORIGINAL_TEST_PIPELINE_ID,
+              pipeline_version_id: ORIGINAL_TEST_PIPELINE_VERSION_ID,
+            },
             runtime_config: { parameters: {}, pipeline_root: undefined },
             service_account: '',
           }),
@@ -867,7 +882,10 @@ describe('NewRunV2', () => {
           expect.objectContaining({
             description: '',
             display_name: 'Clone of Run of v2-xgboost-ilbo',
-            pipeline_version_id: ORIGINAL_TEST_PIPELINE_VERSION_ID,
+            pipeline_version_reference: {
+              pipeline_id: ORIGINAL_TEST_PIPELINE_ID,
+              pipeline_version_id: ORIGINAL_TEST_PIPELINE_VERSION_ID,
+            },
             runtime_config: { parameters: { intParam: 123 } },
             service_account: '',
           }),
@@ -953,7 +971,10 @@ describe('NewRunV2', () => {
           expect.objectContaining({
             description: '',
             display_name: 'Clone of Run of v2-xgboost-ilbo',
-            pipeline_spec: JsYaml.safeLoad(v2YamlTemplateString),
+            pipeline_version_reference: {
+              pipeline_id: ORIGINAL_TEST_PIPELINE_ID,
+              pipeline_version_id: ORIGINAL_TEST_PIPELINE_VERSION_ID,
+            },
             runtime_config: { parameters: { intParam: 123 } },
             trigger: {
               periodic_schedule: { interval_second: '3600' },

--- a/frontend/src/pages/NewRunV2.test.tsx
+++ b/frontend/src/pages/NewRunV2.test.tsx
@@ -121,7 +121,7 @@ describe('NewRunV2', () => {
     display_name: 'Clone of Run of v2-xgboost-ilbo',
     pipeline_version_reference: {
       pipeline_id: NEW_TEST_PIPELINE_ID,
-      pipeline_version_id: ORIGINAL_TEST_PIPELINE_VERSION_ID,
+      pipeline_version_id: NEW_TEST_PIPELINE_VERSION_ID,
     },
     runtime_config: { parameters: { intParam: 123 } },
     scheduled_at: new Date('2022-08-12T20:58:23.000Z'),

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -305,9 +305,12 @@ function NewRunV2(props: NewRunV2Props) {
       pipeline_spec: !(pipelineVersionRefClone || pipelineVersionRefNew)
         ? JsYaml.safeLoad(templateString || '')
         : undefined,
-      pipeline_version_reference: cloneOrigin.isClone
-        ? pipelineVersionRefClone
-        : pipelineVersionRefNew,
+      pipeline_version_reference:
+        pipelineVersionRefClone || pipelineVersionRefNew
+          ? cloneOrigin.isClone
+            ? pipelineVersionRefClone
+            : pipelineVersionRefNew
+          : undefined,
       runtime_config: {
         // TODO(zijianjoy): determine whether to provide pipeline root.
         pipeline_root: undefined, // pipelineRoot,

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -30,7 +30,7 @@ import { Link } from 'react-router-dom';
 import { ApiExperiment, ApiExperimentStorageState } from 'src/apis/experiment';
 import { ApiFilter, PredicateOp } from 'src/apis/filter';
 import { ApiPipeline, ApiPipelineVersion } from 'src/apis/pipeline';
-import { V2beta1Run } from 'src/apisv2beta1/run';
+import { V2beta1PipelineVersionReference, V2beta1Run } from 'src/apisv2beta1/run';
 import BusyButton from 'src/atoms/BusyButton';
 import { ExternalLink } from 'src/atoms/ExternalLink';
 import { HelpButton } from 'src/atoms/HelpButton';
@@ -189,6 +189,19 @@ function NewRunV2(props: NewRunV2Props) {
   const titleVerb = cloneOrigin.isClone ? 'Clone' : 'Start';
   const titleAdjective = cloneOrigin.isClone ? '' : 'new';
 
+  // Pipeline version reference from selected pipeline (version) when "creating" run
+  const pipelineVersionRefNew: V2beta1PipelineVersionReference | undefined = cloneOrigin.isClone
+    ? undefined
+    : {
+        pipeline_id: existingPipeline?.id,
+        pipeline_version_id: existingPipelineVersion?.id,
+      };
+
+  // Pipeline version reference from existing run or recurring run when "cloning" run
+  const pipelineVersionRefClone = cloneOrigin.isRecurring
+    ? cloneOrigin.recurringRun?.pipeline_version_reference
+    : cloneOrigin.run?.pipeline_version_reference;
+
   // Title and list of actions on the top of page.
   useEffect(() => {
     props.updateToolbar({
@@ -288,11 +301,13 @@ function NewRunV2(props: NewRunV2Props) {
       description: runDescription,
       display_name: runName,
       experiment_id: apiExperiment?.id,
-      // pipeline_spec and pipeline_version_id is exclusive.
-      pipeline_spec: !(existingRun?.pipeline_version_id || existingPipelineVersion?.id)
+      // pipeline_spec and pipeline_version_reference is exclusive.
+      pipeline_spec: !(pipelineVersionRefClone || pipelineVersionRefNew)
         ? JsYaml.safeLoad(templateString || '')
         : undefined,
-      pipeline_version_id: existingRun?.pipeline_version_id || existingPipelineVersion?.id,
+      pipeline_version_reference: cloneOrigin.isClone
+        ? pipelineVersionRefClone
+        : pipelineVersionRefNew,
       runtime_config: {
         // TODO(zijianjoy): determine whether to provide pipeline root.
         pipeline_root: undefined, // pipelineRoot,

--- a/frontend/src/pages/PipelineDetails.test.tsx
+++ b/frontend/src/pages/PipelineDetails.test.tsx
@@ -145,11 +145,13 @@ describe('PipelineDetails', () => {
     testV2Run = {
       run_id: 'test-run-id',
       display_name: 'test run',
+      pipeline_version_reference: {},
     };
 
     testV2RecurringRun = {
       recurring_run_id: 'test-recurring-run-id',
       display_name: 'test recurring run',
+      pipeline_version_reference: {},
     };
 
     getPipelineSpy.mockImplementation(() => Promise.resolve(testPipeline));
@@ -359,7 +361,7 @@ describe('PipelineDetails', () => {
 
   it('use pipeline_version_id in run to get pipeline template string (v2)', async () => {
     jest.spyOn(features, 'isFeatureEnabled').mockReturnValue(true);
-    testV2Run.pipeline_version_id = 'test-pipeline-version-id';
+    testV2Run.pipeline_version_reference.pipeline_version_id = 'test-pipeline-version-id';
 
     tree = shallow(<PipelineDetails {...generateProps(true)} />);
     await getV1RunSpy;
@@ -372,7 +374,7 @@ describe('PipelineDetails', () => {
 
   it('use pipeline_version_id in recurring run to get pipeline template string (v2)', async () => {
     jest.spyOn(features, 'isFeatureEnabled').mockReturnValue(true);
-    testV2RecurringRun.pipeline_version_id = 'test-pipeline-version-id';
+    testV2RecurringRun.pipeline_version_reference.pipeline_version_id = 'test-pipeline-version-id';
 
     tree = shallow(<PipelineDetails {...generateProps(false, true)} />);
     await getV1RecurringRunSpy;

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -226,7 +226,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
     // existing run or recurring run have two kinds of resources that can provide template string
 
     // 1. Pipeline version id
-    const pipelineVersionId = existingObj.pipeline_version_id;
+    const pipelineVersionId = existingObj.pipeline_version_reference?.pipeline_version_id;
     let templateStrFromOrigin: string | undefined;
     if (pipelineVersionId) {
       const response = await Apis.pipelineServiceApi.getPipelineVersionTemplate(pipelineVersionId);

--- a/frontend/src/pages/RecurringRunDetailsRouter.tsx
+++ b/frontend/src/pages/RecurringRunDetailsRouter.tsx
@@ -49,7 +49,7 @@ export default function RecurringRunDetailsRouter(props: PageProps) {
     pipelineManifest = JsYaml.safeDump(v2RecurringRun.pipeline_spec);
   }
 
-  const pipelineVersionId = v2RecurringRun?.pipeline_version_id;
+  const pipelineVersionId = v2RecurringRun?.pipeline_version_reference?.pipeline_version_id;
 
   const { isFetching: pipelineTemplateStrIsFetching, data: templateStrFromVersionId } = useQuery<
     string,

--- a/frontend/src/pages/RecurringRunDetailsV2.test.tsx
+++ b/frontend/src/pages/RecurringRunDetailsV2.test.tsx
@@ -74,7 +74,10 @@ describe('RecurringRunDetailsV2', () => {
       display_name: 'test recurring run',
       max_concurrency: '50',
       no_catchup: true,
-      pipeline_version_id: 'test-pipeline-version-id',
+      pipeline_version_reference: {
+        pipeline_id: 'test-pipeline-id',
+        pipeline_version_id: 'test-pipeline-version-id',
+      },
       recurring_run_id: 'test-recurring-run-id',
       runtime_config: { parameters: { param1: 'value1' } },
       status: V2beta1RecurringRunStatus.ENABLED,

--- a/frontend/src/pages/RunDetailsRouter.tsx
+++ b/frontend/src/pages/RunDetailsRouter.tsx
@@ -40,7 +40,7 @@ export default function RunDetailsRouter(props: RunDetailsProps) {
     pipelineManifest = JsYaml.safeDump(v2Run.pipeline_spec);
   }
 
-  const pipelineVersionId = v2Run?.pipeline_version_id;
+  const pipelineVersionId = v2Run?.pipeline_version_reference?.pipeline_version_id;
 
   const { data: templateStrFromVersionId } = useQuery<string, Error>(
     ['PipelineVersionTemplate', pipelineVersionId],

--- a/frontend/src/pages/RunList.test.tsx
+++ b/frontend/src/pages/RunList.test.tsx
@@ -465,6 +465,7 @@ describe('RunList', () => {
   it('shows pipeline version name', async () => {
     mockNRuns(1, {
       pipeline_version_reference: {
+        pipeline_id: 'testpipeline1',
         pipeline_version_id: 'testversion1',
       },
     });

--- a/frontend/src/pages/RunList.test.tsx
+++ b/frontend/src/pages/RunList.test.tsx
@@ -56,31 +56,42 @@ describe('RunList', () => {
   }
 
   function mockNRuns(n: number, runTemplate: Partial<V2beta1Run>): void {
-    getRunSpy.mockImplementation(id =>
-      Promise.resolve(
+    getRunSpy.mockImplementation(id => {
+      let pipelineVersionRef = {
+        pipeline_id: 'testpipeline' + id,
+        pipeline_version_id: 'testversion' + id,
+      };
+      return Promise.resolve(
         produce(runTemplate, draft => {
           draft = draft || {};
           draft.run_id = id;
           draft.display_name = 'run with id: ' + id;
-          draft.pipeline_version_id = 'testversion' + id;
+          draft.pipeline_version_reference = pipelineVersionRef;
         }),
-      ),
-    );
+      );
+    });
 
     listRunsSpy.mockImplementation(() =>
       Promise.resolve({
         runs: range(1, n + 1).map(i => {
           if (runTemplate) {
+            let pipelineVersionRef = {
+              pipeline_id: 'testpipeline' + i,
+              pipeline_version_id: 'testversion' + i,
+            };
             return produce(runTemplate as Partial<V2beta1Run>, draft => {
               draft.run_id = 'testrun' + i;
               draft.display_name = 'run with id: testrun' + i;
-              draft.pipeline_version_id = 'testversion' + i;
+              draft.pipeline_version_reference = pipelineVersionRef;
             });
           }
           return {
             run_id: 'testrun' + i,
             display_name: 'run with id: testrun' + i,
-            pipeline_version_id: 'testversion' + i,
+            pipeline_version_reference: {
+              pipeline_id: 'testpipeline' + i,
+              pipeline_version_id: 'testversion' + i,
+            },
           } as V2beta1Run;
         }),
       }),
@@ -453,7 +464,9 @@ describe('RunList', () => {
 
   it('shows pipeline version name', async () => {
     mockNRuns(1, {
-      pipeline_version_id: 'testversion1',
+      pipeline_version_reference: {
+        pipeline_version_id: 'testversion1',
+      },
     });
     const props = generateProps();
     render(

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -452,7 +452,7 @@ class RunList extends React.PureComponent<RunListProps, RunListState> {
    * '-'.
    */
   private async _getAndSetPipelineVersionNames(displayRun: DisplayRun): Promise<void> {
-    const pipelineVersionId = displayRun.run.pipeline_version_id;
+    const pipelineVersionId = displayRun.run.pipeline_version_reference?.pipeline_version_id;
     if (pipelineVersionId) {
       try {
         const pipelineVersion = await Apis.pipelineServiceApi.getPipelineVersion(pipelineVersionId);


### PR DESCRIPTION
In the latest backend changes, `pipeline_id` is also added in the return value of run and recurring run. In addition, `pipeline_id` and `pipeline_version_id` are wrapped as `pipeline_version_reference`. The main purpose of this PR is modifying frontend implementation to match the changes.