### PR TITLE
fix(frontend): Pipeline Root is not used when provided during New Run creation

### DIFF
--- a/frontend/src/components/NewRunParametersV2.tsx
+++ b/frontend/src/components/NewRunParametersV2.tsx
@@ -55,7 +55,7 @@ interface NewRunParametersProps {
   // ComponentInputsSpec_ParameterSpec
   specParameters: SpecParameters;
   clonedRuntimeConfig?: PipelineSpecRuntimeConfig;
-  handlePipelineRootChange?: (pipelineRoot: string) => void;
+  handlePipelineRootChange?: (pipelineRoot?: string) => void;
   handleParameterChange?: (parameters: RuntimeParameters) => void;
   setIsValidInput?: (isValid: boolean) => void;
 }
@@ -166,7 +166,13 @@ function convertNonUserInputParamToString(
 }
 
 function NewRunParametersV2(props: NewRunParametersProps) {
-  const { specParameters, clonedRuntimeConfig, handleParameterChange, setIsValidInput } = props;
+  const {
+    specParameters,
+    clonedRuntimeConfig,
+    handlePipelineRootChange,
+    handleParameterChange,
+    setIsValidInput,
+  } = props;
   const [customPipelineRootChecked, setCustomPipelineRootChecked] = useState(false);
   const [customPipelineRoot, setCustomPipelineRoot] = useState(props.pipelineRoot);
   const [errorMessages, setErrorMessages] = useState<string[]>([]);
@@ -242,6 +248,9 @@ function NewRunParametersV2(props: NewRunParametersProps) {
                 setCustomPipelineRootChecked(checked);
                 if (!checked) {
                   setCustomPipelineRoot(undefined);
+                  if (handlePipelineRootChange) {
+                    handlePipelineRootChange(undefined);
+                  }
                 }
               }}
               inputProps={{ 'aria-label': 'Set custom pipeline root.' }}
@@ -257,6 +266,9 @@ function NewRunParametersV2(props: NewRunParametersProps) {
           value={customPipelineRoot || ''}
           onChange={ev => {
             setCustomPipelineRoot(ev.target.value);
+            if (handlePipelineRootChange) {
+              handlePipelineRootChange(ev.target.value);
+            }
           }}
           className={classes(commonCss.textField, css.textfield)}
         />

--- a/frontend/src/pages/NewRunV2.test.tsx
+++ b/frontend/src/pages/NewRunV2.test.tsx
@@ -496,7 +496,7 @@ describe('NewRunV2', () => {
               pipeline_id: ORIGINAL_TEST_PIPELINE_ID,
               pipeline_version_id: ORIGINAL_TEST_PIPELINE_VERSION_ID,
             },
-            runtime_config: { parameters: {}, pipeline_root: undefined },
+            runtime_config: { parameters: {}, pipeline_root: 'dummy_root' },
             service_account: '',
           }),
         );
@@ -955,7 +955,7 @@ describe('NewRunV2', () => {
               pipeline_id: ORIGINAL_TEST_PIPELINE_ID,
               pipeline_version_id: ORIGINAL_TEST_PIPELINE_VERSION_ID,
             },
-            runtime_config: { parameters: { intParam: 123 } },
+            runtime_config: { parameters: { intParam: 123 }, pipeline_root: 'dummy_root' },
             service_account: '',
           }),
         );
@@ -997,7 +997,7 @@ describe('NewRunV2', () => {
             description: '',
             display_name: 'Clone of Run of v2-xgboost-ilbo',
             pipeline_spec: JsYaml.safeLoad(v2XGYamlTemplateString),
-            runtime_config: { parameters: { intParam: 123 } },
+            runtime_config: { parameters: { intParam: 123 }, pipeline_root: 'dummy_root' },
             service_account: '',
           }),
         );
@@ -1044,7 +1044,7 @@ describe('NewRunV2', () => {
               pipeline_id: ORIGINAL_TEST_PIPELINE_ID,
               pipeline_version_id: ORIGINAL_TEST_PIPELINE_VERSION_ID,
             },
-            runtime_config: { parameters: { intParam: 123 } },
+            runtime_config: { parameters: { intParam: 123 }, pipeline_root: 'dummy_root' },
             trigger: {
               periodic_schedule: { interval_second: '3600' },
             },
@@ -1096,7 +1096,7 @@ describe('NewRunV2', () => {
             description: '',
             display_name: 'Clone of Run of v2-xgboost-ilbo',
             pipeline_spec: JsYaml.safeLoad(v2XGYamlTemplateString),
-            runtime_config: { parameters: { intParam: 123 } },
+            runtime_config: { parameters: { intParam: 123 }, pipeline_root: 'dummy_root' },
             trigger: {
               periodic_schedule: { interval_second: '3600' },
             },

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -335,8 +335,7 @@ function NewRunV2(props: NewRunV2Props) {
             : pipelineVersionRefNew
           : undefined,
       runtime_config: {
-        // TODO(zijianjoy): determine whether to provide pipeline root.
-        pipeline_root: undefined, // pipelineRoot,
+        pipeline_root: pipelineRoot,
         parameters: runtimeParameters,
       },
       service_account: serviceAccount,


### PR DESCRIPTION
Before:

https://github.com/kubeflow/pipelines/assets/56132941/d37e820f-3436-4116-a42c-938c2e84d7a1


After:

https://github.com/kubeflow/pipelines/assets/56132941/d60d0f10-9c11-4e3a-bd8a-12ca9dfa36af

