### PR TITLE
fix(frontend): Splitting logsDetails into lines based on CR and LF. Fixes #9593

### DIFF
--- a/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
+++ b/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
@@ -202,7 +202,7 @@ function TaskNodeDetail({
             )}
             {!logsBannerMessage && (
               <div className={commonCss.pageOverflowHidden} data-testid={'logs-view-window'}>
-                <LogViewer logLines={(logsDetails || '').split('\n')} />
+                <LogViewer logLines={(logsDetails || '').split(/[\r\n]+/)} />
               </div>
             )}
           </div>


### PR DESCRIPTION
**Description of your changes:**

Fixing #9593

Replacing `.split('\n')` with `.split(/[\r\n]+/)` to ensure lines are properly split. 


## Tests:

After fixing the split argument:
![image](https://github.com/kubeflow/pipelines/assets/42176370/18f1b2e4-9f1f-4de8-80e1-6abb1dcf5bd9)

