### PR TITLE
fix(frontend): Make pipeline definition in YAML tab more readable

### DIFF
--- a/frontend/src/components/PipelineSpecTabContent.tsx
+++ b/frontend/src/components/PipelineSpecTabContent.tsx
@@ -31,9 +31,14 @@ export function PipelineSpecTabContent(props: PipelineSpecTabContentProps) {
     <Editor
       value={
         isTemplateV2(props.templateString)
-          ? jsyaml.safeDump(jsyaml.safeLoad(props.templateString || ''))
-          : props.templateString || ''
-      } // Use safeLoad and then safeDump to make sure the v2 PipelineSpec is in Yaml Form.
+          ? props.templateString || ''
+          : jsyaml.safeDump(jsyaml.safeLoad(props.templateString || ''))
+      }
+      // V2(YAML-formatted):
+      //    Directly use it to render in <PipelineSpecTabContent>
+      // V1(JSON-formatted):
+      //    safeLoad() convert string to object first, and safeDump() changes the object
+      //    to yaml format and then render it in <PipelineSpecTabContent>
       height={editorHeightWidth}
       width={editorHeightWidth}
       mode='yaml'

--- a/frontend/src/components/PipelineSpecTabContent.tsx
+++ b/frontend/src/components/PipelineSpecTabContent.tsx
@@ -17,7 +17,6 @@
 import jsyaml from 'js-yaml';
 import React from 'react';
 import { isSafari } from 'src/lib/Utils';
-import { isTemplateV2 } from 'src/lib/v2/WorkflowUtils';
 import Editor from './Editor';
 
 interface PipelineSpecTabContentProps {

--- a/frontend/src/components/PipelineSpecTabContent.tsx
+++ b/frontend/src/components/PipelineSpecTabContent.tsx
@@ -29,16 +29,13 @@ const editorHeightWidth = isSafari() ? '640px' : '100%';
 export function PipelineSpecTabContent(props: PipelineSpecTabContentProps) {
   return (
     <Editor
-      value={
-        isTemplateV2(props.templateString)
-          ? props.templateString || ''
-          : jsyaml.safeDump(jsyaml.safeLoad(props.templateString || ''))
-      }
-      // V2(YAML-formatted):
-      //    Directly use it to render in <PipelineSpecTabContent>
+      value={jsyaml.safeDump(jsyaml.safeLoad(props.templateString || ''))}
+      // Render the yaml-formatted string in <PipelineSpecTabContent>
       // V1(JSON-formatted):
-      //    safeLoad() convert string to object first, and safeDump() changes the object
-      //    to yaml format and then render it in <PipelineSpecTabContent>
+      //    safeLoad() convert templateString to object first,
+      //    safeDump() changes the object to yaml-formatted string
+      // V2(YAML-formatted):
+      //    Still yaml format after safeLoad() and safeDump().
       height={editorHeightWidth}
       width={editorHeightWidth}
       mode='yaml'

--- a/frontend/src/pages/PipelineDetailsV1.tsx
+++ b/frontend/src/pages/PipelineDetailsV1.tsx
@@ -36,7 +36,6 @@ import StaticNodeDetails from '../components/StaticNodeDetails';
 import { color, commonCss, fonts, fontsize, padding, zIndex } from '../Css';
 import * as StaticGraphParser from '../lib/StaticGraphParser';
 import { formatDateString, logger } from '../lib/Utils';
-import jsyaml from 'js-yaml';
 
 const summaryCardWidth = 500;
 
@@ -261,14 +260,7 @@ const PipelineDetailsV1: React.FC<PipelineDetailsV1Props> = ({
         )}
         {selectedTab === 1 && !!templateString && (
           <div className={css.containerCss} data-testid={'spec-yaml'}>
-            {/* The templateString is from getPipelineTemplated() and it's JSON-formatted.
-              In order to make consistent with v2 pipeline behavior, we decide to render
-              it in yaml format.
-              safeLoad() convert string to object first, and safeDump() changes the object
-              to yaml format which is also acceptable by <PipelineSpecTabContent> */}
-            <PipelineSpecTabContent
-              templateString={jsyaml.safeDump(jsyaml.safeLoad(templateString)) || ''}
-            />
+            <PipelineSpecTabContent templateString={templateString || ''} />
           </div>
         )}
       </div>

--- a/frontend/src/pages/PipelineDetailsV1.tsx
+++ b/frontend/src/pages/PipelineDetailsV1.tsx
@@ -261,6 +261,11 @@ const PipelineDetailsV1: React.FC<PipelineDetailsV1Props> = ({
         )}
         {selectedTab === 1 && !!templateString && (
           <div className={css.containerCss} data-testid={'spec-yaml'}>
+            {/* The templateString is from getPipelineTemplated() and it's JSON-formatted.
+              In order to make consistent with v2 pipeline behavior, we decide to render
+              it in yaml format.
+              safeLoad() convert string to object first, and safeDump() changes the object
+              to yaml format which is also acceptable by <PipelineSpecTabContent> */}
             <PipelineSpecTabContent
               templateString={jsyaml.safeDump(jsyaml.safeLoad(templateString)) || ''}
             />

--- a/frontend/src/pages/PipelineDetailsV1.tsx
+++ b/frontend/src/pages/PipelineDetailsV1.tsx
@@ -36,6 +36,7 @@ import StaticNodeDetails from '../components/StaticNodeDetails';
 import { color, commonCss, fonts, fontsize, padding, zIndex } from '../Css';
 import * as StaticGraphParser from '../lib/StaticGraphParser';
 import { formatDateString, logger } from '../lib/Utils';
+import jsyaml from 'js-yaml';
 
 const summaryCardWidth = 500;
 
@@ -260,7 +261,9 @@ const PipelineDetailsV1: React.FC<PipelineDetailsV1Props> = ({
         )}
         {selectedTab === 1 && !!templateString && (
           <div className={css.containerCss} data-testid={'spec-yaml'}>
-            <PipelineSpecTabContent templateString={templateString || ''} />
+            <PipelineSpecTabContent
+              templateString={jsyaml.safeDump(jsyaml.safeLoad(templateString)) || ''}
+            />
           </div>
         )}
       </div>


### PR DESCRIPTION
Before:
![Screenshot 2023-05-25 at 11 29 51 AM](https://github.com/kubeflow/pipelines/assets/56132941/64eac7e6-6239-469c-824f-d4f89e6d3ac4)

After:
![Screenshot 2023-05-25 at 11 30 12 AM](https://github.com/kubeflow/pipelines/assets/56132941/3464f853-e6ec-4814-a6d4-c971ebee2258)
