### PR TITLE
feat(sdk): ability to use pydantic V2 with sdk/release-1.8

### DIFF
--- a/sdk/python/kfp/v2/components/experimental/structures.py
+++ b/sdk/python/kfp/v2/components/experimental/structures.py
@@ -20,7 +20,13 @@ from typing import Any, Dict, Mapping, Optional, Sequence, Union
 
 from kfp.components import _components
 from kfp.components import structures as v1_structures
-import pydantic
+
+try:
+    import pydantic.v1 as pydantic
+    # from pydantic.v1 import BaseModel, Field, validator, root_validator, ValidationError
+except ImportError:
+    import pydantic
+    # from pydantic import BaseModel, Field, validator, root_validator, ValidationError
 import yaml
 
 

--- a/sdk/python/kfp/v2/components/experimental/structures_test.py
+++ b/sdk/python/kfp/v2/components/experimental/structures_test.py
@@ -17,7 +17,11 @@ import textwrap
 import unittest
 from unittest import mock
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
+
 from absl.testing import parameterized
 from kfp.v2.components.experimental import structures
 

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -36,6 +36,6 @@ absl-py>=0.9,<=0.11
 kfp-pipeline-spec>=0.1.16,<0.2.0
 fire>=0.3.1,<1
 google-api-python-client>=1.7.8,<2
-pydantic>=1.8.2,<2
+pydantic>=1.8.2
 dataclasses>=0.8,<1; python_version<"3.7"
 typing-extensions>=3.7.4,<5; python_version<"3.9"

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -90,7 +90,7 @@ pyasn1==0.4.8
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
-pydantic==1.9.1
+pydantic==2.4.2
     # via -r requirements.in
 pyparsing==3.0.9
     # via httplib2

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -56,7 +56,7 @@ REQUIRES = [
     'uritemplate>=3.0.1,<4',
     # pin to avoid break in requests-toolbelt due to https://github.com/psf/requests/commit/2ad18e0e10e7d7ecd5384c378f25ec8821a10a29
     'urllib3<2',
-    'pydantic>=1.8.2,<2',
+    'pydantic>=1.8.2',
     'typer>=0.3.2,<1.0',
     # Standard library backports
     'dataclasses;python_version<"3.7"',

--- a/test/sample-test/requirements.txt
+++ b/test/sample-test/requirements.txt
@@ -127,7 +127,7 @@ pyarrow==2.0.0            # via apache-beam, tensorflow-data-validation, tensorf
 pyasn1-modules==0.2.8     # via google-auth, oauth2client
 pyasn1==0.4.8             # via oauth2client, pyasn1-modules, rsa
 pycparser==2.20           # via cffi
-pydantic==1.8.2           # via -r -
+pydantic==2.4.2           # via -r -
 pydot==1.4.2              # via apache-beam, tensorflow-transform
 pygments==2.10.0          # via ipython, jupyterlab-pygments, nbconvert
 pymongo==3.12.0           # via apache-beam


### PR DESCRIPTION
**Description of your changes:**
Hello! For this PR I changed the cap on the pydantic import to allow for users using kfp 1.8 to also use `pydantic` version 2. When a user installs pydantic V2 they can [still use the v1 functionality](https://docs.pydantic.dev/latest/migration/#continue-using-pydantic-v1-features) by implementing `import pydantic.v1` insuring that functionality doesn't change. Within this PR I also changed the files `structures.py` and `structures-test.py` to import `pydantic` or `pydantic.v1` depending on their installed version. 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
