### PR TITLE
feat(frontend): make container name configurable

### DIFF
--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -196,7 +196,7 @@ function createUIServer(options: UIConfigs) {
     registerHandler(
       app.get,
       '/k8s/pod/logs',
-      getPodLogsHandler(options.argo, options.artifacts, options.pod),
+      getPodLogsHandler(options.argo, options.artifacts, options.pod.logContainerName),
     );
   }
 
@@ -222,7 +222,7 @@ function createUIServer(options: UIConfigs) {
     registerHandler(
       app.get,
       '/k8s/pod/logs',
-      getPodLogsHandler(options.argo, options.artifacts, options.pod),
+      getPodLogsHandler(options.argo, options.artifacts, options.pod.logContainerName),
     );
   }
 

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -193,7 +193,11 @@ function createUIServer(options: UIConfigs) {
       }),
     );
   } else {
-    registerHandler(app.get, '/k8s/pod/logs', getPodLogsHandler(options.argo, options.artifacts));
+    registerHandler(
+      app.get,
+      '/k8s/pod/logs',
+      getPodLogsHandler(options.argo, options.artifacts, options.pod),
+    );
   }
 
   if (options.artifacts.streamLogsFromServerApi) {
@@ -215,7 +219,11 @@ function createUIServer(options: UIConfigs) {
       }),
     );
   } else {
-    registerHandler(app.get, '/k8s/pod/logs', getPodLogsHandler(options.argo, options.artifacts));
+    registerHandler(
+      app.get,
+      '/k8s/pod/logs',
+      getPodLogsHandler(options.argo, options.artifacts, options.pod),
+    );
   }
 
   /** Pod info */

--- a/frontend/server/configs.ts
+++ b/frontend/server/configs.ts
@@ -92,6 +92,8 @@ export function loadConfigs(argv: string[], env: ProcessEnv): UIConfigs {
     ARGO_ARCHIVE_PREFIX = 'logs',
     /** Should use server API for log streaming? */
     STREAM_LOGS_FROM_SERVER_API = 'false',
+    /** The main container name of a pod where logs are retrieved */
+    POD_LOG_CONTAINER_NAME = 'main',
     /** Disables GKE metadata endpoint. */
     DISABLE_GKE_METADATA = 'false',
     /** Enable authorization checks for multi user mode. */
@@ -123,6 +125,9 @@ export function loadConfigs(argv: string[], env: ProcessEnv): UIConfigs {
       archiveBucketName: ARGO_ARCHIVE_BUCKETNAME,
       archiveLogs: asBool(ARGO_ARCHIVE_LOGS),
       archivePrefix: ARGO_ARCHIVE_PREFIX,
+    },
+    pod: {
+      logContainerName: POD_LOG_CONTAINER_NAME,
     },
     artifacts: {
       aws: {
@@ -269,6 +274,9 @@ export interface UIConfigs {
     http: HttpConfigs;
     proxy: ArtifactsProxyConfig;
     streamLogsFromServerApi: boolean;
+  };
+  pod: {
+    logContainerName: string;
   };
   argo: ArgoConfigs;
   metadata: MetadataConfigs;

--- a/frontend/server/handlers/pod-logs.ts
+++ b/frontend/server/handlers/pod-logs.ts
@@ -37,9 +37,7 @@ export function getPodLogsHandler(
     minio: MinioConfigs;
     aws: AWSConfigs;
   },
-  pod: {
-    logContainerName: string;
-  },
+  podLogContainerName: string,
 ): Handler {
   const { archiveLogs, archiveArtifactory, archiveBucketName, archivePrefix = '' } = argoOptions;
 
@@ -55,7 +53,7 @@ export function getPodLogsHandler(
   // get the pod log stream (with fallbacks).
   const getPodLogsStream = composePodLogsStreamHandler(
     (podName: string, namespace?: string) => {
-      return getPodLogsStreamFromK8s(podName, namespace, pod.logContainerName);
+      return getPodLogsStreamFromK8s(podName, namespace, podLogContainerName);
     },
     // if archive logs flag is set, then final attempt will try to retrieve the artifacts
     // from the bucket and prefix provided in the config. Otherwise, only attempts

--- a/frontend/server/handlers/pod-logs.ts
+++ b/frontend/server/handlers/pod-logs.ts
@@ -37,6 +37,9 @@ export function getPodLogsHandler(
     minio: MinioConfigs;
     aws: AWSConfigs;
   },
+  pod: {
+    logContainerName: string;
+  },
 ): Handler {
   const { archiveLogs, archiveArtifactory, archiveBucketName, archivePrefix = '' } = argoOptions;
 
@@ -51,7 +54,9 @@ export function getPodLogsHandler(
 
   // get the pod log stream (with fallbacks).
   const getPodLogsStream = composePodLogsStreamHandler(
-    getPodLogsStreamFromK8s,
+    (podName: string, namespace?: string) => {
+      return getPodLogsStreamFromK8s(podName, namespace, pod.logContainerName);
+    },
     // if archive logs flag is set, then final attempt will try to retrieve the artifacts
     // from the bucket and prefix provided in the config. Otherwise, only attempts
     // to read from worflow status if the default handler fails.

--- a/frontend/server/k8s-helper.ts
+++ b/frontend/server/k8s-helper.ts
@@ -240,14 +240,18 @@ export function waitForTensorboardInstance(
   });
 }
 
-export function getPodLogs(podName: string, podNamespace?: string): Promise<string> {
+export function getPodLogs(
+  podName: string,
+  podNamespace?: string,
+  containerName: string = 'main',
+): Promise<string> {
   podNamespace = podNamespace || serverNamespace;
   if (!podNamespace) {
     throw new Error(
       `podNamespace is not specified and cannot get namespace from ${namespaceFilePath}.`,
     );
   }
-  return (k8sV1Client.readNamespacedPodLog(podName, podNamespace, 'main') as any).then(
+  return (k8sV1Client.readNamespacedPodLog(podName, podNamespace, containerName) as any).then(
     (response: any) => (response && response.body ? response.body.toString() : ''),
     (error: any) => {
       throw new Error(JSON.stringify(error.body));

--- a/frontend/server/workflow-helper.test.ts
+++ b/frontend/server/workflow-helper.test.ts
@@ -83,7 +83,7 @@ describe('workflow-helper', () => {
       mockedGetPodLogs.mockResolvedValueOnce('pod logs');
 
       const stream = await getPodLogsStreamFromK8s('podName', 'namespace');
-      expect(mockedGetPodLogs).toBeCalledWith('podName', 'namespace');
+      expect(mockedGetPodLogs).toBeCalledWith('podName', 'namespace', undefined);
       expect(stream.read().toString()).toBe('pod logs');
     });
   });

--- a/frontend/server/workflow-helper.test.ts
+++ b/frontend/server/workflow-helper.test.ts
@@ -83,7 +83,7 @@ describe('workflow-helper', () => {
       mockedGetPodLogs.mockResolvedValueOnce('pod logs');
 
       const stream = await getPodLogsStreamFromK8s('podName', 'namespace');
-      expect(mockedGetPodLogs).toBeCalledWith('podName', 'namespace', undefined);
+      expect(mockedGetPodLogs).toBeCalledWith('podName', 'namespace', 'main');
       expect(stream.read().toString()).toBe('pod logs');
     });
   });

--- a/frontend/server/workflow-helper.ts
+++ b/frontend/server/workflow-helper.ts
@@ -86,7 +86,7 @@ export function composePodLogsStreamHandler<T = Stream>(
 export async function getPodLogsStreamFromK8s(
   podName: string,
   namespace?: string,
-  containerName?: string,
+  containerName: string = 'main',
 ) {
   const stream = new PassThrough();
   stream.end(await getPodLogs(podName, namespace, containerName));

--- a/frontend/server/workflow-helper.ts
+++ b/frontend/server/workflow-helper.ts
@@ -81,10 +81,15 @@ export function composePodLogsStreamHandler<T = Stream>(
  * Returns a stream containing the pod logs using kubernetes api.
  * @param podName name of the pod.
  * @param namespace namespace of the pod (uses the same namespace as the server if not provided).
+ * @param containerName container's name of the pod, the default value is 'main'.
  */
-export async function getPodLogsStreamFromK8s(podName: string, namespace?: string) {
+export async function getPodLogsStreamFromK8s(
+  podName: string,
+  namespace?: string,
+  containerName?: string,
+) {
   const stream = new PassThrough();
-  stream.end(await getPodLogs(podName, namespace));
+  stream.end(await getPodLogs(podName, namespace, containerName));
   console.log(`Getting logs for pod:${podName} in namespace ${namespace}.`);
   return stream;
 }


### PR DESCRIPTION
**Description of your changes:**
Add an UIConfig param to specify the container name in a pod where logs are retrieved. The default container name for the Argo is `main`. However, in Tekton, the main container name contains the `step-` prefix. Make this configurable to support other orchestrations.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
