### PR TITLE
feat(sdk): support for local execution of `dsl.importer`

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -2,6 +2,7 @@
 
 ## Features
 * Support local execution of sequential pipelines [\#10423](https://github.com/kubeflow/pipelines/pull/10423)
+* Support local execution of `dsl.importer` components [\#10431](https://github.com/kubeflow/pipelines/pull/10431)
 
 ## Breaking changes
 

--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -684,14 +684,14 @@ class ComponentSpec:
                 schema_version = type_utils._GOOGLE_TYPES_VERSION
 
             elif isinstance(type_, str) and type_.lower(
-            ) in type_utils._ARTIFACT_CLASSES_MAPPING:
-                artifact_class = type_utils._ARTIFACT_CLASSES_MAPPING[
+            ) in type_utils.ARTIFACT_CLASSES_MAPPING:
+                artifact_class = type_utils.ARTIFACT_CLASSES_MAPPING[
                     type_.lower()]
                 schema_title = artifact_class.schema_title
                 schema_version = artifact_class.schema_version
 
             elif type_ is None or isinstance(type_, dict) or type_.lower(
-            ) not in type_utils._ARTIFACT_CLASSES_MAPPING:
+            ) not in type_utils.ARTIFACT_CLASSES_MAPPING:
                 schema_title = artifact_types.Artifact.schema_title
                 schema_version = artifact_types.Artifact.schema_version
 
@@ -734,14 +734,14 @@ class ComponentSpec:
                 schema_version = type_utils._GOOGLE_TYPES_VERSION
 
             elif isinstance(type_, str) and type_.lower(
-            ) in type_utils._ARTIFACT_CLASSES_MAPPING:
-                artifact_class = type_utils._ARTIFACT_CLASSES_MAPPING[
+            ) in type_utils.ARTIFACT_CLASSES_MAPPING:
+                artifact_class = type_utils.ARTIFACT_CLASSES_MAPPING[
                     type_.lower()]
                 schema_title = artifact_class.schema_title
                 schema_version = artifact_class.schema_version
 
             elif type_ is None or isinstance(type_, dict) or type_.lower(
-            ) not in type_utils._ARTIFACT_CLASSES_MAPPING:
+            ) not in type_utils.ARTIFACT_CLASSES_MAPPING:
                 schema_title = artifact_types.Artifact.schema_title
                 schema_version = artifact_types.Artifact.schema_version
 

--- a/sdk/python/kfp/dsl/types/artifact_types.py
+++ b/sdk/python/kfp/dsl/types/artifact_types.py
@@ -21,6 +21,10 @@ _GCS_LOCAL_MOUNT_PREFIX = '/gcs/'
 _MINIO_LOCAL_MOUNT_PREFIX = '/minio/'
 _S3_LOCAL_MOUNT_PREFIX = '/s3/'
 
+GCS_REMOTE_PREFIX = 'gs://'
+MINIO_REMOTE_PREFIX = 'minio://'
+S3_REMOTE_PREFIX = 's3://'
+
 
 class Artifact:
     """Represents a generic machine learning artifact.
@@ -83,12 +87,13 @@ class Artifact:
         self._set_path(path)
 
     def _get_path(self) -> Optional[str]:
-        if self.uri.startswith('gs://'):
-            return _GCS_LOCAL_MOUNT_PREFIX + self.uri[len('gs://'):]
-        elif self.uri.startswith('minio://'):
-            return _MINIO_LOCAL_MOUNT_PREFIX + self.uri[len('minio://'):]
-        elif self.uri.startswith('s3://'):
-            return _S3_LOCAL_MOUNT_PREFIX + self.uri[len('s3://'):]
+        if self.uri.startswith(GCS_REMOTE_PREFIX):
+            return _GCS_LOCAL_MOUNT_PREFIX + self.uri[len(GCS_REMOTE_PREFIX):]
+        elif self.uri.startswith(MINIO_REMOTE_PREFIX):
+            return _MINIO_LOCAL_MOUNT_PREFIX + self.uri[len(MINIO_REMOTE_PREFIX
+                                                           ):]
+        elif self.uri.startswith(S3_REMOTE_PREFIX):
+            return _S3_LOCAL_MOUNT_PREFIX + self.uri[len(S3_REMOTE_PREFIX):]
         # uri == path for local execution
         return self.uri
 
@@ -98,11 +103,11 @@ class Artifact:
 
 def convert_local_path_to_remote_path(path: str) -> str:
     if path.startswith(_GCS_LOCAL_MOUNT_PREFIX):
-        return 'gs://' + path[len(_GCS_LOCAL_MOUNT_PREFIX):]
+        return GCS_REMOTE_PREFIX + path[len(_GCS_LOCAL_MOUNT_PREFIX):]
     elif path.startswith(_MINIO_LOCAL_MOUNT_PREFIX):
-        return 'minio://' + path[len(_MINIO_LOCAL_MOUNT_PREFIX):]
+        return MINIO_REMOTE_PREFIX + path[len(_MINIO_LOCAL_MOUNT_PREFIX):]
     elif path.startswith(_S3_LOCAL_MOUNT_PREFIX):
-        return 's3://' + path[len(_S3_LOCAL_MOUNT_PREFIX):]
+        return S3_REMOTE_PREFIX + path[len(_S3_LOCAL_MOUNT_PREFIX):]
     return path
 
 

--- a/sdk/python/kfp/dsl/types/custom_artifact_types.py
+++ b/sdk/python/kfp/dsl/types/custom_artifact_types.py
@@ -44,7 +44,7 @@ def get_param_to_custom_artifact_class(func: Callable) -> Dict[str, type]:
     typing.NamedTuple returns.
     """
     param_to_artifact_cls: Dict[str, type] = {}
-    kfp_artifact_classes = set(type_utils._ARTIFACT_CLASSES_MAPPING.values())
+    kfp_artifact_classes = set(type_utils.ARTIFACT_CLASSES_MAPPING.values())
 
     signature = inspect.signature(func)
     for name, param in signature.parameters.items():

--- a/sdk/python/kfp/dsl/types/type_annotations.py
+++ b/sdk/python/kfp/dsl/types/type_annotations.py
@@ -105,10 +105,10 @@ def construct_type_for_inputpath_or_outputpath(
                                                        type_.schema_version)
     elif isinstance(
             type_,
-            str) and type_.lower() in type_utils._ARTIFACT_CLASSES_MAPPING:
+            str) and type_.lower() in type_utils.ARTIFACT_CLASSES_MAPPING:
         # v1 artifact backward compat, e.g. dsl.OutputPath('Dataset')
         return type_utils.create_bundled_artifact_type(
-            type_utils._ARTIFACT_CLASSES_MAPPING[type_.lower()].schema_title)
+            type_utils.ARTIFACT_CLASSES_MAPPING[type_.lower()].schema_title)
     elif type_utils.get_parameter_type(type_):
         return type_
     else:

--- a/sdk/python/kfp/dsl/types/type_utils.py
+++ b/sdk/python/kfp/dsl/types/type_utils.py
@@ -27,7 +27,7 @@ DEFAULT_ARTIFACT_SCHEMA_VERSION = '0.0.1'
 PARAMETER_TYPES = Union[str, int, float, bool, dict, list]
 
 # ComponentSpec I/O types to DSL ontology artifact classes mapping.
-_ARTIFACT_CLASSES_MAPPING = {
+ARTIFACT_CLASSES_MAPPING = {
     'artifact': artifact_types.Artifact,
     'model': artifact_types.Model,
     'dataset': artifact_types.Dataset,

--- a/sdk/python/kfp/local/importer_handler.py
+++ b/sdk/python/kfp/local/importer_handler.py
@@ -1,0 +1,142 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Code for running a dsl.importer locally."""
+import logging
+from typing import Any, Dict, Tuple
+import warnings
+
+from google.protobuf import json_format
+from kfp import dsl
+from kfp.dsl.types import artifact_types
+from kfp.dsl.types import type_utils
+from kfp.local import logging_utils
+from kfp.local import placeholder_utils
+from kfp.local import status
+from kfp.pipeline_spec import pipeline_spec_pb2
+
+Outputs = Dict[str, Any]
+
+
+def run_importer(
+    pipeline_resource_name: str,
+    component_name: str,
+    component_spec: pipeline_spec_pb2.ComponentSpec,
+    executor_spec: pipeline_spec_pb2.PipelineDeploymentConfig.ExecutorSpec,
+    arguments: Dict[str, Any],
+    pipeline_root: str,
+    unique_pipeline_id: str,
+) -> Tuple[Outputs, status.Status]:
+    """Runs an importer component and returns a two-tuple of (outputs, status).
+
+    Args:
+        pipeline_resource_name: The root pipeline resource name.
+        component_name: The name of the component.
+        component_spec: The ComponentSpec of the importer.
+        executor_spec: The ExecutorSpec of the importer.
+        arguments: The arguments to the importer, as determined by the TaskInputsSpec for the importer.
+        pipeline_root: The local pipeline root directory of the current pipeline.
+        unique_pipeline_id: A unique identifier for the pipeline for placeholder resolution.
+
+    Returns:
+        A two-tuple of the output dictionary ({"artifact": <the-artifact>}) and the status. The outputs dictionary will be empty when status is failure.
+    """
+    from kfp.local import executor_input_utils
+
+    task_resource_name = executor_input_utils.get_local_task_resource_name(
+        component_name)
+    task_name_for_logs = logging_utils.format_task_name(task_resource_name)
+    with logging_utils.local_logger_context():
+        logging.info(f'Executing task {task_name_for_logs}')
+
+    task_root = executor_input_utils.construct_local_task_root(
+        pipeline_root=pipeline_root,
+        pipeline_resource_name=pipeline_resource_name,
+        task_resource_name=task_resource_name,
+    )
+    executor_input = executor_input_utils.construct_executor_input(
+        component_spec=component_spec,
+        arguments=arguments,
+        task_root=task_root,
+        block_input_artifact=True,
+    )
+    uri = get_importer_uri(
+        importer_spec=executor_spec.importer,
+        executor_input=executor_input,
+    )
+    metadata = json_format.MessageToDict(executor_spec.importer.metadata)
+    executor_input_dict = executor_input_utils.executor_input_to_dict(
+        executor_input=executor_input,
+        component_spec=component_spec,
+    )
+    metadata = placeholder_utils.recursively_resolve_json_dict_placeholders(
+        metadata,
+        executor_input_dict=executor_input_dict,
+        pipeline_resource_name=pipeline_resource_name,
+        task_resource_name=task_resource_name,
+        pipeline_root=pipeline_root,
+        pipeline_job_id=unique_pipeline_id,
+        pipeline_task_id=placeholder_utils.make_random_id(),
+    )
+    ArtifactCls = get_artifact_class_from_schema_title(
+        executor_spec.importer.type_schema.schema_title)
+    outputs = {
+        'artifact': ArtifactCls(
+            name='artifact',
+            uri=uri,
+            metadata=metadata,
+        )
+    }
+    with logging_utils.local_logger_context():
+        logging.info(
+            f'Task {task_name_for_logs} finished with status {logging_utils.format_status(status.Status.SUCCESS)}'
+        )
+        output_string = [
+            f'Task {task_name_for_logs} outputs:',
+            *logging_utils.make_log_lines_for_outputs(outputs),
+        ]
+        logging.info('\n'.join(output_string))
+        logging_utils.print_horizontal_line()
+
+    return outputs, status.Status.SUCCESS
+
+
+def get_importer_uri(
+    importer_spec: pipeline_spec_pb2.PipelineDeploymentConfig.ImporterSpec,
+    executor_input: pipeline_spec_pb2.ExecutorInput,
+) -> str:
+    value_or_runtime_param = importer_spec.artifact_uri.WhichOneof('value')
+    if value_or_runtime_param == 'constant':
+        uri = importer_spec.artifact_uri.constant.string_value
+    elif value_or_runtime_param == 'runtime_parameter':
+        uri = executor_input.inputs.parameter_values['uri'].string_value
+    else:
+        raise ValueError(
+            f'Got unknown value of artifact_uri: {value_or_runtime_param}')
+
+    if uri.startswith(artifact_types.GCS_REMOTE_PREFIX) or uri.startswith(
+            artifact_types.S3_REMOTE_PREFIX) or uri.startswith(
+                artifact_types.MINIO_REMOTE_PREFIX):
+        warnings.warn(
+            f"It looks like you're using the remote file '{uri}' in a 'dsl.importer'. Note that you will only be able to read and write to/from local files using 'artifact.path' in local executed pipelines."
+        )
+
+    return uri
+
+
+def get_artifact_class_from_schema_title(schema_title: str) -> dsl.Artifact:
+    system_prefix = 'system.'
+    if schema_title.startswith(system_prefix):
+        return type_utils.ARTIFACT_CLASSES_MAPPING[schema_title.lstrip(
+            system_prefix).lower()]
+    return dsl.Artifact

--- a/sdk/python/kfp/local/importer_handler_test.py
+++ b/sdk/python/kfp/local/importer_handler_test.py
@@ -1,0 +1,392 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for importer_handler_test.py."""
+import unittest
+
+from google.protobuf import json_format
+from kfp import dsl
+from kfp.local import importer_handler
+from kfp.local import status
+from kfp.local import testing_utilities
+from kfp.pipeline_spec import pipeline_spec_pb2
+
+
+class TestRunImporter(testing_utilities.LocalRunnerEnvironmentTestCase):
+
+    def test_uri_from_upstream(self):
+        component_spec_dict = {
+            'inputDefinitions': {
+                'parameters': {
+                    'metadata': {
+                        'parameterType': 'STRING'
+                    },
+                    'uri': {
+                        'parameterType': 'STRING'
+                    }
+                }
+            },
+            'outputDefinitions': {
+                'artifacts': {
+                    'artifact': {
+                        'artifactType': {
+                            'schemaTitle': 'system.Dataset',
+                            'schemaVersion': '0.0.1'
+                        }
+                    }
+                }
+            },
+            'executorLabel': 'exec-importer'
+        }
+        component_spec = pipeline_spec_pb2.ComponentSpec()
+        json_format.ParseDict(component_spec_dict, component_spec)
+
+        executor_spec_dict = {
+            'importer': {
+                'artifactUri': {
+                    'runtimeParameter': 'uri'
+                },
+                'typeSchema': {
+                    'schemaTitle': 'system.Dataset',
+                    'schemaVersion': '0.0.1'
+                },
+                'metadata': {
+                    'foo': "{{$.inputs.parameters['metadata']}}"
+                }
+            }
+        }
+        executor_spec = pipeline_spec_pb2.PipelineDeploymentConfig.ExecutorSpec(
+        )
+        json_format.ParseDict(executor_spec_dict, executor_spec)
+
+        outputs, task_status = importer_handler.run_importer(
+            pipeline_resource_name='my-pipeline-2024-01-24-15-16-30-586674',
+            component_name='comp-importer',
+            component_spec=component_spec,
+            executor_spec=executor_spec,
+            arguments={
+                'metadata': 'bar',
+                'uri': '/fizz/buzz'
+            },
+            pipeline_root='/foo/bar',
+            unique_pipeline_id='19024073',
+        )
+        expected_artifact = dsl.Dataset(
+            name='artifact',
+            uri='/fizz/buzz',
+            metadata={'foo': 'bar'},
+        )
+        self.assertEqual(outputs['artifact'].schema_title,
+                         expected_artifact.schema_title)
+        self.assertEqual(outputs['artifact'].name, expected_artifact.name)
+        self.assertEqual(outputs['artifact'].uri, expected_artifact.uri)
+        self.assertEqual(outputs['artifact'].metadata,
+                         expected_artifact.metadata)
+        self.assertEqual(task_status, status.Status.SUCCESS)
+
+    def test_uri_constant(self):
+        component_spec_dict = {
+            'inputDefinitions': {
+                'parameters': {
+                    'metadata': {
+                        'parameterType': 'STRING'
+                    },
+                    'uri': {
+                        'parameterType': 'STRING'
+                    }
+                }
+            },
+            'outputDefinitions': {
+                'artifacts': {
+                    'artifact': {
+                        'artifactType': {
+                            'schemaTitle': 'system.Artifact',
+                            'schemaVersion': '0.0.1'
+                        }
+                    }
+                }
+            },
+            'executorLabel': 'exec-importer'
+        }
+        component_spec = pipeline_spec_pb2.ComponentSpec()
+        json_format.ParseDict(component_spec_dict, component_spec)
+
+        executor_spec_dict = {
+            'importer': {
+                'artifactUri': {
+                    'constant': 'gs://path'
+                },
+                'typeSchema': {
+                    'schemaTitle': 'system.Artifact',
+                    'schemaVersion': '0.0.1'
+                },
+                'metadata': {
+                    'foo': [
+                        "{{$.inputs.parameters['metadata']}}",
+                        "{{$.inputs.parameters['metadata']}}"
+                    ]
+                }
+            }
+        }
+        executor_spec = pipeline_spec_pb2.PipelineDeploymentConfig.ExecutorSpec(
+        )
+        json_format.ParseDict(executor_spec_dict, executor_spec)
+
+        outputs, task_status = importer_handler.run_importer(
+            pipeline_resource_name='my-pipeline-2024-01-24-15-16-30-586674',
+            component_name='comp-importer',
+            component_spec=component_spec,
+            executor_spec=executor_spec,
+            arguments={
+                'metadata': 'text',
+                'uri': 'gs://path'
+            },
+            pipeline_root='/foo/bar',
+            unique_pipeline_id='19024073',
+        )
+        expected_artifact = dsl.Artifact(
+            name='artifact',
+            uri='gs://path',
+            metadata={'foo': ['text', 'text']},
+        )
+        self.assertEqual(outputs['artifact'].schema_title,
+                         expected_artifact.schema_title)
+        self.assertEqual(outputs['artifact'].name, expected_artifact.name)
+        self.assertEqual(outputs['artifact'].uri, expected_artifact.uri)
+        self.assertEqual(outputs['artifact'].metadata,
+                         expected_artifact.metadata)
+        self.assertEqual(task_status, status.Status.SUCCESS)
+
+
+class TestGetImporterUri(unittest.TestCase):
+
+    def test_constant(self):
+        importer_spec_dict = {
+            'artifactUri': {
+                'constant': '/foo/path'
+            },
+            'typeSchema': {
+                'schemaTitle': 'system.Artifact',
+                'schemaVersion': '0.0.1'
+            },
+            'metadata': {
+                'foo': 'bar'
+            }
+        }
+        importer_spec = pipeline_spec_pb2.PipelineDeploymentConfig.ImporterSpec(
+        )
+        json_format.ParseDict(importer_spec_dict, importer_spec)
+        executor_input_dict = {
+            'inputs': {
+                'parameterValues': {
+                    'uri': '/foo/path'
+                }
+            },
+            'outputs': {
+                'artifacts': {
+                    'artifact': {
+                        'artifacts': [{
+                            'name': 'artifact',
+                            'type': {
+                                'schemaTitle': 'system.Artifact',
+                                'schemaVersion': '0.0.1'
+                            },
+                            'uri': '/pipeline_root/task/artifact',
+                            'metadata': {}
+                        }]
+                    }
+                },
+                'outputFile': '/pipeline_root/task/executor_output.json'
+            }
+        }
+        executor_input = pipeline_spec_pb2.ExecutorInput()
+        json_format.ParseDict(executor_input_dict, executor_input)
+        uri = importer_handler.get_importer_uri(
+            importer_spec=importer_spec,
+            executor_input=executor_input,
+        )
+        self.assertEqual(uri, '/foo/path')
+
+    def test_runtime_parameter(self):
+        importer_spec_dict = {
+            'artifactUri': {
+                'runtimeParameter': 'uri'
+            },
+            'typeSchema': {
+                'schemaTitle': 'system.Artifact',
+                'schemaVersion': '0.0.1'
+            },
+            'metadata': {
+                'foo': 'bar'
+            }
+        }
+        importer_spec = pipeline_spec_pb2.PipelineDeploymentConfig.ImporterSpec(
+        )
+        json_format.ParseDict(importer_spec_dict, importer_spec)
+        executor_input_dict = {
+            'inputs': {
+                'parameterValues': {
+                    'uri': '/fizz/buzz'
+                }
+            },
+            'outputs': {
+                'artifacts': {
+                    'artifact': {
+                        'artifacts': [{
+                            'name': 'artifact',
+                            'type': {
+                                'schemaTitle': 'system.Artifact',
+                                'schemaVersion': '0.0.1'
+                            },
+                            'uri': '/pipeline_root/foo/task/artifact',
+                            'metadata': {}
+                        }]
+                    }
+                },
+                'outputFile': '/pipeline_root/task/executor_output.json'
+            }
+        }
+        executor_input = pipeline_spec_pb2.ExecutorInput()
+        json_format.ParseDict(executor_input_dict, executor_input)
+        uri = importer_handler.get_importer_uri(
+            importer_spec=importer_spec,
+            executor_input=executor_input,
+        )
+        self.assertEqual(uri, '/fizz/buzz')
+
+    def test_constant_warns(self):
+        importer_spec_dict = {
+            'artifactUri': {
+                'constant': 'gs://foo/bar'
+            },
+            'typeSchema': {
+                'schemaTitle': 'system.Artifact',
+                'schemaVersion': '0.0.1'
+            },
+            'metadata': {
+                'foo': 'bar'
+            }
+        }
+        importer_spec = pipeline_spec_pb2.PipelineDeploymentConfig.ImporterSpec(
+        )
+        json_format.ParseDict(importer_spec_dict, importer_spec)
+        executor_input_dict = {
+            'inputs': {
+                'parameterValues': {
+                    'uri': 'gs://foo/bar'
+                }
+            },
+            'outputs': {
+                'artifacts': {
+                    'artifact': {
+                        'artifacts': [{
+                            'name': 'artifact',
+                            'type': {
+                                'schemaTitle': 'system.Artifact',
+                                'schemaVersion': '0.0.1'
+                            },
+                            'uri': '/pipeline_root/foo/task/artifact',
+                            'metadata': {}
+                        }]
+                    }
+                },
+                'outputFile': '/pipeline_root/task/executor_output.json'
+            }
+        }
+        executor_input = pipeline_spec_pb2.ExecutorInput()
+        json_format.ParseDict(executor_input_dict, executor_input)
+        with self.assertWarnsRegex(
+                UserWarning,
+                r"It looks like you're using the remote file 'gs://foo/bar' in a 'dsl\.importer'\. Note that you will only be able to read and write to/from local files using 'artifact\.path' in local executed pipelines\."
+        ):
+            uri = importer_handler.get_importer_uri(
+                importer_spec=importer_spec,
+                executor_input=executor_input,
+            )
+        self.assertEqual(uri, 'gs://foo/bar')
+
+    def test_runtime_parameter_warns(self):
+        importer_spec_dict = {
+            'artifactUri': {
+                'runtimeParameter': 'uri'
+            },
+            'typeSchema': {
+                'schemaTitle': 'system.Artifact',
+                'schemaVersion': '0.0.1'
+            },
+            'metadata': {
+                'foo': 'bar'
+            }
+        }
+        importer_spec = pipeline_spec_pb2.PipelineDeploymentConfig.ImporterSpec(
+        )
+        json_format.ParseDict(importer_spec_dict, importer_spec)
+        executor_input_dict = {
+            'inputs': {
+                'parameterValues': {
+                    'uri': 's3://fizz/buzz'
+                }
+            },
+            'outputs': {
+                'artifacts': {
+                    'artifact': {
+                        'artifacts': [{
+                            'name': 'artifact',
+                            'type': {
+                                'schemaTitle': 'system.Artifact',
+                                'schemaVersion': '0.0.1'
+                            },
+                            'uri': '/pipeline_root/foo/task/artifact',
+                            'metadata': {}
+                        }]
+                    }
+                },
+                'outputFile': '/pipeline_root/task/executor_output.json'
+            }
+        }
+        executor_input = pipeline_spec_pb2.ExecutorInput()
+        json_format.ParseDict(executor_input_dict, executor_input)
+        with self.assertWarnsRegex(
+                UserWarning,
+                r"It looks like you're using the remote file 's3://fizz/buzz' in a 'dsl\.importer'\. Note that you will only be able to read and write to/from local files using 'artifact\.path' in local executed pipelines\."
+        ):
+            uri = importer_handler.get_importer_uri(
+                importer_spec=importer_spec,
+                executor_input=executor_input,
+            )
+        self.assertEqual(uri, 's3://fizz/buzz')
+
+
+class TestGetArtifactClassForSchemaTitle(unittest.TestCase):
+
+    def test_artifact(self):
+        actual = importer_handler.get_artifact_class_from_schema_title(
+            'system.Artifact')
+        expected = dsl.Artifact
+        self.assertEqual(actual, expected)
+
+    def test_classification_metrics(self):
+        actual = importer_handler.get_artifact_class_from_schema_title(
+            'system.ClassificationMetrics')
+        expected = dsl.ClassificationMetrics
+        self.assertEqual(actual, expected)
+
+    def test_not_system_type(self):
+        actual = importer_handler.get_artifact_class_from_schema_title(
+            'unknown.Type')
+        expected = dsl.Artifact
+        self.assertEqual(actual, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/python/kfp/local/task_dispatcher.py
+++ b/sdk/python/kfp/local/task_dispatcher.py
@@ -54,7 +54,7 @@ def run_single_task(
 
     # all global state should be accessed here
     # do not access local config state downstream
-    outputs, _ = _run_single_task_implementation(
+    outputs, _ = run_single_task_implementation(
         pipeline_resource_name=pipeline_resource_name,
         component_name=component_name,
         component_spec=component_spec,
@@ -78,7 +78,7 @@ def get_executor_spec(
 Outputs = Dict[str, Any]
 
 
-def _run_single_task_implementation(
+def run_single_task_implementation(
     pipeline_resource_name: str,
     component_name: str,
     component_spec: pipeline_spec_pb2.ComponentSpec,


### PR DESCRIPTION
**Description of your changes:**
Support for local execution of `dsl.importer`:

```python
local.init(local.SubprocessRunner(), pipeline_root=ROOT_FOR_TESTING)

@dsl.component
def artifact_printer(a: Dataset):
    print(a)

@dsl.pipeline
def my_pipeline() -> Dataset:
    imp_op = dsl.importer(
        artifact_uri='/local/path/to/dataset',
        artifact_class=Dataset,
        metadata={
            'foo': 'bar',
        })
    artifact_printer(a=imp_op.outputs['artifact'])
    return imp_op.outputs['artifact']
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
