### PR TITLE
fix(frontend): Pipeline version is not updated in new run page

### DIFF
--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -578,7 +578,6 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
         v => v.pipeline_version_id === versionId,
       );
       const pageTitle = this.state.v1Pipeline.name?.concat(' (', selectedVersionV1?.name!, ')');
-      this.props.updateToolbar({ pageTitle });
 
       const selectedVersionPipelineTemplate = await this._getTemplateString(
         this.state.v1Pipeline.id!,
@@ -587,6 +586,8 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
       this.props.history.replace({
         pathname: `/pipelines/details/${this.state.v1Pipeline.id}/version/${versionId}`,
       });
+      this.props.updateToolbar(this.getInitialToolbarState());
+      this.props.updateToolbar({ pageTitle });
 
       const [graph, reducedGraph, graphV2] = await this._createGraph(
         selectedVersionPipelineTemplate,
@@ -624,7 +625,6 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
         selectedVersionV2?.display_name!,
         ')',
       );
-      this.props.updateToolbar({ pageTitle });
 
       const selectedVersionPipelineTemplate = await this._getTemplateString(
         this.state.v2Pipeline.pipeline_id!,
@@ -633,6 +633,8 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
       this.props.history.replace({
         pathname: `/pipelines/details/${this.state.v2Pipeline.pipeline_id}/version/${versionId}`,
       });
+      this.props.updateToolbar(this.getInitialToolbarState());
+      this.props.updateToolbar({ pageTitle });
 
       const [graph, reducedGraph, graphV2] = await this._createGraph(
         selectedVersionPipelineTemplate,


### PR DESCRIPTION
In the pipeline details page, users can switch between different versions; however, pipeline version is not updated after clicking `Create run` button.

Before:

https://github.com/kubeflow/pipelines/assets/56132941/72285dc8-6d2a-429e-83a8-77fa73727c87


After:

https://github.com/kubeflow/pipelines/assets/56132941/f575cf0a-ace0-4eb1-8802-7c2032e895e0


