### PR TITLE
chore(test): change hard-coded GKE version to 1.25

### DIFF
--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -92,7 +92,9 @@ else
   # reference: https://github.com/kubeflow/pipelines/issues/6696
   # Hard-coded GKE to 1.25.10-gke.1200 (the latest 1.25 in STABLE channel). Reference: 
   # https://github.com/kubeflow/pipelines/issues/9704#issuecomment-1622310358
-  gcloud container clusters create ${TEST_CLUSTER} --image-type cos_containerd --release-channel stable --cluster-version 1.25.10-gke.1200 ${SCOPE_ARG} ${NODE_POOL_CONFIG_ARG} ${WI_ARG}
+  # 08/09/2023 update: 1.25.10-gke.1200 no longer supported, use 1.25.10-gke.2100 instead. Reference:
+  # https://cloud.google.com/kubernetes-engine/docs/release-notes-nochannel#2023-r17_version_updates
+  gcloud container clusters create ${TEST_CLUSTER} --image-type cos_containerd --release-channel stable --cluster-version 1.25.10-gke.2100 ${SCOPE_ARG} ${NODE_POOL_CONFIG_ARG} ${WI_ARG}
 fi
 
 gcloud container clusters get-credentials ${TEST_CLUSTER}

--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -94,7 +94,7 @@ else
   # https://github.com/kubeflow/pipelines/issues/9704#issuecomment-1622310358
   # 08/09/2023 update: 1.25.10-gke.1200 no longer supported, use 1.25.10-gke.2100 instead. Reference:
   # https://cloud.google.com/kubernetes-engine/docs/release-notes-nochannel#2023-r17_version_updates
-  gcloud container clusters create ${TEST_CLUSTER} --image-type cos_containerd --release-channel stable ${SCOPE_ARG} ${NODE_POOL_CONFIG_ARG} ${WI_ARG}
+  gcloud container clusters create ${TEST_CLUSTER} --image-type cos_containerd --release-channel stable --cluster-version 1.25.10-gke.2100 ${SCOPE_ARG} ${NODE_POOL_CONFIG_ARG} ${WI_ARG}
 fi
 
 gcloud container clusters get-credentials ${TEST_CLUSTER}

--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -94,7 +94,7 @@ else
   # https://github.com/kubeflow/pipelines/issues/9704#issuecomment-1622310358
   # 08/09/2023 update: 1.25.10-gke.1200 no longer supported, use 1.25.10-gke.2100 instead. Reference:
   # https://cloud.google.com/kubernetes-engine/docs/release-notes-nochannel#2023-r17_version_updates
-  gcloud container clusters create ${TEST_CLUSTER} --image-type cos_containerd --release-channel stable --cluster-version 1.25.10-gke.2100 ${SCOPE_ARG} ${NODE_POOL_CONFIG_ARG} ${WI_ARG}
+  gcloud container clusters create ${TEST_CLUSTER} --image-type cos_containerd --release-channel stable ${SCOPE_ARG} ${NODE_POOL_CONFIG_ARG} ${WI_ARG}
 fi
 
 gcloud container clusters get-credentials ${TEST_CLUSTER}

--- a/test/deploy-cluster.sh
+++ b/test/deploy-cluster.sh
@@ -94,7 +94,7 @@ else
   # https://github.com/kubeflow/pipelines/issues/9704#issuecomment-1622310358
   # 08/09/2023 update: 1.25.10-gke.1200 no longer supported, use 1.25.10-gke.2100 instead. Reference:
   # https://cloud.google.com/kubernetes-engine/docs/release-notes-nochannel#2023-r17_version_updates
-  gcloud container clusters create ${TEST_CLUSTER} --image-type cos_containerd --release-channel stable --cluster-version 1.25.10-gke.2100 ${SCOPE_ARG} ${NODE_POOL_CONFIG_ARG} ${WI_ARG}
+  gcloud container clusters create ${TEST_CLUSTER} --image-type cos_containerd --release-channel stable --cluster-version 1.25 ${SCOPE_ARG} ${NODE_POOL_CONFIG_ARG} ${WI_ARG}
 fi
 
 gcloud container clusters get-credentials ${TEST_CLUSTER}


### PR DESCRIPTION
**Description of your changes:**
e2e test failing due to 1.25.10-gke.1200 is no longer supported. ~~Now change the pinned version to 1.25.10-gke.2100, which is what GKE would auto-upgrade to from an 1.25 version.~~

Use version 1.25 instead to allow auto upgrade, as @chensun suggested in the comments.

Error message:
https://oss.gprow.dev/view/gs/oss-prow/pr-logs/pull/kubeflow_pipelines/9798/kubeflow-pipeline-upgrade-test/1689342821942693888#1:build-log.txt%3A129

GKE release note:
https://cloud.google.com/kubernetes-engine/docs/release-notes#2023-r17_version_updates

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
