### PR TITLE
fix(frontend): Run name should be empty if no pipeline is selected

### DIFF
--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -843,9 +843,9 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
         pipelineSelectorOpen: false,
         pipelineVersion,
         pipelineVersionName: (pipelineVersion && pipelineVersion.name) || '',
-        runName: this._getRunNameFromPipelineVersion(
-          (pipelineVersion && pipelineVersion.name) || '',
-        ),
+        runName: pipelineVersion?.name
+          ? this._getRunNameFromPipelineVersion(pipelineVersion.name)
+          : '',
       },
       () => this._validate(),
     );


### PR DESCRIPTION
Before:

https://github.com/kubeflow/pipelines/assets/56132941/d29145ba-04e4-4645-be8b-bb4c862914a5


After:

https://github.com/kubeflow/pipelines/assets/56132941/81ecdd19-1aab-437d-a050-a7fb9d72a044

