### PR TITLE
test(sdk): add more `DockerRunner` tests #localexecution

### DIFF
--- a/sdk/python/kfp/local/executor_output_utils.py
+++ b/sdk/python/kfp/local/executor_output_utils.py
@@ -129,7 +129,7 @@ def special_dsl_outputpath_read(
         return value
     except Exception as e:
         raise ValueError(
-            f'Could not deserialize output {parameter_name!r} from path {output_file}'
+            f'Could not deserialize output {parameter_name!r} with value {value!r} from path {output_file}'
         ) from e
 
 


### PR DESCRIPTION
**Description of your changes:**
Improves `DockerRunner` tests by testing component types that use more placeholders. The resulting commands + args, with interpolated placeholders, were verified to run successfully on Vertex Pipelines.

Also cleans up unused/unnecessary code.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
