### PR TITLE
feat(sdk): support local pipeline execution

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -1,6 +1,7 @@
 # Current Version (in development)
 
 ## Features
+* Support local execution of sequential pipelines [\#10423](https://github.com/kubeflow/pipelines/pull/10423)
 
 ## Breaking changes
 

--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -28,6 +28,7 @@ from kfp.dsl import placeholders
 from kfp.dsl import structures
 from kfp.dsl import utils
 from kfp.dsl.types import type_utils
+from kfp.local import pipeline_orchestrator
 from kfp.pipeline_spec import pipeline_spec_pb2
 
 _register_task_handler = lambda task: utils.maybe_rename_for_k8s(
@@ -190,13 +191,20 @@ class PipelineTask:
         from kfp.local import task_dispatcher
 
         if self.pipeline_spec is not None:
-            raise NotImplementedError(
-                'Local pipeline execution is not currently supported.')
-
-        self._outputs = task_dispatcher.run_single_task(
-            pipeline_spec=self.component_spec.to_pipeline_spec(),
-            arguments=args,
-        )
+            self._outputs = pipeline_orchestrator.run_local_pipeline(
+                pipeline_spec=self.pipeline_spec,
+                arguments=args,
+            )
+        elif self.component_spec is not None:
+            self._outputs = task_dispatcher.run_single_task(
+                pipeline_spec=self.component_spec.to_pipeline_spec(),
+                arguments=args,
+            )
+        else:
+            # user should never hit this
+            raise ValueError(
+                'One of pipeline_spec or component_spec must not be None for local execution.'
+            )
         self.state = TaskState.FINAL
 
     @property

--- a/sdk/python/kfp/dsl/types/type_utils.py
+++ b/sdk/python/kfp/dsl/types/type_utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Utilities for component I/O type mapping."""
 
-from distutils import util
 import inspect
 import json
 from typing import Any, Callable, Dict, Optional, Type, Union
@@ -71,9 +70,27 @@ PARAMETER_TYPES_MAPPING = {
 }
 
 
+# copied from distutils.util, which was removed in Python 3.12
+# https://github.com/pypa/distutils/blob/fb5c5704962cd3f40c69955437da9a88f4b28567/distutils/util.py#L340-L353
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError('invalid truth value %r' % (val,))
+
+
 def bool_cast_fn(default: Union[str, bool]) -> bool:
     if isinstance(default, str):
-        default = util.strtobool(default) == 1
+        default = strtobool(default) == 1
     return default
 
 

--- a/sdk/python/kfp/local/dag_orchestrator.py
+++ b/sdk/python/kfp/local/dag_orchestrator.py
@@ -1,0 +1,316 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Code for locally executing a DAG within a pipeline."""
+from typing import Any, Dict, Optional, Tuple
+
+from kfp.local import config
+from kfp.local import graph_utils
+from kfp.local import io
+from kfp.local import status
+from kfp.pipeline_spec import pipeline_spec_pb2
+
+
+def run_dag(
+    pipeline_resource_name: str,
+    dag_component_spec: pipeline_spec_pb2.ComponentSpec,
+    executors: Dict[str,
+                    pipeline_spec_pb2.PipelineDeploymentConfig.ExecutorSpec],
+    components: Dict[str, pipeline_spec_pb2.ComponentSpec],
+    dag_arguments: Dict[str, Any],
+    io_store: io.IOStore,
+    pipeline_root: str,
+    runner: config.LocalRunnerType,
+    unique_pipeline_id: str,
+) -> Tuple[status.Status, Optional[str]]:
+    """Runs a DAGSpec.
+
+    Args:
+        pipeline_resource_name: The root pipeline resource name.
+        dag_component_spec: The ComponentSpec which defines the DAG to execute.
+        executors: The ExecutorSpecs corresponding to the DAG.
+        components: The ComponentSpecs corresponding to the DAG.
+        dag_arguments: The arguments to the DAG's outer ComponentSpec.
+        io_store: The IOStore instance corresponding to this DAG.
+        pipeline_root: The local pipeline root.
+        runner: The user-specified local runner.
+        unique_pipeline_id: A unique identifier for the pipeline for placeholder resolution.
+
+    Returns:
+        If DAG succeeds, a two-tuple of: (Status.SUCCESS, None).
+        If DAG fails, a two-tuple of: (Status.FAILURE, '<task-that-failed>').
+    """
+    from kfp.local import task_dispatcher
+
+    # prepare IOStore for DAG
+    dag_arguments_with_defaults = bind_defaults_to_dag_arguments(
+        dag_arguments=dag_arguments,
+        dag_inputs_spec=dag_component_spec.input_definitions,
+    )
+    for k, v in dag_arguments_with_defaults.items():
+        io_store.put_parent_input(k, v)
+
+    # execute tasks in order
+    dag_spec = dag_component_spec.dag
+    sorted_tasks = graph_utils.topological_sort_tasks(dag_spec.tasks)
+    while sorted_tasks:
+        task_name = sorted_tasks.pop()
+        component_name = dag_spec.tasks[task_name].component_ref.name
+        component_spec = components[component_name]
+        implementation = component_spec.WhichOneof('implementation')
+        # TODO: support pipeline-in-pipeline + control flow features
+        if implementation == 'dag':
+            raise ValueError(
+                'Control flow features and pipelines in pipelines are not yet supported by local pipeline execution.'
+            )
+        elif implementation != 'executor_label':
+            raise ValueError(
+                f'Got unknown component implementation: {implementation}')
+
+        executor_spec = executors[component_spec.executor_label]
+        validate_executor(executor_spec)
+        task_arguments = make_task_arguments(
+            task_inputs_spec=dag_spec.tasks[task_name].inputs,
+            io_store=io_store,
+        )
+
+        outputs, task_status = task_dispatcher._run_single_task_implementation(
+            pipeline_resource_name=pipeline_resource_name,
+            component_name=component_name,
+            component_spec=component_spec,
+            executor_spec=executor_spec,
+            arguments=task_arguments,
+            pipeline_root=pipeline_root,
+            runner=runner,
+            # let the outer pipeline raise the error
+            raise_on_error=False,
+            # components may consume input artifacts when passed from upstream
+            # outputs or parent component inputs
+            block_input_artifact=False,
+            # provide the same unique job id for each task for
+            # consistent placeholder resolution
+            unique_pipeline_id=unique_pipeline_id,
+        )
+
+        if task_status == status.Status.FAILURE:
+            return status.Status.FAILURE, task_name
+        elif task_status == status.Status.SUCCESS:
+            # update IO store when a task succeeds
+            for key, output in outputs.items():
+                io_store.put_task_output(
+                    task_name,
+                    key,
+                    output,
+                )
+        else:
+            raise ValueError(f'Got unknown task status: {task_status.name}')
+
+    return status.Status.SUCCESS, None
+
+
+def bind_defaults_to_dag_arguments(
+    dag_arguments: Dict[str, Any],
+    dag_inputs_spec: pipeline_spec_pb2.ComponentInputsSpec,
+) -> Dict[str, Any]:
+    """For each required argument in dag_arguments which is missing, adds the
+    default argument.
+
+    Args:
+        dag_arguments: The user-provided arguments to the DAG.
+        dag_inputs_spec: The ComponentInputSpec for the DAG.
+
+    Returns:
+        The complete DAG inputs, with defaults included where the user-provided argument is missing.
+    """
+    from kfp.local import executor_output_utils
+
+    dag_arguments_with_defaults = {}
+    for input_name, input_spec in dag_inputs_spec.parameters.items():
+        if input_name not in dag_arguments:
+            dag_arguments_with_defaults[
+                input_name] = executor_output_utils.pb2_value_to_python(
+                    input_spec.default_value)
+        else:
+            dag_arguments_with_defaults[input_name] = dag_arguments[input_name]
+    return dag_arguments_with_defaults
+
+
+def make_task_arguments(
+    task_inputs_spec: pipeline_spec_pb2.TaskInputsSpec,
+    io_store: io.IOStore,
+) -> Dict[str, Any]:
+    """Obtains a dictionary of arguments required to execute the task
+    corresponding to TaskInputsSpec.
+
+    Args:
+        task_inputs_spec: The TaskInputsSpec for the task.
+        io_store: The IOStore of the current DAG. Used to obtain task arguments which come from upstream task outputs and parent component inputs.
+
+    Returns:
+        The arguments for the task.
+    """
+    from kfp.local import executor_output_utils
+
+    task_arguments = {}
+    # handle parameters
+    for input_name, input_spec in task_inputs_spec.parameters.items():
+
+        # handle constants
+        if input_spec.HasField('runtime_value'):
+            # runtime_value's value should always be constant for the v2 compiler
+            if input_spec.runtime_value.WhichOneof('value') != 'constant':
+                raise ValueError('Expected constant.')
+            task_arguments[
+                input_name] = executor_output_utils.pb2_value_to_python(
+                    input_spec.runtime_value.constant)
+
+        # handle upstream outputs
+        elif input_spec.HasField('task_output_parameter'):
+            task_arguments[input_name] = io_store.get_task_output(
+                input_spec.task_output_parameter.producer_task,
+                input_spec.task_output_parameter.output_parameter_key,
+            )
+
+        # handle parent pipeline input parameters
+        elif input_spec.HasField('component_input_parameter'):
+            task_arguments[input_name] = io_store.get_parent_input(
+                input_spec.component_input_parameter)
+
+        # TODO: support dsl.ExitHandler
+        elif input_spec.HasField('task_final_status'):
+            raise ValueError(
+                "'dsl.ExitHandler' is not yet support for local execution.")
+
+        else:
+            raise ValueError(f'Missing input for parameter {input_name}.')
+
+    # handle artifacts
+    for input_name, input_spec in task_inputs_spec.artifacts.items():
+        if input_spec.HasField('task_output_artifact'):
+            task_arguments[input_name] = io_store.get_task_output(
+                input_spec.task_output_artifact.producer_task,
+                input_spec.task_output_artifact.output_artifact_key,
+            )
+        elif input_spec.HasField('component_input_artifact'):
+            task_arguments[input_name] = io_store.get_parent_input(
+                input_spec.component_input_artifact)
+        else:
+            raise ValueError(f'Missing input for artifact {input_name}.')
+
+    return task_arguments
+
+
+def validate_executor(
+        executor: pipeline_spec_pb2.PipelineDeploymentConfig.ExecutorSpec
+) -> None:
+    """Validates that an ExecutorSpec is a supported executor for local
+    execution.
+
+    Args:
+        executor: The ExecutorSpec to validate.
+    """
+    if executor.WhichOneof('spec') == 'importer':
+        raise ValueError(
+            "Importer is not yet supported by local pipeline execution. Found 'dsl.importer' task in pipeline."
+        )
+    elif executor.WhichOneof('spec') != 'container':
+        raise ValueError(
+            'Got unknown spec in ExecutorSpec. Only dsl.component and dsl.container_component are supported in local pipeline execution.'
+        )
+
+
+def get_dag_output_parameters(
+    dag_outputs_spec: pipeline_spec_pb2.DagOutputsSpec,
+    io_store: io.IOStore,
+) -> Dict[str, Any]:
+    """Gets the DAG output parameter values from a DagOutputsSpec and the DAG's
+    IOStore.
+
+    Args:
+        dag_outputs_spec: DagOutputsSpec corresponding to the DAG.
+        io_store: IOStore corresponding to the DAG.
+
+    Returns:
+        The DAG output parameters.
+    """
+    outputs = {}
+    for root_output_key, parameter_selector_spec in dag_outputs_spec.parameters.items(
+    ):
+        kind = parameter_selector_spec.WhichOneof('kind')
+        if kind == 'value_from_parameter':
+            value_from_parameter = parameter_selector_spec.value_from_parameter
+            outputs[root_output_key] = io_store.get_task_output(
+                value_from_parameter.producer_subtask,
+                value_from_parameter.output_parameter_key,
+            )
+        elif kind == 'value_from_oneof':
+            raise ValueError(
+                "'dsl.OneOf' is not yet supported in local execution.")
+        else:
+            raise ValueError(
+                f"Got unknown 'parameter_selector_spec' kind: {kind}")
+    return outputs
+
+
+def get_dag_output_artifacts(
+    dag_outputs_spec: pipeline_spec_pb2.DagOutputsSpec,
+    io_store: io.IOStore,
+) -> Dict[str, Any]:
+    """Gets the DAG output artifact values from a DagOutputsSpec and the DAG's
+    IOStore.
+
+    Args:
+        dag_outputs_spec: DagOutputsSpec corresponding to the DAG.
+        io_store: IOStore corresponding to the DAG.
+
+    Returns:
+        The DAG output artifacts.
+    """
+    outputs = {}
+    for root_output_key, artifact_selector_spec in dag_outputs_spec.artifacts.items(
+    ):
+        len_artifact_selectors = len(artifact_selector_spec.artifact_selectors)
+        if len_artifact_selectors != 1:
+            raise ValueError(
+                f'Expected 1 artifact in ArtifactSelectorSpec. Got: {len_artifact_selectors}'
+            )
+        artifact_selector = artifact_selector_spec.artifact_selectors[0]
+        outputs[root_output_key] = io_store.get_task_output(
+            artifact_selector.producer_subtask,
+            artifact_selector.output_artifact_key,
+        )
+    return outputs
+
+
+def get_dag_outputs(
+    dag_outputs_spec: pipeline_spec_pb2.DagOutputsSpec,
+    io_store: io.IOStore,
+) -> Dict[str, Any]:
+    """Gets the DAG output values from a DagOutputsSpec and the DAG's IOStore.
+
+    Args:
+        dag_outputs_spec: DagOutputsSpec corresponding to the DAG.
+        io_store: IOStore corresponding to the DAG.
+
+    Returns:
+        The DAG outputs.
+    """
+    output_params = get_dag_output_parameters(
+        dag_outputs_spec=dag_outputs_spec,
+        io_store=io_store,
+    )
+    output_artifacts = get_dag_output_artifacts(
+        dag_outputs_spec=dag_outputs_spec,
+        io_store=io_store,
+    )
+    return {**output_params, **output_artifacts}

--- a/sdk/python/kfp/local/executor_input_utils.py
+++ b/sdk/python/kfp/local/executor_input_utils.py
@@ -18,6 +18,7 @@ from typing import Any, Dict
 
 from google.protobuf import json_format
 from google.protobuf import struct_pb2
+from kfp import dsl
 from kfp.compiler import pipeline_spec_builder
 from kfp.dsl import utils
 from kfp.pipeline_spec import pipeline_spec_pb2
@@ -29,19 +30,16 @@ def construct_executor_input(
     component_spec: pipeline_spec_pb2.ComponentSpec,
     arguments: Dict[str, Any],
     task_root: str,
+    block_input_artifact: bool,
 ) -> pipeline_spec_pb2.ExecutorInput:
     """Constructs the executor input message for a task execution."""
     input_parameter_keys = list(
         component_spec.input_definitions.parameters.keys())
     input_artifact_keys = list(
         component_spec.input_definitions.artifacts.keys())
-    if input_artifact_keys:
+    if input_artifact_keys and block_input_artifact:
         raise ValueError(
             'Input artifacts are not yet supported for local execution.')
-
-    output_parameter_keys = list(
-        component_spec.output_definitions.parameters.keys())
-    output_artifact_specs_dict = component_spec.output_definitions.artifacts
 
     inputs = pipeline_spec_pb2.ExecutorInput.Inputs(
         parameter_values={
@@ -51,9 +49,18 @@ def construct_executor_input(
             .parameters[param_name].default_value
             for param_name in input_parameter_keys
         },
-        # input artifact constants are not supported yet
-        artifacts={},
+        # input artifact constants are not supported yet,
+        # except when passed from an upstream output or parent component input
+        artifacts={
+            artifact_name:
+            dsl_artifact_to_artifact_list(arguments[artifact_name])
+            for artifact_name, _ in
+            component_spec.input_definitions.artifacts.items()
+        },
     )
+
+    output_parameter_keys = list(
+        component_spec.output_definitions.parameters.keys())
     outputs = pipeline_spec_pb2.ExecutorInput.Outputs(
         parameters={
             param_name: pipeline_spec_pb2.ExecutorInput.OutputParameter(
@@ -66,7 +73,7 @@ def construct_executor_input(
                 artifact_type=artifact_spec.artifact_type,
                 task_root=task_root,
             ) for artifact_name, artifact_spec in
-            output_artifact_specs_dict.items()
+            component_spec.output_definitions.artifacts.items()
         },
         output_file=os.path.join(task_root, _EXECUTOR_OUTPUT_FILE),
     )
@@ -130,6 +137,28 @@ def artifact_type_schema_to_artifact_list(
             uri=os.path.join(task_root, name),
             # metadata always starts empty for output artifacts
             metadata=struct_pb2.Struct(),
+        )
+    ])
+
+
+def dict_to_protobuf_struct(d: Dict[str, Any]) -> struct_pb2.Struct:
+    """Converts a Python dictionary to a prototobuf Struct."""
+    protobuf_struct = struct_pb2.Struct()
+    protobuf_struct.update(d)
+    return protobuf_struct
+
+
+def dsl_artifact_to_artifact_list(
+        artifact: dsl.Artifact) -> pipeline_spec_pb2.ArtifactList:
+    """Converts a single dsl.Aritfact to a protobuf ArtifactList."""
+    return pipeline_spec_pb2.ArtifactList(artifacts=[
+        pipeline_spec_pb2.RuntimeArtifact(
+            name=artifact.name,
+            type=pipeline_spec_pb2.ArtifactTypeSchema(
+                schema_title=artifact.schema_title,
+                schema_version=artifact.schema_version),
+            uri=artifact.uri,
+            metadata=dict_to_protobuf_struct(artifact.metadata),
         )
     ])
 

--- a/sdk/python/kfp/local/executor_input_utils_test.py
+++ b/sdk/python/kfp/local/executor_input_utils_test.py
@@ -16,6 +16,7 @@
 import unittest
 
 from google.protobuf import json_format
+from kfp import dsl
 from kfp.local import executor_input_utils
 from kfp.local import testing_utilities
 from kfp.pipeline_spec import pipeline_spec_pb2
@@ -76,6 +77,7 @@ class TestConstructExecutorInput(unittest.TestCase):
             component_spec=component_spec,
             arguments=arguments,
             task_root=task_root,
+            block_input_artifact=True,
         )
         expected = pipeline_spec_pb2.ExecutorInput()
         json_format.ParseDict(
@@ -129,6 +131,7 @@ class TestConstructExecutorInput(unittest.TestCase):
             component_spec=component_spec,
             arguments=arguments,
             task_root=task_root,
+            block_input_artifact=True,
         )
         expected = pipeline_spec_pb2.ExecutorInput()
         json_format.ParseDict(
@@ -166,7 +169,7 @@ class TestConstructExecutorInput(unittest.TestCase):
             }, expected)
         self.assertEqual(actual, expected)
 
-    def test_input_artifacts_not_yet_supported(self):
+    def test_block_input_artifact(self):
         component_spec = pipeline_spec_pb2.ComponentSpec()
         json_format.ParseDict(
             {
@@ -191,7 +194,68 @@ class TestConstructExecutorInput(unittest.TestCase):
                 component_spec=component_spec,
                 arguments=arguments,
                 task_root=task_root,
+                block_input_artifact=True,
             )
+
+    def test_allow_input_artifact(self):
+        component_spec = pipeline_spec_pb2.ComponentSpec()
+        json_format.ParseDict(
+            {
+                'inputDefinitions': {
+                    'artifacts': {
+                        'in_artifact': {
+                            'artifactType': {
+                                'schemaTitle': 'system.Artifact',
+                                'schemaVersion': '0.0.1'
+                            }
+                        }
+                    }
+                },
+                'executorLabel': 'exec-comp'
+            }, component_spec)
+        task_root = '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/comp'
+        arguments = {
+            'in_artifact':
+                dsl.Artifact(
+                    name='artifact',
+                    uri='/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/prev-comp/artifact',
+                    metadata={'foo': 'bar'})
+        }
+        actual = executor_input_utils.construct_executor_input(
+            component_spec=component_spec,
+            arguments=arguments,
+            task_root=task_root,
+            # this param says input artifacts should be permitted
+            block_input_artifact=False,
+        )
+        expected = pipeline_spec_pb2.ExecutorInput()
+        json_format.ParseDict(
+            {
+                'inputs': {
+                    'artifacts': {
+                        'in_artifact': {
+                            'artifacts': [{
+                                'name':
+                                    'artifact',
+                                'type': {
+                                    'schemaTitle': 'system.Artifact',
+                                    'schemaVersion': '0.0.1'
+                                },
+                                'uri':
+                                    '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/prev-comp/artifact',
+                                'metadata': {
+                                    'foo': 'bar'
+                                }
+                            }]
+                        }
+                    }
+                },
+                'outputs': {
+                    'outputFile':
+                        '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/comp/executor_output.json'
+                }
+            }, expected)
+        self.assertEqual(actual, expected)
 
 
 class TestExecutorInputToDict(unittest.TestCase):

--- a/sdk/python/kfp/local/graph_utils.py
+++ b/sdk/python/kfp/local/graph_utils.py
@@ -29,22 +29,22 @@ def topological_sort_tasks(
     Returns:
         A totally ordered stack of tasks. Tasks should be executed in the order they are popped off the right side of the stack.
     """
-    adj_list = build_adjacency_list(tasks)
-    return topological_sort(adj_list)
+    dependency_map = build_dependency_map(tasks)
+    return topological_sort(dependency_map)
 
 
-def build_adjacency_list(
+def build_dependency_map(
     tasks: Dict[str,
                 pipeline_spec_pb2.PipelineTaskSpec]) -> Dict[str, List[str]]:
-    """Builds an adjacency list from a dictionary of task name to
-    PipelineTaskSpec. This is a data structure simplification step, which
-    allows for a general topological_sort sort implementation.
+    """Builds a dictionary of task name to all upstream task names
+    (dependencies). This is a data structure simplification step, which allows
+    for a general topological_sort sort implementation.
 
     Args:
         tasks: The tasks in the pipeline.
 
     Returns:
-        An adjacency list of tasks name to a list of upstream tasks. The key task depends on all value tasks being executed first.
+        An dictionary of task name to all upstream tasks. The key task depends on all value tasks being executed first.
     """
     return {
         task_name: task_details.dependent_tasks
@@ -52,11 +52,11 @@ def build_adjacency_list(
     }
 
 
-def topological_sort(adj_list: Dict[str, List[str]]) -> List[str]:
-    """Topologicall sorts an adjacency list.
+def topological_sort(dependency_map: Dict[str, List[str]]) -> List[str]:
+    """Topologically sorts a dictionary of task names to upstream tasks.
 
     Args:
-        adj_list: An adjacency list of tasks name to a list of upstream tasks. The key task depends on all value tasks being executed first.
+        dependency_map: A dictionary of tasks name to a list of upstream tasks. The key task depends on all value tasks being executed first.
 
     Returns:
         A totally ordered stack of tasks. Tasks should be executed in the order they are popped off the right side of the stack.
@@ -64,16 +64,16 @@ def topological_sort(adj_list: Dict[str, List[str]]) -> List[str]:
 
     def dfs(node: str) -> None:
         visited.add(node)
-        for neighbor in adj_list[node]:
+        for neighbor in dependency_map[node]:
             if neighbor not in visited:
                 dfs(neighbor)
         result.append(node)
 
     # sort lists to force deterministic result
-    adj_list = {k: sorted(v) for k, v in adj_list.items()}
+    dependency_map = {k: sorted(v) for k, v in dependency_map.items()}
     visited: Set[str] = set()
     result = []
-    for node in adj_list:
+    for node in dependency_map:
         if node not in visited:
             dfs(node)
     return result[::-1]

--- a/sdk/python/kfp/local/graph_utils.py
+++ b/sdk/python/kfp/local/graph_utils.py
@@ -1,0 +1,79 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Graph algorithms which are useful for working with PipelineSpec."""
+
+from typing import Dict, List, Set
+
+from kfp.pipeline_spec import pipeline_spec_pb2
+
+
+def topological_sort_tasks(
+        tasks: Dict[str, pipeline_spec_pb2.PipelineTaskSpec]) -> List[str]:
+    """Given a dictionary of task name to PipelineTaskSpec, obtains a
+    topologically sorted stack of task names.
+
+    Args:
+        tasks: The tasks in the pipeline.
+
+    Returns:
+        A totally ordered stack of tasks. Tasks should be executed in the order they are popped off the right side of the stack.
+    """
+    adj_list = build_adjacency_list(tasks)
+    return topological_sort(adj_list)
+
+
+def build_adjacency_list(
+    tasks: Dict[str,
+                pipeline_spec_pb2.PipelineTaskSpec]) -> Dict[str, List[str]]:
+    """Builds an adjacency list from a dictionary of task name to
+    PipelineTaskSpec. This is a data structure simplification step, which
+    allows for a general topological_sort sort implementation.
+
+    Args:
+        tasks: The tasks in the pipeline.
+
+    Returns:
+        An adjacency list of tasks name to a list of upstream tasks. The key task depends on all value tasks being executed first.
+    """
+    return {
+        task_name: task_details.dependent_tasks
+        for task_name, task_details in tasks.items()
+    }
+
+
+def topological_sort(adj_list: Dict[str, List[str]]) -> List[str]:
+    """Topologicall sorts an adjacency list.
+
+    Args:
+        adj_list: An adjacency list of tasks name to a list of upstream tasks. The key task depends on all value tasks being executed first.
+
+    Returns:
+        A totally ordered stack of tasks. Tasks should be executed in the order they are popped off the right side of the stack.
+    """
+
+    def dfs(node: str) -> None:
+        visited.add(node)
+        for neighbor in adj_list[node]:
+            if neighbor not in visited:
+                dfs(neighbor)
+        result.append(node)
+
+    # sort lists to force deterministic result
+    adj_list = {k: sorted(v) for k, v in adj_list.items()}
+    visited: Set[str] = set()
+    result = []
+    for node in adj_list:
+        if node not in visited:
+            dfs(node)
+    return result[::-1]

--- a/sdk/python/kfp/local/graph_utils_test.py
+++ b/sdk/python/kfp/local/graph_utils_test.py
@@ -1,0 +1,290 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for graph_utils.py."""
+from typing import Any, Dict
+import unittest
+
+from google.protobuf import json_format
+from kfp.local import graph_utils
+from kfp.pipeline_spec import pipeline_spec_pb2
+
+
+class TestBuildAdjacencyList(unittest.TestCase):
+
+    def test_simple(self):
+        tasks = {
+            k: make_pipeline_task_spec(v)
+            for k, v in SIMPLE_TASK_TOPOLOGY.items()
+        }
+        actual = graph_utils.build_adjacency_list(tasks)
+        expected = {'identity': [], 'identity-2': ['identity']}
+        self.assertEqual(actual, expected)
+
+    def test_complex(self):
+        tasks = {
+            k: make_pipeline_task_spec(v)
+            for k, v in COMPLEX_TASK_TOPOLOGY.items()
+        }
+        actual = graph_utils.build_adjacency_list(tasks)
+        expected = {
+            'add': [],
+            'add-2': ['multiply'],
+            'divide': ['add-2'],
+            'multiply': ['add'],
+            'printer': ['add', 'divide', 'multiply']
+        }
+        self.assertEqual(actual, expected)
+
+
+class TestTopologicalSort(unittest.TestCase):
+
+    def test_empty_graph(self):
+        self.assertEqual(graph_utils.topological_sort({}), [])
+
+    def test_simple_linear_graph(self):
+        graph = {'A': ['B'], 'B': ['C'], 'C': []}
+        actual = graph_utils.topological_sort(graph)
+        expected = ['A', 'B', 'C']
+        self.assertEqual(actual, expected)
+
+    def test_separate_components(self):
+        graph = {'A': ['B'], 'B': [], 'C': ['D'], 'D': []}
+        actual = graph_utils.topological_sort(graph)
+        expected = ['C', 'D', 'A', 'B']
+        self.assertEqual(actual, expected)
+
+    def test_complex_graph(self):
+        graph = {'A': ['B', 'C'], 'B': ['D'], 'C': ['D'], 'D': []}
+        actual = graph_utils.topological_sort(graph)
+        expected = ['A', 'C', 'B', 'D']
+        self.assertEqual(actual, expected)
+
+
+class TestTopologicalSortTasks(unittest.TestCase):
+
+    def test_simple(self):
+        tasks = {
+            k: make_pipeline_task_spec(v)
+            for k, v in SIMPLE_TASK_TOPOLOGY.items()
+        }
+        actual = graph_utils.topological_sort_tasks(tasks)
+        expected = ['identity-2', 'identity']
+        self.assertEqual(actual, expected)
+
+    def test_complex(self):
+        tasks = {
+            k: make_pipeline_task_spec(v)
+            for k, v in COMPLEX_TASK_TOPOLOGY.items()
+        }
+        actual = graph_utils.topological_sort_tasks(tasks)
+        expected = ['printer', 'divide', 'add-2', 'multiply', 'add']
+        self.assertEqual(actual, expected)
+
+
+SIMPLE_TASK_TOPOLOGY = {
+    'identity': {
+        'cachingOptions': {
+            'enableCache': True
+        },
+        'componentRef': {
+            'name': 'comp-identity'
+        },
+        'inputs': {
+            'parameters': {
+                'string': {
+                    'componentInputParameter': 'string'
+                }
+            }
+        },
+        'taskInfo': {
+            'name': 'identity'
+        }
+    },
+    'identity-2': {
+        'cachingOptions': {
+            'enableCache': True
+        },
+        'componentRef': {
+            'name': 'comp-identity-2'
+        },
+        'dependentTasks': ['identity'],
+        'inputs': {
+            'parameters': {
+                'string': {
+                    'taskOutputParameter': {
+                        'outputParameterKey': 'Output',
+                        'producerTask': 'identity'
+                    }
+                }
+            }
+        },
+        'taskInfo': {
+            'name': 'identity-2'
+        }
+    }
+}
+
+COMPLEX_TASK_TOPOLOGY = {
+    'add': {
+        'cachingOptions': {
+            'enableCache': True
+        },
+        'componentRef': {
+            'name': 'comp-add'
+        },
+        'inputs': {
+            'parameters': {
+                'a': {
+                    'runtimeValue': {
+                        'constant': 1.0
+                    }
+                },
+                'b': {
+                    'runtimeValue': {
+                        'constant': 2.0
+                    }
+                }
+            }
+        },
+        'taskInfo': {
+            'name': 'add'
+        }
+    },
+    'add-2': {
+        'cachingOptions': {
+            'enableCache': True
+        },
+        'componentRef': {
+            'name': 'comp-add-2'
+        },
+        'dependentTasks': ['multiply'],
+        'inputs': {
+            'parameters': {
+                'a': {
+                    'taskOutputParameter': {
+                        'outputParameterKey': 'Output',
+                        'producerTask': 'multiply'
+                    }
+                },
+                'b': {
+                    'runtimeValue': {
+                        'constant': 4.0
+                    }
+                }
+            }
+        },
+        'taskInfo': {
+            'name': 'add-2'
+        }
+    },
+    'divide': {
+        'cachingOptions': {
+            'enableCache': True
+        },
+        'componentRef': {
+            'name': 'comp-divide'
+        },
+        'dependentTasks': ['add-2'],
+        'inputs': {
+            'parameters': {
+                'denominator': {
+                    'runtimeValue': {
+                        'constant': 2.0
+                    }
+                },
+                'numerator': {
+                    'taskOutputParameter': {
+                        'outputParameterKey': 'Output',
+                        'producerTask': 'add-2'
+                    }
+                }
+            }
+        },
+        'taskInfo': {
+            'name': 'divide'
+        }
+    },
+    'multiply': {
+        'cachingOptions': {
+            'enableCache': True
+        },
+        'componentRef': {
+            'name': 'comp-multiply'
+        },
+        'dependentTasks': ['add'],
+        'inputs': {
+            'parameters': {
+                'x': {
+                    'taskOutputParameter': {
+                        'outputParameterKey': 'Output',
+                        'producerTask': 'add'
+                    }
+                },
+                'y': {
+                    'runtimeValue': {
+                        'constant': 3.0
+                    }
+                }
+            }
+        },
+        'taskInfo': {
+            'name': 'multiply'
+        }
+    },
+    'printer': {
+        'cachingOptions': {
+            'enableCache': True
+        },
+        'componentRef': {
+            'name': 'comp-printer'
+        },
+        'dependentTasks': ['add', 'divide', 'multiply'],
+        'inputs': {
+            'parameters': {
+                'flt': {
+                    'taskOutputParameter': {
+                        'outputParameterKey': 'Output',
+                        'producerTask': 'divide'
+                    }
+                },
+                'int1': {
+                    'taskOutputParameter': {
+                        'outputParameterKey': 'Output',
+                        'producerTask': 'add'
+                    }
+                },
+                'int2': {
+                    'taskOutputParameter': {
+                        'outputParameterKey': 'Output',
+                        'producerTask': 'multiply'
+                    }
+                }
+            }
+        },
+        'taskInfo': {
+            'name': 'printer'
+        }
+    }
+}
+
+
+def make_pipeline_task_spec(
+        d: Dict[str, Any]) -> pipeline_spec_pb2.PipelineTaskSpec:
+    spec = pipeline_spec_pb2.PipelineTaskSpec()
+    json_format.ParseDict(d, spec)
+    return spec
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/python/kfp/local/graph_utils_test.py
+++ b/sdk/python/kfp/local/graph_utils_test.py
@@ -20,14 +20,14 @@ from kfp.local import graph_utils
 from kfp.pipeline_spec import pipeline_spec_pb2
 
 
-class TestBuildAdjacencyList(unittest.TestCase):
+class TestBuildDependencyMap(unittest.TestCase):
 
     def test_simple(self):
         tasks = {
             k: make_pipeline_task_spec(v)
             for k, v in SIMPLE_TASK_TOPOLOGY.items()
         }
-        actual = graph_utils.build_adjacency_list(tasks)
+        actual = graph_utils.build_dependency_map(tasks)
         expected = {'identity': [], 'identity-2': ['identity']}
         self.assertEqual(actual, expected)
 
@@ -36,7 +36,7 @@ class TestBuildAdjacencyList(unittest.TestCase):
             k: make_pipeline_task_spec(v)
             for k, v in COMPLEX_TASK_TOPOLOGY.items()
         }
-        actual = graph_utils.build_adjacency_list(tasks)
+        actual = graph_utils.build_dependency_map(tasks)
         expected = {
             'add': [],
             'add-2': ['multiply'],
@@ -93,188 +93,25 @@ class TestTopologicalSortTasks(unittest.TestCase):
 
 
 SIMPLE_TASK_TOPOLOGY = {
-    'identity': {
-        'cachingOptions': {
-            'enableCache': True
-        },
-        'componentRef': {
-            'name': 'comp-identity'
-        },
-        'inputs': {
-            'parameters': {
-                'string': {
-                    'componentInputParameter': 'string'
-                }
-            }
-        },
-        'taskInfo': {
-            'name': 'identity'
-        }
-    },
+    'identity': {},
     'identity-2': {
-        'cachingOptions': {
-            'enableCache': True
-        },
-        'componentRef': {
-            'name': 'comp-identity-2'
-        },
         'dependentTasks': ['identity'],
-        'inputs': {
-            'parameters': {
-                'string': {
-                    'taskOutputParameter': {
-                        'outputParameterKey': 'Output',
-                        'producerTask': 'identity'
-                    }
-                }
-            }
-        },
-        'taskInfo': {
-            'name': 'identity-2'
-        }
     }
 }
 
 COMPLEX_TASK_TOPOLOGY = {
-    'add': {
-        'cachingOptions': {
-            'enableCache': True
-        },
-        'componentRef': {
-            'name': 'comp-add'
-        },
-        'inputs': {
-            'parameters': {
-                'a': {
-                    'runtimeValue': {
-                        'constant': 1.0
-                    }
-                },
-                'b': {
-                    'runtimeValue': {
-                        'constant': 2.0
-                    }
-                }
-            }
-        },
-        'taskInfo': {
-            'name': 'add'
-        }
-    },
+    'add': {},
     'add-2': {
-        'cachingOptions': {
-            'enableCache': True
-        },
-        'componentRef': {
-            'name': 'comp-add-2'
-        },
         'dependentTasks': ['multiply'],
-        'inputs': {
-            'parameters': {
-                'a': {
-                    'taskOutputParameter': {
-                        'outputParameterKey': 'Output',
-                        'producerTask': 'multiply'
-                    }
-                },
-                'b': {
-                    'runtimeValue': {
-                        'constant': 4.0
-                    }
-                }
-            }
-        },
-        'taskInfo': {
-            'name': 'add-2'
-        }
     },
     'divide': {
-        'cachingOptions': {
-            'enableCache': True
-        },
-        'componentRef': {
-            'name': 'comp-divide'
-        },
         'dependentTasks': ['add-2'],
-        'inputs': {
-            'parameters': {
-                'denominator': {
-                    'runtimeValue': {
-                        'constant': 2.0
-                    }
-                },
-                'numerator': {
-                    'taskOutputParameter': {
-                        'outputParameterKey': 'Output',
-                        'producerTask': 'add-2'
-                    }
-                }
-            }
-        },
-        'taskInfo': {
-            'name': 'divide'
-        }
     },
     'multiply': {
-        'cachingOptions': {
-            'enableCache': True
-        },
-        'componentRef': {
-            'name': 'comp-multiply'
-        },
         'dependentTasks': ['add'],
-        'inputs': {
-            'parameters': {
-                'x': {
-                    'taskOutputParameter': {
-                        'outputParameterKey': 'Output',
-                        'producerTask': 'add'
-                    }
-                },
-                'y': {
-                    'runtimeValue': {
-                        'constant': 3.0
-                    }
-                }
-            }
-        },
-        'taskInfo': {
-            'name': 'multiply'
-        }
     },
     'printer': {
-        'cachingOptions': {
-            'enableCache': True
-        },
-        'componentRef': {
-            'name': 'comp-printer'
-        },
         'dependentTasks': ['add', 'divide', 'multiply'],
-        'inputs': {
-            'parameters': {
-                'flt': {
-                    'taskOutputParameter': {
-                        'outputParameterKey': 'Output',
-                        'producerTask': 'divide'
-                    }
-                },
-                'int1': {
-                    'taskOutputParameter': {
-                        'outputParameterKey': 'Output',
-                        'producerTask': 'add'
-                    }
-                },
-                'int2': {
-                    'taskOutputParameter': {
-                        'outputParameterKey': 'Output',
-                        'producerTask': 'multiply'
-                    }
-                }
-            }
-        },
-        'taskInfo': {
-            'name': 'printer'
-        }
     }
 }
 

--- a/sdk/python/kfp/local/io.py
+++ b/sdk/python/kfp/local/io.py
@@ -1,0 +1,101 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Object for storing task outputs in-memory during local execution."""
+
+import collections
+from typing import Any, Dict
+
+
+class IOStore:
+
+    def __init__(self):
+
+        self._task_output_data: Dict[str,
+                                     Dict[str,
+                                          Any]] = collections.defaultdict(dict)
+        self._parent_input_data: Dict[str, Any] = {}
+
+    def put_parent_input(
+        self,
+        key: str,
+        value: Any,
+    ) -> None:
+        """Persist the value of a parent component (i.e., parent pipeline)
+        input.
+
+        Args:
+            key: Parent component input name.
+            value: Value associated with key.
+        """
+        self._parent_input_data[key] = value
+
+    def get_parent_input(
+        self,
+        key: str,
+    ) -> None:
+        """Get the value of the parent component (i.e., parent pipeline) input
+        named key.
+
+        Args:
+            key: Parent component input name.
+
+        Returns:
+            The output value.
+        """
+        if key in self._parent_input_data:
+            return self._parent_input_data[key]
+        raise ValueError(f"Parent pipeline input argument '{key}' not found.")
+
+    def put_task_output(
+        self,
+        task_name: str,
+        key: str,
+        value: Any,
+    ) -> None:
+        """Persist the value of an upstream task output.
+
+        Args:
+            task_name: Upstream task name.
+            key: Output name.
+            value: Value associated with key.
+        """
+        self._task_output_data[task_name][key] = value
+
+    def get_task_output(
+        self,
+        task_name: str,
+        key: str,
+    ) -> Any:
+        """Get the value of an upstream task output.
+
+        Args:
+            task_name: Upstream task name.
+            key: Output name.
+
+        Returns:
+            The output value.
+        """
+        common_exception_string = f"Tried to get output '{key}' from task '{task_name}'"
+        if task_name in self._task_output_data:
+            outputs = self._task_output_data[task_name]
+        else:
+            raise ValueError(
+                f"{common_exception_string}, but task '{task_name}' not found.")
+
+        if key in outputs:
+            return outputs[key]
+        else:
+            raise ValueError(
+                f"{common_exception_string}, but task '{task_name}' has no output named '{key}'."
+            )

--- a/sdk/python/kfp/local/io_test.py
+++ b/sdk/python/kfp/local/io_test.py
@@ -1,0 +1,95 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for io.py."""
+
+import unittest
+
+from kfp import dsl
+from kfp.local import io
+
+
+class IOStoreTest(unittest.TestCase):
+
+    def test_task_not_found(self):
+        store = io.IOStore()
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Tried to get output 'foo' from task 'my-task', but task 'my-task' not found\."
+        ):
+            store.get_task_output('my-task', 'foo')
+
+    def test_output_not_found(self):
+        store = io.IOStore()
+        store.put_task_output('my-task', 'bar', 'baz')
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Tried to get output 'foo' from task 'my-task', but task 'my-task' has no output named 'foo'\."
+        ):
+            store.get_task_output('my-task', 'foo')
+
+    def test_parent_input_not_found(self):
+        store = io.IOStore()
+        with self.assertRaisesRegex(
+                ValueError, r"Parent pipeline input argument 'foo' not found."):
+            store.get_parent_input('foo')
+
+    def test_put_and_get_task_output(self):
+        store = io.IOStore()
+        store.put_task_output('my-task', 'foo', 'bar')
+        store.put_task_output('my-task', 'baz', 'bat')
+        self.assertEqual(
+            store.get_task_output('my-task', 'foo'),
+            'bar',
+        )
+        self.assertEqual(
+            store.get_task_output('my-task', 'baz'),
+            'bat',
+        )
+        # test getting doesn't remove by getting twice
+        self.assertEqual(
+            store.get_task_output('my-task', 'baz'),
+            'bat',
+        )
+
+    def test_put_and_get_parent_input(self):
+        store = io.IOStore()
+        store.put_parent_input('foo', 'bar')
+        store.put_parent_input('baz', 'bat')
+        self.assertEqual(
+            store.get_parent_input('foo'),
+            'bar',
+        )
+        self.assertEqual(
+            store.get_parent_input('baz'),
+            'bat',
+        )
+        # test getting doesn't remove by getting twice
+        self.assertEqual(
+            store.get_parent_input('baz'),
+            'bat',
+        )
+
+    def test_put_and_get_task_output_with_artifact(self):
+        artifact = dsl.Artifact(
+            name='foo', uri='/my/uri', metadata={'foo': 'bar'})
+        store = io.IOStore()
+        store.put_task_output('my-task', 'foo', artifact)
+        self.assertEqual(
+            store.get_task_output('my-task', 'foo'),
+            artifact,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/python/kfp/local/logging_utils.py
+++ b/sdk/python/kfp/local/logging_utils.py
@@ -16,6 +16,7 @@ import builtins
 import contextlib
 import datetime
 import logging
+import shutil
 import sys
 from typing import Any, Dict, Generator, List
 
@@ -24,9 +25,14 @@ from kfp.local import status
 
 
 class Color:
+    # color for task name
     CYAN = '\033[96m'
+    # color for status success
     GREEN = '\033[92m'
+    # color for status failure
     RED = '\033[91m'
+    # color for pipeline name
+    MAGENTA = '\033[95m'
     RESET = '\033[0m'
 
 
@@ -142,6 +148,11 @@ def make_log_lines_for_outputs(outputs: Dict[str, Any]) -> List[str]:
     return output_lines
 
 
+def print_horizontal_line() -> None:
+    columns, _ = shutil.get_terminal_size(fallback=(80, 24))
+    print('-' * columns)
+
+
 def format_task_name(task_name: str) -> str:
     return color_text(f'{task_name!r}', Color.CYAN)
 
@@ -153,3 +164,7 @@ def format_status(task_status: status.Status) -> str:
         return color_text(task_status.name, Color.RED)
     else:
         raise ValueError(f'Got unknown status: {task_status}')
+
+
+def format_pipeline_name(pipeline_name: str) -> str:
+    return color_text(f'{pipeline_name!r}', Color.MAGENTA)

--- a/sdk/python/kfp/local/logging_utils_test.py
+++ b/sdk/python/kfp/local/logging_utils_test.py
@@ -229,5 +229,13 @@ class TestFormatTaskName(unittest.TestCase):
             '\x1b[96m\'my-task\'\x1b[0m')
 
 
+class TestFormatPipelineName(unittest.TestCase):
+
+    def test(self):
+        self.assertEqual(
+            logging_utils.format_pipeline_name('my-pipeline'),
+            '\033[95m\'my-pipeline\'\033[0m')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/local/pipeline_orchestrator.py
+++ b/sdk/python/kfp/local/pipeline_orchestrator.py
@@ -1,0 +1,142 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Code for locally executing a compiled pipeline."""
+import logging
+from typing import Any, Dict, Optional
+
+from kfp.local import config
+from kfp.local import dag_orchestrator
+from kfp.local import io
+from kfp.local import logging_utils
+from kfp.local import placeholder_utils
+from kfp.local import status
+from kfp.local import utils
+from kfp.pipeline_spec import pipeline_spec_pb2
+
+
+def run_local_pipeline(
+    pipeline_spec: pipeline_spec_pb2.PipelineSpec,
+    arguments: Dict[str, Any],
+) -> Dict[str, Any]:
+    """kfp.local's entrypoint for running a local pipeline.
+
+    Args:
+        pipeline_spec: PipelineSpec to run.
+        arguments: User-provided arguments.
+
+    Returns:
+        The pipeline outputs.
+    """
+
+    # validate and access all global state in this function, not downstream
+    config.LocalExecutionConfig.validate()
+    return _run_local_pipeline_implementation(
+        pipeline_spec=pipeline_spec,
+        arguments=arguments,
+        raise_on_error=config.LocalExecutionConfig.instance.raise_on_error,
+        pipeline_root=config.LocalExecutionConfig.instance.pipeline_root,
+        runner=config.LocalExecutionConfig.instance.runner,
+    )
+
+
+def _run_local_pipeline_implementation(
+    pipeline_spec: pipeline_spec_pb2.PipelineSpec,
+    arguments: Dict[str, Any],
+    raise_on_error: bool,
+    pipeline_root: str,
+    runner: config.LocalRunnerType,
+) -> Dict[str, Any]:
+    """Implementation of run local pipeline.
+
+    Args:
+        pipeline_spec: PipelineSpec to run.
+        arguments: User-provided arguments.
+        raise_on_error: Whether to raise an exception if a task exits with failure.
+        pipeline_root: The local pipeline root.
+        runner: The user-specified local runner.
+
+    Returns:
+        The pipeline outputs.
+    """
+    from kfp.local import executor_input_utils
+
+    pipeline_name = pipeline_spec.pipeline_info.name
+    pipeline_resource_name = executor_input_utils.get_local_pipeline_resource_name(
+        pipeline_name)
+    pipeline_name_with_color = logging_utils.format_pipeline_name(pipeline_name)
+
+    with logging_utils.local_logger_context():
+        logging.info(f'Running pipeline: {pipeline_name_with_color}')
+        logging_utils.print_horizontal_line()
+
+    executors = {
+        name: utils.struct_to_executor_spec(executor) for name, executor in
+        pipeline_spec.deployment_spec['executors'].items()
+    }
+    # convert to dict for consistency with executors
+    components = dict(pipeline_spec.components.items())
+    io_store = io.IOStore()
+    dag_status, fail_task_name = dag_orchestrator.run_dag(
+        pipeline_resource_name=pipeline_resource_name,
+        dag_component_spec=pipeline_spec.root,
+        executors=executors,
+        components=components,
+        dag_arguments=arguments,
+        io_store=io_store,
+        pipeline_root=pipeline_root,
+        runner=runner,
+        unique_pipeline_id=placeholder_utils.make_random_id(),
+    )
+    if dag_status == status.Status.SUCCESS:
+        status_with_color = logging_utils.format_status(status.Status.SUCCESS)
+        with logging_utils.local_logger_context():
+            logging.info(
+                f'Pipeline {pipeline_name_with_color} finished with status {status_with_color}'
+            )
+        return dag_orchestrator.get_dag_outputs(
+            dag_outputs_spec=pipeline_spec.root.dag.outputs,
+            io_store=io_store,
+        )
+    elif dag_status == status.Status.FAILURE:
+        log_and_maybe_raise_for_failure(
+            pipeline_name=pipeline_name,
+            fail_task_name=fail_task_name,
+            raise_on_error=raise_on_error,
+        )
+        return {}
+    else:
+        raise ValueError(f'Got unknown task status {dag_status.name}')
+
+
+def log_and_maybe_raise_for_failure(
+    pipeline_name: str,
+    raise_on_error: bool,
+    fail_task_name: Optional[str] = None,
+) -> None:
+    """To be called if an inner pipeline task exits with failure status. Either
+    logs error or throws exception, depending on raise_on_error.
+
+    Args:
+        pipeline_name: The name of the root pipeline.
+        raise_on_error: Whether to raise on error.
+        fail_task_name: The name of the task that failed. None if no failure.
+    """
+    status_with_color = logging_utils.format_status(status.Status.FAILURE)
+    pipeline_name_with_color = logging_utils.format_pipeline_name(pipeline_name)
+    task_name_with_color = logging_utils.format_task_name(fail_task_name)
+    msg = f'Pipeline {pipeline_name_with_color} finished with status {status_with_color}. Inner task failed: {task_name_with_color}.'
+    if raise_on_error:
+        raise RuntimeError(msg)
+    with logging_utils.local_logger_context():
+        logging.error(msg)

--- a/sdk/python/kfp/local/pipeline_orchestrator_test.py
+++ b/sdk/python/kfp/local/pipeline_orchestrator_test.py
@@ -314,7 +314,7 @@ class TestRunLocalPipeline(testing_utilities.LocalRunnerEnvironmentTestCase):
             )
 
         with self.assertRaisesRegex(
-                ValueError,
+                NotImplementedError,
                 r"Importer is not yet supported by local pipeline execution\. Found 'dsl\.importer' task in pipeline\."
         ):
             my_pipeline()
@@ -335,7 +335,7 @@ class TestRunLocalPipeline(testing_utilities.LocalRunnerEnvironmentTestCase):
             inner_pipeline()
 
         with self.assertRaisesRegex(
-                ValueError,
+                NotImplementedError,
                 r'Control flow features and pipelines in pipelines are not yet supported by local pipeline execution\.'
         ):
             my_pipeline()
@@ -353,7 +353,7 @@ class TestRunLocalPipeline(testing_utilities.LocalRunnerEnvironmentTestCase):
                 pass_op()
 
         with self.assertRaisesRegex(
-                ValueError,
+                NotImplementedError,
                 r'Control flow features and pipelines in pipelines are not yet supported by local pipeline execution\.'
         ):
             my_pipeline()

--- a/sdk/python/kfp/local/pipeline_orchestrator_test.py
+++ b/sdk/python/kfp/local/pipeline_orchestrator_test.py
@@ -1,0 +1,423 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for pipeline_orchestrator.py."""
+
+import io as stdlib_io
+import os
+from typing import NamedTuple
+import unittest
+from unittest import mock
+
+from kfp import dsl
+from kfp import local
+from kfp.dsl import Dataset
+from kfp.dsl import Input
+from kfp.dsl import Model
+from kfp.dsl import Output
+from kfp.dsl import pipeline_task
+from kfp.local import testing_utilities
+
+ROOT_FOR_TESTING = './testing_root'
+
+
+class TestRunLocalPipeline(testing_utilities.LocalRunnerEnvironmentTestCase):
+
+    def assert_output_dir_contents(
+        self,
+        expected_dirs_in_pipeline_root: int,
+        expected_files_in_pipeline_dir: int,
+    ) -> None:
+        # check that output files are correctly nested
+        # and only one directory for the outer pipeline in pipeline root
+        actual_dirs_in_pipeline_root = os.listdir(ROOT_FOR_TESTING)
+        self.assertLen(
+            actual_dirs_in_pipeline_root,
+            expected_dirs_in_pipeline_root,
+        )
+
+        # and check that each task has a directory
+        actual_contents_of_pipeline_dir = os.listdir(
+            os.path.join(
+                ROOT_FOR_TESTING,
+                actual_dirs_in_pipeline_root[0],
+            ))
+        self.assertLen(
+            actual_contents_of_pipeline_dir,
+            expected_files_in_pipeline_dir,
+        )
+
+    def test_must_initialize(self):
+
+        @dsl.component
+        def identity(string: str) -> str:
+            return string
+
+        @dsl.pipeline
+        def my_pipeline():
+            identity(string='foo')
+
+        with self.assertRaisesRegex(
+                RuntimeError,
+                r"Local environment not initialized\. Please run 'kfp\.local\.init\(\)' before executing tasks locally\."
+        ):
+            my_pipeline()
+
+    def test_no_io(self):
+        local.init(local.SubprocessRunner(), pipeline_root=ROOT_FOR_TESTING)
+
+        @dsl.component
+        def pass_op():
+            pass
+
+        @dsl.pipeline
+        def my_pipeline():
+            pass_op()
+            pass_op()
+
+        result = my_pipeline()
+        self.assertIsInstance(result, pipeline_task.PipelineTask)
+        self.assertEqual(result.outputs, {})
+        self.assert_output_dir_contents(1, 2)
+
+    def test_missing_args(self):
+        local.init(local.SubprocessRunner())
+
+        @dsl.component
+        def identity(string: str) -> str:
+            return string
+
+        @dsl.pipeline
+        def my_pipeline(string: str) -> str:
+            t1 = identity(string=string)
+            t2 = identity(string=t1.output)
+            return t2.output
+
+        with self.assertRaisesRegex(
+                TypeError,
+                r'my-pipeline\(\) missing 1 required argument: string\.'):
+            my_pipeline()
+
+    def test_single_return(self):
+        local.init(local.SubprocessRunner(), pipeline_root=ROOT_FOR_TESTING)
+
+        @dsl.component
+        def identity(string: str) -> str:
+            return string
+
+        @dsl.pipeline
+        def my_pipeline(string: str = 'text') -> str:
+            t1 = identity(string=string)
+            t2 = identity(string=t1.output)
+            return t2.output
+
+        task = my_pipeline()
+        self.assertEqual(task.output, 'text')
+        self.assert_output_dir_contents(1, 2)
+
+    def test_can_run_loaded_pipeline(self):
+        local.init(local.SubprocessRunner(), pipeline_root=ROOT_FOR_TESTING)
+
+        @dsl.component
+        def identity(string: str) -> str:
+            return string
+
+        @dsl.pipeline
+        def my_pipeline(string: str = 'text') -> str:
+            t1 = identity(string=string)
+            t2 = identity(string=t1.output)
+            return t2.output
+
+        my_pipeline_loaded = testing_utilities.compile_and_load_component(
+            my_pipeline)
+
+        task = my_pipeline_loaded(string='foo')
+        self.assertEqual(task.output, 'foo')
+        self.assert_output_dir_contents(1, 2)
+
+    def test_all_param_io(self):
+        local.init(local.SubprocessRunner(), pipeline_root=ROOT_FOR_TESTING)
+
+        # tests all I/O types with:
+        # - use of component args/defaults
+        # - use of pipeline args/defaults
+        # - passing pipeline args to first run component and not first run component
+        # - passing args from pipeline param, upstream output, and constant
+        # - pipeline surfacing outputs from last run component and not last run component
+
+        @dsl.component
+        def many_parameter_component(
+            a_float: float,
+            a_boolean: bool,
+            a_dict: dict,
+            a_string: str = 'default',
+            an_integer: int = 12,
+            a_list: list = ['item1', 'item2'],
+        ) -> NamedTuple(
+                'outputs',
+                a_string=str,
+                a_float=float,
+                an_integer=int,
+                a_boolean=bool,
+                a_list=list,
+                a_dict=dict,
+        ):
+            outputs = NamedTuple(
+                'outputs',
+                a_string=str,
+                a_float=float,
+                an_integer=int,
+                a_boolean=bool,
+                a_list=list,
+                a_dict=dict,
+            )
+            return outputs(
+                a_string=a_string,
+                a_float=a_float,
+                an_integer=an_integer,
+                a_boolean=a_boolean,
+                a_list=a_list,
+                a_dict=a_dict,
+            )
+
+        @dsl.pipeline
+        def my_pipeline(
+            flt: float,
+            boolean: bool,
+            dictionary: dict = {'foo': 'bar'},
+        ) -> NamedTuple(
+                'outputs',
+                another_string=str,
+                another_float=float,
+                another_integer=int,
+                another_boolean=bool,
+                another_list=list,
+                another_dict=dict,
+        ):
+
+            t1 = many_parameter_component(
+                a_float=flt,
+                a_boolean=True,
+                a_dict={'baz': 'bat'},
+                an_integer=10,
+            )
+            t2 = many_parameter_component(
+                a_float=t1.outputs['a_float'],
+                a_dict=dictionary,
+                a_boolean=boolean,
+            )
+
+            outputs = NamedTuple(
+                'outputs',
+                another_string=str,
+                another_float=float,
+                another_integer=int,
+                another_boolean=bool,
+                another_list=list,
+                another_dict=dict,
+            )
+            return outputs(
+                another_string=t1.outputs['a_string'],
+                another_float=t1.outputs['a_float'],
+                another_integer=t1.outputs['an_integer'],
+                another_boolean=t2.outputs['a_boolean'],
+                another_list=t2.outputs['a_list'],
+                another_dict=t1.outputs['a_dict'],
+            )
+
+        task = my_pipeline(
+            flt=2.718,
+            boolean=False,
+        )
+        self.assertEqual(task.outputs['another_string'], 'default')
+        self.assertEqual(task.outputs['another_float'], 2.718)
+        self.assertEqual(task.outputs['another_integer'], 10)
+        self.assertEqual(task.outputs['another_boolean'], False)
+        self.assertEqual(task.outputs['another_list'], ['item1', 'item2'])
+        self.assertEqual(task.outputs['another_dict'], {'baz': 'bat'})
+        self.assert_output_dir_contents(1, 2)
+
+    def test_artifact_io(self):
+        local.init(local.SubprocessRunner(), pipeline_root=ROOT_FOR_TESTING)
+
+        @dsl.component
+        def make_dataset(content: str) -> Dataset:
+            d = Dataset(uri=dsl.get_uri(), metadata={'framework': 'pandas'})
+            with open(d.path, 'w') as f:
+                f.write(content)
+            return d
+
+        @dsl.component
+        def make_model(dataset: Input[Dataset], model: Output[Model]):
+            with open(dataset.path) as f:
+                content = f.read()
+            with open(model.path, 'w') as f:
+                f.write(content * 2)
+            model.metadata['framework'] = 'tensorflow'
+            model.metadata['dataset'] = dataset.metadata
+
+        @dsl.pipeline
+        def my_pipeline(content: str = 'string') -> Model:
+            t1 = make_dataset(content=content)
+            t2 = make_model(dataset=t1.output)
+            return t2.outputs['model']
+
+        task = my_pipeline(content='text')
+        output_model = task.output
+        self.assertIsInstance(output_model, Model)
+        self.assertEqual(output_model.name, 'model')
+        self.assertTrue(output_model.uri.endswith('/make-model/model'))
+        self.assertEqual(output_model.metadata, {
+            'framework': 'tensorflow',
+            'dataset': {
+                'framework': 'pandas'
+            }
+        })
+        self.assert_output_dir_contents(1, 2)
+
+    def test_input_artifact_constant_not_permitted(self):
+        local.init(local.SubprocessRunner(), pipeline_root=ROOT_FOR_TESTING)
+
+        @dsl.component
+        def print_model(model: Input[Model]):
+            print(model.name)
+            print(model.uri)
+            print(model.metadata)
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Input artifacts are not supported\. Got input artifact of type 'Model'\."
+        ):
+
+            @dsl.pipeline
+            def my_pipeline():
+                print_model(model=dsl.Model(name='model', uri='/foo/bar/model'))
+
+    def test_importer_not_supported(self):
+        local.init(local.SubprocessRunner())
+
+        @dsl.pipeline
+        def my_pipeline():
+            dsl.importer(
+                artifact_uri='/foo/bar',
+                artifact_class=dsl.Artifact,
+            )
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Importer is not yet supported by local pipeline execution\. Found 'dsl\.importer' task in pipeline\."
+        ):
+            my_pipeline()
+
+    def test_pipeline_in_pipeline_not_supported(self):
+        local.init(local.SubprocessRunner())
+
+        @dsl.component
+        def identity(string: str) -> str:
+            return string
+
+        @dsl.pipeline
+        def inner_pipeline():
+            identity(string='foo')
+
+        @dsl.pipeline
+        def my_pipeline():
+            inner_pipeline()
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r'Control flow features and pipelines in pipelines are not yet supported by local pipeline execution\.'
+        ):
+            my_pipeline()
+
+    def test_control_flow_features_not_supported(self):
+        local.init(local.SubprocessRunner())
+
+        @dsl.component
+        def pass_op():
+            pass
+
+        @dsl.pipeline
+        def my_pipeline():
+            with dsl.ParallelFor([1, 2, 3]):
+                pass_op()
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r'Control flow features and pipelines in pipelines are not yet supported by local pipeline execution\.'
+        ):
+            my_pipeline()
+
+    @mock.patch('sys.stdout', new_callable=stdlib_io.StringIO)
+    def test_fails_with_raise_on_error_true(self, mock_stdout):
+        local.init(local.SubprocessRunner(), raise_on_error=True)
+
+        @dsl.component
+        def raise_component():
+            raise Exception('Error from raise_component.')
+
+        @dsl.pipeline
+        def my_pipeline():
+            raise_component()
+
+        with self.assertRaisesRegex(
+                RuntimeError,
+                r"Pipeline \x1b\[95m\'my-pipeline\'\x1b\[0m finished with status \x1b\[91mFAILURE\x1b\[0m\. Inner task failed: \x1b\[96m\'raise-component\'\x1b\[0m\.",
+        ):
+            my_pipeline()
+
+        logged_output = mock_stdout.getvalue()
+        # Logs should:
+        # - log task failure trace
+        # - log pipeline failure
+        # - indicate which task the failure came from
+        self.assertRegex(
+            logged_output,
+            r'raise Exception\(\'Error from raise_component\.\'\)',
+        )
+
+    @mock.patch('sys.stdout', new_callable=stdlib_io.StringIO)
+    def test_fails_with_raise_on_error_false(self, mock_stdout):
+        local.init(local.SubprocessRunner(), raise_on_error=False)
+
+        @dsl.component
+        def raise_component():
+            raise Exception('Error from raise_component.')
+
+        @dsl.pipeline
+        def my_pipeline():
+            raise_component()
+
+        task = my_pipeline()
+        logged_output = mock_stdout.getvalue()
+        # Logs should:
+        # - log task failure trace
+        # - log pipeline failure
+        # - indicate which task the failure came from
+        self.assertRegex(
+            logged_output,
+            r'raise Exception\(\'Error from raise_component\.\'\)',
+        )
+        self.assertRegex(
+            logged_output,
+            r'ERROR - Task \x1b\[96m\'raise-component\'\x1b\[0m finished with status \x1b\[91mFAILURE\x1b\[0m\n',
+        )
+        self.assertRegex(
+            logged_output,
+            r'ERROR - Pipeline \x1b\[95m\'my-pipeline\'\x1b\[0m finished with status \x1b\[91mFAILURE\x1b\[0m\. Inner task failed: \x1b\[96m\'raise-component\'\x1b\[0m\.\n',
+        )
+        self.assertEqual(task.outputs, {})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/python/kfp/local/placeholder_utils.py
+++ b/sdk/python/kfp/local/placeholder_utils.py
@@ -20,8 +20,8 @@ from typing import Any, Dict, List, Optional, Union
 from kfp import dsl
 
 
-def make_random_id():
-    """Makes a random 8 digit integer."""
+def make_random_id() -> str:
+    """Makes a random 8 digit integer as a string."""
     return str(random.randint(0, 99999999))
 
 
@@ -31,9 +31,15 @@ def replace_placeholders(
     pipeline_resource_name: str,
     task_resource_name: str,
     pipeline_root: str,
+    unique_pipeline_id: str,
 ) -> List[str]:
-    """Iterates over each element in the command and replaces placeholders."""
-    unique_pipeline_id = make_random_id()
+    """Iterates over each element in the command and replaces placeholders.
+
+    This should only be called once per each task, since the task's
+    random ID is created within the scope of the function. Multiple
+    calls on the same task will result in multiple random IDs per single
+    task.
+    """
     unique_task_id = make_random_id()
     provided_inputs = get_provided_inputs(executor_input_dict)
     full_command = [

--- a/sdk/python/kfp/local/placeholder_utils_test.py
+++ b/sdk/python/kfp/local/placeholder_utils_test.py
@@ -31,7 +31,26 @@ json_format.ParseDict(
                 'dictionary': {
                     'foo': 'bar'
                 },
-            }
+            },
+            'artifacts': {
+                'in_a': {
+                    'artifacts': [{
+                        'name':
+                            'in_a',
+                        'type': {
+                            'schemaTitle': 'system.Dataset',
+                            'schemaVersion': '0.0.1'
+                        },
+                        'uri':
+                            '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/upstream-comp/in_a',
+                        'metadata': {
+                            'foo': {
+                                'bar': 'baz'
+                            }
+                        }
+                    }]
+                }
+            },
         },
         'outputs': {
             'parameters': {
@@ -90,6 +109,7 @@ class TestReplacePlaceholders(unittest.TestCase):
             pipeline_resource_name='my-pipeline-2023-10-10-13-32-59-420710',
             task_resource_name='comp',
             pipeline_root='/foo/bar/my-pipeline-2023-10-10-13-32-59-420710',
+            unique_pipeline_id=placeholder_utils.make_random_id(),
         )
         expected = [
             'echo',
@@ -206,6 +226,24 @@ class TestResolveIndividualPlaceholder(parameterized.TestCase):
         ),
         (
             "{{$.outputs.artifacts[''out_a''].metadata[''foo'']}}",
+            json.dumps({'bar': 'baz'}),
+        ),
+        (
+            "{{$.inputs.artifacts[''in_a''].metadata}}",
+            json.dumps({'foo': {
+                'bar': 'baz'
+            }}),
+        ),
+        (
+            "{{$.inputs.artifacts[''in_a''].uri}}",
+            '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/upstream-comp/in_a',
+        ),
+        (
+            "{{$.inputs.artifacts[''in_a''].path}}",
+            '/foo/bar/my-pipeline-2023-10-10-13-32-59-420710/upstream-comp/in_a',
+        ),
+        (
+            "{{$.inputs.artifacts[''in_a''].metadata[''foo'']}}",
             json.dumps({'bar': 'baz'}),
         ),
     ])

--- a/sdk/python/kfp/local/task_dispatcher.py
+++ b/sdk/python/kfp/local/task_dispatcher.py
@@ -49,11 +49,13 @@ def run_single_task(
         component_spec.executor_label,
     )
     executor_spec = utils.struct_to_executor_spec(executor_spec)
+    pipeline_resource_name = executor_input_utils.get_local_pipeline_resource_name(
+        pipeline_spec.pipeline_info.name)
 
     # all global state should be accessed here
     # do not access local config state downstream
     outputs, _ = _run_single_task_implementation(
-        pipeline_name=pipeline_spec.pipeline_info.name,
+        pipeline_resource_name=pipeline_resource_name,
         component_name=component_name,
         component_spec=component_spec,
         executor_spec=executor_spec,
@@ -61,7 +63,8 @@ def run_single_task(
         pipeline_root=config.LocalExecutionConfig.instance.pipeline_root,
         runner=config.LocalExecutionConfig.instance.runner,
         raise_on_error=config.LocalExecutionConfig.instance.raise_on_error,
-    )
+        block_input_artifact=True,
+        unique_pipeline_id=placeholder_utils.make_random_id())
     return outputs
 
 
@@ -76,7 +79,7 @@ Outputs = Dict[str, Any]
 
 
 def _run_single_task_implementation(
-    pipeline_name: str,
+    pipeline_resource_name: str,
     component_name: str,
     component_spec: pipeline_spec_pb2.ComponentSpec,
     executor_spec: pipeline_spec_pb2.PipelineDeploymentConfig.ExecutorSpec,
@@ -84,6 +87,8 @@ def _run_single_task_implementation(
     pipeline_root: str,
     runner: config.LocalRunnerType,
     raise_on_error: bool,
+    block_input_artifact: bool,
+    unique_pipeline_id: str,
 ) -> Tuple[Outputs, status.Status]:
     """The implementation of a single component runner.
 
@@ -93,8 +98,6 @@ def _run_single_task_implementation(
 
     task_resource_name = executor_input_utils.get_local_task_resource_name(
         component_name)
-    pipeline_resource_name = executor_input_utils.get_local_pipeline_resource_name(
-        pipeline_name)
     task_root = executor_input_utils.construct_local_task_root(
         pipeline_root=pipeline_root,
         pipeline_resource_name=pipeline_resource_name,
@@ -104,6 +107,7 @@ def _run_single_task_implementation(
         component_spec=component_spec,
         arguments=arguments,
         task_root=task_root,
+        block_input_artifact=block_input_artifact,
     )
 
     container = executor_spec.container
@@ -120,6 +124,7 @@ def _run_single_task_implementation(
         pipeline_resource_name=pipeline_resource_name,
         task_resource_name=task_resource_name,
         pipeline_root=pipeline_root,
+        unique_pipeline_id=unique_pipeline_id,
     )
 
     runner_type = type(runner)
@@ -179,5 +184,6 @@ def _run_single_task_implementation(
         else:
             # for developers; user should never hit this
             raise ValueError(f'Got unknown status: {task_status}')
+        logging_utils.print_horizontal_line()
 
         return outputs, task_status

--- a/sdk/python/kfp/local/task_dispatcher_test.py
+++ b/sdk/python/kfp/local/task_dispatcher_test.py
@@ -114,63 +114,6 @@ class TestArgumentValidation(parameterized.TestCase):
 class TestSupportOfComponentTypes(
         testing_utilities.LocalRunnerEnvironmentTestCase):
 
-    def test_local_pipeline_unsupported_two_tasks(self):
-        local.init(runner=local.SubprocessRunner(use_venv=True))
-
-        @dsl.component
-        def identity(x: str) -> str:
-            return x
-
-        @dsl.pipeline
-        def my_pipeline():
-            identity(x='foo')
-            identity(x='bar')
-
-        # compile and load into a YamlComponent to ensure the NotImplementedError isn't simply being thrown because this is a GraphComponent
-        my_pipeline = testing_utilities.compile_and_load_component(my_pipeline)
-        with self.assertRaisesRegex(
-                NotImplementedError,
-                r'Local pipeline execution is not currently supported\.',
-        ):
-            my_pipeline()
-
-    def test_local_pipeline_unsupported_one_task_different_interface(self):
-        local.init(runner=local.SubprocessRunner(use_venv=True))
-
-        @dsl.component
-        def identity(x: str) -> str:
-            return x
-
-        @dsl.pipeline
-        def my_pipeline():
-            identity(x='foo')
-
-        # compile and load into a YamlComponent to ensure the NotImplementedError isn't simply being thrown because this is a GraphComponent
-        my_pipeline = testing_utilities.compile_and_load_component(my_pipeline)
-        with self.assertRaisesRegex(
-                NotImplementedError,
-                r'Local pipeline execution is not currently supported\.',
-        ):
-            my_pipeline()
-
-    def test_local_pipeline_unsupported_if_is_graph_component(self):
-        local.init(runner=local.SubprocessRunner(use_venv=True))
-
-        @dsl.component
-        def identity(x: str) -> str:
-            return x
-
-        # even if there is one task with the same interface as the pipeline, the code should catch that the pipeline is a GraphComponent and throw the NotImplementedError
-        @dsl.pipeline
-        def my_pipeline(string: str) -> str:
-            return identity(x=string).output
-
-        with self.assertRaisesRegex(
-                NotImplementedError,
-                r'Local pipeline execution is not currently supported\.',
-        ):
-            my_pipeline(string='foo')
-
     def test_can_run_loaded_component(self):
         # use venv to avoid installing non-local KFP into test process
         local.init(runner=local.SubprocessRunner(use_venv=True))


### PR DESCRIPTION
**Description of your changes:**
Enables running a pipeline locally:
```python
from kfp import dsl
from kfp import local

local.init(runner=local.SubprocessRunner())


@dsl.component
def add(a: int, b: int) -> int:
    return a + b


@dsl.pipeline
def my_pipeline(num: int) -> int:
    t1 = add(a=num, b=2)
    t2 = add(a=t1.output, b=3)
    return t2.output


task = my_pipeline(num=1)
print(f'Got result: {task.output}')
```

Currently:
- Only sequential pipelines are supported. Control flow features (`dsl.Condition`, `dsl.ParallelFor`, and `dsl.ExitHandler`) are not supported yet.
- `dsl.importer`is not supported yet.
- Pipeline-in-pipeline is not supported yet.
- Passing data via f-strings is not supported.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
