### PR TITLE
chore(sdk): Remove the ` (<type>)`from docstring args.

### DIFF
--- a/sdk/python/kfp/compiler/read_write_test.py
+++ b/sdk/python/kfp/compiler/read_write_test.py
@@ -175,12 +175,12 @@ class ReadWriteTest(parameterized.TestCase):
         """Tests serialization and deserialization consistency and correctness.
 
         Args:
-            name : '{test_group_name}-{test_case_name}'. Useful for print statements/debugging.
-            test_case : Test case name (without file extension).
-            test_data_dir : The directory containing the test case files.
-            function : The function name to compile.
-            read : Whether the pipeline/component supports deserialization from YAML (IR, except for V1 component YAML back compatability tests).
-            write : Whether the pipeline/component supports compilation from a Python file.
+            name: '{test_group_name}-{test_case_name}'. Useful for print statements/debugging.
+            test_case: Test case name (without file extension).
+            test_data_dir: The directory containing the test case files.
+            function: The function name to compile.
+            read: Whether the pipeline/component supports deserialization from YAML (IR, except for V1 component YAML back compatability tests).
+            write: Whether the pipeline/component supports compilation from a Python file.
         """
         yaml_file = os.path.join(test_data_dir, f'{test_case}.yaml')
         py_file = os.path.join(test_data_dir, f'{test_case}.py')

--- a/sdk/python/kfp/compiler/read_write_test.py
+++ b/sdk/python/kfp/compiler/read_write_test.py
@@ -175,12 +175,12 @@ class ReadWriteTest(parameterized.TestCase):
         """Tests serialization and deserialization consistency and correctness.
 
         Args:
-            name (str): '{test_group_name}-{test_case_name}'. Useful for print statements/debugging.
-            test_case (str): Test case name (without file extension).
-            test_data_dir (str): The directory containing the test case files.
-            function (str, optional): The function name to compile.
-            read (bool): Whether the pipeline/component supports deserialization from YAML (IR, except for V1 component YAML back compatability tests).
-            write (bool): Whether the pipeline/component supports compilation from a Python file.
+            name : '{test_group_name}-{test_case_name}'. Useful for print statements/debugging.
+            test_case : Test case name (without file extension).
+            test_data_dir : The directory containing the test case files.
+            function : The function name to compile.
+            read : Whether the pipeline/component supports deserialization from YAML (IR, except for V1 component YAML back compatability tests).
+            write : Whether the pipeline/component supports compilation from a Python file.
         """
         yaml_file = os.path.join(test_data_dir, f'{test_case}.yaml')
         py_file = os.path.join(test_data_dir, f'{test_case}.py')


### PR DESCRIPTION
**Description of your changes:**
- Remote the ` (<type>)` from the docstring args, which are redundant since there are type annotations.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
