### PR TITLE
feat(backend) Enable auth between pesistence agent and pipelineAPI (ReportServer)

### DIFF
--- a/backend/src/agent/persistence/client/pipeline_client.go
+++ b/backend/src/agent/persistence/client/pipeline_client.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
@@ -46,11 +47,13 @@ type PipelineClient struct {
 	timeout             time.Duration
 	reportServiceClient api.ReportServiceClient
 	runServiceClient    api.RunServiceClient
+	tokenRefresher      TokenRefresherInterface
 }
 
 func NewPipelineClient(
 	initializeTimeout time.Duration,
 	timeout time.Duration,
+	tokenRefresher TokenRefresherInterface,
 	basePath string,
 	mlPipelineServiceName string,
 	mlPipelineServiceHttpPort string,
@@ -71,13 +74,19 @@ func NewPipelineClient(
 	return &PipelineClient{
 		initializeTimeout:   initializeTimeout,
 		timeout:             timeout,
+		tokenRefresher:      tokenRefresher,
 		reportServiceClient: api.NewReportServiceClient(connection),
 		runServiceClient:    api.NewRunServiceClient(connection),
 	}, nil
 }
 
 func (p *PipelineClient) ReportWorkflow(workflow util.ExecutionSpec) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	pctx := context.Background()
+	if os.Getenv("MULTIUSER") == "True" {
+		pctx = metadata.AppendToOutgoingContext(pctx, "Authorization",
+			"Bearer "+p.tokenRefresher.GetToken())
+	}
+	ctx, cancel := context.WithTimeout(pctx, time.Minute)
 	defer cancel()
 
 	_, err := p.reportServiceClient.ReportWorkflowV1(ctx, &api.ReportWorkflowRequest{
@@ -91,6 +100,15 @@ func (p *PipelineClient) ReportWorkflow(workflow util.ExecutionSpec) error {
 			// * there is something wrong with the workflow
 			// * the workflow has been deleted by someone else
 			return util.NewCustomError(err, util.CUSTOM_CODE_PERMANENT,
+				"Error while reporting workflow resource (code: %v, message: %v): %v, %+v",
+				statusCode.Code(),
+				statusCode.Message(),
+				err.Error(),
+				workflow.ToStringForStore())
+		} else if statusCode.Code() == codes.Unauthenticated && strings.Contains(err.Error(), "service account token has expired") {
+			//if unauthenticated because SA token is expired, re-read/refresh the token and try again
+			p.tokenRefresher.RefreshToken()
+			return util.NewCustomError(err, util.CUSTOM_CODE_TRANSIENT,
 				"Error while reporting workflow resource (code: %v, message: %v): %v, %+v",
 				statusCode.Code(),
 				statusCode.Message(),
@@ -110,7 +128,12 @@ func (p *PipelineClient) ReportWorkflow(workflow util.ExecutionSpec) error {
 }
 
 func (p *PipelineClient) ReportScheduledWorkflow(swf *util.ScheduledWorkflow) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	pctx := context.Background()
+	if os.Getenv("MULTIUSER") == "True" {
+		pctx = metadata.AppendToOutgoingContext(pctx, "Authorization",
+			"Bearer "+p.tokenRefresher.GetToken())
+	}
+	ctx, cancel := context.WithTimeout(pctx, time.Minute)
 	defer cancel()
 
 	_, err := p.reportServiceClient.ReportScheduledWorkflowV1(ctx,
@@ -123,6 +146,15 @@ func (p *PipelineClient) ReportScheduledWorkflow(swf *util.ScheduledWorkflow) er
 		if statusCode.Code() == codes.InvalidArgument {
 			// Do not retry if there is something wrong with the workflow
 			return util.NewCustomError(err, util.CUSTOM_CODE_PERMANENT,
+				"Error while reporting workflow resource (code: %v, message: %v): %v, %+v",
+				statusCode.Code(),
+				statusCode.Message(),
+				err.Error(),
+				swf.ScheduledWorkflow)
+		} else if statusCode.Code() == codes.Unauthenticated && strings.Contains(err.Error(), "service account token has expired") {
+			//if unauthenticated because SA token is expired, re-read/refresh the token and try again
+			p.tokenRefresher.RefreshToken()
+			return util.NewCustomError(err, util.CUSTOM_CODE_TRANSIENT,
 				"Error while reporting workflow resource (code: %v, message: %v): %v, %+v",
 				statusCode.Code(),
 				statusCode.Message(),

--- a/backend/src/agent/persistence/client/pipeline_client.go
+++ b/backend/src/agent/persistence/client/pipeline_client.go
@@ -82,10 +82,9 @@ func NewPipelineClient(
 
 func (p *PipelineClient) ReportWorkflow(workflow util.ExecutionSpec) error {
 	pctx := context.Background()
-	if os.Getenv("MULTIUSER") == "True" {
-		pctx = metadata.AppendToOutgoingContext(pctx, "Authorization",
-			"Bearer "+p.tokenRefresher.GetToken())
-	}
+	pctx = metadata.AppendToOutgoingContext(pctx, "Authorization",
+		"Bearer "+p.tokenRefresher.GetToken())
+
 	ctx, cancel := context.WithTimeout(pctx, time.Minute)
 	defer cancel()
 
@@ -106,7 +105,7 @@ func (p *PipelineClient) ReportWorkflow(workflow util.ExecutionSpec) error {
 				err.Error(),
 				workflow.ToStringForStore())
 		} else if statusCode.Code() == codes.Unauthenticated && strings.Contains(err.Error(), "service account token has expired") {
-			//if unauthenticated because SA token is expired, re-read/refresh the token and try again
+			// If unauthenticated because SA token is expired, re-read/refresh the token and try again
 			p.tokenRefresher.RefreshToken()
 			return util.NewCustomError(err, util.CUSTOM_CODE_TRANSIENT,
 				"Error while reporting workflow resource (code: %v, message: %v): %v, %+v",
@@ -129,10 +128,9 @@ func (p *PipelineClient) ReportWorkflow(workflow util.ExecutionSpec) error {
 
 func (p *PipelineClient) ReportScheduledWorkflow(swf *util.ScheduledWorkflow) error {
 	pctx := context.Background()
-	if os.Getenv("MULTIUSER") == "True" {
-		pctx = metadata.AppendToOutgoingContext(pctx, "Authorization",
-			"Bearer "+p.tokenRefresher.GetToken())
-	}
+	pctx = metadata.AppendToOutgoingContext(pctx, "Authorization",
+		"Bearer "+p.tokenRefresher.GetToken())
+
 	ctx, cancel := context.WithTimeout(pctx, time.Minute)
 	defer cancel()
 
@@ -152,7 +150,7 @@ func (p *PipelineClient) ReportScheduledWorkflow(swf *util.ScheduledWorkflow) er
 				err.Error(),
 				swf.ScheduledWorkflow)
 		} else if statusCode.Code() == codes.Unauthenticated && strings.Contains(err.Error(), "service account token has expired") {
-			//if unauthenticated because SA token is expired, re-read/refresh the token and try again
+			// If unauthenticated because SA token is expired, re-read/refresh the token and try again
 			p.tokenRefresher.RefreshToken()
 			return util.NewCustomError(err, util.CUSTOM_CODE_TRANSIENT,
 				"Error while reporting workflow resource (code: %v, message: %v): %v, %+v",

--- a/backend/src/agent/persistence/client/token_refresher.go
+++ b/backend/src/agent/persistence/client/token_refresher.go
@@ -12,7 +12,7 @@ type TokenRefresherInterface interface {
 	RefreshToken()
 }
 
-const SA_TOKEN_FILE = "/var/run/secrets/kubeflow/tokens/persistenceagent-sa-token"
+const SaTokenFile = "/var/run/secrets/kubeflow/tokens/persistenceagent-sa-token"
 
 type tokenRefresher struct {
 	mu      sync.RWMutex
@@ -29,11 +29,6 @@ func NewTokenRefresher(seconds time.Duration) *tokenRefresher {
 }
 
 func (tr *tokenRefresher) StartTokenRefreshTicker(stopCh <-chan struct{}) error {
-	//TODO use viper
-	if os.Getenv("MULTIUSER") != "True" {
-		log.Info("MULTIUSER is not True. Skip reading persistent agent service account token.")
-		return nil
-	}
 	err := tr.readToken()
 	if err != nil {
 		return err
@@ -67,9 +62,9 @@ func (tr *tokenRefresher) RefreshToken() {
 func (tr *tokenRefresher) readToken() error {
 	tr.mu.Lock()
 	defer tr.mu.Unlock()
-	b, err := os.ReadFile(SA_TOKEN_FILE)
+	b, err := os.ReadFile(SaTokenFile)
 	if err != nil {
-		log.Errorf("Error reading persistence agent service account token '%s': %v", SA_TOKEN_FILE, err)
+		log.Errorf("Error reading persistence agent service account token '%s': %v", SaTokenFile, err)
 		return err
 	}
 	tr.token = string(b)

--- a/backend/src/agent/persistence/client/token_refresher.go
+++ b/backend/src/agent/persistence/client/token_refresher.go
@@ -1,0 +1,77 @@
+package client
+
+import (
+	log "github.com/sirupsen/logrus"
+	"os"
+	"sync"
+	"time"
+)
+
+type TokenRefresherInterface interface {
+	GetToken() string
+	RefreshToken()
+}
+
+const SA_TOKEN_FILE = "/var/run/secrets/kubeflow/tokens/persistenceagent-sa-token"
+
+type tokenRefresher struct {
+	mu      sync.RWMutex
+	seconds *time.Duration
+	token   string
+}
+
+func NewTokenRefresher(seconds time.Duration) *tokenRefresher {
+	tokenRefresher := &tokenRefresher{
+		seconds: &seconds,
+	}
+
+	return tokenRefresher
+}
+
+func (tr *tokenRefresher) StartTokenRefreshTicker(stopCh <-chan struct{}) error {
+	//TODO use viper
+	if os.Getenv("MULTIUSER") != "True" {
+		log.Info("MULTIUSER is not True. Skip reading persistent agent service account token.")
+		return nil
+	}
+	err := tr.readToken()
+	if err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(*tr.seconds)
+	go func() {
+		for {
+			select {
+			case <-stopCh:
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				tr.readToken()
+			}
+		}
+	}()
+	return err
+}
+
+func (tr *tokenRefresher) GetToken() string {
+	tr.mu.RLock()
+	defer tr.mu.RUnlock()
+	return tr.token
+}
+
+func (tr *tokenRefresher) RefreshToken() {
+	tr.readToken()
+}
+
+func (tr *tokenRefresher) readToken() error {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	b, err := os.ReadFile(SA_TOKEN_FILE)
+	if err != nil {
+		log.Errorf("Error reading persistence agent service account token '%s': %v", SA_TOKEN_FILE, err)
+		return err
+	}
+	tr.token = string(b)
+	return nil
+}

--- a/backend/src/agent/persistence/client/token_refresher_test.go
+++ b/backend/src/agent/persistence/client/token_refresher_test.go
@@ -1,0 +1,111 @@
+package client
+
+import (
+	"fmt"
+	"io/fs"
+	"log"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const refreshInterval = 2 * time.Second
+
+type FileReaderFake struct {
+	Data        string
+	Err         error
+	readCounter int
+}
+
+func (m *FileReaderFake) ReadFile(filename string) ([]byte, error) {
+	if m.Err != nil {
+		return nil, m.Err
+	}
+	content := fmt.Sprintf("%s-%v", m.Data, m.readCounter)
+	m.readCounter++
+	return []byte(content), nil
+}
+
+func Test_token_refresher(t *testing.T) {
+	tests := []struct {
+		name           string
+		baseToken      string
+		wanted         string
+		refreshedToken string
+		err            error
+	}{
+		{
+			name:      "TestTokenRefresher_GetToken_Success",
+			baseToken: "rightToken",
+			wanted:    "rightToken-0",
+			err:       nil,
+		},
+		{
+			name:      "TestTokenRefresher_GetToken_Failed_PathError",
+			baseToken: "rightToken",
+			wanted:    "rightToken-0",
+			err:       &fs.PathError{Err: syscall.ENOENT},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// setup
+			fakeFileReader := &FileReaderFake{
+				Data: tt.baseToken,
+				Err:  tt.err,
+			}
+			tr := NewTokenRefresher(refreshInterval, fakeFileReader)
+			err := tr.StartTokenRefreshTicker()
+			if err != nil {
+				got, sameType := err.(*fs.PathError)
+				if sameType != true {
+					t.Errorf("%v(): got = %v, wanted %v", tt.name, got, tt.err)
+				}
+				return
+			}
+			if err != nil {
+				log.Fatalf("Error starting Service Account Token Refresh Ticker: %v", err)
+			}
+
+			if got := tr.GetToken(); got != tt.wanted {
+				t.Errorf("%v(): got %v, wanted %v", tt.name, got, tt.wanted)
+			}
+		})
+	}
+}
+
+func TestTokenRefresher_GetToken_After_TickerRefresh_Success(t *testing.T) {
+	fakeFileReader := &FileReaderFake{
+		Data: "Token",
+		Err:  nil,
+	}
+	tr := NewTokenRefresher(1*time.Second, fakeFileReader)
+	err := tr.StartTokenRefreshTicker()
+	if err != nil {
+		log.Fatalf("Error starting Service Account Token Refresh Ticker: %v", err)
+	}
+	time.Sleep(1200 * time.Millisecond)
+	expectedToken := "Token-1"
+
+	if got := tr.GetToken(); got != expectedToken {
+		t.Errorf("%v(): got %v, wanted 'refreshed baseToken' %v", t.Name(), got, expectedToken)
+	}
+}
+
+func TestTokenRefresher_GetToken_After_ForceRefresh_Success(t *testing.T) {
+	fakeFileReader := &FileReaderFake{
+		Data: "Token",
+		Err:  nil,
+	}
+	tr := NewTokenRefresher(refreshInterval, fakeFileReader)
+	err := tr.StartTokenRefreshTicker()
+	if err != nil {
+		log.Fatalf("Error starting Service Account Token Refresh Ticker: %v", err)
+	}
+	tr.RefreshToken()
+	expectedToken := "Token-1"
+
+	if got := tr.GetToken(); got != expectedToken {
+		t.Errorf("%v(): got %v, wanted 'refreshed baseToken' %v", t.Name(), got, expectedToken)
+	}
+}

--- a/backend/src/agent/persistence/main.go
+++ b/backend/src/agent/persistence/main.go
@@ -100,10 +100,10 @@ func main() {
 		Burst: clientBurst,
 	})
 
-	tokenRefresher := client.NewTokenRefresher(time.Duration(saTokenRefreshInterval))
-	err = tokenRefresher.StartTokenRefreshTicker(stopCh)
+	tokenRefresher := client.NewTokenRefresher(time.Duration(saTokenRefreshInterval), nil)
+	err = tokenRefresher.StartTokenRefreshTicker()
 	if err != nil {
-		log.Fatalf("Error starting Service Account Token Refresh Ticker: %v", err)
+		log.Fatalf("Error starting Service Account Token Refresh Ticker due to: %v", err)
 	}
 
 	pipelineClient, err := client.NewPipelineClient(

--- a/backend/src/agent/persistence/main.go
+++ b/backend/src/agent/persistence/main.go
@@ -150,7 +150,7 @@ func init() {
 	// k8s.io/client-go/rest/config.go#RESTClientFor
 	flag.Float64Var(&clientQPS, clientQPSFlagName, 5, "The maximum QPS to the master from this client.")
 	flag.IntVar(&clientBurst, clientBurstFlagName, 10, "Maximum burst for throttle from this client.")
-	//TODO use viper/config file instead (also for MULTIUSER env variable). Sync `saTokenRefreshIntervalFlagName` with the value from manifest file by using ENV var.
+	// TODO use viper/config file instead. Sync `saTokenRefreshIntervalFlagName` with the value from manifest file by using ENV var.
 	flag.Float64Var(&saTokenRefreshInterval, saTokenRefreshIntervalFlagName, DefaultTokenRefresherInterval.Seconds(), "Persistence agent service account token read interval in seconds. "+
 		"Defines how often `/var/run/secrets/kubeflow/tokens/kubeflow-persistent_agent-api-token` to be read")
 

--- a/backend/src/agent/persistence/main.go
+++ b/backend/src/agent/persistence/main.go
@@ -43,6 +43,7 @@ var (
 	numWorker                     int
 	clientQPS                     float64
 	clientBurst                   int
+	saTokenRefreshInterval        float64
 )
 
 const (
@@ -59,10 +60,12 @@ const (
 	numWorkerName                         = "numWorker"
 	clientQPSFlagName                     = "clientQPS"
 	clientBurstFlagName                   = "clientBurst"
+	saTokenRefreshIntervalFlagName        = "saTokenRefreshInterval"
 )
 
 const (
-	DefaultConnectionTimeout = 6 * time.Minute
+	DefaultConnectionTimeout      = 6 * time.Minute
+	DefaultTokenRefresherInterval = 1 * time.Hour
 )
 
 func main() {
@@ -97,9 +100,16 @@ func main() {
 		Burst: clientBurst,
 	})
 
+	tokenRefresher := client.NewTokenRefresher(time.Duration(saTokenRefreshInterval))
+	err = tokenRefresher.StartTokenRefreshTicker(stopCh)
+	if err != nil {
+		log.Fatalf("Error starting Service Account Token Refresh Ticker: %v", err)
+	}
+
 	pipelineClient, err := client.NewPipelineClient(
 		initializeTimeout,
 		timeout,
+		tokenRefresher,
 		mlPipelineAPIServerBasePath,
 		mlPipelineAPIServerName,
 		mlPipelineServiceHttpPort,
@@ -140,4 +150,8 @@ func init() {
 	// k8s.io/client-go/rest/config.go#RESTClientFor
 	flag.Float64Var(&clientQPS, clientQPSFlagName, 5, "The maximum QPS to the master from this client.")
 	flag.IntVar(&clientBurst, clientBurstFlagName, 10, "Maximum burst for throttle from this client.")
+	//TODO use viper/config file instead (also for MULTIUSER env variable). Sync `saTokenRefreshIntervalFlagName` with the value from manifest file by using ENV var.
+	flag.Float64Var(&saTokenRefreshInterval, saTokenRefreshIntervalFlagName, DefaultTokenRefresherInterval.Seconds(), "Persistence agent service account token read interval in seconds. "+
+		"Defines how often `/var/run/secrets/kubeflow/tokens/kubeflow-persistent_agent-api-token` to be read")
+
 }

--- a/backend/src/apiserver/auth/authenticator_token_review.go
+++ b/backend/src/apiserver/auth/authenticator_token_review.go
@@ -92,7 +92,8 @@ func (tra *TokenReviewAuthenticator) doTokenReview(ctx context.Context, userIden
 	if !review.Status.Authenticated {
 		return nil, util.NewUnauthenticatedError(
 			errors.New("Failed to authenticate token review"),
-			"Review.Status.Authenticated is false",
+			"Review.Status.Authenticated is false. Error %s",
+			review.Status.Error,
 		)
 	}
 	if !tra.ensureAudience(review.Status.Audiences) {

--- a/backend/src/apiserver/common/const.go
+++ b/backend/src/apiserver/common/const.go
@@ -19,12 +19,14 @@ const (
 	RbacPipelinesGroup   = "pipelines.kubeflow.org"
 	RbacPipelinesVersion = "v1beta1"
 
-	RbacResourceTypePipelines      = "pipelines"
-	RbacResourceTypeExperiments    = "experiments"
-	RbacResourceTypeRuns           = "runs"
-	RbacResourceTypeJobs           = "jobs"
-	RbacResourceTypeViewers        = "viewers"
-	RbacResourceTypeVisualizations = "visualizations"
+	RbacResourceTypePipelines          = "pipelines"
+	RbacResourceTypeExperiments        = "experiments"
+	RbacResourceTypeRuns               = "runs"
+	RbacResourceTypeJobs               = "jobs"
+	RbacResourceTypeViewers            = "viewers"
+	RbacResourceTypeVisualizations     = "visualizations"
+	RbacResourceTypeScheduledWorkflows = "scheduledworkflows"
+	RbacResourceTypeWorkflows          = "workflows"
 
 	RbacResourceVerbArchive       = "archive"
 	RbacResourceVerbUpdate        = "update"
@@ -39,6 +41,7 @@ const (
 	RbacResourceVerbUnarchive     = "unarchive"
 	RbacResourceVerbReportMetrics = "reportMetrics"
 	RbacResourceVerbReadArtifact  = "readArtifact"
+	RbacResourceVerbReport        = "report"
 )
 
 const (

--- a/backend/src/apiserver/server/report_server.go
+++ b/backend/src/apiserver/server/report_server.go
@@ -17,6 +17,8 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	authorizationv1 "k8s.io/api/authorization/v1"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	apiv1beta1 "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
@@ -49,6 +51,17 @@ func (s *ReportServer) reportWorkflow(ctx context.Context, workflow string) (*em
 	if err != nil {
 		return nil, util.Wrap(err, "Report workflow failed")
 	}
+
+	executionName := (*execSpec).ExecutionName()
+	resourceAttributes := &authorizationv1.ResourceAttributes{
+		Verb:     common.RbacResourceVerbReport,
+		Resource: common.RbacResourceTypeWorkflows,
+	}
+
+	if err := s.canAccessWorkflow(ctx, executionName, resourceAttributes); err != nil {
+		return nil, err
+	}
+
 	newExecSpec, err := s.resourceManager.ReportWorkflowResource(ctx, *execSpec)
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to report workflow")
@@ -80,6 +93,15 @@ func (s *ReportServer) reportScheduledWorkflow(ctx context.Context, swf string) 
 	if err != nil {
 		return nil, util.Wrap(err, "Report scheduled workflow failed")
 	}
+	resourceAttributes := &authorizationv1.ResourceAttributes{
+		Verb:     common.RbacResourceVerbReport,
+		Resource: common.RbacResourceTypeScheduledWorkflows,
+	}
+	err = s.canAccessWorkflow(ctx, string(scheduledWorkflow.UID), resourceAttributes)
+	if err != nil {
+		return nil, err
+	}
+
 	err = s.resourceManager.ReportScheduledWorkflowResource(scheduledWorkflow)
 	if err != nil {
 		return nil, err
@@ -134,6 +156,20 @@ func validateReportScheduledWorkflowRequest(swfManifest string) (*util.Scheduled
 		return nil, util.NewInvalidInputError("The resource must have a UID: %+v", swf.UID)
 	}
 	return swf, nil
+}
+
+func (s *ReportServer) canAccessWorkflow(ctx context.Context, executionName string, resourceAttributes *authorizationv1.ResourceAttributes) error {
+	if !common.IsMultiUserMode() {
+		// Skip authz if not multi-user mode.
+		return nil
+	}
+	resourceAttributes.Group = common.RbacPipelinesGroup
+	resourceAttributes.Version = common.RbacPipelinesVersion
+	err := s.resourceManager.IsAuthorized(ctx, resourceAttributes)
+	if err != nil {
+		return util.Wrapf(err, "Failed to report %s `%s` due to authorization error.", resourceAttributes.Resource, executionName)
+	}
+	return nil
 }
 
 func NewReportServer(resourceManager *resource.ResourceManager) *ReportServer {

--- a/backend/src/apiserver/server/report_server.go
+++ b/backend/src/apiserver/server/report_server.go
@@ -159,10 +159,6 @@ func validateReportScheduledWorkflowRequest(swfManifest string) (*util.Scheduled
 }
 
 func (s *ReportServer) canAccessWorkflow(ctx context.Context, executionName string, resourceAttributes *authorizationv1.ResourceAttributes) error {
-	if !common.IsMultiUserMode() {
-		// Skip authz if not multi-user mode.
-		return nil
-	}
 	resourceAttributes.Group = common.RbacPipelinesGroup
 	resourceAttributes.Version = common.RbacPipelinesVersion
 	err := s.resourceManager.IsAuthorized(ctx, resourceAttributes)

--- a/manifests/kustomize/base/installs/multi-user/persistence-agent/cluster-role.yaml
+++ b/manifests/kustomize/base/installs/multi-user/persistence-agent/cluster-role.yaml
@@ -20,6 +20,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - pipelines.kubeflow.org
+  resources:
+  - scheduledworkflows
+  - workflows
+  verbs:
+  - report
+- apiGroups:
   - ''
   resources:
   - namespaces

--- a/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
@@ -36,4 +36,15 @@ spec:
           requests:
             cpu: 120m
             memory: 500Mi
+        volumeMounts:
+          - mountPath: /var/run/secrets/kubeflow/tokens
+            name: persistenceagent-sa-token
       serviceAccountName: ml-pipeline-persistenceagent
+      volumes:
+        - name: persistenceagent-sa-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: persistenceagent-sa-token
+                  expirationSeconds: 3600
+                  audience: pipelines.kubeflow.org

--- a/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-role.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-role.yaml
@@ -20,6 +20,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - pipelines.kubeflow.org
+  resources:
+  - scheduledworkflows
+  - workflows
+  verbs:
+  - report
+- apiGroups:
   - ''
   resources:
   - namespaces


### PR DESCRIPTION
1. Add authentication and authorization logic to PipelineAPI PeportServer's methods - [reportworkflow](https://github.com/kubeflow/pipelines/blob/a634eef3ec541ee64eb0220d5db12b82f682479e/backend/src/apiserver/server/report_server.go#L47C24-L47C38) & [reportSheduledWorkflow](https://github.com/kubeflow/pipelines/blob/a634eef3ec541ee64eb0220d5db12b82f682479e/backend/src/apiserver/server/report_server.go#L78C24-L78C47) and
2. Force Persistence Agent to authenticate itself through Service Account Token Volume Projection when calling the above methods.

Issue: https://github.com/kubeflow/pipelines/issues/8074

**Description of your changes:**


**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
