### PR TITLE
fix(frontend): Toolbar in pipeline details (from run) should only have "Clone run" button

### DIFF
--- a/frontend/src/pages/PipelineDetails.test.tsx
+++ b/frontend/src/pages/PipelineDetails.test.tsx
@@ -590,7 +590,7 @@ describe('PipelineDetails', () => {
     expect(newExperimentBtn).toBeDefined();
   });
 
-  it("has 'create run' toolbar button if viewing an embedded pipeline", async () => {
+  it("has 'clone run' toolbar button if viewing an embedded pipeline", async () => {
     tree = shallow(<PipelineDetails {...generateProps(true)} />);
     await getPipelineVersionTemplateSpy;
     await TestUtils.flushPromises();
@@ -602,8 +602,8 @@ describe('PipelineDetails', () => {
   });
 
   it(
-    'clicking new run button when viewing embedded pipeline navigates to ' +
-      'the new run page with run ID',
+    'clicking clone run button when viewing embedded pipeline navigates to ' +
+      'the new run page (clone a run) with run ID',
     async () => {
       tree = shallow(<PipelineDetails {...generateProps(true)} />);
       await TestUtils.flushPromises();

--- a/frontend/src/pages/PipelineDetails.test.tsx
+++ b/frontend/src/pages/PipelineDetails.test.tsx
@@ -596,11 +596,9 @@ describe('PipelineDetails', () => {
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
     /* create run and create pipeline version, so 2 */
-    expect(Object.keys(instance.getInitialToolbarState().actions)).toHaveLength(2);
-    const newRunBtn = instance.getInitialToolbarState().actions[
-      (ButtonKeys.NEW_RUN_FROM_PIPELINE_VERSION, ButtonKeys.NEW_PIPELINE_VERSION)
-    ];
-    expect(newRunBtn).toBeDefined();
+    expect(Object.keys(instance.getInitialToolbarState().actions)).toHaveLength(1);
+    const cloneRunBtn = instance.getInitialToolbarState().actions[ButtonKeys.CLONE_RUN];
+    expect(cloneRunBtn).toBeDefined();
   });
 
   it(
@@ -610,13 +608,11 @@ describe('PipelineDetails', () => {
       tree = shallow(<PipelineDetails {...generateProps(true)} />);
       await TestUtils.flushPromises();
       const instance = tree.instance() as PipelineDetails;
-      const newRunBtn = instance.getInitialToolbarState().actions[
-        ButtonKeys.NEW_RUN_FROM_PIPELINE_VERSION
-      ];
-      newRunBtn!.action();
+      const cloneRunBtn = instance.getInitialToolbarState().actions[ButtonKeys.CLONE_RUN];
+      cloneRunBtn!.action();
       expect(historyPushSpy).toHaveBeenCalledTimes(1);
       expect(historyPushSpy).toHaveBeenLastCalledWith(
-        RoutePage.NEW_RUN + `?${QUERY_PARAMS.fromRunId}=${testV1Run.run!.id}`,
+        RoutePage.NEW_RUN + `?${QUERY_PARAMS.cloneFromRun}=${testV1Run.run!.id}`,
       );
     },
   );

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -104,20 +104,11 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
     const origin = this.getOrigin();
     const pipelineIdFromParams = this.props.match.params[RouteParams.pipelineId];
     const pipelineVersionIdFromParams = this.props.match.params[RouteParams.pipelineVersionId];
-    buttons
-      .newRunFromPipelineVersion(
-        () => {
-          return pipelineIdFromParams ? pipelineIdFromParams : '';
-        },
-        () => {
-          return pipelineVersionIdFromParams ? pipelineVersionIdFromParams : '';
-        },
-      )
-      .newPipelineVersion('Upload version', () =>
-        pipelineIdFromParams ? pipelineIdFromParams : '',
-      );
 
     if (origin) {
+      const getRunIdList = () => [origin.runId!];
+      buttons.cloneRun(getRunIdList, true);
+
       return {
         actions: buttons.getToolbarActionMap(),
         breadcrumbs: [
@@ -136,6 +127,17 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
     } else {
       // Add buttons for creating experiment and deleting pipeline version
       buttons
+        .newRunFromPipelineVersion(
+          () => {
+            return pipelineIdFromParams ? pipelineIdFromParams : '';
+          },
+          () => {
+            return pipelineVersionIdFromParams ? pipelineVersionIdFromParams : '';
+          },
+        )
+        .newPipelineVersion('Upload version', () =>
+          pipelineIdFromParams ? pipelineIdFromParams : '',
+        )
         .newExperiment(() =>
           this.state.v1Pipeline
             ? this.state.v1Pipeline.id!


### PR DESCRIPTION
We have 2 possible source for pipeline details (from version and from run). For the details from run (clone existing run or SDK-created run), action should be `Clone run` rather `Create run`. Also, we shouldn't allow `Upload version` in this case, because pipeline is not existed.

Pipeline details from version:

https://github.com/kubeflow/pipelines/assets/56132941/94ca9ab1-1617-4d82-8eb9-69da9c801538

Pipeline details from run (SDK-created run)

https://github.com/kubeflow/pipelines/assets/56132941/0133fa5e-a609-48ef-acb7-a121081a0a4f

Pipeline details from run (clone existing run)

https://github.com/kubeflow/pipelines/assets/56132941/c780a086-6a52-4687-8022-014585924e47

Pipeline details from run (after fix)

https://github.com/kubeflow/pipelines/assets/56132941/118341c2-0cad-4736-84ab-a99cdf28677d

