### PR TITLE
fix(frontend): Make the hover text for "Archive" button more informative

### DIFF
--- a/frontend/src/lib/Buttons.ts
+++ b/frontend/src/lib/Buttons.ts
@@ -78,7 +78,9 @@ export default class Buttons {
       disabledTitle: useCurrentResource ? undefined : 'Select at least one resource to archive',
       id: 'archiveBtn',
       title: 'Archive',
-      tooltip: 'Archive',
+      tooltip: useCurrentResource
+        ? `Archive this ${resourceName}`
+        : `Archive selected ${resourceName}(s)`,
     };
     return this;
   }

--- a/frontend/src/pages/__snapshots__/AllRunsList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/AllRunsList.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`AllRunsList renders all runs 1`] = `
             "disabledTitle": "Select at least one resource to archive",
             "id": "archiveBtn",
             "title": "Archive",
-            "tooltip": "Archive",
+            "tooltip": "Archive selected run(s)",
           },
           "cloneRun": Object {
             "action": [Function],

--- a/frontend/src/pages/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`ExperimentDetails fetches this experiment's recurring runs 1`] = `
             "disabledTitle": "Select at least one resource to archive",
             "id": "archiveBtn",
             "title": "Archive",
-            "tooltip": "Archive",
+            "tooltip": "Archive selected run(s)",
           },
           "cloneRun": Object {
             "action": [Function],
@@ -352,7 +352,7 @@ exports[`ExperimentDetails removes all description text after second newline and
             "disabledTitle": "Select at least one resource to archive",
             "id": "archiveBtn",
             "title": "Archive",
-            "tooltip": "Archive",
+            "tooltip": "Archive selected run(s)",
           },
           "cloneRun": Object {
             "action": [Function],
@@ -603,7 +603,7 @@ exports[`ExperimentDetails renders a page with no runs or recurring runs 1`] = `
             "disabledTitle": "Select at least one resource to archive",
             "id": "archiveBtn",
             "title": "Archive",
-            "tooltip": "Archive",
+            "tooltip": "Archive selected run(s)",
           },
           "cloneRun": Object {
             "action": [Function],
@@ -852,7 +852,7 @@ exports[`ExperimentDetails uses an empty string if the experiment has no descrip
             "disabledTitle": "Select at least one resource to archive",
             "id": "archiveBtn",
             "title": "Archive",
-            "tooltip": "Archive",
+            "tooltip": "Archive selected run(s)",
           },
           "cloneRun": Object {
             "action": [Function],


### PR DESCRIPTION
Before

https://github.com/kubeflow/pipelines/assets/56132941/ab418e89-3f88-4f4a-87e2-1576f72ddfb4




After

https://github.com/kubeflow/pipelines/assets/56132941/314f112c-6f43-457b-b169-7a1870cad354



