### PR TITLE
feat(sdk): support collecting outputs from conditional branches using `dsl.OneOf`

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -3,6 +3,7 @@
 ## Features
 
 ## Breaking changes
+* Support collecting outputs from conditional branches using `dsl.OneOf` [\#10067](https://github.com/kubeflow/pipelines/pull/10067)
 
 ## Deprecations
 

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -4553,13 +4553,10 @@ class TestDslOneOf(unittest.TestCase):
 
     # Data type validation (e.g., dsl.OneOf(artifact, param) fails) and similar is covered in pipeline_channel_test.py.
 
-    # To help narrow the tests further (we already test lots of aspects in the following cases), we choose focus on dsl.OneOf behavior, not the conditional logic if If/Elif/Else. This is more verbose, but more maintainable and the behavior under test is clearer.
+    # To help narrow the tests further (we already test lots of aspects in the following cases), we choose focus on the dsl.OneOf behavior, not the conditional logic if If/Elif/Else. This is more verbose, but more maintainable and the behavior under test is clearer.
 
     def test_if_else_returned(self):
-        # if/else
-        # returned
-        # parameters
-        # different output keys
+        """Uses If and Else branches, parameters passed to dsl.OneOf, dsl.OneOf returned from a pipeline, and different output keys on dsl.OneOf channels."""
 
         @dsl.pipeline
         def roll_die_pipeline() -> str:
@@ -4596,39 +4593,31 @@ class TestDslOneOf(unittest.TestCase):
         parameter_selectors = roll_die_pipeline.pipeline_spec.components[
             'comp-condition-branches-1'].dag.outputs.parameters[
                 'pipelinechannel--condition-branches-1-oneof-1'].value_from_oneof.parameter_selectors
+
         self.assertEqual(
-            parameter_selectors[0].output_parameter_key,
-            'pipelinechannel--print-and-return-Output',
-        )
+            parameter_selectors[0],
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                output_parameter_key='pipelinechannel--print-and-return-Output',
+                producer_subtask='condition-2',
+            ))
         self.assertEqual(
-            parameter_selectors[0].producer_subtask,
-            'condition-2',
-        )
-        self.assertEqual(
-            parameter_selectors[1].output_parameter_key,
-            'pipelinechannel--print-and-return-with-output-key-output_key',
-        )
-        self.assertEqual(
-            parameter_selectors[1].producer_subtask,
-            'condition-3',
-        )
+            parameter_selectors[1],
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                output_parameter_key='pipelinechannel--print-and-return-with-output-key-output_key',
+                producer_subtask='condition-3',
+            ))
         # surfaced as output
         self.assertEqual(
             roll_die_pipeline.pipeline_spec.root.dag.outputs
-            .parameters['Output'].value_from_parameter.producer_subtask,
-            'condition-branches-1',
-        )
-        self.assertEqual(
-            roll_die_pipeline.pipeline_spec.root.dag.outputs
-            .parameters['Output'].value_from_parameter.output_parameter_key,
-            'pipelinechannel--condition-branches-1-oneof-1',
+            .parameters['Output'].value_from_parameter,
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                producer_subtask='condition-branches-1',
+                output_parameter_key='pipelinechannel--condition-branches-1-oneof-1',
+            ),
         )
 
     def test_if_elif_else_returned(self):
-        # if/elif/else
-        # returned
-        # parameters
-        # different output keys
+        """Uses If, Elif, and Else branches, parameters passed to dsl.OneOf, dsl.OneOf returned from a pipeline, and different output keys on dsl.OneOf channels."""
 
         @dsl.pipeline
         def roll_die_pipeline() -> str:
@@ -4675,46 +4664,35 @@ class TestDslOneOf(unittest.TestCase):
             'comp-condition-branches-1'].dag.outputs.parameters[
                 'pipelinechannel--condition-branches-1-oneof-1'].value_from_oneof.parameter_selectors
         self.assertEqual(
-            parameter_selectors[0].output_parameter_key,
-            'pipelinechannel--print-and-return-Output',
-        )
+            parameter_selectors[0],
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                output_parameter_key='pipelinechannel--print-and-return-Output',
+                producer_subtask='condition-2',
+            ))
         self.assertEqual(
-            parameter_selectors[0].producer_subtask,
-            'condition-2',
-        )
+            parameter_selectors[1],
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                output_parameter_key='pipelinechannel--print-and-return-2-Output',
+                producer_subtask='condition-3',
+            ))
         self.assertEqual(
-            parameter_selectors[1].output_parameter_key,
-            'pipelinechannel--print-and-return-2-Output',
-        )
-        self.assertEqual(
-            parameter_selectors[1].producer_subtask,
-            'condition-3',
-        )
-        self.assertEqual(
-            parameter_selectors[2].output_parameter_key,
-            'pipelinechannel--print-and-return-with-output-key-output_key',
-        )
-        self.assertEqual(
-            parameter_selectors[2].producer_subtask,
-            'condition-4',
-        )
+            parameter_selectors[2],
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                output_parameter_key='pipelinechannel--print-and-return-with-output-key-output_key',
+                producer_subtask='condition-4',
+            ))
         # surfaced as output
         self.assertEqual(
             roll_die_pipeline.pipeline_spec.root.dag.outputs
-            .parameters['Output'].value_from_parameter.producer_subtask,
-            'condition-branches-1',
-        )
-        self.assertEqual(
-            roll_die_pipeline.pipeline_spec.root.dag.outputs
-            .parameters['Output'].value_from_parameter.output_parameter_key,
-            'pipelinechannel--condition-branches-1-oneof-1',
+            .parameters['Output'].value_from_parameter,
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                producer_subtask='condition-branches-1',
+                output_parameter_key='pipelinechannel--condition-branches-1-oneof-1',
+            ),
         )
 
     def test_if_elif_else_consumed(self):
-        # tests if/elif/else
-        # returned
-        # parameters
-        # different output keys
+        """Uses If, Elif, and Else branches, parameters passed to dsl.OneOf, dsl.OneOf passed to a consumer task, and different output keys on dsl.OneOf channels."""
 
         @dsl.pipeline
         def roll_die_pipeline():
@@ -4762,47 +4740,36 @@ class TestDslOneOf(unittest.TestCase):
             'comp-condition-branches-1'].dag.outputs.parameters[
                 'pipelinechannel--condition-branches-1-oneof-1'].value_from_oneof.parameter_selectors
         self.assertEqual(
-            parameter_selectors[0].output_parameter_key,
-            'pipelinechannel--print-and-return-Output',
-        )
+            parameter_selectors[0],
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                output_parameter_key='pipelinechannel--print-and-return-Output',
+                producer_subtask='condition-2',
+            ))
         self.assertEqual(
-            parameter_selectors[0].producer_subtask,
-            'condition-2',
-        )
+            parameter_selectors[1],
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                output_parameter_key='pipelinechannel--print-and-return-2-Output',
+                producer_subtask='condition-3',
+            ))
         self.assertEqual(
-            parameter_selectors[1].output_parameter_key,
-            'pipelinechannel--print-and-return-2-Output',
-        )
-        self.assertEqual(
-            parameter_selectors[1].producer_subtask,
-            'condition-3',
-        )
-        self.assertEqual(
-            parameter_selectors[2].output_parameter_key,
-            'pipelinechannel--print-and-return-with-output-key-output_key',
-        )
-        self.assertEqual(
-            parameter_selectors[2].producer_subtask,
-            'condition-4',
-        )
+            parameter_selectors[2],
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                output_parameter_key='pipelinechannel--print-and-return-with-output-key-output_key',
+                producer_subtask='condition-4',
+            ))
         # consumed from condition-branches
         self.assertEqual(
             roll_die_pipeline.pipeline_spec.root.dag.tasks['print-and-return-3']
-            .inputs.parameters['text'].task_output_parameter.producer_task,
-            'condition-branches-1',
-        )
-        self.assertEqual(
-            roll_die_pipeline.pipeline_spec.root.dag.tasks['print-and-return-3']
-            .inputs.parameters['text'].task_output_parameter
-            .output_parameter_key,
-            'pipelinechannel--condition-branches-1-oneof-1',
+            .inputs.parameters['text'].task_output_parameter,
+            pipeline_spec_pb2.TaskInputsSpec.InputParameterSpec
+            .TaskOutputParameterSpec(
+                producer_task='condition-branches-1',
+                output_parameter_key='pipelinechannel--condition-branches-1-oneof-1',
+            ),
         )
 
     def test_if_else_consumed_and_returned(self):
-        # tests if/else
-        # consumed and returned
-        # parameters
-        # same output key
+        """Uses If, Elif, and Else branches, parameters passed to dsl.OneOf, and dsl.OneOf passed to a consumer task and returned from the pipeline."""
 
         @dsl.pipeline
         def flip_coin_pipeline() -> str:
@@ -4841,52 +4808,41 @@ class TestDslOneOf(unittest.TestCase):
             'comp-condition-branches-1'].dag.outputs.parameters[
                 'pipelinechannel--condition-branches-1-oneof-1'].value_from_oneof.parameter_selectors
         self.assertEqual(
-            parameter_selectors[0].output_parameter_key,
-            'pipelinechannel--print-and-return-Output',
-        )
+            parameter_selectors[0],
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                output_parameter_key='pipelinechannel--print-and-return-Output',
+                producer_subtask='condition-2',
+            ))
         self.assertEqual(
-            parameter_selectors[0].producer_subtask,
-            'condition-2',
-        )
-        self.assertEqual(
-            parameter_selectors[1].output_parameter_key,
-            'pipelinechannel--print-and-return-2-Output',
-        )
-        self.assertEqual(
-            parameter_selectors[1].producer_subtask,
-            'condition-3',
-        )
+            parameter_selectors[1],
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                output_parameter_key='pipelinechannel--print-and-return-2-Output',
+                producer_subtask='condition-3',
+            ))
         # consumed from condition-branches
         self.assertEqual(
             flip_coin_pipeline.pipeline_spec.root.dag
             .tasks['print-and-return-3'].inputs.parameters['text']
-            .task_output_parameter.producer_task,
-            'condition-branches-1',
-        )
-        self.assertEqual(
-            flip_coin_pipeline.pipeline_spec.root.dag
-            .tasks['print-and-return-3'].inputs.parameters['text']
-            .task_output_parameter.output_parameter_key,
-            'pipelinechannel--condition-branches-1-oneof-1',
+            .task_output_parameter,
+            pipeline_spec_pb2.TaskInputsSpec.InputParameterSpec
+            .TaskOutputParameterSpec(
+                producer_task='condition-branches-1',
+                output_parameter_key='pipelinechannel--condition-branches-1-oneof-1',
+            ),
         )
 
         # surfaced as output
         self.assertEqual(
             flip_coin_pipeline.pipeline_spec.root.dag.outputs
-            .parameters['Output'].value_from_parameter.producer_subtask,
-            'condition-branches-1',
-        )
-        self.assertEqual(
-            flip_coin_pipeline.pipeline_spec.root.dag.outputs
-            .parameters['Output'].value_from_parameter.output_parameter_key,
-            'pipelinechannel--condition-branches-1-oneof-1',
+            .parameters['Output'].value_from_parameter,
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                producer_subtask='condition-branches-1',
+                output_parameter_key='pipelinechannel--condition-branches-1-oneof-1',
+            ),
         )
 
     def test_if_else_consumed_and_returned_artifacts(self):
-        # tests if/else
-        # consumed and returned
-        # artifacts
-        # same output key
+        """Uses If, Elif, and Else branches, artifacts passed to dsl.OneOf, and dsl.OneOf passed to a consumer task and returned from the pipeline."""
 
         @dsl.pipeline
         def flip_coin_pipeline() -> Artifact:
@@ -4927,48 +4883,41 @@ class TestDslOneOf(unittest.TestCase):
             'comp-condition-branches-1'].dag.outputs.artifacts[
                 'pipelinechannel--condition-branches-1-oneof-1'].artifact_selectors
         self.assertEqual(
-            artifact_selectors[0].output_artifact_key,
-            'pipelinechannel--print-and-return-as-artifact-a',
-        )
+            artifact_selectors[0],
+            pipeline_spec_pb2.DagOutputsSpec.ArtifactSelectorSpec(
+                output_artifact_key='pipelinechannel--print-and-return-as-artifact-a',
+                producer_subtask='condition-2',
+            ))
         self.assertEqual(
-            artifact_selectors[0].producer_subtask,
-            'condition-2',
-        )
-        self.assertEqual(
-            artifact_selectors[1].output_artifact_key,
-            'pipelinechannel--print-and-return-as-artifact-2-a',
-        )
-        self.assertEqual(
-            artifact_selectors[1].producer_subtask,
-            'condition-3',
-        )
+            artifact_selectors[1],
+            pipeline_spec_pb2.DagOutputsSpec.ArtifactSelectorSpec(
+                output_artifact_key='pipelinechannel--print-and-return-as-artifact-2-a',
+                producer_subtask='condition-3',
+            ))
+
         # consumed from condition-branches
         self.assertEqual(
             flip_coin_pipeline.pipeline_spec.root.dag.tasks['print-artifact']
-            .inputs.artifacts['a'].task_output_artifact.producer_task,
-            'condition-branches-1',
-        )
-        self.assertEqual(
-            flip_coin_pipeline.pipeline_spec.root.dag.tasks['print-artifact']
-            .inputs.artifacts['a'].task_output_artifact.output_artifact_key,
-            'pipelinechannel--condition-branches-1-oneof-1',
+            .inputs.artifacts['a'].task_output_artifact,
+            pipeline_spec_pb2.TaskInputsSpec.InputArtifactSpec
+            .TaskOutputArtifactSpec(
+                producer_task='condition-branches-1',
+                output_artifact_key='pipelinechannel--condition-branches-1-oneof-1',
+            ),
         )
 
         # surfaced as output
         self.assertEqual(
             flip_coin_pipeline.pipeline_spec.root.dag.outputs
-            .artifacts['Output'].artifact_selectors[0].producer_subtask,
-            'condition-branches-1',
-        )
-        self.assertEqual(
-            flip_coin_pipeline.pipeline_spec.root.dag.outputs
-            .artifacts['Output'].artifact_selectors[0].output_artifact_key,
-            'pipelinechannel--condition-branches-1-oneof-1',
+            .artifacts['Output'].artifact_selectors[0],
+            pipeline_spec_pb2.DagOutputsSpec.ArtifactSelectorSpec(
+                producer_subtask='condition-branches-1',
+                output_artifact_key='pipelinechannel--condition-branches-1-oneof-1',
+            ),
         )
 
     def test_nested_under_condition_consumed(self):
-        # nested under loop and condition
-        # artifact
+        """Uses If, Else, and OneOf nested under a parent If."""
 
         @dsl.pipeline
         def flip_coin_pipeline(execute_pipeline: bool):
@@ -5012,38 +4961,29 @@ class TestDslOneOf(unittest.TestCase):
             'comp-condition-branches-2'].dag.outputs.artifacts[
                 'pipelinechannel--condition-branches-2-oneof-1'].artifact_selectors
         self.assertEqual(
-            artifact_selectors[0].output_artifact_key,
-            'pipelinechannel--print-and-return-as-artifact-a',
-        )
+            artifact_selectors[0],
+            pipeline_spec_pb2.DagOutputsSpec.ArtifactSelectorSpec(
+                output_artifact_key='pipelinechannel--print-and-return-as-artifact-a',
+                producer_subtask='condition-3',
+            ))
         self.assertEqual(
-            artifact_selectors[0].producer_subtask,
-            'condition-3',
-        )
-        self.assertEqual(
-            artifact_selectors[1].output_artifact_key,
-            'pipelinechannel--print-and-return-as-artifact-2-a',
-        )
-        self.assertEqual(
-            artifact_selectors[1].producer_subtask,
-            'condition-4',
-        )
+            artifact_selectors[1],
+            pipeline_spec_pb2.DagOutputsSpec.ArtifactSelectorSpec(
+                output_artifact_key='pipelinechannel--print-and-return-as-artifact-2-a',
+                producer_subtask='condition-4',
+            ))
         # consumed from condition-branches
         self.assertEqual(
             flip_coin_pipeline.pipeline_spec.components['comp-condition-1'].dag
-            .tasks['print-artifact'].inputs.artifacts['a'].task_output_artifact
-            .producer_task,
-            'condition-branches-2',
-        )
-        self.assertEqual(
-            flip_coin_pipeline.pipeline_spec.components['comp-condition-1'].dag
-            .tasks['print-artifact'].inputs.artifacts['a'].task_output_artifact
-            .output_artifact_key,
-            'pipelinechannel--condition-branches-2-oneof-1',
+            .tasks['print-artifact'].inputs.artifacts['a'].task_output_artifact,
+            pipeline_spec_pb2.TaskInputsSpec.InputArtifactSpec
+            .TaskOutputArtifactSpec(
+                producer_task='condition-branches-2',
+                output_artifact_key='pipelinechannel--condition-branches-2-oneof-1',
+            ),
         )
 
     def test_nested_under_condition_returned_raises(self):
-        # nested under loop and condition
-        # artifact
         with self.assertRaisesRegex(
                 compiler_utils.InvalidTopologyException,
                 f'Pipeline outputs may only be returned from the top level of the pipeline function scope\. Got pipeline output dsl\.OneOf from within the control flow group dsl\.If\.'
@@ -5063,9 +5003,7 @@ class TestDslOneOf(unittest.TestCase):
                                      print_task_2.outputs['a'])
 
     def test_deeply_nested_consumed(self):
-        # nested under loop and condition and exit handler
-        # consumed
-        # artifact
+        """Uses If, Elif, Else, and OneOf deeply nested within multiple dub-DAGs."""
 
         @dsl.pipeline
         def flip_coin_pipeline(execute_pipeline: bool):
@@ -5089,21 +5027,15 @@ class TestDslOneOf(unittest.TestCase):
         # consumed from condition-branches
         self.assertEqual(
             flip_coin_pipeline.pipeline_spec.components['comp-condition-4'].dag
-            .tasks['print-artifact'].inputs.artifacts['a'].task_output_artifact
-            .producer_task,
-            'condition-branches-5',
-        )
-        self.assertEqual(
-            flip_coin_pipeline.pipeline_spec.components['comp-condition-4'].dag
-            .tasks['print-artifact'].inputs.artifacts['a'].task_output_artifact
-            .output_artifact_key,
-            'pipelinechannel--condition-branches-5-oneof-1',
+            .tasks['print-artifact'].inputs.artifacts['a'].task_output_artifact,
+            pipeline_spec_pb2.TaskInputsSpec.InputArtifactSpec
+            .TaskOutputArtifactSpec(
+                producer_task='condition-branches-5',
+                output_artifact_key='pipelinechannel--condition-branches-5-oneof-1',
+            ),
         )
 
     def test_deeply_nested_returned_raises(self):
-        # nested under loop and condition
-        # returned
-        # artifact
 
         with self.assertRaisesRegex(
                 compiler_utils.InvalidTopologyException,
@@ -5169,7 +5101,61 @@ class TestDslOneOf(unittest.TestCase):
                 return dsl.OneOf(print_task_1.outputs['a'],
                                  print_task_2.outputs['a'])
 
+    def test_oneof_in_condition(self):
+        """Tests that dsl.OneOf's channel can be consumed in a downstream group nested one level"""
+
+        @dsl.pipeline
+        def roll_die_pipeline(repeat_on: str = 'Got heads!'):
+            flip_coin_task = roll_three_sided_die()
+            with dsl.If(flip_coin_task.output == 'heads'):
+                t1 = print_and_return(text='Got heads!')
+            with dsl.Elif(flip_coin_task.output == 'tails'):
+                t2 = print_and_return(text='Got tails!')
+            with dsl.Else():
+                t3 = print_and_return_with_output_key(text='Draw!')
+            x = dsl.OneOf(t1.output, t2.output, t3.outputs['output_key'])
+
+            with dsl.If(x == repeat_on):
+                print_and_return(text=x)
+
+        # condition-branches surfaces
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec
+            .components['comp-condition-branches-1'].output_definitions
+            .parameters['pipelinechannel--condition-branches-1-oneof-1']
+            .parameter_type,
+            type_utils.STRING,
+        )
+        parameter_selectors = roll_die_pipeline.pipeline_spec.components[
+            'comp-condition-branches-1'].dag.outputs.parameters[
+                'pipelinechannel--condition-branches-1-oneof-1'].value_from_oneof.parameter_selectors
+        self.assertEqual(
+            parameter_selectors[0],
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                output_parameter_key='pipelinechannel--print-and-return-Output',
+                producer_subtask='condition-2',
+            ))
+        self.assertEqual(
+            parameter_selectors[1],
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                output_parameter_key='pipelinechannel--print-and-return-2-Output',
+                producer_subtask='condition-3',
+            ))
+        self.assertEqual(
+            parameter_selectors[2],
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                output_parameter_key='pipelinechannel--print-and-return-with-output-key-output_key',
+                producer_subtask='condition-4',
+            ))
+        # condition points to correct upstream output
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.root.dag.tasks['condition-5']
+            .trigger_policy.condition,
+            "inputs.parameter_values['pipelinechannel--condition-branches-1-pipelinechannel--condition-branches-1-oneof-1'] == inputs.parameter_values['pipelinechannel--repeat_on']"
+        )
+
     def test_consumed_in_nested_groups(self):
+        """Tests that dsl.OneOf's channel can be consumed in a downstream group nested multiple levels"""
 
         @dsl.pipeline
         def roll_die_pipeline(
@@ -5201,29 +5187,23 @@ class TestDslOneOf(unittest.TestCase):
             'comp-condition-branches-1'].dag.outputs.parameters[
                 'pipelinechannel--condition-branches-1-oneof-1'].value_from_oneof.parameter_selectors
         self.assertEqual(
-            parameter_selectors[0].output_parameter_key,
-            'pipelinechannel--print-and-return-Output',
-        )
+            parameter_selectors[0],
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                output_parameter_key='pipelinechannel--print-and-return-Output',
+                producer_subtask='condition-2',
+            ))
         self.assertEqual(
-            parameter_selectors[0].producer_subtask,
-            'condition-2',
-        )
+            parameter_selectors[1],
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                output_parameter_key='pipelinechannel--print-and-return-2-Output',
+                producer_subtask='condition-3',
+            ))
         self.assertEqual(
-            parameter_selectors[1].output_parameter_key,
-            'pipelinechannel--print-and-return-2-Output',
-        )
-        self.assertEqual(
-            parameter_selectors[1].producer_subtask,
-            'condition-3',
-        )
-        self.assertEqual(
-            parameter_selectors[2].output_parameter_key,
-            'pipelinechannel--print-and-return-with-output-key-output_key',
-        )
-        self.assertEqual(
-            parameter_selectors[2].producer_subtask,
-            'condition-4',
-        )
+            parameter_selectors[2],
+            pipeline_spec_pb2.DagOutputsSpec.ParameterSelectorSpec(
+                output_parameter_key='pipelinechannel--print-and-return-with-output-key-output_key',
+                producer_subtask='condition-4',
+            ))
         # condition points to correct upstream output
         self.assertEqual(
             roll_die_pipeline.pipeline_spec.components['comp-condition-6']
@@ -5255,64 +5235,6 @@ class TestDslOneOf(unittest.TestCase):
                 print_and_return(
                     text=f"Final result: {dsl.OneOf(t1.output, t2.output, t3.outputs['output_key'])}"
                 )
-
-    def test_oneof_in_condition(self):
-
-        @dsl.pipeline
-        def roll_die_pipeline(repeat_on: str = 'Got heads!'):
-            flip_coin_task = roll_three_sided_die()
-            with dsl.If(flip_coin_task.output == 'heads'):
-                t1 = print_and_return(text='Got heads!')
-            with dsl.Elif(flip_coin_task.output == 'tails'):
-                t2 = print_and_return(text='Got tails!')
-            with dsl.Else():
-                t3 = print_and_return_with_output_key(text='Draw!')
-            x = dsl.OneOf(t1.output, t2.output, t3.outputs['output_key'])
-
-            with dsl.If(x == repeat_on):
-                print_and_return(text=x)
-
-        # condition-branches surfaces
-        self.assertEqual(
-            roll_die_pipeline.pipeline_spec
-            .components['comp-condition-branches-1'].output_definitions
-            .parameters['pipelinechannel--condition-branches-1-oneof-1']
-            .parameter_type,
-            type_utils.STRING,
-        )
-        parameter_selectors = roll_die_pipeline.pipeline_spec.components[
-            'comp-condition-branches-1'].dag.outputs.parameters[
-                'pipelinechannel--condition-branches-1-oneof-1'].value_from_oneof.parameter_selectors
-        self.assertEqual(
-            parameter_selectors[0].output_parameter_key,
-            'pipelinechannel--print-and-return-Output',
-        )
-        self.assertEqual(
-            parameter_selectors[0].producer_subtask,
-            'condition-2',
-        )
-        self.assertEqual(
-            parameter_selectors[1].output_parameter_key,
-            'pipelinechannel--print-and-return-2-Output',
-        )
-        self.assertEqual(
-            parameter_selectors[1].producer_subtask,
-            'condition-3',
-        )
-        self.assertEqual(
-            parameter_selectors[2].output_parameter_key,
-            'pipelinechannel--print-and-return-with-output-key-output_key',
-        )
-        self.assertEqual(
-            parameter_selectors[2].producer_subtask,
-            'condition-4',
-        )
-        # condition points to correct upstream output
-        self.assertEqual(
-            roll_die_pipeline.pipeline_spec.root.dag.tasks['condition-5']
-            .trigger_policy.condition,
-            "inputs.parameter_values['pipelinechannel--condition-branches-1-pipelinechannel--condition-branches-1-oneof-1'] == inputs.parameter_values['pipelinechannel--repeat_on']"
-        )
 
     def test_type_checking_parameters(self):
         with self.assertRaisesRegex(

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -5221,7 +5221,7 @@ class TestDslOneOf(unittest.TestCase):
     def test_oneof_in_fstring(self):
         with self.assertRaisesRegex(
                 NotImplementedError,
-                f'dsl\.OneOf is not yet supported in f-strings\.'):
+                f'dsl\.OneOf does not support string interpolation\.'):
 
             @dsl.pipeline
             def roll_die_pipeline():

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -148,8 +148,33 @@ def print_hello():
 
 
 @dsl.component
+def cleanup():
+    print('cleanup')
+
+
+@dsl.component
 def double(num: int) -> int:
     return 2 * num
+
+
+@dsl.component
+def print_and_return_as_artifact(text: str, a: Output[Artifact]):
+    print(text)
+    with open(a.path, 'w') as f:
+        f.write(text)
+
+
+@dsl.component
+def print_and_return_with_output_key(text: str, output_key: OutputPath(str)):
+    print(text)
+    with open(output_key, 'w') as f:
+        f.write(text)
+
+
+@dsl.component
+def print_artifact(a: Input[Artifact]):
+    with open(a.path) as f:
+        print(f.read())
 
 
 ###########
@@ -4140,6 +4165,44 @@ class ExtractInputOutputDescription(unittest.TestCase):
             'Component output artifact.')
 
 
+class TestCannotReturnFromWithinControlFlowGroup(unittest.TestCase):
+
+    def test_condition_raises(self):
+        with self.assertRaisesRegex(
+                compiler_utils.InvalidTopologyException,
+                r'Pipeline outputs may only be returned from the top level of the pipeline function scope\. Got pipeline output from within the control flow group dsl\.Condition\.'
+        ):
+
+            @dsl.pipeline
+            def my_pipeline(string: str = 'string') -> str:
+                with dsl.Condition(string == 'foo'):
+                    return print_and_return(text=string).output
+
+    def test_loop_raises(self):
+
+        with self.assertRaisesRegex(
+                compiler_utils.InvalidTopologyException,
+                r'Pipeline outputs may only be returned from the top level of the pipeline function scope\. Got pipeline output from within the control flow group dsl\.ParallelFor\.'
+        ):
+
+            @dsl.pipeline
+            def my_pipeline(string: str = 'string') -> str:
+                with dsl.ParallelFor([1, 2, 3]):
+                    return print_and_return(text=string).output
+
+    def test_exit_handler_raises(self):
+
+        with self.assertRaisesRegex(
+                compiler_utils.InvalidTopologyException,
+                r'Pipeline outputs may only be returned from the top level of the pipeline function scope\. Got pipeline output from within the control flow group dsl\.ExitHandler\.'
+        ):
+
+            @dsl.pipeline
+            def my_pipeline(string: str = 'string') -> str:
+                with dsl.ExitHandler(print_and_return(text='exit task')):
+                    return print_and_return(text=string).output
+
+
 class TestConditionLogic(unittest.TestCase):
 
     def test_if(self):
@@ -4478,6 +4541,820 @@ class TestConditionLogic(unittest.TestCase):
                     print_and_return(text=item)
                 with dsl.Else():
                     print_and_return(text='Got tails!')
+
+
+class TestDslOneOf(unittest.TestCase):
+    # The space of possible tests is very large, so we test a representative set of cases covering the following styles of usage:
+    # - upstream conditions: if/else v if/elif/else
+    # - data consumed: parameters v artifacts
+    # - where dsl.OneOf goes: consumed by task v returned v both
+    # - when outputs have different keys: e.g., .output v .outputs[<key>]
+    # - how the if/elif/else are nested and at what level they are consumed
+
+    # Data type validation (e.g., dsl.OneOf(artifact, param) fails) and similar is covered in pipeline_channel_test.py.
+
+    # To help narrow the tests further (we already test lots of aspects in the following cases), we choose focus on dsl.OneOf behavior, not the conditional logic if If/Elif/Else. This is more verbose, but more maintainable and the behavior under test is clearer.
+
+    def test_if_else_returned(self):
+        # if/else
+        # returned
+        # parameters
+        # different output keys
+
+        @dsl.pipeline
+        def roll_die_pipeline() -> str:
+            flip_coin_task = flip_coin()
+            with dsl.If(flip_coin_task.output == 'heads'):
+                t1 = print_and_return(text='Got heads!')
+            with dsl.Else():
+                t2 = print_and_return_with_output_key(text='Got tails!')
+            return dsl.OneOf(t1.output, t2.outputs['output_key'])
+
+        # hole punched through if
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.components['comp-condition-2']
+            .output_definitions.parameters[
+                'pipelinechannel--print-and-return-Output'].parameter_type,
+            type_utils.STRING,
+        )
+        # hole punched through else
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.components['comp-condition-3']
+            .output_definitions.parameters[
+                'pipelinechannel--print-and-return-with-output-key-output_key']
+            .parameter_type,
+            type_utils.STRING,
+        )
+        # condition-branches surfaces
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec
+            .components['comp-condition-branches-1'].output_definitions
+            .parameters['pipelinechannel--condition-branches-1-oneof-1']
+            .parameter_type,
+            type_utils.STRING,
+        )
+        parameter_selectors = roll_die_pipeline.pipeline_spec.components[
+            'comp-condition-branches-1'].dag.outputs.parameters[
+                'pipelinechannel--condition-branches-1-oneof-1'].value_from_oneof.parameter_selectors
+        self.assertEqual(
+            parameter_selectors[0].output_parameter_key,
+            'pipelinechannel--print-and-return-Output',
+        )
+        self.assertEqual(
+            parameter_selectors[0].producer_subtask,
+            'condition-2',
+        )
+        self.assertEqual(
+            parameter_selectors[1].output_parameter_key,
+            'pipelinechannel--print-and-return-with-output-key-output_key',
+        )
+        self.assertEqual(
+            parameter_selectors[1].producer_subtask,
+            'condition-3',
+        )
+        # surfaced as output
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.root.dag.outputs
+            .parameters['Output'].value_from_parameter.producer_subtask,
+            'condition-branches-1',
+        )
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.root.dag.outputs
+            .parameters['Output'].value_from_parameter.output_parameter_key,
+            'pipelinechannel--condition-branches-1-oneof-1',
+        )
+
+    def test_if_elif_else_returned(self):
+        # if/elif/else
+        # returned
+        # parameters
+        # different output keys
+
+        @dsl.pipeline
+        def roll_die_pipeline() -> str:
+            flip_coin_task = roll_three_sided_die()
+            with dsl.If(flip_coin_task.output == 'heads'):
+                t1 = print_and_return(text='Got heads!')
+            with dsl.Elif(flip_coin_task.output == 'tails'):
+                t2 = print_and_return(text='Got tails!')
+            with dsl.Else():
+                t3 = print_and_return_with_output_key(text='Draw!')
+            return dsl.OneOf(t1.output, t2.output, t3.outputs['output_key'])
+
+        # hole punched through if
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.components['comp-condition-2']
+            .output_definitions.parameters[
+                'pipelinechannel--print-and-return-Output'].parameter_type,
+            type_utils.STRING,
+        )
+        # hole punched through elif
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.components['comp-condition-3']
+            .output_definitions.parameters[
+                'pipelinechannel--print-and-return-2-Output'].parameter_type,
+            type_utils.STRING,
+        )
+        # hole punched through else
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.components['comp-condition-4']
+            .output_definitions.parameters[
+                'pipelinechannel--print-and-return-with-output-key-output_key']
+            .parameter_type,
+            type_utils.STRING,
+        )
+        # condition-branches surfaces
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec
+            .components['comp-condition-branches-1'].output_definitions
+            .parameters['pipelinechannel--condition-branches-1-oneof-1']
+            .parameter_type,
+            type_utils.STRING,
+        )
+        parameter_selectors = roll_die_pipeline.pipeline_spec.components[
+            'comp-condition-branches-1'].dag.outputs.parameters[
+                'pipelinechannel--condition-branches-1-oneof-1'].value_from_oneof.parameter_selectors
+        self.assertEqual(
+            parameter_selectors[0].output_parameter_key,
+            'pipelinechannel--print-and-return-Output',
+        )
+        self.assertEqual(
+            parameter_selectors[0].producer_subtask,
+            'condition-2',
+        )
+        self.assertEqual(
+            parameter_selectors[1].output_parameter_key,
+            'pipelinechannel--print-and-return-2-Output',
+        )
+        self.assertEqual(
+            parameter_selectors[1].producer_subtask,
+            'condition-3',
+        )
+        self.assertEqual(
+            parameter_selectors[2].output_parameter_key,
+            'pipelinechannel--print-and-return-with-output-key-output_key',
+        )
+        self.assertEqual(
+            parameter_selectors[2].producer_subtask,
+            'condition-4',
+        )
+        # surfaced as output
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.root.dag.outputs
+            .parameters['Output'].value_from_parameter.producer_subtask,
+            'condition-branches-1',
+        )
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.root.dag.outputs
+            .parameters['Output'].value_from_parameter.output_parameter_key,
+            'pipelinechannel--condition-branches-1-oneof-1',
+        )
+
+    def test_if_elif_else_consumed(self):
+        # tests if/elif/else
+        # returned
+        # parameters
+        # different output keys
+
+        @dsl.pipeline
+        def roll_die_pipeline():
+            flip_coin_task = roll_three_sided_die()
+            with dsl.If(flip_coin_task.output == 'heads'):
+                t1 = print_and_return(text='Got heads!')
+            with dsl.Elif(flip_coin_task.output == 'tails'):
+                t2 = print_and_return(text='Got tails!')
+            with dsl.Else():
+                t3 = print_and_return_with_output_key(text='Draw!')
+            print_and_return(
+                text=dsl.OneOf(t1.output, t2.output, t3.outputs['output_key']))
+
+        # hole punched through if
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.components['comp-condition-2']
+            .output_definitions.parameters[
+                'pipelinechannel--print-and-return-Output'].parameter_type,
+            type_utils.STRING,
+        )
+        # hole punched through elif
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.components['comp-condition-3']
+            .output_definitions.parameters[
+                'pipelinechannel--print-and-return-2-Output'].parameter_type,
+            type_utils.STRING,
+        )
+        # hole punched through else
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.components['comp-condition-4']
+            .output_definitions.parameters[
+                'pipelinechannel--print-and-return-with-output-key-output_key']
+            .parameter_type,
+            type_utils.STRING,
+        )
+        # condition-branches surfaces
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec
+            .components['comp-condition-branches-1'].output_definitions
+            .parameters['pipelinechannel--condition-branches-1-oneof-1']
+            .parameter_type,
+            type_utils.STRING,
+        )
+        parameter_selectors = roll_die_pipeline.pipeline_spec.components[
+            'comp-condition-branches-1'].dag.outputs.parameters[
+                'pipelinechannel--condition-branches-1-oneof-1'].value_from_oneof.parameter_selectors
+        self.assertEqual(
+            parameter_selectors[0].output_parameter_key,
+            'pipelinechannel--print-and-return-Output',
+        )
+        self.assertEqual(
+            parameter_selectors[0].producer_subtask,
+            'condition-2',
+        )
+        self.assertEqual(
+            parameter_selectors[1].output_parameter_key,
+            'pipelinechannel--print-and-return-2-Output',
+        )
+        self.assertEqual(
+            parameter_selectors[1].producer_subtask,
+            'condition-3',
+        )
+        self.assertEqual(
+            parameter_selectors[2].output_parameter_key,
+            'pipelinechannel--print-and-return-with-output-key-output_key',
+        )
+        self.assertEqual(
+            parameter_selectors[2].producer_subtask,
+            'condition-4',
+        )
+        # consumed from condition-branches
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.root.dag.tasks['print-and-return-3']
+            .inputs.parameters['text'].task_output_parameter.producer_task,
+            'condition-branches-1',
+        )
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.root.dag.tasks['print-and-return-3']
+            .inputs.parameters['text'].task_output_parameter
+            .output_parameter_key,
+            'pipelinechannel--condition-branches-1-oneof-1',
+        )
+
+    def test_if_else_consumed_and_returned(self):
+        # tests if/else
+        # consumed and returned
+        # parameters
+        # same output key
+
+        @dsl.pipeline
+        def flip_coin_pipeline() -> str:
+            flip_coin_task = flip_coin()
+            with dsl.If(flip_coin_task.output == 'heads'):
+                print_task_1 = print_and_return(text='Got heads!')
+            with dsl.Else():
+                print_task_2 = print_and_return(text='Got tails!')
+            x = dsl.OneOf(print_task_1.output, print_task_2.output)
+            print_and_return(text=x)
+            return x
+
+        # hole punched through if
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.components['comp-condition-2']
+            .output_definitions.parameters[
+                'pipelinechannel--print-and-return-Output'].parameter_type,
+            type_utils.STRING,
+        )
+        # hole punched through else
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.components['comp-condition-3']
+            .output_definitions.parameters[
+                'pipelinechannel--print-and-return-2-Output'].parameter_type,
+            type_utils.STRING,
+        )
+        # condition-branches surfaces
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec
+            .components['comp-condition-branches-1'].output_definitions
+            .parameters['pipelinechannel--condition-branches-1-oneof-1']
+            .parameter_type,
+            type_utils.STRING,
+        )
+        parameter_selectors = flip_coin_pipeline.pipeline_spec.components[
+            'comp-condition-branches-1'].dag.outputs.parameters[
+                'pipelinechannel--condition-branches-1-oneof-1'].value_from_oneof.parameter_selectors
+        self.assertEqual(
+            parameter_selectors[0].output_parameter_key,
+            'pipelinechannel--print-and-return-Output',
+        )
+        self.assertEqual(
+            parameter_selectors[0].producer_subtask,
+            'condition-2',
+        )
+        self.assertEqual(
+            parameter_selectors[1].output_parameter_key,
+            'pipelinechannel--print-and-return-2-Output',
+        )
+        self.assertEqual(
+            parameter_selectors[1].producer_subtask,
+            'condition-3',
+        )
+        # consumed from condition-branches
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.root.dag
+            .tasks['print-and-return-3'].inputs.parameters['text']
+            .task_output_parameter.producer_task,
+            'condition-branches-1',
+        )
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.root.dag
+            .tasks['print-and-return-3'].inputs.parameters['text']
+            .task_output_parameter.output_parameter_key,
+            'pipelinechannel--condition-branches-1-oneof-1',
+        )
+
+        # surfaced as output
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.root.dag.outputs
+            .parameters['Output'].value_from_parameter.producer_subtask,
+            'condition-branches-1',
+        )
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.root.dag.outputs
+            .parameters['Output'].value_from_parameter.output_parameter_key,
+            'pipelinechannel--condition-branches-1-oneof-1',
+        )
+
+    def test_if_else_consumed_and_returned_artifacts(self):
+        # tests if/else
+        # consumed and returned
+        # artifacts
+        # same output key
+
+        @dsl.pipeline
+        def flip_coin_pipeline() -> Artifact:
+            flip_coin_task = flip_coin()
+            with dsl.If(flip_coin_task.output == 'heads'):
+                print_task_1 = print_and_return_as_artifact(text='Got heads!')
+            with dsl.Else():
+                print_task_2 = print_and_return_as_artifact(text='Got tails!')
+            x = dsl.OneOf(print_task_1.outputs['a'], print_task_2.outputs['a'])
+            print_artifact(a=x)
+            return x
+
+        # hole punched through if
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.components['comp-condition-2']
+            .output_definitions
+            .artifacts['pipelinechannel--print-and-return-as-artifact-a']
+            .artifact_type.schema_title,
+            'system.Artifact',
+        )
+        # hole punched through else
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.components['comp-condition-3']
+            .output_definitions
+            .artifacts['pipelinechannel--print-and-return-as-artifact-2-a']
+            .artifact_type.schema_title,
+            'system.Artifact',
+        )
+        # condition-branches surfaces
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec
+            .components['comp-condition-branches-1'].output_definitions
+            .artifacts['pipelinechannel--condition-branches-1-oneof-1']
+            .artifact_type.schema_title,
+            'system.Artifact',
+        )
+        artifact_selectors = flip_coin_pipeline.pipeline_spec.components[
+            'comp-condition-branches-1'].dag.outputs.artifacts[
+                'pipelinechannel--condition-branches-1-oneof-1'].artifact_selectors
+        self.assertEqual(
+            artifact_selectors[0].output_artifact_key,
+            'pipelinechannel--print-and-return-as-artifact-a',
+        )
+        self.assertEqual(
+            artifact_selectors[0].producer_subtask,
+            'condition-2',
+        )
+        self.assertEqual(
+            artifact_selectors[1].output_artifact_key,
+            'pipelinechannel--print-and-return-as-artifact-2-a',
+        )
+        self.assertEqual(
+            artifact_selectors[1].producer_subtask,
+            'condition-3',
+        )
+        # consumed from condition-branches
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.root.dag.tasks['print-artifact']
+            .inputs.artifacts['a'].task_output_artifact.producer_task,
+            'condition-branches-1',
+        )
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.root.dag.tasks['print-artifact']
+            .inputs.artifacts['a'].task_output_artifact.output_artifact_key,
+            'pipelinechannel--condition-branches-1-oneof-1',
+        )
+
+        # surfaced as output
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.root.dag.outputs
+            .artifacts['Output'].artifact_selectors[0].producer_subtask,
+            'condition-branches-1',
+        )
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.root.dag.outputs
+            .artifacts['Output'].artifact_selectors[0].output_artifact_key,
+            'pipelinechannel--condition-branches-1-oneof-1',
+        )
+
+    def test_nested_under_condition_consumed(self):
+        # nested under loop and condition
+        # artifact
+
+        @dsl.pipeline
+        def flip_coin_pipeline(execute_pipeline: bool):
+            with dsl.If(execute_pipeline == True):
+                flip_coin_task = flip_coin()
+                with dsl.If(flip_coin_task.output == 'heads'):
+                    print_task_1 = print_and_return_as_artifact(
+                        text='Got heads!')
+                with dsl.Else():
+                    print_task_2 = print_and_return_as_artifact(
+                        text='Got tails!')
+                x = dsl.OneOf(print_task_1.outputs['a'],
+                              print_task_2.outputs['a'])
+                print_artifact(a=x)
+
+        # hole punched through if
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.components['comp-condition-3']
+            .output_definitions
+            .artifacts['pipelinechannel--print-and-return-as-artifact-a']
+            .artifact_type.schema_title,
+            'system.Artifact',
+        )
+        # hole punched through else
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.components['comp-condition-4']
+            .output_definitions
+            .artifacts['pipelinechannel--print-and-return-as-artifact-2-a']
+            .artifact_type.schema_title,
+            'system.Artifact',
+        )
+        # condition-branches surfaces
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec
+            .components['comp-condition-branches-2'].output_definitions
+            .artifacts['pipelinechannel--condition-branches-2-oneof-1']
+            .artifact_type.schema_title,
+            'system.Artifact',
+        )
+        artifact_selectors = flip_coin_pipeline.pipeline_spec.components[
+            'comp-condition-branches-2'].dag.outputs.artifacts[
+                'pipelinechannel--condition-branches-2-oneof-1'].artifact_selectors
+        self.assertEqual(
+            artifact_selectors[0].output_artifact_key,
+            'pipelinechannel--print-and-return-as-artifact-a',
+        )
+        self.assertEqual(
+            artifact_selectors[0].producer_subtask,
+            'condition-3',
+        )
+        self.assertEqual(
+            artifact_selectors[1].output_artifact_key,
+            'pipelinechannel--print-and-return-as-artifact-2-a',
+        )
+        self.assertEqual(
+            artifact_selectors[1].producer_subtask,
+            'condition-4',
+        )
+        # consumed from condition-branches
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.components['comp-condition-1'].dag
+            .tasks['print-artifact'].inputs.artifacts['a'].task_output_artifact
+            .producer_task,
+            'condition-branches-2',
+        )
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.components['comp-condition-1'].dag
+            .tasks['print-artifact'].inputs.artifacts['a'].task_output_artifact
+            .output_artifact_key,
+            'pipelinechannel--condition-branches-2-oneof-1',
+        )
+
+    def test_nested_under_condition_returned_raises(self):
+        # nested under loop and condition
+        # artifact
+        with self.assertRaisesRegex(
+                compiler_utils.InvalidTopologyException,
+                f'Pipeline outputs may only be returned from the top level of the pipeline function scope\. Got pipeline output dsl\.OneOf from within the control flow group dsl\.If\.'
+        ):
+
+            @dsl.pipeline
+            def flip_coin_pipeline(execute_pipeline: bool):
+                with dsl.If(execute_pipeline == True):
+                    flip_coin_task = flip_coin()
+                    with dsl.If(flip_coin_task.output == 'heads'):
+                        print_task_1 = print_and_return_as_artifact(
+                            text='Got heads!')
+                    with dsl.Else():
+                        print_task_2 = print_and_return_as_artifact(
+                            text='Got tails!')
+                    return dsl.OneOf(print_task_1.outputs['a'],
+                                     print_task_2.outputs['a'])
+
+    def test_deeply_nested_consumed(self):
+        # nested under loop and condition and exit handler
+        # consumed
+        # artifact
+
+        @dsl.pipeline
+        def flip_coin_pipeline(execute_pipeline: bool):
+            with dsl.ExitHandler(cleanup()):
+                with dsl.ParallelFor([1, 2, 3]):
+                    with dsl.If(execute_pipeline == True):
+                        flip_coin_task = flip_coin()
+                        with dsl.If(flip_coin_task.output == 'heads'):
+                            print_task_1 = print_and_return_as_artifact(
+                                text='Got heads!')
+                        with dsl.Else():
+                            print_task_2 = print_and_return_as_artifact(
+                                text='Got tails!')
+                        x = dsl.OneOf(print_task_1.outputs['a'],
+                                      print_task_2.outputs['a'])
+                        print_artifact(a=x)
+
+        self.assertIn(
+            'condition-branches-5', flip_coin_pipeline.pipeline_spec
+            .components['comp-condition-4'].dag.tasks)
+        # consumed from condition-branches
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.components['comp-condition-4'].dag
+            .tasks['print-artifact'].inputs.artifacts['a'].task_output_artifact
+            .producer_task,
+            'condition-branches-5',
+        )
+        self.assertEqual(
+            flip_coin_pipeline.pipeline_spec.components['comp-condition-4'].dag
+            .tasks['print-artifact'].inputs.artifacts['a'].task_output_artifact
+            .output_artifact_key,
+            'pipelinechannel--condition-branches-5-oneof-1',
+        )
+
+    def test_deeply_nested_returned_raises(self):
+        # nested under loop and condition
+        # returned
+        # artifact
+
+        with self.assertRaisesRegex(
+                compiler_utils.InvalidTopologyException,
+                f'Pipeline outputs may only be returned from the top level of the pipeline function scope\. Got pipeline output dsl\.OneOf from within the control flow group dsl\.ParallelFor\.'
+        ):
+
+            @dsl.pipeline
+            def flip_coin_pipeline(execute_pipeline: bool) -> str:
+                with dsl.ExitHandler(cleanup()):
+                    with dsl.If(execute_pipeline == True):
+                        with dsl.ParallelFor([1, 2, 3]):
+                            flip_coin_task = flip_coin()
+                            with dsl.If(flip_coin_task.output == 'heads'):
+                                print_task_1 = print_and_return_as_artifact(
+                                    text='Got heads!')
+                            with dsl.Else():
+                                print_task_2 = print_and_return_as_artifact(
+                                    text='Got tails!')
+                            return dsl.OneOf(print_task_1.outputs['a'],
+                                             print_task_2.outputs['a'])
+
+    def test_consume_at_wrong_level(self):
+
+        with self.assertRaisesRegex(
+                compiler_utils.InvalidTopologyException,
+                f'Illegal task dependency across DSL context managers\. A downstream task cannot depend on an upstream task within a dsl\.If context unless the downstream is within that context too\. Found task print-artifact which depends on upstream task condition-branches-5 within an uncommon dsl\.If context\.'
+        ):
+
+            @dsl.pipeline
+            def flip_coin_pipeline(execute_pipeline: bool):
+                with dsl.ExitHandler(cleanup()):
+                    with dsl.ParallelFor([1, 2, 3]):
+                        with dsl.If(execute_pipeline == True):
+                            flip_coin_task = flip_coin()
+                            with dsl.If(flip_coin_task.output == 'heads'):
+                                print_task_1 = print_and_return_as_artifact(
+                                    text='Got heads!')
+                            with dsl.Else():
+                                print_task_2 = print_and_return_as_artifact(
+                                    text='Got tails!')
+                            x = dsl.OneOf(print_task_1.outputs['a'],
+                                          print_task_2.outputs['a'])
+                        # this is one level dedented from the permitted case
+                        print_artifact(a=x)
+
+    def test_return_at_wrong_level(self):
+        with self.assertRaisesRegex(
+                compiler_utils.InvalidTopologyException,
+                f'Pipeline outputs may only be returned from the top level of the pipeline function scope\. Got pipeline output dsl\.OneOf from within the control flow group dsl\.If\.'
+        ):
+
+            @dsl.pipeline
+            def flip_coin_pipeline(execute_pipeline: bool):
+                with dsl.If(execute_pipeline == True):
+                    flip_coin_task = flip_coin()
+                    with dsl.If(flip_coin_task.output == 'heads'):
+                        print_task_1 = print_and_return_as_artifact(
+                            text='Got heads!')
+                    with dsl.Else():
+                        print_task_2 = print_and_return_as_artifact(
+                            text='Got tails!')
+                # this is returned at the right level, but not permitted since it's still effectively returning from within the dsl.If group
+                return dsl.OneOf(print_task_1.outputs['a'],
+                                 print_task_2.outputs['a'])
+
+    def test_consumed_in_nested_groups(self):
+
+        @dsl.pipeline
+        def roll_die_pipeline(
+            repeat: bool = True,
+            rounds: List[str] = ['a', 'b', 'c'],
+        ):
+            flip_coin_task = roll_three_sided_die()
+            with dsl.If(flip_coin_task.output == 'heads'):
+                t1 = print_and_return(text='Got heads!')
+            with dsl.Elif(flip_coin_task.output == 'tails'):
+                t2 = print_and_return(text='Got tails!')
+            with dsl.Else():
+                t3 = print_and_return_with_output_key(text='Draw!')
+            x = dsl.OneOf(t1.output, t2.output, t3.outputs['output_key'])
+
+            with dsl.ParallelFor(rounds):
+                with dsl.If(repeat == True):
+                    print_and_return(text=x)
+
+        # condition-branches surfaces
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec
+            .components['comp-condition-branches-1'].output_definitions
+            .parameters['pipelinechannel--condition-branches-1-oneof-1']
+            .parameter_type,
+            type_utils.STRING,
+        )
+        parameter_selectors = roll_die_pipeline.pipeline_spec.components[
+            'comp-condition-branches-1'].dag.outputs.parameters[
+                'pipelinechannel--condition-branches-1-oneof-1'].value_from_oneof.parameter_selectors
+        self.assertEqual(
+            parameter_selectors[0].output_parameter_key,
+            'pipelinechannel--print-and-return-Output',
+        )
+        self.assertEqual(
+            parameter_selectors[0].producer_subtask,
+            'condition-2',
+        )
+        self.assertEqual(
+            parameter_selectors[1].output_parameter_key,
+            'pipelinechannel--print-and-return-2-Output',
+        )
+        self.assertEqual(
+            parameter_selectors[1].producer_subtask,
+            'condition-3',
+        )
+        self.assertEqual(
+            parameter_selectors[2].output_parameter_key,
+            'pipelinechannel--print-and-return-with-output-key-output_key',
+        )
+        self.assertEqual(
+            parameter_selectors[2].producer_subtask,
+            'condition-4',
+        )
+        # condition points to correct upstream output
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.components['comp-condition-6']
+            .input_definitions.parameters[
+                'pipelinechannel--condition-branches-1-pipelinechannel--condition-branches-1-oneof-1']
+            .parameter_type, type_utils.STRING)
+        # inner task consumes from condition input parameter
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.components['comp-condition-6'].dag
+            .tasks['print-and-return-3'].inputs.parameters['text']
+            .component_input_parameter,
+            'pipelinechannel--condition-branches-1-pipelinechannel--condition-branches-1-oneof-1'
+        )
+
+    def test_oneof_in_fstring(self):
+        with self.assertRaisesRegex(
+                NotImplementedError,
+                f'dsl\.OneOf is not yet supported in f-strings\.'):
+
+            @dsl.pipeline
+            def roll_die_pipeline():
+                flip_coin_task = roll_three_sided_die()
+                with dsl.If(flip_coin_task.output == 'heads'):
+                    t1 = print_and_return(text='Got heads!')
+                with dsl.Elif(flip_coin_task.output == 'tails'):
+                    t2 = print_and_return(text='Got tails!')
+                with dsl.Else():
+                    t3 = print_and_return_with_output_key(text='Draw!')
+                print_and_return(
+                    text=f"Final result: {dsl.OneOf(t1.output, t2.output, t3.outputs['output_key'])}"
+                )
+
+    def test_oneof_in_condition(self):
+
+        @dsl.pipeline
+        def roll_die_pipeline(repeat_on: str = 'Got heads!'):
+            flip_coin_task = roll_three_sided_die()
+            with dsl.If(flip_coin_task.output == 'heads'):
+                t1 = print_and_return(text='Got heads!')
+            with dsl.Elif(flip_coin_task.output == 'tails'):
+                t2 = print_and_return(text='Got tails!')
+            with dsl.Else():
+                t3 = print_and_return_with_output_key(text='Draw!')
+            x = dsl.OneOf(t1.output, t2.output, t3.outputs['output_key'])
+
+            with dsl.If(x == repeat_on):
+                print_and_return(text=x)
+
+        # condition-branches surfaces
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec
+            .components['comp-condition-branches-1'].output_definitions
+            .parameters['pipelinechannel--condition-branches-1-oneof-1']
+            .parameter_type,
+            type_utils.STRING,
+        )
+        parameter_selectors = roll_die_pipeline.pipeline_spec.components[
+            'comp-condition-branches-1'].dag.outputs.parameters[
+                'pipelinechannel--condition-branches-1-oneof-1'].value_from_oneof.parameter_selectors
+        self.assertEqual(
+            parameter_selectors[0].output_parameter_key,
+            'pipelinechannel--print-and-return-Output',
+        )
+        self.assertEqual(
+            parameter_selectors[0].producer_subtask,
+            'condition-2',
+        )
+        self.assertEqual(
+            parameter_selectors[1].output_parameter_key,
+            'pipelinechannel--print-and-return-2-Output',
+        )
+        self.assertEqual(
+            parameter_selectors[1].producer_subtask,
+            'condition-3',
+        )
+        self.assertEqual(
+            parameter_selectors[2].output_parameter_key,
+            'pipelinechannel--print-and-return-with-output-key-output_key',
+        )
+        self.assertEqual(
+            parameter_selectors[2].producer_subtask,
+            'condition-4',
+        )
+        # condition points to correct upstream output
+        self.assertEqual(
+            roll_die_pipeline.pipeline_spec.root.dag.tasks['condition-5']
+            .trigger_policy.condition,
+            "inputs.parameter_values['pipelinechannel--condition-branches-1-pipelinechannel--condition-branches-1-oneof-1'] == inputs.parameter_values['pipelinechannel--repeat_on']"
+        )
+
+    def test_type_checking_parameters(self):
+        with self.assertRaisesRegex(
+                type_utils.InconsistentTypeException,
+                "Incompatible argument passed to the input 'val' of component 'print-int': Argument type 'STRING' is incompatible with the input type 'NUMBER_INTEGER'",
+        ):
+
+            @dsl.component
+            def print_int(val: int):
+                print(val)
+
+            @dsl.pipeline
+            def roll_die_pipeline():
+                flip_coin_task = roll_three_sided_die()
+                with dsl.If(flip_coin_task.output == 'heads'):
+                    t1 = print_and_return(text='Got heads!')
+                with dsl.Elif(flip_coin_task.output == 'tails'):
+                    t2 = print_and_return(text='Got tails!')
+                with dsl.Else():
+                    t3 = print_and_return_with_output_key(text='Draw!')
+                print_int(
+                    val=dsl.OneOf(t1.output, t2.output,
+                                  t3.outputs['output_key']))
+
+    def test_oneof_of_oneof(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                r'dsl.OneOf cannot be used inside of another dsl\.OneOf\.'):
+
+            @dsl.pipeline
+            def roll_die_pipeline() -> str:
+                outer_flip_coin_task = flip_coin()
+                with dsl.If(outer_flip_coin_task.output == 'heads'):
+                    inner_flip_coin_task = flip_coin()
+                    with dsl.If(inner_flip_coin_task.output == 'heads'):
+                        t1 = print_and_return(text='Got heads!')
+                    with dsl.Else():
+                        t2 = print_and_return(text='Got tails!')
+                    t3 = dsl.OneOf(t1.output, t2.output)
+                with dsl.Else():
+                    t4 = print_and_return(text='First flip was not heads!')
+                return dsl.OneOf(t3, t4.output)
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/dsl/__init__.py
+++ b/sdk/python/kfp/dsl/__init__.py
@@ -229,8 +229,10 @@ Example:
 if os.environ.get('_KFP_RUNTIME', 'false') != 'true':
     from kfp.dsl.component_decorator import component
     from kfp.dsl.container_component_decorator import container_component
+    # TODO: Collected should be moved to pipeline_channel.py, consistent with OneOf
     from kfp.dsl.for_loop import Collected
     from kfp.dsl.importer_node import importer
+    from kfp.dsl.pipeline_channel import OneOf
     from kfp.dsl.pipeline_context import pipeline
     from kfp.dsl.pipeline_task import PipelineTask
     from kfp.dsl.placeholders import ConcatPlaceholder
@@ -252,6 +254,7 @@ if os.environ.get('_KFP_RUNTIME', 'false') != 'true':
         'If',
         'Elif',
         'Else',
+        'OneOf',
         'ExitHandler',
         'ParallelFor',
         'Collected',

--- a/sdk/python/kfp/dsl/for_loop.py
+++ b/sdk/python/kfp/dsl/for_loop.py
@@ -274,6 +274,7 @@ class LoopArgumentVariable(pipeline_channel.PipelineChannel):
         return f'{loop_arg_name}{self.SUBVAR_NAME_DELIMITER}{subvar_name}'
 
 
+# TODO: migrate Collected to OneOfMixin style implementation
 class Collected(pipeline_channel.PipelineChannel):
     """For collecting into a list the output from a task in dsl.ParallelFor
     loops.
@@ -313,3 +314,13 @@ class Collected(pipeline_channel.PipelineChannel):
             channel_type=channel_type,
             task_name=output.task_name,
         )
+        self._validate_no_oneof_channel(self.output)
+
+    def _validate_no_oneof_channel(
+        self, channel: Union[pipeline_channel.PipelineParameterChannel,
+                             pipeline_channel.PipelineArtifactChannel]
+    ) -> None:
+        if isinstance(channel, pipeline_channel.OneOfMixin):
+            raise ValueError(
+                f'dsl.{pipeline_channel.OneOf.__name__} cannot be used inside of dsl.{Collected.__name__}.'
+            )

--- a/sdk/python/kfp/dsl/pipeline_channel.py
+++ b/sdk/python/kfp/dsl/pipeline_channel.py
@@ -102,12 +102,31 @@ class PipelineChannel(abc.ABC):
         self.task_name = task_name or None
         from kfp.dsl import pipeline_context
 
-        default_pipeline = pipeline_context.Pipeline.get_default_pipeline()
-        if self.task_name is not None and default_pipeline is not None and default_pipeline.tasks:
-            self.task = pipeline_context.Pipeline.get_default_pipeline().tasks[
-                self.task_name]
-        else:
-            self.task = None
+        self.pipeline = pipeline_context.Pipeline.get_default_pipeline()
+
+    @property
+    def task(self) -> Union['PipelineTask', 'TasksGroup']:
+        # TODO: migrate Collected to OneOfMixin style implementation,
+        # then move this out of a property
+        if self.task_name is None or self.pipeline is None:
+            return None
+
+        if self.task_name in self.pipeline.tasks:
+            return self.pipeline.tasks[self.task_name]
+
+        from kfp.compiler import compiler_utils
+        all_groups = compiler_utils.get_all_groups(self.pipeline.groups[0])
+        # pipeline hasn't exited, so it doesn't have a name
+        all_groups_no_pipeline = all_groups[1:]
+        group_name_to_group = {
+            group.name: group for group in all_groups_no_pipeline
+        }
+        if self.task_name in group_name_to_group:
+            return group_name_to_group[self.task_name]
+
+        raise ValueError(
+            f"PipelineChannel task name '{self.task_name}' not found in pipeline."
+        )
 
     @property
     def full_name(self) -> str:
@@ -263,6 +282,234 @@ class PipelineArtifactChannel(PipelineChannel):
             channel_type=channel_type,
             task_name=task_name,
         )
+
+
+class OneOfMixin(PipelineChannel):
+    """Shared functionality for OneOfParameter and OneOfAritfact."""
+
+    def _set_condition_branches_group(
+        self, channels: List[Union[PipelineParameterChannel,
+                                   PipelineArtifactChannel]]
+    ) -> None:
+        # avoid circular import
+        from kfp.dsl import tasks_group
+
+        # .condition_branches_group could really be collapsed into just .task,
+        # but we prefer keeping both for clarity in the rest of the compiler
+        # code. When the code is logically related to a
+        # condition_branches_group, it aids understanding to reference this
+        # attribute name. When the code is trying to treat the OneOfMixin like
+        # a typical PipelineChannel, it aids to reference task.
+        self.condition_branches_group: tasks_group.ConditionBranches = channels[
+            0].task.parent_task_group.parent_task_group
+
+    def _make_oneof_name(self) -> str:
+        # avoid circular imports
+        from kfp.compiler import compiler_utils
+
+        # This is a different type of "injected channel".
+        # We know that this output will _always_ be a pipeline channel, so we
+        # set the pipeline-channel-- prefix immediately (here).
+        # In the downstream compiler logic, we get to treat this output like a
+        # normal task output.
+        return compiler_utils.additional_input_name_for_pipeline_channel(
+            f'{self.condition_branches_group.name}-oneof-{self.condition_branches_group._get_oneof_id()}'
+        )
+
+    def _validate_channels(
+        self,
+        channels: List[Union[PipelineParameterChannel,
+                             PipelineArtifactChannel]],
+    ):
+        self._validate_no_collected_channel(channels)
+        self._validate_no_oneof_channel(channels)
+        self._validate_no_mix_of_parameters_and_artifacts(channels)
+        self._validate_has_else_group(self.condition_branches_group)
+
+    def _validate_no_collected_channel(
+        self, channels: List[Union[PipelineParameterChannel,
+                                   PipelineArtifactChannel]]
+    ) -> None:
+        # avoid circular imports
+        from kfp.dsl import for_loop
+        if any(isinstance(channel, for_loop.Collected) for channel in channels):
+            raise ValueError(
+                f'dsl.{for_loop.Collected.__name__} cannot be used inside of dsl.{OneOf.__name__}.'
+            )
+
+    def _validate_no_oneof_channel(
+        self, channels: List[Union[PipelineParameterChannel,
+                                   PipelineArtifactChannel]]
+    ) -> None:
+        if any(isinstance(channel, OneOfMixin) for channel in channels):
+            raise ValueError(
+                f'dsl.{OneOf.__name__} cannot be used inside of another dsl.{OneOf.__name__}.'
+            )
+
+    def _validate_no_mix_of_parameters_and_artifacts(
+        self, channels: List[Union[PipelineParameterChannel,
+                                   PipelineArtifactChannel]]
+    ) -> None:
+        readable_name_map = {
+            PipelineParameterChannel: 'parameter',
+            PipelineArtifactChannel: 'artifact',
+            OneOfParameter: 'parameter',
+            OneOfArtifact: 'artifact',
+        }
+        # if channels[0] is any subclass of a PipelineParameterChannel
+        # check the rest of the channels against that parent type
+        # ensures check permits OneOfParameter and PipelineParameterChannel
+        # to be passed to OneOf together
+        if isinstance(channels[0], PipelineParameterChannel):
+            expected_type = PipelineParameterChannel
+        else:
+            expected_type = PipelineArtifactChannel
+
+        for i, channel in enumerate(channels[1:], start=1):
+            if not isinstance(channel, expected_type):
+                raise TypeError(
+                    f'Task outputs passed to dsl.{OneOf.__name__} must be the same type. Got two channels with different types: {readable_name_map[expected_type]} at index 0 and {readable_name_map[type(channel)]} at index {i}.'
+                )
+
+    def _validate_has_else_group(
+        self,
+        parent_group: 'tasks_group.ConditionBranches',
+    ) -> None:
+        # avoid circular imports
+        from kfp.dsl import tasks_group
+        if not isinstance(parent_group.groups[-1], tasks_group.Else):
+            raise ValueError(
+                f'dsl.{OneOf.__name__} must include an output from a task in a dsl.{tasks_group.Else.__name__} group to ensure at least one output is available at runtime.'
+            )
+
+    def __str__(self):
+        # supporting oneof in f-strings is technically feasible, but would
+        # require somehow encoding all of the oneof channels into the
+        # f-string
+        # another way to do this would be to maintain a pipeline-level
+        # map of PipelineChannels and encode a lookup key in the f-string
+        # the combination of OneOf and an f-string is not common, so prefer
+        # deferring implementation
+        raise NotImplementedError(
+            f'dsl.{OneOf.__name__} is not yet supported in f-strings.')
+
+    @property
+    def pattern(self) -> str:
+        # override self.pattern to avoid calling __str__, allowing us to block f-strings for now
+        # this makes it OneOfMixin hashable for use in sets/dicts
+        task_name = self.task_name or ''
+        name = self.name
+        channel_type = self.channel_type or ''
+        if isinstance(channel_type, dict):
+            channel_type = json.dumps(channel_type)
+        return _PIPELINE_CHANNEL_PLACEHOLDER_TEMPLATE % (task_name, name,
+                                                         channel_type)
+
+
+# splitting out OneOf into subclasses significantly decreases the amount of
+# branching in downstream compiler logic, since the
+# isinstance(<some channel>, PipelineParameterChannel/PipelineArtifactChannel)
+# checks continue to behave in desirable ways
+class OneOfParameter(PipelineParameterChannel, OneOfMixin):
+    """OneOf that results in an parameter channel for all downstream tasks."""
+
+    def __init__(self, channels: List[PipelineParameterChannel]) -> None:
+        self.channels = channels
+        self._set_condition_branches_group(channels)
+        super().__init__(
+            name=self._make_oneof_name(),
+            channel_type=channels[0].channel_type,
+            task_name=None,
+        )
+        self.task_name = self.condition_branches_group.name
+        self.channels = channels
+        self._validate_channels(channels)
+        self._validate_same_kfp_type(channels)
+
+    def _validate_same_kfp_type(
+            self, channels: List[PipelineParameterChannel]) -> None:
+        expected_type = channels[0].channel_type
+        for i, channel in enumerate(channels[1:], start=1):
+            if channel.channel_type != expected_type:
+                raise TypeError(
+                    f'Task outputs passed to dsl.{OneOf.__name__} must be the same type. Got two channels with different types: {expected_type} at index 0 and {channel.channel_type} at index {i}.'
+                )
+
+
+class OneOfArtifact(PipelineArtifactChannel, OneOfMixin):
+    """OneOf that results in an artifact channel for all downstream tasks."""
+
+    def __init__(self, channels: List[PipelineArtifactChannel]) -> None:
+        self.channels = channels
+        self._set_condition_branches_group(channels)
+        super().__init__(
+            name=self._make_oneof_name(),
+            channel_type=channels[0].channel_type,
+            task_name=None,
+            is_artifact_list=channels[0].is_artifact_list,
+        )
+        self.task_name = self.condition_branches_group.name
+        self._validate_channels(channels)
+        self._validate_same_kfp_type(channels)
+
+    def _validate_same_kfp_type(
+            self, channels: List[PipelineArtifactChannel]) -> None:
+        # Unlike for component interface type checking where anything is
+        # passable to Artifact, we should require the output artifacts for a
+        # OneOf to be the same. This reduces the complexity/ambiguity for the
+        # user of the actual type checking logic. What should the type checking
+        # behavior be if the OneOf surfaces an Artifact and a Dataset? We can
+        # always loosen backward compatibly in the future, so prefer starting
+        # conservatively.
+        expected_type = channels[0].channel_type
+        expected_is_list = channels[0].is_artifact_list
+        for i, channel in enumerate(channels[1:], start=1):
+            if channel.channel_type != expected_type or channel.is_artifact_list != expected_is_list:
+                raise TypeError(
+                    f'Task outputs passed to dsl.{OneOf.__name__} must be the same type. Got two channels with different types: {expected_type} at index 0 and {channel.channel_type} at index {i}.'
+                )
+
+
+class OneOf:
+    """For collecting mutually exclusive outputs from conditional branches into
+    a single pipeline channel.
+
+    Args:
+        channels: The channels to collect into a OneOf. Must be of the same type.
+
+    Example:
+      ::
+
+        @dsl.pipeline
+        def flip_coin_pipeline() -> str:
+            flip_coin_task = flip_coin()
+            with dsl.If(flip_coin_task.output == 'heads'):
+                print_task_1 = print_and_return(text='Got heads!')
+            with dsl.Else():
+                print_task_2 = print_and_return(text='Got tails!')
+
+            # use the output from the branch that gets executed
+            oneof = dsl.OneOf(print_task_1.output, print_task_2.output)
+
+            # consume it
+            print_and_return(text=oneof)
+
+            # return it
+            return oneof
+    """
+
+    def __new__(
+        cls, *channels: Union[PipelineParameterChannel, PipelineArtifactChannel]
+    ) -> Union[OneOfParameter, OneOfArtifact]:
+        first_channel = channels[0]
+        if isinstance(first_channel, PipelineParameterChannel):
+            return OneOfParameter(channels=list(channels))
+        elif isinstance(first_channel, PipelineArtifactChannel):
+            return OneOfArtifact(channels=list(channels))
+        else:
+            raise ValueError(
+                f'Got unknown input to dsl.{OneOf.__name__} with type {type(first_channel)}.'
+            )
 
 
 def create_pipeline_channel(

--- a/sdk/python/kfp/dsl/pipeline_channel_test.py
+++ b/sdk/python/kfp/dsl/pipeline_channel_test.py
@@ -357,7 +357,7 @@ class TestOneOfRequiresSameType(unittest.TestCase):
 
         with self.assertRaisesRegex(
                 TypeError,
-                r'Task outputs passed to dsl\.OneOf must be the same type\. Got two channels with different types: artifact at index 0 and parameter at index 1\.'
+                r'Task outputs passed to dsl\.OneOf must be the same type\. Found a mix of parameters and artifacts passed to dsl\.OneOf\.'
         ):
 
             @dsl.pipeline

--- a/sdk/python/kfp/dsl/pipeline_channel_test.py
+++ b/sdk/python/kfp/dsl/pipeline_channel_test.py
@@ -13,10 +13,14 @@
 # limitations under the License.
 """Tests for kfp.dsl.pipeline_channel."""
 
+from typing import List
 import unittest
 
 from absl.testing import parameterized
 from kfp import dsl
+from kfp.dsl import Artifact
+from kfp.dsl import Dataset
+from kfp.dsl import Output
 from kfp.dsl import pipeline_channel
 
 
@@ -156,18 +160,228 @@ class PipelineChannelTest(parameterized.TestCase):
         self.assertListEqual([p1, p2, p3], params)
 
 
+@dsl.component
+def string_comp() -> str:
+    return 'text'
+
+
+@dsl.component
+def list_comp() -> List[str]:
+    return ['text']
+
+
+@dsl.component
+def roll_three_sided_die() -> str:
+    import random
+    val = random.randint(0, 2)
+
+    if val == 0:
+        return 'heads'
+    elif val == 1:
+        return 'tails'
+    else:
+        return 'draw'
+
+
+@dsl.component
+def print_and_return(text: str) -> str:
+    print(text)
+    return text
+
+
 class TestCanAccessTask(unittest.TestCase):
 
     def test(self):
 
-        @dsl.component
-        def comp() -> str:
-            return 'text'
-
         @dsl.pipeline
         def my_pipeline():
-            op1 = comp()
+            op1 = string_comp()
             self.assertEqual(op1.output.task, op1)
+
+
+class TestOneOfAndCollectedNotComposable(unittest.TestCase):
+
+    def test_collected_in_oneof(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                'dsl.Collected cannot be used inside of dsl.OneOf.'):
+
+            @dsl.pipeline
+            def my_pipeline(x: str):
+                with dsl.If(x == 'foo'):
+                    t1 = list_comp()
+                with dsl.Else():
+                    with dsl.ParallelFor([1, 2, 3]):
+                        t2 = string_comp()
+                    collected = dsl.Collected(t2.output)
+                # test cases doesn't return or pass to task to ensure validation is in the OneOf
+                dsl.OneOf(t1.output, collected)
+
+    def test_oneof_in_collected(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                'dsl.OneOf cannot be used inside of dsl.Collected.'):
+
+            @dsl.pipeline
+            def my_pipeline(x: str):
+                with dsl.ParallelFor([1, 2, 3]):
+                    with dsl.If(x == 'foo'):
+                        t1 = string_comp()
+                    with dsl.Else():
+                        t2 = string_comp()
+                    oneof = dsl.OneOf(t1.output, t2.output)
+                # test cases doesn't return or pass to task to ensure validation is in the Collected constructor
+                dsl.Collected(oneof)
+
+
+class TestOneOfRequiresSameType(unittest.TestCase):
+
+    def test_same_parameter_type(self):
+
+        @dsl.pipeline
+        def my_pipeline(x: str) -> str:
+            with dsl.If(x == 'foo'):
+                t1 = string_comp()
+            with dsl.Else():
+                t2 = string_comp()
+            return dsl.OneOf(t1.output, t2.output)
+
+        self.assertEqual(
+            my_pipeline.pipeline_spec.components['comp-condition-branches-1']
+            .output_definitions.parameters[
+                'pipelinechannel--condition-branches-1-oneof-1'].parameter_type,
+            3)
+
+    def test_different_parameter_types(self):
+
+        with self.assertRaisesRegex(
+                TypeError,
+                r'Task outputs passed to dsl\.OneOf must be the same type. Got two channels with different types: String at index 0 and typing\.List\[str\] at index 1\.'
+        ):
+
+            @dsl.pipeline
+            def my_pipeline(x: str) -> str:
+                with dsl.If(x == 'foo'):
+                    t1 = string_comp()
+                with dsl.Else():
+                    t2 = list_comp()
+                return dsl.OneOf(t1.output, t2.output)
+
+    def test_same_artifact_type(self):
+
+        @dsl.component
+        def artifact_comp(out: Output[Artifact]):
+            with open(out.path, 'w') as f:
+                f.write('foo')
+
+        @dsl.pipeline
+        def my_pipeline(x: str) -> Artifact:
+            with dsl.If(x == 'foo'):
+                t1 = artifact_comp()
+            with dsl.Else():
+                t2 = artifact_comp()
+            return dsl.OneOf(t1.outputs['out'], t2.outputs['out'])
+
+        self.assertEqual(
+            my_pipeline.pipeline_spec.components['comp-condition-branches-1']
+            .output_definitions
+            .artifacts['pipelinechannel--condition-branches-1-oneof-1']
+            .artifact_type.schema_title,
+            'system.Artifact',
+        )
+        self.assertEqual(
+            my_pipeline.pipeline_spec.components['comp-condition-branches-1']
+            .output_definitions
+            .artifacts['pipelinechannel--condition-branches-1-oneof-1']
+            .artifact_type.schema_version,
+            '0.0.1',
+        )
+
+    def test_different_artifact_type(self):
+
+        @dsl.component
+        def artifact_comp_one(out: Output[Artifact]):
+            with open(out.path, 'w') as f:
+                f.write('foo')
+
+        @dsl.component
+        def artifact_comp_two(out: Output[Dataset]):
+            with open(out.path, 'w') as f:
+                f.write('foo')
+
+        with self.assertRaisesRegex(
+                TypeError,
+                r'Task outputs passed to dsl\.OneOf must be the same type. Got two channels with different types: system.Artifact@0.0.1 at index 0 and system.Dataset@0.0.1 at index 1\.'
+        ):
+
+            @dsl.pipeline
+            def my_pipeline(x: str) -> Artifact:
+                with dsl.If(x == 'foo'):
+                    t1 = artifact_comp_one()
+                with dsl.Else():
+                    t2 = artifact_comp_two()
+                return dsl.OneOf(t1.outputs['out'], t2.outputs['out'])
+
+    def test_different_artifact_type_due_to_list(self):
+        # if we ever support list of artifact outputs from components, this test will fail, which is good because it needs to be changed
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Output lists of artifacts are only supported for pipelines\. Got output list of artifacts for output parameter 'out' of component 'artifact-comp-two'\."
+        ):
+
+            @dsl.component
+            def artifact_comp_one(out: Output[Artifact]):
+                with open(out.path, 'w') as f:
+                    f.write('foo')
+
+            @dsl.component
+            def artifact_comp_two(out: Output[List[Artifact]]):
+                with open(out.path, 'w') as f:
+                    f.write('foo')
+
+            @dsl.pipeline
+            def my_pipeline(x: str) -> Artifact:
+                with dsl.If(x == 'foo'):
+                    t1 = artifact_comp_one()
+                with dsl.Else():
+                    t2 = artifact_comp_two()
+                return dsl.OneOf(t1.outputs['out'], t2.outputs['out'])
+
+    def test_parameters_mixed_with_artifacts(self):
+
+        @dsl.component
+        def artifact_comp(out: Output[Artifact]):
+            with open(out.path, 'w') as f:
+                f.write('foo')
+
+        with self.assertRaisesRegex(
+                TypeError,
+                r'Task outputs passed to dsl\.OneOf must be the same type\. Got two channels with different types: artifact at index 0 and parameter at index 1\.'
+        ):
+
+            @dsl.pipeline
+            def my_pipeline(x: str) -> str:
+                with dsl.If(x == 'foo'):
+                    t1 = artifact_comp()
+                with dsl.Else():
+                    t2 = string_comp()
+                return dsl.OneOf(t1.output, t2.output)
+
+    def test_no_else_raises(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                r'dsl\.OneOf must include an output from a task in a dsl\.Else group to ensure at least one output is available at runtime\.'
+        ):
+
+            @dsl.pipeline
+            def roll_die_pipeline():
+                flip_coin_task = roll_three_sided_die()
+                with dsl.If(flip_coin_task.output == 'heads'):
+                    t1 = print_and_return(text='Got heads!')
+                with dsl.Elif(flip_coin_task.output == 'tails'):
+                    t2 = print_and_return(text='Got tails!')
+                print_and_return(text=dsl.OneOf(t1.output, t2.output))
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/dsl/pipeline_context.py
+++ b/sdk/python/kfp/dsl/pipeline_context.py
@@ -182,6 +182,7 @@ class Pipeline:
             group: A TasksGroup. Typically it is one of ExitHandler, Condition,
                 and ParallelFor.
         """
+        group.parent_task_group = self.get_parent_group()
         self.groups[-1].groups.append(group)
         self.groups.append(group)
 
@@ -194,6 +195,9 @@ class Pipeline:
         of the pipeline definition."""
         groups = self.groups[-1].groups
         return groups[-1] if groups else None
+
+    def get_parent_group(self) -> 'tasks_group.TasksGroup':
+        return self.groups[-1]
 
     def remove_task_from_groups(self, task: pipeline_task.PipelineTask):
         """Removes a task from the pipeline.

--- a/sdk/python/kfp/dsl/tasks_group.py
+++ b/sdk/python/kfp/dsl/tasks_group.py
@@ -153,7 +153,7 @@ class ConditionBranches(TasksGroup):
             is_root=False,
         )
 
-    def _get_oneof_id(self) -> int:
+    def get_oneof_id(self) -> int:
         """Incrementor for uniquely identifying a OneOf for the parent
         ConditionBranches group.
 

--- a/sdk/python/kfp/dsl/tasks_group.py
+++ b/sdk/python/kfp/dsl/tasks_group.py
@@ -68,6 +68,8 @@ class TasksGroup:
         self.display_name = name
         self.dependencies = []
         self.is_root = is_root
+        # backref to parent, set when the pipeline is called in pipeline_context
+        self.parent_task_group: Optional[TasksGroup] = None
 
     def __enter__(self):
         if not pipeline_context.Pipeline.get_default_pipeline():
@@ -142,6 +144,7 @@ class ExitHandler(TasksGroup):
 
 
 class ConditionBranches(TasksGroup):
+    _oneof_id = 0
 
     def __init__(self) -> None:
         super().__init__(
@@ -149,6 +152,16 @@ class ConditionBranches(TasksGroup):
             name=None,
             is_root=False,
         )
+
+    def _get_oneof_id(self) -> int:
+        """Incrementor for uniquely identifying a OneOf for the parent
+        ConditionBranches group.
+
+        This is analogous to incrementing a unique identifier for tasks
+        groups belonging to a pipeline.
+        """
+        self._oneof_id += 1
+        return self._oneof_id
 
 
 class _ConditionBase(TasksGroup):

--- a/sdk/python/test_data/pipelines/if_elif_else_complex.py
+++ b/sdk/python/test_data/pipelines/if_elif_else_complex.py
@@ -59,18 +59,24 @@ def lucky_number_pipeline(add_drumroll: bool = True,
             even_or_odd_task = is_even_or_odd(num=int_task.output)
 
             with dsl.If(even_or_odd_task.output == 'even'):
-                print_and_return(text='Got a low even number!')
+                t1 = print_and_return(text='Got a low even number!')
             with dsl.Else():
-                print_and_return(text='Got a low odd number!')
+                t2 = print_and_return(text='Got a low odd number!')
+
+            repeater_task = print_and_return(
+                text=dsl.OneOf(t1.output, t2.output))
 
         with dsl.Elif(int_task.output > 5000):
 
             even_or_odd_task = is_even_or_odd(num=int_task.output)
 
             with dsl.If(even_or_odd_task.output == 'even'):
-                print_and_return(text='Got a high even number!')
+                t3 = print_and_return(text='Got a high even number!')
             with dsl.Else():
-                print_and_return(text='Got a high odd number!')
+                t4 = print_and_return(text='Got a high odd number!')
+
+            repeater_task = print_and_return(
+                text=dsl.OneOf(t3.output, t4.output))
 
         with dsl.Else():
             print_and_return(

--- a/sdk/python/test_data/pipelines/if_elif_else_complex.yaml
+++ b/sdk/python/test_data/pipelines/if_elif_else_complex.yaml
@@ -7,27 +7,12 @@
 components:
   comp-condition-11:
     dag:
-      tasks:
-        print-and-return-4:
-          cachingOptions:
-            enableCache: true
-          componentRef:
-            name: comp-print-and-return-4
-          inputs:
-            parameters:
-              text:
-                runtimeValue:
-                  constant: Got a high even number!
-          taskInfo:
-            name: print-and-return-4
-    inputDefinitions:
-      parameters:
-        pipelinechannel--int-0-to-9999-Output:
-          parameterType: NUMBER_INTEGER
-        pipelinechannel--is-even-or-odd-2-Output:
-          parameterType: STRING
-  comp-condition-12:
-    dag:
+      outputs:
+        parameters:
+          pipelinechannel--print-and-return-5-Output:
+            valueFromParameter:
+              outputParameterKey: Output
+              producerSubtask: print-and-return-5
       tasks:
         print-and-return-5:
           cachingOptions:
@@ -38,7 +23,7 @@ components:
             parameters:
               text:
                 runtimeValue:
-                  constant: Got a high odd number!
+                  constant: Got a high even number!
           taskInfo:
             name: print-and-return-5
     inputDefinitions:
@@ -46,6 +31,41 @@ components:
         pipelinechannel--int-0-to-9999-Output:
           parameterType: NUMBER_INTEGER
         pipelinechannel--is-even-or-odd-2-Output:
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        pipelinechannel--print-and-return-5-Output:
+          parameterType: STRING
+  comp-condition-12:
+    dag:
+      outputs:
+        parameters:
+          pipelinechannel--print-and-return-6-Output:
+            valueFromParameter:
+              outputParameterKey: Output
+              producerSubtask: print-and-return-6
+      tasks:
+        print-and-return-6:
+          cachingOptions:
+            enableCache: true
+          componentRef:
+            name: comp-print-and-return-6
+          inputs:
+            parameters:
+              text:
+                runtimeValue:
+                  constant: Got a high odd number!
+          taskInfo:
+            name: print-and-return-6
+    inputDefinitions:
+      parameters:
+        pipelinechannel--int-0-to-9999-Output:
+          parameterType: NUMBER_INTEGER
+        pipelinechannel--is-even-or-odd-2-Output:
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        pipelinechannel--print-and-return-6-Output:
           parameterType: STRING
   comp-condition-13:
     dag:
@@ -64,11 +84,11 @@ components:
           triggerPolicy:
             condition: inputs.parameter_values['pipelinechannel--repeat_if_lucky_number']
               == true
-        print-and-return-6:
+        print-and-return-8:
           cachingOptions:
             enableCache: true
           componentRef:
-            name: comp-print-and-return-6
+            name: comp-print-and-return-8
           inputs:
             parameters:
               text:
@@ -76,7 +96,7 @@ components:
                   constant: 'Announcing: Got the lucky number 5000! A one in 10,000
                     chance.'
           taskInfo:
-            name: print-and-return-6
+            name: print-and-return-8
     inputDefinitions:
       parameters:
         pipelinechannel--int-0-to-9999-Output:
@@ -153,6 +173,12 @@ components:
           parameterType: NUMBER_INTEGER
   comp-condition-6:
     dag:
+      outputs:
+        parameters:
+          pipelinechannel--print-and-return-2-Output:
+            valueFromParameter:
+              outputParameterKey: Output
+              producerSubtask: print-and-return-2
       tasks:
         print-and-return-2:
           cachingOptions:
@@ -172,8 +198,18 @@ components:
           parameterType: NUMBER_INTEGER
         pipelinechannel--is-even-or-odd-Output:
           parameterType: STRING
+    outputDefinitions:
+      parameters:
+        pipelinechannel--print-and-return-2-Output:
+          parameterType: STRING
   comp-condition-7:
     dag:
+      outputs:
+        parameters:
+          pipelinechannel--print-and-return-3-Output:
+            valueFromParameter:
+              outputParameterKey: Output
+              producerSubtask: print-and-return-3
       tasks:
         print-and-return-3:
           cachingOptions:
@@ -192,6 +228,10 @@ components:
         pipelinechannel--int-0-to-9999-Output:
           parameterType: NUMBER_INTEGER
         pipelinechannel--is-even-or-odd-Output:
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        pipelinechannel--print-and-return-3-Output:
           parameterType: STRING
   comp-condition-8:
     dag:
@@ -222,6 +262,21 @@ components:
                 componentInputParameter: pipelinechannel--int-0-to-9999-Output
           taskInfo:
             name: is-even-or-odd
+        print-and-return-4:
+          cachingOptions:
+            enableCache: true
+          componentRef:
+            name: comp-print-and-return-4
+          dependentTasks:
+          - condition-branches-5
+          inputs:
+            parameters:
+              text:
+                taskOutputParameter:
+                  outputParameterKey: pipelinechannel--condition-branches-5-oneof-1
+                  producerTask: condition-branches-5
+          taskInfo:
+            name: print-and-return-4
     inputDefinitions:
       parameters:
         pipelinechannel--int-0-to-9999-Output:
@@ -255,12 +310,36 @@ components:
                 componentInputParameter: pipelinechannel--int-0-to-9999-Output
           taskInfo:
             name: is-even-or-odd-2
+        print-and-return-7:
+          cachingOptions:
+            enableCache: true
+          componentRef:
+            name: comp-print-and-return-7
+          dependentTasks:
+          - condition-branches-10
+          inputs:
+            parameters:
+              text:
+                taskOutputParameter:
+                  outputParameterKey: pipelinechannel--condition-branches-10-oneof-1
+                  producerTask: condition-branches-10
+          taskInfo:
+            name: print-and-return-7
     inputDefinitions:
       parameters:
         pipelinechannel--int-0-to-9999-Output:
           parameterType: NUMBER_INTEGER
   comp-condition-branches-10:
     dag:
+      outputs:
+        parameters:
+          pipelinechannel--condition-branches-10-oneof-1:
+            valueFromOneof:
+              parameterSelectors:
+              - outputParameterKey: pipelinechannel--print-and-return-5-Output
+                producerSubtask: condition-11
+              - outputParameterKey: pipelinechannel--print-and-return-6-Output
+                producerSubtask: condition-12
       tasks:
         condition-11:
           componentRef:
@@ -295,6 +374,10 @@ components:
         pipelinechannel--int-0-to-9999-Output:
           parameterType: NUMBER_INTEGER
         pipelinechannel--is-even-or-odd-2-Output:
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        pipelinechannel--condition-branches-10-oneof-1:
           parameterType: STRING
   comp-condition-branches-4:
     dag:
@@ -347,6 +430,15 @@ components:
           parameterType: BOOLEAN
   comp-condition-branches-5:
     dag:
+      outputs:
+        parameters:
+          pipelinechannel--condition-branches-5-oneof-1:
+            valueFromOneof:
+              parameterSelectors:
+              - outputParameterKey: pipelinechannel--print-and-return-2-Output
+                producerSubtask: condition-6
+              - outputParameterKey: pipelinechannel--print-and-return-3-Output
+                producerSubtask: condition-7
       tasks:
         condition-6:
           componentRef:
@@ -381,6 +473,10 @@ components:
         pipelinechannel--int-0-to-9999-Output:
           parameterType: NUMBER_INTEGER
         pipelinechannel--is-even-or-odd-Output:
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        pipelinechannel--condition-branches-5-oneof-1:
           parameterType: STRING
   comp-for-loop-1:
     dag:
@@ -443,11 +539,11 @@ components:
   comp-for-loop-16:
     dag:
       tasks:
-        print-and-return-7:
+        print-and-return-9:
           cachingOptions:
             enableCache: true
           componentRef:
-            name: comp-print-and-return-7
+            name: comp-print-and-return-9
           inputs:
             parameters:
               text:
@@ -455,7 +551,7 @@ components:
                   constant: 'Announcing again: Got the lucky number 5000! A one in
                     10,000 chance.'
           taskInfo:
-            name: print-and-return-7
+            name: print-and-return-9
     inputDefinitions:
       parameters:
         pipelinechannel--int-0-to-9999-Output:
@@ -552,6 +648,26 @@ components:
           parameterType: STRING
   comp-print-and-return-7:
     executorLabel: exec-print-and-return-7
+    inputDefinitions:
+      parameters:
+        text:
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        Output:
+          parameterType: STRING
+  comp-print-and-return-8:
+    executorLabel: exec-print-and-return-8
+    inputDefinitions:
+      parameters:
+        text:
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        Output:
+          parameterType: STRING
+  comp-print-and-return-9:
+    executorLabel: exec-print-and-return-9
     inputDefinitions:
       parameters:
         text:
@@ -830,6 +946,64 @@ deploymentSpec:
           \ text\n\n"
         image: python:3.7
     exec-print-and-return-7:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - print_and_return
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef print_and_return(text: str) -> str:\n    print(text)\n    return\
+          \ text\n\n"
+        image: python:3.7
+    exec-print-and-return-8:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - print_and_return
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef print_and_return(text: str) -> str:\n    print(text)\n    return\
+          \ text\n\n"
+        image: python:3.7
+    exec-print-and-return-9:
       container:
         args:
         - --executor_input

--- a/sdk/python/test_data/pipelines/if_elif_else_with_oneof_parameters.py
+++ b/sdk/python/test_data/pipelines/if_elif_else_with_oneof_parameters.py
@@ -1,0 +1,65 @@
+# Copyright 2023 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from kfp import compiler
+from kfp import dsl
+
+
+@dsl.component
+def flip_three_sided_die() -> str:
+    import random
+    val = random.randint(0, 2)
+
+    if val == 0:
+        return 'heads'
+    elif val == 1:
+        return 'tails'
+    else:
+        return 'draw'
+
+
+@dsl.component
+def print_and_return(text: str) -> str:
+    print(text)
+    return text
+
+
+@dsl.component
+def special_print_and_return(text: str, output_key: dsl.OutputPath(str)):
+    print('Got the special state:', text)
+    with open(output_key, 'w') as f:
+        f.write(text)
+
+
+@dsl.pipeline
+def roll_die_pipeline() -> str:
+    flip_coin_task = flip_three_sided_die()
+    with dsl.If(flip_coin_task.output == 'heads'):
+        t1 = print_and_return(text='Got heads!')
+    with dsl.Elif(flip_coin_task.output == 'tails'):
+        t2 = print_and_return(text='Got tails!')
+    with dsl.Else():
+        t3 = special_print_and_return(text='Draw!')
+    return dsl.OneOf(t1.output, t2.output, t3.outputs['output_key'])
+
+
+@dsl.pipeline
+def outer_pipeline() -> str:
+    flip_coin_task = roll_die_pipeline()
+    return print_and_return(text=flip_coin_task.output).output
+
+
+if __name__ == '__main__':
+    compiler.Compiler().compile(
+        pipeline_func=outer_pipeline,
+        package_path=__file__.replace('.py', '.yaml'))

--- a/sdk/python/test_data/pipelines/if_elif_else_with_oneof_parameters.yaml
+++ b/sdk/python/test_data/pipelines/if_elif_else_with_oneof_parameters.yaml
@@ -1,8 +1,16 @@
 # PIPELINE DEFINITION
-# Name: roll-die-pipeline
+# Name: outer-pipeline
+# Outputs:
+#    Output: str
 components:
   comp-condition-2:
     dag:
+      outputs:
+        parameters:
+          pipelinechannel--print-and-return-Output:
+            valueFromParameter:
+              outputParameterKey: Output
+              producerSubtask: print-and-return
       tasks:
         print-and-return:
           cachingOptions:
@@ -20,8 +28,18 @@ components:
       parameters:
         pipelinechannel--flip-three-sided-die-Output:
           parameterType: STRING
+    outputDefinitions:
+      parameters:
+        pipelinechannel--print-and-return-Output:
+          parameterType: STRING
   comp-condition-3:
     dag:
+      outputs:
+        parameters:
+          pipelinechannel--print-and-return-2-Output:
+            valueFromParameter:
+              outputParameterKey: Output
+              producerSubtask: print-and-return-2
       tasks:
         print-and-return-2:
           cachingOptions:
@@ -39,27 +57,52 @@ components:
       parameters:
         pipelinechannel--flip-three-sided-die-Output:
           parameterType: STRING
+    outputDefinitions:
+      parameters:
+        pipelinechannel--print-and-return-2-Output:
+          parameterType: STRING
   comp-condition-4:
     dag:
+      outputs:
+        parameters:
+          pipelinechannel--special-print-and-return-output_key:
+            valueFromParameter:
+              outputParameterKey: output_key
+              producerSubtask: special-print-and-return
       tasks:
-        print-and-return-3:
+        special-print-and-return:
           cachingOptions:
             enableCache: true
           componentRef:
-            name: comp-print-and-return-3
+            name: comp-special-print-and-return
           inputs:
             parameters:
               text:
                 runtimeValue:
                   constant: Draw!
           taskInfo:
-            name: print-and-return-3
+            name: special-print-and-return
     inputDefinitions:
       parameters:
         pipelinechannel--flip-three-sided-die-Output:
           parameterType: STRING
+    outputDefinitions:
+      parameters:
+        pipelinechannel--special-print-and-return-output_key:
+          parameterType: STRING
   comp-condition-branches-1:
     dag:
+      outputs:
+        parameters:
+          pipelinechannel--condition-branches-1-oneof-1:
+            valueFromOneof:
+              parameterSelectors:
+              - outputParameterKey: pipelinechannel--print-and-return-Output
+                producerSubtask: condition-2
+              - outputParameterKey: pipelinechannel--print-and-return-2-Output
+                producerSubtask: condition-3
+              - outputParameterKey: pipelinechannel--special-print-and-return-output_key
+                producerSubtask: condition-4
       tasks:
         condition-2:
           componentRef:
@@ -103,6 +146,10 @@ components:
       parameters:
         pipelinechannel--flip-three-sided-die-Output:
           parameterType: STRING
+    outputDefinitions:
+      parameters:
+        pipelinechannel--condition-branches-1-oneof-1:
+          parameterType: STRING
   comp-flip-three-sided-die:
     executorLabel: exec-flip-three-sided-die
     outputDefinitions:
@@ -138,6 +185,49 @@ components:
     outputDefinitions:
       parameters:
         Output:
+          parameterType: STRING
+  comp-roll-die-pipeline:
+    dag:
+      outputs:
+        parameters:
+          Output:
+            valueFromParameter:
+              outputParameterKey: pipelinechannel--condition-branches-1-oneof-1
+              producerSubtask: condition-branches-1
+      tasks:
+        condition-branches-1:
+          componentRef:
+            name: comp-condition-branches-1
+          dependentTasks:
+          - flip-three-sided-die
+          inputs:
+            parameters:
+              pipelinechannel--flip-three-sided-die-Output:
+                taskOutputParameter:
+                  outputParameterKey: Output
+                  producerTask: flip-three-sided-die
+          taskInfo:
+            name: condition-branches-1
+        flip-three-sided-die:
+          cachingOptions:
+            enableCache: true
+          componentRef:
+            name: comp-flip-three-sided-die
+          taskInfo:
+            name: flip-three-sided-die
+    outputDefinitions:
+      parameters:
+        Output:
+          parameterType: STRING
+  comp-special-print-and-return:
+    executorLabel: exec-special-print-and-return
+    inputDefinitions:
+      parameters:
+        text:
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        output_key:
           parameterType: STRING
 deploymentSpec:
   executors:
@@ -259,30 +349,72 @@ deploymentSpec:
           \ *\n\ndef print_and_return(text: str) -> str:\n    print(text)\n    return\
           \ text\n\n"
         image: python:3.7
+    exec-special-print-and-return:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - special_print_and_return
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef special_print_and_return(text: str, output_key: dsl.OutputPath(str)):\n\
+          \    print('Got the special state:', text)\n    with open(output_key, 'w')\
+          \ as f:\n        f.write(text)\n\n"
+        image: python:3.7
 pipelineInfo:
-  name: roll-die-pipeline
+  name: outer-pipeline
 root:
   dag:
+    outputs:
+      parameters:
+        Output:
+          valueFromParameter:
+            outputParameterKey: Output
+            producerSubtask: print-and-return
     tasks:
-      condition-branches-1:
-        componentRef:
-          name: comp-condition-branches-1
-        dependentTasks:
-        - flip-three-sided-die
-        inputs:
-          parameters:
-            pipelinechannel--flip-three-sided-die-Output:
-              taskOutputParameter:
-                outputParameterKey: Output
-                producerTask: flip-three-sided-die
-        taskInfo:
-          name: condition-branches-1
-      flip-three-sided-die:
+      print-and-return:
         cachingOptions:
           enableCache: true
         componentRef:
-          name: comp-flip-three-sided-die
+          name: comp-print-and-return-3
+        dependentTasks:
+        - roll-die-pipeline
+        inputs:
+          parameters:
+            text:
+              taskOutputParameter:
+                outputParameterKey: Output
+                producerTask: roll-die-pipeline
         taskInfo:
-          name: flip-three-sided-die
+          name: print-and-return
+      roll-die-pipeline:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-roll-die-pipeline
+        taskInfo:
+          name: roll-die-pipeline
+  outputDefinitions:
+    parameters:
+      Output:
+        parameterType: STRING
 schemaVersion: 2.1.0
 sdkVersion: kfp-2.3.0

--- a/sdk/python/test_data/pipelines/if_else_with_oneof_artifacts.yaml
+++ b/sdk/python/test_data/pipelines/if_else_with_oneof_artifacts.yaml
@@ -1,0 +1,380 @@
+# PIPELINE DEFINITION
+# Name: outer-pipeline
+components:
+  comp-condition-2:
+    dag:
+      outputs:
+        artifacts:
+          pipelinechannel--param-to-artifact-a:
+            artifactSelectors:
+            - outputArtifactKey: a
+              producerSubtask: param-to-artifact
+      tasks:
+        param-to-artifact:
+          cachingOptions:
+            enableCache: true
+          componentRef:
+            name: comp-param-to-artifact
+          inputs:
+            parameters:
+              val:
+                componentInputParameter: pipelinechannel--flip-coin-Output
+          taskInfo:
+            name: param-to-artifact
+    inputDefinitions:
+      parameters:
+        pipelinechannel--flip-coin-Output:
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        pipelinechannel--param-to-artifact-a:
+          artifactType:
+            schemaTitle: system.Artifact
+            schemaVersion: 0.0.1
+  comp-condition-3:
+    dag:
+      outputs:
+        artifacts:
+          pipelinechannel--param-to-artifact-2-a:
+            artifactSelectors:
+            - outputArtifactKey: a
+              producerSubtask: param-to-artifact-2
+      tasks:
+        param-to-artifact-2:
+          cachingOptions:
+            enableCache: true
+          componentRef:
+            name: comp-param-to-artifact-2
+          inputs:
+            parameters:
+              val:
+                componentInputParameter: pipelinechannel--flip-coin-Output
+          taskInfo:
+            name: param-to-artifact-2
+    inputDefinitions:
+      parameters:
+        pipelinechannel--flip-coin-Output:
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        pipelinechannel--param-to-artifact-2-a:
+          artifactType:
+            schemaTitle: system.Artifact
+            schemaVersion: 0.0.1
+  comp-condition-branches-1:
+    dag:
+      outputs:
+        artifacts:
+          pipelinechannel--condition-branches-1-oneof-1:
+            artifactSelectors:
+            - outputArtifactKey: pipelinechannel--param-to-artifact-a
+              producerSubtask: condition-2
+            - outputArtifactKey: pipelinechannel--param-to-artifact-2-a
+              producerSubtask: condition-3
+      tasks:
+        condition-2:
+          componentRef:
+            name: comp-condition-2
+          inputs:
+            parameters:
+              pipelinechannel--flip-coin-Output:
+                componentInputParameter: pipelinechannel--flip-coin-Output
+          taskInfo:
+            name: condition-2
+          triggerPolicy:
+            condition: inputs.parameter_values['pipelinechannel--flip-coin-Output']
+              == 'heads'
+        condition-3:
+          componentRef:
+            name: comp-condition-3
+          inputs:
+            parameters:
+              pipelinechannel--flip-coin-Output:
+                componentInputParameter: pipelinechannel--flip-coin-Output
+          taskInfo:
+            name: condition-3
+          triggerPolicy:
+            condition: '!(inputs.parameter_values[''pipelinechannel--flip-coin-Output'']
+              == ''heads'')'
+    inputDefinitions:
+      parameters:
+        pipelinechannel--flip-coin-Output:
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        pipelinechannel--condition-branches-1-oneof-1:
+          artifactType:
+            schemaTitle: system.Artifact
+            schemaVersion: 0.0.1
+  comp-flip-coin:
+    executorLabel: exec-flip-coin
+    outputDefinitions:
+      parameters:
+        Output:
+          parameterType: STRING
+  comp-flip-coin-pipeline:
+    dag:
+      outputs:
+        artifacts:
+          Output:
+            artifactSelectors:
+            - outputArtifactKey: pipelinechannel--condition-branches-1-oneof-1
+              producerSubtask: condition-branches-1
+      tasks:
+        condition-branches-1:
+          componentRef:
+            name: comp-condition-branches-1
+          dependentTasks:
+          - flip-coin
+          inputs:
+            parameters:
+              pipelinechannel--flip-coin-Output:
+                taskOutputParameter:
+                  outputParameterKey: Output
+                  producerTask: flip-coin
+          taskInfo:
+            name: condition-branches-1
+        flip-coin:
+          cachingOptions:
+            enableCache: true
+          componentRef:
+            name: comp-flip-coin
+          taskInfo:
+            name: flip-coin
+        print-artifact:
+          cachingOptions:
+            enableCache: true
+          componentRef:
+            name: comp-print-artifact
+          dependentTasks:
+          - condition-branches-1
+          inputs:
+            artifacts:
+              a:
+                taskOutputArtifact:
+                  outputArtifactKey: pipelinechannel--condition-branches-1-oneof-1
+                  producerTask: condition-branches-1
+          taskInfo:
+            name: print-artifact
+    outputDefinitions:
+      artifacts:
+        Output:
+          artifactType:
+            schemaTitle: system.Artifact
+            schemaVersion: 0.0.1
+  comp-param-to-artifact:
+    executorLabel: exec-param-to-artifact
+    inputDefinitions:
+      parameters:
+        val:
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        a:
+          artifactType:
+            schemaTitle: system.Artifact
+            schemaVersion: 0.0.1
+  comp-param-to-artifact-2:
+    executorLabel: exec-param-to-artifact-2
+    inputDefinitions:
+      parameters:
+        val:
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        a:
+          artifactType:
+            schemaTitle: system.Artifact
+            schemaVersion: 0.0.1
+  comp-print-artifact:
+    executorLabel: exec-print-artifact
+    inputDefinitions:
+      artifacts:
+        a:
+          artifactType:
+            schemaTitle: system.Artifact
+            schemaVersion: 0.0.1
+  comp-print-artifact-2:
+    executorLabel: exec-print-artifact-2
+    inputDefinitions:
+      artifacts:
+        a:
+          artifactType:
+            schemaTitle: system.Artifact
+            schemaVersion: 0.0.1
+deploymentSpec:
+  executors:
+    exec-flip-coin:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - flip_coin
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef flip_coin() -> str:\n    import random\n    return 'heads' if\
+          \ random.randint(0, 1) == 0 else 'tails'\n\n"
+        image: python:3.7
+    exec-param-to-artifact:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - param_to_artifact
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef param_to_artifact(val: str, a: Output[Artifact]):\n    with open(a.path,\
+          \ 'w') as f:\n        f.write(val)\n\n"
+        image: python:3.7
+    exec-param-to-artifact-2:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - param_to_artifact
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef param_to_artifact(val: str, a: Output[Artifact]):\n    with open(a.path,\
+          \ 'w') as f:\n        f.write(val)\n\n"
+        image: python:3.7
+    exec-print-artifact:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - print_artifact
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef print_artifact(a: Input[Artifact]):\n    with open(a.path) as\
+          \ f:\n        print(f.read())\n\n"
+        image: python:3.7
+    exec-print-artifact-2:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - print_artifact
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef print_artifact(a: Input[Artifact]):\n    with open(a.path) as\
+          \ f:\n        print(f.read())\n\n"
+        image: python:3.7
+pipelineInfo:
+  name: outer-pipeline
+root:
+  dag:
+    tasks:
+      flip-coin-pipeline:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-flip-coin-pipeline
+        taskInfo:
+          name: flip-coin-pipeline
+      print-artifact:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-print-artifact-2
+        dependentTasks:
+        - flip-coin-pipeline
+        inputs:
+          artifacts:
+            a:
+              taskOutputArtifact:
+                outputArtifactKey: Output
+                producerTask: flip-coin-pipeline
+        taskInfo:
+          name: print-artifact
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.3.0

--- a/sdk/python/test_data/pipelines/if_else_with_oneof_parameters.py
+++ b/sdk/python/test_data/pipelines/if_else_with_oneof_parameters.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from kfp import compiler
 from kfp import dsl
 
 
@@ -28,15 +27,19 @@ def print_and_return(text: str) -> str:
 
 
 @dsl.pipeline
-def flip_coin_pipeline():
+def flip_coin_pipeline() -> str:
     flip_coin_task = flip_coin()
     with dsl.If(flip_coin_task.output == 'heads'):
-        print_and_return(text='Got heads!')
+        print_task_1 = print_and_return(text='Got heads!')
     with dsl.Else():
-        print_and_return(text='Got tails!')
+        print_task_2 = print_and_return(text='Got tails!')
+    x = dsl.OneOf(print_task_1.output, print_task_2.output)
+    print_and_return(text=x)
+    return x
 
 
 if __name__ == '__main__':
+    from kfp import compiler
     compiler.Compiler().compile(
         pipeline_func=flip_coin_pipeline,
         package_path=__file__.replace('.py', '.yaml'))

--- a/sdk/python/test_data/pipelines/if_else_with_oneof_parameters.yaml
+++ b/sdk/python/test_data/pipelines/if_else_with_oneof_parameters.yaml
@@ -1,8 +1,16 @@
 # PIPELINE DEFINITION
 # Name: flip-coin-pipeline
+# Outputs:
+#    Output: str
 components:
   comp-condition-2:
     dag:
+      outputs:
+        parameters:
+          pipelinechannel--print-and-return-Output:
+            valueFromParameter:
+              outputParameterKey: Output
+              producerSubtask: print-and-return
       tasks:
         print-and-return:
           cachingOptions:
@@ -20,8 +28,18 @@ components:
       parameters:
         pipelinechannel--flip-coin-Output:
           parameterType: STRING
+    outputDefinitions:
+      parameters:
+        pipelinechannel--print-and-return-Output:
+          parameterType: STRING
   comp-condition-3:
     dag:
+      outputs:
+        parameters:
+          pipelinechannel--print-and-return-2-Output:
+            valueFromParameter:
+              outputParameterKey: Output
+              producerSubtask: print-and-return-2
       tasks:
         print-and-return-2:
           cachingOptions:
@@ -39,8 +57,21 @@ components:
       parameters:
         pipelinechannel--flip-coin-Output:
           parameterType: STRING
+    outputDefinitions:
+      parameters:
+        pipelinechannel--print-and-return-2-Output:
+          parameterType: STRING
   comp-condition-branches-1:
     dag:
+      outputs:
+        parameters:
+          pipelinechannel--condition-branches-1-oneof-1:
+            valueFromOneof:
+              parameterSelectors:
+              - outputParameterKey: pipelinechannel--print-and-return-Output
+                producerSubtask: condition-2
+              - outputParameterKey: pipelinechannel--print-and-return-2-Output
+                producerSubtask: condition-3
       tasks:
         condition-2:
           componentRef:
@@ -70,6 +101,10 @@ components:
       parameters:
         pipelinechannel--flip-coin-Output:
           parameterType: STRING
+    outputDefinitions:
+      parameters:
+        pipelinechannel--condition-branches-1-oneof-1:
+          parameterType: STRING
   comp-flip-coin:
     executorLabel: exec-flip-coin
     outputDefinitions:
@@ -88,6 +123,16 @@ components:
           parameterType: STRING
   comp-print-and-return-2:
     executorLabel: exec-print-and-return-2
+    inputDefinitions:
+      parameters:
+        text:
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        Output:
+          parameterType: STRING
+  comp-print-and-return-3:
+    executorLabel: exec-print-and-return-3
     inputDefinitions:
       parameters:
         text:
@@ -185,10 +230,45 @@ deploymentSpec:
           \ *\n\ndef print_and_return(text: str) -> str:\n    print(text)\n    return\
           \ text\n\n"
         image: python:3.7
+    exec-print-and-return-3:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - print_and_return
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.3.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef print_and_return(text: str) -> str:\n    print(text)\n    return\
+          \ text\n\n"
+        image: python:3.7
 pipelineInfo:
   name: flip-coin-pipeline
 root:
   dag:
+    outputs:
+      parameters:
+        Output:
+          valueFromParameter:
+            outputParameterKey: pipelinechannel--condition-branches-1-oneof-1
+            producerSubtask: condition-branches-1
     tasks:
       condition-branches-1:
         componentRef:
@@ -210,5 +290,24 @@ root:
           name: comp-flip-coin
         taskInfo:
           name: flip-coin
+      print-and-return-3:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-print-and-return-3
+        dependentTasks:
+        - condition-branches-1
+        inputs:
+          parameters:
+            text:
+              taskOutputParameter:
+                outputParameterKey: pipelinechannel--condition-branches-1-oneof-1
+                producerTask: condition-branches-1
+        taskInfo:
+          name: print-and-return-3
+  outputDefinitions:
+    parameters:
+      Output:
+        parameterType: STRING
 schemaVersion: 2.1.0
 sdkVersion: kfp-2.3.0

--- a/sdk/python/test_data/test_data_config.yaml
+++ b/sdk/python/test_data/test_data_config.yaml
@@ -168,14 +168,17 @@ pipelines:
     - module: pipeline_with_metadata_fields
       name: dataset_concatenator
       execute: false
-    - module: if_else
-      name: flip_coin_pipeline
-      execute: false
-    - module: if_elif_else
-      name: roll_die_pipeline
+    - module: if_else_with_oneof_artifacts
+      name: outer_pipeline
       execute: false
     - module: if_elif_else_complex
       name: lucky_number_pipeline
+      execute: false
+    - module: if_else_with_oneof_parameters
+      name: flip_coin_pipeline
+      execute: false
+    - module: if_elif_else_with_oneof_parameters
+      name: outer_pipeline
       execute: false
 components:
   test_data_dir: sdk/python/test_data/components


### PR DESCRIPTION
**Description of your changes:**
Supports collecting outputs from conditional branches in a pipeline using `dsl.OneOf`. For example:

```python
from kfp import dsl

@dsl.component
def flip_coin() -> str:
    import random
    return 'heads' if random.randint(0, 1) == 0 else 'tails'

@dsl.component
def print_and_return(text: str) -> str:
    print(text)
    return text

@dsl.pipeline
def flip_coin_pipeline() -> str:
    flip_coin_task = flip_coin()
    with dsl.If(flip_coin_task.output == 'heads'):
        print_task_1 = print_and_return(text='Got heads!')
    with dsl.Else():
        print_task_2 = print_and_return(text='Got tails!')

    # use the output from the branch that gets executed
    oneof = dsl.OneOf(print_task_1.output, print_task_2.output)

    # consume it
    print_and_return(text=oneof)

    # return it
    return oneof
```

There are three future work items to consider following this PR:
1. Migrate the `dsl.Collected` implementation to the `dsl.OneOf`-style implementation. The abstraction for the `dsl.OneOf` is much cleaner and permits more implementation alignment and code reuse between `dsl.OneOf` and `dsl.Collected`. I left TODOs for this, opting not to implement in this CL to simplify the already large diff.
2. After 1, we can _consider_ (but may choose not to) support composing `dsl.Collected` into `dsl.OneOf`. This composability increases the complexity of the compiler code + authorable pipelines considerably (high implementation + maintenance cost). We should weigh this against the suspected benefit. Leaving this note here to document the choice and the likely dependency on 1.
3. We can _consider_ supporting `dsl.OneOf` and `dsl.Collected` in f-strings. `dsl.Collected` support in f-strings follows naturally from 1 above. `dsl.OneOf` support in f-strings requires a new way of injecting a channel into a user string in the compiler code such that all the member channels of a `dsl.OneOf` are not lost. The approach which I suspect will be most successful (included in a code comment) is to maintain a pipeline-level map of unique key to pipeline channel, then injecting/extracting that key from the user string, then looking up in the map. Similar level of effort consideration to 2 above.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this 
repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
