### PR TITLE
fix(frontend): Change the empty message of archived experiment list.

### DIFF
--- a/frontend/src/components/ExperimentList.tsx
+++ b/frontend/src/components/ExperimentList.tsx
@@ -93,7 +93,7 @@ export class ExperimentList extends React.PureComponent<ExperimentListProps, Exp
           toggleExpansion={this._toggleRowExpand.bind(this)}
           getExpandComponent={this._getExpandedExperimentComponent.bind(this)}
           filterLabel='Filter experiments'
-          emptyMessage='No experiments found. Click "Create experiment" to start.'
+          emptyMessage='No archived experiments found.'
         />
       </div>
     );

--- a/frontend/src/components/__snapshots__/ExperimentList.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/ExperimentList.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`ExperimentList loads multiple experiments 1`] = `
       ]
     }
     disableSelection={true}
-    emptyMessage="No experiments found. Click \\"Create experiment\\" to start."
+    emptyMessage="No archived experiments found."
     filterLabel="Filter experiments"
     getExpandComponent={[Function]}
     initialSortColumn="created_at"
@@ -95,7 +95,7 @@ exports[`ExperimentList loads one experiment 1`] = `
       ]
     }
     disableSelection={true}
-    emptyMessage="No experiments found. Click \\"Create experiment\\" to start."
+    emptyMessage="No archived experiments found."
     filterLabel="Filter experiments"
     getExpandComponent={[Function]}
     initialSortColumn="created_at"
@@ -146,7 +146,7 @@ exports[`ExperimentList reloads the experiment when refresh is called 1`] = `
         ]
       }
       disableSelection={true}
-      emptyMessage="No experiments found. Click \\"Create experiment\\" to start."
+      emptyMessage="No archived experiments found."
       filterLabel="Filter experiments"
       getExpandComponent={[Function]}
       initialSortColumn="created_at"
@@ -2401,7 +2401,7 @@ exports[`ExperimentList reloads the experiment when refresh is called 1`] = `
           <div
             className="emptyMessage"
           >
-            No experiments found. Click "Create experiment" to start.
+            No archived experiments found.
           </div>
         </div>
         <div
@@ -3827,7 +3827,7 @@ exports[`ExperimentList renders the empty experience 1`] = `
       ]
     }
     disableSelection={true}
-    emptyMessage="No experiments found. Click \\"Create experiment\\" to start."
+    emptyMessage="No archived experiments found."
     filterLabel="Filter experiments"
     getExpandComponent={[Function]}
     initialSortColumn="created_at"
@@ -3856,7 +3856,7 @@ exports[`ExperimentList renders the empty experience in ARCHIVED state 1`] = `
       ]
     }
     disableSelection={true}
-    emptyMessage="No experiments found. Click \\"Create experiment\\" to start."
+    emptyMessage="No archived experiments found."
     filterLabel="Filter experiments"
     getExpandComponent={[Function]}
     initialSortColumn="created_at"


### PR DESCRIPTION
Before
<img width="1305" alt="Screenshot 2023-05-10 at 1 48 37 PM" src="https://github.com/kubeflow/pipelines/assets/56132941/efb9325a-f7ff-4379-9fc1-b8989b011a44">


After
<img width="1305" alt="Screenshot 2023-05-10 at 1 48 09 PM" src="https://github.com/kubeflow/pipelines/assets/56132941/e7ec114e-2f6b-4c94-837e-0d218e75c53f">
