### PR TITLE
docs: fix GCP Resource Proto example

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/proto/README.md
+++ b/components/google-cloud/google_cloud_pipeline_components/proto/README.md
@@ -14,7 +14,7 @@ pip install -U google-cloud-pipeline-components
 To write a resource as an output parameter
 
 ```
-from google_cloud_pipeline_components.experimental.proto.gcp_resources_pb2 import GcpResources
+from google_cloud_pipeline_components.proto.gcp_resources_pb2 import GcpResources
 from google.protobuf.json_format import MessageToJson
 
 dataflow_resources = GcpResources()


### PR DESCRIPTION
**Description of your changes:**

The directory named experimental does not exist and leaving the current documentation in place will cause an error in the GCP Resouce Proto example.

**error log**
```
Traceback (most recent call last):
...

  File "sandbox/gcp_resource/demo.py", line 5, in <module>
    from google_cloud_pipeline_components.experimental.proto.gcp_resources_pb2 import (
ModuleNotFoundError: No module named 'google_cloud_pipeline_components.experimental'
```


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
