### PR TITLE
fix(sdk): print docker error messages

### DIFF
--- a/sdk/python/kfp/cli/component.py
+++ b/sdk/python/kfp/cli/component.py
@@ -330,9 +330,12 @@ class ComponentBuilder():
                 self._target_image, stream=True, decode=True)
             for log in response:
                 status = log.get('status', '').rstrip('\n')
+                error = log.get('error', '').rstrip('\n')
                 layer = log.get('id', '')
                 if status:
                     logging.info(f'{docker_log_prefix}: {layer} {status}')
+                if error:
+                    logging.error(f'{docker_log_prefix} ERROR: {error}')
         except docker.errors.BuildError as e:
             logging.error(f'{docker_log_prefix}: {e}')
             raise e


### PR DESCRIPTION
Without this commit, `kfp component build` doesn't print any error messages that docker emits, e.g. if docker push fails.

## Environment:

Docker 20.10.21
kfp 2.0.0-rc.1

## How to test:

Just implement the example for a containerized python component from [the kubeflow docs](https://www.kubeflow.org/docs/components/pipelines/v2/components/containerized-python-components/#3-build-the-component).

If you now try to build and push the component image as described in the docs using: `kfp component build src/ --component-filepattern my_component.py` with an invalid target_image string, you will see an error message in the logs. Without this PR, you'd just get "Built and pushed component container <image name>", which isn't the case.
