### PR TITLE
feat(manifests): Add a postgresql deployment manifest in third-party folder

### DIFF
--- a/manifests/kustomize/third-party/postgresql/README.md
+++ b/manifests/kustomize/third-party/postgresql/README.md
@@ -1,0 +1,15 @@
+## Build PostgreSQL yaml
+
+```bash
+# In this folder of manifests/kustomize/third-party/postgresql
+rm -rf build
+mkdir buidl
+kustomize build ./base -o build
+```
+
+## Deploy PostgreSQL container
+
+```bash
+# In this folder of manifests/kustomize/third-party/postgresql
+kubectl apply -f build
+```

--- a/manifests/kustomize/third-party/postgresql/base/kustomization.yaml
+++ b/manifests/kustomize/third-party/postgresql/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- pg-deployment.yaml
+- pg-pvc.yaml
+- pg-service.yaml
+- pg-secret.yaml
+- pg-serviceaccount.yaml

--- a/manifests/kustomize/third-party/postgresql/base/pg-deployment.yaml
+++ b/manifests/kustomize/third-party/postgresql/base/pg-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres-deployment
+  labels:
+    app: postgres
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      serviceAccountName: postgresql
+      containers:
+        - image: postgres:14.7-alpine3.17
+          name: postgres
+          env:
+            - name: POSTGRES_DB
+              value: postgres
+            - name: POSTGRES_USER
+              value: user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: root_password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: 5432
+              name: postgres
+          volumeMounts:
+            - name: postgres-stateful-data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: postgres-stateful-data
+          persistentVolumeClaim:
+            claimName: postgres-pvc

--- a/manifests/kustomize/third-party/postgresql/base/pg-pvc.yaml
+++ b/manifests/kustomize/third-party/postgresql/base/pg-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  labels:
+    app: postgres
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/manifests/kustomize/third-party/postgresql/base/pg-secret.yaml
+++ b/manifests/kustomize/third-party/postgresql/base/pg-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-secret
+type: Opaque
+data:
+  root_password: password

--- a/manifests/kustomize/third-party/postgresql/base/pg-service.yaml
+++ b/manifests/kustomize/third-party/postgresql/base/pg-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-service
+  labels:
+    app: postgres
+spec:
+  ports:
+    - port: 5432
+  type: LoadBalancer
+  selector:
+    app: postgres

--- a/manifests/kustomize/third-party/postgresql/base/pg-serviceaccount.yaml
+++ b/manifests/kustomize/third-party/postgresql/base/pg-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: postgresql
+  


### PR DESCRIPTION
**Description of your changes:**

This is a default deployment yaml folder for a postgresql database. There are two deployment approaches in KFP: standalone and full Kubeflow. This folder can be used for full kubeflow, and can serve as an example for standalone manifest as well.

Related: #7512

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
