### PR TITLE
fix(frontend): Choose button is disable even if pipeline is already selected (after uploading a new pipeline)

### DIFF
--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -938,6 +938,7 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
         {
           pipeline: uploadedPipeline,
           pipelineName: (uploadedPipeline && uploadedPipeline.name) || '',
+          unconfirmedSelectedPipeline: uploadedPipeline,
           pipelineSelectorOpen: false,
           uploadDialogOpen: false,
         },


### PR DESCRIPTION
The enable / disable logic of choose button in pipeline version box was changed in #8831 , and cause the bug.

Before:

https://github.com/kubeflow/pipelines/assets/56132941/5aae95ef-e96f-47b3-984b-1308f43d9e96


After:

https://github.com/kubeflow/pipelines/assets/56132941/608cdf2f-2f1c-4906-8bce-f1f1fe8cd3f9


