### PR TITLE
fix(frontend): Render graph for yaml file containing platform_spec

### DIFF
--- a/frontend/src/lib/v2/WorkflowUtils.ts
+++ b/frontend/src/lib/v2/WorkflowUtils.ts
@@ -19,7 +19,7 @@ import { convertFlowElements } from 'src/lib/v2/StaticFlow';
 import * as WorkflowUtils from 'src/lib/v2/WorkflowUtils';
 import { Workflow } from 'src/third_party/mlmd/argo_template';
 
-// This key can be used to retrieve 'pipeline_spec' in yaml file which contains 'platform_spec'
+// This key is used to retrieve the platform-agnostic pipeline definition
 export const PIPELINE_SPEC_TEMPLATE_KEY = 'pipeline_spec';
 
 export function isV2Pipeline(workflow: Workflow): boolean {

--- a/frontend/src/lib/v2/WorkflowUtils.ts
+++ b/frontend/src/lib/v2/WorkflowUtils.ts
@@ -19,8 +19,8 @@ import { convertFlowElements } from 'src/lib/v2/StaticFlow';
 import * as WorkflowUtils from 'src/lib/v2/WorkflowUtils';
 import { Workflow } from 'src/third_party/mlmd/argo_template';
 
-// This key can be used to retrieve 'pipeline_spec' in yaml file containing 'platform_spec'
-export const PIPELINE_SPEC_TEMPLATE_KEY = 'pipeline_spec'; 
+// This key can be used to retrieve 'pipeline_spec' in yaml file which contains 'platform_spec'
+export const PIPELINE_SPEC_TEMPLATE_KEY = 'pipeline_spec';
 
 export function isV2Pipeline(workflow: Workflow): boolean {
   return workflow?.metadata?.annotations?.['pipelines.kubeflow.org/v2_pipeline'] === 'true';
@@ -36,7 +36,8 @@ export function isArgoWorkflowTemplate(template: Workflow): boolean {
 export function isTemplateV2(templateString: string): boolean {
   try {
     const template =
-      jsyaml.safeLoad(templateString)[PIPELINE_SPEC_TEMPLATE_KEY] ?? jsyaml.safeLoad(templateString);
+      jsyaml.safeLoad(templateString)[PIPELINE_SPEC_TEMPLATE_KEY] ??
+      jsyaml.safeLoad(templateString);
     if (isArgoWorkflowTemplate(template)) {
       return false;
     } else if (isFeatureEnabled(FeatureKey.V2_ALPHA)) {
@@ -54,7 +55,8 @@ export function isTemplateV2(templateString: string): boolean {
 export function convertYamlToV2PipelineSpec(template: string): PipelineSpec {
   // If pipeline_spec exists in the return value of safeload, which means the original yaml contains
   // platform_spec, then the pipeline spec is stored in pipeline_spec field.
-  const pipelineSpecYAML = jsyaml.safeLoad(template)[PIPELINE_SPEC_TEMPLATE_KEY] ?? jsyaml.safeLoad(template);
+  const pipelineSpecYAML =
+    jsyaml.safeLoad(template)[PIPELINE_SPEC_TEMPLATE_KEY] ?? jsyaml.safeLoad(template);
   const ts_pipelinespec = PipelineSpec.fromJSON(pipelineSpecYAML);
   if (!ts_pipelinespec.root || !ts_pipelinespec.pipelineInfo || !ts_pipelinespec.deploymentSpec) {
     throw new Error('Important infomation is missing. Pipeline Spec is invalid.');
@@ -76,7 +78,8 @@ export function isPipelineSpec(templateString: string) {
   }
   try {
     const template =
-      jsyaml.safeLoad(templateString)[PIPELINE_SPEC_TEMPLATE_KEY] ?? jsyaml.safeLoad(templateString);
+      jsyaml.safeLoad(templateString)[PIPELINE_SPEC_TEMPLATE_KEY] ??
+      jsyaml.safeLoad(templateString);
     if (WorkflowUtils.isArgoWorkflowTemplate(template)) {
       StaticGraphParser.createGraph(template!);
       return false;

--- a/frontend/src/lib/v2/WorkflowUtils.ts
+++ b/frontend/src/lib/v2/WorkflowUtils.ts
@@ -19,6 +19,8 @@ import { convertFlowElements } from 'src/lib/v2/StaticFlow';
 import * as WorkflowUtils from 'src/lib/v2/WorkflowUtils';
 import { Workflow } from 'src/third_party/mlmd/argo_template';
 
+export const PIPELINE_SPEC = 'pipeline_spec';
+
 export function isV2Pipeline(workflow: Workflow): boolean {
   return workflow?.metadata?.annotations?.['pipelines.kubeflow.org/v2_pipeline'] === 'true';
 }
@@ -33,7 +35,7 @@ export function isArgoWorkflowTemplate(template: Workflow): boolean {
 export function isTemplateV2(templateString: string): boolean {
   try {
     const template =
-      jsyaml.safeLoad(templateString)['pipeline_spec'] ?? jsyaml.safeLoad(templateString);
+      jsyaml.safeLoad(templateString)[PIPELINE_SPEC] ?? jsyaml.safeLoad(templateString);
     if (isArgoWorkflowTemplate(template)) {
       return false;
     } else if (isFeatureEnabled(FeatureKey.V2_ALPHA)) {

--- a/frontend/src/lib/v2/WorkflowUtils.ts
+++ b/frontend/src/lib/v2/WorkflowUtils.ts
@@ -32,7 +32,8 @@ export function isArgoWorkflowTemplate(template: Workflow): boolean {
 
 export function isTemplateV2(templateString: string): boolean {
   try {
-    const template = jsyaml.safeLoad(templateString);
+    const template =
+      jsyaml.safeLoad(templateString)['pipeline_spec'] ?? jsyaml.safeLoad(templateString);
     if (isArgoWorkflowTemplate(template)) {
       return false;
     } else if (isFeatureEnabled(FeatureKey.V2_ALPHA)) {
@@ -48,7 +49,9 @@ export function isTemplateV2(templateString: string): boolean {
 
 // Assuming template is the JSON format of PipelineSpec in api/v2alpha1/pipeline_spec.proto
 export function convertYamlToV2PipelineSpec(template: string): PipelineSpec {
-  const pipelineSpecYAML = jsyaml.safeLoad(template);
+  // If pipeline_spec exists in the return value of safeload, which means the original yaml contains
+  // platform_spec, then the pipeline spec is stored in pipeline_spec field.
+  const pipelineSpecYAML = jsyaml.safeLoad(template)['pipeline_spec'] ?? jsyaml.safeLoad(template);
   const ts_pipelinespec = PipelineSpec.fromJSON(pipelineSpecYAML);
   if (!ts_pipelinespec.root || !ts_pipelinespec.pipelineInfo || !ts_pipelinespec.deploymentSpec) {
     throw new Error('Important infomation is missing. Pipeline Spec is invalid.');
@@ -69,7 +72,8 @@ export function isPipelineSpec(templateString: string) {
     return false;
   }
   try {
-    const template = jsyaml.safeLoad(templateString);
+    const template =
+      jsyaml.safeLoad(templateString)['pipeline_spec'] ?? jsyaml.safeLoad(templateString);
     if (WorkflowUtils.isArgoWorkflowTemplate(template)) {
       StaticGraphParser.createGraph(template!);
       return false;
@@ -90,7 +94,8 @@ export function isPipelineSpec(templateString: string) {
 export function getContainer(componentSpec: ComponentSpec, templateString: string) {
   const executionLabel = componentSpec?.executorLabel;
 
-  const jsonTemplate = jsyaml.safeLoad(templateString);
+  const jsonTemplate =
+    jsyaml.safeLoad(templateString)['pipeline_spec'] ?? jsyaml.safeLoad(templateString);
   const deploymentSpec = jsonTemplate['deploymentSpec'];
 
   const executorsMap = deploymentSpec['executors'];


### PR DESCRIPTION
Previously, we directly use the return value from safeLoad(), which is PipelineSpec, to draw the graph. However, after the concept `platform_spec` is introduced, the return value from safeLoad() will become a nested structure, and the PipelineSpec we use to draw graph is stored in `pipeline_spec` field.