### PR TITLE
fix(backend): Avoid multiple PutParentContexts on the same primary key.

### DIFF
--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -261,6 +261,31 @@ func (c *Client) GetPipeline(ctx context.Context, pipelineName, runID, namespace
 		return nil, err
 	}
 
+	// Detect whether such parent-child relationship exists.
+	resParents, err := c.svc.GetParentContextsByContext(ctx, &pb.GetParentContextsByContextRequest{
+		ContextId: runContext.Id,
+	})
+	if err != nil {
+		return nil, err
+	}
+	parents := resParents.GetContexts()
+	if len(parents) > 1 {
+		return nil, fmt.Errorf("Current run context has more than 1 parent context: %v", parents)
+	}
+	if len(parents) == 1 {
+		// Parent-child context alredy exists.
+		if parents[0].Id != pipelineContext.Id {
+			return nil, fmt.Errorf("Parent context ID %d of current run is different from expected: %d",
+				parents[0].Id,
+				pipelineContext.Id)
+		}
+		return &Pipeline{
+			pipelineCtx:    pipelineContext,
+			pipelineRunCtx: runContext,
+		}, nil
+	}
+
+	// Insert ParentContext relationship if doesn't exist.
 	err = c.putParentContexts(ctx, &pb.PutParentContextsRequest{
 		ParentContexts: []*pb.ParentContext{{
 			ChildId:  runContext.Id,

--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -274,10 +274,10 @@ func (c *Client) GetPipeline(ctx context.Context, pipelineName, runID, namespace
 	}
 	if len(parents) == 1 {
 		// Parent-child context alredy exists.
-		if parents[0].Id != pipelineContext.Id {
+		if parents[0].GetId() != pipelineContext.GetId() {
 			return nil, fmt.Errorf("Parent context ID %d of current run is different from expected: %d",
-				parents[0].Id,
-				pipelineContext.Id)
+				parents[0].GetId(),
+				pipelineContext.GetId())
 		}
 		return &Pipeline{
 			pipelineCtx:    pipelineContext,

--- a/backend/src/v2/metadata/client_test.go
+++ b/backend/src/v2/metadata/client_test.go
@@ -121,6 +121,33 @@ func Test_GetPipeline(t *testing.T) {
 	}
 }
 
+func Test_GetPipeline_Twice(t *testing.T) {
+	t.Skip("Temporarily disable the test that requires cluster connection.")
+
+	fatalIf := func(err error) {
+		if err != nil {
+			debug.PrintStack()
+			t.Fatal(err)
+		}
+	}
+
+	ctx := context.Background()
+	runUuid, err := uuid.NewRandom()
+	fatalIf(err)
+	runId := runUuid.String()
+	client, err := metadata.NewClient(testMlmdServerAddress, testMlmdServerPort)
+	fatalIf(err)
+
+	pipeline, err := client.GetPipeline(ctx, "get-pipeline-test", runId, namespace, runResource, pipelineRoot)
+	fatalIf(err)
+	// The second call to GetPipeline won't fail because it avoid inserting to MLMD again.
+	samePipeline, err := client.GetPipeline(ctx, "get-pipeline-test", runId, namespace, runResource, pipelineRoot)
+	fatalIf(err)
+	if (pipeline.GetCtxID() != samePipeline.GetCtxID()) {
+		t.Errorf("Expect pipeline context ID %d, actual is %d", pipeline.GetCtxID(), samePipeline.GetCtxID())
+	}
+}
+
 func Test_GetPipelineFromExecution(t *testing.T) {
 	t.Skip("Temporarily disable the test that requires cluster connection.")
 


### PR DESCRIPTION
**Description of your changes:**
Related: #9586 

MLMD will complain for primary key (parent context id + child context id) conflict if PutParentContexts() is called multiple times. The fix is to check this relationship exists before calling PutParentContexts(). If this relationship already exists, we should not return error. 

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
