### PR TITLE
fix(backend): Sync scheduled workflows v1 if APIVersion and Kind are missing. Fixes #9809

### DIFF
--- a/backend/src/agent/persistence/client/scheduled_workflow_client.go
+++ b/backend/src/agent/persistence/client/scheduled_workflow_client.go
@@ -62,5 +62,11 @@ func (c *ScheduledWorkflowClient) Get(namespace string, name string) (
 			"Error retrieving scheduled workflow (%v) in namespace (%v): %v", name, namespace, err)
 	}
 
+	// If the APIVersion and Kind are not set then set them to the default values.
+	if schedule.APIVersion == "" && schedule.Kind == "" {
+		schedule.Kind = util.SwfKind
+		schedule.APIVersion = util.ApiVersionV1
+	}
+
 	return util.NewScheduledWorkflow(schedule), nil
 }

--- a/backend/src/common/util/scheduled_workflow.go
+++ b/backend/src/common/util/scheduled_workflow.go
@@ -31,9 +31,9 @@ const (
 	SWFlegacy  ScheduledWorkflowType = "legacy"
 	SWFunknown ScheduledWorkflowType = "Unknown"
 
-	apiVersionV1 = "kubeflow.org/v1beta1"
-	apiVersionV2 = "kubeflow.org/v2beta1"
-	swfKind      = "ScheduledWorkflow"
+	ApiVersionV1 = "kubeflow.org/v1beta1"
+	ApiVersionV2 = "kubeflow.org/v2beta1"
+	SwfKind      = "ScheduledWorkflow"
 )
 
 // ScheduledWorkflow is a type to help manipulate ScheduledWorkflow objects.
@@ -160,9 +160,9 @@ func (s *ScheduledWorkflow) ToStringForStore() string {
 }
 
 func (s *ScheduledWorkflow) GetVersion() ScheduledWorkflowType {
-	if strings.HasPrefix(s.APIVersion, apiVersionV1) && s.Kind == swfKind {
+	if strings.HasPrefix(s.APIVersion, ApiVersionV1) && s.Kind == SwfKind {
 		return SWFv1
-	} else if strings.HasPrefix(s.APIVersion, apiVersionV2) && s.Kind == swfKind {
+	} else if strings.HasPrefix(s.APIVersion, ApiVersionV2) && s.Kind == SwfKind {
 		return SWFv2
 	} else if s.APIVersion == "" && s.Kind == "" {
 		return SWFlegacy


### PR DESCRIPTION
**Description of your changes:**

Trying to fix #9809 which also became an issue for our deployment. The k8s go client does not return APIVersion and Kind in some situations (see https://github.com/kubernetes/client-go/issues/308) - when debugging this, APIVersion and Kind could be retrieved on first pass over but afterwards the information is missing. I assume that this has something to do with the cache, but I am not sure.

Regarding the change: As far as I can tell, kind in APIVersion are fixed anyway in the place that I add the information, since these are `v1beta1.ScheduledWorkflow` objects.