### PR TITLE
feature(frontent): Support both "Flat" and "Group" view for Execution list

### DIFF
--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -38,7 +38,7 @@ import AllRunsAndArchive, { AllRunsAndArchiveTab } from 'src/pages/AllRunsAndArc
 import ArtifactDetails from 'src/pages/ArtifactDetails';
 import ArtifactList from 'src/pages/ArtifactList';
 import ExecutionDetails from 'src/pages/ExecutionDetails';
-import ExecutionListRouter from 'src/pages/ExecutionListRouter';
+import ExecutionListSwitcher from 'src/pages/ExecutionListSwitcher';
 import ExperimentDetails from 'src/pages/ExperimentDetails';
 import { GettingStarted } from 'src/pages/GettingStarted';
 import NewExperiment from 'src/pages/NewExperiment';
@@ -184,7 +184,7 @@ const Router: React.FC<RouterProps> = ({ configs }) => {
     },
     { path: RoutePage.ARTIFACTS, Component: ArtifactList },
     { path: RoutePage.ARTIFACT_DETAILS, Component: ArtifactDetails, notExact: true },
-    { path: RoutePage.EXECUTIONS, Component: ExecutionListRouter },
+    { path: RoutePage.EXECUTIONS, Component: ExecutionListSwitcher },
     { path: RoutePage.EXECUTION_DETAILS, Component: ExecutionDetails },
     {
       Component: AllExperimentsAndArchive,

--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -26,26 +26,28 @@ import Compare from 'src/pages/Compare';
 import FrontendFeatures from 'src/pages/FrontendFeatures';
 import RunDetailsRouter from 'src/pages/RunDetailsRouter';
 import { classes, stylesheet } from 'typestyle';
-import Banner, { BannerProps } from '../components/Banner';
-import { commonCss } from '../Css';
-import { Deployments, KFP_FLAGS } from '../lib/Flags';
-import Page404 from '../pages/404';
+import Banner, { BannerProps } from 'src/components/Banner';
+import { commonCss } from 'src/Css';
+import { Deployments, KFP_FLAGS } from 'src/lib/Flags';
+import Page404 from 'src/pages/404';
 import AllExperimentsAndArchive, {
   AllExperimentsAndArchiveTab,
-} from '../pages/AllExperimentsAndArchive';
-import AllRecurringRunsList from '../pages/AllRecurringRunsList';
-import AllRunsAndArchive, { AllRunsAndArchiveTab } from '../pages/AllRunsAndArchive';
-import ArtifactDetails from '../pages/ArtifactDetails';
-import ArtifactList from '../pages/ArtifactList';
-import ExecutionDetails from '../pages/ExecutionDetails';
-import ExecutionList from '../pages/ExecutionList';
-import ExperimentDetails from '../pages/ExperimentDetails';
-import { GettingStarted } from '../pages/GettingStarted';
-import NewExperiment from '../pages/NewExperiment';
-import NewPipelineVersion from '../pages/NewPipelineVersion';
-import NewRunSwitcher from '../pages/NewRunSwitcher';
-import PipelineDetails from '../pages/PipelineDetails';
-import PrivateAndSharedPipelines, { PrivateAndSharedTab } from '../pages/PrivateAndSharedPipelines';
+} from 'src/pages/AllExperimentsAndArchive';
+import AllRecurringRunsList from 'src/pages/AllRecurringRunsList';
+import AllRunsAndArchive, { AllRunsAndArchiveTab } from 'src/pages/AllRunsAndArchive';
+import ArtifactDetails from 'src/pages/ArtifactDetails';
+import ArtifactList from 'src/pages/ArtifactList';
+import ExecutionDetails from 'src/pages/ExecutionDetails';
+import ExecutionListRouter from 'src/pages/ExecutionListRouter';
+import ExperimentDetails from 'src/pages/ExperimentDetails';
+import { GettingStarted } from 'src/pages/GettingStarted';
+import NewExperiment from 'src/pages/NewExperiment';
+import NewPipelineVersion from 'src/pages/NewPipelineVersion';
+import NewRunSwitcher from 'src/pages/NewRunSwitcher';
+import PipelineDetails from 'src/pages/PipelineDetails';
+import PrivateAndSharedPipelines, {
+  PrivateAndSharedTab,
+} from 'src/pages/PrivateAndSharedPipelines';
 import RecurringRunDetailsRouter from 'src/pages/RecurringRunDetailsRouter';
 import SideNav from './SideNav';
 import Toolbar, { ToolbarProps } from './Toolbar';
@@ -182,7 +184,7 @@ const Router: React.FC<RouterProps> = ({ configs }) => {
     },
     { path: RoutePage.ARTIFACTS, Component: ArtifactList },
     { path: RoutePage.ARTIFACT_DETAILS, Component: ArtifactDetails, notExact: true },
-    { path: RoutePage.EXECUTIONS, Component: ExecutionList },
+    { path: RoutePage.EXECUTIONS, Component: ExecutionListRouter },
     { path: RoutePage.EXECUTION_DETAILS, Component: ExecutionDetails },
     {
       Component: AllExperimentsAndArchive,

--- a/frontend/src/pages/ExecutionList.test.tsx
+++ b/frontend/src/pages/ExecutionList.test.tsx
@@ -34,7 +34,7 @@ import { CommonTestWrapper } from 'src/TestWrapper';
 
 testBestPractices();
 
-describe('ExecutionList', () => {
+describe('ExecutionList ("Default" view)', () => {
   let updateBannerSpy: jest.Mock<{}>;
   let updateDialogSpy: jest.Mock<{}>;
   let updateSnackbarSpy: jest.Mock<{}>;
@@ -117,7 +117,7 @@ describe('ExecutionList', () => {
     });
     render(
       <CommonTestWrapper>
-        <ExecutionList {...generateProps()} />
+        <ExecutionList {...generateProps()} isGroupView={false} />
       </CommonTestWrapper>,
     );
 
@@ -132,7 +132,7 @@ describe('ExecutionList', () => {
   it('displays footer with "10" as default value', async () => {
     render(
       <CommonTestWrapper>
-        <ExecutionList {...generateProps()} />
+        <ExecutionList {...generateProps()} isGroupView={false} />
       </CommonTestWrapper>,
     );
 
@@ -148,7 +148,7 @@ describe('ExecutionList', () => {
   it('shows 20th execution if page size is 20', async () => {
     render(
       <CommonTestWrapper>
-        <ExecutionList {...generateProps()} />
+        <ExecutionList {...generateProps()} isGroupView={false} />
       </CommonTestWrapper>,
     );
 
@@ -190,7 +190,7 @@ describe('ExecutionList', () => {
     });
     render(
       <CommonTestWrapper>
-        <ExecutionList {...generateProps()} />
+        <ExecutionList {...generateProps()} isGroupView={false} />
       </CommonTestWrapper>,
     );
     await waitFor(() => {

--- a/frontend/src/pages/ExecutionList.tsx
+++ b/frontend/src/pages/ExecutionList.tsx
@@ -46,7 +46,7 @@ import {
 import { Page } from 'src/pages/Page';
 
 interface ExecutionListProps {
-  isGroupped: boolean;
+  isGroupView: boolean;
 }
 
 interface ExecutionListState {
@@ -104,13 +104,13 @@ class ExecutionList extends Page<ExecutionListProps, ExecutionListState> {
           ref={this.tableRef}
           columns={columns}
           rows={rows}
-          disablePaging={this.props.isGroupped}
+          disablePaging={this.props.isGroupView}
           disableSelection={true}
           reload={this.reload}
           initialSortColumn='pipelineName'
           initialSortOrder='asc'
-          getExpandComponent={this.props.isGroupped ? this.getExpandedExecutionsRow : undefined}
-          toggleExpansion={this.props.isGroupped ? this.toggleRowExpand : undefined}
+          getExpandComponent={this.props.isGroupView ? this.getExpandedExecutionsRow : undefined}
+          toggleExpansion={this.props.isGroupView ? this.toggleRowExpand : undefined}
           emptyMessage='No executions found.'
         />
       </div>
@@ -138,7 +138,7 @@ class ExecutionList extends Page<ExecutionListProps, ExecutionListState> {
       if (!this.executionTypesMap || !this.executionTypesMap.size) {
         this.executionTypesMap = await this.getExecutionTypes();
       }
-      const executions = this.props.isGroupped
+      const executions = this.props.isGroupView
         ? await this.getExecutions()
         : await this.getExecutions(listOperationOpts);
       this.clearBanner();
@@ -147,8 +147,8 @@ class ExecutionList extends Page<ExecutionListProps, ExecutionListState> {
       // TODO(jlyaoyuli): Consider to support grouped rows with pagination.
       this.setState({
         executions,
-        expandedRows: this.props.isGroupped ? grouppedRows.expandedRows : new Map(),
-        rows: this.props.isGroupped ? grouppedRows.collapsedRows : flattenedRows,
+        expandedRows: this.props.isGroupView ? grouppedRows.expandedRows : new Map(),
+        rows: this.props.isGroupView ? grouppedRows.collapsedRows : flattenedRows,
       });
     } catch (err) {
       this.showPageError(serviceErrorToString(err));

--- a/frontend/src/pages/ExecutionList.tsx
+++ b/frontend/src/pages/ExecutionList.tsx
@@ -143,12 +143,12 @@ class ExecutionList extends Page<ExecutionListProps, ExecutionListState> {
         : await this.getExecutions(listOperationOpts);
       this.clearBanner();
       const flattenedRows = this.getFlattenedRowsFromExecutions(request, executions);
-      const grouppedRows = this.getGroupedRowsFromExecutions(request, executions);
+      const groupedRows = this.getGroupedRowsFromExecutions(request, executions);
       // TODO(jlyaoyuli): Consider to support grouped rows with pagination.
       this.setState({
         executions,
-        expandedRows: this.props.isGroupView ? grouppedRows.expandedRows : new Map(),
-        rows: this.props.isGroupView ? grouppedRows.collapsedRows : flattenedRows,
+        expandedRows: this.props.isGroupView ? groupedRows.expandedRows : new Map(),
+        rows: this.props.isGroupView ? groupedRows.collapsedRows : flattenedRows,
       });
     } catch (err) {
       this.showPageError(serviceErrorToString(err));

--- a/frontend/src/pages/ExecutionListRouter.tsx
+++ b/frontend/src/pages/ExecutionListRouter.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import MD2Tabs from 'src/atoms/MD2Tabs';
+import { commonCss, padding } from 'src/Css';
+import { classes } from 'typestyle';
+import { PageProps } from './Page';
+import ExecutionList from 'src/pages/ExecutionList';
+
+function ExecutionListRouter(props: PageProps) {
+  const [selectedTab, setSelectedTab] = useState(0);
+
+  return (
+    <div className={classes(commonCss.page, padding(20, 't'))}>
+      <MD2Tabs tabs={['Flat', 'Group']} selectedTab={selectedTab} onSwitch={setSelectedTab} />
+
+      {selectedTab === 0 && <ExecutionList {...props} isGroupped={false}></ExecutionList>}
+
+      {selectedTab === 1 && <ExecutionList {...props} isGroupped={true}></ExecutionList>}
+    </div>
+  );
+}
+
+export default ExecutionListRouter;

--- a/frontend/src/pages/ExecutionListSwitcher.tsx
+++ b/frontend/src/pages/ExecutionListSwitcher.tsx
@@ -18,10 +18,10 @@ import React, { useState } from 'react';
 import MD2Tabs from 'src/atoms/MD2Tabs';
 import { commonCss, padding } from 'src/Css';
 import { classes } from 'typestyle';
-import { PageProps } from './Page';
+import { PageProps } from 'src/pages/Page';
 import ExecutionList from 'src/pages/ExecutionList';
 
-function ExecutionListRouter(props: PageProps) {
+function ExecutionListSwitcher(props: PageProps) {
   const [selectedTab, setSelectedTab] = useState(0);
 
   return (
@@ -35,4 +35,4 @@ function ExecutionListRouter(props: PageProps) {
   );
 }
 
-export default ExecutionListRouter;
+export default ExecutionListSwitcher;

--- a/frontend/src/pages/ExecutionListSwitcher.tsx
+++ b/frontend/src/pages/ExecutionListSwitcher.tsx
@@ -26,7 +26,7 @@ function ExecutionListSwitcher(props: PageProps) {
 
   return (
     <div className={classes(commonCss.page, padding(20, 't'))}>
-      <MD2Tabs tabs={['Flat', 'Group']} selectedTab={selectedTab} onSwitch={setSelectedTab} />
+      <MD2Tabs tabs={['Default', 'Grouped']} selectedTab={selectedTab} onSwitch={setSelectedTab} />
 
       {selectedTab === 0 && <ExecutionList {...props} isGroupView={false}></ExecutionList>}
 

--- a/frontend/src/pages/ExecutionListSwitcher.tsx
+++ b/frontend/src/pages/ExecutionListSwitcher.tsx
@@ -28,9 +28,9 @@ function ExecutionListSwitcher(props: PageProps) {
     <div className={classes(commonCss.page, padding(20, 't'))}>
       <MD2Tabs tabs={['Flat', 'Group']} selectedTab={selectedTab} onSwitch={setSelectedTab} />
 
-      {selectedTab === 0 && <ExecutionList {...props} isGroupped={false}></ExecutionList>}
+      {selectedTab === 0 && <ExecutionList {...props} isGroupView={false}></ExecutionList>}
 
-      {selectedTab === 1 && <ExecutionList {...props} isGroupped={true}></ExecutionList>}
+      {selectedTab === 1 && <ExecutionList {...props} isGroupView={true}></ExecutionList>}
     </div>
   );
 }

--- a/frontend/src/pages/ExecutionListSwticher.test.tsx
+++ b/frontend/src/pages/ExecutionListSwticher.test.tsx
@@ -101,8 +101,8 @@ describe('ExecutionListSwitcher', () => {
       </CommonTestWrapper>,
     );
 
-    screen.getByText('Flat');
-    screen.getByText('Group');
+    screen.getByText('Default');
+    screen.getByText('Grouped');
   });
 
   it('disable pagination if switch to "Group" view', async () => {
@@ -112,7 +112,7 @@ describe('ExecutionListSwitcher', () => {
       </CommonTestWrapper>,
     );
 
-    const groupTab = screen.getByText('Group');
+    const groupTab = screen.getByText('Grouped');
     fireEvent.click(groupTab);
 
     // "Group" view will call getExection() without list options

--- a/frontend/src/pages/ExecutionListSwticher.test.tsx
+++ b/frontend/src/pages/ExecutionListSwticher.test.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { Api } from 'src/mlmd/library';
+import {
+  Execution,
+  ExecutionType,
+  GetExecutionsRequest,
+  GetExecutionsResponse,
+  GetExecutionTypesResponse,
+  Value,
+} from 'src/third_party/mlmd';
+import { RoutePage } from 'src/components/Router';
+import { testBestPractices } from 'src/TestUtils';
+import ExecutionListSwitcher from 'src/pages/ExecutionListSwitcher';
+import { PageProps } from 'src/pages/Page';
+import { CommonTestWrapper } from 'src/TestWrapper';
+
+testBestPractices();
+
+describe('ExecutionListSwitcher', () => {
+  let getExecutionsSpy: jest.Mock<{}>;
+  let getExecutionTypesSpy: jest.Mock<{}>;
+  const getExecutionsRequest = new GetExecutionsRequest();
+
+  beforeEach(() => {
+    getExecutionsSpy = jest.spyOn(Api.getInstance().metadataStoreService, 'getExecutions');
+    getExecutionTypesSpy = jest.spyOn(Api.getInstance().metadataStoreService, 'getExecutionTypes');
+
+    getExecutionTypesSpy.mockImplementation(() => {
+      const executionType = new ExecutionType();
+      executionType.setId(6);
+      executionType.setName('String');
+      const response = new GetExecutionTypesResponse();
+      response.setExecutionTypesList([executionType]);
+      return Promise.resolve(response);
+    });
+
+    getExecutionsSpy.mockImplementation(() => {
+      const executions = mockNExecutions(5);
+      const response = new GetExecutionsResponse();
+      response.setExecutionsList(executions);
+      return Promise.resolve(response);
+    });
+  });
+
+  function generateProps(): PageProps {
+    const pageProps: PageProps = {
+      history: {} as any,
+      location: {
+        pathname: RoutePage.EXECUTIONS,
+      } as any,
+      match: {} as any,
+      toolbarProps: { actions: {}, breadcrumbs: [], pageTitle: '' },
+      updateBanner: () => null,
+      updateDialog: () => null,
+      updateSnackbar: () => null,
+      updateToolbar: () => null,
+    };
+    return pageProps;
+  }
+
+  function mockNExecutions(n: number) {
+    let executions: Execution[] = [];
+    for (let i = 1; i <= n; i++) {
+      const execution = new Execution();
+      const pipelineValue = new Value();
+      const pipelineName = `pipeline ${i}`;
+      pipelineValue.setStringValue(pipelineName);
+      execution.getCustomPropertiesMap().set('pipeline_name', pipelineValue);
+      const executionValue = new Value();
+      const executionName = `test execution ${i}`;
+      executionValue.setStringValue(executionName);
+      execution.getPropertiesMap().set('name', executionValue);
+      execution.setName(executionName);
+      execution.setId(i);
+      executions.push(execution);
+    }
+    return executions;
+  }
+
+  it('shows "Flat" and "Group" tabs', () => {
+    render(
+      <CommonTestWrapper>
+        <ExecutionListSwitcher {...generateProps()} />
+      </CommonTestWrapper>,
+    );
+
+    screen.getByText('Flat');
+    screen.getByText('Group');
+  });
+
+  it('disable pagination if switch to "Group" view', async () => {
+    render(
+      <CommonTestWrapper>
+        <ExecutionListSwitcher {...generateProps()} />
+      </CommonTestWrapper>,
+    );
+
+    const groupTab = screen.getByText('Group');
+    fireEvent.click(groupTab);
+
+    // "Group" view will call getExection() without list options
+    getExecutionsRequest.setOptions(undefined);
+
+    await waitFor(() => {
+      expect(getExecutionTypesSpy).toHaveBeenCalledTimes(2); // once for flat, once for group
+      expect(getExecutionsSpy).toHaveBeenCalledTimes(2); // once for flat, once for group
+      expect(getExecutionsSpy).toHaveBeenLastCalledWith(getExecutionsRequest);
+    });
+
+    expect(screen.queryByText('Rows per page:')).toBeNull(); // no footer
+    expect(screen.queryByText('10')).toBeNull(); // no footer
+  });
+});


### PR DESCRIPTION
We supported `Flat` view and pagination feature for the execution list in our last rc release. However, we hope that the original `Group` view can be preserved as well. The main purpose of this PR is adding a little tab on the top of execution list for users to switch between both views.

[Demo]

https://github.com/kubeflow/pipelines/assets/56132941/c57d97c9-855d-40d5-9489-19e58ea4c205



