### PR TITLE
fix(sdk): update backoff factor type to int to be consistent with argo workflows type.

### DIFF
--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -1345,7 +1345,7 @@ class TestSetRetryCompilation(unittest.TestCase):
             hello_world(text=text).set_retry(
                 num_retries=3,
                 backoff_duration='30s',
-                backoff_factor=1.0,
+                backoff_factor=1,
                 backoff_max_duration='3h',
             )
 
@@ -1358,7 +1358,7 @@ class TestSetRetryCompilation(unittest.TestCase):
         retry_policy = pipeline_spec.root.dag.tasks['hello-world'].retry_policy
         self.assertEqual(retry_policy.max_retry_count, 3)
         self.assertEqual(retry_policy.backoff_duration.seconds, 30)
-        self.assertEqual(retry_policy.backoff_factor, 1.0)
+        self.assertEqual(retry_policy.backoff_factor, 1)
         self.assertEqual(retry_policy.backoff_max_duration.seconds, 3600)
 
 

--- a/sdk/python/kfp/components/pipeline_task.py
+++ b/sdk/python/kfp/components/pipeline_task.py
@@ -471,7 +471,7 @@ class PipelineTask:
     def set_retry(self,
                   num_retries: int,
                   backoff_duration: Optional[str] = None,
-                  backoff_factor: Optional[float] = None,
+                  backoff_factor: Optional[int] = None,
                   backoff_max_duration: Optional[str] = None) -> 'PipelineTask':
         """Sets task retry parameters.
 

--- a/sdk/python/kfp/deprecated/dsl/_container_op.py
+++ b/sdk/python/kfp/deprecated/dsl/_container_op.py
@@ -1017,7 +1017,7 @@ class BaseOp(object):
                   num_retries: int,
                   policy: Optional[str] = None,
                   backoff_duration: Optional[str] = None,
-                  backoff_factor: Optional[float] = None,
+                  backoff_factor: Optional[int] = None,
                   backoff_max_duration: Optional[str] = None):
         """Sets the number of times the task is retried until it's declared
         failed.


### PR DESCRIPTION
**Description of your changes:**
Currently, the type states `Optional[float]` which is inconsistent with the underlying argo workflow definition of the field [here](https://argoproj.github.io/argo-workflows/fields/#fields_33). Fixing that since when uploading with the value set to float KFP raises an exception in the following format
```
json: cannot unmarshal number 2.0 into Go struct field Backoff.spec.templates.retryStrategy.backoff.factor of type int32"}]}
```

There's an issue in argo [here](https://github.com/argoproj/argo-workflows/issues/6454) to add support for float, but it's still open, unfortunately.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
