### PR TITLE
fix(sdk): Optimize wait_for_run_completion sdk function to skip an extra wait

### DIFF
--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -1370,8 +1370,8 @@ class Client:
         if isinstance(timeout, datetime.timedelta):
             timeout = timeout.total_seconds()
         is_valid_token = False
-        while (state is None or state.lower()
-               not in ['succeeded', 'failed', 'skipped', 'error']):
+        finish_states = ['succeeded', 'failed', 'skipped', 'error']
+        while True:
             try:
                 get_run_response = self._run_api.get_run(run_id=run_id)
                 is_valid_token = True
@@ -1390,8 +1390,9 @@ class Client:
             logging.info('Waiting for the job to complete...')
             if elapsed_time > timeout:
                 raise TimeoutError('Run timeout')
+            if state is not None and state.lower() in finish_states:
+                return get_run_response
             time.sleep(sleep_duration)
-        return get_run_response
 
     def upload_pipeline(
         self,


### PR DESCRIPTION
**Description of your changes:**
close #9406 

The sdk client `wait_for_run_completion` has to sleep for at least one iteration no matter state of the run. Optimize the function to check the state right after and return the run response if ready.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
