### PR TITLE
fix(SDK): fix `client.run_pipeline` with `pipeline_id` and `version_id` gives error

### DIFF
--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -956,7 +956,7 @@ class Client:
         if params is None:
             params = {}
 
-        pipeline_doc = None
+        pipeline_spec = None
         if pipeline_package_path:
             pipeline_doc = _extract_pipeline_yaml(pipeline_package_path)
 
@@ -965,6 +965,7 @@ class Client:
             if enable_caching is not None:
                 _override_caching_options(pipeline_doc.pipeline_spec,
                                           enable_caching)
+            pipeline_spec = pipeline_doc.to_dict()
 
         pipeline_version_reference = None
         if pipeline_id is not None and version_id is not None:
@@ -976,7 +977,7 @@ class Client:
             parameters=params,
         )
         return _JobConfig(
-            pipeline_spec=pipeline_doc.to_dict(),
+            pipeline_spec=pipeline_spec,
             pipeline_version_reference=pipeline_version_reference,
             runtime_config=runtime_config,
         )


### PR DESCRIPTION
**Description of your changes:**
The method should work with either providing `pipeline_package_path` or providing both `pipeline_id` and `version_id`.
Before the fix, if one provides `pipeline_id` and `version_id`, it causes the below error:
```
    client.run_pipeline(
  File "/usr/local/google/home/chesu/git/pipelines/sdk/python/kfp/client/client.py", line 727, in run_pipeline
    job_config = self._create_job_config(
  File "/usr/local/google/home/chesu/git/pipelines/sdk/python/kfp/client/client.py", line 979, in _create_job_config
    pipeline_spec=pipeline_doc.to_dict(),
AttributeError: 'NoneType' object has no attribute 'to_dict'
```
Manually tested.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
