### PR TITLE
docs(sdk): fix readthedocs build error

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,3 +6,7 @@ python:
   version: 3.7
   install:
     - requirements: docs/requirements.txt
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"


### PR DESCRIPTION
**Description of your changes:**
Fixes this issue: https://blog.readthedocs.com/use-build-os-config/


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn 
more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
