### PR TITLE
chore(backend): Remove deprecated experiment id from run server's endpoints

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1793,12 +1793,3 @@ func (r *ResourceManager) GetTask(taskId string) (*model.Task, error) {
 	}
 	return task, nil
 }
-
-// Fetches run metric entries for a given run id.
-func (r *ResourceManager) GetRunMetrics(runId string) ([]*model.RunMetric, error) {
-	metrics, err := r.runStore.GetMetrics(runId)
-	if err != nil {
-		return nil, util.Wrapf(err, "Failed to fetch run metrics for run %s", runId)
-	}
-	return metrics, nil
-}

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -524,6 +524,10 @@ func (r *ResourceManager) ListRuns(filterContext *model.FilterContext, opts *lis
 
 // Archives a run with a given id.
 func (r *ResourceManager) ArchiveRun(runId string) error {
+	_, err := r.GetRun(runId)
+	if err != nil {
+		return util.Wrapf(err, "Failed to archive run %v as it failed to be retrieved", runId)
+	}
 	if err := r.runStore.ArchiveRun(runId); err != nil {
 		return util.Wrapf(err, "Failed to archive run %v", runId)
 	}

--- a/backend/src/apiserver/server/run_server.go
+++ b/backend/src/apiserver/server/run_server.go
@@ -274,17 +274,10 @@ func (s *RunServer) ListRunsV1(ctx context.Context, r *apiv1beta1.ListRunsReques
 
 // Archives a run.
 // Applies common logic on v1beta1 and v2beta1 API.
-func (s *RunServer) archiveRun(ctx context.Context, runId string, experimentId string) error {
+func (s *RunServer) archiveRun(ctx context.Context, runId string) error {
 	err := s.canAccessRun(ctx, runId, &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbArchive})
 	if err != nil {
 		return util.Wrap(err, "Failed to authorize the request")
-	}
-	run, err := s.getRun(ctx, runId)
-	if err != nil {
-		return util.Wrap(err, "Failed to fetch a run")
-	}
-	if experimentId != "" && run.ExperimentId != experimentId && run.ExperimentId != "" {
-		return util.NewInternalServerError(util.NewInvalidInputError("The requested run '%s' belongs to experiment '%s' (requested experiment '%s')", runId, run.ExperimentId, experimentId), "Failed to archive a run")
 	}
 	return s.resourceManager.ArchiveRun(runId)
 }
@@ -295,7 +288,7 @@ func (s *RunServer) ArchiveRunV1(ctx context.Context, request *apiv1beta1.Archiv
 	if s.options.CollectMetrics {
 		archiveRunRequests.Inc()
 	}
-	err := s.archiveRun(ctx, request.GetId(), "")
+	err := s.archiveRun(ctx, request.GetId())
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to archive a v1beta1 run")
 	}
@@ -304,17 +297,10 @@ func (s *RunServer) ArchiveRunV1(ctx context.Context, request *apiv1beta1.Archiv
 
 // Un-archives a run.
 // Applies common logic on v1beta1 and v2beta1 API.
-func (s *RunServer) unarchiveRun(ctx context.Context, runId string, experimentId string) error {
+func (s *RunServer) unarchiveRun(ctx context.Context, runId string) error {
 	err := s.canAccessRun(ctx, runId, &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbUnarchive})
 	if err != nil {
 		return util.Wrap(err, "Failed to authorize the request")
-	}
-	run, err := s.getRun(ctx, runId)
-	if err != nil {
-		return util.Wrap(err, "Failed to fetch a run")
-	}
-	if experimentId != "" && run.ExperimentId != experimentId && run.ExperimentId != "" {
-		return util.NewInternalServerError(util.NewInvalidInputError("The requested run '%s' belongs to experiment '%s' (requested experiment '%s')", runId, run.ExperimentId, experimentId), "Failed to unarchive a run")
 	}
 	return s.resourceManager.UnarchiveRun(runId)
 }
@@ -325,7 +311,7 @@ func (s *RunServer) UnarchiveRunV1(ctx context.Context, request *apiv1beta1.Unar
 	if s.options.CollectMetrics {
 		unarchiveRunRequests.Inc()
 	}
-	err := s.unarchiveRun(ctx, request.GetId(), "")
+	err := s.unarchiveRun(ctx, request.GetId())
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to unarchive a v1beta1 run")
 	}
@@ -334,17 +320,10 @@ func (s *RunServer) UnarchiveRunV1(ctx context.Context, request *apiv1beta1.Unar
 
 // Deletes a run.
 // Applies common logic on v1beta1 and v2beta1 API.
-func (s *RunServer) deleteRun(ctx context.Context, runId string, experimentId string) error {
+func (s *RunServer) deleteRun(ctx context.Context, runId string) error {
 	err := s.canAccessRun(ctx, runId, &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbUnarchive})
 	if err != nil {
 		return util.Wrap(err, "Failed to authorize the request")
-	}
-	run, err := s.getRun(ctx, runId)
-	if err != nil {
-		return util.Wrap(err, "Failed to fetch a run")
-	}
-	if experimentId != "" && run.ExperimentId != experimentId && run.ExperimentId != "" {
-		return util.NewInternalServerError(util.NewInvalidInputError("The requested run '%s' belongs to experiment '%s' (requested experiment '%s')", runId, run.ExperimentId, experimentId), "Failed to delete a run")
 	}
 	return s.resourceManager.DeleteRun(ctx, runId)
 }
@@ -355,7 +334,7 @@ func (s *RunServer) DeleteRunV1(ctx context.Context, request *apiv1beta1.DeleteR
 	if s.options.CollectMetrics {
 		deleteRunRequests.Inc()
 	}
-	if err := s.deleteRun(ctx, request.GetId(), ""); err != nil {
+	if err := s.deleteRun(ctx, request.GetId()); err != nil {
 		return nil, util.Wrap(err, "Failed to delete a v1beta1 run")
 	}
 	if s.options.CollectMetrics {
@@ -478,34 +457,20 @@ func (s *RunServer) ReadArtifactV1(ctx context.Context, request *apiv1beta1.Read
 
 // Terminates a run.
 // Applies common logic on v1beta1 and v2beta1 API.
-func (s *RunServer) terminateRun(ctx context.Context, runId string, experimentId string) error {
+func (s *RunServer) terminateRun(ctx context.Context, runId string) error {
 	err := s.canAccessRun(ctx, runId, &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbUnarchive})
 	if err != nil {
 		return util.Wrap(err, "Failed to authorize the request")
-	}
-	run, err := s.getRun(ctx, runId)
-	if err != nil {
-		return util.Wrap(err, "Failed to fetch a run")
-	}
-	if experimentId != "" && run.ExperimentId != experimentId && run.ExperimentId != "" {
-		return util.NewInternalServerError(util.NewInvalidInputError("The requested run '%s' belongs to experiment '%s' (requested experiment '%s')", runId, run.ExperimentId, experimentId), "Failed to terminate a run")
 	}
 	return s.resourceManager.TerminateRun(ctx, runId)
 }
 
 // Retries a run.
 // Applies common logic on v1beta1 and v2beta1 API.
-func (s *RunServer) retryRun(ctx context.Context, runId string, experimentId string) error {
+func (s *RunServer) retryRun(ctx context.Context, runId string) error {
 	err := s.canAccessRun(ctx, runId, &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbRetry})
 	if err != nil {
 		return util.Wrap(err, "Failed to authorize the request")
-	}
-	run, err := s.getRun(ctx, runId)
-	if err != nil {
-		return util.Wrap(err, "Failed to fetch a run")
-	}
-	if experimentId != "" && run.ExperimentId != experimentId && run.ExperimentId != "" {
-		return util.NewInternalServerError(util.NewInvalidInputError("The requested run '%s' belongs to experiment '%s' (requested experiment '%s')", runId, run.ExperimentId, experimentId), "Failed to retry a run")
 	}
 	return s.resourceManager.RetryRun(ctx, runId)
 }
@@ -516,7 +481,7 @@ func (s *RunServer) TerminateRunV1(ctx context.Context, request *apiv1beta1.Term
 	if s.options.CollectMetrics {
 		terminateRunRequests.Inc()
 	}
-	err := s.terminateRun(ctx, request.GetRunId(), "")
+	err := s.terminateRun(ctx, request.GetRunId())
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to terminate a v1beta1 run")
 	}
@@ -530,7 +495,7 @@ func (s *RunServer) RetryRunV1(ctx context.Context, request *apiv1beta1.RetryRun
 		retryRunRequests.Inc()
 	}
 
-	err := s.retryRun(ctx, request.GetRunId(), "")
+	err := s.retryRun(ctx, request.GetRunId())
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to retry a run")
 	}
@@ -596,11 +561,10 @@ func (s *RunServer) ListRuns(ctx context.Context, r *apiv2beta1.ListRunsRequest)
 // Archives a run.
 // Supports v2beta1 behavior.
 func (s *RunServer) ArchiveRun(ctx context.Context, request *apiv2beta1.ArchiveRunRequest) (*empty.Empty, error) {
-	// TODO(gkcalat): consider validating the experiment id.
 	if s.options.CollectMetrics {
 		archiveRunRequests.Inc()
 	}
-	err := s.archiveRun(ctx, request.GetRunId(), request.GetExperimentId())
+	err := s.archiveRun(ctx, request.GetRunId())
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to archive a run")
 	}
@@ -610,11 +574,10 @@ func (s *RunServer) ArchiveRun(ctx context.Context, request *apiv2beta1.ArchiveR
 // Un-archives a run.
 // Supports v2beta1 behavior.
 func (s *RunServer) UnarchiveRun(ctx context.Context, request *apiv2beta1.UnarchiveRunRequest) (*empty.Empty, error) {
-	// TODO(gkcalat): consider validating the experiment id.
 	if s.options.CollectMetrics {
 		unarchiveRunRequests.Inc()
 	}
-	err := s.unarchiveRun(ctx, request.GetRunId(), request.GetExperimentId())
+	err := s.unarchiveRun(ctx, request.GetRunId())
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to unarchive a run")
 	}
@@ -624,11 +587,10 @@ func (s *RunServer) UnarchiveRun(ctx context.Context, request *apiv2beta1.Unarch
 // Deletes a run.
 // Supports v2beta1 behavior.
 func (s *RunServer) DeleteRun(ctx context.Context, request *apiv2beta1.DeleteRunRequest) (*empty.Empty, error) {
-	// TODO(gkcalat): consider validating the experiment id.
 	if s.options.CollectMetrics {
 		deleteRunRequests.Inc()
 	}
-	if err := s.deleteRun(ctx, request.GetRunId(), request.GetExperimentId()); err != nil {
+	if err := s.deleteRun(ctx, request.GetRunId()); err != nil {
 		return nil, util.Wrap(err, "Failed to delete a run")
 	}
 	if s.options.CollectMetrics {
@@ -662,11 +624,10 @@ func (s *RunServer) ReadArtifact(ctx context.Context, request *apiv2beta1.ReadAr
 // Terminates a run.
 // Supports v2beta1 behavior.
 func (s *RunServer) TerminateRun(ctx context.Context, request *apiv2beta1.TerminateRunRequest) (*empty.Empty, error) {
-	// TODO(gkcalat): consider validating the experiment id.
 	if s.options.CollectMetrics {
 		terminateRunRequests.Inc()
 	}
-	err := s.terminateRun(ctx, request.GetRunId(), request.GetExperimentId())
+	err := s.terminateRun(ctx, request.GetRunId())
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to terminate a run")
 	}
@@ -680,7 +641,7 @@ func (s *RunServer) RetryRun(ctx context.Context, request *apiv2beta1.RetryRunRe
 		retryRunRequests.Inc()
 	}
 
-	err := s.retryRun(ctx, request.GetRunId(), request.GetExperimentId())
+	err := s.retryRun(ctx, request.GetRunId())
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to retry a run")
 	}

--- a/backend/src/apiserver/server/run_server.go
+++ b/backend/src/apiserver/server/run_server.go
@@ -454,20 +454,6 @@ func (s *RunServer) ReportRunMetricsV1(ctx context.Context, request *apiv1beta1.
 	}, nil
 }
 
-// Fetches run metrics for a given run id.
-// Supports v1beta1 behavior.
-func (s *RunServer) getRunMetrics(ctx context.Context, runId string) ([]*model.RunMetric, error) {
-	err := s.canAccessRun(ctx, runId, &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbReportMetrics})
-	if err != nil {
-		return nil, util.Wrap(err, "CreateJob(job.ToV2())Failed to fetch run metrics due to authorization error")
-	}
-	_, err = s.resourceManager.GetRun(runId)
-	if err != nil {
-		return nil, util.Wrapf(err, "CreateJob(job.ToV2())Failed to fetch run metrics. Check if run %s can be fetched", runId)
-	}
-	return s.resourceManager.GetRunMetrics(runId)
-}
-
 // Reads an artifact.
 // Supports v1beta1 behavior.
 func (s *RunServer) ReadArtifactV1(ctx context.Context, request *apiv1beta1.ReadArtifactRequest) (*apiv1beta1.ReadArtifactResponse, error) {

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -93,9 +93,6 @@ type RunStoreInterface interface {
 	// Creates a new metric entry.
 	CreateMetric(metric *model.RunMetric) (err error)
 
-	// Fetches metrics for a given run.
-	GetMetrics(runId string) ([]*model.RunMetric, error)
-
 	// Terminates a run.
 	TerminateRun(runId string) error
 }
@@ -793,28 +790,6 @@ func (s *RunStore) scanRowsToRunMetrics(rows *sql.Rows) ([]*model.RunMetric, err
 				Payload:     payload,
 			},
 		)
-	}
-	return metrics, nil
-}
-
-// TODO(gkcalat): consider removing this if we no longer support separate metrics API in v2beta1 API.
-// Fetches run metrics for a given run id.
-func (s *RunStore) GetMetrics(runId string) ([]*model.RunMetric, error) {
-	sql, args, err := sq.Select(runMetricsColumns...).
-		From("run_metrics").
-		Where(sq.Eq{"RunUUID": runId}).
-		ToSql()
-	if err != nil {
-		return nil, util.NewInternalServerError(err, "Failed to get run metrics: %v", err.Error())
-	}
-	r, err := s.db.Query(sql, args...)
-	if err != nil {
-		return nil, util.NewInternalServerError(err, "Failed to get run metrics: %v", err.Error())
-	}
-	defer r.Close()
-	metrics, err := s.scanRowsToRunMetrics(r)
-	if err != nil {
-		return nil, util.NewInternalServerError(err, "Failed to get run metrics: %v", err.Error())
 	}
 	return metrics, nil
 }

--- a/backend/src/apiserver/storage/run_store_test.go
+++ b/backend/src/apiserver/storage/run_store_test.go
@@ -1386,25 +1386,6 @@ func TestParseMetrics(t *testing.T) {
 	assert.Equal(t, expectedModelRunMetrics, parsedMetrics)
 }
 
-func TestGetMetrics(t *testing.T) {
-	db, runStore := initializeRunStore()
-	defer db.Close()
-
-	metric := &model.RunMetric{
-		RunUUID:     "1",
-		NodeID:      "node1",
-		Name:        "acurracy",
-		NumberValue: 0.77,
-		Format:      "PERCENTAGE",
-	}
-	runStore.CreateMetric(metric)
-
-	metric.Payload = "{\"RunUUID\":\"1\",\"NodeID\":\"node1\",\"Name\":\"acurracy\",\"NumberValue\":0.77,\"Format\":\"PERCENTAGE\",\"Payload\":\"\"}"
-	getMetrics, err := runStore.GetMetrics("1")
-	assert.Nil(t, err)
-	assert.Equal(t, metric, getMetrics[0])
-}
-
 func TestParseRuntimeConfig(t *testing.T) {
 	expectedRuntimeConfig := model.RuntimeConfig{
 		Parameters:   `[{"name":"param2","value":"world1"}]`,


### PR DESCRIPTION
**Description of your changes:**

- Removed `experimentId` from some of the functions in run server
- Removed redundant calls to DB, which should improve performance

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
