### PR TITLE
fix(backend): publish launcher execution even if it fails

### DIFF
--- a/backend/src/v2/compiler/argocompiler/argo.go
+++ b/backend/src/v2/compiler/argocompiler/argo.go
@@ -117,7 +117,7 @@ func Compile(jobArg *pipelinespec.PipelineJob, kubernetesSpecArg *pipelinespec.S
 		templates: make(map[string]*wfapi.Template),
 		// TODO(chensun): release process and update the images.
 		driverImage:   "gcr.io/ml-pipeline/kfp-driver@sha256:9e98973138c620754f71f2fd3fd95ef070cc68e22dbde026c1f2068c8fb1d537",
-		launcherImage: "gcr.io/ml-pipeline/kfp-launcher@sha256:74f6aa020100660f67525674b7cc7421d9335cefebfe347716ec8382fb68903b",
+		launcherImage: "gcr.io/ml-pipeline/kfp-launcher@sha256:2b844d5509a2f8713f677045695e5622b7aab57b8880159e7872c60b57fae0d9",
 		job:           job,
 		spec:          spec,
 		executors:     deploy.GetExecutors(),

--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -129,8 +129,23 @@ func (l *LauncherV2) Execute(ctx context.Context) (err error) {
 			err = fmt.Errorf("failed to execute component: %w", err)
 		}
 	}()
+	// publish execution regardless the task succeeds or not
+	var execution *metadata.Execution
+	var executorOutput *pipelinespec.ExecutorOutput
+	var outputArtifacts []*metadata.OutputArtifact
+	status := pb.Execution_FAILED
+	defer func() {
+		if perr := l.publish(ctx, execution, executorOutput, outputArtifacts, status); perr != nil {
+			if err != nil {
+				err = fmt.Errorf("failed to publish execution with error %w after execution failed: %w", perr, err)
+			} else {
+				err = perr
+			}
+		}
+		glog.Infof("publish success.")
+	}()
 	executedStartedTime := time.Now().Unix()
-	execution, err := l.prePublish(ctx)
+	execution, err = l.prePublish(ctx)
 	if err != nil {
 		return err
 	}
@@ -146,13 +161,11 @@ func (l *LauncherV2) Execute(ctx context.Context) (err error) {
 	if err = prepareOutputFolders(l.executorInput); err != nil {
 		return err
 	}
-	executorOutput, outputArtifacts, err := executeV2(ctx, l.executorInput, l.component, l.command, l.args, bucket, bucketConfig, l.metadataClient, l.options.Namespace, l.k8sClient)
+	executorOutput, outputArtifacts, err = executeV2(ctx, l.executorInput, l.component, l.command, l.args, bucket, bucketConfig, l.metadataClient, l.options.Namespace, l.k8sClient)
 	if err != nil {
 		return err
 	}
-	if err := l.publish(ctx, execution, executorOutput, outputArtifacts); err != nil {
-		return err
-	}
+	status = pb.Execution_COMPLETE
 	// if fingerPrint is not empty, it means this task enables cache but it does not hit cache, we need to create cache entry for this task
 	if fingerPrint != "" {
 		id := execution.GetID()
@@ -227,7 +240,13 @@ func (l *LauncherV2) prePublish(ctx context.Context) (execution *metadata.Execut
 }
 
 // TODO(Bobgy): consider passing output artifacts info from executor output.
-func (l *LauncherV2) publish(ctx context.Context, execution *metadata.Execution, executorOutput *pipelinespec.ExecutorOutput, outputArtifacts []*metadata.OutputArtifact) (err error) {
+func (l *LauncherV2) publish(
+	ctx context.Context,
+	execution *metadata.Execution,
+	executorOutput *pipelinespec.ExecutorOutput,
+	outputArtifacts []*metadata.OutputArtifact,
+	status pb.Execution_State,
+) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("failed to publish results to ML Metadata: %w", err)
@@ -237,7 +256,8 @@ func (l *LauncherV2) publish(ctx context.Context, execution *metadata.Execution,
 	// TODO(Bobgy): upload output artifacts.
 	// TODO(Bobgy): when adding artifacts, we will need execution.pipeline to be non-nil, because we need
 	// to publish output artifacts to the context too.
-	return l.metadataClient.PublishExecution(ctx, execution, outputParameters, outputArtifacts, pb.Execution_COMPLETE)
+	// return l.metadataClient.PublishExecution(ctx, execution, outputParameters, outputArtifacts, pb.Execution_COMPLETE)
+	return l.metadataClient.PublishExecution(ctx, execution, outputParameters, outputArtifacts, status)
 }
 
 func executeV2(ctx context.Context, executorInput *pipelinespec.ExecutorInput, component *pipelinespec.ComponentSpec, cmd string, args []string, bucket *blob.Bucket, bucketConfig *objectstore.Config, metadataClient *metadata.Client, namespace string, k8sClient *kubernetes.Clientset) (*pipelinespec.ExecutorOutput, []*metadata.OutputArtifact, error) {


### PR DESCRIPTION
**Description of your changes:**
@jlyaoyuli found that when a task fails, the launcher does not publish the execution, leading the status of the task to remain `running`.  This PR fixes that by moving the publish function into a defer function, so it is always carried out, even if the task fails.

Manually tested that failed status is reported.

Note:
Need to build and update launcher image once the PR is approved. 


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
