### PR TITLE
chore(sdk): loosen python kubernetes version requirement for v1

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -10,6 +10,7 @@
 ## Deprecations
 
 ## Bug Fixes and Other Changes
+* Change `kubernetes` version requirement from `kubernetes>=8.0.0,<26` to `kubernetes>=8.0.0,<27`  [\#9544](https://github.com/kubeflow/pipelines/pull/9544)
 
 ## Documentation Updates
 # 1.8.22

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -14,7 +14,7 @@ uritemplate>=3.0.1,<4
 # kfp.dsl
 PyYAML>=5.3,<7
 jsonschema>=3.0.1,<5
-kubernetes>=8.0.0,<26
+kubernetes>=8.0.0,<27
 
 # kfp.Client
 kfp-server-api>=1.1.2,<2.0.0

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -31,7 +31,7 @@ REQUIRES = [
     # `Blob.from_string` was introduced in google-cloud-storage 1.20.0
     # https://github.com/googleapis/python-storage/blob/master/CHANGELOG.md#1200
     'google-cloud-storage>=1.20.0,<3',
-    'kubernetes>=8.0.0,<26',
+    'kubernetes>=8.0.0,<27',
     # google-api-python-client v2 doesn't work for private dicovery by default:
     # https://github.com/googleapis/google-api-python-client/issues/1225#issuecomment-791058235
     'google-api-python-client>=1.7.8,<2',


### PR DESCRIPTION
**Description of your changes:**
Part of #9543 

Loosen python kubernetes version requirement. This PR is for v1 SDK.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
