### PR TITLE
fix(frontend): Missing pipeline version name in new run page.

### DIFF
--- a/frontend/src/pages/PipelineDetails.test.tsx
+++ b/frontend/src/pages/PipelineDetails.test.tsx
@@ -760,6 +760,21 @@ describe('PipelineDetails', () => {
     expect(newRunBtn).toBeDefined();
   });
 
+  it('uses selected version ID to create run if URL does not contain version ID', async () => {
+    tree = shallow(<PipelineDetails {...generateProps()} />);
+    await TestUtils.flushPromises();
+    const instance = tree.instance() as PipelineDetails;
+    const newRunFromPipelineVersionBtn = instance.getInitialToolbarState().actions[
+      ButtonKeys.NEW_RUN_FROM_PIPELINE_VERSION
+    ];
+    newRunFromPipelineVersionBtn.action();
+    expect(historyPushSpy).toHaveBeenCalledTimes(1);
+    expect(historyPushSpy).toHaveBeenLastCalledWith(
+      RoutePage.NEW_RUN +
+        `?${QUERY_PARAMS.pipelineId}=${testV2Pipeline.pipeline_id}&${QUERY_PARAMS.pipelineVersionId}=${originalTestV2PipelineVersion.pipeline_version_id}`,
+    );
+  });
+
   it('clicking new run button navigates to the new run page', async () => {
     tree = shallow(<PipelineDetails {...generateProps(PIPELINE_VERSION_ID, false)} />);
     await TestUtils.flushPromises();

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -131,10 +131,18 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
       buttons
         .newRunFromPipelineVersion(
           () => {
-            return pipelineIdFromParams ? pipelineIdFromParams : '';
+            return this.state.v2Pipeline
+              ? this.state.v2Pipeline.pipeline_id
+              : pipelineIdFromParams
+              ? pipelineIdFromParams
+              : '';
           },
           () => {
-            return pipelineVersionIdFromParams ? pipelineVersionIdFromParams : '';
+            return this.state.v2SelectedVersion
+              ? this.state.v2SelectedVersion.pipeline_version_id
+              : pipelineVersionIdFromParams
+              ? pipelineVersionIdFromParams
+              : '';
           },
         )
         .newPipelineVersion('Upload version', () =>


### PR DESCRIPTION
Before:

https://github.com/kubeflow/pipelines/assets/56132941/55c99d6e-4d9a-4cf4-8a83-5468dfe50b3d



After:

https://github.com/kubeflow/pipelines/assets/56132941/5d67a453-40cb-4408-9aef-592231abd8bb


