### PR TITLE
chore(sdk): loosen python kubernetes version requirement

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -8,6 +8,7 @@
 
 ## Bug fixes and other changes
 * Fix integer value not allowed as float-typed return [\#9481](https://github.com/kubeflow/pipelines/pull/9481)
+* Change `kubernetes` version requirement from `kubernetes>=8.0.0,<24` to `kubernetes>=8.0.0,<27`  [\#9545](https://github.com/kubeflow/pipelines/pull/9545)
 
 ## Documentation updates
 

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -17,7 +17,7 @@ kfp-pipeline-spec==0.2.2
 # Update the lower version when kfp sdk depends on new apis/fields in
 # kfp-server-api.
 kfp-server-api==2.0.0-rc.1
-kubernetes>=8.0.0,<24
+kubernetes>=8.0.0,<27
 protobuf>=3.13.0,<4
 PyYAML>=5.3,<7
 requests-toolbelt>=0.8.0,<1


### PR DESCRIPTION
**Description of your changes:**
Part of https://github.com/kubeflow/pipelines/issues/9543

Loosen python kubernetes version requirement. This PR is for v2 SDK.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
