### PR TITLE
fix(sdk): allow user to choose platform for component container build. Fixes #8883

### DIFF
--- a/sdk/python/kfp/cli/component.py
+++ b/sdk/python/kfp/cli/component.py
@@ -292,7 +292,7 @@ class ComponentBuilder():
         self._maybe_write_file(_DOCKERFILE, dockerfile_contents,
                                overwrite_dockerfile)
 
-    def build_image(self, push_image: bool):
+    def build_image(self, platform: str, push_image: bool):
         logging.info(f'Building image {self._target_image} using Docker...')
         client = docker.from_env()
 
@@ -305,6 +305,7 @@ class ComponentBuilder():
                 dockerfile='Dockerfile',
                 tag=self._target_image,
                 decode=True,
+                platform=platform,
             )
             for log in logs:
                 message = log.get('stream', '').rstrip('\n')
@@ -379,6 +380,11 @@ def component():
     default=True,
     help='Build the container image.')
 @click.option(
+    '--platform',
+    type=str,
+    default='linux/amd64',
+    help='The platform to build the container image for.')
+@click.option(
     '--push-image/--no-push-image',
     type=bool,
     is_flag=True,
@@ -386,7 +392,7 @@ def component():
     help='Push the built image to its remote repository.')
 def build(components_directory: str, component_filepattern: str, engine: str,
           kfp_package_path: Optional[str], overwrite_dockerfile: bool,
-          build_image: bool, push_image: bool):
+          build_image: bool, platform: str, push_image: bool):
     """Builds containers for KFP v2 Python-based components."""
 
     if build_image and engine != 'docker':
@@ -428,4 +434,4 @@ def build(components_directory: str, component_filepattern: str, engine: str,
     builder.maybe_generate_dockerignore()
     builder.maybe_generate_dockerfile(overwrite_dockerfile=overwrite_dockerfile)
     if build_image:
-        builder.build_image(push_image=push_image)
+        builder.build_image(platform=platform, push_image=push_image)

--- a/sdk/python/kfp/cli/component_test.py
+++ b/sdk/python/kfp/cli/component_test.py
@@ -407,7 +407,13 @@ class Test(unittest.TestCase):
         )
         self.assertEqual(result.exit_code, 0)
 
-        self._docker_client.api.build.assert_called_once()
+        self._docker_client.api.build.assert_called_once_with(
+            path=mock.ANY,
+            dockerfile='Dockerfile',
+            tag=mock.ANY,
+            decode=True,
+            platform='linux/amd64',
+        )
         self._docker_client.images.push.assert_called_once_with(
             'custom-image', stream=True, decode=True)
 


### PR DESCRIPTION
**Description of your changes:**

Add the `--platform` option to `kfp component build` to choose container build architecture. Fixes #8883 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
