### PR TITLE
chore(sdk): wrap conditional branch groups in outer pipeline

### DIFF
--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -1286,6 +1286,20 @@ def build_spec_by_group(
                 is_parent_component_root=is_parent_component_root,
             )
 
+        # handles the conditional group wrapping only
+        elif isinstance(subgroup, tasks_group.ConditionBranches):
+            subgroup_component_spec = build_component_spec_for_group(
+                input_pipeline_channels=subgroup_input_channels,
+                output_pipeline_channels={},
+            )
+
+            subgroup_task_spec = build_task_spec_for_group(
+                group=subgroup,
+                pipeline_channels=subgroup_input_channels,
+                tasks_in_current_dag=tasks_in_current_dag,
+                is_parent_component_root=is_parent_component_root,
+            )
+
         else:
             raise RuntimeError(
                 f'Unexpected task/group type: Got {subgroup} of type '

--- a/sdk/python/kfp/dsl/tasks_group.py
+++ b/sdk/python/kfp/dsl/tasks_group.py
@@ -28,6 +28,7 @@ class TasksGroupType(str, enum.Enum):
     """Types of TasksGroup."""
     PIPELINE = 'pipeline'
     CONDITION = 'condition'
+    CONDITION_BRANCHES = 'condition-branches'
     FOR_LOOP = 'for-loop'
     EXIT_HANDLER = 'exit-handler'
 
@@ -138,6 +139,16 @@ class ExitHandler(TasksGroup):
         exit_task.is_exit_handler = True
 
         self.exit_task = exit_task
+
+
+class ConditionBranches(TasksGroup):
+
+    def __init__(self) -> None:
+        super().__init__(
+            group_type=TasksGroupType.CONDITION_BRANCHES,
+            name=None,
+            is_root=False,
+        )
 
 
 class _ConditionBase(TasksGroup):
@@ -263,6 +274,18 @@ class Elif(_ConditionBase):
             name=name,
         )
 
+    def __enter__(self):
+        if not pipeline_context.Pipeline.get_default_pipeline():
+            raise ValueError('Default pipeline not defined.')
+
+        pipeline = pipeline_context.Pipeline.get_default_pipeline()
+
+        maybe_make_and_insert_conditional_branches_group(pipeline)
+
+        self._make_name_unique()
+        pipeline.push_tasks_group(self)
+        return self
+
 
 class Else(_ConditionBase):
     """A class for creating a conditional control flow "else" block within a
@@ -293,7 +316,9 @@ class Else(_ConditionBase):
         prev_cond = pipeline_context.Pipeline.get_default_pipeline(
         ).get_last_tasks_group()
 
-        if isinstance(prev_cond, Else):
+        # if it immediately follows as TasksGroup, this is because it immediately
+        # follows Else in the user code and we wrap Else in a TasksGroup
+        if isinstance(prev_cond, ConditionBranches):
             # prefer pushing toward dsl.If rather than dsl.Condition for syntactic consistency with the if-elif-else keywords in Python
             raise InvalidControlFlowException(
                 'Cannot use dsl.Else following another dsl.Else. dsl.Else can only be used following an upstream dsl.If or dsl.Elif.'
@@ -308,6 +333,58 @@ class Else(_ConditionBase):
             conditions=prev_cond._negated_upstream_conditions,
             name=name,
         )
+
+    def __enter__(self):
+        if not pipeline_context.Pipeline.get_default_pipeline():
+            raise ValueError('Default pipeline not defined.')
+
+        pipeline = pipeline_context.Pipeline.get_default_pipeline()
+
+        maybe_make_and_insert_conditional_branches_group(pipeline)
+
+        self._make_name_unique()
+        pipeline.push_tasks_group(self)
+        return self
+
+    def __exit__(self, *unused_args):
+        pipeline = pipeline_context.Pipeline.get_default_pipeline()
+        pipeline.pop_tasks_group()
+
+        # since this is an else, also pop off the parent dag for conditional branches
+        # this parent TasksGroup is not a context manager, so we simulate its
+        # __exit__ call with this
+        pipeline.pop_tasks_group()
+
+
+def maybe_make_and_insert_conditional_branches_group(
+        pipeline: 'pipeline_context.Pipeline') -> None:
+
+    already_has_pipeline_wrapper = isinstance(
+        pipeline.get_last_tasks_group(),
+        Elif,
+    )
+    if already_has_pipeline_wrapper:
+        return
+
+    condition_wrapper_group = ConditionBranches()
+    condition_wrapper_group._make_name_unique()
+
+    # swap outer and inner group ids so that numbering stays sequentially consistent with how such hypothetical code would be authored
+    def swap_group_ids(parent: TasksGroup, cond: TasksGroup):
+        parent_name, parent_id = parent.name.rsplit('-', 1)
+        cond_name, cond_id = cond.name.split('-')
+        cond.name = f'{cond_name}-{parent_id}'
+        parent.name = f'{parent_name}-{cond_id}'
+
+    # replace last pushed group (If or Elif) with condition group
+    last_pushed_group = pipeline.groups[-1].groups.pop()
+    swap_group_ids(condition_wrapper_group, last_pushed_group)
+    pipeline.push_tasks_group(condition_wrapper_group)
+
+    # then repush (__enter__) and pop (__exit__) the last pushed group
+    # before the wrapper to emulate re-entering and exiting its context
+    pipeline.push_tasks_group(last_pushed_group)
+    pipeline.pop_tasks_group()
 
 
 class InvalidControlFlowException(Exception):

--- a/sdk/python/test_data/pipelines/if_elif_else.yaml
+++ b/sdk/python/test_data/pipelines/if_elif_else.yaml
@@ -1,7 +1,7 @@
 # PIPELINE DEFINITION
 # Name: roll-die-pipeline
 components:
-  comp-condition-1:
+  comp-condition-2:
     dag:
       tasks:
         print-and-return:
@@ -20,7 +20,7 @@ components:
       parameters:
         pipelinechannel--flip-three-sided-die-Output:
           parameterType: STRING
-  comp-condition-2:
+  comp-condition-3:
     dag:
       tasks:
         print-and-return-2:
@@ -39,7 +39,7 @@ components:
       parameters:
         pipelinechannel--flip-three-sided-die-Output:
           parameterType: STRING
-  comp-condition-3:
+  comp-condition-4:
     dag:
       tasks:
         print-and-return-3:
@@ -54,6 +54,51 @@ components:
                   constant: Draw!
           taskInfo:
             name: print-and-return-3
+    inputDefinitions:
+      parameters:
+        pipelinechannel--flip-three-sided-die-Output:
+          parameterType: STRING
+  comp-condition-branches-1:
+    dag:
+      tasks:
+        condition-2:
+          componentRef:
+            name: comp-condition-2
+          inputs:
+            parameters:
+              pipelinechannel--flip-three-sided-die-Output:
+                componentInputParameter: pipelinechannel--flip-three-sided-die-Output
+          taskInfo:
+            name: condition-2
+          triggerPolicy:
+            condition: inputs.parameter_values['pipelinechannel--flip-three-sided-die-Output']
+              == 'heads'
+        condition-3:
+          componentRef:
+            name: comp-condition-3
+          inputs:
+            parameters:
+              pipelinechannel--flip-three-sided-die-Output:
+                componentInputParameter: pipelinechannel--flip-three-sided-die-Output
+          taskInfo:
+            name: condition-3
+          triggerPolicy:
+            condition: '!(inputs.parameter_values[''pipelinechannel--flip-three-sided-die-Output'']
+              == ''heads'') && inputs.parameter_values[''pipelinechannel--flip-three-sided-die-Output'']
+              == ''tails'''
+        condition-4:
+          componentRef:
+            name: comp-condition-4
+          inputs:
+            parameters:
+              pipelinechannel--flip-three-sided-die-Output:
+                componentInputParameter: pipelinechannel--flip-three-sided-die-Output
+          taskInfo:
+            name: condition-4
+          triggerPolicy:
+            condition: '!(inputs.parameter_values[''pipelinechannel--flip-three-sided-die-Output'']
+              == ''heads'') && !(inputs.parameter_values[''pipelinechannel--flip-three-sided-die-Output'']
+              == ''tails'')'
     inputDefinitions:
       parameters:
         pipelinechannel--flip-three-sided-die-Output:
@@ -108,7 +153,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -139,7 +184,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -168,7 +213,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -197,7 +242,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -219,9 +264,9 @@ pipelineInfo:
 root:
   dag:
     tasks:
-      condition-1:
+      condition-branches-1:
         componentRef:
-          name: comp-condition-1
+          name: comp-condition-branches-1
         dependentTasks:
         - flip-three-sided-die
         inputs:
@@ -231,44 +276,7 @@ root:
                 outputParameterKey: Output
                 producerTask: flip-three-sided-die
         taskInfo:
-          name: condition-1
-        triggerPolicy:
-          condition: inputs.parameter_values['pipelinechannel--flip-three-sided-die-Output']
-            == 'heads'
-      condition-2:
-        componentRef:
-          name: comp-condition-2
-        dependentTasks:
-        - flip-three-sided-die
-        inputs:
-          parameters:
-            pipelinechannel--flip-three-sided-die-Output:
-              taskOutputParameter:
-                outputParameterKey: Output
-                producerTask: flip-three-sided-die
-        taskInfo:
-          name: condition-2
-        triggerPolicy:
-          condition: '!(inputs.parameter_values[''pipelinechannel--flip-three-sided-die-Output'']
-            == ''heads'') && inputs.parameter_values[''pipelinechannel--flip-three-sided-die-Output'']
-            == ''tails'''
-      condition-3:
-        componentRef:
-          name: comp-condition-3
-        dependentTasks:
-        - flip-three-sided-die
-        inputs:
-          parameters:
-            pipelinechannel--flip-three-sided-die-Output:
-              taskOutputParameter:
-                outputParameterKey: Output
-                producerTask: flip-three-sided-die
-        taskInfo:
-          name: condition-3
-        triggerPolicy:
-          condition: '!(inputs.parameter_values[''pipelinechannel--flip-three-sided-die-Output'']
-            == ''heads'') && !(inputs.parameter_values[''pipelinechannel--flip-three-sided-die-Output'']
-            == ''tails'')'
+          name: condition-branches-1
       flip-three-sided-die:
         cachingOptions:
           enableCache: true
@@ -277,4 +285,4 @@ root:
         taskInfo:
           name: flip-three-sided-die
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.1.3
+sdkVersion: kfp-2.3.0

--- a/sdk/python/test_data/pipelines/if_elif_else_complex.py
+++ b/sdk/python/test_data/pipelines/if_elif_else_complex.py
@@ -39,6 +39,11 @@ def print_strings(strings: List[str]):
     print(strings)
 
 
+@dsl.component
+def print_ints(ints: List[int]):
+    print(ints)
+
+
 @dsl.pipeline
 def lucky_number_pipeline(add_drumroll: bool = True,
                           repeat_if_lucky_number: bool = True,
@@ -77,7 +82,7 @@ def lucky_number_pipeline(add_drumroll: bool = True,
                         text='Announcing again: Got the lucky number 5000! A one in 10,000 chance.'
                     )
 
-    print_strings(strings=dsl.Collected(even_or_odd_task.output))
+    print_ints(ints=dsl.Collected(int_task.output))
 
 
 if __name__ == '__main__':

--- a/sdk/python/test_data/pipelines/if_elif_else_complex.yaml
+++ b/sdk/python/test_data/pipelines/if_elif_else_complex.yaml
@@ -5,12 +5,54 @@
 #    repeat_if_lucky_number: bool [Default: True]
 #    trials: list [Default: [1.0, 2.0, 3.0]]
 components:
-  comp-condition-10:
+  comp-condition-11:
     dag:
       tasks:
-        condition-11:
+        print-and-return-4:
+          cachingOptions:
+            enableCache: true
           componentRef:
-            name: comp-condition-11
+            name: comp-print-and-return-4
+          inputs:
+            parameters:
+              text:
+                runtimeValue:
+                  constant: Got a high even number!
+          taskInfo:
+            name: print-and-return-4
+    inputDefinitions:
+      parameters:
+        pipelinechannel--int-0-to-9999-Output:
+          parameterType: NUMBER_INTEGER
+        pipelinechannel--is-even-or-odd-2-Output:
+          parameterType: STRING
+  comp-condition-12:
+    dag:
+      tasks:
+        print-and-return-5:
+          cachingOptions:
+            enableCache: true
+          componentRef:
+            name: comp-print-and-return-5
+          inputs:
+            parameters:
+              text:
+                runtimeValue:
+                  constant: Got a high odd number!
+          taskInfo:
+            name: print-and-return-5
+    inputDefinitions:
+      parameters:
+        pipelinechannel--int-0-to-9999-Output:
+          parameterType: NUMBER_INTEGER
+        pipelinechannel--is-even-or-odd-2-Output:
+          parameterType: STRING
+  comp-condition-13:
+    dag:
+      tasks:
+        condition-14:
+          componentRef:
+            name: comp-condition-14
           inputs:
             parameters:
               pipelinechannel--int-0-to-9999-Output:
@@ -18,7 +60,7 @@ components:
               pipelinechannel--repeat_if_lucky_number:
                 componentInputParameter: pipelinechannel--repeat_if_lucky_number
           taskInfo:
-            name: condition-11
+            name: condition-14
           triggerPolicy:
             condition: inputs.parameter_values['pipelinechannel--repeat_if_lucky_number']
               == true
@@ -41,12 +83,12 @@ components:
           parameterType: NUMBER_INTEGER
         pipelinechannel--repeat_if_lucky_number:
           parameterType: BOOLEAN
-  comp-condition-11:
+  comp-condition-14:
     dag:
       tasks:
-        for-loop-13:
+        for-loop-16:
           componentRef:
-            name: comp-for-loop-13
+            name: comp-for-loop-16
           inputs:
             parameters:
               pipelinechannel--int-0-to-9999-Output:
@@ -54,11 +96,11 @@ components:
               pipelinechannel--repeat_if_lucky_number:
                 componentInputParameter: pipelinechannel--repeat_if_lucky_number
           parameterIterator:
-            itemInput: pipelinechannel--loop-item-param-12
+            itemInput: pipelinechannel--loop-item-param-15
             items:
               raw: '[1, 2]'
           taskInfo:
-            name: for-loop-13
+            name: for-loop-16
     inputDefinitions:
       parameters:
         pipelinechannel--int-0-to-9999-Output:
@@ -109,61 +151,7 @@ components:
           parameterType: BOOLEAN
         pipelinechannel--trials-loop-item:
           parameterType: NUMBER_INTEGER
-  comp-condition-4:
-    dag:
-      tasks:
-        condition-5:
-          componentRef:
-            name: comp-condition-5
-          dependentTasks:
-          - is-even-or-odd
-          inputs:
-            parameters:
-              pipelinechannel--int-0-to-9999-Output:
-                componentInputParameter: pipelinechannel--int-0-to-9999-Output
-              pipelinechannel--is-even-or-odd-Output:
-                taskOutputParameter:
-                  outputParameterKey: Output
-                  producerTask: is-even-or-odd
-          taskInfo:
-            name: condition-5
-          triggerPolicy:
-            condition: inputs.parameter_values['pipelinechannel--is-even-or-odd-Output']
-              == 'even'
-        condition-6:
-          componentRef:
-            name: comp-condition-6
-          dependentTasks:
-          - is-even-or-odd
-          inputs:
-            parameters:
-              pipelinechannel--int-0-to-9999-Output:
-                componentInputParameter: pipelinechannel--int-0-to-9999-Output
-              pipelinechannel--is-even-or-odd-Output:
-                taskOutputParameter:
-                  outputParameterKey: Output
-                  producerTask: is-even-or-odd
-          taskInfo:
-            name: condition-6
-          triggerPolicy:
-            condition: '!(inputs.parameter_values[''pipelinechannel--is-even-or-odd-Output'']
-              == ''even'')'
-        is-even-or-odd:
-          cachingOptions:
-            enableCache: true
-          componentRef:
-            name: comp-is-even-or-odd
-          inputs:
-            parameters:
-              num:
-                componentInputParameter: pipelinechannel--int-0-to-9999-Output
-          taskInfo:
-            name: is-even-or-odd
-    inputDefinitions:
-      parameters:
-        pipelinechannel--int-0-to-9999-Output:
-          parameterType: NUMBER_INTEGER
-  comp-condition-5:
+  comp-condition-6:
     dag:
       tasks:
         print-and-return-2:
@@ -184,7 +172,7 @@ components:
           parameterType: NUMBER_INTEGER
         pipelinechannel--is-even-or-odd-Output:
           parameterType: STRING
-  comp-condition-6:
+  comp-condition-7:
     dag:
       tasks:
         print-and-return-3:
@@ -205,18 +193,45 @@ components:
           parameterType: NUMBER_INTEGER
         pipelinechannel--is-even-or-odd-Output:
           parameterType: STRING
-  comp-condition-7:
+  comp-condition-8:
     dag:
-      outputs:
-        parameters:
-          pipelinechannel--is-even-or-odd-2-Output:
-            valueFromParameter:
-              outputParameterKey: Output
-              producerSubtask: is-even-or-odd-2
       tasks:
-        condition-8:
+        condition-branches-5:
           componentRef:
-            name: comp-condition-8
+            name: comp-condition-branches-5
+          dependentTasks:
+          - is-even-or-odd
+          inputs:
+            parameters:
+              pipelinechannel--int-0-to-9999-Output:
+                componentInputParameter: pipelinechannel--int-0-to-9999-Output
+              pipelinechannel--is-even-or-odd-Output:
+                taskOutputParameter:
+                  outputParameterKey: Output
+                  producerTask: is-even-or-odd
+          taskInfo:
+            name: condition-branches-5
+        is-even-or-odd:
+          cachingOptions:
+            enableCache: true
+          componentRef:
+            name: comp-is-even-or-odd
+          inputs:
+            parameters:
+              num:
+                componentInputParameter: pipelinechannel--int-0-to-9999-Output
+          taskInfo:
+            name: is-even-or-odd
+    inputDefinitions:
+      parameters:
+        pipelinechannel--int-0-to-9999-Output:
+          parameterType: NUMBER_INTEGER
+  comp-condition-9:
+    dag:
+      tasks:
+        condition-branches-10:
+          componentRef:
+            name: comp-condition-branches-10
           dependentTasks:
           - is-even-or-odd-2
           inputs:
@@ -228,28 +243,7 @@ components:
                   outputParameterKey: Output
                   producerTask: is-even-or-odd-2
           taskInfo:
-            name: condition-8
-          triggerPolicy:
-            condition: inputs.parameter_values['pipelinechannel--is-even-or-odd-2-Output']
-              == 'even'
-        condition-9:
-          componentRef:
-            name: comp-condition-9
-          dependentTasks:
-          - is-even-or-odd-2
-          inputs:
-            parameters:
-              pipelinechannel--int-0-to-9999-Output:
-                componentInputParameter: pipelinechannel--int-0-to-9999-Output
-              pipelinechannel--is-even-or-odd-2-Output:
-                taskOutputParameter:
-                  outputParameterKey: Output
-                  producerTask: is-even-or-odd-2
-          taskInfo:
-            name: condition-9
-          triggerPolicy:
-            condition: '!(inputs.parameter_values[''pipelinechannel--is-even-or-odd-2-Output'']
-              == ''even'')'
+            name: condition-branches-10
         is-even-or-odd-2:
           cachingOptions:
             enableCache: true
@@ -265,80 +259,138 @@ components:
       parameters:
         pipelinechannel--int-0-to-9999-Output:
           parameterType: NUMBER_INTEGER
-    outputDefinitions:
-      parameters:
-        pipelinechannel--is-even-or-odd-2-Output:
-          parameterType: NUMBER_INTEGER
-  comp-condition-8:
+  comp-condition-branches-10:
     dag:
       tasks:
-        print-and-return-4:
-          cachingOptions:
-            enableCache: true
+        condition-11:
           componentRef:
-            name: comp-print-and-return-4
+            name: comp-condition-11
           inputs:
             parameters:
-              text:
-                runtimeValue:
-                  constant: Got a high even number!
+              pipelinechannel--int-0-to-9999-Output:
+                componentInputParameter: pipelinechannel--int-0-to-9999-Output
+              pipelinechannel--is-even-or-odd-2-Output:
+                componentInputParameter: pipelinechannel--is-even-or-odd-2-Output
           taskInfo:
-            name: print-and-return-4
+            name: condition-11
+          triggerPolicy:
+            condition: inputs.parameter_values['pipelinechannel--is-even-or-odd-2-Output']
+              == 'even'
+        condition-12:
+          componentRef:
+            name: comp-condition-12
+          inputs:
+            parameters:
+              pipelinechannel--int-0-to-9999-Output:
+                componentInputParameter: pipelinechannel--int-0-to-9999-Output
+              pipelinechannel--is-even-or-odd-2-Output:
+                componentInputParameter: pipelinechannel--is-even-or-odd-2-Output
+          taskInfo:
+            name: condition-12
+          triggerPolicy:
+            condition: '!(inputs.parameter_values[''pipelinechannel--is-even-or-odd-2-Output'']
+              == ''even'')'
     inputDefinitions:
       parameters:
         pipelinechannel--int-0-to-9999-Output:
           parameterType: NUMBER_INTEGER
         pipelinechannel--is-even-or-odd-2-Output:
           parameterType: STRING
-  comp-condition-9:
+  comp-condition-branches-4:
     dag:
       tasks:
-        print-and-return-5:
-          cachingOptions:
-            enableCache: true
+        condition-13:
           componentRef:
-            name: comp-print-and-return-5
+            name: comp-condition-13
           inputs:
             parameters:
-              text:
-                runtimeValue:
-                  constant: Got a high odd number!
+              pipelinechannel--int-0-to-9999-Output:
+                componentInputParameter: pipelinechannel--int-0-to-9999-Output
+              pipelinechannel--repeat_if_lucky_number:
+                componentInputParameter: pipelinechannel--repeat_if_lucky_number
           taskInfo:
-            name: print-and-return-5
+            name: condition-13
+          triggerPolicy:
+            condition: '!(int(inputs.parameter_values[''pipelinechannel--int-0-to-9999-Output''])
+              < 5000) && !(int(inputs.parameter_values[''pipelinechannel--int-0-to-9999-Output''])
+              > 5000)'
+        condition-8:
+          componentRef:
+            name: comp-condition-8
+          inputs:
+            parameters:
+              pipelinechannel--int-0-to-9999-Output:
+                componentInputParameter: pipelinechannel--int-0-to-9999-Output
+          taskInfo:
+            name: condition-8
+          triggerPolicy:
+            condition: int(inputs.parameter_values['pipelinechannel--int-0-to-9999-Output'])
+              < 5000
+        condition-9:
+          componentRef:
+            name: comp-condition-9
+          inputs:
+            parameters:
+              pipelinechannel--int-0-to-9999-Output:
+                componentInputParameter: pipelinechannel--int-0-to-9999-Output
+          taskInfo:
+            name: condition-9
+          triggerPolicy:
+            condition: '!(int(inputs.parameter_values[''pipelinechannel--int-0-to-9999-Output''])
+              < 5000) && int(inputs.parameter_values[''pipelinechannel--int-0-to-9999-Output''])
+              > 5000'
     inputDefinitions:
       parameters:
         pipelinechannel--int-0-to-9999-Output:
           parameterType: NUMBER_INTEGER
-        pipelinechannel--is-even-or-odd-2-Output:
+        pipelinechannel--repeat_if_lucky_number:
+          parameterType: BOOLEAN
+  comp-condition-branches-5:
+    dag:
+      tasks:
+        condition-6:
+          componentRef:
+            name: comp-condition-6
+          inputs:
+            parameters:
+              pipelinechannel--int-0-to-9999-Output:
+                componentInputParameter: pipelinechannel--int-0-to-9999-Output
+              pipelinechannel--is-even-or-odd-Output:
+                componentInputParameter: pipelinechannel--is-even-or-odd-Output
+          taskInfo:
+            name: condition-6
+          triggerPolicy:
+            condition: inputs.parameter_values['pipelinechannel--is-even-or-odd-Output']
+              == 'even'
+        condition-7:
+          componentRef:
+            name: comp-condition-7
+          inputs:
+            parameters:
+              pipelinechannel--int-0-to-9999-Output:
+                componentInputParameter: pipelinechannel--int-0-to-9999-Output
+              pipelinechannel--is-even-or-odd-Output:
+                componentInputParameter: pipelinechannel--is-even-or-odd-Output
+          taskInfo:
+            name: condition-7
+          triggerPolicy:
+            condition: '!(inputs.parameter_values[''pipelinechannel--is-even-or-odd-Output'']
+              == ''even'')'
+    inputDefinitions:
+      parameters:
+        pipelinechannel--int-0-to-9999-Output:
+          parameterType: NUMBER_INTEGER
+        pipelinechannel--is-even-or-odd-Output:
           parameterType: STRING
   comp-for-loop-1:
     dag:
       outputs:
         parameters:
-          pipelinechannel--is-even-or-odd-2-Output:
+          pipelinechannel--int-0-to-9999-Output:
             valueFromParameter:
-              outputParameterKey: pipelinechannel--is-even-or-odd-2-Output
-              producerSubtask: condition-7
+              outputParameterKey: Output
+              producerSubtask: int-0-to-9999
       tasks:
-        condition-10:
-          componentRef:
-            name: comp-condition-10
-          dependentTasks:
-          - int-0-to-9999
-          inputs:
-            parameters:
-              pipelinechannel--int-0-to-9999-Output:
-                taskOutputParameter:
-                  outputParameterKey: Output
-                  producerTask: int-0-to-9999
-              pipelinechannel--repeat_if_lucky_number:
-                componentInputParameter: pipelinechannel--repeat_if_lucky_number
-          taskInfo:
-            name: condition-10
-          triggerPolicy:
-            condition: '!(int(inputs.parameter_values[''pipelinechannel--int-0-to-9999-Output''])
-              < 5000) && !(int(inputs.parameter_values[''pipelinechannel--int-0-to-9999-Output''])
-              > 5000)'
         condition-2:
           componentRef:
             name: comp-condition-2
@@ -353,9 +405,9 @@ components:
           triggerPolicy:
             condition: inputs.parameter_values['pipelinechannel--add_drumroll'] ==
               true
-        condition-4:
+        condition-branches-4:
           componentRef:
-            name: comp-condition-4
+            name: comp-condition-branches-4
           dependentTasks:
           - int-0-to-9999
           inputs:
@@ -364,28 +416,10 @@ components:
                 taskOutputParameter:
                   outputParameterKey: Output
                   producerTask: int-0-to-9999
+              pipelinechannel--repeat_if_lucky_number:
+                componentInputParameter: pipelinechannel--repeat_if_lucky_number
           taskInfo:
-            name: condition-4
-          triggerPolicy:
-            condition: int(inputs.parameter_values['pipelinechannel--int-0-to-9999-Output'])
-              < 5000
-        condition-7:
-          componentRef:
-            name: comp-condition-7
-          dependentTasks:
-          - int-0-to-9999
-          inputs:
-            parameters:
-              pipelinechannel--int-0-to-9999-Output:
-                taskOutputParameter:
-                  outputParameterKey: Output
-                  producerTask: int-0-to-9999
-          taskInfo:
-            name: condition-7
-          triggerPolicy:
-            condition: '!(int(inputs.parameter_values[''pipelinechannel--int-0-to-9999-Output''])
-              < 5000) && int(inputs.parameter_values[''pipelinechannel--int-0-to-9999-Output''])
-              > 5000'
+            name: condition-branches-4
         int-0-to-9999:
           cachingOptions: {}
           componentRef:
@@ -404,9 +438,9 @@ components:
           parameterType: NUMBER_INTEGER
     outputDefinitions:
       parameters:
-        pipelinechannel--is-even-or-odd-2-Output:
+        pipelinechannel--int-0-to-9999-Output:
           parameterType: NUMBER_INTEGER
-  comp-for-loop-13:
+  comp-for-loop-16:
     dag:
       tasks:
         print-and-return-7:
@@ -426,7 +460,7 @@ components:
       parameters:
         pipelinechannel--int-0-to-9999-Output:
           parameterType: NUMBER_INTEGER
-        pipelinechannel--loop-item-param-12:
+        pipelinechannel--loop-item-param-15:
           parameterType: NUMBER_INTEGER
         pipelinechannel--repeat_if_lucky_number:
           parameterType: BOOLEAN
@@ -526,11 +560,11 @@ components:
       parameters:
         Output:
           parameterType: STRING
-  comp-print-strings:
-    executorLabel: exec-print-strings
+  comp-print-ints:
+    executorLabel: exec-print-ints
     inputDefinitions:
       parameters:
-        strings:
+        ints:
           parameterType: LIST
 deploymentSpec:
   executors:
@@ -546,7 +580,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -575,7 +609,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -604,7 +638,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -633,7 +667,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -662,7 +696,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -691,7 +725,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -720,7 +754,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -749,7 +783,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -778,7 +812,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -807,7 +841,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -824,19 +858,19 @@ deploymentSpec:
           \ *\n\ndef print_and_return(text: str) -> str:\n    print(text)\n    return\
           \ text\n\n"
         image: python:3.7
-    exec-print-strings:
+    exec-print-ints:
       container:
         args:
         - --executor_input
         - '{{$}}'
         - --function_to_execute
-        - print_strings
+        - print_ints
         command:
         - sh
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -850,7 +884,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef print_strings(strings: List[str]):\n    print(strings)\n\n"
+          \ *\n\ndef print_ints(ints: List[int]):\n    print(ints)\n\n"
         image: python:3.7
 pipelineInfo:
   name: lucky-number-pipeline
@@ -874,21 +908,21 @@ root:
             inputParameter: pipelinechannel--trials
         taskInfo:
           name: for-loop-1
-      print-strings:
+      print-ints:
         cachingOptions:
           enableCache: true
         componentRef:
-          name: comp-print-strings
+          name: comp-print-ints
         dependentTasks:
         - for-loop-1
         inputs:
           parameters:
-            strings:
+            ints:
               taskOutputParameter:
-                outputParameterKey: pipelinechannel--is-even-or-odd-2-Output
+                outputParameterKey: pipelinechannel--int-0-to-9999-Output
                 producerTask: for-loop-1
         taskInfo:
-          name: print-strings
+          name: print-ints
   inputDefinitions:
     parameters:
       add_drumroll:
@@ -907,4 +941,4 @@ root:
         isOptional: true
         parameterType: LIST
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.1.3
+sdkVersion: kfp-2.3.0

--- a/sdk/python/test_data/pipelines/if_else.yaml
+++ b/sdk/python/test_data/pipelines/if_else.yaml
@@ -1,7 +1,7 @@
 # PIPELINE DEFINITION
 # Name: flip-coin-pipeline
 components:
-  comp-condition-1:
+  comp-condition-2:
     dag:
       tasks:
         print-and-return:
@@ -20,7 +20,7 @@ components:
       parameters:
         pipelinechannel--flip-coin-Output:
           parameterType: STRING
-  comp-condition-2:
+  comp-condition-3:
     dag:
       tasks:
         print-and-return-2:
@@ -35,6 +35,37 @@ components:
                   constant: Got tails!
           taskInfo:
             name: print-and-return-2
+    inputDefinitions:
+      parameters:
+        pipelinechannel--flip-coin-Output:
+          parameterType: STRING
+  comp-condition-branches-1:
+    dag:
+      tasks:
+        condition-2:
+          componentRef:
+            name: comp-condition-2
+          inputs:
+            parameters:
+              pipelinechannel--flip-coin-Output:
+                componentInputParameter: pipelinechannel--flip-coin-Output
+          taskInfo:
+            name: condition-2
+          triggerPolicy:
+            condition: inputs.parameter_values['pipelinechannel--flip-coin-Output']
+              == 'heads'
+        condition-3:
+          componentRef:
+            name: comp-condition-3
+          inputs:
+            parameters:
+              pipelinechannel--flip-coin-Output:
+                componentInputParameter: pipelinechannel--flip-coin-Output
+          taskInfo:
+            name: condition-3
+          triggerPolicy:
+            condition: '!(inputs.parameter_values[''pipelinechannel--flip-coin-Output'']
+              == ''heads'')'
     inputDefinitions:
       parameters:
         pipelinechannel--flip-coin-Output:
@@ -79,7 +110,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -108,7 +139,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -137,7 +168,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.1.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -159,9 +190,9 @@ pipelineInfo:
 root:
   dag:
     tasks:
-      condition-1:
+      condition-branches-1:
         componentRef:
-          name: comp-condition-1
+          name: comp-condition-branches-1
         dependentTasks:
         - flip-coin
         inputs:
@@ -171,26 +202,7 @@ root:
                 outputParameterKey: Output
                 producerTask: flip-coin
         taskInfo:
-          name: condition-1
-        triggerPolicy:
-          condition: inputs.parameter_values['pipelinechannel--flip-coin-Output']
-            == 'heads'
-      condition-2:
-        componentRef:
-          name: comp-condition-2
-        dependentTasks:
-        - flip-coin
-        inputs:
-          parameters:
-            pipelinechannel--flip-coin-Output:
-              taskOutputParameter:
-                outputParameterKey: Output
-                producerTask: flip-coin
-        taskInfo:
-          name: condition-2
-        triggerPolicy:
-          condition: '!(inputs.parameter_values[''pipelinechannel--flip-coin-Output'']
-            == ''heads'')'
+          name: condition-branches-1
       flip-coin:
         cachingOptions:
           enableCache: true
@@ -199,4 +211,4 @@ root:
         taskInfo:
           name: flip-coin
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.1.3
+sdkVersion: kfp-2.3.0


### PR DESCRIPTION
**Description of your changes:**
This change is a pre-requisite for collecting outputs from conditional branches. Each conditional branch (if, elif, else) must be wrapped in a common outer pipeline which can surface "one of" the inner task outputs via [`value_from_oneof`](https://github.com/kubeflow/pipelines/blob/45fe8e86583646143d1685d9e04d887ff27440ee/api/v2alpha1/pipeline_spec.proto#L165) for parameters and [`artifact_selectors`](https://github.com/kubeflow/pipelines/blob/45fe8e86583646143d1685d9e04d887ff27440ee/api/v2alpha1/pipeline_spec.proto#L124) for artifacts.

No functional change. There is a UI change.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more 
about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
