### PR TITLE
feat(sdk): support direct indexing into top-level of artifact metadata struct in Container Components

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -2,6 +2,7 @@
 
 ## Features
 * `pip_index_urls` is now considered also for containerized python component - the urls will be used for Dockerfile generation [\#8871](https://github.com/kubeflow/pipelines/pull/8871)
+* Support direct indexing into top-level of artifact metadata struct in Container Components [\#9131](https://github.com/kubeflow/pipelines/pull/9131)
 
 ## Breaking changes
 

--- a/sdk/python/kfp/components/placeholders.py
+++ b/sdk/python/kfp/components/placeholders.py
@@ -127,6 +127,9 @@ class InputMetadataPlaceholder(Placeholder):
     def _to_string(self) -> str:
         return f"{{{{$.inputs.artifacts['{self.input_name}'].metadata}}}}"
 
+    def __getitem__(self, key: str) -> str:
+        return f"{{{{$.inputs.artifacts['{self.input_name}'].metadata['{key}']}}}}"
+
 
 class OutputParameterPlaceholder(Placeholder):
 
@@ -162,6 +165,9 @@ class OutputMetadataPlaceholder(Placeholder):
 
     def _to_string(self) -> str:
         return f"{{{{$.outputs.artifacts['{self.output_name}'].metadata}}}}"
+
+    def __getitem__(self, key: str) -> str:
+        return f"{{{{$.outputs.artifacts['{self.output_name}'].metadata['{key}']}}}}"
 
 
 class ConcatPlaceholder(Placeholder):

--- a/sdk/python/kfp/components/placeholders_test.py
+++ b/sdk/python/kfp/components/placeholders_test.py
@@ -64,6 +64,18 @@ class TestInputMetadataPlaceholder(parameterized.TestCase):
             placeholders.InputMetadataPlaceholder('input1')._to_string(),
             "{{$.inputs.artifacts['input1'].metadata}}")
 
+    def test_access_top_level_metadata_key(self):
+
+        @dsl.container_component
+        def echo(d: Input[Dataset]):
+            return dsl.ContainerSpec(
+                image='alpine', command=['echo', d.metadata['key']])
+
+        self.assertEqual(
+            echo.pipeline_spec.deployment_spec['executors']['exec-echo']
+            ['container']['command'][1],
+            "{{$.inputs.artifacts['d'].metadata['key']}}")
+
 
 class TestOutputPathPlaceholder(parameterized.TestCase):
 
@@ -95,6 +107,18 @@ class TestOutputMetadataPlaceholder(parameterized.TestCase):
         self.assertEqual(
             placeholders.OutputMetadataPlaceholder('output1')._to_string(),
             "{{$.outputs.artifacts['output1'].metadata}}")
+
+    def test_access_top_level_metadata_key(self):
+
+        @dsl.container_component
+        def echo(d: Output[Dataset]):
+            return dsl.ContainerSpec(
+                image='alpine', command=['echo', d.metadata['key']])
+
+        self.assertEqual(
+            echo.pipeline_spec.deployment_spec['executors']['exec-echo']
+            ['container']['command'][1],
+            "{{$.outputs.artifacts['d'].metadata['key']}}")
 
 
 class TestIfPresentPlaceholder(parameterized.TestCase):


### PR DESCRIPTION
**Description of your changes:**
Container Components may now pass top-level artifact metadata fields directly to container commands/args, eliminating the need to parse the metadata struct in the container logic. For example, `echo` obtains the `'value'` string directly via `artifact.metadata['key']`:

```python
from kfp import dsl
from kfp.dsl import Dataset, Input

@dsl.container_component
def echo(artifact: Input[Dataset]):
    return dsl.ContainerSpec(
        image='alpine', command=['echo', artifact.metadata['key']])

@dsl.pipeline
def my_pipeline():
    imp = dsl.importer(
        artifact_uri='gs://ml-pipeline-playground/shakespeare1.txt',
        artifact_class=Dataset,
        reimport=False,
        metadata={'key': 'value'})
    echo(artifact=imp.output)
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our 
title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
