### PR TITLE
feat(frontend): Adding logic to fetch pipeline name in ArtifactsList

### DIFF
--- a/frontend/src/mlmd/MlmdUtils.ts
+++ b/frontend/src/mlmd/MlmdUtils.ts
@@ -252,12 +252,7 @@ export async function getContextByExecution(
   return result[0];
 }
 
-export async function getContextsByExecution(execution: Execution): Promise<Context[]> {
-  const executionId = execution.getId();
-  if (!executionId) {
-    throw new Error('Execution must have an ID');
-  }
-
+export async function getContextsByExecutionID(executionId: number): Promise<Context[]> {
   const request = new GetContextsByExecutionRequest().setExecutionId(executionId);
   let response: GetContextsByExecutionResponse;
   try {
@@ -267,6 +262,15 @@ export async function getContextsByExecution(execution: Execution): Promise<Cont
     throw err;
   }
   return response.getContextsList();
+}
+
+export async function getContextsByExecution(execution: Execution): Promise<Context[]> {
+  const executionId = execution.getId();
+  if (!executionId) {
+    throw new Error('Execution must have an ID');
+  }
+
+  return await getContextsByExecutionID(executionId);
 }
 
 async function getContextType(contextTypeName: string): Promise<ContextType | undefined> {

--- a/frontend/src/mlmd/MlmdUtils.ts
+++ b/frontend/src/mlmd/MlmdUtils.ts
@@ -38,10 +38,10 @@ import {
   GetArtifactsByIDResponse,
   GetArtifactTypesRequest,
   GetArtifactTypesResponse,
-  GetContextByTypeAndNameRequest,
+  GetContextByTypeAndNameRequest, GetEventsByArtifactIDsRequest, GetEventsByArtifactIDsResponse,
   GetEventsByExecutionIDsRequest,
   GetEventsByExecutionIDsResponse,
-  GetExecutionsByContextRequest,
+  GetExecutionsByContextRequest, GetExecutionsByIDRequest, GetExecutionsByIDResponse,
 } from 'src/third_party/mlmd';
 import {
   GetArtifactsByContextRequest,
@@ -248,7 +248,7 @@ export async function getContextByExecution(
   return result[0];
 }
 
-async function getContextsByExecution(execution: Execution): Promise<Context[]> {
+export async function getContextsByExecution(execution: Execution): Promise<Context[]> {
   const executionId = execution.getId();
   if (!executionId) {
     throw new Error('Execution must have an ID');
@@ -353,6 +353,36 @@ export async function getArtifactTypes(): Promise<ArtifactType[]> {
     throw err;
   }
   return res.getArtifactTypesList();
+}
+
+export async function GetEventsByArtifactIDs(artifactIds: number[]): Promise<Event[]> {
+  const request = new GetEventsByArtifactIDsRequest();
+  request.setArtifactIdsList(artifactIds);
+
+  let res: GetEventsByArtifactIDsResponse;
+  try {
+    res = await Api.getInstance().metadataStoreService.getEventsByArtifactIDs(request);
+  } catch (err) {
+    err.message = 'Failed to GetEventsByArtifactIDs: ' + err.message;
+    throw err;
+  }
+  return res.getEventsList();
+}
+
+export async function GetExecutionsByIDs(executionIds: number[]): Promise<Execution[]> {
+  console.log("getExecutions", executionIds);
+  const request = new GetExecutionsByIDRequest();
+  request.setExecutionIdsList(executionIds);
+
+  let res: GetExecutionsByIDResponse;
+  try {
+    res = await Api.getInstance().metadataStoreService.getExecutionsByID(request);
+  } catch (err) {
+    err.message = 'Failed to GetEventsByArtifactIDs: ' + err.message;
+    throw err;
+  }
+
+  return res.getExecutionsList();
 }
 
 export function filterArtifactsByType(

--- a/frontend/src/mlmd/MlmdUtils.ts
+++ b/frontend/src/mlmd/MlmdUtils.ts
@@ -38,10 +38,14 @@ import {
   GetArtifactsByIDResponse,
   GetArtifactTypesRequest,
   GetArtifactTypesResponse,
-  GetContextByTypeAndNameRequest, GetEventsByArtifactIDsRequest, GetEventsByArtifactIDsResponse,
+  GetContextByTypeAndNameRequest,
+  GetEventsByArtifactIDsRequest,
+  GetEventsByArtifactIDsResponse,
   GetEventsByExecutionIDsRequest,
   GetEventsByExecutionIDsResponse,
-  GetExecutionsByContextRequest, GetExecutionsByIDRequest, GetExecutionsByIDResponse,
+  GetExecutionsByContextRequest,
+  GetExecutionsByIDRequest,
+  GetExecutionsByIDResponse,
 } from 'src/third_party/mlmd';
 import {
   GetArtifactsByContextRequest,
@@ -370,7 +374,6 @@ export async function GetEventsByArtifactIDs(artifactIds: number[]): Promise<Eve
 }
 
 export async function GetExecutionsByIDs(executionIds: number[]): Promise<Execution[]> {
-  console.log("getExecutions", executionIds);
   const request = new GetExecutionsByIDRequest();
   request.setExecutionIdsList(executionIds);
 

--- a/frontend/src/mlmd/Utils.tsx
+++ b/frontend/src/mlmd/Utils.tsx
@@ -29,7 +29,7 @@ import {
   ExecutionHelpers,
   getContextsByExecution,
   GetEventsByArtifactIDs,
-  GetExecutionsByIDs
+  GetExecutionsByIDs,
 } from './MlmdUtils';
 
 const ARTIFACT_FIELD_REPOS = [ArtifactProperties, ArtifactCustomProperties];
@@ -53,35 +53,19 @@ export function getResourceProperty(
   return (props && props.get(propertyName) && getMetadataValue(props.get(propertyName))) || null;
 }
 
-export async function getPipelineNameByArtifact(
-    res: Artifact
-): Promise<string> {
+export async function getPipelineNameByArtifact(res: Artifact): Promise<string> {
   const events = await GetEventsByArtifactIDs([res.getId()]);
-  if(events.length === 0)
-    return "[unknown]";
-
-  console.log("found " + events.length + " events: ", events);
+  if (events.length === 0) return '[unknown]';
 
   const executionId = events[0].getExecutionId();
   const executions = await GetExecutionsByIDs([executionId]);
-  if(executions.length === 0)
-    return "[unknown]";
-
-  console.log("found " + executions.length + " executions: ", executions);
+  if (executions.length === 0) return '[unknown]';
 
   const execution = executions[0];
   const contexts = await getContextsByExecution(execution);
-  if(contexts.length === 0)
-    return "[unknown]";
+  if (contexts.length === 0) return '[unknown]';
 
-  console.log("found " + contexts.length + " contexts: ", contexts);
-
-  contexts.forEach((context) => {
-    console.log(context.getPropertiesMap());
-    console.log(context.getName());
-  });
-
-  return contexts[0].getName()
+  return contexts[0].getName();
 }
 
 export function getResourcePropertyViaFallBack(
@@ -89,7 +73,6 @@ export function getResourcePropertyViaFallBack(
   fieldRepos: RepoType[],
   fields: string[],
 ): string {
-  console.log("getResourcePropertyViaFallBack", res, fieldRepos, fields);
   const prop =
     fields.reduce(
       (value: string, field: string) =>

--- a/frontend/src/mlmd/Utils.tsx
+++ b/frontend/src/mlmd/Utils.tsx
@@ -27,9 +27,8 @@ import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
 import {
   ArtifactHelpers,
   ExecutionHelpers,
-  getContextsByExecution,
+  getContextsByExecutionID,
   GetEventsByArtifactIDs,
-  GetExecutionsByIDs,
 } from './MlmdUtils';
 
 const ARTIFACT_FIELD_REPOS = [ArtifactProperties, ArtifactCustomProperties];
@@ -58,11 +57,7 @@ export async function getPipelineNameByArtifact(res: Artifact): Promise<string> 
   if (events.length === 0) return '[unknown]';
 
   const executionId = events[0].getExecutionId();
-  const executions = await GetExecutionsByIDs([executionId]);
-  if (executions.length === 0) return '[unknown]';
-
-  const execution = executions[0];
-  const contexts = await getContextsByExecution(execution);
+  const contexts = await getContextsByExecutionID(executionId);
   if (contexts.length === 0) return '[unknown]';
 
   return contexts[0].getName();

--- a/frontend/src/pages/ArtifactList.tsx
+++ b/frontend/src/pages/ArtifactList.tsx
@@ -47,7 +47,7 @@ import {
   serviceErrorToString,
 } from 'src/lib/Utils';
 import { Page } from 'src/pages/Page';
-import {getPipelineNameByArtifact} from "../mlmd/Utils";
+import { getPipelineNameByArtifact } from '../mlmd/Utils';
 
 interface ArtifactListProps {
   isGroupView: boolean;
@@ -214,7 +214,7 @@ export class ArtifactList extends Page<ArtifactListProps, ArtifactListState> {
   private async getFlattenedRowsFromArtifacts(
     request: ListRequest,
     artifacts: Artifact[],
-    artifactIdToPipelineName: Map<number, string>
+    artifactIdToPipelineName: Map<number, string>,
   ): Promise<Row[]> {
     try {
       const artifactsWithCreationTimes = await Promise.all(
@@ -239,7 +239,7 @@ export class ArtifactList extends Page<ArtifactListProps, ArtifactListState> {
           return {
             id: `${artifact.getId()}`,
             otherFields: [
-              artifactIdToPipelineName.get(artifact.getId()) || "[unknown]",
+              artifactIdToPipelineName.get(artifact.getId()) || '[unknown]',
               getResourcePropertyViaFallBack(artifact, ARTIFACT_PROPERTY_REPOS, NAME_FIELDS) ||
                 '[unknown]',
               artifact.getId(),
@@ -274,9 +274,13 @@ export class ArtifactList extends Page<ArtifactListProps, ArtifactListState> {
   private async getGroupedRowsFromArtifacts(
     request: ListRequest,
     artifacts: Artifact[],
-    artifactIdToPipelineName: Map<number, string>
+    artifactIdToPipelineName: Map<number, string>,
   ): Promise<CollapsedAndExpandedRows> {
-    const flattenedRows = await this.getFlattenedRowsFromArtifacts(request, artifacts, artifactIdToPipelineName);
+    const flattenedRows = await this.getFlattenedRowsFromArtifacts(
+      request,
+      artifacts,
+      artifactIdToPipelineName,
+    );
     return groupRows(flattenedRows);
   }
 


### PR DESCRIPTION
Fixes https://github.com/kubeflow/pipelines/issues/9746

**Description of your changes:**

Here is a small fix for removing the `getResourcePropertyViaFallBack` inside `pages/ArtifactList` responsible of getting the pipeline/workspace name from Artifact.

From what I can see when using V2, nor the Artifact and execution hold the Pipeline name, or workspaces.

To work around, I created a function taking called `getPipelineNameByArtifact`, the only place I could find the pipeline name was in the Context, to get the context I had to:
- Get Events By Artifact
- Take the execution id in the event
- GetContextByExecutionID
- Getting pipeline-name from context name.
