### PR TITLE
Fix(frontend): content is not available

### DIFF
--- a/frontend/src/lib/v2/DynamicFlow.test.ts
+++ b/frontend/src/lib/v2/DynamicFlow.test.ts
@@ -142,6 +142,25 @@ describe('DynamicFlow', () => {
       expect(nodeMlmdInfo).toEqual({ execution });
     });
 
+    it('execution found with custom name', () => {
+      const label = 'custom-label';
+      const elem: Node<FlowElementDataBase> = {
+        id: 'task.exec',
+        data: {
+          label: label,
+          mlmdId: 1
+        },
+        type: NodeTypeNames.EXECUTION,
+        position: { x: 1, y: 2 },
+      };
+
+      const execution = new Execution();
+      execution.setId(1);
+      execution.getCustomPropertiesMap().set(TASK_NAME_KEY, new Value().setStringValue(label));
+      const nodeMlmdInfo = getNodeMlmdInfo(elem, [execution], [], []);
+      expect(nodeMlmdInfo).toEqual({ execution });
+    });
+
     it('artifact not exist', () => {
       const elem: Node<FlowElementDataBase> = {
         id: 'artifact.exec.arti',

--- a/frontend/src/lib/v2/DynamicFlow.test.ts
+++ b/frontend/src/lib/v2/DynamicFlow.test.ts
@@ -148,7 +148,7 @@ describe('DynamicFlow', () => {
         id: 'task.exec',
         data: {
           label: label,
-          mlmdId: 1
+          mlmdId: 1,
         },
         type: NodeTypeNames.EXECUTION,
         position: { x: 1, y: 2 },

--- a/frontend/src/lib/v2/DynamicFlow.ts
+++ b/frontend/src/lib/v2/DynamicFlow.ts
@@ -263,12 +263,13 @@ export function updateFlowElementsState(
     }
     return flowGraph;
   }
-
   for (let elem of elems) {
+    const taskLabel = elem.data?.label;
+    if (taskLabel === undefined)
+      throw new Error('task label cannot be undefined');
     let updatedElem = Object.assign({}, elem);
     if (NodeTypeNames.EXECUTION === elem.type) {
-      const taskName = getTaskKeyFromNodeKey(elem.id);
-      const executions = getExecutionsUnderDAG(taskNameToExecution, taskName, executionLayers);
+      const executions = getExecutionsUnderDAG(taskNameToExecution, taskLabel, executionLayers);
       if (executions) {
         (updatedElem.data as ExecutionFlowElementData).state = executions[0]?.getLastKnownState();
         (updatedElem.data as ExecutionFlowElementData).mlmdId = executions[0]?.getId();
@@ -291,8 +292,7 @@ export function updateFlowElementsState(
       (updatedElem.data as ArtifactFlowElementData).mlmdId = linkedArtifact?.artifact?.getId();
     } else if (NodeTypeNames.SUB_DAG === elem.type) {
       // TODO: Update sub-dag state based on future design.
-      const taskName = getTaskKeyFromNodeKey(elem.id);
-      const executions = getExecutionsUnderDAG(taskNameToExecution, taskName, executionLayers);
+      const executions = getExecutionsUnderDAG(taskNameToExecution, taskLabel, executionLayers);
       if (executions) {
         (updatedElem.data as SubDagFlowElementData).state = executions[0]?.getLastKnownState();
         (updatedElem.data as SubDagFlowElementData).mlmdId = executions[0]?.getId();

--- a/frontend/src/lib/v2/DynamicFlow.ts
+++ b/frontend/src/lib/v2/DynamicFlow.ts
@@ -349,9 +349,9 @@ export function getNodeMlmdInfo(
   );
 
   if (NodeTypeNames.EXECUTION === elem.type) {
-    const taskName = getTaskKeyFromNodeKey(elem.id);
+    const taskLabel = getTaskLabelByPipelineFlowElement(elem);
     const executions = taskNameToExecution
-      .get(taskName)
+      .get(taskLabel)
       ?.filter(exec => exec.getId() === elem.data?.mlmdId);
     return executions ? { execution: executions[0] } : {};
   } else if (NodeTypeNames.ARTIFACT === elem.type) {
@@ -373,9 +373,9 @@ export function getNodeMlmdInfo(
     return { execution, linkedArtifact };
   } else if (NodeTypeNames.SUB_DAG === elem.type) {
     // TODO: Update sub-dag state based on future design.
-    const taskName = getTaskKeyFromNodeKey(elem.id);
+    const taskLabel = getTaskLabelByPipelineFlowElement(elem);
     const executions = taskNameToExecution
-      .get(taskName)
+      .get(taskLabel)
       ?.filter(exec => exec.getId() === elem.data?.mlmdId);
     return executions ? { execution: executions[0] } : {};
   }

--- a/frontend/src/lib/v2/DynamicFlow.ts
+++ b/frontend/src/lib/v2/DynamicFlow.ts
@@ -264,12 +264,13 @@ export function updateFlowElementsState(
     return flowGraph;
   }
   for (let elem of elems) {
-    const taskLabel = elem.data?.label;
-    if (taskLabel === undefined)
-      throw new Error('task label cannot be undefined');
     let updatedElem = Object.assign({}, elem);
     if (NodeTypeNames.EXECUTION === elem.type) {
-      const executions = getExecutionsUnderDAG(taskNameToExecution, taskLabel, executionLayers);
+      const executions = getExecutionsUnderDAG(
+          taskNameToExecution,
+          getTaskLabelByPipelineFlowElement(elem),
+          executionLayers
+      );
       if (executions) {
         (updatedElem.data as ExecutionFlowElementData).state = executions[0]?.getLastKnownState();
         (updatedElem.data as ExecutionFlowElementData).mlmdId = executions[0]?.getId();
@@ -292,7 +293,11 @@ export function updateFlowElementsState(
       (updatedElem.data as ArtifactFlowElementData).mlmdId = linkedArtifact?.artifact?.getId();
     } else if (NodeTypeNames.SUB_DAG === elem.type) {
       // TODO: Update sub-dag state based on future design.
-      const executions = getExecutionsUnderDAG(taskNameToExecution, taskLabel, executionLayers);
+      const executions = getExecutionsUnderDAG(
+          taskNameToExecution,
+          getTaskLabelByPipelineFlowElement(elem),
+          executionLayers
+      );
       if (executions) {
         (updatedElem.data as SubDagFlowElementData).state = executions[0]?.getLastKnownState();
         (updatedElem.data as SubDagFlowElementData).mlmdId = executions[0]?.getId();
@@ -301,6 +306,13 @@ export function updateFlowElementsState(
     flowGraph.push(updatedElem);
   }
   return flowGraph;
+}
+
+function getTaskLabelByPipelineFlowElement(elem: PipelineFlowElement) {
+  const taskLabel = elem.data?.label;
+  if (taskLabel === undefined)
+    throw new Error('task label is undefined');
+  return taskLabel;
 }
 
 function getExecutionsUnderDAG(

--- a/frontend/src/lib/v2/DynamicFlow.ts
+++ b/frontend/src/lib/v2/DynamicFlow.ts
@@ -311,7 +311,7 @@ export function updateFlowElementsState(
 function getTaskLabelByPipelineFlowElement(elem: PipelineFlowElement) {
   const taskLabel = elem.data?.label;
   if (taskLabel === undefined)
-    throw new Error('task label is undefined');
+    return getTaskKeyFromNodeKey(elem.id);
   return taskLabel;
 }
 

--- a/frontend/src/lib/v2/DynamicFlow.ts
+++ b/frontend/src/lib/v2/DynamicFlow.ts
@@ -267,9 +267,9 @@ export function updateFlowElementsState(
     let updatedElem = Object.assign({}, elem);
     if (NodeTypeNames.EXECUTION === elem.type) {
       const executions = getExecutionsUnderDAG(
-          taskNameToExecution,
-          getTaskLabelByPipelineFlowElement(elem),
-          executionLayers
+        taskNameToExecution,
+        getTaskLabelByPipelineFlowElement(elem),
+        executionLayers,
       );
       if (executions) {
         (updatedElem.data as ExecutionFlowElementData).state = executions[0]?.getLastKnownState();
@@ -294,9 +294,9 @@ export function updateFlowElementsState(
     } else if (NodeTypeNames.SUB_DAG === elem.type) {
       // TODO: Update sub-dag state based on future design.
       const executions = getExecutionsUnderDAG(
-          taskNameToExecution,
-          getTaskLabelByPipelineFlowElement(elem),
-          executionLayers
+        taskNameToExecution,
+        getTaskLabelByPipelineFlowElement(elem),
+        executionLayers,
       );
       if (executions) {
         (updatedElem.data as SubDagFlowElementData).state = executions[0]?.getLastKnownState();
@@ -310,8 +310,7 @@ export function updateFlowElementsState(
 
 function getTaskLabelByPipelineFlowElement(elem: PipelineFlowElement) {
   const taskLabel = elem.data?.label;
-  if (taskLabel === undefined)
-    return getTaskKeyFromNodeKey(elem.id);
+  if (taskLabel === undefined) return getTaskKeyFromNodeKey(elem.id);
   return taskLabel;
 }
 


### PR DESCRIPTION
Fix: https://github.com/kubeflow/pipelines/issues/9611

## Description

The `metadata.Execution` object does not store, the task name, but the task display_name used. When calling [getTaskNameToExecution](https://github.com/kubeflow/pipelines/blob/ba322abb010d832539d57e90c34be0557f550252/frontend/src/lib/v2/DynamicFlow.ts#L373), you get a map of `display_name -> executions[]`. The frontend was using the task name as key, leading to undefined execution.

