### PR TITLE
fix(frontend): Remove redundant "(optional)" text in the optional input fields.

### DIFF
--- a/frontend/src/pages/NewExperiment.tsx
+++ b/frontend/src/pages/NewExperiment.tsx
@@ -95,9 +95,10 @@ export class NewExperiment extends Page<{ namespace?: string }, NewExperimentSta
           />
           <Input
             id='experimentDescription'
-            label='Description (optional)'
+            label='Description'
             multiline={true}
             onChange={this.handleChange('description')}
+            required={false}
             value={description}
             variant='outlined'
           />

--- a/frontend/src/pages/NewPipelineVersion.tsx
+++ b/frontend/src/pages/NewPipelineVersion.tsx
@@ -424,9 +424,10 @@ export class NewPipelineVersion extends Page<NewPipelineVersionProps, NewPipelin
           {/* Fill pipeline version code source url */}
           <Input
             id='pipelineVersionCodeSource'
-            label='Code Source (optional)'
+            label='Code Source'
             multiline={true}
             onChange={this.handleChange('codeSourceUrl')}
+            required={false}
             value={codeSourceUrl}
             variant='outlined'
           />

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -463,9 +463,10 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
             variant='outlined'
           />
           <Input
-            label='Description (optional)'
+            label='Description'
             multiline={true}
             onChange={this.handleChange('description')}
+            required={false}
             value={description}
             variant='outlined'
           />
@@ -513,7 +514,8 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
           <Input
             value={serviceAccount}
             onChange={this.handleChange('serviceAccount')}
-            label='Service Account (Optional)'
+            required={false}
+            label='Service Account'
             variant='outlined'
           />
 

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -509,9 +509,10 @@ function NewRunV2(props: NewRunV2Props) {
           variant='outlined'
         />
         <Input
-          label='Description (optional)'
+          label='Description'
           multiline={true}
           onChange={event => setRunDescription(event.target.value)}
+          required={false}
           value={runDescription}
           variant='outlined'
         />
@@ -575,7 +576,8 @@ function NewRunV2(props: NewRunV2Props) {
         <Input
           value={serviceAccount}
           onChange={event => setServiceAccount(event.target.value)}
-          label='Service Account (Optional)'
+          required={false}
+          label='Service Account'
           variant='outlined'
         />
 

--- a/frontend/src/pages/__snapshots__/NewExperiment.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewExperiment.test.tsx.snap
@@ -33,9 +33,10 @@ exports[`NewExperiment enables the 'Next' button when an experiment name is ente
     />
     <Input
       id="experimentDescription"
-      label="Description (optional)"
+      label="Description"
       multiline={true}
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -97,9 +98,10 @@ exports[`NewExperiment re-disables the 'Next' button when an experiment name is 
     />
     <Input
       id="experimentDescription"
-      label="Description (optional)"
+      label="Description"
       multiline={true}
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -163,9 +165,10 @@ exports[`NewExperiment renders the new experiment page 1`] = `
     />
     <Input
       id="experimentDescription"
-      label="Description (optional)"
+      label="Description"
       multiline={true}
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />

--- a/frontend/src/pages/__snapshots__/NewPipelineVersion.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewPipelineVersion.test.tsx.snap
@@ -183,9 +183,10 @@ exports[`NewPipelineVersion creating new pipeline renders the new pipeline page 
     </div>
     <Input
       id="pipelineVersionCodeSource"
-      label="Code Source (optional)"
+      label="Code Source"
       multiline={true}
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -308,9 +308,10 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
       variant="outlined"
     />
     <Input
-      label="Description (optional)"
+      label="Description"
       multiline={true}
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -369,8 +370,9 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
       />
     </div>
     <Input
-      label="Service Account (Optional)"
+      label="Service Account"
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -793,9 +795,10 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
       variant="outlined"
     />
     <Input
-      label="Description (optional)"
+      label="Description"
       multiline={true}
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -854,8 +857,9 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
       />
     </div>
     <Input
-      label="Service Account (Optional)"
+      label="Service Account"
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -1278,9 +1282,10 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
       variant="outlined"
     />
     <Input
-      label="Description (optional)"
+      label="Description"
       multiline={true}
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -1339,8 +1344,9 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
       />
     </div>
     <Input
-      label="Service Account (Optional)"
+      label="Service Account"
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -1781,9 +1787,10 @@ exports[`NewRun changes title and form to default state if the new run is a one-
       variant="outlined"
     />
     <Input
-      label="Description (optional)"
+      label="Description"
       multiline={true}
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -1842,8 +1849,9 @@ exports[`NewRun changes title and form to default state if the new run is a one-
       />
     </div>
     <Input
-      label="Service Account (Optional)"
+      label="Service Account"
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -2266,9 +2274,10 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
       variant="outlined"
     />
     <Input
-      label="Description (optional)"
+      label="Description"
       multiline={true}
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -2327,8 +2336,9 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
       />
     </div>
     <Input
-      label="Service Account (Optional)"
+      label="Service Account"
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -2749,9 +2759,10 @@ exports[`NewRun renders the new run page 1`] = `
       variant="outlined"
     />
     <Input
-      label="Description (optional)"
+      label="Description"
       multiline={true}
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -2810,8 +2821,9 @@ exports[`NewRun renders the new run page 1`] = `
       />
     </div>
     <Input
-      label="Service Account (Optional)"
+      label="Service Account"
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -3234,9 +3246,10 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
       variant="outlined"
     />
     <Input
-      label="Description (optional)"
+      label="Description"
       multiline={true}
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -3295,8 +3308,9 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
       />
     </div>
     <Input
-      label="Service Account (Optional)"
+      label="Service Account"
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -3737,9 +3751,10 @@ exports[`NewRun updates the run's state with the associated experiment if one is
       variant="outlined"
     />
     <Input
-      label="Description (optional)"
+      label="Description"
       multiline={true}
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />
@@ -3798,8 +3813,9 @@ exports[`NewRun updates the run's state with the associated experiment if one is
       />
     </div>
     <Input
-      label="Service Account (Optional)"
+      label="Service Account"
       onChange={[Function]}
+      required={false}
       value=""
       variant="outlined"
     />


### PR DESCRIPTION
We already use asterisk to indicate required field, so `(optional)` can be removed.

Before:
<img width="888" alt="Screenshot 2023-05-10 at 1 45 10 PM" src="https://github.com/kubeflow/pipelines/assets/56132941/a1324f39-2f43-4145-b2db-d7ce1e048e3d">


After:
<img width="888" alt="Screenshot 2023-05-10 at 1 44 24 PM" src="https://github.com/kubeflow/pipelines/assets/56132941/68d8030a-81be-4d03-ad93-8ebc3dd32499">
