### PR TITLE
fix(samples): Fix the loop_output.py example to handle the new parallel loop type requirement

### DIFF
--- a/samples/core/loop_output/loop_output.py
+++ b/samples/core/loop_output/loop_output.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 from kfp import compiler, dsl
+from typing import List
 
 
 @dsl.component
-def args_generator_op() -> str:
-    return '[1.1, 1.2, 1.3]'
+def args_generator_op() -> List[str]:
+    return ['1.1', '1.2', '1.3']
 
 
 # TODO(Bobgy): how can we make this component with type float?


### PR DESCRIPTION
**Description of your changes:**
After PR #10494, all the parallel loop input type has to be `List`. The current loop_output.py example still output as `str` which causes the following errors:
```shell
Cannot iterate over a single parameter using `dsl.ParallelFor`. Expected a list of parameters as argument to `items`.
```

Thus, fix the loop_output.py example to output type `List[str]`.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
