### PR TITLE
fix(sdk): fixes module not found error for containerized python components. Fixes #8385

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -7,6 +7,7 @@
 ## Deprecations
 
 ## Bug fixes and other changes
+* Fix module not found error for containerized python components [\#9157](https://github.com/kubeflow/pipelines/pull/9157)
 
 ## Documentation updates
 

--- a/sdk/python/kfp/cli/component_test.py
+++ b/sdk/python/kfp/cli/component_test.py
@@ -265,6 +265,24 @@ class Test(unittest.TestCase):
 
             '''))
 
+    def test_nested_module_imports(self):
+        module_two = 'two = 2'
+        _write_file('module_two.py', module_two)
+
+        module_one = 'from module_two import two\none = 1'
+        _write_file('module_one.py', module_one)
+
+        component = _make_component(
+            func_name='comp', target_image='custom-image')
+        component = 'from module_one import one\n' + component
+        _write_components('component.py', component)
+
+        result = self.runner.invoke(
+            self.cli,
+            ['build', str(self._working_dir)],
+        )
+        self.assertEqual(result.exit_code, 0)
+
     def test_emptry_requirements_txt_file_is_generated(self):
         component = _make_component(
             func_name='train', target_image='custom-image')

--- a/sdk/python/kfp/components/utils.py
+++ b/sdk/python/kfp/components/utils.py
@@ -44,6 +44,7 @@ def load_module(module_name: str, module_directory: str) -> types.ModuleType:
         location=os.path.join(module_directory, f'{module_name}.py'))
     module = importlib.util.module_from_spec(module_spec)
     sys.modules[module_spec.name] = module
+    sys.path.insert(0, str(module_directory))
     module_spec.loader.exec_module(module)
     return module
 


### PR DESCRIPTION
**Description of your changes:**
Prepends the `module_directory` to sys.path. `module_directory` is [WindowsPath](https://docs.python.org/3/library/pathlib.html#pathlib.WindowsPath) object on windows, hence casting to string as sys.path doesn't support pathlib objects.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
