### PR TITLE
feat(sdk): add `output_key` and `component_name` parameters to `dsl.importer`. Fixes #7541

### DIFF
--- a/sdk/python/kfp/dsl/importer_node.py
+++ b/sdk/python/kfp/dsl/importer_node.py
@@ -25,23 +25,28 @@ from kfp.dsl.types import artifact_types
 from kfp.dsl.types import type_utils
 
 URI_KEY = 'uri'
-OUTPUT_KEY = 'artifact'
 METADATA_KEY = 'metadata'
+DEFAULT_OUTPUT_KEY = 'artifact'
+DEFAULT_COMPONENT_NAME = 'importer'
 
 
 def importer(
     artifact_uri: Union[pipeline_channel.PipelineParameterChannel, str],
     artifact_class: Type[artifact_types.Artifact],
+    output_key: Optional[str] = DEFAULT_OUTPUT_KEY,
     reimport: bool = False,
     metadata: Optional[Mapping[str, Any]] = None,
+    component_name: Optional[str] = DEFAULT_COMPONENT_NAME,
 ) -> pipeline_task.PipelineTask:
     """Imports an existing artifact for use in a downstream component.
 
     Args:
       artifact_uri: The URI of the artifact to import.
       artifact_class: The artifact class being imported.
+      output_key: The name given to the output artifact.
       reimport: Whether to reimport the artifact.
       metadata: Properties of the artifact.
+      component_name: The name of this importer component.
 
     Returns:
       A task with the artifact accessible via its ``.output`` attribute.
@@ -118,7 +123,7 @@ def importer(
         metadata)
 
     component_spec = structures.ComponentSpec(
-        name='importer',
+        name=component_name,
         implementation=structures.Implementation(
             importer=structures.ImporterSpec(
                 artifact_uri=placeholders.InputValuePlaceholder(
@@ -133,7 +138,7 @@ def importer(
             **component_inputs
         },
         outputs={
-            OUTPUT_KEY:
+            output_key:
                 structures.OutputSpec(
                     type=type_utils.create_bundled_artifact_type(
                         artifact_class.schema_title,


### PR DESCRIPTION
**Description of your changes:**
- Add `output_key` and `component_name` parameters to `dsl.importer` component.

- Fixes #7541 

Happy to add docs, tests etc. if this change gets approved 🤙 

**Motivation**
These parameters add support for setting the name of the imported artifact and the component itself, improving the readability of the pipeline spec and the resulting DAG.

Current:
<img width="1242" alt="image" src="https://github.com/kubeflow/pipelines/assets/22200114/2ca89621-d16e-4ed5-b7ff-05011371de62">

New:
<img width="1130" alt="image" src="https://github.com/kubeflow/pipelines/assets/22200114/ef3fc10f-eead-4214-89a1-76ab8811bf54">

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
