### PR TITLE
feat(GH workflow): migrate periodic functional tests to GH actions

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Create k8s Kind Cluster
         uses: container-tools/kind-action@v2
         with:

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -8,26 +8,22 @@ jobs:
   run_tests:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      jobs:
-      setup_kind:
-      runs-on: ubuntu-latest
-      steps:
-    - name: Create k8s Kind Cluster
-      uses: container-tools/kind-action@v2
-      with:
-        cluster_name: kfp-tekton
-        kubectl_version: v1.29.2
-        version: v0.22.0
-        node_image: kindest/node:v1.29.2      
-    - name: Run Functional Tests
-      run: 
-        ./test/kfp-functional-test/kfp-functional-test.sh > periodic_tests.txt
-        mkdir -p ./test/artifacts  # Directory to store artifacts
-        cp periodic_tests.txt ./test/artifacts/
-    
-
-
-
-          
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Create k8s Kind Cluster
+        uses: container-tools/kind-action@v2
+        with:
+          cluster_name: kfp-tekton
+          kubectl_version: v1.29.2
+          version: v0.22.0
+          node_image: kindest/node:v1.29.2
+      - name: Run Functional Tests
+        run: |
+          log_dir=$(mktemp -d)
+          ./test/kfp-functional-test/kfp-functional-test.sh > $log_dir/periodic_tests.txt
+      - name: Collect test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: periodic-functional-artifacts
+          path: $log_dir

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -14,32 +14,19 @@ jobs:
       setup_kind:
       runs-on: ubuntu-latest
       steps:
-    - name: Check if Docker is installed
-      run: |
-        if ! command -v docker &> /dev/null
-        then
-            echo "Docker is not installed. Installing Docker..."
-            sudo apt-get update
-            sudo apt-get install -y docker.io
-        else
-            echo "Docker is already installed."
-        fi
-    - name: Install KinD
-      run: |
-        curl -Lo kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
-        chmod +x kind
-        sudo mv kind /usr/local/bin
-    - name: Verify KinD installation
-      run: kind version        
+    - name: Create k8s Kind Cluster
+      uses: container-tools/kind-action@v2
+      with:
+        cluster_name: kfp-tekton
+        kubectl_version: v1.29.2
+        version: v0.22.0
+        node_image: kindest/node:v1.29.2      
     - name: Run Functional Tests
       run: 
-        ./test/kfp-functional-test/kfp-functional-test.sh
-    - name: Collect test results
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-          name: periodic-test-artifacts
-          path: /tmp/tmp.*/*
+        ./test/kfp-functional-test/kfp-functional-test.sh > periodic_tests.txt
+        mkdir -p ./test/artifacts  # Directory to store artifacts
+        cp periodic_tests.txt ./test/artifacts/
+    
 
 
 

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -19,6 +19,7 @@ jobs:
           node_image: kindest/node:v1.29.2
       - name: Run Functional Tests
         run: |
+          log_dir=$(mktemp -d)
           ./test/kfp-functional-test/kfp-functional-test.sh > $log_dir/periodic_tests.txt
       - name: Collect test results
         if: always()

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -19,11 +19,10 @@ jobs:
           node_image: kindest/node:v1.29.2
       - name: Run Functional Tests
         run: |
-          log_dir=$(mktemp -d)
           ./test/kfp-functional-test/kfp-functional-test.sh > $log_dir/periodic_tests.txt
       - name: Collect test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: periodic-functional-artifacts
-          path: $log_dir
+          path: /tmp/tmp.*/*

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -1,0 +1,46 @@
+name: Periodic Functional Tests
+
+on:
+  schedule:
+    - cron: '*/5 * * * *' # Run every 5 minutes
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      jobs:
+      setup_kind:
+      runs-on: ubuntu-latest
+      steps:
+    - name: Check if Docker is installed
+      run: |
+        if ! command -v docker &> /dev/null
+        then
+            echo "Docker is not installed. Installing Docker..."
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+        else
+            echo "Docker is already installed."
+        fi
+    - name: Install KinD
+      run: |
+        curl -Lo kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+        chmod +x kind
+        sudo mv kind /usr/local/bin
+    - name: Verify KinD installation
+      run: kind version        
+    - name: Run Functional Tests
+      run: 
+        ./test/kfp-functional-test/kfp-functional-test.sh
+    - name: Collect test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+          name: periodic-test-artifacts
+          path: /tmp/tmp.*/*
+
+
+
+          


### PR DESCRIPTION
**Description of your changes:**
Fixes #10745. I have added the workflow file and tried running it locally, but I guess there is some issue with the package versions in `requirements.txt`. 

Error Log:

```
|   × Preparing metadata (pyproject.toml) did not run successfully.
|   │ exit code: 1
|   ╰─> [40 lines of output]
|       Traceback (most recent call last):
|         File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
|           main()
|         File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
|           json_out['return_val'] = hook(**hook_input['kwargs'])
|         File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 164, in prepare_metadata_for_build_wheel
|           return hook(metadata_directory, config_settings)
|         File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 174, in prepare_metadata_for_build_wheel
|           self.run_setup()
|         File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 267, in run_setup
|           super(_BuildMetaLegacyBackend,
|         File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 158, in run_setup
|           exec(compile(code, __file__, 'exec'), locals())
|         File "setup.py", line 68, in <module>
|           main()
|         File "setup.py", line 54, in main
|           setuptools.setup(
|         File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 153, in setup
|           return distutils.core.setup(**attrs)
|         File "/usr/lib/python3/dist-packages/setuptools/_distutils/core.py", line 109, in setup
|           _setup_distribution = dist = klass(attrs)
|         File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 459, in __init__
|           _Distribution.__init__(
|         File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 293, in __init__
|           self.finalize_options()
|         File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 837, in finalize_options
|           ep(self)
|         File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 858, in _finalize_setup_keywords
|           ep.load()(self, ep.name, value)
|         File "/tmp/pip-build-env-sd7akepb/normal/local/lib/python3.10/dist-packages/cffi/setuptools_ext.py", line 216, in cffi_modules
|           add_cffi_module(dist, cffi_module)
|         File "/tmp/pip-build-env-sd7akepb/normal/local/lib/python3.10/dist-packages/cffi/setuptools_ext.py", line 49, in add_cffi_module
|           execfile(build_file_name, mod_vars)
|         File "/tmp/pip-build-env-sd7akepb/normal/local/lib/python3.10/dist-packages/cffi/setuptools_ext.py", line 25, in execfile
|           exec(code, glob, glob)
|         File "src/google_crc32c_build.py", line 47, in <module>
|           FFIBUILDER = cffi.FFI()
|         File "/tmp/pip-build-env-sd7akepb/normal/local/lib/python3.10/dist-packages/cffi/api.py", line 54, in __init__
|           raise Exception("Version mismatch: this is the 'cffi' package version %s, located in %r.  When we import the top-level '_cffi_backend' extension module, we get version %s, located in %r.  The two versions should be equal; check your installation." % (
|       Exception: Version mismatch: this is the 'cffi' package version 1.16.0, located in '/tmp/pip-build-env-sd7akepb/normal/local/lib/python3.10/dist-packages/cffi/api.py'.  When we import the top-level '_cffi_backend' extension module, we get version 1.15.0, located in '/usr/lib/python3/dist-packages/_cffi_backend.cpython-310-x86_64-linux-gnu.so'.  The two versions should be equal; check your installation.
|       [end of output]
|   
|   note: This error originates from a subprocess, and is likely not a problem with pip.
| error: metadata-generation-failed
| 
| × Encountered error while generating package metadata.
| ╰─> See above for output.
| 
| note: This is an issue with the package mentioned above, not pip.
| hint: See above for details.
[Periodic Functional Tests/run_tests]   ❌  Failure - Main Run Functional Tests
[Periodic Functional Tests/run_tests] exitcode '1': failure
[Periodic Functional Tests/run_tests] 🏁  Job failed
Error: Job 'run_tests' failed
```


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
CC @rimolive 