### PR TITLE
fix(sdk): fix compilation of boolean constant passed to component

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -7,6 +7,8 @@
 ## Deprecations
 
 ## Bug fixes and other changes
+* Fix compilation of boolean constant passed to component [\#9390](https://github.com/kubeflow/pipelines/pull/9390)
+
 
 ## Documentation updates
 

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -61,12 +61,13 @@ def to_protobuf_value(value: type_utils.PARAMETER_TYPES) -> struct_pb2.Value:
     Raises:
         ValueError if the given value is not one of the parameter types.
     """
-    if isinstance(value, str):
+    # bool check must be above (int, float) check because bool is a subclass of int so isinstance(True, int) == True
+    if isinstance(value, bool):
+        return struct_pb2.Value(bool_value=value)
+    elif isinstance(value, str):
         return struct_pb2.Value(string_value=value)
     elif isinstance(value, (int, float)):
         return struct_pb2.Value(number_value=value)
-    elif isinstance(value, bool):
-        return struct_pb2.Value(bool_value=value)
     elif isinstance(value, dict):
         return struct_pb2.Value(
             struct_value=struct_pb2.Struct(


### PR DESCRIPTION
**Description of your changes:**
Fix compilation of boolean constant passed to component.

Previously, compiling a pipeline like the one below would result in the boolean cast to an int. This is 
resolved.

```python
@dsl.pipeline
def my_pipeline():
    my_comp(boolean=True)
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the 
pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
