### PR TITLE
fix(frontend): Incorrect page title after switching to another pipeline version.

### DIFF
--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -562,6 +562,9 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
   public async handleVersionSelected(versionId: string): Promise<void> {
     if (this.state.v1Pipeline) {
       const selectedVersion = (this.state.v1Versions || []).find(v => v.id === versionId);
+      const pageTitle = this.state.v1Pipeline.name?.concat(' (', selectedVersion?.name!, ')');
+      this.props.updateToolbar({ pageTitle });
+
       const selectedVersionPipelineTemplate = await this._getTemplateString(
         this.state.v1Pipeline.id!,
         versionId,
@@ -600,6 +603,13 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
       const selectedVersion = (this.state.v2Versions || []).find(
         v => v.pipeline_version_id === versionId,
       );
+      const pageTitle = this.state.v2Pipeline.display_name?.concat(
+        ' (',
+        selectedVersion?.display_name!,
+        ')',
+      );
+      this.props.updateToolbar({ pageTitle });
+
       const selectedVersionPipelineTemplate = await this._getTemplateString(
         this.state.v2Pipeline.pipeline_id!,
         versionId,


### PR DESCRIPTION
The pipeline version name in page title should be changed as well after switching to another pipeline version.

Before:


https://github.com/kubeflow/pipelines/assets/56132941/ec699e27-d07e-41f1-9a55-e9c2347d7432



After:


https://github.com/kubeflow/pipelines/assets/56132941/2df6f260-3ea0-4374-86fe-cfcf672055a3

