### PR TITLE
fix(frontend): Mismatched error text in new run page

### DIFF
--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -1222,8 +1222,18 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
 
   private _validate(): void {
     // Validate state
-    const { pipelineVersion, workflowFromRun, maxConcurrentRuns, runName, trigger } = this.state;
+    const {
+      pipeline,
+      pipelineVersion,
+      workflowFromRun,
+      maxConcurrentRuns,
+      runName,
+      trigger,
+    } = this.state;
     try {
+      if (!pipeline && !workflowFromRun) {
+        throw new Error('A pipeline must be selected');
+      }
       if (!pipelineVersion && !workflowFromRun) {
         throw new Error('A pipeline version must be selected');
       }

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -920,7 +920,7 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
           }
         }
       >
-        A pipeline version must be selected
+        A pipeline must be selected
       </div>
     </div>
   </div>
@@ -1425,7 +1425,7 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
           }
         }
       >
-        A pipeline version must be selected
+        A pipeline must be selected
       </div>
     </div>
   </div>
@@ -1912,7 +1912,7 @@ exports[`NewRun changes title and form to default state if the new run is a one-
           }
         }
       >
-        A pipeline version must be selected
+        A pipeline must be selected
       </div>
     </div>
   </div>
@@ -2884,7 +2884,7 @@ exports[`NewRun renders the new run page 1`] = `
           }
         }
       >
-        A pipeline version must be selected
+        A pipeline must be selected
       </div>
     </div>
   </div>
@@ -3389,7 +3389,7 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
           }
         }
       >
-        A pipeline version must be selected
+        A pipeline must be selected
       </div>
     </div>
   </div>
@@ -3876,7 +3876,7 @@ exports[`NewRun updates the run's state with the associated experiment if one is
           }
         }
       >
-        A pipeline version must be selected
+        A pipeline must be selected
       </div>
     </div>
   </div>


### PR DESCRIPTION
Error text should be **"A pipeline must be selected"** when no pipeline is selected.

Before:
<img width="1706" alt="Screenshot 2023-06-05 at 12 04 12 PM" src="https://github.com/kubeflow/pipelines/assets/56132941/b0cfc03b-0c98-47c2-8ee6-b76ad5a744ed">


After:
<img width="1706" alt="Screenshot 2023-06-05 at 12 03 15 PM" src="https://github.com/kubeflow/pipelines/assets/56132941/13c325f2-5236-42db-8084-f16218379ea1">
