### PR TITLE
chore(sdk): write local execution logs to stdout #localexecution

### DIFF
--- a/sdk/python/kfp/local/logging_utils.py
+++ b/sdk/python/kfp/local/logging_utils.py
@@ -16,6 +16,7 @@ import builtins
 import contextlib
 import datetime
 import logging
+import sys
 from typing import Any, Dict, Generator, List
 
 from kfp import dsl
@@ -52,7 +53,11 @@ def local_logger_context() -> Generator[None, None, None]:
         fmt='%(asctime)s - %(levelname)s - %(message)s',
         datefmt='%H:%M:%S.%f',
     )
-    handler = logging.StreamHandler()
+    # use sys.stdout so that both inner process and outer process logs
+    # go to stdout
+    # this is needed for logs to present sequentially in a colab notebook,
+    # since stderr will print above stdout
+    handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(formatter)
     logger.handlers.clear()
     logger.addHandler(handler)


### PR DESCRIPTION
**Description of your changes:**
In a notebook, `stderr` prints above `stdout`. For the logs to present sequentially and interleave correctly in a notebook, they must both write to the same place. We choose to write to `stdout`, consistent with `print`.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
