### PR TITLE
chore(sdk): relax name validation when upload pipeline

### DIFF
--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -1625,7 +1625,7 @@ def _add_generated_apis(
 def validate_pipeline_display_name(name: str) -> None:
     if not name or name.isspace():
         raise ValueError(
-            f'Invalid pipeline name. Pipeline name cannot be empty or containing only whitespace.'
+            f'Invalid pipeline name. Pipeline name cannot be empty or contain only whitespace.'
         )
 
 

--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -1417,7 +1417,7 @@ class Client:
         if pipeline_name is None:
             pipeline_doc = _extract_pipeline_yaml(pipeline_package_path)
             pipeline_name = pipeline_doc.pipeline_spec.pipeline_info.name
-        validate_pipeline_resource_name(pipeline_name)
+        validate_pipeline_display_name(pipeline_name)
         response = self._upload_api.upload_pipeline(
             pipeline_package_path,
             name=pipeline_name,
@@ -1622,12 +1622,10 @@ def _add_generated_apis(
     target_struct.api_models = models_struct
 
 
-def validate_pipeline_resource_name(name: str) -> None:
-    REGEX = r'[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
-
-    if re.fullmatch(REGEX, name) is None:
+def validate_pipeline_display_name(name: str) -> None:
+    if not name or name.isspace():
         raise ValueError(
-            f'Invalid pipeline name: "{name}". Pipeline name must conform to the regex: "{REGEX}".'
+            f'Invalid pipeline name. Pipeline name cannot be empty or containing only whitespace.'
         )
 
 

--- a/sdk/python/kfp/client/client_test.py
+++ b/sdk/python/kfp/client/client_test.py
@@ -40,19 +40,21 @@ class TestValidatePipelineName(parameterized.TestCase):
         'my-pipeline-1',
         '1pipeline',
         'pipeline1',
-    ])
-    def test_valid(self, name: str):
-        client.validate_pipeline_resource_name(name)
-
-    @parameterized.parameters([
         'my_pipeline',
         "person's-pipeline",
         'my pipeline',
         'pipeline.yaml',
     ])
+    def test_valid(self, name: str):
+        client.validate_pipeline_display_name(name)
+
+    @parameterized.parameters(['', '   ', '\t'])
     def test_invalid(self, name: str):
-        with self.assertRaisesRegex(ValueError, r'Invalid pipeline name:'):
-            client.validate_pipeline_resource_name(name)
+        with self.assertRaisesRegex(
+                ValueError,
+                'Invalid pipeline name. Pipeline name cannot be empty or containing only whitespace.'
+        ):
+            client.validate_pipeline_display_name(name)
 
 
 class TestOverrideCachingOptions(parameterized.TestCase):
@@ -187,7 +189,7 @@ class TestExtractPipelineYAML(parameterized.TestCase):
                 ['pvcMount'][0]['constant'])
 
 
-class TestClient(unittest.TestCase):
+class TestClient(parameterized.TestCase):
 
     def setUp(self):
         self.client = client.Client(namespace='ns1')
@@ -385,20 +387,50 @@ class TestClient(unittest.TestCase):
                         description='description',
                         namespace='ns1')
 
-    def test_upload_pipeline_with_name(self):
+    @parameterized.parameters([
+        'pipeline',
+        'my-pipeline',
+        'my-pipeline-1',
+        '1pipeline',
+        'pipeline1',
+        'my_pipeline',
+        "person's-pipeline",
+        'my pipeline',
+        'pipeline.yaml',
+    ])
+    def test_upload_pipeline_with_name(self, pipeline_name):
         with patch.object(self.client._upload_api,
                           'upload_pipeline') as mock_upload_pipeline:
             with patch.object(self.client, '_is_ipython', return_value=False):
                 self.client.upload_pipeline(
                     pipeline_package_path='fake.yaml',
-                    pipeline_name='overwritten-name',
+                    pipeline_name=pipeline_name,
                     description='description',
                     namespace='ns1')
                 mock_upload_pipeline.assert_called_once_with(
                     'fake.yaml',
-                    name='overwritten-name',
+                    name=pipeline_name,
                     description='description',
                     namespace='ns1')
+
+    @parameterized.parameters([
+        '',
+        '   ',
+        '\t',
+    ])
+    def test_upload_pipeline_with_name_invalid(self, pipeline_name):
+        with patch.object(self.client._upload_api,
+                          'upload_pipeline') as mock_upload_pipeline:
+            with patch.object(self.client, '_is_ipython', return_value=False):
+                with self.assertRaisesRegex(
+                        ValueError,
+                        'Invalid pipeline name. Pipeline name cannot be empty or containing only whitespace.'
+                ):
+                    self.client.upload_pipeline(
+                        pipeline_package_path='fake.yaml',
+                        pipeline_name=pipeline_name,
+                        description='description',
+                        namespace='ns1')
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/client/client_test.py
+++ b/sdk/python/kfp/client/client_test.py
@@ -52,7 +52,7 @@ class TestValidatePipelineName(parameterized.TestCase):
     def test_invalid(self, name: str):
         with self.assertRaisesRegex(
                 ValueError,
-                'Invalid pipeline name. Pipeline name cannot be empty or containing only whitespace.'
+                'Invalid pipeline name. Pipeline name cannot be empty or contain only whitespace.'
         ):
             client.validate_pipeline_display_name(name)
 
@@ -424,7 +424,7 @@ class TestClient(parameterized.TestCase):
             with patch.object(self.client, '_is_ipython', return_value=False):
                 with self.assertRaisesRegex(
                         ValueError,
-                        'Invalid pipeline name. Pipeline name cannot be empty or containing only whitespace.'
+                        'Invalid pipeline name. Pipeline name cannot be empty or contain only whitespace.'
                 ):
                     self.client.upload_pipeline(
                         pipeline_package_path='fake.yaml',


### PR DESCRIPTION
**Description of your changes:**
The name is used display name and doesn't carry special requirements. UI has removed the validation already. Removing it from SDK client side as well.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
