### PR TITLE
fix(frontend): No values in "Finished at" & "Duration" when run is finished

### DIFF
--- a/frontend/src/pages/RunDetailsV2.tsx
+++ b/frontend/src/pages/RunDetailsV2.tsx
@@ -329,13 +329,6 @@ function updateToolBarActions(
 }
 
 function getDetailsFields(run?: V2beta1Run): Array<KeyValue<string>> {
-  // check if the run has finished or not. The default value for run.finished_at is
-  // Date(0), when it is not specified.
-  let finishedAt = new Date(0);
-  if (run?.finished_at) {
-    finishedAt = run?.finished_at;
-  }
-
   return [
     ['Run ID', run?.run_id || '-'],
     ['Workflow name', run?.display_name || '-'],
@@ -343,7 +336,7 @@ function getDetailsFields(run?: V2beta1Run): Array<KeyValue<string>> {
     ['Description', run?.description || ''],
     ['Created at', run?.created_at ? formatDateString(run.created_at) : '-'],
     ['Started at', formatDateString(run?.scheduled_at)],
-    ['Finished at', finishedAt > new Date(0) ? formatDateString(run?.finished_at) : '-'],
-    ['Duration', finishedAt > new Date(0) ? getRunDurationV2(run) : '-'],
+    ['Finished at', hasFinishedV2(run?.state) ? formatDateString(run?.finished_at) : '-'],
+    ['Duration', hasFinishedV2(run?.state) ? getRunDurationV2(run) : '-'],
   ];
 }


### PR DESCRIPTION
(Correct) Run is not finished:
<img width="1714" alt="Screenshot 2023-05-10 at 1 30 21 PM" src="https://github.com/kubeflow/pipelines/assets/56132941/33f642b0-dbf7-464c-84e1-a9d59adf374a">

Before fix:
<img width="1714" alt="Screenshot 2023-05-10 at 1 36 48 PM" src="https://github.com/kubeflow/pipelines/assets/56132941/29a3191e-c2e2-430f-a7a7-0f2e686b788c">


After fix:
<img width="1714" alt="Screenshot 2023-05-10 at 1 35 25 PM" src="https://github.com/kubeflow/pipelines/assets/56132941/c5939083-30de-40d9-9f25-d97a9353759e">
