### PR TITLE
fix(sdk): fix bug when iterating over output from upstream task in nested parallelfor loops

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -9,6 +9,7 @@
 ## Bug fixes and other changes
 * Fix integer value not allowed as float-typed return [\#9481](https://github.com/kubeflow/pipelines/pull/9481)
 * Change `kubernetes` version requirement from `kubernetes>=8.0.0,<24` to `kubernetes>=8.0.0,<27`  [\#9545](https://github.com/kubeflow/pipelines/pull/9545)
+* Fix bug when iterating over upstream task output in nested `dsl.ParallelFor` loop [\#9580](https://github.com/kubeflow/pipelines/pull/9580)
 
 ## Documentation updates
 

--- a/sdk/python/kfp/compiler/compiler_utils.py
+++ b/sdk/python/kfp/compiler/compiler_utils.py
@@ -668,9 +668,9 @@ def get_dependencies(
                         f'{ILLEGAL_CROSS_DAG_ERROR_PREFIX} A downstream task cannot depend on an upstream task within a dsl.{dependent_group.__class__.__name__} context unless the downstream is within that context too or the outputs are begin fanned-in to a list using dsl.{for_loop.Collected.__name__}. Found task {task.name} which depends on upstream task {upstream_task.name} within an uncommon dsl.{dependent_group.__class__.__name__} context.'
                     )
 
-            # tasks in a deeper part of a nested parallelfor cannot depend directory on a task in a shallower part of the nested parallelfor
+            # tasks in a deeper part of a nested parallelfor cannot depend directly on a task in a shallower part of the nested parallelfor
             # to check for this we need to know that:
-            # - the upstream task has at least one parallelfor parent groups
+            # - the upstream task has at least one parallelfor parent group
             # - the downstream task has at least one parallelfor parent group uncommon to the upstream task
             # - the downstream consumes from the upstream or has an explicit dependency (.after) on it (a dependency transitively via the parent task group doesn't satisfy the error condition, since the parallelfor should be permitted to iterate over the upstreams list output)
             if isinstance(upstream_task, pipeline_task.PipelineTask):

--- a/sdk/python/kfp/compiler/compiler_utils.py
+++ b/sdk/python/kfp/compiler/compiler_utils.py
@@ -654,6 +654,11 @@ def get_dependencies(
             uncommon_upstream_groups.remove(
                 upstream_task.name
             )  # because a task's `upstream_groups` contains the task's name
+
+            # TODO: this logic can be simplified
+            # - ExitHandler check can be removed
+            # - the logic to check for consumption from a task in an upstream
+            # Condition and ExitHandler should be the same and can be unified with the ParallelFor checks
             if uncommon_upstream_groups:
                 dependent_group = group_name_to_group.get(
                     uncommon_upstream_groups[0], None)
@@ -668,11 +673,11 @@ def get_dependencies(
                         f'{ILLEGAL_CROSS_DAG_ERROR_PREFIX} A downstream task cannot depend on an upstream task within a dsl.{dependent_group.__class__.__name__} context unless the downstream is within that context too or the outputs are begin fanned-in to a list using dsl.{for_loop.Collected.__name__}. Found task {task.name} which depends on upstream task {upstream_task.name} within an uncommon dsl.{dependent_group.__class__.__name__} context.'
                     )
 
-            # tasks in a deeper part of a nested parallelfor cannot depend directly on a task in a shallower part of the nested parallelfor
+            # tasks in a deeper part of a nested ParallelFor cannot depend directly on a task in a shallower part of the nested ParallelFor
             # to check for this we need to know that:
-            # - the upstream task has at least one parallelfor parent group
-            # - the downstream task has at least one parallelfor parent group uncommon to the upstream task
-            # - the downstream consumes from the upstream or has an explicit dependency (.after) on it (a dependency transitively via the parent task group doesn't satisfy the error condition, since the parallelfor should be permitted to iterate over the upstreams list output)
+            # - the upstream task has at least one ParallelFor parent group
+            # - the downstream task has at least one ParallelFor parent group uncommon to the upstream task
+            # - the downstream consumes from the upstream or has an explicit dependency (.after) on it (a dependency transitively via the parent task group doesn't satisfy the error condition, since the ParallelFor should be permitted to iterate over the upstreams list output)
             if isinstance(upstream_task, pipeline_task.PipelineTask):
                 upstream_parent_tasks = task_name_to_parent_groups[
                     upstream_task.name]

--- a/sdk/python/kfp/compiler/compiler_utils.py
+++ b/sdk/python/kfp/compiler/compiler_utils.py
@@ -655,9 +655,7 @@ def get_dependencies(
                 upstream_task.name
             )  # because a task's `upstream_groups` contains the task's name
 
-            # TODO: this logic can be simplified
-            # - ExitHandler check can be removed
-            # - the logic to check for consumption from a task in an upstream
+            # TODO: this logic can be simplified: the logic to check for consumption from a task in an upstream
             # Condition and ExitHandler should be the same and can be unified with the ParallelFor checks
             if uncommon_upstream_groups:
                 dependent_group = group_name_to_group.get(

--- a/sdk/python/kfp/components/pipeline_task.py
+++ b/sdk/python/kfp/components/pipeline_task.py
@@ -99,7 +99,7 @@ class PipelineTask:
             dependent_tasks=[],
             component_ref=component_spec.name,
             enable_caching=True)
-        self._run_after: List[PipelineTask] = []
+        self._run_after: List[str] = []
 
         self.importer_spec = None
         self.container_spec = None

--- a/sdk/python/kfp/components/pipeline_task.py
+++ b/sdk/python/kfp/components/pipeline_task.py
@@ -99,6 +99,7 @@ class PipelineTask:
             dependent_tasks=[],
             component_ref=component_spec.name,
             enable_caching=True)
+        self._run_after: List[PipelineTask] = []
 
         self.importer_spec = None
         self.container_spec = None
@@ -575,6 +576,7 @@ class PipelineTask:
                 task2 = my_component(text='2nd task').after(task1)
         """
         for task in tasks:
+            self._run_after.append(task.name)
             self._task_spec.dependent_tasks.append(task.name)
         return self
 

--- a/sdk/python/kfp/components/types/type_annotations.py
+++ b/sdk/python/kfp/components/types/type_annotations.py
@@ -237,6 +237,9 @@ def is_list_of_artifacts(
                     Type[artifact_types.Artifact]]
 ) -> bool:
     # the type annotation for this function's `type_var` parameter may not actually be a subclass of the KFP SDK's Artifact class for custom artifact types
-    return getattr(type_var, '__origin__',
-                   None) == list and type_annotations.is_artifact_class(
-                       type_var.__args__[0])
+    is_list_or_list_generic = getattr(type_var, '__origin__', None) == list
+    # in >= python3.9, List wont have .__args__ if it's used as `-> List` with no inner type argument
+    contains_artifact = hasattr(
+        type_var, '__args__') and type_annotations.is_artifact_class(
+            type_var.__args__[0])
+    return is_list_or_list_generic and contains_artifact


### PR DESCRIPTION
**Description of your changes:**

Fixes a bug where a nested ParallelFor loop could not iterate over an output created in a shallower ParallelFor loop. For example, the following previously threw an `InvalidTopologyException`, but now does not:

```python
from kfp import dsl
from typing import List

@dsl.component
def str_to_list(string: str) -> List:
    return [string]

@dsl.component
def identity(string: str) -> str:
    return string

@dsl.pipeline
def my_pipeline():
    with dsl.ParallelFor(['a', 'b', 'c']) as itema:
        t1 = str_to_list(string=itema)
        with dsl.ParallelFor(t1.output) as itemb:
            identity(string=itemb)
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
