### PR TITLE
fix(frontend): Rename button in pipeline/run details side panel

### DIFF
--- a/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
+++ b/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
@@ -474,7 +474,7 @@ function SubDAGNodeDetail({
       <div className={commonCss.page}>
         <div className={padding(20, 'blr')}>
           <Button variant='contained' onClick={onSubDagOpenClick}>
-            Open Workflow
+            Open Sub-DAG
           </Button>
         </div>
         <MD2Tabs

--- a/frontend/src/components/tabs/StaticNodeDetailsV2.test.tsx
+++ b/frontend/src/components/tabs/StaticNodeDetailsV2.test.tsx
@@ -140,7 +140,7 @@ describe('StaticNodeDetailsV2', () => {
         ></StaticNodeDetailsV2>
       </CommonTestWrapper>,
     );
-    screen.getByText('Open Workflow');
+    screen.getByText('Open Sub-DAG');
 
     screen.getByText('pipelinechannel--flip-coin-op-Output');
     expect(screen.getAllByText('STRING').length).toEqual(2);
@@ -163,7 +163,7 @@ describe('StaticNodeDetailsV2', () => {
         ></StaticNodeDetailsV2>
       </CommonTestWrapper>,
     );
-    screen.getByText('Open Workflow');
+    screen.getByText('Open Sub-DAG');
 
     screen.getByText('pipelinechannel--flip-coin-op-Output');
     expect(screen.getAllByText('STRING').length).toEqual(3);

--- a/frontend/src/components/tabs/StaticNodeDetailsV2.tsx
+++ b/frontend/src/components/tabs/StaticNodeDetailsV2.tsx
@@ -123,7 +123,7 @@ function TaskNodeDetail({
       {componentDag && (
         <div>
           <Button variant='contained' onClick={onSubDagOpenClick}>
-            Open Workflow
+            Open Sub-DAG
           </Button>
         </div>
       )}


### PR DESCRIPTION
Currently, we use `Open workflow` on the button for expanding Sub-DAG. The term `Workflow` is a little confusing, so we change to `Open Sub-DAG`.

Before:
<img width="1709" alt="Screenshot 2023-05-10 at 2 56 30 PM" src="https://github.com/kubeflow/pipelines/assets/56132941/1f1e137d-7e22-4d53-87ec-e5f36c3ffa67">


After:
<img width="1709" alt="Screenshot 2023-05-10 at 2 56 58 PM" src="https://github.com/kubeflow/pipelines/assets/56132941/9831c313-571f-4bd7-96ea-2019b5bd6ae3">
