### PR TITLE
fix(frontend): Recurring run card in experiment details page

### DIFF
--- a/frontend/src/pages/ExperimentDetails.tsx
+++ b/frontend/src/pages/ExperimentDetails.tsx
@@ -59,6 +59,7 @@ const css = stylesheet({
     fontSize: 12,
     minHeight: 16,
     paddingLeft: 0,
+    marginRight: 0,
   },
   cardContent: {
     color: color.secondaryText,
@@ -90,7 +91,7 @@ const css = stylesheet({
     color: '#0d652d',
   },
   recurringRunsCard: {
-    width: 158,
+    width: 270,
   },
   recurringRunsDialog: {
     minWidth: 600,
@@ -170,7 +171,17 @@ export class ExperimentDetails extends Page<{}, ExperimentDetailsState> {
                 elevation={0}
               >
                 <div>
-                  <div className={css.cardTitle}>Recurring run configs</div>
+                  <div className={css.cardTitle}>
+                    <span>Recurring run configs</span>
+                    <Button
+                      className={css.cardBtn}
+                      id='manageExperimentRecurringRunsBtn'
+                      disableRipple={true}
+                      onClick={() => this.setState({ recurringRunsManagerOpen: true })}
+                    >
+                      Manage
+                    </Button>
+                  </div>
                   <div
                     className={classes(
                       css.cardContent,
@@ -179,14 +190,6 @@ export class ExperimentDetails extends Page<{}, ExperimentDetailsState> {
                   >
                     {activeRecurringRunsCount + ' active'}
                   </div>
-                  <Button
-                    className={css.cardBtn}
-                    id='manageExperimentRecurringRunsBtn'
-                    disableRipple={true}
-                    onClick={() => this.setState({ recurringRunsManagerOpen: true })}
-                  >
-                    Manage
-                  </Button>
                 </div>
               </Paper>
               <Paper

--- a/frontend/src/pages/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -19,21 +19,23 @@ exports[`ExperimentDetails fetches this experiment's recurring runs 1`] = `
           <div
             className="cardTitle"
           >
-            Recurring run configs
+            <span>
+              Recurring run configs
+            </span>
+            <WithStyles(Button)
+              className="cardBtn"
+              disableRipple={true}
+              id="manageExperimentRecurringRunsBtn"
+              onClick={[Function]}
+            >
+              Manage
+            </WithStyles(Button)>
           </div>
           <div
             className="cardContent recurringRunsActive"
           >
             1 active
           </div>
-          <WithStyles(Button)
-            className="cardBtn"
-            disableRipple={true}
-            id="manageExperimentRecurringRunsBtn"
-            onClick={[Function]}
-          >
-            Manage
-          </WithStyles(Button)>
         </div>
       </WithStyles(Paper)>
       <WithStyles(Paper)
@@ -270,21 +272,23 @@ exports[`ExperimentDetails removes all description text after second newline and
           <div
             className="cardTitle"
           >
-            Recurring run configs
+            <span>
+              Recurring run configs
+            </span>
+            <WithStyles(Button)
+              className="cardBtn"
+              disableRipple={true}
+              id="manageExperimentRecurringRunsBtn"
+              onClick={[Function]}
+            >
+              Manage
+            </WithStyles(Button)>
           </div>
           <div
             className="cardContent"
           >
             0 active
           </div>
-          <WithStyles(Button)
-            className="cardBtn"
-            disableRipple={true}
-            id="manageExperimentRecurringRunsBtn"
-            onClick={[Function]}
-          >
-            Manage
-          </WithStyles(Button)>
         </div>
       </WithStyles(Paper)>
       <WithStyles(Paper)
@@ -534,21 +538,23 @@ exports[`ExperimentDetails renders a page with no runs or recurring runs 1`] = `
           <div
             className="cardTitle"
           >
-            Recurring run configs
+            <span>
+              Recurring run configs
+            </span>
+            <WithStyles(Button)
+              className="cardBtn"
+              disableRipple={true}
+              id="manageExperimentRecurringRunsBtn"
+              onClick={[Function]}
+            >
+              Manage
+            </WithStyles(Button)>
           </div>
           <div
             className="cardContent"
           >
             0 active
           </div>
-          <WithStyles(Button)
-            className="cardBtn"
-            disableRipple={true}
-            id="manageExperimentRecurringRunsBtn"
-            onClick={[Function]}
-          >
-            Manage
-          </WithStyles(Button)>
         </div>
       </WithStyles(Paper)>
       <WithStyles(Paper)
@@ -785,21 +791,23 @@ exports[`ExperimentDetails uses an empty string if the experiment has no descrip
           <div
             className="cardTitle"
           >
-            Recurring run configs
+            <span>
+              Recurring run configs
+            </span>
+            <WithStyles(Button)
+              className="cardBtn"
+              disableRipple={true}
+              id="manageExperimentRecurringRunsBtn"
+              onClick={[Function]}
+            >
+              Manage
+            </WithStyles(Button)>
           </div>
           <div
             className="cardContent"
           >
             0 active
           </div>
-          <WithStyles(Button)
-            className="cardBtn"
-            disableRipple={true}
-            id="manageExperimentRecurringRunsBtn"
-            onClick={[Function]}
-          >
-            Manage
-          </WithStyles(Button)>
         </div>
       </WithStyles(Paper)>
       <WithStyles(Paper)


### PR DESCRIPTION
Before:

<img width="1706" alt="Screenshot 2023-06-30 at 2 12 17 PM" src="https://github.com/kubeflow/pipelines/assets/56132941/c931b474-e8d3-4e4a-b9f1-1931586f288d">


After:

<img width="1706" alt="Screenshot 2023-06-30 at 2 13 02 PM" src="https://github.com/kubeflow/pipelines/assets/56132941/55cb1895-2e8f-4224-b0d0-385a2ee67038">
