### PR TITLE
feat(Backend + SDK): Update kfp backend and kubernetes sdk to support node affinity

### DIFF
--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -538,17 +538,17 @@ func extendPodSpecPatch(
 		var nodeSelectorTerms []k8score.NodeSelectorTerm
 		var preferredSchedulingTerms []k8score.PreferredSchedulingTerm
 		var requiredDuringSchedulingIgnoredDuringExecution *k8score.NodeSelector
-		
-		for _ , nodeAffinityTerm := range nodeAffinity {
+
+		for _, nodeAffinityTerm := range nodeAffinity {
 			if nodeAffinityTerm != nil {
 				var matchExpressions []k8score.NodeSelectorRequirement
 				var matchFields []k8score.NodeSelectorRequirement
 				for _, requirement := range nodeAffinityTerm.MatchExpressions {
 					if requirement != nil {
 						matchExpressions = append(matchExpressions, k8score.NodeSelectorRequirement{
-							Key: requirement.Key,
+							Key:      requirement.Key,
 							Operator: k8score.NodeSelectorOperator(requirement.Operator),
-							Values: requirement.Values,
+							Values:   requirement.Values,
 						})
 					}
 				}
@@ -556,21 +556,21 @@ func extendPodSpecPatch(
 				for _, requirement := range nodeAffinityTerm.MatchFields {
 					if requirement != nil {
 						matchFields = append(matchFields, k8score.NodeSelectorRequirement{
-							Key: requirement.Key,
+							Key:      requirement.Key,
 							Operator: k8score.NodeSelectorOperator(requirement.Operator),
-							Values: requirement.Values,
+							Values:   requirement.Values,
 						})
 					}
 				}
-				
+
 				nodeSelectorTerm := k8score.NodeSelectorTerm{
 					MatchExpressions: matchExpressions,
-					MatchFields: matchFields,
+					MatchFields:      matchFields,
 				}
 
 				if (0 < nodeAffinityTerm.GetWeight()) && (nodeAffinityTerm.GetWeight() < 101) {
 					preferredSchedulingTerms = append(preferredSchedulingTerms, k8score.PreferredSchedulingTerm{
-						Weight: nodeAffinityTerm.GetWeight(),
+						Weight:     nodeAffinityTerm.GetWeight(),
 						Preference: nodeSelectorTerm,
 					})
 				} else {
@@ -581,13 +581,13 @@ func extendPodSpecPatch(
 		}
 		if nodeSelectorTerms != nil {
 			requiredDuringSchedulingIgnoredDuringExecution = &k8score.NodeSelector{
-				NodeSelectorTerms: nodeSelectorTerms, 
+				NodeSelectorTerms: nodeSelectorTerms,
 			}
 		}
 
 		podSpec.Affinity = &k8score.Affinity{
 			NodeAffinity: &k8score.NodeAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: requiredDuringSchedulingIgnoredDuringExecution,
+				RequiredDuringSchedulingIgnoredDuringExecution:  requiredDuringSchedulingIgnoredDuringExecution,
 				PreferredDuringSchedulingIgnoredDuringExecution: preferredSchedulingTerms,
 			},
 		}

--- a/backend/src/v2/driver/driver_test.go
+++ b/backend/src/v2/driver/driver_test.go
@@ -532,7 +532,7 @@ func Test_extendPodSpecPatch_Secret(t *testing.T) {
 					{
 						Name: "secret1",
 						VolumeSource: k8score.VolumeSource{
-							Secret: &k8score.SecretVolumeSource{SecretName: "secret1", Optional:  &[]bool{false}[0],},
+							Secret: &k8score.SecretVolumeSource{SecretName: "secret1", Optional: &[]bool{false}[0]},
 						},
 					},
 				},
@@ -730,7 +730,7 @@ func Test_extendPodSpecPatch_ConfigMap(t *testing.T) {
 						VolumeSource: k8score.VolumeSource{
 							ConfigMap: &k8score.ConfigMapVolumeSource{
 								LocalObjectReference: k8score.LocalObjectReference{Name: "cm1"},
-								Optional:             &[]bool{false}[0],},
+								Optional:             &[]bool{false}[0]},
 						},
 					},
 				},
@@ -1040,11 +1040,11 @@ func Test_extendPodSpecPatch_Tolerations(t *testing.T) {
 	}
 }
 
-func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
-	var preferredWeightA int32 = 50 
+func Test_extendPodSpecPatch_NodeAffinity(t *testing.T) {
+	var preferredWeightA int32 = 50
 	var preferredWeightB int32 = 42
-	tests := []struct{
-		name string
+	tests := []struct {
+		name       string
 		k8sExecCfg *kubernetesplatform.KubernetesExecutorConfig
 		expected   *k8score.PodSpec
 	}{
@@ -1057,7 +1057,7 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 						Name: "main",
 					},
 				},
-			},	
+			},
 		},
 		{
 			"Valid - Affinity with terms without weight",
@@ -1066,7 +1066,7 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 					{
 						MatchExpressions: []*kubernetesplatform.SelectorRequirement{
 							{
-								Key: "key1",
+								Key:      "key1",
 								Operator: "In",
 								Values: []string{
 									"val1",
@@ -1076,7 +1076,7 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 						},
 						MatchFields: []*kubernetesplatform.SelectorRequirement{
 							{
-								Key: "key2",
+								Key:      "key2",
 								Operator: "In",
 								Values: []string{
 									"val1",
@@ -1085,7 +1085,6 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 							},
 						},
 					},
-
 				},
 			},
 			&k8score.PodSpec{
@@ -1101,7 +1100,7 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 								{
 									MatchExpressions: []k8score.NodeSelectorRequirement{
 										{
-											Key: "key1",
+											Key:      "key1",
 											Operator: "In",
 											Values: []string{
 												"val1",
@@ -1111,13 +1110,12 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 									},
 									MatchFields: []k8score.NodeSelectorRequirement{
 										{
-											Key: "key2",
+											Key:      "key2",
 											Operator: "In",
 											Values: []string{
 												"val1",
 												"val2",
 											},
-
 										},
 									},
 								},
@@ -1125,8 +1123,7 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 						},
 					},
 				},
-
-			},	
+			},
 		},
 		{
 			"Valid - Affinity with terms with weight",
@@ -1135,7 +1132,7 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 					{
 						MatchExpressions: []*kubernetesplatform.SelectorRequirement{
 							{
-								Key: "key1",
+								Key:      "key1",
 								Operator: "In",
 								Values: []string{
 									"val1",
@@ -1145,7 +1142,7 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 						},
 						MatchFields: []*kubernetesplatform.SelectorRequirement{
 							{
-								Key: "key2",
+								Key:      "key2",
 								Operator: "In",
 								Values: []string{
 									"val1",
@@ -1155,7 +1152,6 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 						},
 						Weight: &preferredWeightA,
 					},
-
 				},
 			},
 			&k8score.PodSpec{
@@ -1166,15 +1162,15 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 				},
 				Affinity: &k8score.Affinity{
 					NodeAffinity: &k8score.NodeAffinity{
-						
+
 						PreferredDuringSchedulingIgnoredDuringExecution: []k8score.PreferredSchedulingTerm{
 							{
 								Weight: preferredWeightA,
 								Preference: k8score.NodeSelectorTerm{
-									
+
 									MatchExpressions: []k8score.NodeSelectorRequirement{
 										{
-											Key: "key1",
+											Key:      "key1",
 											Operator: "In",
 											Values: []string{
 												"val1",
@@ -1184,7 +1180,7 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 									},
 									MatchFields: []k8score.NodeSelectorRequirement{
 										{
-											Key: "key2",
+											Key:      "key2",
 											Operator: "In",
 											Values: []string{
 												"val1",
@@ -1192,14 +1188,12 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 											},
 										},
 									},
-								
 								},
 							},
 						},
 					},
 				},
-
-			},	
+			},
 		},
 		{
 			"Valid - Affinity mixed terms",
@@ -1208,7 +1202,7 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 					{
 						MatchExpressions: []*kubernetesplatform.SelectorRequirement{
 							{
-								Key: "key1",
+								Key:      "key1",
 								Operator: "In",
 								Values: []string{
 									"val1",
@@ -1220,12 +1214,11 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 						Weight: &preferredWeightB,
 						MatchFields: []*kubernetesplatform.SelectorRequirement{
 							{
-								Key: "field1",
+								Key:      "field1",
 								Operator: "Exists",
 							},
 						},
 					},
-
 				},
 			},
 			&k8score.PodSpec{
@@ -1241,36 +1234,33 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 								{
 									MatchExpressions: []k8score.NodeSelectorRequirement{
 										{
-											Key: "key1",
+											Key:      "key1",
 											Operator: "In",
 											Values: []string{
 												"val1",
 											},
 										},
 									},
-								}, 
+								},
 							},
 						},
 						PreferredDuringSchedulingIgnoredDuringExecution: []k8score.PreferredSchedulingTerm{
 							{
 								Weight: preferredWeightB,
 								Preference: k8score.NodeSelectorTerm{
-									
+
 									MatchFields: []k8score.NodeSelectorRequirement{
 										{
-											Key: "field1",
+											Key:      "field1",
 											Operator: "Exists",
 										},
 									},
-									
-								
 								},
 							},
 						},
 					},
 				},
-
-			},	
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -1287,7 +1277,6 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T){
 		})
 	}
 }
-
 
 func Test_extendPodSpecPatch_FieldPathAsEnv(t *testing.T) {
 	tests := []struct {

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-exithandler v0.0.0-20231127195001-a75d4b3711ff
 	github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-kfptask v0.0.0-20231127195001-a75d4b3711ff
 	github.com/kubeflow/pipelines/api v0.0.0-20231027040853-58ce09e07d03
-	github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240403164522-8b2a099e8c9f
+	github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240530221006-6d3b8c3492c2
 	github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20230810215105-e1f0c010f800
 	github.com/lestrrat-go/strftime v1.0.4
 	github.com/mattn/go-sqlite3 v1.14.19

--- a/go.sum
+++ b/go.sum
@@ -2200,6 +2200,8 @@ github.com/kubeflow/pipelines/api v0.0.0-20231027040853-58ce09e07d03 h1:reL3LbkR
 github.com/kubeflow/pipelines/api v0.0.0-20231027040853-58ce09e07d03/go.mod h1:T7TOQB36gGe97yUdfVAnYK5uuT0+uQbLNHDUHxYkmE4=
 github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240403164522-8b2a099e8c9f h1:O5GmJN8tALpiqL0dUo4uhOkqHG8xOkNCgT7QI9q9GnE=
 github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240403164522-8b2a099e8c9f/go.mod h1:CJkKr356RlpZP/gQRuHf3Myrn1qJtoUVe4EMCmtwarg=
+github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240530221006-6d3b8c3492c2 h1:nOb8DBGgU4a4SIhxJNPiEpYhNH7kfEYSPE8SqW6dPzc=
+github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240530221006-6d3b8c3492c2/go.mod h1:CJkKr356RlpZP/gQRuHf3Myrn1qJtoUVe4EMCmtwarg=
 github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20230810215105-e1f0c010f800 h1:YAW+X9xCW8Yq5tQaBBQaLTNU9CJj8Nr7lx1+k66ZHJ0=
 github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20230810215105-e1f0c010f800/go.mod h1:chIDffBaVQ/asNl1pTTdbAymYcuBKf8BR3YtSP+3FEU=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=

--- a/go.sum
+++ b/go.sum
@@ -2198,8 +2198,6 @@ github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-kfptask v0.0.0-202311271950
 github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-kfptask v0.0.0-20231127195001-a75d4b3711ff/go.mod h1:lAFdPugzj3bcAXyN3+8y0NByidZ88zwGxMc+gdc8cHw=
 github.com/kubeflow/pipelines/api v0.0.0-20231027040853-58ce09e07d03 h1:reL3LbkRIozBkKSUYjtQFV2kVC1R4WHG9FrTClRT1FY=
 github.com/kubeflow/pipelines/api v0.0.0-20231027040853-58ce09e07d03/go.mod h1:T7TOQB36gGe97yUdfVAnYK5uuT0+uQbLNHDUHxYkmE4=
-github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240403164522-8b2a099e8c9f h1:O5GmJN8tALpiqL0dUo4uhOkqHG8xOkNCgT7QI9q9GnE=
-github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240403164522-8b2a099e8c9f/go.mod h1:CJkKr356RlpZP/gQRuHf3Myrn1qJtoUVe4EMCmtwarg=
 github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240530221006-6d3b8c3492c2 h1:nOb8DBGgU4a4SIhxJNPiEpYhNH7kfEYSPE8SqW6dPzc=
 github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240530221006-6d3b8c3492c2/go.mod h1:CJkKr356RlpZP/gQRuHf3Myrn1qJtoUVe4EMCmtwarg=
 github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20230810215105-e1f0c010f800 h1:YAW+X9xCW8Yq5tQaBBQaLTNU9CJj8Nr7lx1+k66ZHJ0=

--- a/kubernetes_platform/python/kfp/kubernetes/__init__.py
+++ b/kubernetes_platform/python/kfp/kubernetes/__init__.py
@@ -20,6 +20,8 @@ __all__ = [
     'add_pod_annotation',
     'add_pod_label',
     'add_toleration',
+    'add_node_affinity',
+    'SelectorRequirement',
     'CreatePVC',
     'DeletePVC',
     'mount_pvc',
@@ -45,6 +47,7 @@ from kfp.kubernetes.secret import use_secret_as_env
 from kfp.kubernetes.secret import use_secret_as_volume
 from kfp.kubernetes.timeout import set_timeout
 from kfp.kubernetes.toleration import add_toleration
+from kfp.kubernetes.affinity import SelectorRequirement, add_node_affinity
 from kfp.kubernetes.volume import add_ephemeral_volume
 from kfp.kubernetes.volume import CreatePVC
 from kfp.kubernetes.volume import DeletePVC

--- a/kubernetes_platform/python/kfp/kubernetes/affinity.py
+++ b/kubernetes_platform/python/kfp/kubernetes/affinity.py
@@ -1,0 +1,82 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, List
+from dataclasses import dataclass
+
+from google.protobuf import json_format
+from kfp.dsl import PipelineTask
+from kfp.kubernetes import common
+from kfp.kubernetes import kubernetes_executor_config_pb2 as pb
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
+
+@dataclass
+class SelectorRequirement:
+    """Used to define the requirements of an affinity.
+    key: either the field (if used with match_fields) or the label key (match_expressions) to match on
+    operator: One of: In, NotIn, Exists, DoesNotExist. For nodeAffinity, Gt and Lt are also legal. More info: `https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#operators`
+    values: List of string values to match on.
+    """
+    key: str
+    operator: Literal["In", "NotIn", "Exists", "DoesNotExist", "Gt", "Lt"]
+    values: List[str]
+
+def add_node_affinity(
+    task: PipelineTask,
+    match_expressions: List[SelectorRequirement] = [],
+    match_fields: List[SelectorRequirement] = [],
+    weight: Optional[int] = None
+    
+):
+    """Add a `node affinity<https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity>`_. to a task.
+    Args:
+        task:
+            Pipeline task.
+        match_expressions:
+            A list of requirements of the affinity that will match node labels. 
+        match_fields:
+            A list of requirements of the affinity that will match node's other fields
+        weight:
+            affinity weight indicates that the affinity rule is preferred/soft, not required/hard.
+    Returns:
+        Task object with added node affinity terms.
+    """
+    match_expressions_list = [
+        pb.SelectorRequirement(key = requirement.key, operator= requirement.operator, values = requirement.values)
+        for requirement in match_expressions
+    ]
+    match_fields_list = [
+        pb.SelectorRequirement(key = requirement.key, operator= requirement.operator, values = requirement.values)
+        for requirement in match_fields
+    ]
+    
+    if weight is not None and not (1 <= weight <= 100):
+        raise ValueError("If weight is set, it should be an integer between 1 and 100") 
+    
+    msg = common.get_existing_kubernetes_config_as_message(task)
+    msg.node_affinity.append(
+        pb.NodeAffinityTerm(
+            match_expressions=match_expressions_list,
+            match_fields=match_fields_list,
+            weight=weight
+        )
+    )
+    task.platform_config["kubernetes"] = json_format.MessageToDict(msg)
+
+    return task

--- a/kubernetes_platform/python/test/unit/test_affinity.py
+++ b/kubernetes_platform/python/test/unit/test_affinity.py
@@ -1,0 +1,63 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.protobuf import json_format
+from kfp import compiler
+from kfp import dsl
+from kfp import kubernetes
+
+
+class TestAffinities:
+
+    def test_add_one_node_affinity(self):
+
+        @dsl.pipeline
+        def my_pipeline():
+            task = comp()
+            kubernetes.add_node_affinity(
+                task,
+                match_expressions=[kubernetes.SelectorRequirement(key="key1", operator="In", values=["value1"])],
+            )
+
+        compiler.Compiler().compile(
+            pipeline_func=my_pipeline, package_path='my_pipeline.yaml')
+        print(json_format.MessageToDict(my_pipeline.platform_spec))
+        assert json_format.MessageToDict(my_pipeline.platform_spec) == {
+            'platforms': {
+                'kubernetes': {
+                    'deploymentSpec': {
+                        'executors': {
+                            'exec-comp': {
+                                'nodeAffinity': [
+                                    {
+                                        'matchExpressions': [
+                                            {
+                                            'key': 'key1',
+                                            'operator': 'In',
+                                            'values': ['value1']
+                                            }
+                                        ]
+                                    } 
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+
+@dsl.component
+def comp():
+    pass


### PR DESCRIPTION
**Description of your changes:**
This PR adds support for node affinity to the driver and kubernetes_platform SDK.

It is a follow up to #10671 and #10583, which updated the protobuf and Golang stub.

It follows the excellent example set by https://github.com/kubeflow/pipelines/pull/10427.

Huge thanks to @Tomcli for paving the way and sharing how to validate things end to end.
Part of https://github.com/kubeflow/pipelines/issues/9768 and https://github.com/kubeflow/pipelines/issues/9682

Pod (Anti)Affinity will be added in a separate PR

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
