### PR TITLE
fix(frontend): Missing pipeline info while cloning recurring run.

### DIFF
--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -537,7 +537,13 @@ function NewRunV2(props: NewRunV2Props) {
                   [QUERY_PARAMS.experimentId]: experiment.experiment_id || '',
                   [QUERY_PARAMS.cloneFromRun]: existingRunId || '',
                 });
+              } else if (existingRecurringRunId) {
+                searchString = urlParser.build({
+                  [QUERY_PARAMS.experimentId]: experiment.experiment_id || '',
+                  [QUERY_PARAMS.cloneFromRecurringRun]: existingRecurringRunId || '',
+                });
               } else {
+                // Enter new run page from run list (none of pipeline is selected)
                 searchString = urlParser.build({
                   [QUERY_PARAMS.experimentId]: experiment.experiment_id || '',
                 });


### PR DESCRIPTION
In the new run page, we allow user to change experiment selection. With the updated experiment, search string in URL is changed as well. Previously, the scenario of cloning recurring run is not handled, which lead to the missing pipeline information issue after changing experiment.

Before:

https://user-images.githubusercontent.com/56132941/234348697-7d5a2d46-ca27-4450-8959-7b8c10c89c24.mov

After:

https://user-images.githubusercontent.com/56132941/234348765-b6b22b63-c3e3-49f6-8c54-ebda24b4113d.mov


