### PR TITLE
test: Use GKE stable release channel to unblock presubmit tests. Fixes #9704. Part of #9706.

### DIFF
--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -87,9 +87,8 @@ else
     SCOPE_ARG="--scopes=storage-rw,cloud-platform"
   fi
   # Use regular release channel to keep up with newly created clusters in Google Cloud Marketplace.
-  # gcloud container clusters create ${TEST_CLUSTER} --release-channel regular ${SCOPE_ARG} ${NODE_POOL_CONFIG_ARG} ${WI_ARG}
-  # Temporarily use cos as image type until docker dependencies gets removed. reference: https://github.com/kubeflow/pipelines/issues/6696
-  gcloud container clusters create ${TEST_CLUSTER} --image-type cos_containerd --release-channel regular ${SCOPE_ARG} ${NODE_POOL_CONFIG_ARG} ${WI_ARG}
+  # TODO: Switch back to regular channel
+  gcloud container clusters create ${TEST_CLUSTER} --release-channel stable ${SCOPE_ARG} ${NODE_POOL_CONFIG_ARG} ${WI_ARG}
 fi
 
 gcloud container clusters get-credentials ${TEST_CLUSTER}

--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -87,7 +87,7 @@ else
     SCOPE_ARG="--scopes=storage-rw,cloud-platform"
   fi
   # Use regular release channel to keep up with newly created clusters in Google Cloud Marketplace.
-  # TODO: Switch back to regular channel
+  # TODO(#9706): Switch back to regular channel once we stop building test images via dind.
   gcloud container clusters create ${TEST_CLUSTER} --release-channel stable ${SCOPE_ARG} ${NODE_POOL_CONFIG_ARG} ${WI_ARG}
 fi
 


### PR DESCRIPTION
**Description of your changes:**
Fixes https://github.com/kubeflow/pipelines/issues/9704
Temporarily switch to GKE stable release channel to unblock presubmit tests. This should buy us some time (~3 months) until we find alternatives to building test images (#9706).

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
