### PR TITLE
chore(sdk): add Python 3.7 EOL notice

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -6,6 +6,7 @@
 * Support collecting outputs from conditional branches using `dsl.OneOf` [\#10067](https://github.com/kubeflow/pipelines/pull/10067)
 
 ## Deprecations
+* Add notice of Python 3.7 support removal on April 23, 2024 [\#10139](https://github.com/kubeflow/pipelines/pull/10139)
 
 ## Bug fixes and other changes
 * Fix type on `dsl.ParallelFor` sub-DAG output when a `dsl.Collected` is used. Non-functional fix. [\#10069](https://github.com/kubeflow/pipelines/pull/10069)

--- a/sdk/python/kfp/__init__.py
+++ b/sdk/python/kfp/__init__.py
@@ -18,6 +18,17 @@ __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
 __version__ = '2.3.0'
 
+import sys
+import warnings
+
+if sys.version_info < (3, 8):
+    warnings.warn(
+        ('Python 3.7 has reached end-of-life. KFP will drop support for Python 3.7 on April 23, 2024. To use new versions of the KFP SDK after that date, you will need to upgrade to Python >= 3.8. See https://devguide.python.org/versions/ for more details.'
+        ),
+        FutureWarning,
+        stacklevel=2,
+    )
+
 TYPE_CHECK = True
 
 import os

--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -532,6 +532,12 @@ def create_component_from_func(
     args = []
     if base_image is None:
         base_image = _DEFAULT_BASE_IMAGE
+        warnings.warn(
+            ("Python 3.7 has reached end-of-life. The default base_image used by the @dsl.component decorator will switch from 'python:3.7' to 'python:3.8' on April 23, 2024. To ensure your existing components work with versions of the KFP SDK released after that date, you should provide an explicit base_image argument and ensure your component works as intended on Python 3.8."
+            ),
+            FutureWarning,
+            stacklevel=2,
+        )
 
     component_image = base_image
 

--- a/sdk/python/kfp/dsl/component_factory_test.py
+++ b/sdk/python/kfp/dsl/component_factory_test.py
@@ -287,5 +287,19 @@ class TestOutputListsOfArtifactsTemporarilyBlocked(unittest.TestCase):
                 return dsl.ContainerSpec(image='alpine')
 
 
+class TestPythonEOLWarning(unittest.TestCase):
+
+    def test_default_base_image(self):
+
+        with self.assertWarnsRegex(
+                FutureWarning,
+                r"Python 3\.7 has reached end-of-life\. The default base_image used by the @dsl\.component decorator will switch from 'python:3\.7' to 'python:3\.8' on April 23, 2024\. To ensure your existing components work with versions of the KFP SDK released after that date, you should provide an explicit base_image argument and ensure your component works as intended on Python 3\.8\."
+        ):
+
+            @dsl.component
+            def foo():
+                pass
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/init_test.py
+++ b/sdk/python/kfp/init_test.py
@@ -1,0 +1,36 @@
+# Copyright 2023 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import sys
+import unittest
+from unittest import mock
+
+
+@mock.patch.object(sys, 'version_info', new=(3, 7, 12, 'final', 0))
+class TestPythonEOLWarning(unittest.TestCase):
+
+    def test(self):
+        mod = importlib.import_module('kfp')
+
+        with self.assertWarnsRegex(
+                FutureWarning,
+                r'Python 3\.7 has reached end-of-life\. KFP will drop support for Python 3\.7 on April 23, 2024\. To use new versions of the KFP SDK after that date, you will need to upgrade to Python >= 3\.8\. See https:\/\/devguide\.python\.org\/versions\/ for more details\.'
+        ):
+            # simulate first import from kfp
+            importlib.reload(mod)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Description of your changes:**
Adds Python 3.7 EOL warning when:
- The KFP SDK is imported into an environment running Python 3.7  
- The `dsl.component` decorator is called without an explicit `base_image` argument

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this 
repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
