### PR TITLE
fix(sdk): fixes trusted host is the same as index url. Fixes #10743

### DIFF
--- a/sdk/python/kfp/cli/component_test.py
+++ b/sdk/python/kfp/cli/component_test.py
@@ -496,9 +496,9 @@ class Test(unittest.TestCase):
 
                 WORKDIR /usr/local/src/kfp/components
                 COPY runtime-requirements.txt runtime-requirements.txt
-                RUN pip install --index-url https://pypi.org/simple --trusted-host https://pypi.org/simple --no-cache-dir -r runtime-requirements.txt
+                RUN pip install --index-url https://pypi.org/simple --trusted-host pypi.org --no-cache-dir -r runtime-requirements.txt
 
-                RUN pip install --index-url https://pypi.org/simple --trusted-host https://pypi.org/simple --no-cache-dir kfp==1.2.3
+                RUN pip install --index-url https://pypi.org/simple --trusted-host pypi.org --no-cache-dir kfp==1.2.3
                 COPY . .
                 '''))
 
@@ -527,9 +527,9 @@ class Test(unittest.TestCase):
 
                 WORKDIR /usr/local/src/kfp/components
                 COPY runtime-requirements.txt runtime-requirements.txt
-                RUN pip install --index-url https://pypi.org/simple --trusted-host https://pypi.org/simple --extra-index-url https://example.com/pypi/simple --trusted-host https://example.com/pypi/simple --no-cache-dir -r runtime-requirements.txt
+                RUN pip install --index-url https://pypi.org/simple --trusted-host pypi.org --extra-index-url https://example.com/pypi/simple --trusted-host example.com --no-cache-dir -r runtime-requirements.txt
 
-                RUN pip install --index-url https://pypi.org/simple --trusted-host https://pypi.org/simple --extra-index-url https://example.com/pypi/simple --trusted-host https://example.com/pypi/simple --no-cache-dir kfp==1.2.3
+                RUN pip install --index-url https://pypi.org/simple --trusted-host pypi.org --extra-index-url https://example.com/pypi/simple --trusted-host example.com --no-cache-dir kfp==1.2.3
                 COPY . .
                 '''))
 

--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -19,6 +19,7 @@ import re
 import textwrap
 from typing import (Any, Callable, Dict, List, Mapping, Optional, Tuple, Type,
                     Union)
+import urllib
 import warnings
 
 import docstring_parser
@@ -94,9 +95,11 @@ def make_index_url_options(pip_index_urls: Optional[List[str]]) -> str:
     index_url = pip_index_urls[0]
     extra_index_urls = pip_index_urls[1:]
 
-    options = [f'--index-url {index_url} --trusted-host {index_url}']
+    options = [
+        f'--index-url {index_url} --trusted-host {urllib.parse.urlparse(index_url).hostname}'
+    ]
     options.extend(
-        f'--extra-index-url {extra_index_url} --trusted-host {extra_index_url}'
+        f'--extra-index-url {extra_index_url} --trusted-host {urllib.parse.urlparse(extra_index_url).hostname}'
         for extra_index_url in extra_index_urls)
 
     return ' '.join(options) + ' '

--- a/sdk/python/kfp/dsl/component_factory_test.py
+++ b/sdk/python/kfp/dsl/component_factory_test.py
@@ -149,7 +149,7 @@ class TestGetPackagesToInstallCommand(unittest.TestCase):
             strip_kfp_version(command),
             strip_kfp_version([
                 'sh', '-c',
-                '\nif ! [ -x "$(command -v pip)" ]; then\n    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location --index-url https://myurl.org/simple --trusted-host https://myurl.org/simple \'kfp==2.1.3\' \'--no-deps\' \'typing-extensions>=3.7.4,<5; python_version<"3.9"\'  &&  python3 -m pip install --quiet --no-warn-script-location --index-url https://myurl.org/simple --trusted-host https://myurl.org/simple \'package1\' \'package2\' && "$0" "$@"\n'
+                '\nif ! [ -x "$(command -v pip)" ]; then\n    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location --index-url https://myurl.org/simple --trusted-host myurl.org \'kfp==2.1.3\' \'--no-deps\' \'typing-extensions>=3.7.4,<5; python_version<"3.9"\'  &&  python3 -m pip install --quiet --no-warn-script-location --index-url https://myurl.org/simple --trusted-host myurl.org \'package1\' \'package2\' && "$0" "$@"\n'
             ]))
 
 

--- a/sdk/python/requirements-dev.txt
+++ b/sdk/python/requirements-dev.txt
@@ -15,3 +15,4 @@ types-PyYAML==6.0.5
 types-requests==2.27.14
 types-tabulate==0.8.6
 yapf==0.32.0
+uritemplate>=3.0.1,<4

--- a/sdk/python/test_data/components/component_with_pip_install.yaml
+++ b/sdk/python/test_data/components/component_with_pip_install.yaml
@@ -18,9 +18,9 @@ deploymentSpec:
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location --index-url https://pypi.org/simple\
-          \ --trusted-host https://pypi.org/simple 'kfp==2.7.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
+          \ --trusted-host pypi.org 'kfp==2.7.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
           \ python_version<\"3.9\"'  &&  python3 -m pip install --quiet --no-warn-script-location\
-          \ --index-url https://pypi.org/simple --trusted-host https://pypi.org/simple\
+          \ --index-url https://pypi.org/simple --trusted-host pypi.org\
           \ 'yapf' && \"$0\" \"$@\"\n"
         - sh
         - -ec

--- a/sdk/python/test_data/pipelines/component_with_pip_index_urls.yaml
+++ b/sdk/python/test_data/pipelines/component_with_pip_index_urls.yaml
@@ -18,9 +18,9 @@ deploymentSpec:
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location --index-url https://pypi.org/simple\
-          \ --trusted-host https://pypi.org/simple 'kfp==2.7.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
+          \ --trusted-host pypi.org 'kfp==2.7.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
           \ python_version<\"3.9\"'  &&  python3 -m pip install --quiet --no-warn-script-location\
-          \ --index-url https://pypi.org/simple --trusted-host https://pypi.org/simple\
+          \ --index-url https://pypi.org/simple --trusted-host pypi.org\
           \ 'yapf' && \"$0\" \"$@\"\n"
         - sh
         - -ec


### PR DESCRIPTION
**Description of your changes:**

Create a pipeline with the following
```
@dsl.component(base_image=common_base_image, packages_to_install=['pandas'], pip_index_urls=['https://my-bastion.node.com:9443/root/pypi/simple'])
```
If you compile the code, the output will be
```
pip install --quiet --no-warn-script-location --index-url https://my-bastion.node.com:9443/root/pypi/simple --trusted-host https://my-bastion.node.com:9443/root/pypi/simple 'pandas'
{noformat}
This will lead to an error
{noformat}
Traceback (most recent call last):
  File "/home/dlovison/miniconda3/envs/pipe-presentation/bin/pip", line 11, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/dlovison/miniconda3/envs/pipe-presentation/lib/python3.11/site-packages/pip/_internal/cli/main.py", line 79, in main
    return command.main(cmd_args)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dlovison/miniconda3/envs/pipe-presentation/lib/python3.11/site-packages/pip/_internal/cli/base_command.py", line 101, in main
    return self._main(args)
           ^^^^^^^^^^^^^^^^
  File "/home/dlovison/miniconda3/envs/pipe-presentation/lib/python3.11/site-packages/pip/_internal/cli/base_command.py", line 236, in _main
    self.handle_pip_version_check(options)
  File "/home/dlovison/miniconda3/envs/pipe-presentation/lib/python3.11/site-packages/pip/_internal/cli/req_command.py", line 177, in handle_pip_version_check
    session = self._build_session(
              ^^^^^^^^^^^^^^^^^^^^
  File "/home/dlovison/miniconda3/envs/pipe-presentation/lib/python3.11/site-packages/pip/_internal/cli/req_command.py", line 122, in _build_session
    session = PipSession(
              ^^^^^^^^^^^
  File "/home/dlovison/miniconda3/envs/pipe-presentation/lib/python3.11/site-packages/pip/_internal/network/session.py", line 398, in __init__
    self.add_trusted_host(host, suppress_logging=True)
  File "/home/dlovison/miniconda3/envs/pipe-presentation/lib/python3.11/site-packages/pip/_internal/network/session.py", line 422, in add_trusted_host
    parsed_host, parsed_port = parse_netloc(host)
                               ^^^^^^^^^^^^^^^^^^
  File "/home/dlovison/miniconda3/envs/pipe-presentation/lib/python3.11/site-packages/pip/_internal/utils/misc.py", line 475, in parse_netloc
    parsed = urllib.parse.urlparse(url)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dlovison/miniconda3/envs/pipe-presentation/lib/python3.11/urllib/parse.py", line 395, in urlparse
    splitresult = urlsplit(url, scheme, allow_fragments)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dlovison/miniconda3/envs/pipe-presentation/lib/python3.11/urllib/parse.py", line 497, in urlsplit
    raise ValueError("Invalid IPv6 URL")
ValueError: Invalid IPv6 URL
```
 

We believe that the problem is that the --trusted-host parameter value should not start with [https://|https://,/] , as it is supposed to be just hostname. So, the output provided by the SDK should be instead:
```
pip install --quiet --no-warn-script-location --index-url https://my-bastion.node.com:9443/root/pypi/simple --trusted-host my-bastion.node.com 'pandas'
```
The workaround is to have a pip server only with protocol:URL ( without any port and path ). Example {{pip_index_urls=['https://my-bastion.node.com']}}


**Checklist:**
- [ x ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
