### PR TITLE
feature(frontend): Support non-English characters and special characters in pipeline "display" name

### DIFF
--- a/frontend/src/pages/NewPipelineVersion.test.tsx
+++ b/frontend/src/pages/NewPipelineVersion.test.tsx
@@ -118,7 +118,7 @@ describe('NewPipelineVersion', () => {
     it('creates pipeline version is default when landing from pipeline details page', () => {
       tree = shallow(
         <TestNewPipelineVersion
-          {...generateProps(`?${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}`)}
+          {...generateProps(`?${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.pipeline_id}`)}
         />,
       );
 
@@ -187,7 +187,7 @@ describe('NewPipelineVersion', () => {
     it('allows updating package url', async () => {
       tree = shallow(
         <TestNewPipelineVersion
-          {...generateProps(`?${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}`)}
+          {...generateProps(`?${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.pipeline_id}`)}
         />,
       );
       await TestUtils.flushPromises();
@@ -203,7 +203,7 @@ describe('NewPipelineVersion', () => {
     it('allows updating code source', async () => {
       tree = shallow(
         <TestNewPipelineVersion
-          {...generateProps(`?${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}`)}
+          {...generateProps(`?${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.pipeline_id}`)}
         />,
       );
       await TestUtils.flushPromises();
@@ -479,31 +479,12 @@ describe('NewPipelineVersion', () => {
     it('allows updating pipeline version name', async () => {
       render(
         <TestNewPipelineVersion
-          {...generateProps(`?${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}`)}
+          {...generateProps(`?${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.pipeline_id}`)}
         />,
       );
       const pipelineVersionNameInput = await screen.findByLabelText(/Pipeline Version name/);
       fireEvent.change(pipelineVersionNameInput, { target: { value: 'new-pipeline-name' } });
       expect(pipelineVersionNameInput.closest('input')?.value).toBe('new-pipeline-name');
-    });
-
-    it('disable create button if pipeline name is invalid', async () => {
-      render(
-        <TestNewPipelineVersion
-          {...generateProps(`?${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}`)}
-        />,
-      );
-      const formCtlLabel = screen.getByLabelText('Create a new pipeline');
-      fireEvent.click(formCtlLabel);
-      const pipelineNameInput = await screen.findByLabelText(/Pipeline Name/);
-      fireEvent.change(pipelineNameInput, { target: { value: 'new pipeline name?' } });
-      expect(pipelineNameInput.closest('input')?.value).toBe('new pipeline name?');
-
-      const createBtn = await screen.findByText('Create');
-      expect(createBtn.closest('button')?.disabled).toEqual(true);
-      screen.findByText(
-        "Pipeline name must contain only lowercase alphanumeric characters, '-' or '.' and start / end with alphanumeric characters.",
-      );
     });
   });
 });

--- a/frontend/src/pages/NewPipelineVersion.tsx
+++ b/frontend/src/pages/NewPipelineVersion.tsx
@@ -637,7 +637,6 @@ export class NewPipelineVersion extends Page<NewPipelineVersionProps, NewPipelin
         if (!pipelineName) {
           throw new Error('Pipeline name is required');
         }
-        this._isValidName(pipelineName!, 'Pipeline name');
       } else {
         if (!pipeline) {
           throw new Error('Pipeline is required');
@@ -655,22 +654,6 @@ export class NewPipelineVersion extends Page<NewPipelineVersionProps, NewPipelin
       this.setState({ validationError: '' });
     } catch (err) {
       this.setState({ validationError: err.message });
-    }
-  }
-
-  private _isValidName(name: string, title: string): void {
-    if (name.length > 100) {
-      throw new Error(title + ' must contain no more than 100 characters');
-    }
-    if (
-      !name
-        .match('[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
-        ?.includes(name)
-    ) {
-      throw new Error(
-        title +
-          " must contain only lowercase alphanumeric characters, '-' or '.' and start / end with alphanumeric characters.",
-      );
     }
   }
 


### PR DESCRIPTION
Based on #9449

Previously, we don't support run name, which is partly from pipeline name, with non-English characters and special characters. A name precheck for pipeline display name (user-typed input) is set to avoid invalid name.
Currently, there's no limitation for run name any more. The precheck for pipeline name can be eliminated as well.

![Screenshot 2023-05-19 at 10 17 05 AM](https://github.com/kubeflow/pipelines/assets/56132941/1a114092-5062-4fab-bb21-5c7c88901f42)
![Screenshot 2023-05-19 at 10 18 06 AM](https://github.com/kubeflow/pipelines/assets/56132941/15b5760a-d560-4368-b3d1-408f48193d23)

Both of run and pipeline can accept any characters

