### PR TITLE
chore(sdk-1.8): pydantic2 support

### DIFF
--- a/sdk/python/kfp/v2/components/experimental/structures.py
+++ b/sdk/python/kfp/v2/components/experimental/structures.py
@@ -20,8 +20,27 @@ from typing import Any, Dict, Mapping, Optional, Sequence, Union
 
 from kfp.components import _components
 from kfp.components import structures as v1_structures
-import pydantic
 import yaml
+
+try:
+    # Attempt to get the version of Pydantic installed
+    from importlib.metadata import version
+except ImportError:
+    # Fallback for Python < 3.8 using pkg_resources
+    from pkg_resources import get_distribution as version
+
+# Get the version of Pydantic installed
+pydantic_version = version("pydantic")
+
+if pydantic_version.startswith("1."):
+    import pydantic
+elif pydantic_version.startswith("2."):
+    import pydantic.v1 as pydantic
+else:
+    raise ImportError(
+        f"Pydantic version {pydantic_version} is not supported. "
+        "Please install a supported version of Pydantic (>=1.0.0, <3.0.0)."
+    )
 
 
 class BaseModel(pydantic.BaseModel):

--- a/sdk/python/kfp/v2/components/experimental/structures.py
+++ b/sdk/python/kfp/v2/components/experimental/structures.py
@@ -17,17 +17,16 @@ import dataclasses
 import itertools
 import json
 from typing import Any, Dict, Mapping, Optional, Sequence, Union
-
-from kfp.components import _components
-from kfp.components import structures as v1_structures
-import yaml
-
 try:
     # Attempt to get the version of Pydantic installed
     from importlib.metadata import version
 except ImportError:
     # Fallback for Python < 3.8 using pkg_resources
     from pkg_resources import get_distribution as version
+
+from kfp.components import _components
+from kfp.components import structures as v1_structures
+import yaml
 
 # Get the version of Pydantic installed
 pydantic_version = version("pydantic")
@@ -39,8 +38,7 @@ elif pydantic_version.startswith("2."):
 else:
     raise ImportError(
         f"Pydantic version {pydantic_version} is not supported. "
-        "Please install a supported version of Pydantic (>=1.0.0, <3.0.0)."
-    )
+        "Please install a supported version of Pydantic (>=1.0.0, <3.0.0).")
 
 
 class BaseModel(pydantic.BaseModel):

--- a/sdk/python/kfp/v2/components/experimental/structures_test.py
+++ b/sdk/python/kfp/v2/components/experimental/structures_test.py
@@ -16,16 +16,15 @@
 import textwrap
 import unittest
 from unittest import mock
-
-from absl.testing import parameterized
-from kfp.v2.components.experimental import structures
-
 try:
     # Attempt to get the version of Pydantic installed
     from importlib.metadata import version
 except ImportError:
     # Fallback for Python < 3.8 using pkg_resources
     from pkg_resources import get_distribution as version
+
+from absl.testing import parameterized
+from kfp.v2.components.experimental import structures
 
 # Get the version of Pydantic installed
 pydantic_version = version("pydantic")

--- a/sdk/python/kfp/v2/components/experimental/structures_test.py
+++ b/sdk/python/kfp/v2/components/experimental/structures_test.py
@@ -17,9 +17,29 @@ import textwrap
 import unittest
 from unittest import mock
 
-import pydantic
 from absl.testing import parameterized
 from kfp.v2.components.experimental import structures
+
+try:
+    # Attempt to get the version of Pydantic installed
+    from importlib.metadata import version
+except ImportError:
+    # Fallback for Python < 3.8 using pkg_resources
+    from pkg_resources import get_distribution as version
+
+# Get the version of Pydantic installed
+pydantic_version = version("pydantic")
+
+if pydantic_version.startswith("1."):
+    import pydantic
+elif pydantic_version.startswith("2."):
+    import pydantic.v1 as pydantic
+else:
+    raise ImportError(
+        f"Pydantic version {pydantic_version} is not supported. "
+        "Please install a supported version of Pydantic (>=1.0.0, <3.0.0)."
+    )
+
 
 V1_YAML_IF_PLACEHOLDER = textwrap.dedent("""\
     name: component_if

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -36,6 +36,6 @@ absl-py>=0.9,<=0.11
 kfp-pipeline-spec>=0.1.16,<0.2.0
 fire>=0.3.1,<1
 google-api-python-client>=1.7.8,<2
-pydantic>=1.8.2,<2
+pydantic>=1.8.2,<3
 dataclasses>=0.8,<1; python_version<"3.7"
 typing-extensions>=3.7.4,<5; python_version<"3.9"

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -56,7 +56,7 @@ REQUIRES = [
     'uritemplate>=3.0.1,<4',
     # pin to avoid break in requests-toolbelt due to https://github.com/psf/requests/commit/2ad18e0e10e7d7ecd5384c378f25ec8821a10a29
     'urllib3<2',
-    'pydantic>=1.8.2,<2',
+    'pydantic>=1.8.2,<3',
     'typer>=0.3.2,<1.0',
     # Standard library backports
     'dataclasses;python_version<"3.7"',


### PR DESCRIPTION
**Description of your changes:**
Add support for `pydantic >=2.0,<3.0` by using the [compatibility layer](https://docs.pydantic.dev/latest/migration/#continue-using-pydantic-v1-features).
