### PR TITLE
feat(cli): support ssl cert & cookie auth for outside cluster access.

### DIFF
--- a/sdk/python/kfp/cli/cli.py
+++ b/sdk/python/kfp/cli/cli.py
@@ -86,6 +86,12 @@ def _install_completion(shell: str) -> None:
     '--other-client-secret',
     help=parsing.get_param_descr(client.Client, 'other_client_secret'))
 @click.option(
+    '--cookies',
+    help=parsing.get_param_descr(client.Client, 'cookies'))
+@click.option(
+    '--ssl-ca-cert',
+    help=parsing.get_param_descr(client.Client, 'ssl_ca_cert'))
+@click.option(
     '--output',
     type=click.Choice(list(map(lambda x: x.name, OutputFormat))),
     default=OutputFormat.table.name,
@@ -95,7 +101,7 @@ def _install_completion(shell: str) -> None:
 @click.version_option(version=kfp.__version__, message='%(prog)s %(version)s')
 def cli(ctx: click.Context, endpoint: str, iap_client_id: str, namespace: str,
         other_client_id: str, other_client_secret: str, output: OutputFormat,
-        show_completion: str, install_completion: str):
+        show_completion: str, install_completion: str, ssl_ca_cert: str, cookies: str):
     """Kubeflow Pipelines CLI."""
     if show_completion:
         click.echo(_create_completion(show_completion))
@@ -113,6 +119,7 @@ def cli(ctx: click.Context, endpoint: str, iap_client_id: str, namespace: str,
         # Do not create a client for these subcommands
         return
     ctx.obj['client'] = client.Client(endpoint, iap_client_id, namespace,
-                                      other_client_id, other_client_secret)
+                                      other_client_id, other_client_secret, 
+                                      ssl_ca_cert=ssl_ca_cert, cookies=cookies)
     ctx.obj['namespace'] = namespace
     ctx.obj['output'] = output

--- a/sdk/python/kfp/cli/pipeline.py
+++ b/sdk/python/kfp/cli/pipeline.py
@@ -217,13 +217,17 @@ def delete_version(ctx: click.Context, pipeline_id: str, version_id: str):
 
 @pipeline.command()
 @click.argument('pipeline-id')
+@click.option('--name', is_flag=True)
 @click.pass_context
-def get(ctx: click.Context, pipeline_id: str):
+def get(ctx: click.Context, pipeline_id: str, name: bool):
     """Get information about a pipeline."""
     client_obj: client.Client = ctx.obj['client']
     output_format = ctx.obj['output']
 
-    pipeline = client_obj.get_pipeline(pipeline_id)
+    if name:
+        pipeline = client_obj.get_pipeline_by_name(pipeline_id)
+    else:
+        pipeline = client_obj.get_pipeline(pipeline_id)
     output.print_output(
         pipeline,
         output.ModelType.PIPELINE,

--- a/sdk/python/kfp/cli/pipeline.py
+++ b/sdk/python/kfp/cli/pipeline.py
@@ -217,7 +217,9 @@ def delete_version(ctx: click.Context, pipeline_id: str, version_id: str):
 
 @pipeline.command()
 @click.argument('pipeline-id')
-@click.option('--name', is_flag=True)
+@click.option('--name',
+              is_flag=True,
+              help="Retrive pipeline information by it's name.")
 @click.pass_context
 def get(ctx: click.Context, pipeline_id: str, name: bool):
     """Get information about a pipeline."""

--- a/sdk/python/kfp/cli/recurring_run.py
+++ b/sdk/python/kfp/cli/recurring_run.py
@@ -139,6 +139,7 @@ def create(ctx: click.Context,
 
     # Ensure we only split on the first equals char so the value can contain
     # equals signs too.
+    print(args)
     split_args: List = [arg.split('=', 1) for arg in args or []]
     params: Dict[str, Any] = dict(split_args)
     recurring_run = client_obj.create_recurring_run(
@@ -200,6 +201,7 @@ def list(ctx: click.Context, experiment_id: str, page_token: str, max_size: int,
         page_token=page_token,
         page_size=max_size,
         sort_by=sort_by,
+        namespace=namespace,
         filter=filter)
     output.print_output(
         response.recurring_runs or [],

--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -1482,6 +1482,17 @@ class Client:
         """
         return self._pipelines_api.get_pipeline(pipeline_id=pipeline_id)
 
+    def get_pipeline_by_name(self, pipeline_name: str) -> kfp_server_api.V2beta1Pipeline:
+        """Gets pipeline details.
+
+        Args:
+            pipeline_id: ID of the pipeline.
+
+        Returns:
+            ``V2beta1Pipeline`` object.
+        """
+        return self._pipelines_api.get_pipeline_by_name(pipeline_name)
+
     def delete_pipeline(self, pipeline_id: str) -> dict:
         """Deletes a pipeline.
 

--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -1486,7 +1486,7 @@ class Client:
         """Gets pipeline details.
 
         Args:
-            pipeline_id: ID of the pipeline.
+            pipeline_name: Display Name of the pipeline.
 
         Returns:
             ``V2beta1Pipeline`` object.


### PR DESCRIPTION
**Description of your changes:**
1. make cli support cookies & ssl certificate for outside cluster access.
2. support get pipeline infromation by adding a bool flag '--name' using it's name; `kfp pipeline get ${name} --name 

for the first feature, we are tying to use cli & solution https://github.com/kubeflow/website/issues/2916 for outside cluster access. 
but find out that cli is not support this feature yet. 

currently if we are using name to retrive pipeline information , we'll get 404 error. 
thus, add a `--name` flag to support this feature.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
