### PR TITLE
demo: use pkgresources namespace package

### DIFF
--- a/api/v2alpha1/python/setup.py
+++ b/api/v2alpha1/python/setup.py
@@ -29,4 +29,5 @@ setuptools.setup(
     install_requires=['protobuf>=3.13.0,<4'],
     include_package_data=True,
     license='Apache 2.0',
+    namespace_packages=['kfp'],
 )

--- a/kubernetes_platform/python/setup.py
+++ b/kubernetes_platform/python/setup.py
@@ -84,4 +84,5 @@ setuptools.setup(
         'dev': DEV_REQUIREMENTS,
     },
     license='Apache 2.0',
+    namespace_packages=['kfp'],
 )

--- a/sdk/python/kfp-dsl/setup.py
+++ b/sdk/python/kfp-dsl/setup.py
@@ -26,4 +26,5 @@ setuptools.setup(
     install_requires=['typing-extensions>=3.7.4,<5; python_version<"3.9"'],
     include_package_data=True,
     license='Apache 2.0',
+    namespace_packages=['kfp'],
 )

--- a/sdk/python/kfp/__init__.py
+++ b/sdk/python/kfp/__init__.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# `kfp` is a namespace package.
-# https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+# declare an explicit namespace using pkg_resources and use the namespace_packages argument in setup.py to avoid module collision between old versions of kfp and kfp-dsl on pip install
+# https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#pkg-resource-style-namespace-package
+__import__('pkg_resources').declare_namespace(__name__)
 
 __version__ = '2.1.2'
 

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -106,4 +106,6 @@ setuptools.setup(
             'dsl-compile-deprecated = kfp.deprecated.compiler.main:main',
             'kfp=kfp.cli.__main__:main',
         ]
-    })
+    },
+    namespace_packages=['kfp'],
+)

--- a/test/presubmit-test-sdk-upgrade.sh
+++ b/test/presubmit-test-sdk-upgrade.sh
@@ -18,14 +18,15 @@ set -ex
 python3 -m pip install --upgrade pip
 
 python3 -m pip install kfp
-LATEST_KFP_SDK_RELEASE=$(pip show kfp | grep "Version:" | awk '{print $2}' | awk '{$1=$1};1')
+LATEST_KFP_SDK_RELEASE=$(python3 -m pip show kfp | grep "Version:" | awk '{print $2}' | awk '{$1=$1};1')
 echo "Installed latest KFP SDK version: $LATEST_KFP_SDK_RELEASE"
 
 # install in normal mode, not editable mode, to emulate typical user upgrade behavior
-pip3 install sdk/python/kfp-dsl
-pip3 install sdk/python
-HEAD_KFP_SDK_VERSION=$(pip show kfp | grep "Version:" | awk '{print $2}')
+python3 -m pip install sdk/python/kfp-dsl
+python3 -m pip install sdk/python
+HEAD_KFP_SDK_VERSION=$(python3 -m pip show kfp | grep "Version:" | awk '{print $2}')
 echo "Successfully upgraded to KFP SDK version @ HEAD: $HEAD_KFP_SDK_VERSION"
 
-python -c 'import kfp'
+python3 -c 'import kfp'
+python3 -c 'from kfp.dsl import *'
 echo "Successfully ran 'import kfp' @ HEAD: $HEAD_KFP_SDK_VERSION"


### PR DESCRIPTION
**Description of your changes:**
Corrects use of KFP SDK namespace packaging. Fixes https://github.com/kubeflow/pipelines/issues/9820, which describes an issue when upgrading from `kfp<2.1` to `kfp>=2.1`.

Note that this PR does not change that we use a legacy namespace packaging style ([pkg_resources-style namespace packages](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#pkg-resources-style-namespace-packages)) which is "no longer recommended" but still "widely used" and documented on Python.org.

The current best practice is [native namespace packages](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#native-namespace-packages) described by [PEP 420](https://peps.python.org/pep-0420/). However, native namespace packages do not meet our needs due to https://github.com/pypa/pip/issues/12211. Our package structure requires explicitly providing the `namespace_packages` argument in the `setup.py` files of namespace packages (required particularly for `kfp-dsl`).

Once this issue is resolved for native namespace packages, we can migrate to this style.

Note: https://github.com/kubeflow/pipelines/issues/9820 is also resolved if we migrate to native namespace packages now _and_ provide a `namespace_packages` argument in the `setup.py` files of the namespace packages. This approach is confusing, however, as it mixes native namespace packaging and pkg_resources-style namespace packaging. We prefer waiting to migrate to native namespace packages.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
