### PR TITLE
feat(sdk): add local execution output collection #localexecution

### DIFF
--- a/sdk/python/kfp/dsl/types/artifact_types.py
+++ b/sdk/python/kfp/dsl/types/artifact_types.py
@@ -89,7 +89,8 @@ class Artifact:
             return _MINIO_LOCAL_MOUNT_PREFIX + self.uri[len('minio://'):]
         elif self.uri.startswith('s3://'):
             return _S3_LOCAL_MOUNT_PREFIX + self.uri[len('s3://'):]
-        return None
+        # uri == path for local execution
+        return self.uri
 
     def _set_path(self, path: str) -> None:
         self.uri = convert_local_path_to_remote_path(path)

--- a/sdk/python/kfp/local/e2e_test.py
+++ b/sdk/python/kfp/local/e2e_test.py
@@ -1,0 +1,382 @@
+# Copyright 2023 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""E2E local execution tests.
+
+These contain tests of various component definitions/types, tested on each local runner type + configurations.
+
+These can be thought of as local runner conformance tests. The test results should be the same irrespective of the runner.
+"""
+import io
+import sys
+from typing import NamedTuple
+import unittest
+
+from absl.testing import parameterized
+from kfp import dsl
+from kfp import local
+from kfp.dsl import Artifact
+from kfp.dsl import Dataset
+from kfp.dsl import Output
+from kfp.local import testing_utilities
+
+# NOTE when asserting on task.output or task.outputs[<key>]
+# since == is overloaded for dsl.Condition, if local execution is not
+# "hit", then actual will be a channel and actual == expected evaluates
+# to ConditionOperation. Since ConditionOperation is truthy,
+# this may result in a false negative test result. For this reason,
+# we perform an isinstance check first.
+
+ALL_RUNNERS = [
+    (local.SubprocessRunner(use_venv=False),),
+    (local.SubprocessRunner(use_venv=True),),
+]
+
+
+@parameterized.parameters(ALL_RUNNERS)
+class TestLightweightPythonComponentLogic(
+        testing_utilities.LocalRunnerEnvironmentTestCase):
+
+    def test_str_input(self, runner):
+        local.init(runner=runner)
+
+        @dsl.component
+        def identity(x: str) -> str:
+            return x
+
+        actual = identity(x='hello').output
+        expected = 'hello'
+        self.assertIsInstance(actual, str)
+        self.assertEqual(actual, expected)
+
+    def test_int_input(self, runner):
+        local.init(runner=runner)
+
+        @dsl.component
+        def identity(x: int) -> int:
+            return x
+
+        actual = identity(x=1).output
+        expected = 1
+        self.assertIsInstance(actual, int)
+        self.assertEqual(actual, expected)
+
+    def test_float_input(self, runner):
+        local.init(runner=runner)
+
+        @dsl.component
+        def identity(x: float) -> float:
+            return x
+
+        actual = identity(x=1.0).output
+        expected = 1.0
+        self.assertIsInstance(actual, float)
+        self.assertEqual(actual, expected)
+
+    def test_bool_input(self, runner):
+        local.init(runner=runner)
+
+        @dsl.component
+        def identity(x: bool) -> bool:
+            return x
+
+        actual = identity(x=True).output
+        self.assertIsInstance(actual, bool)
+        self.assertTrue(actual)
+
+    def test_list_input(self, runner):
+        local.init(runner=runner)
+
+        @dsl.component
+        def identity(x: list) -> list:
+            return x
+
+        actual = identity(x=['a', 'b']).output
+        expected = ['a', 'b']
+        self.assertIsInstance(actual, list)
+        self.assertEqual(actual, expected)
+
+    def test_dict_input(self, runner):
+        local.init(runner=runner)
+
+        @dsl.component
+        def identity(x: dict) -> dict:
+            return x
+
+        actual = identity(x={'a': 'b'}).output
+        expected = {'a': 'b'}
+        self.assertIsInstance(actual, dict)
+        self.assertEqual(actual, expected)
+
+    def test_multiple_parameter_outputs(self, runner):
+        local.init(runner=runner)
+        from typing import NamedTuple
+
+        @dsl.component
+        def return_twice(x: str) -> NamedTuple('Outputs', x=str, y=str):
+            Outputs = NamedTuple('Output', x=str, y=str)
+            return Outputs(x=x, y=x)
+
+        local_task = return_twice(x='foo')
+        self.assertIsInstance(local_task.outputs['x'], str)
+        self.assertEqual(local_task.outputs['x'], 'foo')
+        self.assertIsInstance(local_task.outputs['y'], str)
+        self.assertEqual(local_task.outputs['y'], 'foo')
+
+    def test_single_output_not_available(self, runner):
+        local.init(runner=runner)
+        from typing import NamedTuple
+
+        @dsl.component
+        def return_twice(x: str) -> NamedTuple('Outputs', x=str, y=str):
+            Outputs = NamedTuple('Output', x=str, y=str)
+            return Outputs(x=x, y=x)
+
+        local_task = return_twice(x='foo')
+        with self.assertRaisesRegex(
+                AttributeError,
+                r'The task has multiple outputs\. Please reference the output by its name\.'
+        ):
+            local_task.output
+
+    def test_single_artifact_output_traditional(self, runner):
+        local.init(runner=runner)
+
+        @dsl.component
+        def artifact_maker(x: str, a: Output[Artifact]):
+            with open(a.path, 'w') as f:
+                f.write(x)
+
+            a.metadata['foo'] = 'bar'
+
+        actual = artifact_maker(x='hello').output
+        self.assertIsInstance(actual, Artifact)
+        self.assertEqual(actual.name, 'a')
+        self.assertTrue(actual.uri.endswith('/a'))
+        self.assertEqual(actual.metadata, {'foo': 'bar'})
+        with open(actual.path) as f:
+            contents = f.read()
+            self.assertEqual(contents, 'hello')
+
+    def test_single_artifact_output_pythonic(self, runner):
+        local.init(runner=runner)
+
+        @dsl.component
+        def artifact_maker(x: str) -> Artifact:
+            artifact = Artifact(
+                name='a', uri=dsl.get_uri('a'), metadata={'foo': 'bar'})
+            with open(artifact.path, 'w') as f:
+                f.write(x)
+
+            return artifact
+
+        actual = artifact_maker(x='hello').output
+        self.assertIsInstance(actual, Artifact)
+        self.assertEqual(actual.name, 'a')
+        self.assertTrue(actual.uri.endswith('/a'))
+        self.assertEqual(actual.metadata, {'foo': 'bar'})
+        with open(actual.path) as f:
+            contents = f.read()
+            self.assertEqual(contents, 'hello')
+
+    def test_multiple_artifact_outputs_traditional(self, runner):
+        local.init(runner=runner)
+
+        @dsl.component
+        def double_artifact_maker(
+            x: str,
+            y: str,
+            a: Output[Artifact],
+            b: Output[Dataset],
+        ):
+            with open(a.path, 'w') as f:
+                f.write(x)
+
+            with open(b.path, 'w') as f:
+                f.write(y)
+
+            a.metadata['foo'] = 'bar'
+            b.metadata['baz'] = 'bat'
+
+        local_task = double_artifact_maker(x='hello', y='goodbye')
+
+        actual_a = local_task.outputs['a']
+        actual_b = local_task.outputs['b']
+
+        self.assertIsInstance(actual_a, Artifact)
+        self.assertEqual(actual_a.name, 'a')
+        self.assertTrue(actual_a.uri.endswith('/a'))
+        with open(actual_a.path) as f:
+            contents = f.read()
+            self.assertEqual(contents, 'hello')
+        self.assertEqual(actual_a.metadata, {'foo': 'bar'})
+
+        self.assertIsInstance(actual_b, Dataset)
+        self.assertEqual(actual_b.name, 'b')
+        self.assertTrue(actual_b.uri.endswith('/b'))
+        self.assertEqual(actual_b.metadata, {'baz': 'bat'})
+        with open(actual_b.path) as f:
+            contents = f.read()
+            self.assertEqual(contents, 'goodbye')
+
+    def test_multiple_artifact_outputs_pythonic(self, runner):
+        local.init(runner=runner)
+
+        @dsl.component
+        def double_artifact_maker(
+            x: str,
+            y: str,
+        ) -> NamedTuple(
+                'Outputs', a=Artifact, b=Dataset):
+            a = Artifact(
+                name='a', uri=dsl.get_uri('a'), metadata={'foo': 'bar'})
+            b = Dataset(name='b', uri=dsl.get_uri('b'), metadata={'baz': 'bat'})
+
+            with open(a.path, 'w') as f:
+                f.write(x)
+
+            with open(b.path, 'w') as f:
+                f.write(y)
+
+            Outputs = NamedTuple('Outputs', a=Artifact, b=Dataset)
+            return Outputs(a=a, b=b)
+
+        local_task = double_artifact_maker(x='hello', y='goodbye')
+
+        actual_a = local_task.outputs['a']
+        actual_b = local_task.outputs['b']
+
+        self.assertIsInstance(actual_a, Artifact)
+        self.assertEqual(actual_a.name, 'a')
+        self.assertTrue(actual_a.uri.endswith('/a'))
+        with open(actual_a.path) as f:
+            contents = f.read()
+            self.assertEqual(contents, 'hello')
+        self.assertEqual(actual_a.metadata, {'foo': 'bar'})
+
+        self.assertIsInstance(actual_b, Dataset)
+        self.assertEqual(actual_b.name, 'b')
+        self.assertTrue(actual_b.uri.endswith('/b'))
+        with open(actual_b.path) as f:
+            contents = f.read()
+            self.assertEqual(contents, 'goodbye')
+        self.assertEqual(actual_b.metadata, {'baz': 'bat'})
+
+    def test_str_input_uses_default(self, runner):
+        local.init(runner=runner)
+
+        @dsl.component
+        def identity(x: str = 'hi') -> str:
+            return x
+
+        actual = identity().output
+        expected = 'hi'
+        self.assertIsInstance(actual, str)
+        self.assertEqual(actual, expected)
+
+    def test_placeholder_default_resolved(self, runner):
+        local.init(runner=runner)
+
+        @dsl.component
+        def identity(x: str = dsl.PIPELINE_TASK_NAME_PLACEHOLDER) -> str:
+            return x
+
+        actual = identity().output
+        expected = 'identity'
+        self.assertIsInstance(actual, str)
+        self.assertEqual(actual, expected)
+
+    def test_int_input_uses_default(self, runner):
+        local.init(runner=runner)
+
+        @dsl.component
+        def identity(x: int = 1) -> int:
+            return 1
+
+        actual = identity().output
+        expected = 1
+        self.assertIsInstance(actual, int)
+        self.assertEqual(actual, expected)
+
+    def test_outputpath(self, runner):
+        local.init(runner=runner)
+
+        @dsl.component
+        def my_comp(out_param: dsl.OutputPath(str),) -> int:
+            with open(out_param, 'w') as f:
+                f.write('Hello' * 2)
+            return 1
+
+        task = my_comp()
+
+        self.assertEqual(task.outputs['out_param'], 'HelloHello')
+        self.assertEqual(task.outputs['Output'], 1)
+
+
+@parameterized.parameters(ALL_RUNNERS)
+class TestExceptionHandling(testing_utilities.LocalRunnerEnvironmentTestCase):
+
+    def setUp(self):
+        super().setUp()
+        # capture logs on a test-by-test basis
+        self.captured_stdout = io.StringIO()
+        sys.stdout = self.captured_stdout
+
+    def tearDown(self):
+        super().setUp()
+        # reset stdout
+        sys.stdout = sys.__stdout__
+
+    def test_user_code_throws_exception_if_raise_on_error(self, runner):
+        local.init(runner=runner, raise_on_error=True)
+
+        @dsl.component
+        def fail_comp():
+            raise Exception('String to match on')
+
+        # use end of line anchor $, since the user code error should be the last thing surfaced to the user
+        with self.assertRaisesRegex(
+                RuntimeError,
+                r'Local execution exited with status FAILURE\.$',
+        ):
+            fail_comp()
+
+        self.assertIn(
+            'Exception: String to match on',
+            self.captured_stdout.getvalue(),
+        )
+
+    def test_user_code_no_exception_if_not_raise_on_error(self, runner):
+        local.init(runner=runner, raise_on_error=False)
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+
+        @dsl.component
+        def fail_comp():
+            raise Exception('String to match on')
+
+        task = fail_comp()
+        self.assertDictEqual(task.outputs, {})
+
+        self.assertIn(
+            'Local execution exited with status FAILURE.',
+            self.captured_stdout.getvalue(),
+        )
+        self.assertIn(
+            'Exception: String to match on',
+            self.captured_stdout.getvalue(),
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/python/kfp/local/e2e_test.py
+++ b/sdk/python/kfp/local/e2e_test.py
@@ -358,8 +358,6 @@ class TestExceptionHandling(testing_utilities.LocalRunnerEnvironmentTestCase):
 
     def test_user_code_no_exception_if_not_raise_on_error(self, runner):
         local.init(runner=runner, raise_on_error=False)
-        captured_output = io.StringIO()
-        sys.stdout = captured_output
 
         @dsl.component
         def fail_comp():

--- a/sdk/python/kfp/local/executor_input_utils_test.py
+++ b/sdk/python/kfp/local/executor_input_utils_test.py
@@ -194,5 +194,82 @@ class TestConstructExecutorInput(unittest.TestCase):
             )
 
 
+class TestExecutorInputToDict(unittest.TestCase):
+
+    def test_with_ints_and_floats(self):
+        component_spec = pipeline_spec_pb2.ComponentSpec()
+        json_format.ParseDict(
+            {
+                'inputDefinitions': {
+                    'parameters': {
+                        'x': {
+                            'parameterType': 'NUMBER_INTEGER'
+                        },
+                        'y': {
+                            'parameterType': 'NUMBER_DOUBLE'
+                        }
+                    }
+                },
+                'outputDefinitions': {
+                    'parameters': {
+                        'Output': {
+                            'parameterType': 'STRING'
+                        }
+                    }
+                },
+                'executorLabel': 'exec-comp'
+            }, component_spec)
+
+        executor_input = pipeline_spec_pb2.ExecutorInput()
+        json_format.ParseDict(
+            {
+                'inputs': {
+                    'parameterValues': {
+                        'x': 1.0,
+                        'y': 2.0
+                    }
+                },
+                'outputs': {
+                    'parameters': {
+                        'Output': {
+                            'outputFile':
+                                '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/comp/Output'
+                        }
+                    },
+                    'outputFile':
+                        '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/comp/executor_output.json'
+                }
+            }, executor_input)
+
+        executor_input_dict = executor_input_utils.executor_input_to_dict(
+            executor_input=executor_input,
+            component_spec=component_spec,
+        )
+        expected = {
+            'inputs': {
+                'parameterValues': {
+                    'x': 1,
+                    'y': 2.0
+                }
+            },
+            'outputs': {
+                'parameters': {
+                    'Output': {
+                        'outputFile':
+                            '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/comp/Output'
+                    }
+                },
+                'outputFile':
+                    '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/comp/executor_output.json'
+            }
+        }
+        # assert types since 1.0 == 1
+        self.assertIsInstance(
+            executor_input_dict['inputs']['parameterValues']['x'], int)
+        self.assertIsInstance(
+            executor_input_dict['inputs']['parameterValues']['y'], float)
+        self.assertEqual(executor_input_dict, expected)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/local/executor_output_utils.py
+++ b/sdk/python/kfp/local/executor_output_utils.py
@@ -1,0 +1,213 @@
+# Copyright 2023 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for reading and processing the ExecutorOutput message."""
+import json
+import os
+from typing import Any, Dict, List, Union
+
+from google.protobuf import json_format
+from google.protobuf import struct_pb2
+from kfp import dsl
+from kfp.compiler import pipeline_spec_builder
+from kfp.dsl import executor
+from kfp.pipeline_spec import pipeline_spec_pb2
+
+
+def load_executor_output(
+        executor_output_path: str) -> pipeline_spec_pb2.ExecutorOutput:
+    """Loads the ExecutorOutput message from a path."""
+    executor_output = pipeline_spec_pb2.ExecutorOutput()
+    with open(executor_output_path) as f:
+        json_format.Parse(f.read(), executor_output)
+    return executor_output
+
+
+def cast_ints_as_floats_to_ints(
+    outputs_dict: Dict[str, Any],
+    outputs_typed_int: List[str],
+) -> Dict[str, Any]:
+    """Casts output fields that are typed as NUMBER_INTEGER to a Python int.
+
+    This is required, since google.protobuf.struct_pb2.Value uses
+    number_value to represent both floats and ints. When converting
+    struct_pb2.Value to a dict/json, int will be upcast to float, even
+    if the component output specifies int.
+    """
+    for float_output_key in outputs_typed_int:
+        outputs_dict[float_output_key] = int(outputs_dict[float_output_key])
+    return outputs_dict
+
+
+def get_outputs_from_executor_output(
+    executor_output: pipeline_spec_pb2.ExecutorOutput,
+    executor_input: pipeline_spec_pb2.ExecutorInput,
+    component_spec: pipeline_spec_pb2.ComponentSpec,
+) -> Dict[str, Any]:
+    """Obtains a dictionary of output key to output value from several messages
+    corresponding to the executed a component/task."""
+    executor_output = add_type_to_executor_output(
+        executor_input=executor_input,
+        executor_output=executor_output,
+    )
+
+    # merge any parameter outputs written using dsl.OutputPath with the rest of ExecutorOutput
+    executor_output = merge_dsl_output_file_parameters_to_executor_output(
+        executor_input=executor_input,
+        executor_output=executor_output,
+        component_spec=component_spec,
+    )
+
+    # collect parameter outputs from executor output
+    output_parameters = {
+        param_name: pb2_value_to_python(value)
+        for param_name, value in executor_output.parameter_values.items()
+    }
+    # process the special case of protobuf ints
+    outputs_typed_int = [
+        output_param_name for output_param_name, parameter_spec in
+        component_spec.output_definitions.parameters.items()
+        if parameter_spec.parameter_type ==
+        pipeline_spec_pb2.ParameterType.ParameterTypeEnum.NUMBER_INTEGER
+    ]
+    output_parameters = cast_ints_as_floats_to_ints(
+        output_parameters,
+        outputs_typed_int,
+    )
+
+    # collect artifact outputs from executor output
+    output_artifact_definitions = component_spec.output_definitions.artifacts
+    output_artifacts = {
+        artifact_name: artifact_list_to_dsl_artifact(
+            artifact_list,
+            is_artifact_list=output_artifact_definitions[artifact_name]
+            .is_artifact_list,
+        ) for artifact_name, artifact_list in executor_output.artifacts.items()
+    }
+    return {**output_parameters, **output_artifacts}
+
+
+def special_dsl_outputpath_read(output_file: str, is_string: bool) -> Any:
+    """Reads the text in dsl.OutputPath files in the same way as the remote
+    backend.
+
+    Basically deserialize all types as JSON, but also support strings
+    that are written directly without quotes (e.g., `foo` instead of
+    `"foo"`).
+    """
+    with open(output_file) as f:
+        parameter_value = f.read()
+    # TODO: verify this is the correct special handling of OutputPath
+    return parameter_value if is_string else json.loads(parameter_value)
+
+
+def merge_dsl_output_file_parameters_to_executor_output(
+    executor_input: pipeline_spec_pb2.ExecutorInput,
+    executor_output: pipeline_spec_pb2.ExecutorOutput,
+    component_spec: pipeline_spec_pb2.ComponentSpec,
+) -> pipeline_spec_pb2.ExecutorOutput:
+    """Merges and output parameters specified via dsl.OutputPath with the rest
+    of the ExecutorOutput message."""
+    for parameter_key, output_parameter in executor_input.outputs.parameters.items(
+    ):
+        if os.path.exists(output_parameter.output_file):
+            is_string = component_spec.output_definitions.parameters[
+                parameter_key].parameter_type == pipeline_spec_pb2.ParameterType.ParameterTypeEnum.STRING
+            parameter_value = special_dsl_outputpath_read(
+                output_parameter.output_file,
+                is_string,
+            )
+            executor_output.parameter_values[parameter_key].CopyFrom(
+                pipeline_spec_builder.to_protobuf_value(parameter_value))
+
+    return executor_output
+
+
+def pb2_value_to_python(value: struct_pb2.Value) -> Any:
+    """Converts protobuf Value to the corresponding Python type."""
+    if value.HasField('null_value'):
+        return None
+    elif value.HasField('number_value'):
+        return value.number_value
+    elif value.HasField('string_value'):
+        return value.string_value
+    elif value.HasField('bool_value'):
+        return value.bool_value
+    elif value.HasField('struct_value'):
+        return pb2_struct_to_python(value.struct_value)
+    elif value.HasField('list_value'):
+        return [pb2_value_to_python(v) for v in value.list_value.values]
+    else:
+        raise ValueError(f'Unknown value type: {value}')
+
+
+def pb2_struct_to_python(struct: struct_pb2.Struct) -> Dict[str, Any]:
+    """Converts protobuf Struct to a dict."""
+    return {k: pb2_value_to_python(v) for k, v in struct.fields.items()}
+
+
+def runtime_artifact_to_dsl_artifact(
+        runtime_artifact: pipeline_spec_pb2.RuntimeArtifact) -> dsl.Artifact:
+    """Converts a single RuntimeArtifact instance to the corresponding
+    dsl.Artifact instance."""
+    return executor.create_artifact_instance(
+        json_format.MessageToDict(runtime_artifact))
+
+
+def artifact_list_to_dsl_artifact(
+    artifact_list: pipeline_spec_pb2.ArtifactList,
+    is_artifact_list: bool,
+) -> Union[dsl.Artifact, List[dsl.Artifact]]:
+    """Converts an ArtifactList instance to a single dsl.Artifact or a list of
+    dsl.Artifacts, depending on whether the ArtifactList is a true list or
+    simply a container for single artifact element."""
+    dsl_artifacts = [
+        runtime_artifact_to_dsl_artifact(artifact_spec)
+        for artifact_spec in artifact_list.artifacts
+    ]
+    return dsl_artifacts if is_artifact_list else dsl_artifacts[0]
+
+
+def add_type_to_executor_output(
+    executor_input: pipeline_spec_pb2.ExecutorInput,
+    executor_output: pipeline_spec_pb2.ExecutorOutput,
+) -> pipeline_spec_pb2.ExecutorOutput:
+    """Adds artifact type information (ArtifactTypeSchema) from the
+    ExecutorInput message to the ExecutorOutput message.
+
+    This information is not present in the ExecutorOutput message
+    written by a task, though it is useful to have it for constructing
+    local outputs. We don't want to change the executor logic and the
+    serialized outputs of all tasks for this case, so we add this extra
+    info to ExecutorOutput in memory.
+    """
+    for key, artifact_list in executor_output.artifacts.items():
+        for artifact in artifact_list.artifacts:
+            artifact.type.CopyFrom(
+                executor_input.outputs.artifacts[key].artifacts[0].type)
+    return executor_output
+
+
+def get_outputs_for_task(
+    executor_input: pipeline_spec_pb2.ExecutorInput,
+    component_spec: pipeline_spec_pb2.ComponentSpec,
+) -> Dict[str, Any]:
+    """Gets outputs from a recently executed task, if available, using the
+    ExecutorInput and ComponentSpec of the task."""
+    executor_output = load_executor_output(
+        executor_output_path=executor_input.outputs.output_file)
+    return get_outputs_from_executor_output(
+        executor_output=executor_output,
+        executor_input=executor_input,
+        component_spec=component_spec,
+    )

--- a/sdk/python/kfp/local/executor_output_utils_test.py
+++ b/sdk/python/kfp/local/executor_output_utils_test.py
@@ -1,0 +1,622 @@
+# Copyright 2023 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for executor_output_utils.py."""
+
+import os
+import tempfile
+from typing import List
+import unittest
+
+from absl.testing import parameterized
+from google.protobuf import json_format
+from google.protobuf import struct_pb2
+from kfp import dsl
+from kfp.local import executor_output_utils
+from kfp.local import testing_utilities
+from kfp.pipeline_spec import pipeline_spec_pb2
+
+
+class TestGetOutputsFromMessages(
+        testing_utilities.LocalRunnerEnvironmentTestCase):
+
+    def test(self):
+        executor_input = pipeline_spec_pb2.ExecutorInput()
+        json_format.ParseDict(
+            {
+                'inputs': {
+                    'parameterValues': {
+                        'string_in': 'foo'
+                    }
+                },
+                'outputs': {
+                    'parameters': {
+                        'int_out': {
+                            'outputFile':
+                                'foo/multiple-io-2023-11-09-12-12-05-528112/multiple-io/int_out'
+                        },
+                        'str_out': {
+                            'outputFile':
+                                'foo/multiple-io-2023-11-09-12-12-05-528112/multiple-io/str_out'
+                        }
+                    },
+                    'artifacts': {
+                        'dataset_out': {
+                            'artifacts': [{
+                                'name':
+                                    'dataset_out',
+                                'type': {
+                                    'schemaTitle': 'system.Dataset',
+                                    'schemaVersion': '0.0.1'
+                                },
+                                'uri':
+                                    'foo/multiple-io-2023-11-09-12-12-05-528112/multiple-io/dataset_out',
+                                'metadata': {}
+                            }]
+                        }
+                    },
+                    'outputFile':
+                        'foo/multiple-io-2023-11-09-12-12-05-528112/multiple-io/executor_output.json'
+                }
+            }, executor_input)
+        component_spec = pipeline_spec_pb2.ComponentSpec()
+        json_format.ParseDict(
+            {
+                'inputDefinitions': {
+                    'parameters': {
+                        'string_in': {
+                            'parameterType': 'STRING'
+                        }
+                    }
+                },
+                'outputDefinitions': {
+                    'artifacts': {
+                        'dataset_out': {
+                            'artifactType': {
+                                'schemaTitle': 'system.Dataset',
+                                'schemaVersion': '0.0.1'
+                            }
+                        }
+                    },
+                    'parameters': {
+                        'int_out': {
+                            'parameterType': 'NUMBER_INTEGER'
+                        },
+                        'str_out': {
+                            'parameterType': 'STRING'
+                        }
+                    }
+                },
+                'executorLabel': 'exec-multiple-io'
+            }, component_spec)
+        executor_output = pipeline_spec_pb2.ExecutorOutput()
+        json_format.ParseDict(
+            {
+                'parameterValues': {
+                    'int_out': 1,
+                    'str_out': 'foo'
+                },
+                'artifacts': {
+                    'dataset_out': {
+                        'artifacts': [{
+                            'name':
+                                'dataset_out',
+                            'uri':
+                                'foo/multiple-io-2023-11-09-12-12-05-528112/multiple-io/dataset_out',
+                            'metadata': {
+                                'foo': 'bar'
+                            }
+                        }]
+                    }
+                }
+            }, executor_output)
+
+        os.makedirs(os.path.dirname(executor_input.outputs.output_file))
+        with open(executor_input.outputs.output_file, 'w') as f:
+            f.write(json_format.MessageToJson(executor_output))
+        outputs = executor_output_utils.get_outputs_for_task(
+            executor_input=executor_input,
+            component_spec=component_spec,
+        )
+
+        self.assertEqual(outputs['int_out'], 1)
+        self.assertEqual(outputs['str_out'], 'foo')
+        assert_artifacts_equal(
+            self,
+            outputs['dataset_out'],
+            dsl.Dataset(
+                name='dataset_out',
+                uri='foo/multiple-io-2023-11-09-12-12-05-528112/multiple-io/dataset_out',
+                metadata={'foo': 'bar'}),
+        )
+
+
+class TestLoadExecutorOutput(unittest.TestCase):
+
+    def test_exists(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            executor_output = pipeline_spec_pb2.ExecutorOutput(
+                parameter_values={
+                    'foo': struct_pb2.Value(string_value='foo_value')
+                })
+            path = os.path.join(tempdir, 'executor_output.json')
+            testing_utilities.write_proto_to_json_file(executor_output, path)
+
+            result = executor_output_utils.load_executor_output(path)
+            self.assertIsInstance(result, pipeline_spec_pb2.ExecutorOutput)
+            self.assertEqual(
+                result.parameter_values['foo'],
+                struct_pb2.Value(string_value='foo_value'),
+            )
+
+    def test_not_exists(self):
+        non_existent_path = 'non_existent_path.json'
+
+        with self.assertRaisesRegex(FileNotFoundError,
+                                    r'No such file or directory:'):
+            executor_output_utils.load_executor_output(non_existent_path)
+
+
+class TestGetOutputsFromExecutorOutput(unittest.TestCase):
+
+    def test_param_and_artifact_outputs(self):
+        # include the special case of an output int for more complete testing of behavior
+        executor_output = pipeline_spec_pb2.ExecutorOutput()
+        json_format.ParseDict(
+            {
+                'parameterValues': {
+                    'int_out': 1,
+                    'str_out': 'foo'
+                },
+                'artifacts': {
+                    'dataset_out': {
+                        'artifacts': [{
+                            'name':
+                                'dataset_out',
+                            'uri':
+                                'foo/multiple-io-2023-11-09-11-31-31-064429/multiple-io/dataset_out',
+                            'metadata': {
+                                'foo': 'bar'
+                            }
+                        }]
+                    }
+                }
+            }, executor_output)
+        executor_input = pipeline_spec_pb2.ExecutorInput()
+        json_format.ParseDict(
+            {
+                'inputs': {
+                    'parameterValues': {
+                        'string_in': 'foo'
+                    }
+                },
+                'outputs': {
+                    'parameters': {
+                        'int_out': {
+                            'outputFile':
+                                'foo/temp_root/multiple-io-2023-11-09-11-31-31-064429/multiple-io/int_out'
+                        },
+                        'str_out': {
+                            'outputFile':
+                                'foo/multiple-io-2023-11-09-11-31-31-064429/multiple-io/str_out'
+                        }
+                    },
+                    'artifacts': {
+                        'dataset_out': {
+                            'artifacts': [{
+                                'name':
+                                    'dataset_out',
+                                'type': {
+                                    'schemaTitle': 'system.Dataset',
+                                    'schemaVersion': '0.0.1'
+                                },
+                                'uri':
+                                    'foo/multiple-io-2023-11-09-11-31-31-064429/multiple-io/dataset_out',
+                                'metadata': {}
+                            }]
+                        }
+                    },
+                    'outputFile':
+                        'foo/multiple-io-2023-11-09-11-31-31-064429/multiple-io/executor_output.json'
+                }
+            }, executor_input)
+        component_spec = pipeline_spec_pb2.ComponentSpec()
+        json_format.ParseDict(
+            {
+                'inputDefinitions': {
+                    'parameters': {
+                        'string_in': {
+                            'parameterType': 'STRING'
+                        }
+                    }
+                },
+                'outputDefinitions': {
+                    'artifacts': {
+                        'dataset_out': {
+                            'artifactType': {
+                                'schemaTitle': 'system.Dataset',
+                                'schemaVersion': '0.0.1'
+                            }
+                        }
+                    },
+                    'parameters': {
+                        'int_out': {
+                            'parameterType': 'NUMBER_INTEGER'
+                        },
+                        'str_out': {
+                            'parameterType': 'STRING'
+                        }
+                    }
+                },
+                'executorLabel': 'exec-multiple-io'
+            }, component_spec)
+
+        outputs = executor_output_utils.get_outputs_from_executor_output(
+            executor_output=executor_output,
+            executor_input=executor_input,
+            component_spec=component_spec,
+        )
+        self.assertIsInstance(outputs, dict)
+        self.assertIsInstance(outputs['dataset_out'], dsl.Dataset)
+        self.assertEqual(outputs['dataset_out'].name, 'dataset_out')
+        self.assertEqual(
+            outputs['dataset_out'].uri,
+            'foo/multiple-io-2023-11-09-11-31-31-064429/multiple-io/dataset_out'
+        )
+        self.assertEqual(outputs['dataset_out'].metadata, {'foo': 'bar'})
+        self.assertEqual(outputs['int_out'], 1)
+        self.assertEqual(outputs['str_out'], 'foo')
+
+
+class TestPb2ValueToPython(unittest.TestCase):
+
+    def test_null(self):
+        inp = struct_pb2.Value(null_value=struct_pb2.NullValue.NULL_VALUE)
+        actual = executor_output_utils.pb2_value_to_python(inp)
+        expected = None
+        self.assertEqual(actual, expected)
+
+    def test_string(self):
+        inp = struct_pb2.Value(string_value='foo_value')
+        actual = executor_output_utils.pb2_value_to_python(inp)
+        expected = 'foo_value'
+        self.assertEqual(actual, expected)
+
+    def test_number_int(self):
+        inp = struct_pb2.Value(number_value=1)
+        actual = executor_output_utils.pb2_value_to_python(inp)
+        expected = 1.0
+        self.assertEqual(actual, expected)
+
+    def test_number_float(self):
+        inp = struct_pb2.Value(number_value=1.0)
+        actual = executor_output_utils.pb2_value_to_python(inp)
+        expected = 1.0
+        self.assertEqual(actual, expected)
+
+    def test_bool(self):
+        inp = struct_pb2.Value(bool_value=True)
+        actual = executor_output_utils.pb2_value_to_python(inp)
+        expected = True
+        self.assertIs(actual, expected)
+
+    def test_dict(self):
+        struct_value = struct_pb2.Struct()
+        struct_value.fields['my_key'].string_value = 'my_value'
+        struct_value.fields['other_key'].bool_value = True
+        inp = struct_pb2.Value(struct_value=struct_value)
+        actual = executor_output_utils.pb2_value_to_python(inp)
+        expected = {'my_key': 'my_value', 'other_key': True}
+        self.assertEqual(actual, expected)
+
+
+class TestRuntimeArtifactToDslArtifact(unittest.TestCase):
+
+    def test_artifact(self):
+        metadata = struct_pb2.Struct()
+        metadata.fields['foo'].string_value = 'bar'
+        type_ = pipeline_spec_pb2.ArtifactTypeSchema(
+            schema_title='system.Artifact',
+            schema_version='0.0.1',
+        )
+        runtime_artifact = pipeline_spec_pb2.RuntimeArtifact(
+            name='a',
+            uri='gs://bucket/foo',
+            metadata=metadata,
+            type=type_,
+        )
+        actual = executor_output_utils.runtime_artifact_to_dsl_artifact(
+            runtime_artifact)
+        expected = dsl.Artifact(
+            name='a',
+            uri='gs://bucket/foo',
+            metadata={'foo': 'bar'},
+        )
+        assert_artifacts_equal(self, actual, expected)
+
+    def test_dataset(self):
+        metadata = struct_pb2.Struct()
+        metadata.fields['baz'].string_value = 'bat'
+        type_ = pipeline_spec_pb2.ArtifactTypeSchema(
+            schema_title='system.Dataset',
+            schema_version='0.0.1',
+        )
+        runtime_artifact = pipeline_spec_pb2.RuntimeArtifact(
+            name='d',
+            uri='gs://bucket/foo',
+            metadata=metadata,
+            type=type_,
+        )
+        actual = executor_output_utils.runtime_artifact_to_dsl_artifact(
+            runtime_artifact)
+        expected = dsl.Dataset(
+            name='d',
+            uri='gs://bucket/foo',
+            metadata={'baz': 'bat'},
+        )
+        assert_artifacts_equal(self, actual, expected)
+
+
+class TestArtifactListToDslArtifact(unittest.TestCase):
+
+    def test_not_list(self):
+        metadata = struct_pb2.Struct()
+        metadata.fields['foo'].string_value = 'bar'
+        type_ = pipeline_spec_pb2.ArtifactTypeSchema(
+            schema_title='system.Artifact',
+            schema_version='0.0.1',
+        )
+        runtime_artifact = pipeline_spec_pb2.RuntimeArtifact(
+            name='a',
+            uri='gs://bucket/foo',
+            metadata=metadata,
+            type=type_,
+        )
+        artifact_list = pipeline_spec_pb2.ArtifactList(
+            artifacts=[runtime_artifact])
+
+        actual = executor_output_utils.artifact_list_to_dsl_artifact(
+            artifact_list,
+            is_artifact_list=False,
+        )
+        expected = dsl.Artifact(
+            name='a',
+            uri='gs://bucket/foo',
+            metadata={'foo': 'bar'},
+        )
+        assert_artifacts_equal(self, actual, expected)
+
+    def test_single_entry_list(self):
+        metadata = struct_pb2.Struct()
+        metadata.fields['foo'].string_value = 'bar'
+        type_ = pipeline_spec_pb2.ArtifactTypeSchema(
+            schema_title='system.Dataset',
+            schema_version='0.0.1',
+        )
+        runtime_artifact = pipeline_spec_pb2.RuntimeArtifact(
+            name='a',
+            uri='gs://bucket/foo',
+            metadata=metadata,
+            type=type_,
+        )
+        artifact_list = pipeline_spec_pb2.ArtifactList(
+            artifacts=[runtime_artifact])
+
+        actual = executor_output_utils.artifact_list_to_dsl_artifact(
+            artifact_list,
+            is_artifact_list=True,
+        )
+        expected = [
+            dsl.Dataset(
+                name='a',
+                uri='gs://bucket/foo',
+                metadata={'foo': 'bar'},
+            )
+        ]
+        assert_artifact_lists_equal(self, actual, expected)
+
+    def test_multi_entry_list(self):
+        metadata = struct_pb2.Struct()
+        metadata.fields['foo'].string_value = 'bar'
+        type_ = pipeline_spec_pb2.ArtifactTypeSchema(
+            schema_title='system.Dataset',
+            schema_version='0.0.1',
+        )
+        runtime_artifact1 = pipeline_spec_pb2.RuntimeArtifact(
+            name='a',
+            uri='gs://bucket/foo/a',
+            metadata=metadata,
+            type=type_,
+        )
+        runtime_artifact2 = pipeline_spec_pb2.RuntimeArtifact(
+            name='b',
+            uri='gs://bucket/foo/b',
+            type=type_,
+        )
+        artifact_list = pipeline_spec_pb2.ArtifactList(
+            artifacts=[runtime_artifact1, runtime_artifact2])
+
+        actual = executor_output_utils.artifact_list_to_dsl_artifact(
+            artifact_list,
+            is_artifact_list=True,
+        )
+        expected = [
+            dsl.Dataset(
+                name='a',
+                uri='gs://bucket/foo/a',
+                metadata={'foo': 'bar'},
+            ),
+            dsl.Dataset(
+                name='b',
+                uri='gs://bucket/foo/b',
+            )
+        ]
+
+        assert_artifact_lists_equal(self, actual, expected)
+
+
+class AddTypeToExecutorOutput(unittest.TestCase):
+
+    def test(self):
+        executor_input = pipeline_spec_pb2.ExecutorInput()
+        json_format.ParseDict(
+            {
+                'inputs': {},
+                'outputs': {
+                    'artifacts': {
+                        'dataset_out': {
+                            'artifacts': [{
+                                'name':
+                                    'dataset_out',
+                                'type': {
+                                    'schemaTitle': 'system.Dataset',
+                                    'schemaVersion': '0.0.1'
+                                },
+                                'uri':
+                                    'foo/multiple-io-2023-11-09-12-04-18-616263/multiple-io/dataset_out',
+                                'metadata': {}
+                            }]
+                        },
+                        'model_out': {
+                            'artifacts': [{
+                                'name':
+                                    'model_out',
+                                'type': {
+                                    'schemaTitle': 'system.Model',
+                                    'schemaVersion': '0.0.1'
+                                },
+                                'uri':
+                                    'foo/multiple-io-2023-11-09-12-04-18-616263/multiple-io/model_out',
+                                'metadata': {}
+                            }]
+                        }
+                    },
+                    'outputFile':
+                        'foo/multiple-io-2023-11-09-12-04-18-616263/multiple-io/executor_output.json'
+                }
+            }, executor_input)
+        executor_output = pipeline_spec_pb2.ExecutorOutput()
+        json_format.ParseDict(
+            {
+                'artifacts': {
+                    'dataset_out': {
+                        'artifacts': [{
+                            'name':
+                                'dataset_out',
+                            'uri':
+                                'foo/multiple-io-2023-11-09-12-04-18-616263/multiple-io/dataset_out',
+                            'metadata': {
+                                'foo': 'bar'
+                            }
+                        }]
+                    },
+                    'model_out': {
+                        'artifacts': [{
+                            'name':
+                                'model_out',
+                            'uri':
+                                'foo/multiple-io-2023-11-09-12-04-18-616263/multiple-io/model_out',
+                            'metadata': {
+                                'baz': 'bat'
+                            }
+                        }]
+                    }
+                }
+            }, executor_output)
+
+        expected = pipeline_spec_pb2.ExecutorOutput()
+        json_format.ParseDict(
+            {
+                'artifacts': {
+                    'dataset_out': {
+                        'artifacts': [{
+                            'name':
+                                'dataset_out',
+                            'uri':
+                                'foo/multiple-io-2023-11-09-12-04-18-616263/multiple-io/dataset_out',
+                            'metadata': {
+                                'foo': 'bar'
+                            },
+                            'type': {
+                                'schemaTitle': 'system.Dataset',
+                                'schemaVersion': '0.0.1'
+                            },
+                        }]
+                    },
+                    'model_out': {
+                        'artifacts': [{
+                            'name':
+                                'model_out',
+                            'uri':
+                                'foo/multiple-io-2023-11-09-12-04-18-616263/multiple-io/model_out',
+                            'metadata': {
+                                'baz': 'bat'
+                            },
+                            'type': {
+                                'schemaTitle': 'system.Model',
+                                'schemaVersion': '0.0.1'
+                            },
+                        }]
+                    }
+                }
+            }, expected)
+
+        actual = executor_output_utils.add_type_to_executor_output(
+            executor_input=executor_input,
+            executor_output=executor_output,
+        )
+        self.assertEqual(actual, expected)
+
+
+class TestSpecialDslOutputPathRead(parameterized.TestCase):
+
+    @parameterized.parameters([('foo', 'foo', True)])
+    def test(self, written_string, expected_object, is_string):
+        with tempfile.TemporaryDirectory() as tempdir:
+            output_file = os.path.join(tempdir, 'Output')
+            with open(output_file, 'w') as f:
+                f.write(written_string)
+
+            actual = executor_output_utils.special_dsl_outputpath_read(
+                output_file,
+                is_string=is_string,
+            )
+
+        self.assertEqual(actual, expected_object)
+
+
+def assert_artifacts_equal(
+    test_class: unittest.TestCase,
+    a1: dsl.Artifact,
+    a2: dsl.Artifact,
+) -> None:
+    test_class.assertEqual(a1.name, a2.name)
+    test_class.assertEqual(a1.uri, a2.uri)
+    test_class.assertEqual(a1.metadata, a2.metadata)
+    test_class.assertEqual(a1.schema_title, a2.schema_title)
+    test_class.assertEqual(a1.schema_version, a2.schema_version)
+    test_class.assertIsInstance(a1, type(a2))
+
+
+def assert_artifact_lists_equal(
+    test_class: unittest.TestCase,
+    l1: List[dsl.Artifact],
+    l2: List[dsl.Artifact],
+) -> None:
+    test_class.assertEqual(len(l1), len(l2))
+    for a1, a2 in zip(l1, l2):
+        assert_artifacts_equal(test_class, a1, a2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/python/kfp/local/placeholder_utils.py
+++ b/sdk/python/kfp/local/placeholder_utils.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Utilities for working with placeholders."""
+import json
 import random
-from typing import List
+from typing import Any, Dict, List
 
-from google.protobuf import json_format
 from kfp import dsl
-from kfp.pipeline_spec import pipeline_spec_pb2
 
 
 def make_random_id():
@@ -27,7 +26,7 @@ def make_random_id():
 
 def replace_placeholders(
     full_command: List[str],
-    executor_input: str,
+    executor_input_dict: Dict[str, Any],
     pipeline_resource_name: str,
     task_resource_name: str,
     pipeline_root: str,
@@ -38,7 +37,7 @@ def replace_placeholders(
     return [
         replace_placeholder_for_element(
             element=el,
-            executor_input=executor_input,
+            executor_input_dict=executor_input_dict,
             pipeline_resource_name=pipeline_resource_name,
             task_resource_name=task_resource_name,
             pipeline_root=pipeline_root,
@@ -50,7 +49,7 @@ def replace_placeholders(
 
 def replace_placeholder_for_element(
     element: str,
-    executor_input: pipeline_spec_pb2.ExecutorInput,
+    executor_input_dict: Dict[str, Any],
     pipeline_resource_name: str,
     task_resource_name: str,
     pipeline_root: str,
@@ -59,14 +58,22 @@ def replace_placeholder_for_element(
 ) -> str:
     """Replaces placeholders for a single element."""
     PLACEHOLDERS = {
-        r'{{$.outputs.output_file}}': executor_input.outputs.output_file,
-        r'{{$.outputMetadataUri}}': executor_input.outputs.output_file,
-        r'{{$}}': json_format.MessageToJson(executor_input),
-        dsl.PIPELINE_JOB_NAME_PLACEHOLDER: pipeline_resource_name,
-        dsl.PIPELINE_JOB_ID_PLACEHOLDER: pipeline_job_id,
-        dsl.PIPELINE_TASK_NAME_PLACEHOLDER: task_resource_name,
-        dsl.PIPELINE_TASK_ID_PLACEHOLDER: pipeline_task_id,
-        dsl.PIPELINE_ROOT_PLACEHOLDER: pipeline_root,
+        r'{{$.outputs.output_file}}':
+            executor_input_dict['outputs']['outputFile'],
+        r'{{$.outputMetadataUri}}':
+            executor_input_dict['outputs']['outputFile'],
+        r'{{$}}':
+            json.dumps(executor_input_dict),
+        dsl.PIPELINE_JOB_NAME_PLACEHOLDER:
+            pipeline_resource_name,
+        dsl.PIPELINE_JOB_ID_PLACEHOLDER:
+            pipeline_job_id,
+        dsl.PIPELINE_TASK_NAME_PLACEHOLDER:
+            task_resource_name,
+        dsl.PIPELINE_TASK_ID_PLACEHOLDER:
+            pipeline_task_id,
+        dsl.PIPELINE_ROOT_PLACEHOLDER:
+            pipeline_root,
     }
     for placeholder, value in PLACEHOLDERS.items():
         element = element.replace(placeholder, value)

--- a/sdk/python/kfp/local/subprocess_task_handler.py
+++ b/sdk/python/kfp/local/subprocess_task_handler.py
@@ -95,6 +95,9 @@ def run_local_subprocess(full_command: List[str]) -> int:
     with subprocess.Popen(
             full_command,
             stdout=subprocess.PIPE,
+            # no change to behavior in terminal for user,
+            # but allows more seamless capture/testing of subprocess logs
+            stderr=subprocess.STDOUT,
             text=True,
             # buffer line-by-line
             bufsize=1,

--- a/sdk/python/kfp/local/task_dispatcher.py
+++ b/sdk/python/kfp/local/task_dispatcher.py
@@ -17,6 +17,7 @@ from typing import Any, Dict
 from kfp import local
 from kfp.local import config
 from kfp.local import executor_input_utils
+from kfp.local import executor_output_utils
 from kfp.local import placeholder_utils
 from kfp.local import status
 from kfp.local import subprocess_task_handler
@@ -114,9 +115,10 @@ def _run_single_component_implementation(
     task_status = task_handler.run()
 
     if task_status == status.Status.SUCCESS:
-        # TODO: get outputs
-        # TODO: add tests for subprocess runner when outputs are collectable
-        outputs = {}
+        outputs = executor_output_utils.get_outputs_for_task(
+            executor_input=executor_input,
+            component_spec=component_spec,
+        )
 
     elif task_status == status.Status.FAILURE:
         msg = f'Local execution exited with status {task_status.name}.'

--- a/sdk/python/kfp/local/task_dispatcher.py
+++ b/sdk/python/kfp/local/task_dispatcher.py
@@ -89,9 +89,13 @@ def _run_single_component_implementation(
     image = container['image']
     # TODO: handler container component placeholders when
     # ContainerRunner is implemented
+    executor_input_dict = executor_input_utils.executor_input_to_dict(
+        executor_input=executor_input,
+        component_spec=component_spec,
+    )
     full_command = placeholder_utils.replace_placeholders(
         full_command=full_command,
-        executor_input=executor_input,
+        executor_input_dict=executor_input_dict,
         pipeline_resource_name=pipeline_resource_name,
         task_resource_name=task_resource_name,
         pipeline_root=pipeline_root,

--- a/sdk/python/kfp/local/testing_utilities.py
+++ b/sdk/python/kfp/local/testing_utilities.py
@@ -26,6 +26,7 @@ from unittest import mock
 
 from absl.testing import parameterized
 from google.protobuf import json_format
+from google.protobuf import message
 from kfp import components
 from kfp import dsl
 from kfp.local import config as local_config
@@ -77,6 +78,17 @@ class MockedDatetimeTestCase(unittest.TestCase):
             wraps=datetime.datetime(2023, 10, 10, 13, 32, 59, 420710))
         self.mock_datetime.now.return_value = mock_now
         mock_now.strftime.return_value = '2023-10-10-13-32-59-420710'
+
+
+def write_proto_to_json_file(
+    proto_message: message.Message,
+    file_path: str,
+) -> None:
+    """Writes proto_message to file_path as JSON."""
+    json_string = json_format.MessageToJson(proto_message)
+
+    with open(file_path, 'w') as json_file:
+        json_file.write(json_string)
 
 
 def compile_and_load_component(


### PR DESCRIPTION
**Description of your changes:**
Adds the code that collects and surfaces the outputs from locally executed tasks on the `task.output` and `task.outputs['<key>']`.

This constitutes E2E local execution for the subprocess task handler. For this reason, we also now include E2E tests.

Forthcoming PRs will add the container task handler, logging, and a few more changes.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
