### PR TITLE
feat(backend): Implement aws-go-sdk crendentials to support IRSA for s3 in V2

### DIFF
--- a/backend/src/v2/objectstore/object_store.go
+++ b/backend/src/v2/objectstore/object_store.go
@@ -53,10 +53,10 @@ func OpenBucket(ctx context.Context, k8sClient kubernetes.Interface, namespace s
 	if config.Scheme == "minio://" {
 		cred, err := getMinioCredential(ctx, k8sClient, namespace)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to get minio credential: %w", err)
+			return nil, fmt.Errorf("Failed to get minio credential: %w", err)	
 		}
 		sess, err := session.NewSession(&aws.Config{
-			Credentials:      credentials.NewStaticCredentials(cred.AccessKey, cred.SecretKey, ""),
+			Credentials:      cred,
 			Region:           aws.String("minio"),
 			Endpoint:         aws.String(MinioDefaultEndpoint()),
 			DisableSSL:       aws.Bool(true),
@@ -307,12 +307,7 @@ func MinioDefaultEndpoint() string {
 	return defaultMinioEndpointInMultiUserMode
 }
 
-type minioCredential struct {
-	AccessKey string
-	SecretKey string
-}
-
-func getMinioCredential(ctx context.Context, clientSet kubernetes.Interface, namespace string) (cred minioCredential, err error) {
+func getMinioCredential(ctx context.Context, clientSet kubernetes.Interface, namespace string) (cred *credentials.Credentials, err error) {
 	defer func() {
 		if err != nil {
 			// wrap error before returning
@@ -324,15 +319,24 @@ func getMinioCredential(ctx context.Context, clientSet kubernetes.Interface, nam
 		minioArtifactSecretName,
 		metav1.GetOptions{})
 	if err != nil {
+		return nil, err
+	}
+	accessKey := string(secret.Data["accesskey"])
+	secretKey := string(secret.Data["secretkey"])
+
+	if accessKey != "" && secretKey != "" {
+		cred = credentials.NewStaticCredentials(accessKey, secretKey, "")
 		return cred, err
 	}
-	cred.AccessKey = string(secret.Data["accesskey"])
-	cred.SecretKey = string(secret.Data["secretkey"])
-	if cred.AccessKey == "" {
-		return cred, fmt.Errorf("does not have 'accesskey' key")
+
+	aws_cred, err := getAWSCredential()
+	if aws_cred != nil {
+		return aws_cred, err
 	}
-	if cred.SecretKey == "" {
-		return cred, fmt.Errorf("does not have 'secretkey' key")
-	}
-	return cred, nil
+
+	return nil, fmt.Errorf("does not have 'accesskey' or 'secretkey' key")
+}
+
+func getAWSCredential() (cred *credentials.Credentials, err error) {
+	return credentials.NewCredentials(&credentials.ChainProvider{}), nil
 }

--- a/backend/src/v2/objectstore/object_store.go
+++ b/backend/src/v2/objectstore/object_store.go
@@ -53,7 +53,7 @@ func OpenBucket(ctx context.Context, k8sClient kubernetes.Interface, namespace s
 	if config.Scheme == "minio://" {
 		cred, err := getMinioCredential(ctx, k8sClient, namespace)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to get minio credential: %w", err)	
+			return nil, fmt.Errorf("Failed to get minio credential: %w", err)
 		}
 		sess, err := session.NewSession(&aws.Config{
 			Credentials:      cred,


### PR DESCRIPTION
**Description of your changes:**
Use the aws-go-sdk credentials.ChainProvider to support IRSA in kfp v2. This functionality is already supported in V1, this pr aims to keep parity with v1 as IRSA is supported in v1 backend https://github.com/kubeflow/pipelines/blob/f167e15c3ca9b2120f8bb2283b0f3974439fef2f/backend/src/apiserver/client/minio.go#L30 Similar work was done for V1 frontend here https://github.com/kubeflow/pipelines/pull/8651. The goal is to maintain IRSA support in Kubeflow Pipelines as V2 goes GA following the effort to support S3 Integration for Artifact Storage (IRSA) in this issue https://github.com/kubeflow/pipelines/issues/8502.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
