### PR TITLE
fix(backend): Fix performance issue within a mysql request

### DIFF
--- a/backend/src/apiserver/storage/db.go
+++ b/backend/src/apiserver/storage/db.go
@@ -93,7 +93,7 @@ func (d MySQLDialect) IsDuplicateError(err error) bool {
 
 // UpdateFromOrJoin TODO(gkcalat): deprecate resource_references table once we migration to v2beta1 is available.
 func (d MySQLDialect) UpdateWithJointOrFrom(targetTable, joinTable, setClause, joinClause, whereClause string) string {
-	return fmt.Sprintf("UPDATE %s JOIN %s ON %s SET %s WHERE %s", targetTable, joinTable, joinClause, setClause, whereClause)
+	return fmt.Sprintf("UPDATE %s LEFT JOIN %s ON %s SET %s WHERE %s", targetTable, joinTable, joinClause, setClause, whereClause)
 }
 
 // SQLiteDialect implements SQLDialect with sqlite dialect implementation.

--- a/backend/src/apiserver/storage/db_test.go
+++ b/backend/src/apiserver/storage/db_test.go
@@ -103,11 +103,35 @@ func TestSQLiteDialect_Upsert(t *testing.T) {
 }
 
 func TestMySQLDialect_Upsert(t *testing.T) {
-	sqliteDialect := NewMySQLDialect()
-	actualQuery := sqliteDialect.Upsert(`insert into table (uuid, name, namespace) values ("a", "item1", "kubeflow"),("b", "item1", "kubeflow")`, "namespace", true, []string{"uuid", "name"}...)
+	mysqlDialect := NewMySQLDialect()
+	actualQuery := mysqlDialect.Upsert(`insert into table (uuid, name, namespace) values ("a", "item1", "kubeflow"),("b", "item1", "kubeflow")`, "namespace", true, []string{"uuid", "name"}...)
 	expectedQuery := `insert into table (uuid, name, namespace) values ("a", "item1", "kubeflow"),("b", "item1", "kubeflow") ON DUPLICATE KEY UPDATE uuid=VALUES(uuid),name=VALUES(name)`
 	assert.Equal(t, expectedQuery, actualQuery)
-	actualQuery2 := sqliteDialect.Upsert(`insert into table (uuid, name, namespace) values ("a", "item1", "kubeflow"),("b", "item1", "kubeflow")`, "namespace", false, []string{"uuid", "name"}...)
+	actualQuery2 := mysqlDialect.Upsert(`insert into table (uuid, name, namespace) values ("a", "item1", "kubeflow"),("b", "item1", "kubeflow")`, "namespace", false, []string{"uuid", "name"}...)
 	expectedQuery2 := `insert into table (uuid, name, namespace) values ("a", "item1", "kubeflow"),("b", "item1", "kubeflow") ON DUPLICATE KEY UPDATE uuid=uuid,name=name`
 	assert.Equal(t, expectedQuery2, actualQuery2)
+}
+
+func TestMySQLDialect_UpdateWithJointOrFrom(t *testing.T) {
+	mysqlDialect := NewMySQLDialect()
+	actualQuery := mysqlDialect.UpdateWithJointOrFrom(
+		"target_table",
+		"other_table",
+		"State = ?",
+		"target_table.Name = other_table.Name",
+		"target_table.status = ?")
+	expectedQuery := `UPDATE target_table JOIN other_table ON target_table.Name = other_table.Name SET State = ? WHERE target_table.status = ?`
+	assert.Equal(t, expectedQuery, actualQuery)
+}
+
+func TestSQLiteDialect_UpdateWithJointOrFrom(t *testing.T) {
+	sqliteDialect := NewSQLiteDialect()
+	actualQuery := sqliteDialect.UpdateWithJointOrFrom(
+		"target_table",
+		"other_table",
+		"State = ?",
+		"target_table.Name = other_table.Name",
+		"target_table.status = ?")
+	expectedQuery := `UPDATE target_table SET State = ? FROM other_table WHERE target_table.Name = other_table.Name AND target_table.status = ?`
+	assert.Equal(t, expectedQuery, actualQuery)
 }

--- a/backend/src/apiserver/storage/db_test.go
+++ b/backend/src/apiserver/storage/db_test.go
@@ -120,7 +120,7 @@ func TestMySQLDialect_UpdateWithJointOrFrom(t *testing.T) {
 		"State = ?",
 		"target_table.Name = other_table.Name",
 		"target_table.status = ?")
-	expectedQuery := `UPDATE target_table JOIN other_table ON target_table.Name = other_table.Name SET State = ? WHERE target_table.status = ?`
+	expectedQuery := `UPDATE target_table LEFT JOIN other_table ON target_table.Name = other_table.Name SET State = ? WHERE target_table.status = ?`
 	assert.Equal(t, expectedQuery, actualQuery)
 }
 


### PR DESCRIPTION
One of the requests used for Archiving Experiments is rewritten to use inner join for better performance, instead of using nested select. The fix leverage 'SQLDialect' interface, because the new Mysql request is not supported by SQLite Dialect (used for testing). 
There are other MySQL requests that use nested requests in Archive Experiment, but only the most problematic one reported by this [comment](https://github.com/kubeflow/pipelines/issues/6815#issuecomment-955935043) (bobgy) is fixed in the PR. 
The other requests are not optimized, as the `resource_reference` table will be deprecated soon - once `v2beta1` is available. 

Issue: https://github.com/kubeflow/pipelines/issues/6845

**Note**: Archive experiments need to be enabled back in test infra. The change done in this [PR](https://github.com/kubeflow/pipelines/pull/6843) needs to be reverted once this PR got merged. 

**Description of your changes:**


**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
