### PR TITLE
fix(frontend): Parameter field is missing after choosing another v2 pipeline

### DIFF
--- a/frontend/src/pages/NewRunV2.test.tsx
+++ b/frontend/src/pages/NewRunV2.test.tsx
@@ -83,11 +83,21 @@ describe('NewRunV2', () => {
 
   const NEW_TEST_PIPELINE_ID = 'new-test-pipeline-id';
   const NEW_TEST_PIPELINE_NAME = 'new-test-pipeline';
+  const NEW_TEST_PIPELINE_VERSION_ID = 'new-test-pipeline-version-id';
+  const NEW_TEST_PIPELINE_VERSION_NAME = 'new-test-pipeline-version';
   const NEW_TEST_PIPELINE: V2beta1Pipeline = {
     created_at: new Date(2018, 8, 7, 6, 5, 4),
     description: '',
     display_name: NEW_TEST_PIPELINE_NAME,
     pipeline_id: NEW_TEST_PIPELINE_ID,
+  };
+
+  const NEW_TEST_PIPELINE_VERSION: V2beta1PipelineVersion = {
+    description: '',
+    display_name: NEW_TEST_PIPELINE_VERSION_NAME,
+    pipeline_id: NEW_TEST_PIPELINE_ID,
+    pipeline_version_id: NEW_TEST_PIPELINE_VERSION_ID,
+    pipeline_spec: v2LWPipelineSpec,
   };
 
   // Reponse from BE while POST a run for creating New UI-Run
@@ -443,6 +453,15 @@ describe('NewRunV2', () => {
       const getPipelineSpy = jest.spyOn(Apis.pipelineServiceApiV2, 'getPipeline');
       getPipelineSpy.mockImplementation(() => NEW_TEST_PIPELINE);
 
+      const listPipelineVersionsSpy = jest.spyOn(Apis.pipelineServiceApiV2, 'listPipelineVersions');
+      listPipelineVersionsSpy.mockImplementation(() => {
+        const response: V2beta1ListPipelinesResponse = {
+          pipeline_versions: [NEW_TEST_PIPELINE_VERSION],
+          total_size: 1,
+        };
+        return response;
+      });
+
       render(
         <CommonTestWrapper>
           <NewRunV2
@@ -474,6 +493,15 @@ describe('NewRunV2', () => {
 
       const usePipelineButton = screen.getByText('Use this pipeline');
       fireEvent.click(usePipelineButton);
+
+      await waitFor(() => {
+        expect(listPipelineVersionsSpy).toHaveBeenCalledWith(
+          NEW_TEST_PIPELINE_ID,
+          undefined,
+          1,
+          'created_at desc',
+        );
+      });
 
       screen.getByDisplayValue(NEW_TEST_PIPELINE_NAME);
     });

--- a/frontend/src/pages/NewRunV2.test.tsx
+++ b/frontend/src/pages/NewRunV2.test.tsx
@@ -494,6 +494,8 @@ describe('NewRunV2', () => {
       const usePipelineButton = screen.getByText('Use this pipeline');
       fireEvent.click(usePipelineButton);
 
+      // After pipeline is selected, listPipelineVersions will be called to
+      // retrieve the latest version.
       await waitFor(() => {
         expect(listPipelineVersionsSpy).toHaveBeenCalledWith(
           NEW_TEST_PIPELINE_ID,

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -28,11 +28,7 @@ import * as JsYaml from 'js-yaml';
 import { useMutation } from 'react-query';
 import { Link } from 'react-router-dom';
 import { V2beta1Experiment, V2beta1ExperimentStorageState } from 'src/apisv2beta1/experiment';
-import {
-  V2beta1ListPipelineVersionsResponse,
-  V2beta1Pipeline,
-  V2beta1PipelineVersion,
-} from 'src/apisv2beta1/pipeline';
+import { V2beta1Pipeline, V2beta1PipelineVersion } from 'src/apisv2beta1/pipeline';
 import { V2beta1PipelineVersionReference, V2beta1Run } from 'src/apisv2beta1/run';
 import { V2beta1Filter, V2beta1PredicateOperation } from 'src/apisv2beta1/filter';
 import BusyButton from 'src/atoms/BusyButton';

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -134,7 +134,7 @@ function getPipelineDetailsUrl(
   return isRecurring ? pipelineDetailsUrlfromRecurringRun : pipelineDetailsUrlfromRun;
 }
 
-async function getLatestVersion(pipelineId: string) {
+export async function getLatestVersion(pipelineId: string) {
   try {
     const listVersionsResponse = await Apis.pipelineServiceApiV2.listPipelineVersions(
       pipelineId,

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -45,7 +45,7 @@ import { color, commonCss, padding } from 'src/Css';
 import { ComponentInputsSpec_ParameterSpec } from 'src/generated/pipeline_spec/pipeline_spec';
 import { Apis, ExperimentSortKeys, PipelineSortKeys, PipelineVersionSortKeys } from 'src/lib/Apis';
 import { URLParser } from 'src/lib/URLParser';
-import { errorToMessage, generateRandomString } from 'src/lib/Utils';
+import { errorToMessage, generateRandomString, logger } from 'src/lib/Utils';
 import { convertYamlToV2PipelineSpec } from 'src/lib/v2/WorkflowUtils';
 import { classes, stylesheet } from 'typestyle';
 import { PageProps } from './Page';
@@ -146,6 +146,7 @@ export async function getLatestVersion(pipelineId: string) {
       ? listVersionsResponse.pipeline_versions[0]
       : undefined;
   } catch (err) {
+    logger.error('Cannot retrieve pipeline version list.', err);
     return;
   }
 }


### PR DESCRIPTION
After the concept of `default_version` is removed in v2 API, listPipelineVersions() need to be called after pipeline is selected to retrieve the latest pipeline version.

Pipeline with parameter:

https://user-images.githubusercontent.com/56132941/233697396-0d1aff73-1954-4d2c-8fdc-3ecef900f8e1.mov


Parameter field is missing:

https://user-images.githubusercontent.com/56132941/233697731-286df3c8-43ab-4bad-9301-a95001795b56.mov

After this PR:

https://user-images.githubusercontent.com/56132941/233698044-ca7be78d-a77a-4465-aec1-77cebf09a71a.mov




