### PR TITLE
fix(sdk): permit empty local execution outputs #localexecution

### DIFF
--- a/sdk/python/kfp/local/executor_output_utils.py
+++ b/sdk/python/kfp/local/executor_output_utils.py
@@ -49,15 +49,17 @@ def cast_protobuf_numbers(
     struct_pb2.Value to a dict/json, int will be upcast to float, even
     if the component output specifies int.
     """
-    output_parameter_types = [
+    int_output_keys = [
         output_param_name
         for output_param_name, parameter_spec in output_parameter_types.items()
         if parameter_spec.parameter_type ==
         pipeline_spec_pb2.ParameterType.ParameterTypeEnum.NUMBER_INTEGER
     ]
-    for float_output_key in output_parameter_types:
-        output_parameters[float_output_key] = int(
-            output_parameters[float_output_key])
+    for int_output_key in int_output_keys:
+        # avoid KeyError when the user never writes to the dsl.OutputPath
+        if int_output_key in output_parameters:
+            output_parameters[int_output_key] = int(
+                output_parameters[int_output_key])
     return output_parameters
 
 

--- a/sdk/python/kfp/local/subprocess_task_handler_test.py
+++ b/sdk/python/kfp/local/subprocess_task_handler_test.py
@@ -404,6 +404,19 @@ class TestLightweightPythonComponentLogic(
         self.assertEqual(task.outputs['out_param'], 'HelloHello')
         self.assertEqual(task.outputs['Output'], 1)
 
+    def test_outputpath_result_not_written(self):
+        local.init(runner=local.SubprocessRunner(use_venv=True))
+
+        # use dsl.OutputPath(int) for more thorough testing
+        # want to ensure that the code that converts protobuf number to
+        # Python int permits unwritten outputs
+        @dsl.component
+        def my_comp(out_param: dsl.OutputPath(int)):
+            pass
+
+        task = my_comp()
+        self.assertEmpty(task.outputs)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of your changes:**
It should be permitted for a user to specify a `dsl.OutputPath` to which the output is not written. This PR fixes a key error when this is the case.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
