### PR TITLE
fix(frontend): Incorrect page text for empty pipeline.

### DIFF
--- a/frontend/src/pages/PipelineDetails.test.tsx
+++ b/frontend/src/pages/PipelineDetails.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { graphlib } from 'dagre';
 import { ReactWrapper, shallow, ShallowWrapper } from 'enzyme';
 import * as React from 'react';
@@ -417,6 +417,17 @@ describe('PipelineDetails', () => {
     expect(tree.state('templateString')).toBe(
       'spec:\n  arguments:\n    parameters:\n      - name: output\n',
     );
+  });
+
+  it('renders "No graph to show" if it is empty pipeline', async () => {
+    TestUtils.makeErrorResponse(getV2PipelineVersionSpy, 'No pipeline version is found');
+    render(<PipelineDetails {...generateProps()} />);
+
+    await waitFor(() => {
+      expect(getV2PipelineVersionSpy).toHaveBeenCalled();
+    });
+
+    screen.getByText('No graph to show');
   });
 
   it('use pipeline_version_id in recurring run to get pipeline template string (v2)', async () => {

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -276,6 +276,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
       try {
         return await Apis.pipelineServiceApiV2.getPipelineVersion(pipelineId, versionId);
       } catch (err) {
+        this.setStateSafe({ graphIsLoading: false });
         await this.showPageError('Cannot retrieve pipeline version.', err);
         logger.error('Cannot retrieve pipeline version.', err);
         return;
@@ -302,6 +303,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
         }
         return undefined;
       } catch (err) {
+        this.setStateSafe({ graphIsLoading: false });
         await this.showPageError('Cannot retrieve pipeline version list.', err);
         logger.error('Cannot retrieve pipeline version list.', err);
         return;
@@ -368,6 +370,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
                 ? workflowManifestString
                 : JsYaml.safeDump(workflowManifest);
             } catch (err) {
+              this.setStateSafe({ graphIsLoading: false });
               await this.showPageError(
                 `Failed to parse pipeline spec from ${msgRunOrRecurringRun} with ID: ${
                   origin.isRecurring ? origin.v1RecurringRun!.id : origin.v1Run!.run!.id
@@ -382,6 +385,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
               );
             }
           } catch (err) {
+            this.setStateSafe({ graphIsLoading: false });
             await this.showPageError(
               `Failed to parse pipeline spec from ${msgRunOrRecurringRun} with ID: ${
                 origin.isRecurring ? origin.v1RecurringRun!.id : origin.v1Run!.run!.id
@@ -440,6 +444,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
         });
         pageTitle = 'Pipeline details';
       } catch (err) {
+        this.setStateSafe({ graphIsLoading: false });
         await this.showPageError(`Cannot retrieve ${msgRunOrRecurringRun} details.`, err);
         logger.error(`Cannot retrieve ${msgRunOrRecurringRun} details.`, err);
         return;
@@ -453,6 +458,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
         v1Pipeline = await Apis.pipelineServiceApi.getPipeline(pipelineId);
         v2Pipeline = await Apis.pipelineServiceApiV2.getPipeline(pipelineId);
       } catch (err) {
+        this.setStateSafe({ graphIsLoading: false });
         await this.showPageError('Cannot retrieve pipeline details.', err);
         logger.error('Cannot retrieve pipeline details.', err);
         return;
@@ -464,6 +470,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
           v1Version = await Apis.pipelineServiceApi.getPipelineVersion(versionId);
         }
       } catch (err) {
+        this.setStateSafe({ graphIsLoading: false });
         await this.showPageError('Cannot retrieve pipeline version.', err);
         logger.error('Cannot retrieve pipeline version.', err);
         return;
@@ -509,6 +516,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
               )
             ).pipeline_versions || [];
         } catch (err) {
+          this.setStateSafe({ graphIsLoading: false });
           await this.showPageError('Cannot retrieve pipeline versions.', err);
           logger.error('Cannot retrieve pipeline versions.', err);
           return;
@@ -674,6 +682,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
         ? templateStrFromSpec
         : templateResponse.template || '';
     } catch (err) {
+      this.setStateSafe({ graphIsLoading: false });
       await this.showPageError('Cannot retrieve pipeline template.', err);
       logger.error('Cannot retrieve pipeline details.', err);
     }
@@ -708,6 +717,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
           );
         }
       } catch (err) {
+        this.setStateSafe({ graphIsLoading: false });
         await this.showPageError('Error: failed to generate Pipeline graph.', err);
       }
     }


### PR DESCRIPTION
For the case that API call returns error, the page text should be **"No graph to show"** rather than **"Currently loading pipeline information"**.

For example, an empty pipeline will get error from getPipelineVersion() call.

Before:

https://github.com/kubeflow/pipelines/assets/56132941/b1e0a9b5-b89a-4ecd-b9f3-af2f9001395e


After:

https://github.com/kubeflow/pipelines/assets/56132941/d1d3c4e4-2e63-4630-8189-d0c13d30e680

