### PR TITLE
chore(frontend): Improve structure of NewExperimentFC.

### DIFF
--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -1699,7 +1699,7 @@ describe('NewRun', () => {
       await screen.findByDisplayValue('prefilled value 1');
       await screen.findByLabelText('param-2');
       await screen.findByDisplayValue('prefilled value 2');
-    });
+    }, 10000);
 
     it('trims whitespace from the pipeline params', async () => {
       tree = shallow(<TestNewRun {...generateProps()} />);

--- a/frontend/src/pages/functional_components/NewExperimentFC.tsx
+++ b/frontend/src/pages/functional_components/NewExperimentFC.tsx
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
-import BusyButton from 'src/atoms/BusyButton';
 import Button from '@material-ui/core/Button';
-import Input from 'src/atoms/Input';
+import React, { useEffect, useState } from 'react';
+import { useMutation, useQuery } from 'react-query';
+import { commonCss, fontsize, padding } from 'src/Css';
 import { V2beta1Experiment } from 'src/apisv2beta1/experiment';
+import { V2beta1PipelineVersion } from 'src/apisv2beta1/pipeline';
+import BusyButton from 'src/atoms/BusyButton';
+import Input from 'src/atoms/Input';
+import { QUERY_PARAMS, RoutePage } from 'src/components/Router';
 import { Apis } from 'src/lib/Apis';
-import { PageProps } from 'src/pages/Page';
-import { RoutePage, QUERY_PARAMS } from 'src/components/Router';
 import { URLParser } from 'src/lib/URLParser';
-import { classes, stylesheet } from 'typestyle';
-import { commonCss, padding, fontsize } from 'src/Css';
 import { errorToMessage } from 'src/lib/Utils';
 import { getLatestVersion } from 'src/pages/NewRunV2';
-import { useMutation } from 'react-query';
-import { V2beta1PipelineVersion } from 'src/apisv2beta1/pipeline';
+import { PageProps } from 'src/pages/Page';
+import { classes, stylesheet } from 'typestyle';
 
 const css = stylesheet({
   errorMessage: {
@@ -52,11 +52,15 @@ export function NewExperimentFC(props: NewExperimentFCProps) {
   const [description, setDescription] = useState<string>('');
   const [experimentName, setExperimentName] = useState<string>('');
   const [isbeingCreated, setIsBeingCreated] = useState<boolean>(false);
-  const [errorMessage, setErrorMessage] = useState<string>('');
-  const [latestVersion, setLatestVersion] = useState<V2beta1PipelineVersion | undefined>();
   const [experimentResponse, setExperimentResponse] = useState<V2beta1Experiment>();
   const [errMsgFromApi, setErrMsgFromApi] = useState<string>();
   const pipelineId = urlParser.get(QUERY_PARAMS.pipelineId);
+
+  const { data: latestVersion } = useQuery<V2beta1PipelineVersion | undefined, Error>(
+    ['pipeline_versions', pipelineId],
+    () => getLatestVersion(pipelineId!),
+    { enabled: !!pipelineId },
+  );
 
   useEffect(() => {
     updateToolbar({
@@ -64,16 +68,9 @@ export function NewExperimentFC(props: NewExperimentFCProps) {
       breadcrumbs: [{ displayName: 'Experiments', href: RoutePage.EXPERIMENTS }],
       pageTitle: 'New experiment',
     });
+    // Initialize toolbar only once during the first render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  useEffect(() => {
-    if (pipelineId) {
-      (async () => {
-        setLatestVersion(await getLatestVersion(pipelineId));
-      })();
-    }
-  }, [pipelineId]);
 
   // Handle the redirection work when createExperiment is succeed
   useEffect(() => {
@@ -97,17 +94,10 @@ export function NewExperimentFC(props: NewExperimentFCProps) {
         open: true,
       });
     }
+    // Only trigger this effect when search string parameters change.
+    // Do not rerun this effect if updateSnackbar callback has changes to avoid re-rendering.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [experimentResponse]);
-
-  // Handle the error when createExperiment() is failed
-  useEffect(() => {
-    if (!experimentName) {
-      setErrorMessage('Experiment name is required');
-    } else {
-      setErrorMessage('');
-    }
-  }, [experimentName]);
+  }, [experimentResponse, latestVersion, pipelineId]);
 
   useEffect(() => {
     if (errMsgFromApi) {
@@ -118,8 +108,9 @@ export function NewExperimentFC(props: NewExperimentFCProps) {
         title: 'Experiment creation failed',
       });
     }
+    // Do not rerun this effect if updateDialog callback has changes to avoid re-rendering.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [errMsgFromApi]);
+  }, [errMsgFromApi, updateDialog]);
 
   const newExperimentMutation = useMutation((experiment: V2beta1Experiment) => {
     return Apis.experimentServiceApiV2.createExperiment(experiment);
@@ -136,6 +127,7 @@ export function NewExperimentFC(props: NewExperimentFCProps) {
     newExperimentMutation.mutate(newExperiment, {
       onSuccess: response => {
         setExperimentResponse(response);
+        setErrMsgFromApi(undefined);
       },
       onError: async err => {
         setErrMsgFromApi(await errorToMessage(err));
@@ -174,7 +166,7 @@ export function NewExperimentFC(props: NewExperimentFCProps) {
         <div className={commonCss.flex}>
           <BusyButton
             id='createExperimentBtn'
-            disabled={!!errorMessage}
+            disabled={!experimentName}
             busy={isbeingCreated}
             className={commonCss.buttonAction}
             title={'Next'}
@@ -186,7 +178,9 @@ export function NewExperimentFC(props: NewExperimentFCProps) {
           >
             Cancel
           </Button>
-          <div className={css.errorMessage}>{errorMessage}</div>
+          <div className={css.errorMessage}>
+            {experimentName ? '' : 'Experiment name is required'}
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/functional_components/NewExperimentFC.tsx
+++ b/frontend/src/pages/functional_components/NewExperimentFC.tsx
@@ -96,8 +96,9 @@ export function NewExperimentFC(props: NewExperimentFCProps) {
     }
     // Only trigger this effect when search string parameters change.
     // Do not rerun this effect if updateSnackbar callback has changes to avoid re-rendering.
+    // Do not rerun this effect if pipelineId has changes to avoid re-rendering.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [experimentResponse, latestVersion, pipelineId]);
+  }, [experimentResponse, latestVersion]);
 
   useEffect(() => {
     if (errMsgFromApi) {


### PR DESCRIPTION
**Description of your changes:**


- Remove the need for `setErrorMessage`, directly set the error message in html based on experiment name availability.
- Remove the need for `useEffect` for `setLatestVersion`, replaced with `useQuery` because `getLatestVersion()` is an API call.
- Add explanation for places where we need to disable `react-hooks/exhaustive-deps`.
- `setErrMsgFromApi` to undefined if the create experiment call is successful.
- Extended timeout for NewRun test since jest has been upgraded implicitly to 27. It is the version which `modern` fake timer has become default.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
