### PR TITLE
chore: remove pytest market for rl-estimator test

### DIFF
--- a/components/aws/sagemaker/tests/integration_tests/component_tests/test_rlestimator_component.py
+++ b/components/aws/sagemaker/tests/integration_tests/component_tests/test_rlestimator_component.py
@@ -10,14 +10,6 @@ from utils import sagemaker_utils
 from utils import argo_utils
 
 
-@pytest.mark.parametrize(
-    "test_file_dir",
-    [
-        pytest.param(
-            "resources/config/rlestimator-training", marks=pytest.mark.canary_test
-        ),
-    ],
-)
 def test_trainingjob(
     kfp_client, experiment_id, region, sagemaker_client, test_file_dir
 ):


### PR DESCRIPTION


**Description of your changes:**
Rl-estimator is removing support for the container image. Removing this test so we don't pull thisimage anymore and they can continue their deprecation plans.
**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
