### PR TITLE
fix(sdk): type annotation for client credentials

### DIFF
--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -32,6 +32,7 @@ from google.protobuf import json_format
 from kfp import compiler
 from kfp.client import auth
 from kfp.client import set_volume_credentials
+from kfp.client.token_credentials_base import TokenCredentialsBase
 from kfp.dsl import base_component
 from kfp.pipeline_spec import pipeline_spec_pb2
 import kfp_server_api
@@ -150,7 +151,7 @@ class Client:
         proxy: Optional[str] = None,
         ssl_ca_cert: Optional[str] = None,
         kube_context: Optional[str] = None,
-        credentials: Optional[str] = None,
+        credentials: Optional[TokenCredentialsBase] = None,
         ui_host: Optional[str] = None,
         verify_ssl: Optional[bool] = None,
     ) -> None:
@@ -221,7 +222,7 @@ class Client:
         proxy: Optional[str],
         ssl_ca_cert: Optional[str],
         kube_context: Optional[str],
-        credentials: Optional[str],
+        credentials: Optional[TokenCredentialsBase],
         verify_ssl: Optional[bool],
     ) -> kfp_server_api.Configuration:
         config = kfp_server_api.Configuration()


### PR DESCRIPTION
**Description of your changes:**

The type annotation for the `credentials` argument of the `kfp.Client` constructor is wrong, it should be `TokenCredentialsBase`, not string.

**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
