### PR TITLE
chore(sdk): clean up artifact code

### DIFF
--- a/sdk/python/kfp-dsl/kfp/dsl/executor.py
+++ b/sdk/python/kfp-dsl/kfp/dsl/executor.py
@@ -357,11 +357,7 @@ def create_artifact_instance(
 
     artifact_cls = artifact_types._SCHEMA_TITLE_TO_TYPE.get(
         schema_title, artifact_cls)
-    return artifact_cls._from_executor_fields(
-        uri=runtime_artifact.get('uri', ''),
-        name=runtime_artifact.get('name', ''),
-        metadata=runtime_artifact.get('metadata', {}),
-    ) if hasattr(artifact_cls, '_from_executor_fields') else artifact_cls(
+    return artifact_cls(
         uri=runtime_artifact.get('uri', ''),
         name=runtime_artifact.get('name', ''),
         metadata=runtime_artifact.get('metadata', {}),

--- a/sdk/python/kfp-dsl/kfp/dsl/types/artifact_types.py
+++ b/sdk/python/kfp-dsl/kfp/dsl/types/artifact_types.py
@@ -11,10 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Classes for input/output Artifacts in KFP SDK.
-
-These are only compatible with v2 Pipelines.
-"""
+"""Classes for input/output Artifacts in KFP SDK."""
 
 from typing import Dict, List, Optional, Type
 
@@ -112,12 +109,6 @@ class Model(Artifact):
     """
     schema_title = 'system.Model'
 
-    def __init__(self,
-                 name: Optional[str] = None,
-                 uri: Optional[str] = None,
-                 metadata: Optional[Dict] = None) -> None:
-        super().__init__(uri=uri, name=name, metadata=metadata)
-
     @property
     def framework(self) -> str:
         return self._get_framework()
@@ -143,12 +134,6 @@ class Dataset(Artifact):
     """
     schema_title = 'system.Dataset'
 
-    def __init__(self,
-                 name: Optional[str] = None,
-                 uri: Optional[str] = None,
-                 metadata: Optional[Dict] = None) -> None:
-        super().__init__(uri=uri, name=name, metadata=metadata)
-
 
 class Metrics(Artifact):
     """An artifact for storing key-value scalar metrics.
@@ -159,12 +144,6 @@ class Metrics(Artifact):
         metadata: Key-value scalar metrics.
     """
     schema_title = 'system.Metrics'
-
-    def __init__(self,
-                 name: Optional[str] = None,
-                 uri: Optional[str] = None,
-                 metadata: Optional[Dict] = None) -> None:
-        super().__init__(uri=uri, name=name, metadata=metadata)
 
     def log_metric(self, metric: str, value: float) -> None:
         """Sets a custom scalar metric in the artifact's metadata.
@@ -185,12 +164,6 @@ class ClassificationMetrics(Artifact):
         metadata: The key-value scalar metrics.
     """
     schema_title = 'system.ClassificationMetrics'
-
-    def __init__(self,
-                 name: Optional[str] = None,
-                 uri: Optional[str] = None,
-                 metadata: Optional[Dict] = None):
-        super().__init__(uri=uri, name=name, metadata=metadata)
 
     def log_roc_data_point(self, fpr: float, tpr: float,
                            threshold: float) -> None:
@@ -355,12 +328,6 @@ class SlicedClassificationMetrics(Artifact):
 
     schema_title = 'system.SlicedClassificationMetrics'
 
-    def __init__(self,
-                 name: Optional[str] = None,
-                 uri: Optional[str] = None,
-                 metadata: Optional[Dict] = None) -> None:
-        super().__init__(uri=uri, name=name, metadata=metadata)
-
     def _upsert_classification_metrics_for_slice(self, slice: str) -> None:
         """Upserts the classification metrics instance for a slice."""
         if slice not in self._sliced_metrics:
@@ -479,12 +446,6 @@ class HTML(Artifact):
     """
     schema_title = 'system.HTML'
 
-    def __init__(self,
-                 name: Optional[str] = None,
-                 uri: Optional[str] = None,
-                 metadata: Optional[Dict] = None) -> None:
-        super().__init__(uri=uri, name=name, metadata=metadata)
-
 
 class Markdown(Artifact):
     """An artifact representing a markdown file.
@@ -495,12 +456,6 @@ class Markdown(Artifact):
         metadata: Arbitrary key-value pairs about the markdown file.
     """
     schema_title = 'system.Markdown'
-
-    def __init__(self,
-                 name: Optional[str] = None,
-                 uri: Optional[str] = None,
-                 metadata: Optional[Dict] = None):
-        super().__init__(uri=uri, name=name, metadata=metadata)
 
 
 _SCHEMA_TITLE_TO_TYPE: Dict[str, Type[Artifact]] = {

--- a/sdk/python/kfp-dsl/runtime_tests/executor_test.py
+++ b/sdk/python/kfp-dsl/runtime_tests/executor_test.py
@@ -21,6 +21,7 @@ import unittest
 from unittest import mock
 
 from absl.testing import parameterized
+from kfp import dsl
 from kfp.dsl import executor
 from kfp.dsl import Input
 from kfp.dsl import Output
@@ -113,14 +114,9 @@ class ExecutorTest(parameterized.TestCase):
         }
         """
 
-        class VertexDataset:
+        class VertexDataset(dsl.Artifact):
             schema_title = 'google.VertexDataset'
             schema_version = '0.0.0'
-
-            def __init__(self, name: str, uri: str, metadata: dict) -> None:
-                self.name = name
-                self.uri = uri
-                self.metadata = metadata
 
             @property
             def path(self) -> str:
@@ -1217,29 +1213,6 @@ class ExecutorTest(parameterized.TestCase):
         self.assertDictEqual(output_metadata, {})
 
 
-class VertexDataset:
-    schema_title = 'google.VertexDataset'
-    schema_version = '0.0.0'
-
-    @classmethod
-    def _from_executor_fields(
-        cls,
-        name: str,
-        uri: str,
-        metadata: dict,
-    ) -> 'VertexDataset':
-
-        instance = VertexDataset()
-        instance.name = name
-        instance.uri = uri
-        instance.metadata = metadata
-        return instance
-
-    @property
-    def path(self) -> str:
-        return self.uri.replace('gs://', artifact_types._GCS_LOCAL_MOUNT_PREFIX)
-
-
 class TestDictToArtifact(parameterized.TestCase):
 
     @parameterized.parameters(
@@ -1354,25 +1327,6 @@ class TestDictToArtifact(parameterized.TestCase):
         # without artifact_cls
         self.assertIsInstance(
             executor.create_artifact_instance(runtime_artifact), expected_type)
-
-    def test_dict_to_artifact_google_artifact(self):
-        runtime_artifact = {
-            'metadata': {},
-            'name': 'input_artifact_one',
-            'type': {
-                'schemaTitle': 'google.VertexDataset'
-            },
-            'uri': 'gs://some-bucket/input_artifact_one'
-        }
-        # with artifact_cls
-        self.assertIsInstance(
-            executor.create_artifact_instance(
-                runtime_artifact, artifact_cls=VertexDataset), VertexDataset)
-
-        # without artifact_cls
-        self.assertIsInstance(
-            executor.create_artifact_instance(runtime_artifact),
-            artifact_types.Artifact)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of your changes:**
Cleans up some outdated and unnecessary artifact code in the KFP SDK. Specifically:
- Removes a note about v2 pipelines. Since this applies throughout the entire KFP SDK, its inclusion in `artifact_types.py` suggests there's something special about this file.
- remove superfluous `super().__init__` calls in `artifact_types.py`
- removes logic and tests for handling `google`-namespaced artifact types that has never been used and will never be used by the GCPC SDK.

**Checklist:**
- [x] The title for your pull request (PR) 
should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
