### PR TITLE
fix(frontend): Display experiment name if experiment is selected

### DIFF
--- a/frontend/src/pages/NewRunSwitcher.tsx
+++ b/frontend/src/pages/NewRunSwitcher.tsx
@@ -119,7 +119,7 @@ function NewRunSwitcher(props: PageProps) {
   const pipelineSpecInVersion = pipelineVersion?.pipeline_spec;
   const templateStrFromSpec = pipelineSpecInVersion ? JsYaml.safeDump(pipelineSpecInVersion) : '';
 
-  const { data: experiment } = useQuery<V2beta1Experiment, Error>(
+  const { isFetching: experimentIsFetching, data: experiment } = useQuery<V2beta1Experiment, Error>(
     ['experiment', experimentId],
     async () => {
       if (!experimentId) {
@@ -139,7 +139,8 @@ function NewRunSwitcher(props: PageProps) {
     v2RunIsFetching ||
     recurringRunIsFetching ||
     pipelineIsFetching ||
-    pipelineVersionIsFetching
+    pipelineVersionIsFetching ||
+    experimentIsFetching
   ) {
     return <div>Currently loading pipeline information</div>;
   }

--- a/frontend/src/pages/NewRunV2.test.tsx
+++ b/frontend/src/pages/NewRunV2.test.tsx
@@ -240,12 +240,12 @@ describe('NewRunV2', () => {
   const updateToolbarSpy = jest.fn();
 
   // For creating new run with no pipeline is selected (enter from run list)
-  function generatePropsNoPipelineDef(): PageProps {
+  function generatePropsNoPipelineDef(eid: string | null): PageProps {
     return {
       history: { push: historyPushSpy, replace: historyReplaceSpy } as any,
       location: {
         pathname: RoutePage.NEW_RUN,
-        search: `?${QUERY_PARAMS.experimentId}=`,
+        search: eid ? `?${QUERY_PARAMS.experimentId}=${eid}` : `?${QUERY_PARAMS.experimentId}=`,
       } as any,
       match: '' as any,
       toolbarProps: { actions: {}, breadcrumbs: [], pageTitle: 'Start a new run' },
@@ -390,7 +390,7 @@ describe('NewRunV2', () => {
     it('directs to new run v2 if no pipeline is selected (enter from run list)', () => {
       render(
         <CommonTestWrapper>
-          <NewRunSwitcher {...generatePropsNoPipelineDef()} />
+          <NewRunSwitcher {...generatePropsNoPipelineDef(null)} />
         </CommonTestWrapper>,
       );
 
@@ -401,6 +401,28 @@ describe('NewRunV2', () => {
       screen.getByText('Pipeline Root'); // only v2 UI has 'Pipeline Root' section
       screen.getByText('A pipeline must be selected');
     });
+
+    it(
+      'shows experiment name in new run v2 if experiment is selected' +
+        '(enter from experiment details)',
+      async () => {
+        const getExperimentSpy = jest.spyOn(Apis.experimentServiceApiV2, 'getExperiment');
+        getExperimentSpy.mockImplementation(() => NEW_EXPERIMENT);
+
+        render(
+          <CommonTestWrapper>
+            <NewRunSwitcher {...generatePropsNoPipelineDef(NEW_EXPERIMENT.experiment_id)} />
+          </CommonTestWrapper>,
+        );
+
+        await waitFor(() => {
+          expect(getExperimentSpy).toHaveBeenCalled();
+        });
+
+        screen.getByDisplayValue(NEW_EXPERIMENT.display_name);
+        screen.getByText('Pipeline Root'); // only v2 UI has 'Pipeline Root' section
+      },
+    );
 
     it('directs to new run v2 if it is v2 template (create run from pipeline)', async () => {
       jest


### PR DESCRIPTION
When the user enter the new run page from experiment details page, it means that the experiment is selected. The text field of experiment name should be automatically filled.

Before:

https://github.com/kubeflow/pipelines/assets/56132941/5c087a45-579a-46b0-aa39-1758c8403448



After:

https://github.com/kubeflow/pipelines/assets/56132941/e4a56290-f79f-4d72-bdd0-b9ab943bbccd


