### PR TITLE
fix(sdk): Prevents dsl.ParallelFor over single parameter from compiling.

### DIFF
--- a/sdk/python/kfp/dsl/for_loop.py
+++ b/sdk/python/kfp/dsl/for_loop.py
@@ -17,6 +17,8 @@ import re
 from typing import Any, Dict, List, Optional, Union
 
 from kfp.dsl import pipeline_channel
+from kfp.dsl.types import type_annotations
+from kfp.dsl.types import type_utils
 
 ItemList = List[Union[int, float, str, Dict[str, Any]]]
 
@@ -188,6 +190,12 @@ class LoopParameterArgument(pipeline_channel.PipelineParameterChannel):
         compilation progress in cases of unknown or missing type
         information.
         """
+        type_name = type_annotations.get_short_type_name(channel.channel_type)
+        parameter_type = type_utils.PARAMETER_TYPES_MAPPING[type_name.lower()]
+        if parameter_type != type_utils.LIST:
+            raise ValueError(
+                'Cannot iterate over a single Parameter using `dsl.ParallelFor`. Expected a list of Parameters as argument to `items`.'
+            )
         return LoopParameterArgument(
             items=channel,
             name_override=channel.name + '-' + LOOP_ITEM_NAME_BASE,

--- a/sdk/python/kfp/dsl/for_loop_test.py
+++ b/sdk/python/kfp/dsl/for_loop_test.py
@@ -147,6 +147,24 @@ class ForLoopTest(parameterized.TestCase):
     @parameterized.parameters(
         {
             'channel':
+                pipeline_channel.PipelineParameterChannel(
+                    name='param1',
+                    channel_type='String',
+                    task_name='task1',
+                ),
+        },)
+    def test_loop_parameter_argument_from_single_pipeline_channel_raises_error(
+            self, channel):
+        with self.assertRaisesRegex(
+                ValueError,
+                r'Cannot iterate over a single Parameter using `dsl\.ParallelFor`\. Expected a list of Parameters as argument to `items`\.'
+        ):
+            loop_argument = for_loop.LoopParameterArgument.from_pipeline_channel(
+                channel)
+
+    @parameterized.parameters(
+        {
+            'channel':
                 pipeline_channel.PipelineArtifactChannel(
                     name='param1',
                     channel_type='system.Artifact@0.0.1',

--- a/sdk/python/kfp/dsl/types/type_utils_test.py
+++ b/sdk/python/kfp/dsl/types/type_utils_test.py
@@ -720,7 +720,7 @@ class TestTypeChecking(parameterized.TestCase):
                     loop_argument=for_loop.LoopParameterArgument
                     .from_pipeline_channel(
                         pipeline_channel.create_pipeline_channel(
-                            'Output-loop-item', 'String',
+                            'Output-loop-item', 'List[str]',
                             'list-dict-without-type-maker-5')),
                     subvar_name='a'),
             'parameter_input_spec':
@@ -732,7 +732,7 @@ class TestTypeChecking(parameterized.TestCase):
             'argument_value':
                 for_loop.LoopParameterArgument.from_pipeline_channel(
                     pipeline_channel.create_pipeline_channel(
-                        'Output-loop-item', 'String',
+                        'Output-loop-item', 'List[int]',
                         'list-dict-without-type-maker-5')),
             'parameter_input_spec':
                 structures.InputSpec('Integer'),


### PR DESCRIPTION
**Description of your changes:**

Prevents the following pipeline from compiling
```
@dsl.component
def str_identity(s: str) -> str:
    return s


@dsl.pipeline
def my_pipeline():
  single_param = str_identity(s='string')
  with dsl.ParallelFor(items=single_param.output) as item:
      str_identity(s=item)
```

The component `str_identity` outputs a `str` so routing this to `dsl.ParallelFor` does not make sense.


**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
