### PR TITLE
fix(sdk): fixes sliced load_confusion_matrix. Fixes #8117

### DIFF
--- a/sdk/python/kfp/dsl/types/artifact_types.py
+++ b/sdk/python/kfp/dsl/types/artifact_types.py
@@ -339,6 +339,7 @@ class SlicedClassificationMetrics(Artifact):
     """
 
     schema_title = 'system.SlicedClassificationMetrics'
+    _sliced_metrics = {}
 
     def _upsert_classification_metrics_for_slice(self, slice: str) -> None:
         """Upserts the classification metrics instance for a slice."""
@@ -443,7 +444,7 @@ class SlicedClassificationMetrics(Artifact):
           matrix: Complete confusion matrix.
         """
         self._upsert_classification_metrics_for_slice(slice)
-        self._sliced_metrics[slice].log_confusion_matrix_cell(
+        self._sliced_metrics[slice].log_confusion_matrix(
             categories, matrix)
         self._update_metadata(slice)
 


### PR DESCRIPTION
**Description of your changes:**

- fix incorrect call of slice ClassificationMetrics in SlicedClassificationMetrics Artifact **load_confusion_matrix**
- add init value for **_sliced_metrics** in SlicedClassificationMetrics

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
