### PR TITLE
feat(sdk): support f-strings in local pipeline execution

### DIFF
--- a/sdk/python/kfp/local/executor_input_utils.py
+++ b/sdk/python/kfp/local/executor_input_utils.py
@@ -35,6 +35,10 @@ def construct_executor_input(
     """Constructs the executor input message for a task execution."""
     input_parameter_keys = list(
         component_spec.input_definitions.parameters.keys())
+    # need to also add injected input parameters for f-string
+    input_parameter_keys += [
+        k for k, v in arguments.items() if not isinstance(v, dsl.Artifact)
+    ]
     input_artifact_keys = list(
         component_spec.input_definitions.artifacts.keys())
     if input_artifact_keys and block_input_artifact:

--- a/sdk/python/kfp/local/placeholder_utils_test.py
+++ b/sdk/python/kfp/local/placeholder_utils_test.py
@@ -418,5 +418,45 @@ class TestResolveStructPlaceholders(parameterized.TestCase):
         self.assertEqual(actual, expected)
 
 
+class TestResolveSelfReferencesInExecutorInput(unittest.TestCase):
+
+    def test_simple(self):
+        executor_input_dict = {
+            'inputs': {
+                'parameterValues': {
+                    'pipelinechannel--identity-Output':
+                        'foo',
+                    'string':
+                        "{{$.inputs.parameters['pipelinechannel--identity-Output']}}-bar"
+                }
+            },
+            'outputs': {
+                'outputFile':
+                    '/foo/bar/my-pipeline-2024-01-26-12-26-24-162075/echo/executor_output.json'
+            }
+        }
+        expected = {
+            'inputs': {
+                'parameterValues': {
+                    'pipelinechannel--identity-Output': 'foo',
+                    'string': 'foo-bar'
+                }
+            },
+            'outputs': {
+                'outputFile':
+                    '/foo/bar/my-pipeline-2024-01-26-12-26-24-162075/echo/executor_output.json'
+            }
+        }
+        actual = placeholder_utils.resolve_self_references_in_executor_input(
+            executor_input_dict,
+            pipeline_resource_name='my-pipeline-2024-01-26-12-26-24-162075',
+            task_resource_name='echo',
+            pipeline_root='/foo/bar/my-pipeline-2024-01-26-12-26-24-162075',
+            pipeline_job_id='123456789',
+            pipeline_task_id='987654321',
+        )
+        self.assertEqual(actual, expected)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of your changes:**
Support f-strings in local pipeline execution.

```python
from kfp import dsl
from kfp import local

local.init(runner=local.SubprocessRunner())

@dsl.component
def identity(string: str) -> str:
    return string

@dsl.pipeline
def my_pipeline(string: str = 'baz') -> str:
    op1 = identity(string=f'bar-{string}')
    op2 = identity(string=f'foo-{op1.output}')
    return op2.output

task = my_pipeline()
assert task.output == 'foo-bar-baz'
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
