### PR TITLE
feat(frontend): adding EventsList components to RuntimeNodeDetailsV2

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p ./server/dist && \
 
 # Generate the dependency licenses files (one for the UI and one for the webserver),
 # concatenate them to one file under ./src/server
-RUN ./scripts/yarn-licenses.sh
+# RUN ./scripts/yarn-licenses.sh
 
 FROM node:14.21.3-alpine3.17
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p ./server/dist && \
 
 # Generate the dependency licenses files (one for the UI and one for the webserver),
 # concatenate them to one file under ./src/server
-# RUN ./scripts/yarn-licenses.sh
+RUN ./scripts/yarn-licenses.sh
 
 FROM node:14.21.3-alpine3.17
 

--- a/frontend/src/components/EventsList.tsx
+++ b/frontend/src/components/EventsList.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import {KubernetesEvent} from "./tabs/RuntimeNodeDetailsV2";
+import Banner from "./Banner";
+import {commonCss, padding} from "../Css";
+import DetailsTable from "./DetailsTable";
+
+interface LogViewerProps {
+    events: KubernetesEvent[];
+}
+
+class EventsList extends React.Component<LogViewerProps> {
+
+    public render(): JSX.Element {
+        return (
+            <div className={commonCss.page}>
+                <div className={padding(20)}>
+                    {
+                        (this.props.events.length === 0) && <Banner message='There is no events for this pod.' mode='info' />
+                    }
+                    {
+                        this.props.events.map((event) => {
+                            return (
+                                <DetailsTable<string>
+                                    key={`input-artifacts-${event.name}`}
+                                    title={event.message}
+                                    fields={Array.of(
+                                        ["Source", `${event.source.host} ${event.source.component}`],
+                                        ["Count", `${event.count}`],
+                                        ["Last seen", `${event.lastTimestamp}`],
+                                    )}
+                                />
+                            )
+                        })
+                    }
+                </div>
+            </div>
+        );
+    }
+}
+
+export default EventsList;

--- a/frontend/src/components/EventsList.tsx
+++ b/frontend/src/components/EventsList.tsx
@@ -19,12 +19,20 @@ import {KubernetesEvent} from "./tabs/RuntimeNodeDetailsV2";
 import Banner from "./Banner";
 import {commonCss, padding} from "../Css";
 import DetailsTable from "./DetailsTable";
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
 
 interface LogViewerProps {
     events: KubernetesEvent[];
 }
 
+function sortEvent(a: KubernetesEvent, b: KubernetesEvent): number {
+    return new Date(a.creationTimestamp).getTime() - new Date(b.creationTimestamp).getTime();
+}
+
 class EventsList extends React.Component<LogViewerProps> {
+
+
 
     public render(): JSX.Element {
         return (
@@ -34,17 +42,22 @@ class EventsList extends React.Component<LogViewerProps> {
                         (this.props.events.length === 0) && <Banner message='There is no events for this pod.' mode='info' />
                     }
                     {
-                        this.props.events.map((event) => {
+                        this.props.events.sort(sortEvent).map((event) => {
                             return (
-                                <DetailsTable<string>
-                                    key={`input-artifacts-${event.name}`}
-                                    title={event.message}
-                                    fields={Array.of(
-                                        ["Source", `${event.source.host} ${event.source.component}`],
-                                        ["Count", `${event.count}`],
-                                        ["Last seen", `${event.lastTimestamp}`],
-                                    )}
-                                />
+                                <Card
+                                    style={{marginBottom: "1rem"}}
+                                    key={`input-artifacts-${event.name}`}>
+                                    <CardContent>
+                                        <DetailsTable<string>
+                                            title={event.message}
+                                            fields={Array.of(
+                                                ["Source", `${event.source.host} ${event.source.component}`],
+                                                ["Count", `${event.count}`],
+                                                ["Last seen", `${event.lastTimestamp}`],
+                                            )}
+                                        />
+                                    </CardContent>
+                                </Card>
                             )
                         })
                     }

--- a/frontend/src/components/EventsList.tsx
+++ b/frontend/src/components/EventsList.tsx
@@ -27,7 +27,7 @@ interface LogViewerProps {
 }
 
 function sortEvent(a: KubernetesEvent, b: KubernetesEvent): number {
-    return new Date(a.creationTimestamp).getTime() - new Date(b.creationTimestamp).getTime();
+    return new Date(b.creationTimestamp).getTime() - new Date(a.creationTimestamp).getTime();
 }
 
 class EventsList extends React.Component<LogViewerProps> {

--- a/frontend/src/components/EventsList.tsx
+++ b/frontend/src/components/EventsList.tsx
@@ -32,8 +32,6 @@ function sortEvent(a: KubernetesEvent, b: KubernetesEvent): number {
 
 class EventsList extends React.Component<LogViewerProps> {
 
-
-
     public render(): JSX.Element {
         return (
             <div className={commonCss.page}>

--- a/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
+++ b/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
@@ -240,7 +240,7 @@ function TaskNodeDetail({
             ):
                 (
                     <React.Fragment>
-                      <Banner message={"banner message"} additionalInfo={"additionalInfo"} />
+                      <Banner message={"Could not get pod events"} />
                     </React.Fragment>
                 )
         )}

--- a/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
+++ b/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
@@ -59,6 +59,7 @@ export const LOGS_BANNER_ADDITIONAL_INFO = 'logs_banner_additional_info';
 export const K8S_PLATFORM_KEY = 'kubernetes';
 
 export type KubernetesEvent = {
+  creationTimestamp: string;
   message: string;
 
   name: string;


### PR DESCRIPTION
## Description

When using the V2, they is no `Events` tags in the Runtime Details side panel. This PR aims to add them as they are really useful to understand the state of pods when something wrongs occurs.

- Events are sorted ascending based on `creationTimestamp` (not in the screenshot bellow)
- Events are took from the `pipeline/k8s/pod/events` endpoints.

## TODO:

- Add tests

## Demo

### No events

![image](https://github.com/kubeflow/pipelines/assets/42176370/6ce88351-b5c0-4d33-ad03-964c0190e972)

### Some events

![image](https://github.com/kubeflow/pipelines/assets/42176370/3873fc77-f3f4-4e5e-8003-ec2609ce9b0a)
