### PR TITLE
feat(backend): Update cache-server to only check if Pod is Succeeded. Fixes #9454

### DIFF
--- a/backend/src/cache/server/watcher.go
+++ b/backend/src/cache/server/watcher.go
@@ -47,7 +47,7 @@ func WatchPods(ctx context.Context, namespaceToWatch string, clientManager Clien
 			}
 			log.Printf((*pod).GetName())
 
-			if !isPodCompletedAndSucceeded(pod) {
+			if !isPodSucceeded(pod) {
 				log.Printf("Pod %s is not completed or not in successful status.", pod.ObjectMeta.Name)
 				continue
 			}
@@ -108,8 +108,8 @@ func WatchPods(ctx context.Context, namespaceToWatch string, clientManager Clien
 	}
 }
 
-func isPodCompletedAndSucceeded(pod *corev1.Pod) bool {
-	return pod.ObjectMeta.Labels[ArgoCompleteLabelKey] == "true" && pod.Status.Phase == corev1.PodSucceeded
+func isPodSucceeded(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodSucceeded
 }
 
 func isCacheWriten(labels map[string]string) bool {

--- a/backend/src/cache/server/watcher_test.go
+++ b/backend/src/cache/server/watcher_test.go
@@ -25,7 +25,7 @@ func TestIsPodSucceeded(t *testing.T) {
 	runningPod.Status.Phase = "Running"
 	podIncomplete := isPodSucceeded(fakePod)
 	assert.False(t, podIncomplete)
-	// Assign pod as succeeded
+	// Assign pod as succeeded.
 	completedPod := *fakePod.DeepCopy()
 	completedPod.Status.Phase = "Succeeded"
 	podComplete := isPodSucceeded(&completedPod)
@@ -35,7 +35,7 @@ func TestIsPodSucceeded(t *testing.T) {
 func TestIsCacheWritten(t *testing.T) {
 	cacheNotWritten := isCacheWriten(fakePod.ObjectMeta.Labels)
 	assert.False(t, cacheNotWritten)
-	// Mutate pod with a cache
+	// Mutate pod with a cache.
 	mutatedPod := *fakePod.DeepCopy()
 	mutatedPod.ObjectMeta.Labels[CacheIDLabelKey] = "1234"
 	cacheWritten := isCacheWriten(mutatedPod.ObjectMeta.Labels)

--- a/backend/src/cache/server/watcher_test.go
+++ b/backend/src/cache/server/watcher_test.go
@@ -1,0 +1,43 @@
+// Copyright 2020 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPodSucceeded(t *testing.T) {
+	runningPod := *fakePod.DeepCopy()
+	runningPod.Status.Phase = "Running"
+	podIncomplete := isPodSucceeded(fakePod)
+	assert.False(t, podIncomplete)
+	// Assign pod as succeeded
+	completedPod := *fakePod.DeepCopy()
+	completedPod.Status.Phase = "Succeeded"
+	podComplete := isPodSucceeded(&completedPod)
+	assert.True(t, podComplete)
+}
+
+func TestIsCacheWritten(t *testing.T) {
+	cacheNotWritten := isCacheWriten(fakePod.ObjectMeta.Labels)
+	assert.False(t, cacheNotWritten)
+	// Mutate pod with a cache
+	mutatedPod := *fakePod.DeepCopy()
+	mutatedPod.ObjectMeta.Labels[CacheIDLabelKey] = "1234"
+	cacheWritten := isCacheWriten(mutatedPod.ObjectMeta.Labels)
+	assert.True(t, cacheWritten)
+}


### PR DESCRIPTION
This is because to cache tasks we shouldn't care if the entire pipeline has completed, once a Pod is Succeeded it must also have completed and can be entered into the cache database.

**Description of your changes:**
The change here is to change the CacheServer to only watch for `Succeeded` Pods
- From the `Succeeded` status it can be inferred the Pod is also `Completed`

The check for whether the Argo Workflow has completed `ObjectMeta.Labels[ArgoCompleteLabelKey] == "true"` has been removed as caching of a task shouldn't be dependent on the whole pipeline.
- This should speed up the rate of caching and it will also allow users to make use of Argos ability to do Pod Garbage Collection `onPodSuccess` instead of relying on the Time to Live of the workflow
    - Ultimately this will allow users to keep a "cleaner" cluster by having fewer `Succeeded` pods hanging around for long running workflows

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
