### PR TITLE
fix(sdk): fix bug when `dsl.importer` argument is provided by loop variable

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -9,6 +9,7 @@
 
 ## Bug fixes and other changes
 * Fix type on `dsl.ParallelFor` sub-DAG output when a `dsl.Collected` is used. Non-functional fix. [\#10069](https://github.com/kubeflow/pipelines/pull/10069)
+* Fix bug when `dsl.importer` argument is provided by a `dsl.ParallelFor` loop variable. [\#10116](https://github.com/kubeflow/pipelines/pull/10116)
 
 ## Documentation updates
 

--- a/sdk/python/kfp/dsl/for_loop.py
+++ b/sdk/python/kfp/dsl/for_loop.py
@@ -77,7 +77,7 @@ class LoopArgument(pipeline_channel.PipelineParameterChannel):
 
 
     Attributes:
-        items_or_pipeline_channel: The raw items or the PipelineChannel object
+        items_or_pipeline_channel: The raw items or the PipelineParameterChannel object
             this LoopArgument is associated to.
     """
     LOOP_ITEM_NAME_BASE = 'loop-item'
@@ -85,7 +85,7 @@ class LoopArgument(pipeline_channel.PipelineParameterChannel):
 
     def __init__(
         self,
-        items: Union[ItemList, pipeline_channel.PipelineChannel],
+        items: Union[ItemList, pipeline_channel.PipelineParameterChannel],
         name_code: Optional[str] = None,
         name_override: Optional[str] = None,
         **kwargs,
@@ -99,8 +99,8 @@ class LoopArgument(pipeline_channel.PipelineParameterChannel):
             name_code: A unique code used to identify these loop arguments.
                 Should match the code for the ParallelFor ops_group which created
                 these LoopArguments. This prevents parameter name collisions.
-            name_override: The override name for PipelineChannel.
-            **kwargs: Any other keyword arguments passed down to PipelineChannel.
+            name_override: The override name for PipelineParameterChannel.
+            **kwargs: Any other keyword arguments passed down to PipelineParameterChannel.
         """
         if (name_code is None) == (name_override is None):
             raise ValueError(
@@ -112,17 +112,19 @@ class LoopArgument(pipeline_channel.PipelineParameterChannel):
         else:
             super().__init__(name=name_override, **kwargs)
 
-        if not isinstance(items,
-                          (list, tuple, pipeline_channel.PipelineChannel)):
+        if not isinstance(
+                items,
+            (list, tuple, pipeline_channel.PipelineParameterChannel)):
             raise TypeError(
-                f'Expected list, tuple, or PipelineChannel, got {items}.')
+                f'Expected list, tuple, or PipelineParameterChannel, got {items}.'
+            )
 
         if isinstance(items, tuple):
             items = list(items)
 
         self.items_or_pipeline_channel = items
         self.is_with_items_loop_argument = not isinstance(
-            items, pipeline_channel.PipelineChannel)
+            items, pipeline_channel.PipelineParameterChannel)
         self._referenced_subvars: Dict[str, LoopArgumentVariable] = {}
 
         if isinstance(items, list) and isinstance(items[0], dict):
@@ -154,9 +156,10 @@ class LoopArgument(pipeline_channel.PipelineParameterChannel):
     @classmethod
     def from_pipeline_channel(
         cls,
-        channel: pipeline_channel.PipelineChannel,
+        channel: pipeline_channel.PipelineParameterChannel,
     ) -> 'LoopArgument':
-        """Creates a LoopArgument object from a PipelineChannel object."""
+        """Creates a LoopArgument object from a PipelineParameterChannel
+        object."""
         return LoopArgument(
             items=channel,
             name_override=channel.name + '-' + cls.LOOP_ITEM_NAME_BASE,
@@ -191,7 +194,7 @@ class LoopArgument(pipeline_channel.PipelineParameterChannel):
           or (cls.LOOP_ITEM_PARAM_NAME_BASE + '-') in name
 
 
-class LoopArgumentVariable(pipeline_channel.PipelineChannel):
+class LoopArgumentVariable(pipeline_channel.PipelineParameterChannel):
     """Represents a subvariable for a loop argument.
 
     This is used for cases where we're looping over maps, each of which contains
@@ -246,7 +249,7 @@ class LoopArgumentVariable(pipeline_channel.PipelineChannel):
 
     @property
     def items_or_pipeline_channel(
-            self) -> Union[ItemList, pipeline_channel.PipelineChannel]:
+            self) -> Union[ItemList, pipeline_channel.PipelineParameterChannel]:
         """Returns the loop argument items."""
         return self.loop_argument.items_or_pipeline_chanenl
 


### PR DESCRIPTION
**Description of your changes:**
Fix bug where a `dsl.importer` argument is provided by a loop variable. For example:

```python
@dsl.component
def make_args() -> list:
    return [{'uri': 'gs://foo'}]

@dsl.pipeline
def my_pipeline():
    with dsl.ParallelFor(make_args().output) as data:
        dsl.importer(artifact_uri=data.uri, artifact_class=Dataset)
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
