### PR TITLE
fix(frontend): Change the incorrect loading context for run details

### DIFF
--- a/frontend/src/pages/RunDetailsRouter.tsx
+++ b/frontend/src/pages/RunDetailsRouter.tsx
@@ -71,7 +71,7 @@ export default function RunDetailsRouter(props: RunDetailsProps) {
   }
 
   if (runIsFetching || templateStrIsFetching) {
-    return <div>Currently loading recurring run information</div>;
+    return <div>Currently loading run information</div>;
   }
 
   return <EnhancedRunDetails {...props} />;


### PR DESCRIPTION
The loading context in run details router was incorrect.

![9sA8nBy8iuZSoar](https://user-images.githubusercontent.com/56132941/233194174-387cf3a1-231c-4274-a09c-1cbdc4d5e26c.png)
