### PR TITLE
feat(sdk): support local Container Component execution #localexecution

### DIFF
--- a/sdk/python/kfp/local/executor_output_utils.py
+++ b/sdk/python/kfp/local/executor_output_utils.py
@@ -28,6 +28,10 @@ def load_executor_output(
         executor_output_path: str) -> pipeline_spec_pb2.ExecutorOutput:
     """Loads the ExecutorOutput message from a path."""
     executor_output = pipeline_spec_pb2.ExecutorOutput()
+
+    if not os.path.isfile(executor_output_path):
+        return executor_output
+
     with open(executor_output_path) as f:
         json_format.Parse(f.read(), executor_output)
     return executor_output

--- a/sdk/python/kfp/local/executor_output_utils_test.py
+++ b/sdk/python/kfp/local/executor_output_utils_test.py
@@ -152,19 +152,23 @@ class TestLoadExecutorOutput(unittest.TestCase):
             path = os.path.join(tempdir, 'executor_output.json')
             testing_utilities.write_proto_to_json_file(executor_output, path)
 
-            result = executor_output_utils.load_executor_output(path)
-            self.assertIsInstance(result, pipeline_spec_pb2.ExecutorOutput)
+            actual = executor_output_utils.load_executor_output(path)
+            expected = pipeline_spec_pb2.ExecutorOutput()
+            expected.parameter_values['foo'].CopyFrom(
+                struct_pb2.Value(string_value='foo_value'))
             self.assertEqual(
-                result.parameter_values['foo'],
-                struct_pb2.Value(string_value='foo_value'),
+                actual.SerializeToString(deterministic=True),
+                expected.SerializeToString(deterministic=True),
             )
 
     def test_not_exists(self):
         non_existent_path = 'non_existent_path.json'
-
-        with self.assertRaisesRegex(FileNotFoundError,
-                                    r'No such file or directory:'):
-            executor_output_utils.load_executor_output(non_existent_path)
+        actual = executor_output_utils.load_executor_output(non_existent_path)
+        expected = pipeline_spec_pb2.ExecutorOutput()
+        self.assertEqual(
+            actual.SerializeToString(deterministic=True),
+            expected.SerializeToString(deterministic=True),
+        )
 
 
 class TestGetOutputsFromExecutorOutput(unittest.TestCase):

--- a/sdk/python/kfp/local/placeholder_utils_test.py
+++ b/sdk/python/kfp/local/placeholder_utils_test.py
@@ -94,6 +94,9 @@ class TestReplacePlaceholders(unittest.TestCase):
 
 class TestReplacePlaceholderForElement(parameterized.TestCase):
 
+    # TODO: consider supporting JSON escape
+    # TODO: update when input artifact constants supported
+    # TODO: update when output lists of artifacts are supported
     @parameterized.parameters([
         (
             '{{$}}',
@@ -173,60 +176,15 @@ class TestReplacePlaceholderForElement(parameterized.TestCase):
             json.dumps(False),
         ),
         (
+            "{{$.outputs.artifacts[''out_a''].metadata}}",
+            json.dumps({'foo': {
+                'bar': 'baz'
+            }}),
+        ),
+        (
             "{{$.outputs.parameters[''Output''].output_file}}",
             '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/comp/Output',
         ),
-        # (
-        #     "{{$.inputs.parameters['$0'].json_escape[0]}}",
-        #     '',
-        # ),
-        # (
-        #     "{{$.inputs.parameters['$0'].json_escape[1]}}",
-        #     '',
-        # ),
-        # TODO: add input lists of artifacts when supported
-        # (
-        #     "{{$.inputs.artifacts['foo']}}",
-        #     '',
-        # ),
-        # TODO: add input artifact constants when supported
-        # (
-        #     "{{$.inputs.artifacts['foo'].uri}}",
-        #     '',
-        # ),
-        # (
-        #     "{{$.inputs.artifacts['foo'].path}}",
-        #     '',
-        # ),
-        # (
-        #     "{{$.inputs.artifacts['foo'].value}}",
-        #     '',
-        # ),
-        # (
-        #     "{{$.inputs.artifacts['foo'].metadata}}",
-        #     '',
-        # ),
-        # (
-        #     "{{$.inputs.artifacts['foo'].metadata.json_escape[1]}}",
-        #     '',
-        # ),
-        # (
-        #     "{{$.inputs.artifacts['foo'].metadata['$1'].json_escape[0]}}",
-        #     '',
-        # ),
-        # (
-        #     "{{$.inputs.artifacts['foo'].metadata['$1'].json_escape[1]}}",
-        #     '',
-        # ),
-        # (
-        #     "{{$.inputs.artifacts[foo].metadata['$1']}}",
-        #     '',
-        # ),
-        # TODO: add output lists of artifacts when supported
-        # (
-        #     "{{$.outputs.artifacts[''out_a'']}}",
-        #     '',
-        # ),
         (
             "{{$.outputs.artifacts[''out_a''].uri}}",
             '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/comp/out_a',
@@ -235,25 +193,6 @@ class TestReplacePlaceholderForElement(parameterized.TestCase):
             "{{$.outputs.artifacts[''out_a''].path}}",
             '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/comp/out_a',
         ),
-        (
-            "{{$.outputs.artifacts[''out_a''].metadata}}",
-            json.dumps({'foo': {
-                'bar': 'baz'
-            }}),
-        ),
-        # TODO: consider supporting JSON escape
-        # (
-        #     "{{$.outputs.artifacts[''out_a''].metadata.json_escape[1]}}",
-        #     '',
-        # ),
-        # (
-        #     "{{$.outputs.artifacts[''out_a''].metadata[''foo''].json_escape[0]}}",
-        #     '',
-        # ),
-        # (
-        #     "{{$.outputs.artifacts[''out_a''].metadata[''foo''].json_escape[1]}}",
-        #     '',
-        # ),
         (
             "{{$.outputs.artifacts[''out_a''].metadata[''foo'']}}",
             json.dumps({'bar': 'baz'}),

--- a/sdk/python/kfp/local/placeholder_utils_test.py
+++ b/sdk/python/kfp/local/placeholder_utils_test.py
@@ -26,7 +26,10 @@ json_format.ParseDict(
     {
         'inputs': {
             'parameterValues': {
-                'boolean': False
+                'boolean': False,
+                'dictionary': {
+                    'foo': 'bar'
+                },
             }
         },
         'outputs': {
@@ -47,7 +50,11 @@ json_format.ParseDict(
                         },
                         'uri':
                             '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/comp/out_a',
-                        'metadata': {}
+                        'metadata': {
+                            'foo': {
+                                'bar': 'baz'
+                            }
+                        }
                     }]
                 }
             },
@@ -121,7 +128,7 @@ class TestReplacePlaceholderForElement(parameterized.TestCase):
             '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710',
         ),
     ])
-    def test(self, element: str, expected: str):
+    def test_constant_placeholders(self, element: str, expected: str):
         actual = placeholder_utils.replace_placeholder_for_element(
             element=element,
             executor_input_dict=EXECUTOR_INPUT_DICT,
@@ -159,6 +166,167 @@ class TestReplacePlaceholderForElement(parameterized.TestCase):
             pipeline_task_id='987654321',
         )
         self.assertEqual(actual, expected)
+
+    @parameterized.parameters([
+        (
+            "{{$.inputs.parameters[''boolean'']}}",
+            json.dumps(False),
+        ),
+        (
+            "{{$.outputs.parameters[''Output''].output_file}}",
+            '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/comp/Output',
+        ),
+        # (
+        #     "{{$.inputs.parameters['$0'].json_escape[0]}}",
+        #     '',
+        # ),
+        # (
+        #     "{{$.inputs.parameters['$0'].json_escape[1]}}",
+        #     '',
+        # ),
+        # TODO: add input lists of artifacts when supported
+        # (
+        #     "{{$.inputs.artifacts['foo']}}",
+        #     '',
+        # ),
+        # TODO: add input artifact constants when supported
+        # (
+        #     "{{$.inputs.artifacts['foo'].uri}}",
+        #     '',
+        # ),
+        # (
+        #     "{{$.inputs.artifacts['foo'].path}}",
+        #     '',
+        # ),
+        # (
+        #     "{{$.inputs.artifacts['foo'].value}}",
+        #     '',
+        # ),
+        # (
+        #     "{{$.inputs.artifacts['foo'].metadata}}",
+        #     '',
+        # ),
+        # (
+        #     "{{$.inputs.artifacts['foo'].metadata.json_escape[1]}}",
+        #     '',
+        # ),
+        # (
+        #     "{{$.inputs.artifacts['foo'].metadata['$1'].json_escape[0]}}",
+        #     '',
+        # ),
+        # (
+        #     "{{$.inputs.artifacts['foo'].metadata['$1'].json_escape[1]}}",
+        #     '',
+        # ),
+        # (
+        #     "{{$.inputs.artifacts[foo].metadata['$1']}}",
+        #     '',
+        # ),
+        # TODO: add output lists of artifacts when supported
+        # (
+        #     "{{$.outputs.artifacts[''out_a'']}}",
+        #     '',
+        # ),
+        (
+            "{{$.outputs.artifacts[''out_a''].uri}}",
+            '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/comp/out_a',
+        ),
+        (
+            "{{$.outputs.artifacts[''out_a''].path}}",
+            '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/comp/out_a',
+        ),
+        (
+            "{{$.outputs.artifacts[''out_a''].metadata}}",
+            json.dumps({'foo': {
+                'bar': 'baz'
+            }}),
+        ),
+        # TODO: consider supporting JSON escape
+        # (
+        #     "{{$.outputs.artifacts[''out_a''].metadata.json_escape[1]}}",
+        #     '',
+        # ),
+        # (
+        #     "{{$.outputs.artifacts[''out_a''].metadata[''foo''].json_escape[0]}}",
+        #     '',
+        # ),
+        # (
+        #     "{{$.outputs.artifacts[''out_a''].metadata[''foo''].json_escape[1]}}",
+        #     '',
+        # ),
+        (
+            "{{$.outputs.artifacts[''out_a''].metadata[''foo'']}}",
+            json.dumps({'bar': 'baz'}),
+        ),
+    ])
+    def test_io_placeholders(self, element: str, expected: str):
+        actual = placeholder_utils.replace_placeholder_for_element(
+            element=element,
+            executor_input_dict=EXECUTOR_INPUT_DICT,
+            pipeline_resource_name='my-pipeline-2023-10-10-13-32-59-420710',
+            task_resource_name='comp',
+            pipeline_root='/foo/bar/my-pipeline-2023-10-10-13-32-59-420710',
+            pipeline_job_id='123456789',
+            pipeline_task_id='987654321',
+        )
+        self.assertEqual(actual, expected)
+
+    @parameterized.parameters([
+        (
+            "my-prefix-{{$.inputs.parameters[''boolean'']}}-suffix",
+            'my-prefix-false-suffix',
+        ),
+        (
+            "prefix{{$.outputs.parameters[''Output''].output_file}}/suffix",
+            'prefix/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/comp/Output/suffix',
+        ),
+        (
+            "prefix{{$.inputs.parameters[''dictionary'']}}suffix",
+            'prefix{"foo": "bar"}suffix',
+        ),
+    ])
+    def test_io_placeholder_with_string_concat(self, element: str,
+                                               expected: str):
+        actual = placeholder_utils.replace_placeholder_for_element(
+            element=element,
+            executor_input_dict=EXECUTOR_INPUT_DICT,
+            pipeline_resource_name='my-pipeline-2023-10-10-13-32-59-420710',
+            task_resource_name='comp',
+            pipeline_root='/foo/bar/my-pipeline-2023-10-10-13-32-59-420710',
+            pipeline_job_id='123456789',
+            pipeline_task_id='987654321',
+        )
+        self.assertEqual(actual, expected)
+
+
+class TestGetValueUsingPath(unittest.TestCase):
+
+    def test_valid_path(self):
+        actual = placeholder_utils.get_value_using_path(
+            {'a': {
+                'b': {
+                    'c': 10
+                }
+            }},
+            ['a', 'b', 'c'],
+        )
+        expected = 10
+        self.assertEqual(actual, expected)
+
+    def test_invalid_path(self):
+        actual = placeholder_utils.get_value_using_path(
+            {'a': {
+                'b': {
+                    'c': 10
+                }
+            }},
+            ['a', 'x'],
+        )
+        self.assertIsNone(actual)
+
+    def test_empty_path(self):
+        with self.assertRaisesRegex(ValueError, r'path cannot be empty\.'):
+            placeholder_utils.get_value_using_path({'a': 20}, [])
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/local/subprocess_task_handler.py
+++ b/sdk/python/kfp/local/subprocess_task_handler.py
@@ -64,8 +64,7 @@ class SubprocessTaskHandler(task_handler_interface.ITaskHandler):
     def validate_image(self, image: str) -> None:
         if 'python' not in image:
             warnings.warn(
-                f"You may be attemping to run a task that uses custom or non-Python base image '{image}' in a Python environment. This may result in incorrect dependencies and/or incorrect behavior.",
-                # TODO: suggest using container runner
+                f"You may be attemping to run a task that uses custom or non-Python base image '{image}' in a Python environment. This may result in incorrect dependencies and/or incorrect behavior. Consider using the 'DockerRunner' to run this task in a container.",
                 RuntimeWarning,
             )
 

--- a/sdk/python/kfp/local/task_dispatcher.py
+++ b/sdk/python/kfp/local/task_dispatcher.py
@@ -86,12 +86,12 @@ def _run_single_component_implementation(
         component_spec.executor_label]
 
     container = executor_spec['container']
-    full_command = list(container['command']) + list(container['args'])
-
-    # image + full_command are "inputs" to local execution
     image = container['image']
-    # TODO: handler container component placeholders when
-    # ContainerRunner is implemented
+
+    command = list(container['command']) if 'command' in container else []
+    args = list(container['args']) if 'args' in container else []
+    full_command = command + args
+
     executor_input_dict = executor_input_utils.executor_input_to_dict(
         executor_input=executor_input,
         component_spec=component_spec,


### PR DESCRIPTION
**Description of your changes:**
Adds support for locally running Container Components using the local `DockerRunner`. The primary changes are to add support for most Container Components placeholder types.

Also:
- Removes the artificial blocker on Container Component execution in the `DockerRunner`'s task handler
- Fixes case where empty commands or args will throw an error
- Corrects erroneous the image pull logic, which previously attempted to pull even when local image was found
- Permits the case when `executor_output.json` is not written, which is typical for Container Components

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
