### PR TITLE
fix(frontend): Choose version button is greyed out after closing pipeline selector

### DIFF
--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -669,6 +669,32 @@ describe('NewRun', () => {
       expect(tree.state('pipelineSelectorOpen')).toBe(false);
       await TestUtils.flushPromises();
     });
+
+    it('enables choose button for pipeline version after clicking cancel in selector', async () => {
+      tree = shallow(<TestNewRun {...generateProps()} />);
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.pipelineId}=${MOCK_PIPELINE.id}&${
+        QUERY_PARAMS.pipelineVersionId
+      }=${MOCK_PIPELINE.default_version!.id}`;
+      render(<NewRun {...props} />);
+
+      await waitFor(() => {
+        expect(getPipelineSpy).toHaveBeenCalled();
+      });
+
+      const chooseVersionBtn = screen.getAllByText('Choose')[1];
+      // Choose button is enabled in the beginning
+      expect(chooseVersionBtn.closest('button')?.disabled).toEqual(false);
+
+      const choosePipelineBtn = screen.getAllByText('Choose')[0];
+      fireEvent.click(choosePipelineBtn); // Open pipeline selector
+
+      const cancelBtn = screen.getAllByText('Cancel')[0];
+      fireEvent.click(cancelBtn);
+
+      // Choose button is still enabled after clicking Cancel in selector
+      expect(chooseVersionBtn.closest('button')?.disabled).toEqual(false);
+    });
   });
 
   describe('choosing a pipeline version', () => {

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -307,9 +307,12 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
             open={pipelineSelectorOpen}
             selectorDialog={css.selectorDialog}
             onClose={(confirmed, selectedPipeline?: ApiPipeline) => {
-              this.setStateSafe({ unconfirmedSelectedPipeline: selectedPipeline }, () => {
-                this._pipelineSelectorClosed(confirmed);
-              });
+              this.setStateSafe(
+                { unconfirmedSelectedPipeline: selectedPipeline ?? this.state.pipeline },
+                () => {
+                  this._pipelineSelectorClosed(confirmed);
+                },
+              );
             }}
             toolbarActionMap={dialogToolbarActionMap}
             namespace={this.props.namespace}


### PR DESCRIPTION
Before:

https://github.com/kubeflow/pipelines/assets/56132941/1289ee8a-f1e9-46d7-883c-538efed6a45c


After:

https://github.com/kubeflow/pipelines/assets/56132941/e7cc34b4-cad3-4042-8c40-1a17777b47f4

