### PR TITLE
fix(backend): change format of some backend error message

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -476,7 +476,7 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 	}
 	executionSpec, err := tmpl.RunWorkflow(run, runWorkflowOptions)
 	if err != nil {
-		return nil, util.NewInternalServerError(err, "failed to generate the ExecutionSpec")
+		return nil, util.Wrap(err, "Failed to generate the ExecutionSpec")
 	}
 	err = executionSpec.Validate(false, false)
 	if err != nil {
@@ -1802,7 +1802,8 @@ func (r *ResourceManager) ValidateExperimentNamespace(experimentId string, names
 		return util.Wrapf(err, "Failed to validate the namespace of experiment %s", experimentId)
 	}
 	if experimentNamespace != "" && experimentNamespace != namespace {
-		return util.NewInternalServerError(util.NewInvalidInputError("Experiment %s belongs to namespace '%s' (claimed a different namespace '%s')", experimentId, experimentNamespace, namespace), "Failed to validate the namespace of experiment %s", experimentId)
+		return util.NewInvalidInputError("Failed to validate the namespace of experiment: experiment %s belongs to namespace '%s' (claimed a different namespace '%s')",
+			experimentId, experimentNamespace, namespace)
 	}
 	return nil
 }

--- a/backend/src/apiserver/template/template.go
+++ b/backend/src/apiserver/template/template.go
@@ -134,7 +134,7 @@ func modelToPipelineJobRuntimeConfig(modelRuntimeConfig *model.RuntimeConfig) (*
 	if modelRuntimeConfig.Parameters != "" {
 		err := json.Unmarshal([]byte(modelRuntimeConfig.Parameters), parameters)
 		if err != nil {
-			return nil, err
+			return nil, util.NewInternalServerError(err, "error unmarshalling model runtime config parameters")
 		}
 	}
 	runtimeConfig := &pipelinespec.PipelineJob_RuntimeConfig{}
@@ -155,12 +155,12 @@ func stringMapToCRDParameters(modelParams string) ([]scheduledworkflow.Parameter
 	}
 	err := json.Unmarshal([]byte(modelParams), &parameters)
 	if err != nil {
-		return nil, err
+		return nil, util.NewInternalServerError(err, "error unmarshalling model parameters")
 	}
 	for name, value := range parameters {
 		valueBytes, err := value.MarshalJSON()
 		if err != nil {
-			return nil, err
+			return nil, util.NewInternalServerError(err, "error marshalling model parameters")
 		}
 		swParam := scheduledworkflow.Parameter{
 			Name:  name,
@@ -183,7 +183,7 @@ func stringArrayToCRDParameters(modelParameters string) ([]scheduledworkflow.Par
 	}
 	err := json.Unmarshal([]byte(modelParameters), &paramsMapList)
 	if err != nil {
-		return nil, err
+		return nil, util.NewInternalServerError(err, "error unmarshalling model parameters")
 	}
 	for _, param := range paramsMapList {
 		desiredParams = append(desiredParams, scheduledworkflow.Parameter{Name: (*param)["name"], Value: (*param)["value"]})
@@ -199,7 +199,7 @@ func modelToParametersMap(modelParameters string) (map[string]string, error) {
 	}
 	err := json.Unmarshal([]byte(modelParameters), &paramsMapList)
 	if err != nil {
-		return nil, err
+		return nil, util.NewInternalServerError(err, "error marshalling model parameters")
 	}
 	for _, param := range paramsMapList {
 		desiredParamsMap[(*param)["name"]] = (*param)["value"]

--- a/backend/src/apiserver/template/template.go
+++ b/backend/src/apiserver/template/template.go
@@ -199,7 +199,7 @@ func modelToParametersMap(modelParameters string) (map[string]string, error) {
 	}
 	err := json.Unmarshal([]byte(modelParameters), &paramsMapList)
 	if err != nil {
-		return nil, util.NewInternalServerError(err, "error marshalling model parameters")
+		return nil, util.NewInternalServerError(err, "error unmarshalling model parameters")
 	}
 	for _, param := range paramsMapList {
 		desiredParamsMap[(*param)["name"]] = (*param)["value"]

--- a/backend/src/apiserver/template/v2_template.go
+++ b/backend/src/apiserver/template/v2_template.go
@@ -97,7 +97,7 @@ func (t *V2Spec) ScheduledWorkflow(modelJob *model.Job) (*scheduledworkflow.Sche
 	}
 	crdTrigger, err := modelToCRDTrigger(modelJob.Trigger)
 	if err != nil {
-		return nil, util.Wrap(err, "convering model trigger to crd trigger failed")
+		return nil, util.Wrap(err, "converting model trigger to crd trigger failed")
 	}
 
 	scheduledWorkflow := &scheduledworkflow.ScheduledWorkflow{
@@ -329,8 +329,8 @@ func (t *V2Spec) validatePipelineJobInputs(job *pipelinespec.PipelineJob) error 
 				requiredParamNames = append(requiredParamNames, name)
 			}
 			return util.NewInvalidInputError(
-				fmt.Sprintf("pipeline requiring input has no paramater(s) provided. Need parameter(s): %s",
-					strings.Join(requiredParamNames, ", ")),
+				"pipeline requiring input has no paramater(s) provided. Need parameter(s): %s",
+				strings.Join(requiredParamNames, ", "),
 			)
 		} else {
 			// both required parameters and inputs are empty
@@ -343,9 +343,8 @@ func (t *V2Spec) validatePipelineJobInputs(job *pipelinespec.PipelineJob) error 
 		if input, ok := runtimeConfig.GetParameterValues()[name]; !ok {
 			// If the parameter is optional, or there is a default value, it's ok to not have a user input
 			if !param.GetIsOptional() && param.GetDefaultValue() == nil {
-				return util.NewInvalidInputError(
-					fmt.Sprintf("parameter %s is not optional, yet has neither default value nor user provided value", name),
-				)
+				return util.NewInvalidInputError("parameter %s is not optional, yet has neither default value "+
+					"nor user provided value", name)
 			}
 		} else {
 			// Verify the parameter type is correct
@@ -354,40 +353,34 @@ func (t *V2Spec) validatePipelineJobInputs(job *pipelinespec.PipelineJob) error 
 				return util.NewInvalidInputError(fmt.Sprintf("input parameter %s has unspecified type", name))
 			case pipelinespec.ParameterType_NUMBER_DOUBLE, pipelinespec.ParameterType_NUMBER_INTEGER:
 				if _, ok := input.GetKind().(*structpb.Value_NumberValue); !ok {
-					return util.NewInvalidInputError(
-						fmt.Sprintf("input parameter %s requires type double or integer, but the parameter value is not of number value type", name),
-					)
+					return util.NewInvalidInputError("input parameter %s requires type double or integer, "+
+						"but the parameter value is not of number value type", name)
 				}
 			case pipelinespec.ParameterType_STRING:
 				if _, ok := input.GetKind().(*structpb.Value_StringValue); !ok {
-					return util.NewInvalidInputError(
-						fmt.Sprintf("input parameter %s requires type string, but the input parameter is not of string value type", name),
-					)
+					return util.NewInvalidInputError("input parameter %s requires type string, but the "+
+						"input parameter is not of string value type", name)
 				}
 			case pipelinespec.ParameterType_BOOLEAN:
 				if _, ok := input.GetKind().(*structpb.Value_BoolValue); !ok {
-					return util.NewInvalidInputError(
-						fmt.Sprintf("input parameter %s requires type bool, but the input parameter is not of bool value type", name),
-					)
+					return util.NewInvalidInputError("input parameter %s requires type bool, but the input "+
+						"parameter is not of bool value type", name)
 				}
 			case pipelinespec.ParameterType_LIST:
 				if _, ok := input.GetKind().(*structpb.Value_ListValue); !ok {
-					return util.NewInvalidInputError(
-						fmt.Sprintf("input parameter %s requires type list, but the input parameter is not of list value type", name),
-					)
+					return util.NewInvalidInputError("input parameter %s requires type list, but the input "+
+						"parameter is not of list value type", name)
 				}
 			case pipelinespec.ParameterType_STRUCT:
 				if _, ok := input.GetKind().(*structpb.Value_StructValue); !ok {
-					return util.NewInvalidInputError(
-						fmt.Sprintf("input parameter %s requires type struct, but the input parameter is not of struct value type", name),
-					)
+					return util.NewInvalidInputError("input parameter %s requires type struct, but the input "+
+						"parameter is not of struct value type", name)
 				}
 			case pipelinespec.ParameterType_TASK_FINAL_STATUS:
-				return util.NewInvalidInputError(
-					fmt.Sprintf("input parameter %s requires type TASK_FINAL_STATUS, which is invalid for root component", name),
-				)
+				return util.NewInvalidInputError("input parameter %s requires type TASK_FINAL_STATUS, which is "+
+					"invalid for root component", name)
 			default:
-				return util.NewInvalidInputError(fmt.Sprintf("input parameter %s requires type unknown", name))
+				return util.NewInvalidInputError("input parameter %s requires type unknown", name)
 			}
 		}
 	}
@@ -400,7 +393,8 @@ func (t *V2Spec) validatePipelineJobInputs(job *pipelinespec.PipelineJob) error 
 		}
 	}
 	if len(extraParams) > 0 {
-		return fmt.Errorf("parameter(s) provided are not required by pipeline: %s", strings.Join(extraParams, ", "))
+		return util.NewInvalidInputError("parameter(s) provided are not required by pipeline: %s",
+			strings.Join(extraParams, ", "))
 	}
 
 	return nil


### PR DESCRIPTION
**Description of your changes:**
Thanks to @chensun who found that when creating a job without the required parameters, the backend returns a 500 error (internal server error), instead of an invalid input error. 
Error message:
![image](https://user-images.githubusercontent.com/12806577/236039493-4280ddbb-9fe8-4872-b26d-e918fd12590a.png)

This PR changes the error code/type. Also changes some other error messages so they are of the right type and more clear. 

Verified manually that the error messages are correct.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
