### PR TITLE
Set image-type to cos_containerd in tests

### DIFF
--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -88,7 +88,9 @@ else
   fi
   # Use regular release channel to keep up with newly created clusters in Google Cloud Marketplace.
   # TODO(#9706): Switch back to regular channel once we stop building test images via dind.
-  gcloud container clusters create ${TEST_CLUSTER} --release-channel stable ${SCOPE_ARG} ${NODE_POOL_CONFIG_ARG} ${WI_ARG}
+  # Temporarily use cos as image type until docker dependencies gets removed. 
+  # reference: https://github.com/kubeflow/pipelines/issues/6696
+  gcloud container clusters create ${TEST_CLUSTER} --release-channel stable --image-type cos_containerd ${SCOPE_ARG} ${NODE_POOL_CONFIG_ARG} ${WI_ARG}
 fi
 
 gcloud container clusters get-credentials ${TEST_CLUSTER}


### PR DESCRIPTION
Reverting the previous change #9705 which removed the `--image-type`.

/hold

Check if this resolves [e2e test failures](https://oss.gprow.dev/view/gs/oss-prow/pr-logs/pull/kubeflow_pipelines/9730/kubeflow-pipeline-e2e-test/1680988618279096320#1:build-log.txt%3A2) in #9730

**Description of your changes:**


**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
