### PR TITLE
fix(metadata): get contexts with a filter query. Fixes #8408

### DIFF
--- a/backend/metadata_writer/src/metadata_helpers.py
+++ b/backend/metadata_writer/src/metadata_helpers.py
@@ -18,7 +18,7 @@ import sys
 import ml_metadata
 from time import sleep
 from ml_metadata.proto import metadata_store_pb2
-from ml_metadata.metadata_store import metadata_store
+from ml_metadata.metadata_store import metadata_store, ListOptions
 from ipaddress import ip_address, IPv4Address 
 
 def value_to_mlmd_value(value) -> metadata_store_pb2.Value:
@@ -175,7 +175,7 @@ def get_context_by_name(
     store,
     context_name: str,
 ) -> metadata_store_pb2.Context:
-    matching_contexts = [context for context in store.get_contexts() if context.name == context_name]
+    matching_contexts = store.get_contexts(ListOptions(filter_query=f'name="{context_name}"'))
     assert len(matching_contexts) <= 1
     if len(matching_contexts) == 0:
         raise ValueError('Context with name "{}" was not found'.format(context_name))


### PR DESCRIPTION
**Description of your changes:**
Try to get Contexts from MLMD with a filter like `name="{context_name}"` instead of retrieving all Contexts and filtering on the client side. This is an attempt to fix the metadata-writer error when there are many pipeline runs (#8408).

It seems that `store.get_contexts()` internally doesn't actually do pagination if `list_options` isn't specified. Because when the `options` attribute of a `metadata_store_service_pb2.GetContextsRequest()` object isn't explicitly set, the MLMD service simply does a SELECT all and would return a too large response if there are too many Contexts (Kubeflow pipeline runs):
* https://github.com/google/ml-metadata/blob/v1.5.0/ml_metadata/metadata_store/metadata_store.py#L1058-L1074
* https://github.com/google/ml-metadata/blob/v1.5.0/ml_metadata/metadata_store/metadata_store.cc#L1010-L1015

```
>>> from grpc import insecure_channel
from ml_metadata.proto import metadata_store_pb2
from ml_metadata.proto import metadata_store_service_pb2
from ml_metadata.proto import metadata_store_service_pb2_grpc
>>> channel = insecure_channel("metadata-grpc-service.kubeflow:8080")
stub = metadata_store_service_pb2_grpc.MetadataStoreServiceStub(channel)
>>> request = metadata_store_service_pb2.GetContextsRequest()
>>> request.options.max_result_size  # <- HERE, the default value is 20
20
>>> response = stub.GetContexts(request) # <- but the call failed due to received msg too large
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/grpc/_channel.py", line 1030, in __call__
    return _end_unary_response_blocking(state, call, False, None)
  File "/usr/local/lib/python3.9/site-packages/grpc/_channel.py", line 910, in _end_unary_response_blocking
    raise _InactiveRpcError(state)  # pytype: disable=not-instantiable
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.RESOURCE_EXHAUSTED
	details = "Received message larger than max (4629639 vs. 4194304)"
	debug_error_string = "UNKNOWN:Error received from peer ipv4:172.20.31.148:8080 {grpc_message:"Received message larger than max (4629639 vs. 4194304)", grpc_status:8, created_time:"2023-08-22T05:00:07.416049563+00:00"}"

>>> request.options.filter_query
''
>>> request.options.filter_query='' # <- HERE, this seems to be meaningless and just set a non-relevant field to its default value
>>> response = stub.GetContexts(request) # <- but the call succeeded
>>> response
contexts {
  id: 1
  type_id: 11
...
```

I'm not sure why we need to query all Contexts and do the filtering on the client side and make this PR that pushes down the filtering to DB by leveraging `ListOptions.filter_query`. Can you help review it, please? Thanks!

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
