### PR TITLE
frontend: Add an option to specify useSSL variable for aws

### DIFF
--- a/frontend/server/configs.ts
+++ b/frontend/server/configs.ts
@@ -62,6 +62,7 @@ export function loadConfigs(argv: string[], env: ProcessEnv): UIConfigs {
     AWS_SECRET_ACCESS_KEY,
     AWS_REGION,
     AWS_S3_ENDPOINT,
+    AWS_SSL = 'true',
     /** http/https base URL */
     HTTP_BASE_URL = '',
     /** By default, allowing access to all domains. Modify this flag to allow querying matching domains */
@@ -137,6 +138,7 @@ export function loadConfigs(argv: string[], env: ProcessEnv): UIConfigs {
         endPoint: AWS_S3_ENDPOINT || 's3.amazonaws.com',
         region: AWS_REGION || 'us-east-1',
         secretKey: AWS_SECRET_ACCESS_KEY || '',
+        useSSL: asBool(AWS_SSL),
       },
       http: {
         auth: {
@@ -218,6 +220,7 @@ export interface AWSConfigs {
   region: string;
   accessKey: string;
   secretKey: string;
+  useSSL: boolean;
 }
 export interface HttpConfigs {
   baseUrl: string;

--- a/frontend/server/integration-tests/artifact-get.test.ts
+++ b/frontend/server/integration-tests/artifact-get.test.ts
@@ -107,6 +107,7 @@ describe('/artifacts', () => {
             endPoint: 's3.amazonaws.com',
             region: 'us-east-1',
             secretKey: 'awsSecret123',
+            useSSL: true,
           });
           done(err);
         });
@@ -129,6 +130,7 @@ describe('/artifacts', () => {
             endPoint: 's3.amazonaws.com',
             region: 'us-east-1',
             secretKey: 'awsSecret123',
+            useSSL: true,
           });
           done(err);
         });
@@ -152,6 +154,7 @@ describe('/artifacts', () => {
             endPoint: 's3.amazonaws.com',
             region: 'eu-central-1',
             secretKey: 'awsSecret123',
+            useSSL: true,
           });
           done(err);
         });


### PR DESCRIPTION
**Description of your changes:**
* Currently with the default object store i.e. minio, we have an option `MINIO_SSL` to specify useSSL variable value while creation of client using minio configs but we don't have a way to specify value of useSSL for aws configs.
* Added an option to specify the `useSSL` variable in AWS configs. This will be used to create client using aws configs.
* This change should not impact any existing users as I kept the default value same.

**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
