### PR TITLE
Fix(backend.util): avoid create user error when input err is nil. Fixes: #10267

### DIFF
--- a/backend/src/common/util/error.go
+++ b/backend/src/common/util/error.go
@@ -91,6 +91,9 @@ type UserError struct {
 func newUserError(internalError error, externalMessage string,
 	externalStatusCode codes.Code,
 ) *UserError {
+	if internalError == nil {
+		return nil
+	}
 	return &UserError{
 		internalError:      internalError,
 		externalMessage:    externalMessage,

--- a/backend/src/common/util/error_test.go
+++ b/backend/src/common/util/error_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -25,4 +26,8 @@ import (
 func TestIsNotFound(t *testing.T) {
 	assert.Equal(t, true, IsNotFound(errors.NewNotFound(schema.GroupResource{}, "NAME")))
 	assert.Equal(t, false, IsNotFound(errors.NewAlreadyExists(schema.GroupResource{}, "NAME")))
+}
+
+func TestUserErrorWithNil(t *testing.T) {
+	assert.Nil(t, newUserError(nil, "dummy error message", codes.Unknown))
 }


### PR DESCRIPTION
**Description of your changes:**
 avoid create UserError when internalError is nil. 

Fixes: #10267

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
