### PR TITLE
fix(frontend): Failed pipeline version creation should not generate an empty pipeline.

### DIFF
--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -19,6 +19,7 @@ import { JobServiceApi } from 'src/apis/job';
 import { RecurringRunServiceApi } from 'src/apisv2beta1/recurringrun';
 import { ApiPipeline, ApiPipelineVersion, PipelineServiceApi } from 'src/apis/pipeline';
 import {
+  V2beta1Pipeline,
   V2beta1PipelineVersion,
   PipelineServiceApi as PipelineServiceApiV2,
 } from 'src/apisv2beta1/pipeline';
@@ -417,6 +418,29 @@ export class Apis {
         method: 'POST',
       },
     );
+  }
+
+  public static async uploadPipelineV2(
+    pipelineName: string,
+    pipelineDescription: string,
+    pipelineData: File,
+    namespace?: string,
+  ): Promise<V2beta1Pipeline> {
+    const fd = new FormData();
+    fd.append('uploadfile', pipelineData, pipelineData.name);
+    let query = `name=${encodeURIComponent(pipelineName)}&description=${encodeURIComponent(
+      pipelineDescription,
+    )}`;
+
+    if (namespace) {
+      query = `${query}&namespace=${encodeURIComponent(namespace)}`;
+    }
+
+    return await this._fetchAndParse<V2beta1Pipeline>('/pipelines/upload', v2beta1Prefix, query, {
+      body: fd,
+      cache: 'no-cache',
+      method: 'POST',
+    });
   }
 
   public static async uploadPipelineVersionV2(

--- a/frontend/src/pages/NewPipelineVersion.test.tsx
+++ b/frontend/src/pages/NewPipelineVersion.test.tsx
@@ -41,7 +41,7 @@ describe('NewPipelineVersion', () => {
   let getPipelineSpy: jest.SpyInstance<{}>;
   let createPipelineSpy: jest.SpyInstance<{}>;
   let createPipelineVersionSpy: jest.SpyInstance<{}>;
-  let uploadPipelineVersionSpy: jest.SpyInstance<{}>;
+  let uploadPipelineSpy: jest.SpyInstance<{}>;
 
   let MOCK_PIPELINE = {
     pipeline_id: 'original-run-pipeline-id',
@@ -81,8 +81,8 @@ describe('NewPipelineVersion', () => {
     createPipelineSpy = jest
       .spyOn(Apis.pipelineServiceApiV2, 'createPipeline')
       .mockImplementation(() => MOCK_PIPELINE);
-    uploadPipelineVersionSpy = jest
-      .spyOn(Apis, 'uploadPipelineVersionV2')
+    uploadPipelineSpy = jest
+      .spyOn(Apis, 'uploadPipelineV2')
       .mockImplementation(() => MOCK_PIPELINE);
   });
 
@@ -395,13 +395,13 @@ describe('NewPipelineVersion', () => {
 
       expect(tree.state()).toHaveProperty('isPrivate', false);
       expect(tree.state('importMethod')).toBe(ImportMethod.LOCAL);
-      // create pipeline first
-      expect(createPipelineSpy).toHaveBeenLastCalledWith({
-        description: 'test pipeline description',
-        display_name: 'test pipeline name',
-      });
-      // then call uploadPipelineVersion
-      expect(uploadPipelineVersionSpy).toHaveBeenCalled();
+
+      expect(uploadPipelineSpy).toHaveBeenLastCalledWith(
+        'test pipeline name',
+        'test pipeline description',
+        file,
+        undefined,
+      );
     });
 
     it('creates private pipeline from local file in multi user mode', async () => {
@@ -431,14 +431,13 @@ describe('NewPipelineVersion', () => {
 
       expect(tree.state()).toHaveProperty('isPrivate', true);
       expect(tree.state('importMethod')).toBe(ImportMethod.LOCAL);
-      // create pipeline first
-      expect(createPipelineSpy).toHaveBeenLastCalledWith({
-        description: 'test pipeline description',
-        display_name: 'test pipeline name',
-        namespace: 'ns',
-      });
-      // then call uploadPipelineVersion
-      expect(uploadPipelineVersionSpy).toHaveBeenCalled();
+
+      expect(uploadPipelineSpy).toHaveBeenLastCalledWith(
+        'test pipeline name',
+        'test pipeline description',
+        file,
+        'ns',
+      );
     });
 
     it('creates shared pipeline from local file in multi user mode', async () => {
@@ -468,13 +467,13 @@ describe('NewPipelineVersion', () => {
 
       expect(tree.state()).toHaveProperty('isPrivate', false);
       expect(tree.state('importMethod')).toBe(ImportMethod.LOCAL);
-      // create pipeline first
-      expect(createPipelineSpy).toHaveBeenLastCalledWith({
-        description: 'test pipeline description',
-        display_name: 'test pipeline name',
-      });
-      // then call uploadPipelineVersion
-      expect(uploadPipelineVersionSpy).toHaveBeenCalled();
+
+      expect(uploadPipelineSpy).toHaveBeenLastCalledWith(
+        'test pipeline name',
+        'test pipeline description',
+        file,
+        undefined,
+      );
     });
 
     it('allows updating pipeline version name', async () => {


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/56132941/236584340-3b9dd663-490c-4460-839a-36383286b213.mov


After:


https://user-images.githubusercontent.com/56132941/236584359-60af7471-3d37-4739-9d93-a6dcebc15821.mov

