### PR TITLE
chore(frontend): Avoid redundant v2 API call in PipelineDetails.

### DIFF
--- a/frontend/src/pages/PipelineDetails.test.tsx
+++ b/frontend/src/pages/PipelineDetails.test.tsx
@@ -54,6 +54,7 @@ describe('PipelineDetails', () => {
   const getExperimentSpy = jest.spyOn(Apis.experimentServiceApiV2, 'getExperiment');
   const deletePipelineVersionSpy = jest.spyOn(Apis.pipelineServiceApiV2, 'deletePipelineVersion');
   const createGraphSpy = jest.spyOn(StaticGraphParser, 'createGraph');
+  const PIPELINE_VERSION_ID = 'test-pipeline-version-id';
 
   let tree: ShallowWrapper | ReactWrapper;
   let testV1Pipeline: ApiPipeline = {};
@@ -61,19 +62,23 @@ describe('PipelineDetails', () => {
   let testV1Run: ApiRunDetail = {};
   let testV1RecurringRun: ApiJob = {};
   let testV2Pipeline: V2beta1Pipeline = {};
-  let testV2PipelineVersion: V2beta1PipelineVersion = {};
+  let originalTestV2PipelineVersion: V2beta1PipelineVersion = {};
+  let newTestV2PipelineVersion: V2beta1PipelineVersion = {};
   let testV2Run: V2beta1Run = {};
   let testV2RecurringRun: V2beta1RecurringRun = {};
 
-  function generateProps(fromRunSpec = false, fromRecurringRunSpec = false): PageProps {
+  function generateProps(
+    versionId?: string,
+    fromRunSpec = false,
+    fromRecurringRunSpec = false,
+  ): PageProps {
     let params = {};
     // If no fromXXX parameter is provided, it means KFP UI expects to
     // show Pipeline detail with pipeline version ID
     if (!fromRunSpec && !fromRecurringRunSpec) {
       params = {
-        [RouteParams.pipelineId]: testV1Pipeline.id,
-        [RouteParams.pipelineVersionId]:
-          (testV1Pipeline.default_version && testV1Pipeline.default_version!.id) || '',
+        [RouteParams.pipelineId]: testV2Pipeline.pipeline_id,
+        [RouteParams.pipelineVersionId]: versionId || '',
       };
     }
 
@@ -151,10 +156,19 @@ describe('PipelineDetails', () => {
       display_name: 'test pipeline',
     };
 
-    testV2PipelineVersion = {
+    originalTestV2PipelineVersion = {
       display_name: 'test-pipeline-version',
       pipeline_id: 'test-pipeline-id',
       pipeline_version_id: 'test-pipeline-version-id',
+      pipeline_spec: JsYaml.safeLoad(
+        'spec:\n  arguments:\n    parameters:\n      - name: output\n',
+      ),
+    };
+
+    newTestV2PipelineVersion = {
+      display_name: 'new-test-pipeline-version',
+      pipeline_id: 'test-pipeline-id',
+      pipeline_version_id: 'new-test-pipeline-version-id',
       pipeline_spec: JsYaml.safeLoad(
         'spec:\n  arguments:\n    parameters:\n      - name: output\n',
       ),
@@ -181,9 +195,11 @@ describe('PipelineDetails', () => {
     getV1RecurringRunSpy.mockImplementation(() => Promise.resolve(testV1RecurringRun));
 
     getV2PipelineSpy.mockImplementation(() => Promise.resolve(testV2Pipeline));
-    getV2PipelineVersionSpy.mockImplementation(() => Promise.resolve(testV2PipelineVersion));
+    getV2PipelineVersionSpy.mockImplementation(() =>
+      Promise.resolve(originalTestV2PipelineVersion),
+    );
     listV2PipelineVersionsSpy.mockImplementation(() =>
-      Promise.resolve({ versions: [testV2PipelineVersion] }),
+      Promise.resolve({ pipeline_versions: [originalTestV2PipelineVersion] }),
     );
     getV2RunSpy.mockImplementation(() => Promise.resolve(testV2Run));
     getV2RecurringRunSpy.mockImplementation(() => Promise.resolve(testV2RecurringRun));
@@ -210,7 +226,8 @@ describe('PipelineDetails', () => {
     expect(updateToolbarSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
         breadcrumbs: [{ displayName: 'Pipelines', href: RoutePage.PIPELINES }],
-        pageTitle: testV1Pipeline.name + ' (' + testV1PipelineVersion.name + ')',
+        pageTitle:
+          testV2Pipeline.display_name + ' (' + originalTestV2PipelineVersion.display_name + ')',
       }),
     );
   });
@@ -219,7 +236,7 @@ describe('PipelineDetails', () => {
     'shows all runs breadcrumbs, and "Pipeline details" as page title when the pipeline ' +
       'comes from a run spec that does not have an experiment',
     async () => {
-      tree = shallow(<PipelineDetails {...generateProps(true)} />);
+      tree = shallow(<PipelineDetails {...generateProps(undefined, true)} />);
       await getV1RunSpy;
       await getV2RunSpy;
       await createGraphSpy;
@@ -243,7 +260,7 @@ describe('PipelineDetails', () => {
     'shows all runs breadcrumbs, and "Pipeline details" as page title when the pipeline ' +
       'comes from a recurring run spec that does not have an experiment',
     async () => {
-      tree = shallow(<PipelineDetails {...generateProps(false, true)} />);
+      tree = shallow(<PipelineDetails {...generateProps(undefined, false, true)} />);
       await getV1RecurringRunSpy;
       await getV2RecurringRunSpy;
       await TestUtils.flushPromises();
@@ -270,7 +287,7 @@ describe('PipelineDetails', () => {
       'comes from a run spec that has an experiment',
     async () => {
       testV2Run.experiment_id = 'test-experiment-id';
-      tree = shallow(<PipelineDetails {...generateProps(true)} />);
+      tree = shallow(<PipelineDetails {...generateProps(undefined, true)} />);
       await getV1RunSpy;
       await getV2RunSpy;
       await getExperimentSpy;
@@ -302,7 +319,7 @@ describe('PipelineDetails', () => {
       'comes from a recurring run spec that has an experiment',
     async () => {
       testV2RecurringRun.experiment_id = 'test-experiment-id';
-      tree = shallow(<PipelineDetails {...generateProps(false, true)} />);
+      tree = shallow(<PipelineDetails {...generateProps(undefined, false, true)} />);
       await getV1RecurringRunSpy;
       await getV2RecurringRunSpy;
       await getExperimentSpy;
@@ -341,7 +358,7 @@ describe('PipelineDetails', () => {
         workflow_manifest: '{"spec": {"arguments": {"parameters": [{"name": "output"}]}}}',
       };
 
-      tree = shallow(<PipelineDetails {...generateProps(true)} />);
+      tree = shallow(<PipelineDetails {...generateProps(undefined, true)} />);
       await getV1RunSpy;
       await getV2RunSpy;
       await TestUtils.flushPromises();
@@ -363,7 +380,7 @@ describe('PipelineDetails', () => {
       });
       testV2Run.pipeline_spec = { spec: { arguments: { parameters: [{ name: 'output' }] } } };
 
-      tree = shallow(<PipelineDetails {...generateProps(true)} />);
+      tree = shallow(<PipelineDetails {...generateProps(undefined, true)} />);
       await getV1RunSpy;
       await getV2RunSpy;
       await TestUtils.flushPromises();
@@ -388,7 +405,7 @@ describe('PipelineDetails', () => {
         spec: { arguments: { parameters: [{ name: 'output' }] } },
       };
 
-      tree = shallow(<PipelineDetails {...generateProps(false, true)} />);
+      tree = shallow(<PipelineDetails {...generateProps(undefined, false, true)} />);
       await getV1RecurringRunSpy;
       await getV2RecurringRunSpy;
       await TestUtils.flushPromises();
@@ -409,7 +426,7 @@ describe('PipelineDetails', () => {
     testV2Run.pipeline_version_reference.pipeline_id = 'test-pipeline-id';
     testV2Run.pipeline_version_reference.pipeline_version_id = 'test-pipeline-version-id';
 
-    tree = shallow(<PipelineDetails {...generateProps(true)} />);
+    tree = shallow(<PipelineDetails {...generateProps(undefined, true)} />);
     await getV1RunSpy;
     await getV2RunSpy;
     await getV2PipelineVersionSpy;
@@ -420,9 +437,29 @@ describe('PipelineDetails', () => {
     );
   });
 
+  it('calls listPipelineVersions() if no pipeline version id', async () => {
+    listV2PipelineVersionsSpy.mockImplementation(() =>
+      Promise.resolve({
+        pipeline_versions: [newTestV2PipelineVersion, originalTestV2PipelineVersion],
+      }),
+    );
+    render(<PipelineDetails {...generateProps()} />);
+
+    await waitFor(() => {
+      expect(listV2PipelineVersionsSpy).toHaveBeenCalled();
+    });
+
+    expect(updateToolbarSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        breadcrumbs: [{ displayName: 'Pipelines', href: RoutePage.PIPELINES }],
+        pageTitle: testV2Pipeline.display_name + ' (' + newTestV2PipelineVersion.display_name + ')',
+      }),
+    );
+  });
+
   it('renders "No graph to show" if it is empty pipeline', async () => {
     TestUtils.makeErrorResponse(getV2PipelineVersionSpy, 'No pipeline version is found');
-    render(<PipelineDetails {...generateProps()} />);
+    render(<PipelineDetails {...generateProps(PIPELINE_VERSION_ID)} />);
 
     await waitFor(() => {
       expect(getV2PipelineVersionSpy).toHaveBeenCalled();
@@ -441,7 +478,7 @@ describe('PipelineDetails', () => {
     testV2RecurringRun.pipeline_version_reference.pipeline_id = 'test-pipeline-id';
     testV2RecurringRun.pipeline_version_reference.pipeline_version_id = 'test-pipeline-version-id';
 
-    tree = shallow(<PipelineDetails {...generateProps(false, true)} />);
+    tree = shallow(<PipelineDetails {...generateProps(undefined, false, true)} />);
     await getV1RecurringRunSpy;
     await getV2RecurringRunSpy;
     await getV2PipelineVersionSpy;
@@ -460,7 +497,7 @@ describe('PipelineDetails', () => {
         pipeline_id: 'run-pipeline-id',
         workflow_manifest: 'not valid JSON',
       };
-      render(<PipelineDetails {...generateProps(true)} />);
+      render(<PipelineDetails {...generateProps(undefined, true)} />);
 
       await waitFor(() => {
         expect(getV1RunSpy).toHaveBeenCalled();
@@ -481,7 +518,7 @@ describe('PipelineDetails', () => {
 
   it('shows load error banner when failing to get run details, when loading from run spec', async () => {
     TestUtils.makeErrorResponseOnce(getV1RunSpy, 'woops');
-    tree = shallow(<PipelineDetails {...generateProps(true)} />);
+    tree = shallow(<PipelineDetails {...generateProps(undefined, true)} />);
     await getV1PipelineSpy;
     await TestUtils.flushPromises();
     expect(updateBannerSpy).toHaveBeenCalledTimes(2); // Once to clear banner, once to show error
@@ -500,7 +537,7 @@ describe('PipelineDetails', () => {
     async () => {
       testV2Run.experiment_id = 'test-experiment-id';
       TestUtils.makeErrorResponse(getExperimentSpy, 'woops');
-      tree = shallow(<PipelineDetails {...generateProps(true)} />);
+      tree = shallow(<PipelineDetails {...generateProps(undefined, true)} />);
       await getV1PipelineSpy;
       await TestUtils.flushPromises();
       expect(updateBannerSpy).toHaveBeenCalledTimes(2); // Once to clear banner, once to show error
@@ -531,10 +568,9 @@ describe('PipelineDetails', () => {
 
   it('shows load error banner when failing to get pipeline version', async () => {
     TestUtils.makeErrorResponse(getV2PipelineVersionSpy, 'No pipeline version is found');
-    render(<PipelineDetails {...generateProps()} />);
+    render(<PipelineDetails {...generateProps(PIPELINE_VERSION_ID)} />);
 
     await waitFor(() => {
-      // one for selected Version, another for template string
       expect(getV2PipelineVersionSpy).toHaveBeenCalled();
       // get version error will use empty string as template string, which won't call createGraph()
       expect(createGraphSpy).toHaveBeenCalledTimes(0);
@@ -566,7 +602,7 @@ describe('PipelineDetails', () => {
         pipeline_version_id: 'test-pipeline-version-id',
         pipeline_spec: undefined, // empty pipeline_spec
       });
-      render(<PipelineDetails {...generateProps()} />);
+      render(<PipelineDetails {...generateProps(PIPELINE_VERSION_ID)} />);
 
       await waitFor(() => {
         expect(getV2PipelineVersionSpy).toHaveBeenCalled();
@@ -596,7 +632,7 @@ describe('PipelineDetails', () => {
         pipeline_version_id: 'test-pipeline-version-id',
         pipeline_spec: {}, // invalid pipeline_spec
       });
-      render(<PipelineDetails {...generateProps()} />);
+      render(<PipelineDetails {...generateProps(PIPELINE_VERSION_ID)} />);
 
       await waitFor(() => {
         expect(getV2PipelineVersionSpy).toHaveBeenCalled();
@@ -630,7 +666,7 @@ describe('PipelineDetails', () => {
       },
     });
     TestUtils.makeErrorResponse(createGraphSpy, 'bad graph');
-    render(<PipelineDetails {...generateProps()} />);
+    render(<PipelineDetails {...generateProps(PIPELINE_VERSION_ID)} />);
 
     await waitFor(() => {
       expect(getV2PipelineVersionSpy).toHaveBeenCalled();
@@ -656,7 +692,7 @@ describe('PipelineDetails', () => {
   });
 
   it("has 'clone run' toolbar button if viewing an embedded pipeline", async () => {
-    tree = shallow(<PipelineDetails {...generateProps(true)} />);
+    tree = shallow(<PipelineDetails {...generateProps(undefined, true)} />);
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
     /* create run and create pipeline version, so 2 */
@@ -666,7 +702,7 @@ describe('PipelineDetails', () => {
   });
 
   it("has 'clone recurring run' toolbar button if viewing an embedded pipeline from recurring run", async () => {
-    tree = shallow(<PipelineDetails {...generateProps(false, true)} />);
+    tree = shallow(<PipelineDetails {...generateProps(undefined, false, true)} />);
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
     /* create run and create pipeline version, so 2 */
@@ -681,7 +717,7 @@ describe('PipelineDetails', () => {
     'clicking clone run button when viewing embedded pipeline navigates to ' +
       'the new run page (clone a run) with run ID',
     async () => {
-      tree = shallow(<PipelineDetails {...generateProps(true)} />);
+      tree = shallow(<PipelineDetails {...generateProps(undefined, true)} />);
       await TestUtils.flushPromises();
       const instance = tree.instance() as PipelineDetails;
       const cloneRunBtn = instance.getInitialToolbarState().actions[ButtonKeys.CLONE_RUN];
@@ -697,7 +733,7 @@ describe('PipelineDetails', () => {
     'clicking clone recurring run button when viewing embedded pipeline from recurring run' +
       'navigates to the new run page (clone a recurring run) with recurring run ID',
     async () => {
-      tree = shallow(<PipelineDetails {...generateProps(false, true)} />);
+      tree = shallow(<PipelineDetails {...generateProps(undefined, false, true)} />);
       await TestUtils.flushPromises();
       const instance = tree.instance() as PipelineDetails;
       const cloneRecurringRunBtn = instance.getInitialToolbarState().actions[
@@ -713,7 +749,7 @@ describe('PipelineDetails', () => {
   );
 
   it("has 'create run' toolbar button if not viewing an embedded pipeline", async () => {
-    tree = shallow(<PipelineDetails {...generateProps(false)} />);
+    tree = shallow(<PipelineDetails {...generateProps(undefined, false)} />);
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
     /* create run, create pipeline version, create experiment and delete run, so 4 */
@@ -725,7 +761,7 @@ describe('PipelineDetails', () => {
   });
 
   it('clicking new run button navigates to the new run page', async () => {
-    tree = shallow(<PipelineDetails {...generateProps(false)} />);
+    tree = shallow(<PipelineDetails {...generateProps(PIPELINE_VERSION_ID, false)} />);
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
     const newRunFromPipelineVersionBtn = instance.getInitialToolbarState().actions[
@@ -735,9 +771,7 @@ describe('PipelineDetails', () => {
     expect(historyPushSpy).toHaveBeenCalledTimes(1);
     expect(historyPushSpy).toHaveBeenLastCalledWith(
       RoutePage.NEW_RUN +
-        `?${QUERY_PARAMS.pipelineId}=${testV1Pipeline.id}&${
-          QUERY_PARAMS.pipelineVersionId
-        }=${testV1Pipeline.default_version!.id!}`,
+        `?${QUERY_PARAMS.pipelineId}=${testV2Pipeline.pipeline_id}&${QUERY_PARAMS.pipelineVersionId}=${PIPELINE_VERSION_ID}`,
     );
   });
 
@@ -745,7 +779,7 @@ describe('PipelineDetails', () => {
     'clicking new run button when viewing half-loaded page navigates to ' +
       'the new run page with pipeline ID and version ID',
     async () => {
-      tree = shallow(<PipelineDetails {...generateProps(false)} />);
+      tree = shallow(<PipelineDetails {...generateProps(PIPELINE_VERSION_ID, false)} />);
       // Intentionally don't wait until all network requests finish.
       const instance = tree.instance() as PipelineDetails;
       const newRunFromPipelineVersionBtn = instance.getInitialToolbarState().actions[
@@ -755,9 +789,7 @@ describe('PipelineDetails', () => {
       expect(historyPushSpy).toHaveBeenCalledTimes(1);
       expect(historyPushSpy).toHaveBeenLastCalledWith(
         RoutePage.NEW_RUN +
-          `?${QUERY_PARAMS.pipelineId}=${testV1Pipeline.id}&${
-            QUERY_PARAMS.pipelineVersionId
-          }=${testV1Pipeline.default_version!.id!}`,
+          `?${QUERY_PARAMS.pipelineId}=${testV2Pipeline.pipeline_id}&${QUERY_PARAMS.pipelineVersionId}=${PIPELINE_VERSION_ID}`,
       );
     },
   );
@@ -791,7 +823,7 @@ describe('PipelineDetails', () => {
   );
 
   it('has a delete button and it is enabled for pipeline version deletion', async () => {
-    tree = shallow(<PipelineDetails {...generateProps()} />);
+    tree = shallow(<PipelineDetails {...generateProps(PIPELINE_VERSION_ID)} />);
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
     const deleteBtn = instance.getInitialToolbarState().actions[ButtonKeys.DELETE_RUN];
@@ -801,9 +833,6 @@ describe('PipelineDetails', () => {
 
   it('has a delete button, and it is disabled because no version is selected', async () => {
     let pageProps = generateProps();
-    pageProps.match.params = {
-      [RouteParams.pipelineId]: testV1Pipeline.id,
-    };
     tree = shallow(<PipelineDetails {...pageProps} />);
 
     await TestUtils.flushPromises();
@@ -814,7 +843,7 @@ describe('PipelineDetails', () => {
   });
 
   it('shows delete confirmation dialog when delete button is clicked', async () => {
-    tree = shallow(<PipelineDetails {...generateProps()} />);
+    tree = shallow(<PipelineDetails {...generateProps(PIPELINE_VERSION_ID)} />);
     const deleteBtn = (tree.instance() as PipelineDetails).getInitialToolbarState().actions[
       ButtonKeys.DELETE_RUN
     ];
@@ -828,7 +857,7 @@ describe('PipelineDetails', () => {
   });
 
   it('does not call delete API for selected pipeline when delete dialog is canceled', async () => {
-    tree = shallow(<PipelineDetails {...generateProps()} />);
+    tree = shallow(<PipelineDetails {...generateProps(PIPELINE_VERSION_ID)} />);
     const deleteBtn = (tree.instance() as PipelineDetails).getInitialToolbarState().actions[
       ButtonKeys.DELETE_RUN
     ];
@@ -840,7 +869,7 @@ describe('PipelineDetails', () => {
   });
 
   it('calls delete API when delete dialog is confirmed', async () => {
-    tree = shallow(<PipelineDetails {...generateProps()} />);
+    tree = shallow(<PipelineDetails {...generateProps(PIPELINE_VERSION_ID)} />);
     await TestUtils.flushPromises();
     const deleteBtn = (tree.instance() as PipelineDetails).getInitialToolbarState().actions[
       ButtonKeys.DELETE_RUN
@@ -857,7 +886,7 @@ describe('PipelineDetails', () => {
   });
 
   it('calls delete API when delete dialog is confirmed and page is half-loaded', async () => {
-    tree = shallow(<PipelineDetails {...generateProps()} />);
+    tree = shallow(<PipelineDetails {...generateProps(PIPELINE_VERSION_ID)} />);
     // Intentionally don't wait until all network requests finish.
     const deleteBtn = (tree.instance() as PipelineDetails).getInitialToolbarState().actions[
       ButtonKeys.DELETE_RUN
@@ -874,7 +903,7 @@ describe('PipelineDetails', () => {
   });
 
   it('shows error dialog if deletion fails', async () => {
-    tree = shallow(<PipelineDetails {...generateProps()} />);
+    tree = shallow(<PipelineDetails {...generateProps(PIPELINE_VERSION_ID)} />);
     TestUtils.makeErrorResponseOnce(deletePipelineVersionSpy, 'woops');
     await TestUtils.flushPromises();
     const deleteBtn = (tree.instance() as PipelineDetails).getInitialToolbarState().actions[
@@ -894,7 +923,7 @@ describe('PipelineDetails', () => {
   });
 
   it('shows success snackbar if deletion succeeds', async () => {
-    tree = shallow(<PipelineDetails {...generateProps()} />);
+    tree = shallow(<PipelineDetails {...generateProps(PIPELINE_VERSION_ID)} />);
     await TestUtils.flushPromises();
     const deleteBtn = (tree.instance() as PipelineDetails).getInitialToolbarState().actions[
       ButtonKeys.DELETE_RUN

--- a/frontend/src/pages/PipelineDetails.test.tsx
+++ b/frontend/src/pages/PipelineDetails.test.tsx
@@ -535,12 +535,12 @@ describe('PipelineDetails', () => {
 
     await waitFor(() => {
       // one for selected Version, another for template string
-      expect(getV2PipelineVersionSpy).toHaveBeenCalledTimes(2);
+      expect(getV2PipelineVersionSpy).toHaveBeenCalled();
       // get version error will use empty string as template string, which won't call createGraph()
       expect(createGraphSpy).toHaveBeenCalledTimes(0);
     });
 
-    expect(updateBannerSpy).toHaveBeenCalledTimes(3); // Clear banner, show error two times
+    expect(updateBannerSpy).toHaveBeenCalledTimes(2); // // Once to clear banner, once to show error
     expect(updateBannerSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
         additionalInfo: 'No pipeline version is found',

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -282,7 +282,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
         this.setStateSafe({ graphIsLoading: false });
         await this.showPageError('Cannot retrieve pipeline version.', err);
         logger.error('Cannot retrieve pipeline version.', err);
-        return;
+        return undefined;
       }
     } else {
       // Get the latest version if no version id
@@ -295,16 +295,19 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
           'created_at desc',
         );
 
-        if (listVersionsResponse.pipeline_versions) {
+        if (
+          listVersionsResponse.pipeline_versions &&
+          listVersionsResponse.pipeline_versions.length > 0
+        ) {
           selectedVersion = listVersionsResponse.pipeline_versions[0];
         } else {
-          return;
+          return undefined;
         }
       } catch (err) {
         this.setStateSafe({ graphIsLoading: false });
         await this.showPageError('Cannot retrieve pipeline version list.', err);
         logger.error('Cannot retrieve pipeline version list.', err);
-        return;
+        return undefined;
       }
     }
     return selectedVersion;

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -273,10 +273,11 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
 
   // We don't have default version in v2 pipeline proto, choose the latest version instead.
   private async getSelectedVersion(pipelineId: string, versionId?: string) {
+    let selectedVersion: V2beta1PipelineVersion;
     // Get specific version if version id is provided
     if (versionId) {
       try {
-        return await Apis.pipelineServiceApiV2.getPipelineVersion(pipelineId, versionId);
+        selectedVersion = await Apis.pipelineServiceApiV2.getPipelineVersion(pipelineId, versionId);
       } catch (err) {
         this.setStateSafe({ graphIsLoading: false });
         await this.showPageError('Cannot retrieve pipeline version.', err);
@@ -286,7 +287,6 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
     } else {
       // Get the latest version if no version id
       let listVersionsResponse: V2beta1ListPipelineVersionsResponse;
-      let latesetVersion: V2beta1PipelineVersion;
       try {
         listVersionsResponse = await Apis.pipelineServiceApiV2.listPipelineVersions(
           pipelineId,
@@ -296,14 +296,10 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
         );
 
         if (listVersionsResponse.pipeline_versions) {
-          latesetVersion = listVersionsResponse.pipeline_versions[0];
-          // Append version id to URL for create run (new run switcher call getPipelineVersion)
-          this.props.history.replace({
-            pathname: `/pipelines/details/${pipelineId}/version/${latesetVersion.pipeline_version_id}`,
-          });
-          return latesetVersion;
+          selectedVersion = listVersionsResponse.pipeline_versions[0];
+        } else {
+          return;
         }
-        return undefined;
       } catch (err) {
         this.setStateSafe({ graphIsLoading: false });
         await this.showPageError('Cannot retrieve pipeline version list.', err);
@@ -311,6 +307,8 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
         return;
       }
     }
+    this.setStateSafe({ v2SelectedVersion: selectedVersion });
+    return selectedVersion;
   }
 
   public async load(): Promise<void> {
@@ -523,10 +521,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
           logger.error('Cannot retrieve pipeline versions.', err);
           return;
         }
-        templateString = await this._getTemplateString(
-          pipelineId,
-          v2SelectedVersion ? v2SelectedVersion.pipeline_version_id! : v1SelectedVersion?.id!,
-        );
+        templateString = await this._getTemplateString(v2SelectedVersion);
       }
 
       breadcrumbs = [{ displayName: 'Pipelines', href: RoutePage.PIPELINES }];
@@ -583,10 +578,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
         ')',
       );
 
-      const selectedVersionPipelineTemplate = await this._getTemplateString(
-        this.state.v2Pipeline.pipeline_id!,
-        versionId,
-      );
+      const selectedVersionPipelineTemplate = await this._getTemplateString(v2SelectedVersion);
       this.props.history.replace({
         pathname: `/pipelines/details/${this.state.v2Pipeline.pipeline_id}/version/${versionId}`,
       });
@@ -618,28 +610,13 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
     }
   }
 
-  private async _getTemplateString(pipelineId: string, versionId: string): Promise<string> {
-    try {
-      // Get template string from pipeline_spec in pipeline version (v2 API)
-      let pipelineVersion;
-      let pipelineSpecInVersion;
-      if (pipelineId && versionId) {
-        pipelineVersion = await Apis.pipelineServiceApiV2.getPipelineVersion(pipelineId, versionId);
-        pipelineSpecInVersion = pipelineVersion.pipeline_spec;
-      }
-
-      if (pipelineSpecInVersion) {
-        return JsYaml.safeDump(pipelineSpecInVersion);
-      } else {
-        logger.error('No template string is found');
-        return '';
-      }
-    } catch (err) {
-      this.setStateSafe({ graphIsLoading: false });
-      await this.showPageError('Cannot retrieve pipeline version.', err);
-      logger.error('Cannot retrieve pipeline details.', err);
+  private async _getTemplateString(pipelineVersion?: V2beta1PipelineVersion): Promise<string> {
+    if (pipelineVersion?.pipeline_spec) {
+      return JsYaml.safeDump(pipelineVersion.pipeline_spec);
+    } else {
+      logger.error('No template string is found');
+      return '';
     }
-    return '';
   }
 
   private async _createGraph(

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -307,7 +307,6 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
         return;
       }
     }
-    this.setStateSafe({ v2SelectedVersion: selectedVersion });
     return selectedVersion;
   }
 


### PR DESCRIPTION
Part of #9731 
Previously, we update the URL with `pipelineVersionId` obtained in getSelectedVersion(), and it will cause to re-render the page, which brings out several redundant API calls. The PR is removing the URL update logic to avoid those calls. Also, the getPipelineVersion() in _getTemplateString() is not necessary either, so it's removed as well.