### PR TITLE
feat(backend): add namespace & prefix scoped credentials to kfp-launcher config for object store paths

### DIFF
--- a/backend/src/v2/component/importer_launcher.go
+++ b/backend/src/v2/component/importer_launcher.go
@@ -111,7 +111,7 @@ func (l *ImportLauncher) Execute(ctx context.Context) (err error) {
 	}()
 	// TODO(Bobgy): there's no need to pass any parameters, because pipeline
 	// and pipeline run context have been created by root DAG driver.
-	pipeline, err := l.metadataClient.GetPipeline(ctx, l.importerLauncherOptions.PipelineName, l.importerLauncherOptions.RunID, "", "", "")
+	pipeline, err := l.metadataClient.GetPipeline(ctx, l.importerLauncherOptions.PipelineName, l.importerLauncherOptions.RunID, "", "", "", "")
 	if err != nil {
 		return err
 	}

--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -156,12 +156,12 @@ func (l *LauncherV2) Execute(ctx context.Context) (err error) {
 		return err
 	}
 	fingerPrint := execution.FingerPrint()
-	bucketSessionInfo, err := objectstore.GetSessionInfoFromString(execution.GetPipeline().GetPipelineBucketSession())
+	storeSessionInfo, err := objectstore.GetSessionInfoFromString(execution.GetPipeline().GetStoreSessionInfo())
 	if err != nil {
 		return err
 	}
 	pipelineRoot := execution.GetPipeline().GetPipelineRoot()
-	bucketConfig, err := objectstore.ParseBucketConfig(pipelineRoot, bucketSessionInfo)
+	bucketConfig, err := objectstore.ParseBucketConfig(pipelineRoot, storeSessionInfo)
 	if err != nil {
 		return err
 	}
@@ -550,7 +550,7 @@ func fetchNonDefaultBuckets(
 			}
 			// check if it's same bucket but under a different path, re-use the default bucket session in this case.
 			if (nonDefaultBucketConfig.Scheme == defaultBucketConfig.Scheme) && (nonDefaultBucketConfig.BucketName == defaultBucketConfig.BucketName) {
-				nonDefaultBucketConfig.Session = defaultBucketConfig.Session
+				nonDefaultBucketConfig.SessionInfo = defaultBucketConfig.SessionInfo
 			}
 			nonDefaultBucket, bucketErr := objectstore.OpenBucket(ctx, k8sClient, namespace, nonDefaultBucketConfig)
 			if bucketErr != nil {

--- a/backend/src/v2/component/launcher_v2_test.go
+++ b/backend/src/v2/component/launcher_v2_test.go
@@ -78,7 +78,7 @@ func Test_executeV2_Parameters(t *testing.T) {
 			fakeMetadataClient := metadata.NewFakeClient()
 			bucket, err := blob.OpenBucket(context.Background(), "mem://test-bucket")
 			assert.Nil(t, err)
-			bucketConfig, err := objectstore.ParseBucketConfig("mem://test-bucket/pipeline-root/")
+			bucketConfig, err := objectstore.ParseBucketConfig("mem://test-bucket/pipeline-root/", nil)
 			assert.Nil(t, err)
 			_, _, err = executeV2(context.Background(), test.executorInput, addNumbersComponent, "sh", test.executorArgs, bucket, bucketConfig, fakeMetadataClient, "namespace", fakeKubernetesClientset)
 

--- a/backend/src/v2/config/env.go
+++ b/backend/src/v2/config/env.go
@@ -19,7 +19,11 @@ package config
 import (
 	"context"
 	"fmt"
+	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
 	"io/ioutil"
+	"reflect"
+	"sigs.k8s.io/yaml"
+	"strconv"
 	"strings"
 
 	"github.com/golang/glog"
@@ -32,7 +36,21 @@ const (
 	configMapName                = "kfp-launcher"
 	defaultPipelineRoot          = "minio://mlpipeline/v2/artifacts"
 	configKeyDefaultPipelineRoot = "defaultPipelineRoot"
+	configBucketProviders        = "providers"
+	minioArtifactSecretName      = "mlpipeline-minio-artifact"
+	minioArtifactSecretKeyKey    = "secretkey"
+	minioArtifactAccessKeyKey    = "accesskey"
 )
+
+type BucketProviders struct {
+	Minio *MinioProviderConfig `json:"minio"`
+	S3    *S3ProviderConfig    `json:"s3"`
+	GCS   *GCSProviderConfig   `json:"gs"`
+}
+
+type SessionInfoProvider interface {
+	ProvideSessionInfo(bucketName, bucketPrefix string) (objectstore.SessionInfo, error)
+}
 
 // Config is the KFP runtime configuration.
 type Config struct {
@@ -53,7 +71,7 @@ func FromConfigMap(ctx context.Context, clientSet kubernetes.Interface, namespac
 	return &Config{data: config.Data}, nil
 }
 
-// Config.DefaultPipelineRoot gets the configured default pipeline root.
+// DefaultPipelineRoot gets the configured default pipeline root.
 func (c *Config) DefaultPipelineRoot() string {
 	// The key defaultPipelineRoot is optional in launcher config.
 	if c == nil || c.data[configKeyDefaultPipelineRoot] == "" {
@@ -81,4 +99,89 @@ func InPodName() (string, error) {
 	}
 	name := string(podName)
 	return strings.TrimSuffix(name, "\n"), nil
+}
+
+func (c *Config) GetBucketSessionInfo(path string) (objectstore.SessionInfo, error) {
+	bucketConfig, err := objectstore.ParseBucketPathToConfig(path)
+	if err != nil {
+		return objectstore.SessionInfo{}, err
+	}
+	bucketName := bucketConfig.BucketName
+	bucketPrefix := bucketConfig.Prefix
+	provider := strings.TrimSuffix(bucketConfig.Scheme, "://")
+	bucketProviders, err := c.getBucketProviders()
+	if err != nil {
+		return objectstore.SessionInfo{}, err
+	}
+
+	if bucketProviders == nil {
+		// Use default minio if provider is minio, otherwise we default to executor env
+		if provider == "minio" {
+			sess, sessErr := getDefaultMinioSessionInfo()
+			if sessErr != nil {
+				return objectstore.SessionInfo{}, nil
+			}
+			return sess, nil
+		} else {
+			// If not using minio, and no other provider config is provided
+			// rely on executor env (e.g. IRSA) for authenticating with provider
+			return objectstore.SessionInfo{}, nil
+		}
+	}
+
+	var sessProvider SessionInfoProvider
+
+	switch provider {
+	case "minio":
+		sessProvider = bucketProviders.Minio
+		break
+	case "s3":
+		sessProvider = bucketProviders.S3
+		break
+	case "gs":
+		sessProvider = bucketProviders.GCS
+		break
+	default:
+		return objectstore.SessionInfo{}, fmt.Errorf("Encountered unsupported provider in BucketProviders %s", provider)
+	}
+
+	if sessProvider == nil || reflect.ValueOf(sessProvider).IsNil() {
+		return objectstore.SessionInfo{}, fmt.Errorf("Encountered unsupported provider in provider config %s", provider)
+	}
+
+	sess, err := sessProvider.ProvideSessionInfo(bucketName, bucketPrefix)
+	if err != nil {
+		return objectstore.SessionInfo{}, err
+	}
+	return sess, nil
+}
+
+// getBucketProviders gets the provider configuration
+func (c *Config) getBucketProviders() (*BucketProviders, error) {
+	if c == nil || c.data[configBucketProviders] == "" {
+		return nil, nil
+	}
+	bucketProviders := &BucketProviders{}
+	configAuth := c.data[configBucketProviders]
+	err := yaml.Unmarshal([]byte(configAuth), bucketProviders)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshall kfp bucket providers, ensure that providers config is well formed: %w", err)
+	}
+	return bucketProviders, nil
+}
+
+func getDefaultMinioSessionInfo() (objectstore.SessionInfo, error) {
+	sess := objectstore.SessionInfo{
+		Provider: "minio",
+		Params: map[string]string{
+			"region":       "minio",
+			"endpoint":     objectstore.MinioDefaultEndpoint(),
+			"disableSsl":   strconv.FormatBool(true),
+			"fromEnv":      strconv.FormatBool(false),
+			"secretName":   minioArtifactSecretName,
+			"accessKeyKey": minioArtifactAccessKeyKey,
+			"secretKeyKey": minioArtifactSecretKeyKey,
+		},
+	}
+	return sess, nil
 }

--- a/backend/src/v2/config/env.go
+++ b/backend/src/v2/config/env.go
@@ -38,8 +38,9 @@ const (
 	configKeyDefaultPipelineRoot = "defaultPipelineRoot"
 	configBucketProviders        = "providers"
 	minioArtifactSecretName      = "mlpipeline-minio-artifact"
-	minioArtifactSecretKeyKey    = "secretkey"
-	minioArtifactAccessKeyKey    = "accesskey"
+	// The k8s secret "Key" for "Artifact SecretKey" and "Artifact AccessKey"
+	minioArtifactSecretKeyKey = "secretkey"
+	minioArtifactAccessKeyKey = "accesskey"
 )
 
 type BucketProviders struct {
@@ -101,7 +102,7 @@ func InPodName() (string, error) {
 	return strings.TrimSuffix(name, "\n"), nil
 }
 
-func (c *Config) GetBucketSessionInfo(path string) (objectstore.SessionInfo, error) {
+func (c *Config) GetStoreSessionInfo(path string) (objectstore.SessionInfo, error) {
 	bucketConfig, err := objectstore.ParseBucketPathToConfig(path)
 	if err != nil {
 		return objectstore.SessionInfo{}, err
@@ -174,11 +175,12 @@ func getDefaultMinioSessionInfo() (objectstore.SessionInfo, error) {
 	sess := objectstore.SessionInfo{
 		Provider: "minio",
 		Params: map[string]string{
-			"region":       "minio",
-			"endpoint":     objectstore.MinioDefaultEndpoint(),
-			"disableSsl":   strconv.FormatBool(true),
-			"fromEnv":      strconv.FormatBool(false),
-			"secretName":   minioArtifactSecretName,
+			"region":     "minio",
+			"endpoint":   objectstore.MinioDefaultEndpoint(),
+			"disableSsl": strconv.FormatBool(true),
+			"fromEnv":    strconv.FormatBool(false),
+			"secretName": minioArtifactSecretName,
+			// The k8s secret "Key" for "Artifact SecretKey" and "Artifact AccessKey"
 			"accessKeyKey": minioArtifactAccessKeyKey,
 			"secretKeyKey": minioArtifactSecretKeyKey,
 		},

--- a/backend/src/v2/config/env_test.go
+++ b/backend/src/v2/config/env_test.go
@@ -1,0 +1,401 @@
+// Copyright 2024 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"sigs.k8s.io/yaml"
+	"testing"
+)
+
+type TestcaseData struct {
+	Testcases []ProviderCase `json:"cases"`
+}
+type ProviderCase struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+func Test_getDefaultMinioSessionInfo(t *testing.T) {
+	actualDefaultSession, err := getDefaultMinioSessionInfo()
+	assert.Nil(t, err)
+	expectedDefaultSession := objectstore.SessionInfo{
+		Provider: "minio",
+		Params: map[string]string{
+			"region":       "minio",
+			"endpoint":     "minio-service.kubeflow:9000",
+			"disableSsl":   "true",
+			"fromEnv":      "false",
+			"secretName":   "mlpipeline-minio-artifact",
+			"accessKeyKey": "accesskey",
+			"secretKeyKey": "secretkey",
+		},
+	}
+	assert.Equal(t, expectedDefaultSession, actualDefaultSession)
+}
+
+func TestGetBucketSessionInfo(t *testing.T) {
+
+	providersDataFile, err := os.ReadFile("testdata/provider_cases.yaml")
+	if os.IsNotExist(err) {
+		panic(err)
+	}
+
+	var providersData TestcaseData
+	err = yaml.Unmarshal(providersDataFile, &providersData)
+	if err != nil {
+		panic(err)
+	}
+
+	tt := []struct {
+		msg                 string
+		config              Config
+		expectedSessionInfo objectstore.SessionInfo
+		pipelineroot        string
+		shouldError         bool
+		errorMsg            string
+		testDataCase        string
+	}{
+		{
+			msg:                 "invalid - unsupported object store protocol",
+			pipelineroot:        "unsupported://my-bucket/v2/artifacts",
+			expectedSessionInfo: objectstore.SessionInfo{},
+			shouldError:         true,
+			errorMsg:            "unsupported Cloud bucket",
+		},
+		{
+			msg:                 "invalid - unsupported pipeline root format",
+			pipelineroot:        "minio.unsupported.format",
+			expectedSessionInfo: objectstore.SessionInfo{},
+			shouldError:         true,
+			errorMsg:            "unrecognized pipeline root format",
+		},
+		{
+			msg:          "valid - no providers, should use minio default",
+			pipelineroot: "minio://my-bucket/v2/artifacts",
+			expectedSessionInfo: objectstore.SessionInfo{
+				Provider: "minio",
+				Params: map[string]string{
+					"region":       "minio",
+					"endpoint":     "minio-service.kubeflow:9000",
+					"disableSsl":   "true",
+					"fromEnv":      "false",
+					"secretName":   "mlpipeline-minio-artifact",
+					"accessKeyKey": "accesskey",
+					"secretKeyKey": "secretkey",
+				},
+			},
+		},
+		{
+			msg:                 "invalid - unsupported provider in providers config",
+			pipelineroot:        "s3://my-bucket",
+			expectedSessionInfo: objectstore.SessionInfo{},
+			shouldError:         true,
+			errorMsg:            "unsupported provider in provider config",
+			testDataCase:        "case0",
+		},
+		{
+			msg:                 "invalid - empty minio provider",
+			pipelineroot:        "minio://my-bucket/v2/artifacts",
+			expectedSessionInfo: objectstore.SessionInfo{},
+			shouldError:         true,
+			errorMsg:            "invalid provider config",
+			testDataCase:        "case1",
+		},
+		{
+			msg:                 "invalid - empty minio provider no override",
+			pipelineroot:        "minio://my-bucket/v2/artifacts",
+			expectedSessionInfo: objectstore.SessionInfo{},
+			shouldError:         true,
+			errorMsg:            "invalid provider config",
+			testDataCase:        "case2",
+		},
+		{
+			msg:                 "invalid - minio provider endpoint only",
+			pipelineroot:        "minio://my-bucket/v2/artifacts",
+			expectedSessionInfo: objectstore.SessionInfo{},
+			shouldError:         true,
+			errorMsg:            "invalid provider config",
+			testDataCase:        "case3",
+		},
+		{
+			msg:                 "invalid - one minio provider no creds",
+			pipelineroot:        "minio://my-bucket/v2/artifacts",
+			expectedSessionInfo: objectstore.SessionInfo{},
+			shouldError:         true,
+			errorMsg:            "missing default credentials",
+			testDataCase:        "case4",
+		},
+		{
+			msg:          "valid - minio provider with default only",
+			pipelineroot: "minio://my-bucket/v2/artifacts",
+			expectedSessionInfo: objectstore.SessionInfo{
+				Provider: "minio",
+				Params: map[string]string{
+					"region":       "minio",
+					"endpoint":     "minio-endpoint-5.com",
+					"disableSSL":   "true",
+					"fromEnv":      "false",
+					"secretName":   "test-secret-5",
+					"accessKeyKey": "test-accessKeyKey-5",
+					"secretKeyKey": "test-secretKeyKey-5",
+				},
+			},
+			testDataCase: "case5",
+		},
+		{
+			msg:          "valid - pick minio provider",
+			pipelineroot: "minio://minio-bucket-a/some/minio/path/a",
+			expectedSessionInfo: objectstore.SessionInfo{
+				Provider: "minio",
+				Params: map[string]string{
+					"region":       "minio-a",
+					"endpoint":     "minio-endpoint-6.com",
+					"disableSSL":   "true",
+					"fromEnv":      "false",
+					"secretName":   "minio-test-secret-6-a",
+					"accessKeyKey": "minio-test-accessKeyKey-6-a",
+					"secretKeyKey": "minio-test-secretKeyKey-6-a",
+				},
+			},
+			testDataCase: "case6",
+		},
+		{
+			msg:                 "invalid - s3 should require default creds",
+			pipelineroot:        "s3://my-bucket/v2/artifacts",
+			expectedSessionInfo: objectstore.SessionInfo{},
+			shouldError:         true,
+			errorMsg:            "missing default credentials",
+			testDataCase:        "case7",
+		},
+		{
+			msg:                 "invalid - gs should require default creds",
+			pipelineroot:        "gs://my-bucket/v2/artifacts",
+			expectedSessionInfo: objectstore.SessionInfo{},
+			shouldError:         true,
+			errorMsg:            "missing default credentials",
+			testDataCase:        "case7",
+		},
+		{
+			msg:                 "invalid - minio should require default creds",
+			pipelineroot:        "minio://my-bucket/v2/artifacts",
+			expectedSessionInfo: objectstore.SessionInfo{},
+			shouldError:         true,
+			errorMsg:            "missing default credentials",
+			testDataCase:        "case7",
+		},
+		{
+			msg:                 "invalid - matching prefix override should require secretref, if fromEnv is false",
+			pipelineroot:        "minio://minio-bucket-a/some/minio/path/a",
+			expectedSessionInfo: objectstore.SessionInfo{},
+			shouldError:         true,
+			errorMsg:            "missing override secretref",
+			testDataCase:        "case8",
+		},
+		{
+			msg:          "valid - matching prefix override should use creds from env, if fromEnv is true",
+			pipelineroot: "minio://minio-bucket-a/some/minio/path/a",
+			expectedSessionInfo: objectstore.SessionInfo{
+				Provider: "minio",
+				Params: map[string]string{
+					"region":     "minio-a",
+					"endpoint":   "minio-endpoint-9.com",
+					"disableSSL": "true",
+					"fromEnv":    "true",
+				},
+			},
+			testDataCase: "case9",
+		},
+		{
+			msg:          "valid - matching prefix override should use secret creds, even if default uses FromEnv",
+			pipelineroot: "minio://minio-bucket-a/some/minio/path/a",
+			expectedSessionInfo: objectstore.SessionInfo{
+				Provider: "minio",
+				Params: map[string]string{
+					"region":       "minio-a",
+					"endpoint":     "minio-endpoint-10.com",
+					"disableSSL":   "true",
+					"fromEnv":      "false",
+					"secretName":   "minio-test-secret-10",
+					"accessKeyKey": "minio-test-accessKeyKey-10",
+					"secretKeyKey": "minio-test-secretKeyKey-10",
+				},
+			},
+			testDataCase: "case10",
+		},
+		{
+			msg:          "valid - secret ref is not required for default s3 when fromEnv is true",
+			pipelineroot: "minio://minio-bucket-a/some/minio/path/b",
+			expectedSessionInfo: objectstore.SessionInfo{
+				Provider: "minio",
+				Params: map[string]string{
+					"region":     "minio",
+					"endpoint":   "minio-endpoint-10.com",
+					"disableSSL": "true",
+					"fromEnv":    "true",
+				},
+			},
+			testDataCase: "case10",
+		},
+		{
+			msg:          "valid - match s3 default config when no override match exists",
+			pipelineroot: "s3://s3-bucket/no/override/path",
+			expectedSessionInfo: objectstore.SessionInfo{
+				Provider: "s3",
+				Params: map[string]string{
+					"region":       "us-east-1",
+					"endpoint":     "s3.amazonaws.com",
+					"disableSSL":   "false",
+					"fromEnv":      "false",
+					"secretName":   "s3-testsecret-6",
+					"accessKeyKey": "s3-testaccessKeyKey-6",
+					"secretKeyKey": "s3-testsecretKeyKey-6",
+				},
+			},
+			testDataCase: "case6",
+		},
+		{
+			msg:          "valid - override should match first subpath prefix in pipelineroot",
+			pipelineroot: "s3://s3-bucket/some/s3/path/b",
+			expectedSessionInfo: objectstore.SessionInfo{
+				Provider: "s3",
+				Params: map[string]string{
+					"region":       "us-east-2",
+					"endpoint":     "s3.us-east-2.amazonaws.com",
+					"disableSSL":   "false",
+					"fromEnv":      "false",
+					"secretName":   "s3-test-secret-6-b",
+					"accessKeyKey": "s3-test-accessKeyKey-6-b",
+					"secretKeyKey": "s3-test-secretKeyKey-6-b",
+				},
+			},
+			testDataCase: "case6",
+		},
+		{
+			msg:          "valid - test order, match first subpath prefix in pipelineroot, ignoring deeper path prefix further in list",
+			pipelineroot: "s3://s3-bucket/some/s3/path/a/b",
+			expectedSessionInfo: objectstore.SessionInfo{
+				Provider: "s3",
+				Params: map[string]string{
+					"region":       "us-east-1",
+					"endpoint":     "s3.amazonaws.com",
+					"disableSSL":   "false",
+					"fromEnv":      "false",
+					"secretName":   "s3-test-secret-6-a",
+					"accessKeyKey": "s3-test-accessKeyKey-6-a",
+					"secretKeyKey": "s3-test-secretKeyKey-6-a",
+				},
+			},
+			testDataCase: "case6",
+		},
+		{
+			msg:          "valid - first matching gs override",
+			pipelineroot: "gs://gs-bucket-a/some/gs/path/1",
+			expectedSessionInfo: objectstore.SessionInfo{
+				Provider: "gs",
+				Params: map[string]string{
+					"fromEnv":    "false",
+					"secretName": "gs-test-secret-6-a",
+					"tokenKey":   "gs-test-tokenKey-6-a",
+				},
+			},
+			testDataCase: "case6",
+		},
+		{
+			msg:          "valid - pick default gs when no matching prefix",
+			pipelineroot: "gs://path/does/not/exist/so/use/default",
+			expectedSessionInfo: objectstore.SessionInfo{
+				Provider: "gs",
+				Params: map[string]string{
+					"fromEnv":    "false",
+					"secretName": "gs-test-secret-6",
+					"tokenKey":   "gs-test-tokenKey-6",
+				},
+			},
+			testDataCase: "case6",
+		},
+		{
+			msg:          "valid - gs secretref not required when default is set to env",
+			pipelineroot: "gs://path/does/not/exist/so/use/default",
+			expectedSessionInfo: objectstore.SessionInfo{
+				Provider: "gs",
+				Params: map[string]string{
+					"fromEnv": "true",
+				},
+			},
+			testDataCase: "case11",
+		},
+		{
+			msg:          "valid - gs secretref not required when matching override is set to env",
+			pipelineroot: "gs://gs-bucket/some/gs/path/1/2",
+			expectedSessionInfo: objectstore.SessionInfo{
+				Provider: "gs",
+				Params: map[string]string{
+					"fromEnv": "true",
+				},
+			},
+			testDataCase: "case11",
+		},
+		{
+			msg:          "valid - gs secretref is required when matching override is fromEnv:false",
+			pipelineroot: "gs://gs-bucket/some/gs/path/1",
+			expectedSessionInfo: objectstore.SessionInfo{
+				Provider: "gs",
+				Params: map[string]string{
+					"fromEnv":    "false",
+					"secretName": "gs-test-secret-11",
+					"tokenKey":   "gs-test-tokenKey-11",
+				},
+			},
+			testDataCase: "case11",
+		},
+	}
+
+	for _, test := range tt {
+		t.Run(test.msg, func(t *testing.T) {
+			config := Config{data: map[string]string{}}
+			if test.testDataCase != "" {
+				config.data["providers"] = fetchProviderFromdata(providersData, test.testDataCase)
+				if config.data["providers"] == "" {
+					panic(fmt.Errorf("provider not found in testdata"))
+				}
+			}
+
+			actualSession, err := config.GetBucketSessionInfo(test.pipelineroot)
+			if test.shouldError {
+				assert.Error(t, err)
+				if err != nil && test.errorMsg != "" {
+					assert.Contains(t, err.Error(), test.errorMsg)
+				}
+			} else {
+				assert.Nil(t, err)
+			}
+
+			assert.Equal(t, test.expectedSessionInfo, actualSession)
+		})
+	}
+}
+
+func fetchProviderFromdata(cases TestcaseData, name string) string {
+	for _, c := range cases.Testcases {
+		if c.Name == name {
+			return c.Value
+		}
+	}
+	return ""
+}

--- a/backend/src/v2/config/env_test.go
+++ b/backend/src/v2/config/env_test.go
@@ -376,7 +376,7 @@ func TestGetBucketSessionInfo(t *testing.T) {
 				}
 			}
 
-			actualSession, err := config.GetBucketSessionInfo(test.pipelineroot)
+			actualSession, err := config.GetStoreSessionInfo(test.pipelineroot)
 			if test.shouldError {
 				assert.Error(t, err)
 				if err != nil && test.errorMsg != "" {

--- a/backend/src/v2/config/gcs.go
+++ b/backend/src/v2/config/gcs.go
@@ -1,0 +1,105 @@
+// Copyright 2024 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
+	"strconv"
+	"strings"
+)
+
+type GCSProviderConfig struct {
+	Default *GCSProviderDefault `json:"default"`
+
+	// optional, ordered, the auth config for the first matching prefix is used
+	Overrides []GCSOverride `json:"Overrides"`
+}
+
+type GCSProviderDefault struct {
+	// required
+	Credentials *GCSCredentials `json:"credentials"`
+}
+
+type GCSOverride struct {
+	BucketName  string          `json:"bucketName"`
+	KeyPrefix   string          `json:"keyPrefix"`
+	Credentials *GCSCredentials `json:"credentials"`
+}
+type GCSCredentials struct {
+	// optional
+	FromEnv bool `json:"fromEnv"`
+	// if FromEnv is False then SecretRef is required
+	SecretRef *GCSSecretRef `json:"secretRef"`
+}
+type GCSSecretRef struct {
+	SecretName string `json:"secretName"`
+	TokenKey   string `json:"tokenKey"`
+}
+
+func (p GCSProviderConfig) ProvideSessionInfo(bucketName, bucketPrefix string) (objectstore.SessionInfo, error) {
+	invalidConfigErr := func(err error) error {
+		return fmt.Errorf("invalid provider config: %w", err)
+	}
+
+	params := map[string]string{}
+
+	if p.Default == nil || p.Default.Credentials == nil {
+		return objectstore.SessionInfo{}, invalidConfigErr(fmt.Errorf("missing default credentials"))
+	}
+
+	params["fromEnv"] = strconv.FormatBool(p.Default.Credentials.FromEnv)
+	if !p.Default.Credentials.FromEnv {
+		params["secretName"] = p.Default.Credentials.SecretRef.SecretName
+		params["tokenKey"] = p.Default.Credentials.SecretRef.TokenKey
+	}
+
+	// Set defaults
+	sessionInfo := objectstore.SessionInfo{
+		Provider: "gs",
+		Params:   params,
+	}
+
+	// If there's a matching override, then override defaults with provided configs
+	override := p.getOverrideByPrefix(bucketName, bucketPrefix)
+	if override != nil {
+		if override.Credentials == nil {
+			return objectstore.SessionInfo{}, invalidConfigErr(fmt.Errorf("missing override secretref"))
+		}
+		params["fromEnv"] = strconv.FormatBool(override.Credentials.FromEnv)
+		if !override.Credentials.FromEnv {
+			if override.Credentials.SecretRef == nil {
+				return objectstore.SessionInfo{}, invalidConfigErr(fmt.Errorf("missing override secretref"))
+			}
+			params["secretName"] = override.Credentials.SecretRef.SecretName
+			params["tokenKey"] = override.Credentials.SecretRef.TokenKey
+		} else {
+			// Don't need a secret if pulling from Env
+			delete(params, "secretName")
+			delete(params, "tokenKey")
+		}
+	}
+	return sessionInfo, nil
+}
+
+// getOverrideByPrefix returns first matching bucketname and prefix in overrides
+func (p GCSProviderConfig) getOverrideByPrefix(bucketName, prefix string) *GCSOverride {
+	for _, override := range p.Overrides {
+		if override.BucketName == bucketName && strings.HasPrefix(prefix, override.KeyPrefix) {
+			return &override
+		}
+	}
+	return nil
+}

--- a/backend/src/v2/config/minio.go
+++ b/backend/src/v2/config/minio.go
@@ -1,0 +1,32 @@
+// Copyright 2024 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "github.com/kubeflow/pipelines/backend/src/v2/objectstore"
+
+type MinioProviderConfig S3ProviderConfig
+
+// ProvideSessionInfo provides the SessionInfo for minio provider.
+// this is the same as s3ProviderConfig.ProvideSessionInfo except
+// the provider is set to minio
+func (p MinioProviderConfig) ProvideSessionInfo(bucketName, bucketPrefix string) (objectstore.SessionInfo, error) {
+	s3ProviderConfig := S3ProviderConfig(p)
+	info, err := s3ProviderConfig.ProvideSessionInfo(bucketName, bucketPrefix)
+	if err != nil {
+		return objectstore.SessionInfo{}, err
+	}
+	info.Provider = "minio"
+	return info, nil
+}

--- a/backend/src/v2/config/s3.go
+++ b/backend/src/v2/config/s3.go
@@ -1,0 +1,135 @@
+// Copyright 2024 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
+	"strconv"
+	"strings"
+)
+
+type S3ProviderConfig struct {
+	Default *S3ProviderDefault `json:"default"`
+	// optional, ordered, the auth config for the first matching prefix is used
+	Overrides []S3Override `json:"Overrides"`
+}
+
+type S3ProviderDefault struct {
+	Endpoint    string         `json:"endpoint"`
+	Credentials *S3Credentials `json:"credentials"`
+	// optional for any non aws s3 provider
+	Region string `json:"region"`
+	// optional
+	DisableSSL *bool `json:"disableSSL"`
+}
+
+type S3Credentials struct {
+	// optional
+	FromEnv bool `json:"fromEnv"`
+	// if FromEnv is False then SecretRef is required
+	SecretRef *S3SecretRef `json:"secretRef"`
+}
+type S3Override struct {
+	Endpoint string `json:"endpoint"`
+	// optional for any non aws s3 provider
+	Region string `json:"region"`
+	// optional
+	DisableSSL *bool  `json:"disableSSL"`
+	BucketName string `json:"bucketName"`
+	KeyPrefix  string `json:"keyPrefix"`
+	// required
+	Credentials *S3Credentials `json:"credentials"`
+}
+type S3SecretRef struct {
+	SecretName   string `json:"secretName"`
+	AccessKeyKey string `json:"accessKeyKey"`
+	SecretKeyKey string `json:"secretKeyKey"`
+}
+
+func (p S3ProviderConfig) ProvideSessionInfo(bucketName, bucketPrefix string) (objectstore.SessionInfo, error) {
+	invalidConfigErr := func(err error) error {
+		return fmt.Errorf("invalid provider config: %w", err)
+	}
+
+	params := map[string]string{}
+	if p.Default == nil || p.Default.Credentials == nil {
+		return objectstore.SessionInfo{}, invalidConfigErr(fmt.Errorf("missing default credentials"))
+	}
+
+	params["region"] = p.Default.Region
+	params["endpoint"] = p.Default.Endpoint
+
+	if p.Default.DisableSSL == nil {
+		params["disableSSL"] = "false"
+	} else {
+		params["disableSSL"] = strconv.FormatBool(*p.Default.DisableSSL)
+	}
+
+	params["fromEnv"] = strconv.FormatBool(p.Default.Credentials.FromEnv)
+	if !p.Default.Credentials.FromEnv {
+		params["secretName"] = p.Default.Credentials.SecretRef.SecretName
+		params["accessKeyKey"] = p.Default.Credentials.SecretRef.AccessKeyKey
+		params["secretKeyKey"] = p.Default.Credentials.SecretRef.SecretKeyKey
+	}
+
+	// Set defaults
+	sessionInfo := objectstore.SessionInfo{
+		Provider: "s3",
+		Params:   params,
+	}
+
+	// If there's a matching override, then override defaults with provided configs
+	override := p.getOverrideByPrefix(bucketName, bucketPrefix)
+	if override != nil {
+		if override.Endpoint != "" {
+			sessionInfo.Params["endpoint"] = override.Endpoint
+		}
+		if override.Region != "" {
+			sessionInfo.Params["region"] = override.Region
+		}
+		if override.DisableSSL != nil {
+			sessionInfo.Params["disableSSL"] = strconv.FormatBool(*override.DisableSSL)
+		}
+		if override.Credentials == nil {
+			return objectstore.SessionInfo{}, invalidConfigErr(fmt.Errorf("missing override credentials"))
+		}
+		params["fromEnv"] = strconv.FormatBool(override.Credentials.FromEnv)
+		if !override.Credentials.FromEnv {
+			if override.Credentials.SecretRef == nil {
+				return objectstore.SessionInfo{}, invalidConfigErr(fmt.Errorf("missing override secretref"))
+			}
+			params["secretName"] = override.Credentials.SecretRef.SecretName
+			params["accessKeyKey"] = override.Credentials.SecretRef.AccessKeyKey
+			params["secretKeyKey"] = override.Credentials.SecretRef.SecretKeyKey
+		} else {
+			// Don't need a secret if pulling from Env
+			delete(params, "secretName")
+			delete(params, "accessKeyKey")
+			delete(params, "secretKeyKey")
+		}
+	}
+	return sessionInfo, nil
+}
+
+// getOverrideByPrefix returns first matching bucketname and prefix in overrides
+func (p S3ProviderConfig) getOverrideByPrefix(bucketName, prefix string) *S3Override {
+	for _, override := range p.Overrides {
+		if override.BucketName == bucketName && strings.HasPrefix(prefix, override.KeyPrefix) {
+			return &override
+		}
+	}
+	return nil
+}

--- a/backend/src/v2/config/s3.go
+++ b/backend/src/v2/config/s3.go
@@ -54,7 +54,8 @@ type S3Override struct {
 	Credentials *S3Credentials `json:"credentials"`
 }
 type S3SecretRef struct {
-	SecretName   string `json:"secretName"`
+	SecretName string `json:"secretName"`
+	// The k8s secret "Key" for "Artifact SecretKey" and "Artifact AccessKey"
 	AccessKeyKey string `json:"accessKeyKey"`
 	SecretKeyKey string `json:"secretKeyKey"`
 }

--- a/backend/src/v2/config/testdata/provider_cases.yaml
+++ b/backend/src/v2/config/testdata/provider_cases.yaml
@@ -1,0 +1,247 @@
+# Case names should be unique
+cases:
+  # invalid
+  - name: case0
+    value: |
+      invalid: {}
+  # invalid
+  - name: case1
+    value: |
+      minio: {}
+  # invalid
+  - name: case2
+    value: |
+      minio:
+        overrides: []
+  # invalid
+  - name: case3
+    value: |
+      minio:
+        endpoint: minio-endpoint-3.com
+  # invalid
+  - name: case4
+    value: |
+      minio:
+        default:
+          endpoint: minio-endpoint-4.com
+          region: minio
+          overrides: []
+  # valid
+  - name: case5
+    value: |
+      minio:
+        default:
+          endpoint: minio-endpoint-5.com
+          region: minio
+          disableSSL: true
+          credentials:
+            fromEnv: false
+            secretRef:
+              secretName: test-secret-5
+              accessKeyKey: test-accessKeyKey-5
+              secretKeyKey: test-secretKeyKey-5
+        overrides: []
+  # valid
+  - name: case6
+    value: |
+      gs:
+        default:
+          credentials:
+            fromEnv: false
+            secretRef:
+              secretName: gs-test-secret-6
+              tokenKey: gs-test-tokenKey-6
+        overrides:
+          - bucketName: gs-bucket-a
+            keyPrefix: some/gs/path/1/2
+            credentials:
+              fromEnv: false
+              secretRef:
+                secretName: gs-test-secret-6-a-1
+                tokenKey: gs-test-tokenKey-6-a-1
+          - bucketName: gs-bucket-a
+            keyPrefix: some/gs/path/1
+            credentials:
+              fromEnv: false
+              secretRef:
+                secretName: gs-test-secret-6-a
+                tokenKey: gs-test-tokenKey-6-a
+      minio:
+        default:
+          endpoint: minio-endpoint-6.com
+          region: minio
+          disableSSL: true
+          credentials:
+            fromEnv: false
+            secretRef:
+              secretName: minio-test-secret-6
+              accessKeyKey: minio-test-accessKeyKey-6
+              secretKeyKey: minio-test-secretKeyKey-6
+        overrides:
+          - endpoint: minio-endpoint-6.com
+            region: minio-a
+            disableSSL: true
+            bucketName: minio-bucket-a
+            keyPrefix: some/minio/path/a
+            credentials:
+              fromEnv: false
+              secretRef:
+                secretName: minio-test-secret-6-a
+                accessKeyKey: minio-test-accessKeyKey-6-a
+                secretKeyKey: minio-test-secretKeyKey-6-a
+      s3:
+        default:
+          endpoint: s3.amazonaws.com
+          region: us-east-1
+          disableSSL: false
+          credentials:
+            fromEnv: false
+            secretRef:
+              secretName: s3-testsecret-6
+              accessKeyKey: s3-testaccessKeyKey-6
+              secretKeyKey: s3-testsecretKeyKey-6
+        overrides:
+          - bucketName: s3-bucket
+            keyPrefix: some/s3/path/a
+            credentials:
+              fromEnv: false
+              secretRef:
+                secretName: s3-test-secret-6-a
+                accessKeyKey: s3-test-accessKeyKey-6-a
+                secretKeyKey: s3-test-secretKeyKey-6-a
+          - bucketName: s3-bucket
+            keyPrefix: some/s3/path/a/b
+            credentials:
+              fromEnv: false
+              secretRef:
+                secretName: s3-test-secret-6-a-1
+                accessKeyKey: s3-test-accessKeyKey-6-a-1
+                secretKeyKey: s3-test-secretKeyKey-6-a-1
+          - bucketName: s3-bucket
+            keyPrefix: some/s3/path/b
+            endpoint: s3.us-east-2.amazonaws.com
+            region: us-east-2
+            disableSSL: false
+            credentials:
+              fromEnv: false
+              secretRef:
+                secretName: s3-test-secret-6-b
+                accessKeyKey: s3-test-accessKeyKey-6-b
+                secretKeyKey: s3-test-secretKeyKey-6-b
+          - bucketName: s3-bucket
+            keyPrefix: some/s3/path/b/c
+            credentials:
+              fromEnv: false
+              secretRef:
+                secretName: s3-test-secret-6-b-1
+                accessKeyKey: s3-test-accessKeyKey-6-b-1
+                secretKeyKey: s3-test-secretKeyKey-6-b-1
+          - bucketName: s3-bucket-2
+            keyPrefix: some/s3/path/a
+            credentials:
+              fromEnv: false
+              secretRef:
+                secretName: s3-test-secret-6-a-2
+                accessKeyKey: s3-test-accessKeyKey-6-a-2
+                secretKeyKey: s3-test-secretKeyKey-6-a-2
+  # invalid
+  - name: case7
+    value: |
+      s3:
+        default:
+          endpoint: s3-endpoint-7.com
+          region: auto
+        overrides: []
+      gs:
+        overrides: []
+      minio:
+        default:
+          endpoint: minio-endpoint-7.com
+          region: auto
+        overrides: []
+  # valid for default case
+  # invalid override - missing secretref in credentials
+  - name: case8
+    value: |
+      minio:
+        default:
+          endpoint: minio-endpoint-8.com
+          region: minio
+          disableSSL: true
+          credentials:
+            fromEnv: false
+            secretRef:
+              secretName: minio-test-secret-8
+              accessKeyKey: minio-test-accessKeyKey-8
+              secretKeyKey: minio-test-secretKeyKey-8
+        overrides:
+          - endpoint: minio-endpoint-8.com
+            region: minio-a
+            disableSSL: true
+            bucketName: minio-bucket-a
+            keyPrefix: some/minio/path/a
+            credentials:
+              fromEnv: false
+  # valid
+  # note that since override has "FromEnv: true"
+  # no secretRef is required
+  - name: case9
+    value: |
+      minio:
+        default:
+          endpoint: minio-endpoint-9.com
+          region: minio
+          disableSSL: true
+          credentials:
+            fromEnv: false
+            secretRef:
+              secretName: minio-test-secret-9
+              accessKeyKey: minio-test-accessKeyKey-9
+              secretKeyKey: minio-test-secretKeyKey-9
+        overrides:
+          - endpoint: minio-endpoint-9.com
+            region: minio-a
+            disableSSL: true
+            bucketName: minio-bucket-a
+            keyPrefix: some/minio/path/a
+            credentials:
+              fromEnv: true
+  - name: case10
+    value: |
+      minio:
+        default:
+          endpoint: minio-endpoint-10.com
+          region: minio
+          disableSSL: true
+          credentials:
+            fromEnv: true
+        overrides:
+          - endpoint: minio-endpoint-10.com
+            region: minio-a
+            disableSSL: true
+            bucketName: minio-bucket-a
+            keyPrefix: some/minio/path/a
+            credentials:
+              fromEnv: false
+              secretRef:
+                secretName: minio-test-secret-10
+                accessKeyKey: minio-test-accessKeyKey-10
+                secretKeyKey: minio-test-secretKeyKey-10
+  - name: case11
+    value: |
+      gs:
+        default:
+          credentials:
+            fromEnv: true
+        overrides:
+          - bucketName: gs-bucket
+            keyPrefix: some/gs/path/1/2
+            credentials:
+              fromEnv: true
+          - bucketName: gs-bucket
+            keyPrefix: some/gs/path/1
+            credentials:
+              fromEnv: false
+              secretRef:
+                secretName: gs-test-secret-11
+                tokenKey: gs-test-tokenKey-11

--- a/backend/src/v2/config/testdata/provider_cases.yaml
+++ b/backend/src/v2/config/testdata/provider_cases.yaml
@@ -1,24 +1,25 @@
 # Case names should be unique
 cases:
-  # invalid
+  # valid
   - name: case0
     value: |
-      invalid: {}
-  # invalid
+      nomatch: {}
+  # valid
   - name: case1
     value: |
       minio: {}
-  # invalid
+  # valid
   - name: case2
     value: |
       minio:
         overrides: []
-  # invalid
+  # invalid if matching against "minio://"
   - name: case3
     value: |
       minio:
-        endpoint: minio-endpoint-3.com
-  # invalid
+        default:
+          endpoint: minio-endpoint-3.com
+  # invalid if matching against "minio://"
   - name: case4
     value: |
       minio:
@@ -227,6 +228,7 @@ cases:
                 secretName: minio-test-secret-10
                 accessKeyKey: minio-test-accessKeyKey-10
                 secretKeyKey: minio-test-secretKeyKey-10
+  # valid
   - name: case11
     value: |
       gs:
@@ -245,3 +247,22 @@ cases:
               secretRef:
                 secretName: gs-test-secret-11
                 tokenKey: gs-test-tokenKey-11
+  # valid
+  - name: case12
+    value: |
+      minio:
+        default:
+          endpoint: minio-endpoint-12.com
+          region: minio
+          disableSSL: true
+          credentials:
+            fromEnv: true
+        overrides:
+          - bucketName: bucket_name
+            keyPrefix: v2/artifacts/profile_name
+            credentials:
+              fromEnv: false
+              secretRef:
+                secretName: minio-test-secret-12-a
+                accessKeyKey: minio-test-accessKeyKey-12-a
+                secretKeyKey: minio-test-secretKeyKey-12-a

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -145,24 +145,24 @@ func RootDAG(ctx context.Context, opts Options, mlmd *metadata.Client) (executio
 		return nil, err
 	}
 
-	pipelineBucketSessionInfo := objectstore.SessionInfo{}
+	storeSessionInfo := objectstore.SessionInfo{}
 	if pipelineRoot != "" {
 		glog.Infof("PipelineRoot=%q", pipelineRoot)
 	} else {
 		pipelineRoot = cfg.DefaultPipelineRoot()
 		glog.Infof("PipelineRoot=%q from default config", pipelineRoot)
 	}
-	pipelineBucketSessionInfo, err = cfg.GetBucketSessionInfo(pipelineRoot)
+	storeSessionInfo, err = cfg.GetStoreSessionInfo(pipelineRoot)
 	if err != nil {
 		return nil, err
 	}
-	bucketSessionInfo, err := json.Marshal(pipelineBucketSessionInfo)
+	storeSessionInfoJSON, err := json.Marshal(storeSessionInfo)
 	if err != nil {
 		return nil, err
 	}
-	bucketSessionInfoEntry := string(bucketSessionInfo)
+	storeSessionInfoStr := string(storeSessionInfoJSON)
 	// TODO(Bobgy): fill in run resource.
-	pipeline, err := mlmd.GetPipeline(ctx, opts.PipelineName, opts.RunID, opts.Namespace, "run-resource", pipelineRoot, bucketSessionInfoEntry)
+	pipeline, err := mlmd.GetPipeline(ctx, opts.PipelineName, opts.RunID, opts.Namespace, "run-resource", pipelineRoot, storeSessionInfoStr)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -77,7 +77,7 @@ var (
 )
 
 type ClientInterface interface {
-	GetPipeline(ctx context.Context, pipelineName, runID, namespace, runResource, pipelineRoot, bucketSessionInfo string) (*Pipeline, error)
+	GetPipeline(ctx context.Context, pipelineName, runID, namespace, runResource, pipelineRoot, storeSessionInfo string) (*Pipeline, error)
 	GetDAG(ctx context.Context, executionID int64) (*DAG, error)
 	PublishExecution(ctx context.Context, execution *Execution, outputParameters map[string]*structpb.Value, outputArtifacts []*OutputArtifact, state pb.Execution_State) error
 	CreateExecution(ctx context.Context, pipeline *Pipeline, config *ExecutionConfig) (*Execution, error)
@@ -200,16 +200,16 @@ func (p *Pipeline) GetCtxID() int64 {
 	return p.pipelineCtx.GetId()
 }
 
-func (p *Pipeline) GetPipelineBucketSession() string {
+func (p *Pipeline) GetStoreSessionInfo() string {
 	if p == nil {
 		return ""
 	}
 	props := p.pipelineRunCtx.GetCustomProperties()
-	bucketSessionInfo, ok := props[keySessionInfoDetails]
+	storeSessionInfo, ok := props[keyStoreSessionInfo]
 	if !ok {
 		return ""
 	}
-	return bucketSessionInfo.GetStringValue()
+	return storeSessionInfo.GetStringValue()
 }
 
 func (p *Pipeline) GetPipelineRoot() string {
@@ -294,7 +294,7 @@ func GenerateOutputURI(pipelineRoot string, paths []string, preserveQueryString 
 
 // GetPipeline returns the current pipeline represented by the specified
 // pipeline name and run ID.
-func (c *Client) GetPipeline(ctx context.Context, pipelineName, runID, namespace, runResource, pipelineRoot, bucketSessionInfo string) (*Pipeline, error) {
+func (c *Client) GetPipeline(ctx context.Context, pipelineName, runID, namespace, runResource, pipelineRoot, storeSessionInfo string) (*Pipeline, error) {
 	pipelineContext, err := c.getOrInsertContext(ctx, pipelineName, pipelineContextType, nil)
 	if err != nil {
 		return nil, err
@@ -304,8 +304,8 @@ func (c *Client) GetPipeline(ctx context.Context, pipelineName, runID, namespace
 		keyNamespace:    stringValue(namespace),
 		keyResourceName: stringValue(runResource),
 		// pipeline root of this run
-		keyPipelineRoot:       stringValue(GenerateOutputURI(pipelineRoot, []string{pipelineName, runID}, true)),
-		keySessionInfoDetails: stringValue(bucketSessionInfo),
+		keyPipelineRoot:     stringValue(GenerateOutputURI(pipelineRoot, []string{pipelineName, runID}, true)),
+		keyStoreSessionInfo: stringValue(storeSessionInfo),
 	}
 	runContext, err := c.getOrInsertContext(ctx, runID, pipelineRunContextType, metadata)
 	glog.Infof("Pipeline Run Context: %+v", runContext)
@@ -497,22 +497,22 @@ func (c *Client) PublishExecution(ctx context.Context, execution *Execution, out
 
 // metadata keys
 const (
-	keyDisplayName        = "display_name"
-	keyTaskName           = "task_name"
-	keyImage              = "image"
-	keyPodName            = "pod_name"
-	keyPodUID             = "pod_uid"
-	keyNamespace          = "namespace"
-	keyResourceName       = "resource_name"
-	keyPipelineRoot       = "pipeline_root"
-	keySessionInfoDetails = "bucket_session_info"
-	keyCacheFingerPrint   = "cache_fingerprint"
-	keyCachedExecutionID  = "cached_execution_id"
-	keyInputs             = "inputs"
-	keyOutputs            = "outputs"
-	keyParentDagID        = "parent_dag_id" // Parent DAG Execution ID.
-	keyIterationIndex     = "iteration_index"
-	keyIterationCount     = "iteration_count"
+	keyDisplayName       = "display_name"
+	keyTaskName          = "task_name"
+	keyImage             = "image"
+	keyPodName           = "pod_name"
+	keyPodUID            = "pod_uid"
+	keyNamespace         = "namespace"
+	keyResourceName      = "resource_name"
+	keyPipelineRoot      = "pipeline_root"
+	keyStoreSessionInfo  = "store_session_info"
+	keyCacheFingerPrint  = "cache_fingerprint"
+	keyCachedExecutionID = "cached_execution_id"
+	keyInputs            = "inputs"
+	keyOutputs           = "outputs"
+	keyParentDagID       = "parent_dag_id" // Parent DAG Execution ID.
+	keyIterationIndex    = "iteration_index"
+	keyIterationCount    = "iteration_count"
 )
 
 // CreateExecution creates a new MLMD execution under the specified Pipeline.

--- a/backend/src/v2/metadata/client_fake.go
+++ b/backend/src/v2/metadata/client_fake.go
@@ -32,7 +32,7 @@ func NewFakeClient() *FakeClient {
 	return &FakeClient{}
 }
 
-func (c *FakeClient) GetPipeline(ctx context.Context, pipelineName, runID, namespace, runResource, pipelineRoot string) (*Pipeline, error) {
+func (c *FakeClient) GetPipeline(ctx context.Context, pipelineName, runID, namespace, runResource, pipelineRoot string, bucketSessionInfo string) (*Pipeline, error) {
 	return nil, nil
 }
 

--- a/backend/src/v2/metadata/client_fake.go
+++ b/backend/src/v2/metadata/client_fake.go
@@ -32,7 +32,7 @@ func NewFakeClient() *FakeClient {
 	return &FakeClient{}
 }
 
-func (c *FakeClient) GetPipeline(ctx context.Context, pipelineName, runID, namespace, runResource, pipelineRoot string, bucketSessionInfo string) (*Pipeline, error) {
+func (c *FakeClient) GetPipeline(ctx context.Context, pipelineName, runID, namespace, runResource, pipelineRoot string, storeSessionInfo string) (*Pipeline, error) {
 	return nil, nil
 }
 

--- a/backend/src/v2/metadata/client_test.go
+++ b/backend/src/v2/metadata/client_test.go
@@ -89,7 +89,7 @@ func Test_GetPipeline(t *testing.T) {
 	mlmdClient, err := NewTestMlmdClient()
 	fatalIf(err)
 
-	pipeline, err := client.GetPipeline(ctx, "get-pipeline-test", runId, namespace, runResource, pipelineRoot)
+	pipeline, err := client.GetPipeline(ctx, "get-pipeline-test", runId, namespace, runResource, pipelineRoot, "")
 	fatalIf(err)
 	expectPipelineRoot := fmt.Sprintf("%s/get-pipeline-test/%s", pipelineRoot, runId)
 	if pipeline.GetPipelineRoot() != expectPipelineRoot {
@@ -138,10 +138,10 @@ func Test_GetPipeline_Twice(t *testing.T) {
 	client, err := metadata.NewClient(testMlmdServerAddress, testMlmdServerPort)
 	fatalIf(err)
 
-	pipeline, err := client.GetPipeline(ctx, "get-pipeline-test", runId, namespace, runResource, pipelineRoot)
+	pipeline, err := client.GetPipeline(ctx, "get-pipeline-test", runId, namespace, runResource, pipelineRoot, "")
 	fatalIf(err)
 	// The second call to GetPipeline won't fail because it avoid inserting to MLMD again.
-	samePipeline, err := client.GetPipeline(ctx, "get-pipeline-test", runId, namespace, runResource, pipelineRoot)
+	samePipeline, err := client.GetPipeline(ctx, "get-pipeline-test", runId, namespace, runResource, pipelineRoot, "")
 	fatalIf(err)
 	if pipeline.GetCtxID() != samePipeline.GetCtxID() {
 		t.Errorf("Expect pipeline context ID %d, actual is %d", pipeline.GetCtxID(), samePipeline.GetCtxID())
@@ -159,7 +159,7 @@ func Test_GetPipelineFromExecution(t *testing.T) {
 	}
 	client := newLocalClientOrFatal(t)
 	ctx := context.Background()
-	pipeline, err := client.GetPipeline(ctx, "get-pipeline-from-execution", newUUIDOrFatal(t), "kubeflow", "workflow/abc", "gs://my-bucket/root")
+	pipeline, err := client.GetPipeline(ctx, "get-pipeline-from-execution", newUUIDOrFatal(t), "kubeflow", "workflow/abc", "gs://my-bucket/root", "")
 	fatalIf(err)
 	execution, err := client.CreateExecution(ctx, pipeline, &metadata.ExecutionConfig{
 		TaskName:      "task1",
@@ -193,7 +193,7 @@ func Test_GetPipelineConcurrently(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := client.GetPipeline(ctx, fmt.Sprintf("get-pipeline-concurrently-test-%s", runIdText), runIdText, namespace, "workflows.argoproj.io/hello-world-"+runIdText, pipelineRoot)
+			_, err := client.GetPipeline(ctx, fmt.Sprintf("get-pipeline-concurrently-test-%s", runIdText), runIdText, namespace, "workflows.argoproj.io/hello-world-"+runIdText, pipelineRoot, "")
 			if err != nil {
 				t.Error(err)
 			}
@@ -205,7 +205,7 @@ func Test_GetPipelineConcurrently(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := client.GetPipeline(ctx, fmt.Sprintf("get-pipeline-concurrently-test-%s", runIdText), runIdText, namespace, "workflows.argoproj.io/hello-world-"+runIdText, pipelineRoot)
+			_, err := client.GetPipeline(ctx, fmt.Sprintf("get-pipeline-concurrently-test-%s", runIdText), runIdText, namespace, "workflows.argoproj.io/hello-world-"+runIdText, pipelineRoot, "")
 			if err != nil {
 				t.Error(err)
 			}
@@ -274,7 +274,7 @@ func Test_DAG(t *testing.T) {
 	client := newLocalClientOrFatal(t)
 	ctx := context.Background()
 	// These parameters do not matter.
-	pipeline, err := client.GetPipeline(ctx, "pipeline-name", newUUIDOrFatal(t), "ns1", "workflow/pipeline-1234", pipelineRoot)
+	pipeline, err := client.GetPipeline(ctx, "pipeline-name", newUUIDOrFatal(t), "ns1", "workflow/pipeline-1234", pipelineRoot, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/src/v2/objectstore/config.go
+++ b/backend/src/v2/objectstore/config.go
@@ -1,0 +1,231 @@
+// Copyright 2024 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This package contains helper methods for using object stores.
+package objectstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/golang/glog"
+	"os"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// The endpoint uses Kubernetes service DNS name with namespace:
+// https://kubernetes.io/docs/concepts/services-networking/service/#dns
+const defaultMinioEndpointInMultiUserMode = "minio-service.kubeflow:9000"
+
+type Config struct {
+	Scheme      string
+	BucketName  string
+	Prefix      string
+	QueryString string
+	Session     *SessionInfo
+}
+
+type SessionInfo struct {
+	Provider string
+	Params   map[string]string
+}
+
+type GCSParams struct {
+	FromEnv    bool
+	SecretName string
+	TokenKey   string
+}
+
+type S3Params struct {
+	FromEnv      bool
+	SecretName   string
+	AccessKeyKey string
+	SecretKeyKey string
+	Region       string
+	Endpoint     string
+	DisableSSL   bool
+}
+
+func (b *Config) bucketURL() string {
+	u := b.Scheme + b.BucketName
+
+	// append prefix=b.prefix to existing queryString
+	q := b.QueryString
+	if len(b.Prefix) > 0 {
+		if len(q) > 0 {
+			q = q + "&prefix=" + b.Prefix
+		} else {
+			q = "?prefix=" + b.Prefix
+		}
+	}
+
+	u = u + q
+	return u
+}
+
+func (b *Config) PrefixedBucket() string {
+	return b.Scheme + path.Join(b.BucketName, b.Prefix)
+}
+
+func (b *Config) KeyFromURI(uri string) (string, error) {
+	prefixedBucket := b.PrefixedBucket()
+	if !strings.HasPrefix(uri, prefixedBucket) {
+		return "", fmt.Errorf("URI %q does not have expected bucket prefix %q", uri, prefixedBucket)
+	}
+
+	key := strings.TrimLeft(strings.TrimPrefix(uri, prefixedBucket), "/")
+	if len(key) == 0 {
+		return "", fmt.Errorf("URI %q has empty key given prefixed bucket %q", uri, prefixedBucket)
+	}
+	return key, nil
+}
+
+func (b *Config) UriFromKey(blobKey string) string {
+	return b.Scheme + path.Join(b.BucketName, b.Prefix, blobKey)
+}
+
+var bucketPattern = regexp.MustCompile(`(^[a-z][a-z0-9]+:///?)([^/?]+)(/[^?]*)?(\?.+)?$`)
+
+func ParseBucketConfig(path string, sess *SessionInfo) (*Config, error) {
+	config, err := ParseBucketPathToConfig(path)
+	if err != nil {
+		return nil, err
+	}
+	config.Session = sess
+
+	return config, nil
+}
+
+func ParseBucketPathToConfig(path string) (*Config, error) {
+	ms := bucketPattern.FindStringSubmatch(path)
+	if ms == nil || len(ms) != 5 {
+		return nil, fmt.Errorf("parse bucket config failed: unrecognized pipeline root format: %q", path)
+	}
+
+	// TODO: Verify/add support for file:///.
+	if ms[1] != "gs://" && ms[1] != "s3://" && ms[1] != "minio://" && ms[1] != "mem://" {
+		return nil, fmt.Errorf("parse bucket config failed: unsupported Cloud bucket: %q", path)
+	}
+
+	prefix := strings.TrimPrefix(ms[3], "/")
+	if len(prefix) > 0 && !strings.HasSuffix(prefix, "/") {
+		prefix = prefix + "/"
+	}
+
+	return &Config{
+		Scheme:      ms[1],
+		BucketName:  ms[2],
+		Prefix:      prefix,
+		QueryString: ms[4],
+	}, nil
+}
+
+func ParseBucketConfigForArtifactURI(uri string) (*Config, error) {
+	ms := bucketPattern.FindStringSubmatch(uri)
+	if ms == nil || len(ms) != 5 {
+		return nil, fmt.Errorf("parse bucket config failed: unrecognized uri format: %q", uri)
+	}
+
+	// TODO: Verify/add support for file:///.
+	if ms[1] != "gs://" && ms[1] != "s3://" && ms[1] != "minio://" && ms[1] != "mem://" {
+		return nil, fmt.Errorf("parse bucket config failed: unsupported Cloud bucket: %q", uri)
+	}
+
+	return &Config{
+		Scheme:     ms[1],
+		BucketName: ms[2],
+	}, nil
+}
+
+func MinioDefaultEndpoint() string {
+	// Discover minio-service in the same namespace by env var.
+	// https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables
+	minioHost := os.Getenv("MINIO_SERVICE_SERVICE_HOST")
+	minioPort := os.Getenv("MINIO_SERVICE_SERVICE_PORT")
+	if minioHost != "" && minioPort != "" {
+		// If there is a minio-service Kubernetes service in the same namespace,
+		// MINIO_SERVICE_SERVICE_HOST and MINIO_SERVICE_SERVICE_PORT env vars should
+		// exist by default, so we use it as default.
+		return minioHost + ":" + minioPort
+	}
+	// If the env vars do not exist, we guess that we are running in KFP multi user mode, so default minio service should be `minio-service.kubeflow:9000`.
+	glog.Infof("Cannot detect minio-service in the same namespace, default to %s as MinIO endpoint.", defaultMinioEndpointInMultiUserMode)
+	return defaultMinioEndpointInMultiUserMode
+}
+
+func GetSessionInfoFromString(sessionInfoJSON string) (*SessionInfo, error) {
+	sessionInfo := &SessionInfo{}
+	if sessionInfoJSON == "" {
+		return nil, nil
+	}
+	err := json.Unmarshal([]byte(sessionInfoJSON), sessionInfo)
+	if err != nil {
+		return nil, fmt.Errorf("Encountered error when attempting to unmarshall bucket session properties: %w", err)
+	}
+	return sessionInfo, nil
+}
+
+func StructuredS3Params(p map[string]string) (*S3Params, error) {
+	sparams := &S3Params{}
+	if val, ok := p["fromEnv"]; ok {
+		boolVal, err := strconv.ParseBool(val)
+		if err != nil {
+			return nil, err
+		}
+		sparams.FromEnv = boolVal
+	}
+	if val, ok := p["secretName"]; ok {
+		sparams.SecretName = val
+	}
+	if val, ok := p["accessKeyKey"]; ok {
+		sparams.AccessKeyKey = val
+	}
+	if val, ok := p["secretKeyKey"]; ok {
+		sparams.SecretKeyKey = val
+	}
+	if val, ok := p["region"]; ok {
+		sparams.Region = val
+	}
+	if val, ok := p["endpoint"]; ok {
+		sparams.Endpoint = val
+	}
+	if val, ok := p["disableSSL"]; ok {
+		boolVal, err := strconv.ParseBool(val)
+		if err != nil {
+			return nil, err
+		}
+		sparams.DisableSSL = boolVal
+	}
+	return sparams, nil
+}
+
+func StructuredGCSParams(p map[string]string) (*GCSParams, error) {
+	sparams := &GCSParams{}
+	if val, ok := p["fromEnv"]; ok {
+		boolVal, err := strconv.ParseBool(val)
+		if err != nil {
+			return nil, err
+		}
+		sparams.FromEnv = boolVal
+	}
+	if val, ok := p["secretName"]; ok {
+		sparams.SecretName = val
+	}
+	if val, ok := p["tokenKey"]; ok {
+		sparams.TokenKey = val
+	}
+	return sparams, nil
+}

--- a/backend/src/v2/objectstore/config.go
+++ b/backend/src/v2/objectstore/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	BucketName  string
 	Prefix      string
 	QueryString string
-	Session     *SessionInfo
+	SessionInfo *SessionInfo
 }
 
 type SessionInfo struct {
@@ -50,8 +50,9 @@ type GCSParams struct {
 }
 
 type S3Params struct {
-	FromEnv      bool
-	SecretName   string
+	FromEnv    bool
+	SecretName string
+	// The k8s secret "Key" for "Artifact SecretKey" and "Artifact AccessKey"
 	AccessKeyKey string
 	SecretKeyKey string
 	Region       string
@@ -104,7 +105,7 @@ func ParseBucketConfig(path string, sess *SessionInfo) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	config.Session = sess
+	config.SessionInfo = sess
 
 	return config, nil
 }
@@ -173,7 +174,7 @@ func GetSessionInfoFromString(sessionInfoJSON string) (*SessionInfo, error) {
 	}
 	err := json.Unmarshal([]byte(sessionInfoJSON), sessionInfo)
 	if err != nil {
-		return nil, fmt.Errorf("Encountered error when attempting to unmarshall bucket session properties: %w", err)
+		return nil, fmt.Errorf("Encountered error when attempting to unmarshall bucket session info properties: %w", err)
 	}
 	return sessionInfo, nil
 }
@@ -190,6 +191,7 @@ func StructuredS3Params(p map[string]string) (*S3Params, error) {
 	if val, ok := p["secretName"]; ok {
 		sparams.SecretName = val
 	}
+	// The k8s secret "Key" for "Artifact SecretKey" and "Artifact AccessKey"
 	if val, ok := p["accessKeyKey"]; ok {
 		sparams.AccessKeyKey = val
 	}

--- a/backend/src/v2/objectstore/object_store.go
+++ b/backend/src/v2/objectstore/object_store.go
@@ -71,8 +71,17 @@ func OpenBucket(ctx context.Context, k8sClient kubernetes.Interface, namespace s
 			}
 		}
 	}
+
+	bucketURL := config.bucketURL()
+	// Since query parameters are only supported for s3:// paths
+	// if we detect minio scheme in pipeline root, replace it with s3:// scheme
+	// ref: https://gocloud.dev/howto/blob/#s3-compatible
+	if len(config.QueryString) > 0 && strings.HasPrefix(bucketURL, "minio://") {
+		bucketURL = strings.Replace(bucketURL, "minio://", "s3://", 1)
+	}
+
 	// When no provider config is provided, or "FromEnv" is specified, use default credentials from the environment
-	return blob.OpenBucket(ctx, config.bucketURL())
+	return blob.OpenBucket(ctx, bucketURL)
 }
 
 func UploadBlob(ctx context.Context, bucket *blob.Bucket, localPath, blobPath string) error {

--- a/backend/src/v2/objectstore/object_store.go
+++ b/backend/src/v2/objectstore/object_store.go
@@ -42,9 +42,9 @@ func OpenBucket(ctx context.Context, k8sClient kubernetes.Interface, namespace s
 			err = fmt.Errorf("Failed to open bucket %q: %w", config.BucketName, err)
 		}
 	}()
-	if config.Session != nil {
-		if config.Session.Provider == "minio" || config.Session.Provider == "s3" {
-			sess, err1 := createS3BucketSession(ctx, namespace, config.Session, k8sClient)
+	if config.SessionInfo != nil {
+		if config.SessionInfo.Provider == "minio" || config.SessionInfo.Provider == "s3" {
+			sess, err1 := createS3BucketSession(ctx, namespace, config.SessionInfo, k8sClient)
 			if err1 != nil {
 				return nil, fmt.Errorf("Failed to retrieve credentials for bucket %s: %w", config.BucketName, err1)
 			}
@@ -57,8 +57,8 @@ func OpenBucket(ctx context.Context, k8sClient kubernetes.Interface, namespace s
 				// Therefore, we need to explicitly configure the prefixed bucket.
 				return blob.PrefixedBucket(openedBucket, config.Prefix), nil
 			}
-		} else if config.Session.Provider == "gs" {
-			client, err1 := getGCSTokenClient(ctx, namespace, config.Session, k8sClient)
+		} else if config.SessionInfo.Provider == "gs" {
+			client, err1 := getGCSTokenClient(ctx, namespace, config.SessionInfo, k8sClient)
 			if err1 != nil {
 				return nil, err1
 			}
@@ -289,6 +289,7 @@ func getS3BucketCredential(
 	if err != nil {
 		return nil, err
 	}
+	// The k8s secret "Key" for "SecretKey" and "AccessKey"
 	accessKey := string(secret.Data[bucketAccessKeyKey])
 	secretKey := string(secret.Data[bucketSecretKeyKey])
 

--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -12,14 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package objectstore_test
+package objectstore
 
 import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 	"os"
 	"reflect"
 	"testing"
 
-	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
 	_ "gocloud.dev/blob/gcsblob"
 )
 
@@ -27,13 +35,13 @@ func Test_parseCloudBucket(t *testing.T) {
 	tests := []struct {
 		name    string
 		path    string
-		want    *objectstore.Config
+		want    *Config
 		wantErr bool
 	}{
 		{
 			name: "Parses GCS - Just the bucket",
 			path: "gs://my-bucket",
-			want: &objectstore.Config{
+			want: &Config{
 				Scheme:     "gs://",
 				BucketName: "my-bucket",
 				Prefix:     "",
@@ -43,7 +51,7 @@ func Test_parseCloudBucket(t *testing.T) {
 		{
 			name: "Parses GCS - Just the bucket with trailing slash",
 			path: "gs://my-bucket/",
-			want: &objectstore.Config{
+			want: &Config{
 				Scheme:     "gs://",
 				BucketName: "my-bucket",
 				Prefix:     "",
@@ -53,7 +61,7 @@ func Test_parseCloudBucket(t *testing.T) {
 		{
 			name: "Parses GCS - Bucket with prefix",
 			path: "gs://my-bucket/my-path",
-			want: &objectstore.Config{
+			want: &Config{
 				Scheme:     "gs://",
 				BucketName: "my-bucket",
 				Prefix:     "my-path/",
@@ -63,7 +71,7 @@ func Test_parseCloudBucket(t *testing.T) {
 		{
 			name: "Parses GCS - Bucket with prefix and trailing slash",
 			path: "gs://my-bucket/my-path/",
-			want: &objectstore.Config{
+			want: &Config{
 				Scheme:     "gs://",
 				BucketName: "my-bucket",
 				Prefix:     "my-path/",
@@ -73,7 +81,7 @@ func Test_parseCloudBucket(t *testing.T) {
 		{
 			name: "Parses GCS - Bucket with multiple path components in prefix",
 			path: "gs://my-bucket/my-path/123",
-			want: &objectstore.Config{
+			want: &Config{
 				Scheme:     "gs://",
 				BucketName: "my-bucket",
 				Prefix:     "my-path/123/",
@@ -83,7 +91,7 @@ func Test_parseCloudBucket(t *testing.T) {
 		{
 			name: "Parses GCS - Bucket with multiple path components in prefix and trailing slash",
 			path: "gs://my-bucket/my-path/123/",
-			want: &objectstore.Config{
+			want: &Config{
 				Scheme:     "gs://",
 				BucketName: "my-bucket",
 				Prefix:     "my-path/123/",
@@ -93,7 +101,7 @@ func Test_parseCloudBucket(t *testing.T) {
 		{
 			name: "Parses Minio - Bucket with query string",
 			path: "minio://my-bucket",
-			want: &objectstore.Config{
+			want: &Config{
 				Scheme:      "minio://",
 				BucketName:  "my-bucket",
 				Prefix:      "",
@@ -103,7 +111,7 @@ func Test_parseCloudBucket(t *testing.T) {
 		}, {
 			name: "Parses Minio - Bucket with prefix",
 			path: "minio://my-bucket/my-path",
-			want: &objectstore.Config{
+			want: &Config{
 				Scheme:      "minio://",
 				BucketName:  "my-bucket",
 				Prefix:      "my-path/",
@@ -113,18 +121,40 @@ func Test_parseCloudBucket(t *testing.T) {
 		}, {
 			name: "Parses Minio - Bucket with multiple path components in prefix",
 			path: "minio://my-bucket/my-path/123",
-			want: &objectstore.Config{
+			want: &Config{
 				Scheme:      "minio://",
 				BucketName:  "my-bucket",
 				Prefix:      "my-path/123/",
 				QueryString: "",
 			},
 			wantErr: false,
+		}, {
+			name: "Parses S3 - Bucket with session",
+			path: "s3://my-bucket/my-path/123",
+			want: &Config{
+				Scheme:      "s3://",
+				BucketName:  "my-bucket",
+				Prefix:      "my-path/123/",
+				QueryString: "",
+				Session: &SessionInfo{
+					Provider: "s3",
+					Params: map[string]string{
+						"region":       "us-east-1",
+						"endpoint":     "s3.amazonaws.com",
+						"disableSSL":   "false",
+						"fromEnv":      "false",
+						"secretName":   "s3-testsecret",
+						"accessKeyKey": "s3-testaccessKeyKey",
+						"secretKeyKey": "s3-testsecretKeyKey",
+					},
+				},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := objectstore.ParseBucketConfig(tt.path)
+			got, err := ParseBucketConfig(tt.path, tt.want.Session)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("%q: parseCloudBucket() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 				return
@@ -132,6 +162,7 @@ func Test_parseCloudBucket(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("%q: parseCloudBucket() = %v, want %v", tt.name, got, tt.want)
 			}
+			assert.Equal(t, got.Session, tt.want.Session)
 		})
 	}
 }
@@ -145,21 +176,21 @@ func Test_bucketConfig_KeyFromURI(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		bucketConfig *objectstore.Config
+		bucketConfig *Config
 		uri          string
 		want         string
 		wantErr      bool
 	}{
 		{
 			name:         "Bucket with empty prefix",
-			bucketConfig: &objectstore.Config{Scheme: "gs://", BucketName: "my-bucket", Prefix: ""},
+			bucketConfig: &Config{Scheme: "gs://", BucketName: "my-bucket", Prefix: ""},
 			uri:          "gs://my-bucket/path1/path2",
 			want:         "path1/path2",
 			wantErr:      false,
 		},
 		{
 			name:         "Bucket with non-empty Prefix ",
-			bucketConfig: &objectstore.Config{Scheme: "gs://", BucketName: "my-bucket", Prefix: "path0/"},
+			bucketConfig: &Config{Scheme: "gs://", BucketName: "my-bucket", Prefix: "path0/"},
 			uri:          "gs://my-bucket/path0/path1/path2",
 			want:         "path1/path2",
 			wantErr:      false,
@@ -215,12 +246,139 @@ func Test_GetMinioDefaultEndpoint(t *testing.T) {
 			} else {
 				os.Unsetenv("MINIO_SERVICE_SERVICE_PORT")
 			}
-			got := objectstore.MinioDefaultEndpoint()
+			got := MinioDefaultEndpoint()
 			if got != tt.want {
 				t.Errorf(
 					"MinioDefaultEndpoint() = %q, want %q\nwhen MINIO_SERVICE_SERVICE_HOST=%q MINIO_SERVICE_SERVICE_PORT=%q",
 					got, tt.want, tt.minioServiceHostEnv, tt.minioServicePortEnv,
 				)
+			}
+		})
+	}
+}
+
+func Test_createS3BucketSession(t *testing.T) {
+	tt := []struct {
+		msg            string
+		ns             string
+		sessionInfo    *SessionInfo
+		sessionSecret  *corev1.Secret
+		expectedConfig *aws.Config
+		wantErr        bool
+		errorMsg       string
+	}{
+		{
+			msg: "Bucket with session",
+			ns:  "testnamespace",
+			sessionInfo: &SessionInfo{
+				Provider: "s3",
+				Params: map[string]string{
+					"region":       "us-east-1",
+					"endpoint":     "s3.amazonaws.com",
+					"disableSSL":   "false",
+					"fromEnv":      "false",
+					"secretName":   "s3-provider-secret",
+					"accessKeyKey": "test_access_key",
+					"secretKeyKey": "test_secret_key",
+				},
+			},
+			sessionSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "s3-provider-secret", Namespace: "testnamespace"},
+				Data:       map[string][]byte{"test_secret_key": []byte("secretKey"), "test_access_key": []byte("accessKey")},
+			},
+			expectedConfig: &aws.Config{
+				Credentials:      credentials.NewStaticCredentials("accessKey", "secretKey", ""),
+				Region:           aws.String("us-east-1"),
+				Endpoint:         aws.String("s3.amazonaws.com"),
+				DisableSSL:       aws.Bool(false),
+				S3ForcePathStyle: aws.Bool(true),
+			},
+		},
+		{
+			msg:            "Bucket with no session",
+			ns:             "testnamespace",
+			sessionInfo:    nil,
+			sessionSecret:  nil,
+			expectedConfig: nil,
+		},
+		{
+			msg: "Bucket with session but secret doesn't exist",
+			ns:  "testnamespace",
+			sessionInfo: &SessionInfo{
+				Provider: "s3",
+				Params: map[string]string{
+					"region":       "us-east-1",
+					"endpoint":     "s3.amazonaws.com",
+					"disableSSL":   "false",
+					"fromEnv":      "false",
+					"secretName":   "does-not-exist",
+					"accessKeyKey": "test_access_key",
+					"secretKeyKey": "test_secret_key",
+				},
+			},
+			sessionSecret:  nil,
+			expectedConfig: nil,
+			wantErr:        true,
+			errorMsg:       "secrets \"does-not-exist\" not found",
+		},
+		{
+			msg: "Bucket with session secret exists but key mismatch",
+			ns:  "testnamespace",
+			sessionInfo: &SessionInfo{
+				Provider: "s3",
+				Params: map[string]string{
+					"region":       "us-east-1",
+					"endpoint":     "s3.amazonaws.com",
+					"disableSSL":   "false",
+					"fromEnv":      "false",
+					"secretName":   "s3-provider-secret",
+					"accessKeyKey": "does_not_exist_secret_key",
+					"secretKeyKey": "does_not_exist_access_key",
+				},
+			},
+			sessionSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "s3-provider-secret", Namespace: "testnamespace"},
+				Data:       map[string][]byte{"test_secret_key": []byte("secretKey"), "test_access_key": []byte("accessKey")},
+			},
+			expectedConfig: nil,
+			wantErr:        true,
+			errorMsg:       "could not find specified keys",
+		},
+	}
+	for _, test := range tt {
+		t.Run(test.msg, func(t *testing.T) {
+			fakeKubernetesClientset := fake.NewSimpleClientset()
+			ctx := context.Background()
+
+			if test.sessionSecret != nil {
+				testersecret, err := fakeKubernetesClientset.CoreV1().Secrets(test.ns).Create(
+					ctx,
+					test.sessionSecret,
+					metav1.CreateOptions{})
+				assert.Nil(t, err)
+				fmt.Printf(testersecret.Namespace)
+			}
+
+			actualSession, err := createS3BucketSession(ctx, test.ns, test.sessionInfo, fakeKubernetesClientset)
+			if test.wantErr {
+				assert.Error(t, err)
+				if test.errorMsg != "" {
+					assert.Contains(t, err.Error(), test.errorMsg)
+				}
+			} else {
+				assert.Nil(t, err)
+			}
+
+			if test.expectedConfig != nil {
+				// confirm config is populated with values from the session
+				expectedSess, err := session.NewSession(test.expectedConfig)
+				assert.Nil(t, err)
+				assert.Equal(t, expectedSess.Config.Region, actualSession.Config.Region)
+				assert.Equal(t, expectedSess.Config.Credentials, actualSession.Config.Credentials)
+				assert.Equal(t, expectedSess.Config.DisableSSL, actualSession.Config.DisableSSL)
+				assert.Equal(t, expectedSess.Config.S3ForcePathStyle, actualSession.Config.S3ForcePathStyle)
+			} else {
+				assert.Nil(t, actualSession)
 			}
 		})
 	}

--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -136,7 +136,7 @@ func Test_parseCloudBucket(t *testing.T) {
 				BucketName:  "my-bucket",
 				Prefix:      "my-path/123/",
 				QueryString: "",
-				Session: &SessionInfo{
+				SessionInfo: &SessionInfo{
 					Provider: "s3",
 					Params: map[string]string{
 						"region":       "us-east-1",
@@ -154,7 +154,7 @@ func Test_parseCloudBucket(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseBucketConfig(tt.path, tt.want.Session)
+			got, err := ParseBucketConfig(tt.path, tt.want.SessionInfo)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("%q: parseCloudBucket() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 				return
@@ -162,7 +162,7 @@ func Test_parseCloudBucket(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("%q: parseCloudBucket() = %v, want %v", tt.name, got, tt.want)
 			}
-			assert.Equal(t, got.Session, tt.want.Session)
+			assert.Equal(t, got.SessionInfo, tt.want.SessionInfo)
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 
 require (
 	github.com/prometheus/client_golang v1.16.0
+	golang.org/x/oauth2 v0.13.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20231002182017-d307bd883b97
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231009173412-8bfb1ae86b6c
 )
@@ -176,7 +177,6 @@ require (
 	golang.org/x/crypto v0.16.0 // indirect
 	golang.org/x/exp v0.0.0-20230307190834-24139beb5833 // indirect
 	golang.org/x/mod v0.12.0 // indirect
-	golang.org/x/oauth2 v0.13.0 // indirect
 	golang.org/x/sync v0.4.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect


### PR DESCRIPTION
**Description of your changes:**

resolves most of: https://github.com/kubeflow/pipelines/issues/9689 and https://github.com/kubeflow/pipelines/issues/10651
the mlpipeline endpoint hardcoding is not addressed here.

This pr extends the kfp-launcher config to support configurations for supporting different credentials for s3/minio/gcs for different path prefixes. The config is parsed in the driver, and passed to executor via mlmd context custom property.

A fleshed out kfp-launcher configmap can look like this:

```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: kfp-launcher
  namespace: kubeflow
data:
  defaultPipelineRoot: "s3://my-s3-bucket-1/pipelines"
  providers: |
    <provider_config>
```

where the `<provider_config>` can look like:

```yaml
## ==========================
## configs for `s3://` paths
## ==========================
s3:
  ## default configs, if not overridden
  default:
    endpoint: "s3.amazonaws.com"
    region: "us-west-2"
    disableSSL: false
    credentials:
      fromEnv: false
      secretRef:
        secretName: "my-s3-secret-1"
        accessKeyKey: "AWS_ACCESS_KEY_ID"
        secretKeyKey: "AWS_SECRET_ACCESS_KEY"

  ## configs for specific bucket + prefix combinations
  overrides:

    ## configs for `s3://my-s3-bucket-2/SOME/KEY/PREFIX`
    - bucketName: "my-s3-bucket-2"
      keyPrefix: "SOME/KEY/PREFIX"
      #endpoint: "s3.amazonaws.com"
      #region: "us-west-1"
      #disableSSL: false
      credentials:
        #fromEnv: false
        secretRef:
          secretName: "my-s3-secret-2"
          accessKeyKey: "AWS_ACCESS_KEY_ID"
          secretKeyKey: "AWS_SECRET_ACCESS_KEY"

## ==========================
## configs for `minio://` paths
## ==========================
minio:
  ...
  (same structure as `s3`)
  ...

## ==========================
## for `gs://` paths
## ==========================
gs:

  ## default configs, if not overridden
  default:
    credentials:
      fromEnv: false
      secretRef:
        secretName: "my-gcs-secret-1"
        tokenKey: "service_account.json"

  ## configs for specific bucket + prefix combinations
  overrides:

    ## select for `gcs://my-gcp-bucket-1/SOME/KEY/PREFIX`
    - bucketName: "my-gcp-bucket-1"
      keyPrefix: "SOME/KEY/PREFIX"
      credentials:
        #fromEnv: false
        secretRef:
          secretName: "my-gcs-secret-2"
          tokenKey: "service_account.json"
    
    ## select for `gs://my-gcp-bucket-1/SOME/OTHER/KEY/PREFIX`
    - bucketName: "my-gcp-bucket-1"
      keyPrefix: "SOME/OTHER/KEY/PREFIX"
      credentials:
        #fromEnv: false
        secretRef:
          secretName: "my-gcs-secret-3"
          tokenKey: "service_account.json"

```

In this example, a `defaultPipelineRoot: 'gs://my-gcp-bucket-1/SOME/OTHER/KEY/PREFIX'` would select the first `gs` provider with the matching `keyprefix`, in this case that would be:

```yaml
  ## select for `gs://my-gcp-bucket-1/SOME/OTHER/KEY/PREFIX`
  - bucketName: "my-gcp-bucket-1"
    keyPrefix: "SOME/OTHER/KEY/PREFIX"
    credentials:
      #fromEnv: false
      secretRef:
        secretName: "my-gcs-secret-3"
        tokenKey: "service_account.json"
``` 

See the unit tests in [env_test.go](https://github.com/HumairAK/data-science-pipelines/blob/issue_9689/backend/src/v2/config/env_test.go#L74) for the various different edge cases, please feel free to identify others that ought to be covered.  The `testdata` in the test cases is pulled from [here](https://github.com/HumairAK/data-science-pipelines/blob/issue_9689/backend/src/v2/config/testdata/provider_cases.yaml).

This [config is parsed in the driver](https://github.com/HumairAK/data-science-pipelines/blob/issue_9689/backend/src/v2/driver/driver.go#L152), and when the matching credentials are identified, [the information is stored as a mlmd contextproperty](https://github.com/HumairAK/data-science-pipelines/blob/issue_9689/backend/src/v2/metadata/client.go#L308) (stringified json) with name: `store_session_info`, an example of how this property looks like:

For GS buckets:
```json
{
  "Provider": "gs",
  "Params": {
    "fromEnv": "false",
    "secretName": "gcs-secret",
    "tokenKey": "credentials.json"
  }
}
```
For AWS S3 buckets (minio, and other s3 compatible store are identical):
```json
{
  "Provider": "s3",
  "Params": {
    "accessKeyKey": "customaccessKey",
    "disableSSL": "false",
    "endpoint": "s3.amazonaws.com",
    "fromEnv": "false",
    "region": "us-east-2",
    "secretKeyKey": "customsecretKey",
    "secretName": "s3secret"
  }
}
```

If `fromEnv` is set to `true`, then the secret information is omitted from `Params`. 

Doing this in the Driver allows us to fetch the configmap once per pipeline execution in the driver, and retrieve it from context custom properties.

### Considerations
* I've tried to make it so that the original behavior remains unchanged, so if `providers` is never specified in `kfp-launcher`, then users should not notice a difference regardless of if they are using the default minio, or gcs, etc.
* I've re-organized the objectstore config from the object store "operational" logic
* a new interface was added to handle config parsing for multiple provider support in the kfp-launcher config, I think a good follow up would be to also split up objectstore.go into a "storemanager" interface that specifies all the blob operations "upload/download/etc.", for s3/minio/gcs this would be the same, but would be useful to have when extending it to other store formats. Making it easier to add additional store provider support.
* the decision to make store_session_info have a dynamic structure "Params" was due to different providers having different cred / config requirements, keeping it unstructured gives us a bit more flexibility here.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

