### PR TITLE
fix(frontend): fail to clone SDK-created run / recurring run

### DIFF
--- a/frontend/src/pages/NewRunSwitcher.tsx
+++ b/frontend/src/pages/NewRunSwitcher.tsx
@@ -147,11 +147,15 @@ function NewRunSwitcher(props: PageProps) {
     { enabled: !!experimentId, staleTime: Infinity },
   );
 
+  // Three possible sources for template string
+  // 1. pipelineManifest: pipeline_spec stored in run or recurring run
+  // 2. templateStrFromSpec: pipeline_spec stored in pipeline_version (direct to v2)
+  // 3. templateStrFromTemplate(v1): template in the response of getPipelineVersionTemplate() (direct to v1)
   const templateString =
-    pipelineManifest ?? isTemplateV2(templateStrFromSpec)
-      ? templateStrFromSpec
-      : templateStrFromTemplate;
+    pipelineManifest ??
+    (isTemplateV2(templateStrFromSpec) ? templateStrFromSpec : templateStrFromTemplate);
 
+  // TODO(jlyaoyuli): simplify the logic of page redirection and usage of template string source
   if (isFeatureEnabled(FeatureKey.V2_ALPHA)) {
     if (
       (getV2RunSuccess || getRecurringRunSuccess || isTemplatePullSuccessFromPipeline) &&

--- a/frontend/src/pages/NewRunSwitcher.tsx
+++ b/frontend/src/pages/NewRunSwitcher.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import * as JsYaml from 'js-yaml';
 import { useQuery } from 'react-query';
 import { QUERY_PARAMS } from 'src/components/Router';
-import { isFeatureEnabled, FeatureKey } from 'src/features';
 import { Apis } from 'src/lib/Apis';
 import { NamespaceContext } from 'src/lib/KubeflowClient';
 import { URLParser } from 'src/lib/URLParser';
@@ -120,22 +119,6 @@ function NewRunSwitcher(props: PageProps) {
   const pipelineSpecInVersion = pipelineVersion?.pipeline_spec;
   const templateStrFromSpec = pipelineSpecInVersion ? JsYaml.safeDump(pipelineSpecInVersion) : '';
 
-  const {
-    isSuccess: isTemplatePullSuccessFromPipeline,
-    isFetching: pipelineTemplateStrIsFetching,
-    data: templateStrFromTemplate,
-  } = useQuery<string, Error>(
-    ['ApiPipelineVersionTemplate', pipelineVersionIdParam],
-    async () => {
-      if (!pipelineVersionId) {
-        return '';
-      }
-      const template = await Apis.pipelineServiceApi.getPipelineVersionTemplate(pipelineVersionId);
-      return template?.template || '';
-    },
-    { enabled: !!pipelineVersion, staleTime: Infinity, cacheTime: 0 },
-  );
-
   const { data: experiment } = useQuery<V2beta1Experiment, Error>(
     ['experiment', experimentId],
     async () => {
@@ -147,37 +130,28 @@ function NewRunSwitcher(props: PageProps) {
     { enabled: !!experimentId, staleTime: Infinity },
   );
 
-  // Three possible sources for template string
-  // 1. pipelineManifest: pipeline_spec stored in run or recurring run
-  // 2. templateStrFromSpec: pipeline_spec stored in pipeline_version (direct to v2)
-  // 3. templateStrFromTemplate(v1): template in the response of getPipelineVersionTemplate() (direct to v1)
-  const templateString =
-    pipelineManifest ??
-    (isTemplateV2(templateStrFromSpec) ? templateStrFromSpec : templateStrFromTemplate);
+  // Two possible sources for template string
+  // 1. pipelineManifest: pipeline_spec stored in run or recurring run created by SDK
+  // 2. templateStrFromSpec: pipeline_spec stored in pipeline_version
+  const templateString = pipelineManifest ?? templateStrFromSpec;
 
-  // TODO(jlyaoyuli): simplify the logic of page redirection and usage of template string source
-  if (isFeatureEnabled(FeatureKey.V2_ALPHA)) {
-    if (
-      (getV2RunSuccess || getRecurringRunSuccess || isTemplatePullSuccessFromPipeline) &&
-      isTemplateV2(templateString || '')
-    ) {
-      return (
-        <NewRunV2
-          {...props}
-          namespace={namespace}
-          existingRunId={existingRunId}
-          existingRun={v2Run}
-          existingRecurringRunId={originalRecurringRunId}
-          existingRecurringRun={recurringRun}
-          existingPipeline={pipeline}
-          handlePipelineIdChange={setPipelineIdFromPipeline}
-          existingPipelineVersion={pipelineVersion}
-          handlePipelineVersionIdChange={setPipelineVersionIdParam}
-          templateString={templateString}
-          chosenExperiment={experiment}
-        />
-      );
-    }
+  if (isTemplateV2(templateString || '')) {
+    return (
+      <NewRunV2
+        {...props}
+        namespace={namespace}
+        existingRunId={existingRunId}
+        existingRun={v2Run}
+        existingRecurringRunId={originalRecurringRunId}
+        existingRecurringRun={recurringRun}
+        existingPipeline={pipeline}
+        handlePipelineIdChange={setPipelineIdFromPipeline}
+        existingPipelineVersion={pipelineVersion}
+        handlePipelineVersionIdChange={setPipelineVersionIdParam}
+        templateString={templateString}
+        chosenExperiment={experiment}
+      />
+    );
   }
 
   // Use experiment ID to create new run
@@ -187,8 +161,7 @@ function NewRunSwitcher(props: PageProps) {
     v2RunIsFetching ||
     recurringRunIsFetching ||
     pipelineIsFetching ||
-    pipelineVersionIsFetching ||
-    pipelineTemplateStrIsFetching
+    pipelineVersionIsFetching
   ) {
     return <div>Currently loading pipeline information</div>;
   }

--- a/frontend/src/pages/NewRunV2.test.tsx
+++ b/frontend/src/pages/NewRunV2.test.tsx
@@ -39,9 +39,9 @@ import { V2beta1RecurringRun, RecurringRunMode } from 'src/apisv2beta1/recurring
 import { QUERY_PARAMS, RoutePage } from 'src/components/Router';
 import { Apis } from 'src/lib/Apis';
 import { convertYamlToV2PipelineSpec } from 'src/lib/v2/WorkflowUtils';
-import NewRunV2 from './NewRunV2';
-import NewRunSwitcher from './NewRunSwitcher';
-import { PageProps } from './Page';
+import NewRunV2 from 'src/pages/NewRunV2';
+import NewRunSwitcher from 'src/pages/NewRunSwitcher';
+import { PageProps } from 'src/Page';
 
 const V2_XG_PIPELINESPEC_PATH = 'src/data/test/xgboost_sample_pipeline.yaml';
 const v2XGYamlTemplateString = fs.readFileSync(V2_XG_PIPELINESPEC_PATH, 'utf8');

--- a/frontend/src/pages/NewRunV2.test.tsx
+++ b/frontend/src/pages/NewRunV2.test.tsx
@@ -17,6 +17,8 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import fs from 'fs';
 import 'jest';
+import * as JsYaml from 'js-yaml';
+import * as features from 'src/features';
 import React from 'react';
 import { testBestPractices } from 'src/TestUtils';
 import { CommonTestWrapper } from 'src/TestWrapper';
@@ -38,10 +40,8 @@ import { QUERY_PARAMS, RoutePage } from 'src/components/Router';
 import { Apis } from 'src/lib/Apis';
 import { convertYamlToV2PipelineSpec } from 'src/lib/v2/WorkflowUtils';
 import NewRunV2 from './NewRunV2';
-import { PageProps } from './Page';
-import * as JsYaml from 'js-yaml';
 import NewRunSwitcher from './NewRunSwitcher';
-import * as features from '../features';
+import { PageProps } from './Page';
 
 const V2_XG_PIPELINESPEC_PATH = 'src/data/test/xgboost_sample_pipeline.yaml';
 const v2XGYamlTemplateString = fs.readFileSync(V2_XG_PIPELINESPEC_PATH, 'utf8');


### PR DESCRIPTION
This is a regression bug caused by https://github.com/kubeflow/pipelines/pull/9123. Main reason is the incorrect in-line expression used to determine template string. This PR fixes the logic and add short comment to describe the source of template string and specify the priority!