### PR TITLE
feat(sdk): support a Pythonic artifact authoring style

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -15,6 +15,7 @@
 # 2.3.0
 ## Features
 * Support `PipelineTaskFinalStatus` in tasks that use `.ignore_upstream_failure()` [\#10010](https://github.com/kubeflow/pipelines/pull/10010)
+* Add support for a Pythonic artifact authoring style [\#9932](https://github.com/kubeflow/pipelines/pull/9932)
 
 
 ## Breaking changes

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -33,6 +33,7 @@ from kfp.compiler import compiler
 from kfp.compiler import compiler_utils
 from kfp.dsl import Artifact
 from kfp.dsl import ContainerSpec
+from kfp.dsl import Dataset
 from kfp.dsl import graph_component
 from kfp.dsl import Input
 from kfp.dsl import Model
@@ -5277,6 +5278,416 @@ class TestDslOneOf(unittest.TestCase):
                 with dsl.Else():
                     t4 = print_and_return(text='First flip was not heads!')
                 return dsl.OneOf(t3, t4.output)
+
+
+class TestPythonicArtifactAuthoring(unittest.TestCase):
+    # python component
+    def test_pythonic_input_artifact(self):
+
+        @dsl.component
+        def pythonic_style(in_artifact: Artifact):
+            print(in_artifact)
+
+        self.assertEqual(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .input_definitions.artifacts['in_artifact'].artifact_type
+            .schema_title,
+            'system.Artifact',
+        )
+
+        self.assertFalse(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .input_definitions.parameters)
+
+        @dsl.component
+        def standard_style(in_artifact: Input[Artifact]):
+            print(in_artifact)
+
+        self.assertEqual(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .input_definitions.artifacts['in_artifact'].artifact_type
+            .schema_title,
+            standard_style.pipeline_spec.components['comp-standard-style']
+            .input_definitions.artifacts['in_artifact'].artifact_type
+            .schema_title,
+        )
+
+    def test_pythonic_input_artifact_optional(self):
+
+        @dsl.component
+        def pythonic_style(in_artifact: Optional[Artifact] = None):
+            print(in_artifact)
+
+        self.assertEqual(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .input_definitions.artifacts['in_artifact'].artifact_type
+            .schema_title,
+            'system.Artifact',
+        )
+
+        self.assertFalse(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .input_definitions.parameters)
+
+        @dsl.component
+        def standard_style(in_artifact: Optional[Input[Artifact]] = None):
+            print(in_artifact)
+
+        self.assertEqual(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .input_definitions.artifacts['in_artifact'].artifact_type
+            .schema_title,
+            standard_style.pipeline_spec.components['comp-standard-style']
+            .input_definitions.artifacts['in_artifact'].artifact_type
+            .schema_title,
+        )
+
+    def test_pythonic_input_list_of_artifacts(self):
+
+        @dsl.component
+        def pythonic_style(in_artifact: List[Artifact]):
+            print(in_artifact)
+
+        self.assertEqual(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .input_definitions.artifacts['in_artifact'].artifact_type
+            .schema_title,
+            'system.Artifact',
+        )
+        self.assertTrue(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .input_definitions.artifacts['in_artifact'].is_artifact_list)
+
+        self.assertFalse(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .input_definitions.parameters)
+
+        @dsl.component
+        def standard_style(in_artifact: Input[List[Artifact]]):
+            print(in_artifact)
+
+        self.assertEqual(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .input_definitions.artifacts['in_artifact'].artifact_type
+            .schema_title,
+            standard_style.pipeline_spec.components['comp-standard-style']
+            .input_definitions.artifacts['in_artifact'].artifact_type
+            .schema_title,
+        )
+
+    def test_pythonic_input_list_of_artifacts_optional(self):
+
+        @dsl.component
+        def pythonic_style(in_artifact: Optional[List[Artifact]] = None):
+            print(in_artifact)
+
+        self.assertEqual(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .input_definitions.artifacts['in_artifact'].artifact_type
+            .schema_title,
+            'system.Artifact',
+        )
+        self.assertTrue(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .input_definitions.artifacts['in_artifact'].is_artifact_list)
+
+        self.assertFalse(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .input_definitions.parameters)
+
+        @dsl.component
+        def standard_style(in_artifact: Optional[Input[List[Artifact]]] = None):
+            print(in_artifact)
+
+        self.assertEqual(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .input_definitions.artifacts['in_artifact'].artifact_type
+            .schema_title,
+            standard_style.pipeline_spec.components['comp-standard-style']
+            .input_definitions.artifacts['in_artifact'].artifact_type
+            .schema_title,
+        )
+
+    def test_pythonic_output_artifact(self):
+
+        @dsl.component
+        def pythonic_style() -> Artifact:
+            return Artifact(uri='gs://my_bucket/foo')
+
+        self.assertEqual(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .output_definitions.artifacts['Output'].artifact_type.schema_title,
+            'system.Artifact',
+        )
+
+        self.assertFalse(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .output_definitions.parameters)
+
+        @dsl.component
+        def standard_style(named_output: Output[Artifact]):
+            return Artifact(uri='gs://my_bucket/foo')
+
+        self.assertEqual(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .output_definitions.artifacts['Output'].artifact_type.schema_title,
+            standard_style.pipeline_spec.components['comp-standard-style']
+            .output_definitions.artifacts['named_output'].artifact_type
+            .schema_title,
+        )
+
+    def test_pythonic_output_artifact_multiple_returns(self):
+
+        @dsl.component
+        def pythonic_style() -> NamedTuple('outputs', a=Artifact, d=Dataset):
+            a = Artifact(uri='gs://my_bucket/foo/artifact')
+            d = Artifact(uri='gs://my_bucket/foo/dataset')
+            outputs = NamedTuple('outputs', a=Artifact, d=Dataset)
+            return outputs(a=a, d=d)
+
+        self.assertEqual(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .output_definitions.artifacts['a'].artifact_type.schema_title,
+            'system.Artifact',
+        )
+        self.assertEqual(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .output_definitions.artifacts['d'].artifact_type.schema_title,
+            'system.Dataset',
+        )
+
+        self.assertFalse(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .output_definitions.parameters)
+
+        @dsl.component
+        def standard_style(a: Output[Artifact], d: Output[Dataset]):
+            a.uri = 'gs://my_bucket/foo/artifact'
+            d.uri = 'gs://my_bucket/foo/dataset'
+
+        self.assertEqual(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .output_definitions.artifacts['a'].artifact_type.schema_title,
+            standard_style.pipeline_spec.components['comp-standard-style']
+            .output_definitions.artifacts['a'].artifact_type.schema_title,
+        )
+
+        self.assertEqual(
+            pythonic_style.pipeline_spec.components['comp-pythonic-style']
+            .output_definitions.artifacts['d'].artifact_type.schema_title,
+            standard_style.pipeline_spec.components['comp-standard-style']
+            .output_definitions.artifacts['d'].artifact_type.schema_title,
+        )
+
+    def test_pythonic_output_list_artifacts(self):
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Output lists of artifacts are only supported for pipelines\. Got output list of artifacts for output parameter 'Output' of component 'pythonic-style'\."
+        ):
+
+            @dsl.component
+            def pythonic_style() -> List[Artifact]:
+                pass
+
+    def test_mixed_component_authoring_styles(self):
+        # can be permitted, since the expected behavior is unambiguous
+
+        # in traditional; out pythonic
+        @dsl.component
+        def back_compat_style(in_artifact: Input[Artifact]) -> Artifact:
+            print(in_artifact)
+            return Artifact(uri='gs://my_bucket/foo')
+
+        self.assertTrue(back_compat_style.pipeline_spec)
+
+        # out traditional; in pythonic
+        @dsl.component
+        def mixed_style(in_artifact: Artifact, out_artifact: Output[Artifact]):
+            print(in_artifact)
+            out_artifact.uri = 'gs://my_bucket/foo'
+
+        self.assertTrue(mixed_style.pipeline_spec)
+
+    # pipeline
+    def test_pipeline_input_artifact(self):
+
+        @dsl.component
+        def pythonic_style(in_artifact: Artifact):
+            print(in_artifact)
+
+        @dsl.pipeline
+        def my_pipeline(in_artifact: Artifact):
+            pythonic_style(in_artifact=in_artifact)
+
+        self.assertEqual(
+            my_pipeline.pipeline_spec.root.input_definitions
+            .artifacts['in_artifact'].artifact_type.schema_title,
+            'system.Artifact',
+        )
+
+        self.assertFalse(
+            my_pipeline.pipeline_spec.root.input_definitions.parameters)
+
+    def test_pipeline_input_artifact_optional(self):
+
+        @dsl.component
+        def pythonic_style(in_artifact: Optional[Artifact] = None):
+            print(in_artifact)
+
+        @dsl.pipeline
+        def my_pipeline(in_artifact: Optional[Artifact] = None):
+            pythonic_style(in_artifact=in_artifact)
+
+        self.assertEqual(
+            my_pipeline.pipeline_spec.root.input_definitions
+            .artifacts['in_artifact'].artifact_type.schema_title,
+            'system.Artifact',
+        )
+
+        self.assertFalse(
+            my_pipeline.pipeline_spec.root.input_definitions.parameters)
+
+    def test_pipeline_input_list_of_artifacts(self):
+
+        @dsl.component
+        def pythonic_style(in_artifact: List[Artifact]):
+            print(in_artifact)
+
+        @dsl.pipeline
+        def my_pipeline(in_artifact: List[Artifact]):
+            pythonic_style(in_artifact=in_artifact)
+
+        self.assertEqual(
+            my_pipeline.pipeline_spec.root.input_definitions
+            .artifacts['in_artifact'].artifact_type.schema_title,
+            'system.Artifact',
+        )
+        self.assertTrue(my_pipeline.pipeline_spec.root.input_definitions
+                        .artifacts['in_artifact'].is_artifact_list)
+
+        self.assertFalse(
+            my_pipeline.pipeline_spec.root.input_definitions.parameters)
+
+    def test_pipeline_input_list_of_artifacts_optional(self):
+
+        @dsl.component
+        def pythonic_style(in_artifact: Optional[List[Artifact]] = None):
+            print(in_artifact)
+
+        @dsl.pipeline
+        def my_pipeline(in_artifact: Optional[List[Artifact]] = None):
+            pythonic_style(in_artifact=in_artifact)
+
+        self.assertEqual(
+            my_pipeline.pipeline_spec.root.input_definitions
+            .artifacts['in_artifact'].artifact_type.schema_title,
+            'system.Artifact',
+        )
+
+        self.assertFalse(
+            my_pipeline.pipeline_spec.root.input_definitions.parameters)
+
+    def test_pipeline_output_artifact(self):
+
+        @dsl.component
+        def pythonic_style() -> Artifact:
+            return Artifact(uri='gs://my_bucket/foo')
+
+        @dsl.pipeline
+        def my_pipeline() -> Artifact:
+            return pythonic_style().output
+
+        self.assertEqual(
+            my_pipeline.pipeline_spec.root.output_definitions
+            .artifacts['Output'].artifact_type.schema_title, 'system.Artifact')
+
+        self.assertFalse(
+            my_pipeline.pipeline_spec.root.output_definitions.parameters)
+
+    def test_pipeline_output_list_of_artifacts(self):
+
+        @dsl.component
+        def noop() -> Artifact:
+            # write artifact
+            return Artifact(uri='gs://my_bucket/foo/bar')
+
+        @dsl.pipeline
+        def my_pipeline() -> List[Artifact]:
+            with dsl.ParallelFor([1, 2, 3]):
+                t = noop()
+
+            return dsl.Collected(t.output)
+
+        self.assertEqual(
+            my_pipeline.pipeline_spec.root.output_definitions
+            .artifacts['Output'].artifact_type.schema_title, 'system.Artifact')
+        self.assertTrue(my_pipeline.pipeline_spec.root.output_definitions
+                        .artifacts['Output'].is_artifact_list)
+
+        self.assertFalse(
+            my_pipeline.pipeline_spec.root.output_definitions.parameters)
+
+    # container
+    def test_container_input_artifact(self):
+        with self.assertRaisesRegex(
+                TypeError,
+                r'Artifacts can only be used in Container Components with Input or Output type markers\. Got function input in_artifact with type Artifact\.'
+        ):
+
+            @dsl.container_component
+            def comp(in_artifact: Artifact):
+                return dsl.ContainerSpec(image='alpine', command=['pwd'])
+
+    def test_container_input_artifact_optional(self):
+        with self.assertRaisesRegex(
+                TypeError,
+                r'Artifacts can only be used in Container Components with Input or Output type markers\. Got function input in_artifact with type Artifact\.'
+        ):
+
+            @dsl.container_component
+            def comp(in_artifact: Optional[Artifact] = None):
+                return dsl.ContainerSpec(image='alpine', command=['pwd'])
+
+    def test_container_input_list_of_artifacts(self):
+        with self.assertRaisesRegex(
+                TypeError,
+                r'Artifacts can only be used in Container Components with Input or Output type markers\. Got function input in_artifact with type Artifact\.'
+        ):
+
+            @dsl.container_component
+            def comp(in_artifact: List[Artifact]):
+                return dsl.ContainerSpec(image='alpine', command=['pwd'])
+
+    def test_container_input_list_of_artifacts_optional(self):
+        with self.assertRaisesRegex(
+                TypeError,
+                r'Artifacts can only be used in Container Components with Input or Output type markers\. Got function input in_artifact with type Artifact\.'
+        ):
+
+            @dsl.container_component
+            def comp(in_artifact: Optional[List[Artifact]] = None):
+                return dsl.ContainerSpec(image='alpine', command=['pwd'])
+
+    def test_container_output_artifact(self):
+        with self.assertRaisesRegex(
+                TypeError,
+                r'Return annotation should be either ContainerSpec or omitted for container components\.'
+        ):
+
+            @dsl.container_component
+            def comp() -> Artifact:
+                return dsl.ContainerSpec(image='alpine', command=['pwd'])
+
+    def test_container_output_list_of_artifact(self):
+        with self.assertRaisesRegex(
+                TypeError,
+                r'Return annotation should be either ContainerSpec or omitted for container components\.'
+        ):
+
+            @dsl.container_component
+            def comp() -> List[Artifact]:
+                return dsl.ContainerSpec(image='alpine', command=['pwd'])
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -5632,7 +5632,7 @@ class TestPythonicArtifactAuthoring(unittest.TestCase):
     def test_container_input_artifact(self):
         with self.assertRaisesRegex(
                 TypeError,
-                r'Artifacts can only be used in Container Components with Input or Output type markers\. Got function input in_artifact with type Artifact\.'
+                r"Container Components must wrap input and output artifact annotations with Input/Output type markers \(Input\[<artifact>\] or Output\[<artifact>\]\)\. Got function input 'in_artifact' with annotation <class 'kfp\.dsl\.types\.artifact_types\.Artifact'>\."
         ):
 
             @dsl.container_component
@@ -5642,7 +5642,7 @@ class TestPythonicArtifactAuthoring(unittest.TestCase):
     def test_container_input_artifact_optional(self):
         with self.assertRaisesRegex(
                 TypeError,
-                r'Artifacts can only be used in Container Components with Input or Output type markers\. Got function input in_artifact with type Artifact\.'
+                r"Container Components must wrap input and output artifact annotations with Input/Output type markers \(Input\[<artifact>\] or Output\[<artifact>\]\)\. Got function input 'in_artifact' with annotation <class 'kfp\.dsl\.types\.artifact_types\.Artifact'>\."
         ):
 
             @dsl.container_component
@@ -5652,7 +5652,7 @@ class TestPythonicArtifactAuthoring(unittest.TestCase):
     def test_container_input_list_of_artifacts(self):
         with self.assertRaisesRegex(
                 TypeError,
-                r'Artifacts can only be used in Container Components with Input or Output type markers\. Got function input in_artifact with type Artifact\.'
+                r"Container Components must wrap input and output artifact annotations with Input/Output type markers \(Input\[<artifact>\] or Output\[<artifact>\]\)\. Got function input 'in_artifact' with annotation typing\.List\[kfp\.dsl\.types\.artifact_types\.Artifact\]\."
         ):
 
             @dsl.container_component
@@ -5662,7 +5662,7 @@ class TestPythonicArtifactAuthoring(unittest.TestCase):
     def test_container_input_list_of_artifacts_optional(self):
         with self.assertRaisesRegex(
                 TypeError,
-                r'Artifacts can only be used in Container Components with Input or Output type markers\. Got function input in_artifact with type Artifact\.'
+                r"Container Components must wrap input and output artifact annotations with Input/Output type markers \(Input\[<artifact>\] or Output\[<artifact>\]\)\. Got function input 'in_artifact' with annotation typing\.List\[kfp\.dsl\.types\.artifact_types\.Artifact\]\."
         ):
 
             @dsl.container_component

--- a/sdk/python/kfp/dsl/__init__.py
+++ b/sdk/python/kfp/dsl/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
     'Metrics',
     'Model',
     'SlicedClassificationMetrics',
+    'get_uri',
     'PIPELINE_JOB_NAME_PLACEHOLDER',
     'PIPELINE_JOB_RESOURCE_NAME_PLACEHOLDER',
     'PIPELINE_JOB_ID_PLACEHOLDER',
@@ -44,6 +45,7 @@ from kfp.dsl.task_final_status import PipelineTaskFinalStatus
 from kfp.dsl.types.artifact_types import Artifact
 from kfp.dsl.types.artifact_types import ClassificationMetrics
 from kfp.dsl.types.artifact_types import Dataset
+from kfp.dsl.types.artifact_types import get_uri
 from kfp.dsl.types.artifact_types import HTML
 from kfp.dsl.types.artifact_types import Markdown
 from kfp.dsl.types.artifact_types import Metrics

--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -251,7 +251,7 @@ def get_name_to_specs(
                     annotation):
             if containerized:
                 raise TypeError(
-                    'Artifacts can only be used in Container Components with Input or Output type markers. Got function input in_artifact with type Artifact.'
+                    f"Container Components must wrap input and output artifact annotations with Input/Output type markers (Input[<artifact>] or Output[<artifact>]). Got function input '{name}' with annotation {annotation}."
                 )
             name_to_input_specs[maybe_make_unique(
                 name, list(name_to_input_specs))] = make_input_spec(

--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -17,7 +17,8 @@ import itertools
 import pathlib
 import re
 import textwrap
-from typing import Callable, List, Mapping, Optional, Tuple, Type, Union
+from typing import (Any, Callable, Dict, List, Mapping, Optional, Tuple, Type,
+                    Union)
 import warnings
 
 import docstring_parser
@@ -192,7 +193,7 @@ def _get_function_source_definition(func: Callable) -> str:
     return '\n'.join(func_code_lines)
 
 
-def _maybe_make_unique(name: str, names: List[str]):
+def maybe_make_unique(name: str, names: List[str]):
     if name not in names:
         return name
 
@@ -204,188 +205,187 @@ def _maybe_make_unique(name: str, names: List[str]):
     raise RuntimeError(f'Too many arguments with the name {name}')
 
 
+def get_name_to_specs(
+    signature: inspect.Signature,
+    containerized: bool = False,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Returns two dictionaries.
+
+    The first is a mapping of input name to input annotation. The second
+    is a mapping of output name to output annotation.
+    """
+    func_params = list(signature.parameters.values())
+
+    name_to_input_specs = {}
+    name_to_output_specs = {}
+
+    ### handle function parameter annotations ###
+    for func_param in func_params:
+        name = func_param.name
+        if name == SINGLE_OUTPUT_NAME:
+            raise ValueError(
+                f'"{SINGLE_OUTPUT_NAME}" is an invalid parameter name.')
+        # Stripping Optional from Optional[<type>] is the only processing done
+        # on annotations in this flow. Other than that, we extract the raw
+        # annotation and process later.
+        annotation = type_annotations.maybe_strip_optional_from_annotation(
+            func_param.annotation)
+
+        # no annotation
+        if annotation == inspect._empty:
+            raise TypeError(f'Missing type annotation for argument: {name}')
+
+        # is Input[Artifact], Input[List[<Artifact>]], <param> (e.g., str), or InputPath(<param>)
+        elif (type_annotations.is_artifact_wrapped_in_Input(annotation) or
+              isinstance(
+                  annotation,
+                  type_annotations.InputPath,
+              ) or type_utils.is_parameter_type(annotation)):
+            name_to_input_specs[maybe_make_unique(
+                name, list(name_to_input_specs))] = make_input_spec(
+                    annotation, func_param)
+        # is Artifact annotation (e.g., Artifact, Dataset, etc.)
+        # or List[<Artifact>]
+        elif type_annotations.issubclass_of_artifact(
+                annotation) or type_annotations.is_list_of_artifacts(
+                    annotation):
+            if containerized:
+                raise TypeError(
+                    'Artifacts can only be used in Container Components with Input or Output type markers. Got function input in_artifact with type Artifact.'
+                )
+            name_to_input_specs[maybe_make_unique(
+                name, list(name_to_input_specs))] = make_input_spec(
+                    annotation, func_param)
+
+        # is Output[Artifact] or OutputPath(<param>)
+        elif type_annotations.is_artifact_wrapped_in_Output(
+                annotation) or isinstance(annotation,
+                                          type_annotations.OutputPath):
+            name_to_output_specs[maybe_make_unique(
+                name,
+                list(name_to_output_specs))] = make_output_spec(annotation)
+
+        # parameter type
+        else:
+            type_string = type_utils._annotation_to_type_struct(annotation)
+            name_to_input_specs[maybe_make_unique(
+                name, list(name_to_input_specs))] = make_input_spec(
+                    type_string, func_param)
+
+    ### handle return annotations ###
+    return_ann = signature.return_annotation
+
+    # validate container component returns
+    if containerized:
+        if return_ann not in [
+                inspect.Parameter.empty,
+                structures.ContainerSpec,
+        ]:
+            raise TypeError(
+                'Return annotation should be either ContainerSpec or omitted for container components.'
+            )
+    # ignore omitted returns
+    elif return_ann is None or return_ann == inspect.Parameter.empty:
+        pass
+    # is NamedTuple
+    elif hasattr(return_ann, '_fields'):
+        # Getting field type annotations.
+        # __annotations__ does not exist in python 3.5 and earlier
+        # _field_types does not exist in python 3.9 and later
+        field_annotations = getattr(return_ann, '__annotations__',
+                                    None) or getattr(return_ann, '_field_types')
+        for name in return_ann._fields:
+            annotation = field_annotations[name]
+            if not type_annotations.is_list_of_artifacts(
+                    annotation) and not type_annotations.is_artifact_class(
+                        annotation):
+                annotation = type_utils._annotation_to_type_struct(annotation)
+            name_to_output_specs[maybe_make_unique(
+                name,
+                list(name_to_output_specs))] = make_output_spec(annotation)
+    # is deprecated dict returns style
+    elif isinstance(return_ann, dict):
+        warnings.warn(
+            'The ability to specify multiple outputs using the dict syntax'
+            ' has been deprecated. It will be removed soon after release'
+            ' 0.1.32. Please use typing.NamedTuple to declare multiple'
+            ' outputs.', DeprecationWarning)
+        for output_name, output_type_annotation in return_ann.items():
+            output_type = type_utils._annotation_to_type_struct(
+                output_type_annotation)
+            name_to_output_specs[maybe_make_unique(
+                output_name, list(name_to_output_specs))] = output_type
+    # is the simple single return case (can be `-> <param>` or `-> Artifact`)
+    # treated the same way, since processing is done in inner functions
+    else:
+        name_to_output_specs[maybe_make_unique(
+            SINGLE_OUTPUT_NAME,
+            list(name_to_output_specs))] = make_output_spec(return_ann)
+    return name_to_input_specs, name_to_output_specs
+
+
+def canonicalize_annotation(annotation: Any):
+    """Does cleaning on annotations that are common between input and output
+    annotations."""
+    if type_annotations.is_Input_Output_artifact_annotation(annotation):
+        annotation = type_annotations.strip_Input_or_Output_marker(annotation)
+    if isinstance(annotation,
+                  (type_annotations.InputPath, type_annotations.OutputPath)):
+        annotation = annotation.type
+    return annotation
+
+
+def make_input_output_spec_args(annotation: Any) -> Dict[str, Any]:
+    """Gets a dict of kwargs shared between InputSpec and OutputSpec."""
+    is_artifact_list = type_annotations.is_list_of_artifacts(annotation)
+    if is_artifact_list:
+        annotation = type_annotations.get_inner_type(annotation)
+
+    if type_annotations.issubclass_of_artifact(annotation):
+        typ = type_utils.create_bundled_artifact_type(annotation.schema_title,
+                                                      annotation.schema_version)
+    else:
+        typ = type_utils._annotation_to_type_struct(annotation)
+    return {'type': typ, 'is_artifact_list': is_artifact_list}
+
+
+def make_output_spec(annotation: Any) -> structures.OutputSpec:
+    annotation = canonicalize_annotation(annotation)
+    args = make_input_output_spec_args(annotation)
+    return structures.OutputSpec(**args)
+
+
+def make_input_spec(annotation: Any,
+                    inspect_param: inspect.Parameter) -> structures.InputSpec:
+    """Makes an InputSpec from a cleaned output annotation."""
+    annotation = canonicalize_annotation(annotation)
+    input_output_spec_args = make_input_output_spec_args(annotation)
+
+    if (type_annotations.issubclass_of_artifact(annotation) or
+            input_output_spec_args['is_artifact_list']
+       ) and inspect_param.default not in {None, inspect._empty}:
+        raise ValueError(
+            f'Optional Input artifacts may only have default value None. Got: {inspect_param.default}.'
+        )
+
+    default = None if inspect_param.default == inspect.Parameter.empty or type_annotations.issubclass_of_artifact(
+        annotation) else inspect_param.default
+
+    optional = inspect_param.default is not inspect.Parameter.empty or type_utils.is_task_final_status_type(
+        getattr(inspect_param.annotation, '__name__', ''))
+    return structures.InputSpec(
+        **input_output_spec_args,
+        default=default,
+        optional=optional,
+    )
+
+
 def extract_component_interface(
     func: Callable,
     containerized: bool = False,
     description: Optional[str] = None,
     name: Optional[str] = None,
 ) -> structures.ComponentSpec:
-
-    signature = inspect.signature(func)
-    parameters = list(signature.parameters.values())
-
-    original_docstring = inspect.getdoc(func)
-    parsed_docstring = docstring_parser.parse(original_docstring)
-
-    inputs = {}
-    outputs = {}
-
-    input_names = set()
-    output_names = set()
-    for parameter in parameters:
-        parameter_type = type_annotations.maybe_strip_optional_from_annotation(
-            parameter.annotation)
-        passing_style = None
-        io_name = parameter.name
-        is_artifact_list = False
-
-        if type_annotations.is_Input_Output_artifact_annotation(parameter_type):
-            # passing_style is either type_annotations.InputAnnotation or
-            # type_annotations.OutputAnnotation.
-            passing_style = type_annotations.get_io_artifact_annotation(
-                parameter_type)
-
-            # parameter_type is a type like typing_extensions.Annotated[kfp.dsl.types.artifact_types.Artifact, <class 'kfp.dsl.types.type_annotations.OutputAnnotation'>] OR typing_extensions.Annotated[typing.List[kfp.dsl.types.artifact_types.Artifact], <class 'kfp.dsl.types.type_annotations.OutputAnnotation'>]
-
-            is_artifact_list = type_annotations.is_list_of_artifacts(
-                parameter_type.__origin__)
-
-            parameter_type = type_annotations.get_io_artifact_class(
-                parameter_type)
-            if not type_annotations.is_artifact_class(parameter_type):
-                raise ValueError(
-                    f'Input[T] and Output[T] are only supported when T is an artifact or list of artifacts. Found `{io_name} with type {parameter_type}`'
-                )
-
-            if parameter.default is not inspect.Parameter.empty:
-                if passing_style in [
-                        type_annotations.OutputAnnotation,
-                        type_annotations.OutputPath,
-                ]:
-                    raise ValueError(
-                        'Default values for Output artifacts are not supported.'
-                    )
-                elif parameter.default is not None:
-                    raise ValueError(
-                        f'Optional Input artifacts may only have default value None. Got: {parameter.default}.'
-                    )
-
-        elif isinstance(
-                parameter_type,
-            (type_annotations.InputPath, type_annotations.OutputPath)):
-            passing_style = type(parameter_type)
-            parameter_type = parameter_type.type
-            if parameter.default is not inspect.Parameter.empty and not (
-                    passing_style == type_annotations.InputPath and
-                    parameter.default is None):
-                raise ValueError(
-                    'Path inputs only support default values of None. Default'
-                    ' values for outputs are not supported.')
-
-        type_struct = type_utils._annotation_to_type_struct(parameter_type)
-        if type_struct is None:
-            raise TypeError(
-                f'Missing type annotation for argument: {parameter.name}')
-
-        if passing_style in [
-                type_annotations.OutputAnnotation, type_annotations.OutputPath
-        ]:
-            if io_name == SINGLE_OUTPUT_NAME:
-                raise ValueError(
-                    f'"{SINGLE_OUTPUT_NAME}" is an invalid parameter name.')
-            io_name = _maybe_make_unique(io_name, output_names)
-            output_names.add(io_name)
-            if type_annotations.is_artifact_class(parameter_type):
-                schema_version = parameter_type.schema_version
-                output_spec = structures.OutputSpec(
-                    type=type_utils.create_bundled_artifact_type(
-                        type_struct, schema_version),
-                    is_artifact_list=is_artifact_list)
-            else:
-                output_spec = structures.OutputSpec(type=type_struct)
-            outputs[io_name] = output_spec
-        else:
-            io_name = _maybe_make_unique(io_name, input_names)
-            input_names.add(io_name)
-            type_ = type_utils.create_bundled_artifact_type(
-                type_struct, parameter_type.schema_version
-            ) if type_annotations.is_artifact_class(
-                parameter_type) else type_struct
-            default = None if parameter.default == inspect.Parameter.empty or type_annotations.is_artifact_class(
-                parameter_type) else parameter.default
-            optional = parameter.default is not inspect.Parameter.empty or type_utils.is_task_final_status_type(
-                type_struct)
-            input_spec = structures.InputSpec(
-                type=type_,
-                default=default,
-                optional=optional,
-                is_artifact_list=is_artifact_list,
-            )
-
-            inputs[io_name] = input_spec
-
-    #Analyzing the return type annotations.
-    return_ann = signature.return_annotation
-    if not containerized:
-        if hasattr(return_ann, '_fields'):  #NamedTuple
-            # Getting field type annotations.
-            # __annotations__ does not exist in python 3.5 and earlier
-            # _field_types does not exist in python 3.9 and later
-            field_annotations = getattr(return_ann, '__annotations__',
-                                        None) or getattr(
-                                            return_ann, '_field_types', None)
-            for field_name in return_ann._fields:
-                output_name = _maybe_make_unique(field_name, output_names)
-                output_names.add(output_name)
-                type_var = field_annotations.get(field_name)
-                if type_annotations.is_list_of_artifacts(type_var):
-                    artifact_cls = type_var.__args__[0]
-                    output_spec = structures.OutputSpec(
-                        type=type_utils.create_bundled_artifact_type(
-                            artifact_cls.schema_title,
-                            artifact_cls.schema_version),
-                        is_artifact_list=True)
-                elif type_annotations.is_artifact_class(type_var):
-                    output_spec = structures.OutputSpec(
-                        type=type_utils.create_bundled_artifact_type(
-                            type_var.schema_title, type_var.schema_version))
-                else:
-                    type_struct = type_utils._annotation_to_type_struct(
-                        type_var)
-                    output_spec = structures.OutputSpec(type=type_struct)
-                outputs[output_name] = output_spec
-        # Deprecated dict-based way of declaring multiple outputs. Was only used by
-        # the @component decorator
-        elif isinstance(return_ann, dict):
-            warnings.warn(
-                'The ability to specify multiple outputs using the dict syntax'
-                ' has been deprecated. It will be removed soon after release'
-                ' 0.1.32. Please use typing.NamedTuple to declare multiple'
-                ' outputs.')
-            for output_name, output_type_annotation in return_ann.items():
-                output_type_struct = type_utils._annotation_to_type_struct(
-                    output_type_annotation)
-                output_spec = structures.OutputSpec(type=output_type_struct)
-                outputs[name] = output_spec
-        elif signature.return_annotation is not None and signature.return_annotation != inspect.Parameter.empty:
-            output_name = _maybe_make_unique(SINGLE_OUTPUT_NAME, output_names)
-            # Fixes exotic, but possible collision:
-            #   `def func(output_path: OutputPath()) -> str: ...`
-            output_names.add(output_name)
-            return_ann = signature.return_annotation
-            if type_annotations.is_list_of_artifacts(return_ann):
-                artifact_cls = return_ann.__args__[0]
-                output_spec = structures.OutputSpec(
-                    type=type_utils.create_bundled_artifact_type(
-                        artifact_cls.schema_title, artifact_cls.schema_version),
-                    is_artifact_list=True)
-            elif type_annotations.is_artifact_class(return_ann):
-                output_spec = structures.OutputSpec(
-                    type=type_utils.create_bundled_artifact_type(
-                        return_ann.schema_title, return_ann.schema_version),
-                    is_artifact_list=False)
-            else:
-                type_struct = type_utils._annotation_to_type_struct(return_ann)
-                output_spec = structures.OutputSpec(type=type_struct)
-
-            outputs[output_name] = output_spec
-    elif return_ann != inspect.Parameter.empty and return_ann != structures.ContainerSpec:
-        raise TypeError(
-            'Return annotation should be either ContainerSpec or omitted for container components.'
-        )
-
-    component_name = name or _python_function_name_to_component_name(
-        func.__name__)
 
     def assign_descriptions(
         inputs_or_outputs: Mapping[str, Union[structures.InputSpec,
@@ -417,23 +417,32 @@ def extract_component_interface(
 
         return None
 
-    assign_descriptions(inputs, parsed_docstring.params)
+    signature = inspect.signature(func)
+    name_to_input_spec, name_to_output_spec = get_name_to_specs(
+        signature, containerized)
+    original_docstring = inspect.getdoc(func)
+    parsed_docstring = docstring_parser.parse(original_docstring)
+
+    assign_descriptions(name_to_input_spec, parsed_docstring.params)
 
     modified_parsed_docstring = parse_docstring_with_return_as_args(
         original_docstring)
     if modified_parsed_docstring is not None:
-        assign_descriptions(outputs, modified_parsed_docstring.params)
+        assign_descriptions(name_to_output_spec,
+                            modified_parsed_docstring.params)
 
     description = get_pipeline_description(
         decorator_description=description,
         docstring=parsed_docstring,
     )
 
+    component_name = name or _python_function_name_to_component_name(
+        func.__name__)
     return structures.ComponentSpec(
         name=component_name,
         description=description,
-        inputs=inputs or None,
-        outputs=outputs or None,
+        inputs=name_to_input_spec or None,
+        outputs=name_to_output_spec or None,
         implementation=structures.Implementation(),
     )
 
@@ -573,7 +582,7 @@ def make_input_for_parameterized_container_component_function(
                                  Type[artifact_types.Artifact]]
 ) -> Union[placeholders.Placeholder, container_component_artifact_channel
            .ContainerComponentArtifactChannel]:
-    if type_annotations.is_input_artifact(annotation):
+    if type_annotations.is_artifact_wrapped_in_Input(annotation):
 
         if type_annotations.is_list_of_artifacts(annotation.__origin__):
             return placeholders.InputListOfArtifactsPlaceholder(name)
@@ -581,7 +590,7 @@ def make_input_for_parameterized_container_component_function(
             return container_component_artifact_channel.ContainerComponentArtifactChannel(
                 io_type='input', var_name=name)
 
-    elif type_annotations.is_output_artifact(annotation):
+    elif type_annotations.is_artifact_wrapped_in_Output(annotation):
 
         if type_annotations.is_list_of_artifacts(annotation.__origin__):
             return placeholders.OutputListOfArtifactsPlaceholder(name)

--- a/sdk/python/kfp/dsl/executor.py
+++ b/sdk/python/kfp/dsl/executor.py
@@ -42,9 +42,9 @@ class Executor:
         self.executor_input = executor_input
         self.executor_output_path = self.executor_input['outputs']['outputFile']
 
-        # drop executor_output.json part from path
-        local_task_root = os.path.split(self.executor_output_path)[0]
-        artifact_types.CONTAINER_TASK_ROOT = local_task_root
+        # drop executor_output.json part from the outputFile path
+        artifact_types.CONTAINER_TASK_ROOT = os.path.split(
+            self.executor_output_path)[0]
 
         self.input_artifacts: Dict[str, Union[dsl.Artifact,
                                               List[dsl.Artifact]]] = {}

--- a/sdk/python/kfp/dsl/types/artifact_types.py
+++ b/sdk/python/kfp/dsl/types/artifact_types.py
@@ -101,8 +101,7 @@ def convert_local_path_to_remote_path(path: str) -> str:
         return 'minio://' + path[len(_MINIO_LOCAL_MOUNT_PREFIX):]
     elif path.startswith(_S3_LOCAL_MOUNT_PREFIX):
         return 's3://' + path[len(_S3_LOCAL_MOUNT_PREFIX):]
-    else:
-        raise ValueError(f'Unknown remote path for local path: {path}')
+    return path
 
 
 class Model(Artifact):

--- a/sdk/python/kfp/dsl/types/artifact_types.py
+++ b/sdk/python/kfp/dsl/types/artifact_types.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Classes for input/output Artifacts in KFP SDK."""
+"""Classes and utilities for using and creating artifacts in components."""
 
+import os
 from typing import Dict, List, Optional, Type
 
 _GCS_LOCAL_MOUNT_PREFIX = '/gcs/'
@@ -90,13 +91,18 @@ class Artifact:
         return None
 
     def _set_path(self, path: str) -> None:
-        if path.startswith(_GCS_LOCAL_MOUNT_PREFIX):
-            path = 'gs://' + path[len(_GCS_LOCAL_MOUNT_PREFIX):]
-        elif path.startswith(_MINIO_LOCAL_MOUNT_PREFIX):
-            path = 'minio://' + path[len(_MINIO_LOCAL_MOUNT_PREFIX):]
-        elif path.startswith(_S3_LOCAL_MOUNT_PREFIX):
-            path = 's3://' + path[len(_S3_LOCAL_MOUNT_PREFIX):]
-        self.uri = path
+        self.uri = convert_local_path_to_remote_path(path)
+
+
+def convert_local_path_to_remote_path(path: str) -> str:
+    if path.startswith(_GCS_LOCAL_MOUNT_PREFIX):
+        return 'gs://' + path[len(_GCS_LOCAL_MOUNT_PREFIX):]
+    elif path.startswith(_MINIO_LOCAL_MOUNT_PREFIX):
+        return 'minio://' + path[len(_MINIO_LOCAL_MOUNT_PREFIX):]
+    elif path.startswith(_S3_LOCAL_MOUNT_PREFIX):
+        return 's3://' + path[len(_S3_LOCAL_MOUNT_PREFIX):]
+    else:
+        raise ValueError(f'Unknown remote path for local path: {path}')
 
 
 class Model(Artifact):
@@ -470,3 +476,25 @@ _SCHEMA_TITLE_TO_TYPE: Dict[str, Type[Artifact]] = {
         Markdown,
     ]
 }
+
+CONTAINER_TASK_ROOT: Optional[str] = None
+
+
+# suffix default of 'Output' should be the same key as the default key for a
+# single output component, but use value not variable for reference docs
+def get_uri(suffix: str = 'Output') -> str:
+    """Gets the task root URI, a unique object storage URI associated with the
+    current task. This function may only be called at task runtime.
+
+    Args:
+        suffix: A suffix to append to the URI. This is a helpful for creating unique subdirectories when the component has multiple outputs.
+
+    Returns:
+        The URI.
+    """
+    if CONTAINER_TASK_ROOT is None:
+        raise RuntimeError(
+            "'dsl.get_uri' can only be called at task runtime. The task root is unknown in the current environment."
+        )
+    remote_task_root = convert_local_path_to_remote_path(CONTAINER_TASK_ROOT)
+    return os.path.join(remote_task_root, suffix)

--- a/sdk/python/kfp/dsl/types/artifact_types_test.py
+++ b/sdk/python/kfp/dsl/types/artifact_types_test.py
@@ -139,6 +139,7 @@ class TestConvertLocalPathToRemotePath(parameterized.TestCase):
         ('/minio/foo/bar', 'minio://foo/bar'),
         ('/s3/foo/bar', 's3://foo/bar'),
         ('/tmp/kfp_outputs', '/tmp/kfp_outputs'),
+        ('/some/random/path', '/some/random/path'),
     ]])
     def test_gcs(self, local_path, expected):
         actual = artifact_types.convert_local_path_to_remote_path(local_path)

--- a/sdk/python/kfp/dsl/types/artifact_types_test.py
+++ b/sdk/python/kfp/dsl/types/artifact_types_test.py
@@ -13,18 +13,19 @@
 # limitations under the License.
 """Tests for kfp.components.types.artifact_types."""
 
+import contextlib
 import json
 import os
 import unittest
 
-from absl.testing import parameterized
+from kfp import dsl
 from kfp.dsl.types import artifact_types
 
 
-class ArtifactsTest(parameterized.TestCase):
+class ArtifactsTest(unittest.TestCase):
 
     def test_complex_metrics(self):
-        metrics = artifact_types.ClassificationMetrics()
+        metrics = dsl.ClassificationMetrics()
         metrics.log_roc_data_point(threshold=0.1, tpr=98.2, fpr=96.2)
         metrics.log_roc_data_point(threshold=24.3, tpr=24.5, fpr=98.4)
         metrics.set_confusion_matrix_categories(['dog', 'cat', 'horses'])
@@ -41,7 +42,7 @@ class ArtifactsTest(parameterized.TestCase):
             self.assertEqual(expected_json, metrics.metadata)
 
     def test_complex_metrics_bulk_loading(self):
-        metrics = artifact_types.ClassificationMetrics()
+        metrics = dsl.ClassificationMetrics()
         metrics.log_roc_curve(
             fpr=[85.1, 85.1, 85.1],
             tpr=[52.6, 52.6, 52.6],
@@ -55,6 +56,58 @@ class ArtifactsTest(parameterized.TestCase):
         ) as json_file:
             expected_json = json.load(json_file)
             self.assertEqual(expected_json, metrics.metadata)
+
+
+@contextlib.contextmanager
+def set_temporary_task_root(task_root: str):
+    artifact_types.CONTAINER_TASK_ROOT = task_root
+    try:
+        yield
+    finally:
+        artifact_types.CONTAINER_TASK_ROOT = None
+
+
+class TestGetUri(unittest.TestCase):
+
+    def test_raise_if_no_env_var(self):
+
+        with self.assertRaisesRegex(
+                RuntimeError,
+                r"'dsl\.get_uri' can only be called at task runtime\. The task root is unknown in the current environment\."
+        ):
+            dsl.get_uri()
+
+    def test_default_gcs(self):
+        with set_temporary_task_root(
+                '/gcs/my_bucket/123456789/abc-09-14-2023-14-21-53/foo_123456789'
+        ):
+            self.assertEqual(
+                'gs://my_bucket/123456789/abc-09-14-2023-14-21-53/foo_123456789/Output',
+                dsl.get_uri())
+
+    def test_default_s3(self):
+        with set_temporary_task_root(
+                '/s3/my_bucket/123456789/abc-09-14-2023-14-21-53/foo_123456789'
+        ):
+            self.assertEqual(
+                's3://my_bucket/123456789/abc-09-14-2023-14-21-53/foo_123456789/Output',
+                dsl.get_uri())
+
+    def test_default_minio(self):
+        with set_temporary_task_root(
+                '/minio/my_bucket/123456789/abc-09-14-2023-14-21-53/foo_123456789'
+        ):
+            self.assertEqual(
+                'minio://my_bucket/123456789/abc-09-14-2023-14-21-53/foo_123456789/Output',
+                dsl.get_uri())
+
+    def test_suffix_arg(self):
+        with set_temporary_task_root(
+                '/gcs/my_bucket/123456789/abc-09-14-2023-14-21-53/foo_123456789'
+        ):
+            self.assertEqual(
+                'gs://my_bucket/123456789/abc-09-14-2023-14-21-53/foo_123456789/model',
+                dsl.get_uri('model'))
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/dsl/types/artifact_types_test.py
+++ b/sdk/python/kfp/dsl/types/artifact_types_test.py
@@ -110,6 +110,24 @@ class TestGetUri(unittest.TestCase):
                 'gs://my_bucket/123456789/abc-09-14-2023-14-21-53/foo_123456789/model',
                 dsl.get_uri('model'))
 
+    def test_suffix_arg_tmp_no_suffix(self):
+        with set_temporary_task_root('/tmp/kfp_outputs'):
+            with self.assertWarnsRegex(
+                    RuntimeWarning,
+                    r'dsl\.get_uri is not yet supported by the KFP backend\. Please specify a URI explicitly\.'
+            ):
+                actual = dsl.get_uri('model')
+                self.assertEqual('', actual)
+
+    def test_suffix_arg_tmp_with_suffix(self):
+        with set_temporary_task_root('/tmp/kfp_outputs'):
+            with self.assertWarnsRegex(
+                    RuntimeWarning,
+                    r'dsl\.get_uri is not yet supported by the KFP backend\. Please specify a URI explicitly\.'
+            ):
+                actual = dsl.get_uri('model')
+                self.assertEqual('', actual)
+
 
 class TestConvertLocalPathToRemotePath(parameterized.TestCase):
 

--- a/sdk/python/kfp/dsl/types/type_annotations.py
+++ b/sdk/python/kfp/dsl/types/type_annotations.py
@@ -17,7 +17,11 @@ These are only compatible with v2 Pipelines.
 """
 
 import re
+<<<<<<< HEAD
 from typing import Any, List, Optional, Type, TypeVar, Union
+=======
+from typing import Any, List, Type, TypeVar, Union
+>>>>>>> 0489000a3 (chore(sdk): test observability, refactorings, and cleanup)
 
 from kfp.dsl.types import artifact_types
 from kfp.dsl.types import type_annotations

--- a/sdk/python/kfp/dsl/types/type_annotations.py
+++ b/sdk/python/kfp/dsl/types/type_annotations.py
@@ -17,11 +17,7 @@ These are only compatible with v2 Pipelines.
 """
 
 import re
-<<<<<<< HEAD
 from typing import Any, List, Optional, Type, TypeVar, Union
-=======
-from typing import Any, List, Type, TypeVar, Union
->>>>>>> 0489000a3 (chore(sdk): test observability, refactorings, and cleanup)
 
 from kfp.dsl.types import artifact_types
 from kfp.dsl.types import type_annotations
@@ -139,7 +135,7 @@ def is_Input_Output_artifact_annotation(typ) -> bool:
     return True
 
 
-def is_input_artifact(typ) -> bool:
+def is_artifact_wrapped_in_Input(typ) -> bool:
     """Returns True if typ is of type Input[T]."""
     if not is_Input_Output_artifact_annotation(typ):
         return False
@@ -147,7 +143,7 @@ def is_input_artifact(typ) -> bool:
     return typ.__metadata__[0] == InputAnnotation
 
 
-def is_output_artifact(typ) -> bool:
+def is_artifact_wrapped_in_Output(typ) -> bool:
     """Returns True if typ is of type Output[T]."""
     if not is_Input_Output_artifact_annotation(typ):
         return False
@@ -164,14 +160,19 @@ def get_io_artifact_class(typ):
         return None
 
     # extract inner type from list of artifacts
-    inner = typ.__args__[0]
+    inner = strip_Input_or_Output_marker(typ)
     if hasattr(inner, '__origin__') and inner.__origin__ == list:
         return inner.__args__[0]
 
     return inner
 
 
-def get_io_artifact_annotation(typ):
+def strip_Input_or_Output_marker(typ):
+    return typ.__args__[0]
+
+
+def get_input_or_output_marker(
+        typ) -> Optional[Union[InputAnnotation, OutputAnnotation]]:
     if not is_Input_Output_artifact_annotation(typ):
         return None
 

--- a/sdk/python/kfp/dsl/types/type_annotations.py
+++ b/sdk/python/kfp/dsl/types/type_annotations.py
@@ -135,7 +135,7 @@ def is_Input_Output_artifact_annotation(typ) -> bool:
     return True
 
 
-def is_artifact_wrapped_in_Input(typ) -> bool:
+def is_artifact_wrapped_in_Input(typ: Any) -> bool:
     """Returns True if typ is of type Input[T]."""
     if not is_Input_Output_artifact_annotation(typ):
         return False
@@ -143,7 +143,7 @@ def is_artifact_wrapped_in_Input(typ) -> bool:
     return typ.__metadata__[0] == InputAnnotation
 
 
-def is_artifact_wrapped_in_Output(typ) -> bool:
+def is_artifact_wrapped_in_Output(typ: Any) -> bool:
     """Returns True if typ is of type Output[T]."""
     if not is_Input_Output_artifact_annotation(typ):
         return False
@@ -167,7 +167,7 @@ def get_io_artifact_class(typ):
     return inner
 
 
-def strip_Input_or_Output_marker(typ):
+def strip_Input_or_Output_marker(typ: Any) -> artifact_types.Artifact:
     return typ.__args__[0]
 
 

--- a/sdk/python/kfp/dsl/types/type_annotations_test.py
+++ b/sdk/python/kfp/dsl/types/type_annotations_test.py
@@ -58,21 +58,24 @@ class AnnotationsTest(parameterized.TestCase):
         Input,
     ])
     def test_is_input_artifact(self, annotation):
-        self.assertTrue(type_annotations.is_input_artifact(annotation))
+        self.assertTrue(
+            type_annotations.is_artifact_wrapped_in_Input(annotation))
 
     @parameterized.parameters([
         Output[Model],
         Output,
     ])
     def test_is_not_input_artifact(self, annotation):
-        self.assertFalse(type_annotations.is_input_artifact(annotation))
+        self.assertFalse(
+            type_annotations.is_artifact_wrapped_in_Input(annotation))
 
     @parameterized.parameters([
         Output[Model],
         Output[List[Model]],
     ])
     def test_is_output_artifact(self, annotation):
-        self.assertTrue(type_annotations.is_output_artifact(annotation))
+        self.assertTrue(
+            type_annotations.is_artifact_wrapped_in_Output(annotation))
 
     @parameterized.parameters([
         Input[Model],
@@ -80,7 +83,8 @@ class AnnotationsTest(parameterized.TestCase):
         Input,
     ])
     def test_is_not_output_artifact(self, annotation):
-        self.assertFalse(type_annotations.is_output_artifact(annotation))
+        self.assertFalse(
+            type_annotations.is_artifact_wrapped_in_Output(annotation))
 
     def test_get_io_artifact_class(self):
         self.assertEqual(
@@ -97,26 +101,26 @@ class AnnotationsTest(parameterized.TestCase):
 
     def test_get_io_artifact_annotation(self):
         self.assertEqual(
-            type_annotations.get_io_artifact_annotation(Output[Model]),
+            type_annotations.get_input_or_output_marker(Output[Model]),
             OutputAnnotation)
         self.assertEqual(
-            type_annotations.get_io_artifact_annotation(Output[List[Model]]),
+            type_annotations.get_input_or_output_marker(Output[List[Model]]),
             OutputAnnotation)
         self.assertEqual(
-            type_annotations.get_io_artifact_annotation(Input[Model]),
+            type_annotations.get_input_or_output_marker(Input[Model]),
             InputAnnotation)
         self.assertEqual(
-            type_annotations.get_io_artifact_annotation(Input[List[Model]]),
+            type_annotations.get_input_or_output_marker(Input[List[Model]]),
             InputAnnotation)
         self.assertEqual(
-            type_annotations.get_io_artifact_annotation(Input), InputAnnotation)
+            type_annotations.get_input_or_output_marker(Input), InputAnnotation)
         self.assertEqual(
-            type_annotations.get_io_artifact_annotation(Output),
+            type_annotations.get_input_or_output_marker(Output),
             OutputAnnotation)
 
         self.assertEqual(
-            type_annotations.get_io_artifact_annotation(Model), None)
-        self.assertEqual(type_annotations.get_io_artifact_annotation(str), None)
+            type_annotations.get_input_or_output_marker(Model), None)
+        self.assertEqual(type_annotations.get_input_or_output_marker(str), None)
 
     @parameterized.parameters(
         {
@@ -253,90 +257,6 @@ class TestIsSubclassOfArtifact(parameterized.TestCase):
         dsl.Dataset(),
         1,
         NotArtifactSubclass,
-    ]])
-    def test_false(self, obj):
-        self.assertFalse(type_annotations.issubclass_of_artifact(obj))
-
-
-class TestIsGenericList(parameterized.TestCase):
-
-    @parameterized.parameters([{
-        'obj': obj
-    } for obj in [
-        List,
-        List[str],
-        List[dsl.Artifact],
-        List[Dict[str, str]],
-    ] + ([
-        list,
-        list[str],
-    ] if sys.version_info >= (3, 9, 0) else [])])
-    def test_true(self, obj):
-        self.assertTrue(type_annotations.is_generic_list(obj))
-
-    @parameterized.parameters([{
-        'obj': obj
-    } for obj in [
-        Optional[List[str]],
-        Dict[str, str],
-        str,
-        int,
-        dsl.Artifact,
-    ]])
-    def test_false(self, obj):
-        self.assertFalse(type_annotations.is_generic_list(obj))
-
-
-class TestGetInnerType(parameterized.TestCase):
-
-    @parameterized.parameters([{
-        'annotation': annotation,
-        'expected': expected
-    } for annotation, expected in [
-        (int, None),
-        (Optional[int], (int, type(None))),
-        (Union[int, None], (int, type(None))),
-        (List[str], str),
-        (Dict[str, str], (str, str)),
-        (List[dsl.Artifact], dsl.Artifact),
-    ] + ([
-        (list[str], str),
-        (dict[str, str], (str, str)),
-        (list[dsl.Artifact], dsl.Artifact),
-    ] if sys.version_info >= (3, 9, 0) else [])])
-    def test(self, annotation, expected):
-        actual = type_annotations.get_inner_type(annotation)
-        self.assertEqual(actual, expected)
-
-
-class MyArtifact(dsl.Artifact):
-    pass
-
-
-class NotArtifact:
-    pass
-
-
-class TestIsSubclassOfArtifact(parameterized.TestCase):
-
-    @parameterized.parameters([{
-        'obj': obj
-    } for obj in [
-        dsl.Artifact,
-        dsl.Dataset,
-        dsl.Metrics,
-        MyArtifact,
-    ]])
-    def test_true(self, obj):
-        self.assertTrue(type_annotations.issubclass_of_artifact(obj))
-
-    @parameterized.parameters([{
-        'obj': obj
-    } for obj in [
-        dsl.Artifact(),
-        dsl.Dataset(),
-        1,
-        NotArtifact(),
     ]])
     def test_false(self, obj):
         self.assertFalse(type_annotations.issubclass_of_artifact(obj))

--- a/sdk/python/test_data/pipelines/pythonic_artifact_with_single_return.py
+++ b/sdk/python/test_data/pipelines/pythonic_artifact_with_single_return.py
@@ -1,0 +1,58 @@
+# Copyright 2023 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kfp import dsl
+from kfp.dsl import Dataset
+from kfp.dsl import Model
+
+
+@dsl.component
+def make_language_model(text_dataset: Dataset) -> Model:
+    # dill allows pickling objects belonging to a function's local namespace
+    import dill
+
+    with open(text_dataset.path) as f:
+        text = f.read()
+
+    # insert train on text here #
+
+    def dummy_model(x: str) -> str:
+        return x
+
+    model = Model(
+        uri=dsl.get_uri(suffix='model'),
+        metadata={'data': text_dataset.name},
+    )
+
+    with open(model.path, 'wb') as f:
+        dill.dump(dummy_model, f)
+
+    return model
+
+
+@dsl.pipeline
+def make_language_model_pipeline() -> Model:
+    importer = dsl.importer(
+        artifact_uri='gs://ml-pipeline-playground/shakespeare1.txt',
+        artifact_class=Dataset,
+        reimport=False,
+        metadata={'key': 'value'})
+    return make_language_model(text_dataset=importer.output).output
+
+
+if __name__ == '__main__':
+    from kfp import compiler
+    compiler.Compiler().compile(
+        pipeline_func=make_language_model_pipeline,
+        package_path=__file__.replace('.py', '.yaml'))

--- a/sdk/python/test_data/pipelines/pythonic_artifact_with_single_return.py
+++ b/sdk/python/test_data/pipelines/pythonic_artifact_with_single_return.py
@@ -17,7 +17,7 @@ from kfp.dsl import Dataset
 from kfp.dsl import Model
 
 
-@dsl.component
+@dsl.component(packages_to_install=['dill==0.3.7'])
 def make_language_model(text_dataset: Dataset) -> Model:
     # dill allows pickling objects belonging to a function's local namespace
     import dill

--- a/sdk/python/test_data/pipelines/pythonic_artifact_with_single_return.yaml
+++ b/sdk/python/test_data/pipelines/pythonic_artifact_with_single_return.yaml
@@ -53,8 +53,9 @@ deploymentSpec:
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.2.0'\
-          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
-          $0\" \"$@\"\n"
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
+          \  python3 -m pip install --quiet --no-warn-script-location 'dill==0.3.7'\
+          \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)

--- a/sdk/python/test_data/pipelines/pythonic_artifact_with_single_return.yaml
+++ b/sdk/python/test_data/pipelines/pythonic_artifact_with_single_return.yaml
@@ -1,0 +1,122 @@
+# PIPELINE DEFINITION
+# Name: make-language-model-pipeline
+# Outputs:
+#    Output: system.Model
+components:
+  comp-importer:
+    executorLabel: exec-importer
+    inputDefinitions:
+      parameters:
+        uri:
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        artifact:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+  comp-make-language-model:
+    executorLabel: exec-make-language-model
+    inputDefinitions:
+      artifacts:
+        text_dataset:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+    outputDefinitions:
+      artifacts:
+        Output:
+          artifactType:
+            schemaTitle: system.Model
+            schemaVersion: 0.0.1
+deploymentSpec:
+  executors:
+    exec-importer:
+      importer:
+        artifactUri:
+          constant: gs://ml-pipeline-playground/shakespeare1.txt
+        metadata:
+          key: value
+        typeSchema:
+          schemaTitle: system.Dataset
+          schemaVersion: 0.0.1
+    exec-make-language-model:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - make_language_model
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.2.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef make_language_model(text_dataset: Dataset) -> Model:\n    # dill\
+          \ allows pickling objects belonging to a function's local namespace\n  \
+          \  import dill\n\n    with open(text_dataset.path) as f:\n        text =\
+          \ f.read()\n\n    # insert train on text here #\n\n    def dummy_model(x:\
+          \ str) -> str:\n        return x\n\n    model = Model(\n        uri=dsl.get_uri(suffix='model'),\n\
+          \        metadata={'data': text_dataset.name},\n    )\n\n    with open(model.path,\
+          \ 'wb') as f:\n        dill.dump(dummy_model, f)\n\n    return model\n\n"
+        image: python:3.7
+pipelineInfo:
+  name: make-language-model-pipeline
+root:
+  dag:
+    outputs:
+      artifacts:
+        Output:
+          artifactSelectors:
+          - outputArtifactKey: Output
+            producerSubtask: make-language-model
+    tasks:
+      importer:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-importer
+        inputs:
+          parameters:
+            uri:
+              runtimeValue:
+                constant: gs://ml-pipeline-playground/shakespeare1.txt
+        taskInfo:
+          name: importer
+      make-language-model:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-make-language-model
+        dependentTasks:
+        - importer
+        inputs:
+          artifacts:
+            text_dataset:
+              taskOutputArtifact:
+                outputArtifactKey: artifact
+                producerTask: importer
+        taskInfo:
+          name: make-language-model
+  outputDefinitions:
+    artifacts:
+      Output:
+        artifactType:
+          schemaTitle: system.Model
+          schemaVersion: 0.0.1
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.2.0

--- a/sdk/python/test_data/pipelines/pythonic_artifacts_with_list_of_artifacts.py
+++ b/sdk/python/test_data/pipelines/pythonic_artifacts_with_list_of_artifacts.py
@@ -1,0 +1,52 @@
+# Copyright 2023 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+from kfp import dsl
+from kfp.dsl import Dataset
+
+
+@dsl.component
+def make_dataset(text: str) -> Dataset:
+    dataset = Dataset(uri=dsl.get_uri(), metadata={'length': len(text)})
+    with open(dataset.path, 'w') as f:
+        f.write(text)
+    return dataset
+
+
+@dsl.component
+def join_datasets(datasets: List[Dataset]) -> Dataset:
+    texts = []
+    for dataset in datasets:
+        with open(dataset.path, 'r') as f:
+            texts.append(f.read())
+
+    return ''.join(texts)
+
+
+@dsl.pipeline
+def make_and_join_datasets(
+        texts: List[str] = ['Hello', ',', ' ', 'world!']) -> Dataset:
+    with dsl.ParallelFor(texts) as text:
+        t1 = make_dataset(text=text)
+
+    return join_datasets(datasets=dsl.Collected(t1.output)).output
+
+
+if __name__ == '__main__':
+    from kfp import compiler
+    compiler.Compiler().compile(
+        pipeline_func=make_and_join_datasets,
+        package_path=__file__.replace('.py', '.yaml'))

--- a/sdk/python/test_data/pipelines/pythonic_artifacts_with_list_of_artifacts.yaml
+++ b/sdk/python/test_data/pipelines/pythonic_artifacts_with_list_of_artifacts.yaml
@@ -1,0 +1,187 @@
+# PIPELINE DEFINITION
+# Name: make-and-join-datasets
+# Inputs:
+#    texts: list [Default: ['Hello', ',', ' ', 'world!']]
+# Outputs:
+#    Output: system.Dataset
+components:
+  comp-for-loop-1:
+    dag:
+      outputs:
+        artifacts:
+          pipelinechannel--make-dataset-Output:
+            artifactSelectors:
+            - outputArtifactKey: Output
+              producerSubtask: make-dataset
+      tasks:
+        make-dataset:
+          cachingOptions:
+            enableCache: true
+          componentRef:
+            name: comp-make-dataset
+          inputs:
+            parameters:
+              text:
+                componentInputParameter: pipelinechannel--texts-loop-item
+          taskInfo:
+            name: make-dataset
+    inputDefinitions:
+      parameters:
+        pipelinechannel--texts:
+          parameterType: LIST
+        pipelinechannel--texts-loop-item:
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        pipelinechannel--make-dataset-Output:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+          isArtifactList: true
+  comp-join-datasets:
+    executorLabel: exec-join-datasets
+    inputDefinitions:
+      artifacts:
+        datasets:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+          isArtifactList: true
+    outputDefinitions:
+      artifacts:
+        Output:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+  comp-make-dataset:
+    executorLabel: exec-make-dataset
+    inputDefinitions:
+      parameters:
+        text:
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        Output:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+deploymentSpec:
+  executors:
+    exec-join-datasets:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - join_datasets
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.2.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef join_datasets(datasets: List[Dataset]) -> Dataset:\n    texts\
+          \ = []\n    for dataset in datasets:\n        with open(dataset.path, 'r')\
+          \ as f:\n            texts.append(f.read())\n\n    return ''.join(texts)\n\
+          \n"
+        image: python:3.7
+    exec-make-dataset:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - make_dataset
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.2.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef make_dataset(text: str) -> Dataset:\n    dataset = Dataset(uri=dsl.get_uri(),\
+          \ metadata={'length': len(text)})\n    with open(dataset.path, 'w') as f:\n\
+          \        f.write(text)\n    return dataset\n\n"
+        image: python:3.7
+pipelineInfo:
+  name: make-and-join-datasets
+root:
+  dag:
+    outputs:
+      artifacts:
+        Output:
+          artifactSelectors:
+          - outputArtifactKey: Output
+            producerSubtask: join-datasets
+    tasks:
+      for-loop-1:
+        componentRef:
+          name: comp-for-loop-1
+        inputs:
+          parameters:
+            pipelinechannel--texts:
+              componentInputParameter: texts
+        parameterIterator:
+          itemInput: pipelinechannel--texts-loop-item
+          items:
+            inputParameter: pipelinechannel--texts
+        taskInfo:
+          name: for-loop-1
+      join-datasets:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-join-datasets
+        dependentTasks:
+        - for-loop-1
+        inputs:
+          artifacts:
+            datasets:
+              taskOutputArtifact:
+                outputArtifactKey: pipelinechannel--make-dataset-Output
+                producerTask: for-loop-1
+        taskInfo:
+          name: join-datasets
+  inputDefinitions:
+    parameters:
+      texts:
+        defaultValue:
+        - Hello
+        - ','
+        - ' '
+        - world!
+        isOptional: true
+        parameterType: LIST
+  outputDefinitions:
+    artifacts:
+      Output:
+        artifactType:
+          schemaTitle: system.Dataset
+          schemaVersion: 0.0.1
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.2.0

--- a/sdk/python/test_data/pipelines/pythonic_artifacts_with_multiple_returns.py
+++ b/sdk/python/test_data/pipelines/pythonic_artifacts_with_multiple_returns.py
@@ -1,0 +1,93 @@
+# Copyright 2023 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import NamedTuple
+
+from kfp import dsl
+from kfp.dsl import Artifact
+from kfp.dsl import Dataset
+
+
+@dsl.component
+def dataset_splitter(
+    in_dataset: Dataset
+) -> NamedTuple(
+        'outputs',
+        dataset1=Dataset,
+        dataset2=Dataset,
+):
+
+    with open(in_dataset.path) as f:
+        in_data = f.read()
+
+    out_data1, out_data2 = in_data[:len(in_data) // 2], in_data[len(in_data) //
+                                                                2:]
+
+    dataset1 = Dataset(
+        uri=dsl.get_uri(suffix='dataset1'),
+        metadata={'original_data': in_dataset.name},
+    )
+    with open(dataset1.path, 'w') as f:
+        f.write(out_data1)
+
+    dataset2 = Dataset(
+        uri=dsl.get_uri(suffix='dataset2'),
+        metadata={'original_data': in_dataset.name},
+    )
+    with open(dataset2.path, 'w') as f:
+        f.write(out_data2)
+
+    outputs = NamedTuple(
+        'outputs',
+        dataset1=Dataset,
+        dataset2=Dataset,
+    )
+    return outputs(dataset1=dataset1, dataset2=dataset2)
+
+
+outputs = NamedTuple(
+    'outputs',
+    dataset1=Dataset,
+    dataset2=Dataset,
+)
+
+
+@dsl.pipeline
+def splitter_pipeline(in_dataset: Dataset) -> outputs:
+    task = dataset_splitter(in_dataset=in_dataset)
+    return outputs(
+        task.outputs['dataset1'],
+        task.outputs['dataset1'],
+    )
+
+
+@dsl.component
+def make_dataset() -> Artifact:
+    artifact = Artifact(uri=dsl.get_uri('dataset'))
+    with open(artifact.path, 'w') as f:
+        f.write('Hello, world')
+    return artifact
+
+
+@dsl.pipeline
+def split_datasets_and_return_first() -> Dataset:
+    t1 = make_dataset()
+    return splitter_pipeline(in_dataset=t1.output).outputs['dataset1']
+
+
+if __name__ == '__main__':
+    from kfp import compiler
+    compiler.Compiler().compile(
+        pipeline_func=split_datasets_and_return_first,
+        package_path=__file__.replace('.py', '.yaml'))

--- a/sdk/python/test_data/pipelines/pythonic_artifacts_with_multiple_returns.yaml
+++ b/sdk/python/test_data/pipelines/pythonic_artifacts_with_multiple_returns.yaml
@@ -1,0 +1,184 @@
+# PIPELINE DEFINITION
+# Name: split-datasets-and-return-first
+# Outputs:
+#    Output: system.Dataset
+components:
+  comp-dataset-splitter:
+    executorLabel: exec-dataset-splitter
+    inputDefinitions:
+      artifacts:
+        in_dataset:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+    outputDefinitions:
+      artifacts:
+        dataset1:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+        dataset2:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+  comp-make-dataset:
+    executorLabel: exec-make-dataset
+    outputDefinitions:
+      artifacts:
+        Output:
+          artifactType:
+            schemaTitle: system.Artifact
+            schemaVersion: 0.0.1
+  comp-splitter-pipeline:
+    dag:
+      outputs:
+        artifacts:
+          dataset1:
+            artifactSelectors:
+            - outputArtifactKey: dataset1
+              producerSubtask: dataset-splitter
+          dataset2:
+            artifactSelectors:
+            - outputArtifactKey: dataset1
+              producerSubtask: dataset-splitter
+      tasks:
+        dataset-splitter:
+          cachingOptions:
+            enableCache: true
+          componentRef:
+            name: comp-dataset-splitter
+          inputs:
+            artifacts:
+              in_dataset:
+                componentInputArtifact: in_dataset
+          taskInfo:
+            name: dataset-splitter
+    inputDefinitions:
+      artifacts:
+        in_dataset:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+    outputDefinitions:
+      artifacts:
+        dataset1:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+        dataset2:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+deploymentSpec:
+  executors:
+    exec-dataset-splitter:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - dataset_splitter
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.2.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef dataset_splitter(\n    in_dataset: Dataset\n) -> NamedTuple(\n\
+          \        'outputs',\n        dataset1=Dataset,\n        dataset2=Dataset,\n\
+          ):\n\n    with open(in_dataset.path) as f:\n        in_data = f.read()\n\
+          \n    out_data1, out_data2 = in_data[:len(in_data) // 2], in_data[len(in_data)\
+          \ //\n                                                                2:]\n\
+          \n    dataset1 = Dataset(\n        uri=dsl.get_uri(suffix='dataset1'),\n\
+          \        metadata={'original_data': in_dataset.name},\n    )\n    with open(dataset1.path,\
+          \ 'w') as f:\n        f.write(out_data1)\n\n    dataset2 = Dataset(\n  \
+          \      uri=dsl.get_uri(suffix='dataset2'),\n        metadata={'original_data':\
+          \ in_dataset.name},\n    )\n    with open(dataset2.path, 'w') as f:\n  \
+          \      f.write(out_data2)\n\n    outputs = NamedTuple(\n        'outputs',\n\
+          \        dataset1=Dataset,\n        dataset2=Dataset,\n    )\n    return\
+          \ outputs(dataset1=dataset1, dataset2=dataset2)\n\n"
+        image: python:3.7
+    exec-make-dataset:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - make_dataset
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.2.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef make_dataset() -> Artifact:\n    artifact = Artifact(uri=dsl.get_uri('dataset'))\n\
+          \    with open(artifact.path, 'w') as f:\n        f.write('Hello, world')\n\
+          \    return artifact\n\n"
+        image: python:3.7
+pipelineInfo:
+  name: split-datasets-and-return-first
+root:
+  dag:
+    outputs:
+      artifacts:
+        Output:
+          artifactSelectors:
+          - outputArtifactKey: dataset1
+            producerSubtask: splitter-pipeline
+    tasks:
+      make-dataset:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-make-dataset
+        taskInfo:
+          name: make-dataset
+      splitter-pipeline:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-splitter-pipeline
+        dependentTasks:
+        - make-dataset
+        inputs:
+          artifacts:
+            in_dataset:
+              taskOutputArtifact:
+                outputArtifactKey: Output
+                producerTask: make-dataset
+        taskInfo:
+          name: splitter-pipeline
+  outputDefinitions:
+    artifacts:
+      Output:
+        artifactType:
+          schemaTitle: system.Dataset
+          schemaVersion: 0.0.1
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.2.0

--- a/sdk/python/test_data/test_data_config.yaml
+++ b/sdk/python/test_data/test_data_config.yaml
@@ -182,10 +182,10 @@ pipelines:
       execute: false
     - module: pythonic_artifact_with_single_return
       name: make_language_model_pipeline
-      execute: true
+      execute: false
     - module: pythonic_artifacts_with_multiple_returns
       name: split_datasets_and_return_first
-      execute: true
+      execute: false
     - module: pythonic_artifacts_with_list_of_artifacts
       name: make_and_join_datasets
       execute: false

--- a/sdk/python/test_data/test_data_config.yaml
+++ b/sdk/python/test_data/test_data_config.yaml
@@ -182,10 +182,10 @@ pipelines:
       execute: false
     - module: pythonic_artifact_with_single_return
       name: make_language_model_pipeline
-      execute: false
+      execute: true
     - module: pythonic_artifacts_with_multiple_returns
       name: split_datasets_and_return_first
-      execute: false
+      execute: true
     - module: pythonic_artifacts_with_list_of_artifacts
       name: make_and_join_datasets
       execute: false

--- a/sdk/python/test_data/test_data_config.yaml
+++ b/sdk/python/test_data/test_data_config.yaml
@@ -180,6 +180,15 @@ pipelines:
     - module: if_elif_else_with_oneof_parameters
       name: outer_pipeline
       execute: false
+    - module: pythonic_artifact_with_single_return
+      name: make_language_model_pipeline
+      execute: false
+    - module: pythonic_artifacts_with_multiple_returns
+      name: split_datasets_and_return_first
+      execute: false
+    - module: pythonic_artifacts_with_list_of_artifacts
+      name: make_and_join_datasets
+      execute: false
 components:
   test_data_dir: sdk/python/test_data/components
   read: true

--- a/test/sdk-execution-tests/requirements.txt
+++ b/test/sdk-execution-tests/requirements.txt
@@ -1,4 +1,3 @@
 sdk/python
 pytest==7.1.3
 pytest-asyncio-cooperative==0.28.0
-pytest-mock==3.8.2


### PR DESCRIPTION
**Description of your changes:**
Supports a Pythonic artifact authoring syntax, creating unity between the parameter and artifact authoring experiences.

```python
from kfp import dsl
from kfp.dsl import Dataset, Model

@dsl.component
def train_model(dataset: Dataset) -> Model:

    with open(dataset.path) as f:
        dataset_lines = f.read()

    # train a model
    trained_model = ...

    model_artifact = Model(uri=dsl.get_uri())
    trained_model.save(model_artifact.path)
    
    return model_artifact
```
**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more 
about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
