### PR TITLE
fix(frontend): Choose version button should be disabled if no pipeline is selected

### DIFF
--- a/frontend/src/pages/NewRunV2.test.tsx
+++ b/frontend/src/pages/NewRunV2.test.tsx
@@ -394,6 +394,10 @@ describe('NewRunV2', () => {
         </CommonTestWrapper>,
       );
 
+      const chooseVersionBtn = screen.getAllByText('Choose')[1];
+      // choose button for pipeline version is diabled if no pipeline is selected
+      expect(chooseVersionBtn.closest('button')?.disabled).toEqual(true);
+
       screen.getByText('Pipeline Root'); // only v2 UI has 'Pipeline Root' section
       screen.getByText('A pipeline must be selected');
     });
@@ -602,6 +606,10 @@ describe('NewRunV2', () => {
       });
 
       screen.getByDisplayValue(NEW_TEST_PIPELINE_NAME);
+
+      const chooseVersionBtn = screen.getAllByText('Choose')[1];
+      // choose button for pipeline version is enabled after pipeline is selected
+      expect(chooseVersionBtn.closest('button')?.disabled).toEqual(false);
     });
   });
 

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -805,6 +805,7 @@ function PipelineVersionSelector(props: PipelineVersionSelectorProps) {
                 id='choosePipelineVersionBtn'
                 onClick={() => setPipelineVersionSelectorOpen(true)}
                 style={{ padding: '3px 5px', margin: 0 }}
+                disabled={!props.pipeline}
               >
                 Choose
               </Button>


### PR DESCRIPTION
Before:

https://github.com/kubeflow/pipelines/assets/56132941/b317e7a3-02de-4b8b-91c7-ce1dfbd95c60


After:


https://github.com/kubeflow/pipelines/assets/56132941/b5f35ba1-efb5-4719-a948-d58258730972



