### PR TITLE
fix(frontend): Unexpected page crash when clicking artifact node.

### DIFF
--- a/frontend/src/components/ArtifactPreview.test.tsx
+++ b/frontend/src/components/ArtifactPreview.test.tsx
@@ -29,7 +29,7 @@ describe('ArtifactPreview', () => {
         <ArtifactPreview value={undefined} />
       </CommonTestWrapper>,
     );
-    screen.getByText('Can not retrieve storage path from artifact uri: undefined');
+    screen.getByText('No artifact URI is found.');
   });
 
   it('handles null artifact', () => {
@@ -38,17 +38,16 @@ describe('ArtifactPreview', () => {
         <ArtifactPreview value={null as any} />
       </CommonTestWrapper>,
     );
-    screen.getByText('Can not retrieve storage path from artifact uri: null');
+    screen.getByText('No artifact URI is found.');
   });
 
-  it('handles empty artifact', () => {
-    expect(() => {
-      render(
-        <CommonTestWrapper>
-          <ArtifactPreview value={'i am random path'} />
-        </CommonTestWrapper>,
-      );
-    }).toThrow(new Error('Unsupported storage path: i am random path'));
+  it('handles unsupported path artifact', () => {
+    render(
+      <CommonTestWrapper>
+        <ArtifactPreview value={'i am random path'} />
+      </CommonTestWrapper>,
+    );
+    screen.getByText('i am random path'); // directly render uri
   });
 
   it('handles invalid artifact: no bucket', async () => {

--- a/frontend/src/components/ArtifactPreview.test.tsx
+++ b/frontend/src/components/ArtifactPreview.test.tsx
@@ -29,7 +29,7 @@ describe('ArtifactPreview', () => {
         <ArtifactPreview value={undefined} />
       </CommonTestWrapper>,
     );
-    screen.getByText('No artifact URI is found.');
+    screen.getByText('Can not retrieve storage path from artifact uri: undefined');
   });
 
   it('handles null artifact', () => {
@@ -38,7 +38,7 @@ describe('ArtifactPreview', () => {
         <ArtifactPreview value={null as any} />
       </CommonTestWrapper>,
     );
-    screen.getByText('No artifact URI is found.');
+    screen.getByText('Can not retrieve storage path from artifact uri: null');
   });
 
   it('handles unsupported path artifact', () => {
@@ -47,7 +47,7 @@ describe('ArtifactPreview', () => {
         <ArtifactPreview value={'i am random path'} />
       </CommonTestWrapper>,
     );
-    screen.getByText('i am random path'); // directly render uri
+    screen.getByText('Can not retrieve storage path from artifact uri: i am random path');
   });
 
   it('handles invalid artifact: no bucket', async () => {

--- a/frontend/src/components/ArtifactPreview.tsx
+++ b/frontend/src/components/ArtifactPreview.tsx
@@ -23,6 +23,7 @@ import WorkflowParser, { StoragePath } from 'src/lib/WorkflowParser';
 import { stylesheet } from 'typestyle';
 import Banner from './Banner';
 import { ValueComponentProps } from './DetailsTable';
+import { logger } from 'src/lib/Utils';
 
 const css = stylesheet({
   root: {
@@ -64,7 +65,11 @@ const ArtifactPreview: React.FC<ArtifactPreviewProps> = ({
 }) => {
   let storage: StoragePath | undefined;
   if (value) {
-    storage = WorkflowParser.parseStoragePath(value);
+    try {
+      storage = WorkflowParser.parseStoragePath(value);
+    } catch (error) {
+      logger.error(error);
+    }
   }
 
   const { isSuccess, isError, data, error } = useQuery<string, Error>(
@@ -74,9 +79,7 @@ const ArtifactPreview: React.FC<ArtifactPreviewProps> = ({
   );
 
   if (!storage) {
-    return (
-      <Banner message={'Can not retrieve storage path from artifact uri: ' + value} mode='error' />
-    );
+    return value ? <div>{value}</div> : <div>No artifact URI is found.</div>;
   }
 
   const linkText = Apis.buildArtifactLinkText(storage);

--- a/frontend/src/components/ArtifactPreview.tsx
+++ b/frontend/src/components/ArtifactPreview.tsx
@@ -79,7 +79,9 @@ const ArtifactPreview: React.FC<ArtifactPreviewProps> = ({
   );
 
   if (!storage) {
-    return value ? <div>{value}</div> : <div>No artifact URI is found.</div>;
+    return (
+      <Banner message={'Can not retrieve storage path from artifact uri: ' + value} mode='info' />
+    );
   }
 
   const linkText = Apis.buildArtifactLinkText(storage);

--- a/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
+++ b/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
@@ -430,7 +430,7 @@ function ArtifactInfo({
       <div>
         <DetailsTable<string>
           key={`artifact-url`}
-          title='Artifact URL'
+          title='Artifact URI'
           fields={getArtifactParamList([linkedArtifact], artifactTypeName)}
           valueComponent={ArtifactPreview}
           valueComponentProps={{


### PR DESCRIPTION
This issue is because of the uncaught error (from parseStoragePath() helper) in ArtifactPreview.
Also, instead of displaying error banner for unsupported artifact URI, we decide to directly render it.

Before:

https://github.com/kubeflow/pipelines/assets/56132941/1d370f5f-6e69-4d3c-90fb-9bc689bb51ce


After:


https://github.com/kubeflow/pipelines/assets/56132941/a0730837-4df5-445e-bd38-cca0a56b2179



