### PR TITLE
Fix(backend): fix timeout for internal server error. Fixes #10267

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1711,9 +1711,9 @@ func (r *ResourceManager) IsAuthorized(ctx context.Context, resourceAttributes *
 		v1.CreateOptions{},
 	)
 	if err != nil {
-		if err, ok := err.(net.Error); ok && err.Timeout() {
+		if err1, ok := err.(net.Error); ok && err1.Timeout() {
 			reportErr := util.NewUnavailableServerError(
-				err,
+				err1,
 				"Failed to create SubjectAccessReview for user '%s' (request: %+v) - try again later",
 				userIdentity,
 				resourceAttributes,

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1711,9 +1711,9 @@ func (r *ResourceManager) IsAuthorized(ctx context.Context, resourceAttributes *
 		v1.CreateOptions{},
 	)
 	if err != nil {
-		if err1, ok := err.(net.Error); ok && err1.Timeout() {
+		if netError, ok := err.(net.Error); ok && netError.Timeout() {
 			reportErr := util.NewUnavailableServerError(
-				err1,
+				err,
 				"Failed to create SubjectAccessReview for user '%s' (request: %+v) - try again later",
 				userIdentity,
 				resourceAttributes,


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/kubeflow/pipelines/pull/9317/commits/cbb86ba64c94d4a9de45927d0b6273ab645e88f6 where an InternalServerError causes the ml-pipeline pod to crash https://github.com/kubeflow/pipelines/issues/10267

The if-else contains an err re-assignment, which can make the err become nil when it enters the else statement. This causes issue as the err was specifically checked against nil before the if/else, and the err's property will be accessed in the else clause, causing segfault equivalent error

Minimal example showing the re-assignment https://go.dev/play/p/52EY9LWNZUJ

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
