### PR TITLE
fix(backend): correct run field map col names

### DIFF
--- a/backend/src/apiserver/model/run.go
+++ b/backend/src/apiserver/model/run.go
@@ -363,11 +363,11 @@ var runAPIToModelFieldMap = map[string]string{
 	"storage_state":    "StorageState",
 	"status":           "Conditions",
 	"namespace":        "Namespace",               // v2beta1 API
-	"experiment_id":    "ExperimentId",            // v2beta1 API
+	"experiment_id":    "ExperimentUUID",          // v2beta1 API
 	"state":            "State",                   // v2beta1 API
 	"state_history":    "StateHistory",            // v2beta1 API
 	"runtime_details":  "PipelineRuntimeManifest", // v2beta1 API
-	"recurring_run_id": "RecurringRunId",          // v2beta1 API
+	"recurring_run_id": "JobUUID",                 // v2beta1 API
 }
 
 // APIToModelFieldMap returns a map from API names to field names for model Run.

--- a/backend/src/apiserver/model/task.go
+++ b/backend/src/apiserver/model/task.go
@@ -81,8 +81,8 @@ var taskAPIToModelFieldMap = map[string]string{
 	"namespace":       "Namespace",
 	"pipeline_name":   "PipelineName",      // v2beta1 API
 	"pipelineName":    "PipelineName",      // v1beta1 API
-	"run_id":          "RunId",             // v2beta1 API
-	"runId":           "RunId",             // v1beta1 API
+	"run_id":          "RunUUID",           // v2beta1 API
+	"runId":           "RunUUID",           // v1beta1 API
 	"display_name":    "Name",              // v2beta1 API
 	"execution_id":    "MLMDExecutionID",   // v2beta1 API
 	"create_time":     "CreatedTimestamp",  // v2beta1 API
@@ -91,7 +91,7 @@ var taskAPIToModelFieldMap = map[string]string{
 	"fingerprint":     "Fingerprint",
 	"state":           "State",             // v2beta1 API
 	"state_history":   "StateHistory",      // v2beta1 API
-	"parent_task_id":  "ParentTaskId",      // v2beta1 API
+	"parent_task_id":  "ParentTaskUUID",    // v2beta1 API
 	"mlmdExecutionID": "MLMDExecutionID",   // v1beta1 API
 	"created_at":      "CreatedTimestamp",  // v1beta1 API
 	"finished_at":     "FinishedTimestamp", // v1beta1 API

--- a/backend/src/apiserver/storage/default_experiment_store_test.go
+++ b/backend/src/apiserver/storage/default_experiment_store_test.go
@@ -15,6 +15,7 @@
 package storage
 
 import (
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -92,4 +93,10 @@ func TestUnsetDefaultExperimentIdIfIdMatches(t *testing.T) {
 	assert.Equal(t, "", defaultExperimentId)
 
 	db.Close()
+}
+
+func TestExperimentAPIFieldMap(t *testing.T) {
+	for _, modelField := range (&model.Experiment{}).APIToModelFieldMap() {
+		assert.Contains(t, experimentColumns, modelField)
+	}
 }

--- a/backend/src/apiserver/storage/job_store_test.go
+++ b/backend/src/apiserver/storage/job_store_test.go
@@ -964,3 +964,9 @@ func TestDeleteJob_InternalError(t *testing.T) {
 	assert.Equal(t, codes.Internal, err.(*util.UserError).ExternalStatusCode(),
 		"Expected delete job to return internal error")
 }
+
+func TestJobAPIFieldMap(t *testing.T) {
+	for _, modelField := range (&model.Job{}).APIToModelFieldMap() {
+		assert.Contains(t, jobColumns, modelField)
+	}
+}

--- a/backend/src/apiserver/storage/run_store_test.go
+++ b/backend/src/apiserver/storage/run_store_test.go
@@ -1421,3 +1421,9 @@ func TestParseResourceReferences(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResourceReferences, actualResourceReferences)
 }
+
+func TestRunAPIFieldMap(t *testing.T) {
+	for _, modelField := range (&model.Run{}).APIToModelFieldMap() {
+		assert.Contains(t, runColumns, modelField)
+	}
+}

--- a/backend/src/apiserver/storage/task_store_test.go
+++ b/backend/src/apiserver/storage/task_store_test.go
@@ -617,3 +617,9 @@ func TestTaskStore_UpdateOrCreateTasks(t *testing.T) {
 		})
 	}
 }
+
+func TestTaskAPIFieldMap(t *testing.T) {
+	for _, modelField := range (&model.Task{}).APIToModelFieldMap() {
+		assert.Contains(t, taskColumns, modelField)
+	}
+}


### PR DESCRIPTION
resolves: #10429

Reference to the col names: https://github.com/kubeflow/pipelines/blob/d4c43f77bc38080506794377647ce5b1d9f18bdf/backend/src/apiserver/storage/run_store.go#L496 and https://github.com/kubeflow/pipelines/blob/d4c43f77bc38080506794377647ce5b1d9f18bdf/backend/src/apiserver/storage/run_store.go#L517