### PR TITLE
feat(backend): preserve querystring in pipeline root (fixes #10318)

### DIFF
--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -17,9 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -1062,8 +1060,9 @@ func provisionOutputs(pipelineRoot, taskName string, outputsSpec *pipelinespec.C
 		outputs.Artifacts[name] = &pipelinespec.ArtifactList{
 			Artifacts: []*pipelinespec.RuntimeArtifact{
 				{
-					// Split off any query strings first
-					Uri:      fmt.Sprintf("%s/%s", strings.TrimRight(strings.Split(pipelineRoot, "?")[0], "/"), path.Join(taskName, name)),
+					// Do not preserve the query string for output artifacts, as otherwise
+					// they'd appear in file and artifact names.
+					Uri:      metadata.GenerateOutputURI(pipelineRoot, []string{taskName, name}, false),
 					Type:     artifact.GetArtifactType(),
 					Metadata: artifact.GetMetadata(),
 				},

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -17,9 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -1062,7 +1060,7 @@ func provisionOutputs(pipelineRoot, taskName string, outputsSpec *pipelinespec.C
 		outputs.Artifacts[name] = &pipelinespec.ArtifactList{
 			Artifacts: []*pipelinespec.RuntimeArtifact{
 				{
-					Uri:      generateOutputURI(pipelineRoot, name, taskName),
+					Uri:      metadata.AppendToPipelineRoot(pipelineRoot, []string{taskName, name}),
 					Type:     artifact.GetArtifactType(),
 					Metadata: artifact.GetMetadata(),
 				},
@@ -1076,20 +1074,6 @@ func provisionOutputs(pipelineRoot, taskName string, outputsSpec *pipelinespec.C
 		}
 	}
 	return outputs
-}
-
-func generateOutputURI(root, artifactName string, taskName string) string {
-	// split the query part off the root, if it exists.
-	// we will append it back later to the full URI.
-	querySplit := strings.Split(root, "?")
-	query := ""
-	if len(querySplit) > 1 {
-		root = querySplit[0]
-		query = "?" + querySplit[1]
-	}
-	// we cannot path.Join(root, taskName, artifactName), because root
-	// contains scheme like gs:// and path.Join cleans up scheme to gs:/
-	return fmt.Sprintf("%s/%s%s", strings.TrimRight(root, "/"), path.Join(taskName, artifactName), query)
 }
 
 var accessModeMap = map[string]k8score.PersistentVolumeAccessMode{

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -17,7 +17,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -1060,7 +1062,8 @@ func provisionOutputs(pipelineRoot, taskName string, outputsSpec *pipelinespec.C
 		outputs.Artifacts[name] = &pipelinespec.ArtifactList{
 			Artifacts: []*pipelinespec.RuntimeArtifact{
 				{
-					Uri:      metadata.AppendToPipelineRoot(pipelineRoot, []string{taskName, name}),
+					// Split off any query strings first
+					Uri:      fmt.Sprintf("%s/%s", strings.TrimRight(strings.Split(pipelineRoot, "?")[0], "/"), path.Join(taskName, name)),
 					Type:     artifact.GetArtifactType(),
 					Metadata: artifact.GetMetadata(),
 				},

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -1079,9 +1079,17 @@ func provisionOutputs(pipelineRoot, taskName string, outputsSpec *pipelinespec.C
 }
 
 func generateOutputURI(root, artifactName string, taskName string) string {
+	// split the query part off the root, if it exists.
+	// we will append it back later to the full URI.
+	querySplit := strings.Split(root, "?")
+	query := ""
+	if len(querySplit) > 1 {
+		root = querySplit[0]
+		query = "?" + querySplit[1]
+	}
 	// we cannot path.Join(root, taskName, artifactName), because root
 	// contains scheme like gs:// and path.Join cleans up scheme to gs:/
-	return fmt.Sprintf("%s/%s", strings.TrimRight(root, "/"), path.Join(taskName, artifactName))
+	return fmt.Sprintf("%s/%s%s", strings.TrimRight(root, "/"), path.Join(taskName, artifactName), query)
 }
 
 var accessModeMap = map[string]k8score.PersistentVolumeAccessMode{

--- a/backend/src/v2/driver/driver_test.go
+++ b/backend/src/v2/driver/driver_test.go
@@ -15,6 +15,7 @@ package driver
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
@@ -604,4 +605,21 @@ func Test_extendPodSpecPatch_Secret(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.podSpec)
 		})
 	}
+}
+
+func Test_generateOutputURI(t *testing.T) {
+	// Const define the artifact name
+	const (
+		artifactName      = "artifact"
+		taskName          = "my-task-name"
+		pipelineRoot      = "minio://mlpipeline/v2/artifacts"
+		pipelineRootQuery = "?query=string&another=query"
+	)
+	// Test output uri generation with plain pipeline root, i.e. without any query strings
+	plainResult := generateOutputURI(pipelineRoot, artifactName, taskName)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s", pipelineRoot, taskName, artifactName), plainResult)
+
+	// Make sure query strings in the pipeline root are correctly preserved (added to the end)
+	queryResult := generateOutputURI(fmt.Sprintf("%s%s", pipelineRoot, pipelineRootQuery), artifactName, taskName)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s%s", pipelineRoot, taskName, artifactName, pipelineRootQuery), queryResult)
 }

--- a/backend/src/v2/driver/driver_test.go
+++ b/backend/src/v2/driver/driver_test.go
@@ -15,7 +15,6 @@ package driver
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
@@ -605,21 +604,4 @@ func Test_extendPodSpecPatch_Secret(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.podSpec)
 		})
 	}
-}
-
-func Test_generateOutputURI(t *testing.T) {
-	// Const define the artifact name
-	const (
-		artifactName      = "artifact"
-		taskName          = "my-task-name"
-		pipelineRoot      = "minio://mlpipeline/v2/artifacts"
-		pipelineRootQuery = "?query=string&another=query"
-	)
-	// Test output uri generation with plain pipeline root, i.e. without any query strings
-	plainResult := generateOutputURI(pipelineRoot, artifactName, taskName)
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s", pipelineRoot, taskName, artifactName), plainResult)
-
-	// Make sure query strings in the pipeline root are correctly preserved (added to the end)
-	queryResult := generateOutputURI(fmt.Sprintf("%s%s", pipelineRoot, pipelineRootQuery), artifactName, taskName)
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s%s", pipelineRoot, taskName, artifactName, pipelineRootQuery), queryResult)
 }

--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -260,17 +260,17 @@ func (e *Execution) FingerPrint() string {
 	return e.execution.GetCustomProperties()[keyCacheFingerPrint].GetStringValue()
 }
 
-// AppendToPipelineRoot appends the specified paths to the pipeline root.
-// It preserves the query part of the pipeline root by splitting it off and
-// appending it back to the full URI.
-func AppendToPipelineRoot(pipelineRoot string, paths []string) string {
-	// split the query part off the root, if it exists.
-	// we will append it back later to the full URI.
+// GenerateOutputURI appends the specified paths to the pipeline root.
+// It may be configured to preserve the query part of the pipeline root
+// by splitting it off and appending it back to the full URI.
+func GenerateOutputURI(pipelineRoot string, paths []string, preserveQueryString bool) string {
 	querySplit := strings.Split(pipelineRoot, "?")
 	query := ""
-	if len(querySplit) > 1 {
+	if len(querySplit) == 2 {
 		pipelineRoot = querySplit[0]
-		query = "?" + querySplit[1]
+		if preserveQueryString {
+			query = "?" + querySplit[1]
+		}
 	} else if len(querySplit) > 2 {
 		// this should never happen, but just in case.
 		glog.Warningf("Unexpected pipeline root: %v", pipelineRoot)
@@ -292,7 +292,7 @@ func (c *Client) GetPipeline(ctx context.Context, pipelineName, runID, namespace
 		keyNamespace:    stringValue(namespace),
 		keyResourceName: stringValue(runResource),
 		// pipeline root of this run
-		keyPipelineRoot: stringValue(AppendToPipelineRoot(pipelineRoot, []string{pipelineName, runID})),
+		keyPipelineRoot: stringValue(GenerateOutputURI(pipelineRoot, []string{pipelineName, runID}, true)),
 	}
 	runContext, err := c.getOrInsertContext(ctx, runID, pipelineRunContextType, metadata)
 	glog.Infof("Pipeline Run Context: %+v", runContext)


### PR DESCRIPTION
The kfp-driver now recognizes query params and assembles bucket names correctly.

See #10318