### PR TITLE
feat(backend): Remove PipelineSpec Template storage from ObjStore responsibilies. Fixes #10509

### DIFF
--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -1489,6 +1489,18 @@ func TestDeletePipelineVersion_FileError(t *testing.T) {
 	assert.True(t, ok)
 	pipelineStore.SetUUIDGenerator(util.NewFakeUUIDGeneratorOrFatal(FakeUUIDOne, nil))
 	manager.CreatePipelineVersion(pv)
+
+	// Switch to a bad object store
+	manager.objectStore = &FakeBadObjectStore{}
+
+	// Delete the above pipeline_version.
+	err = manager.DeletePipelineVersion(FakeUUIDOne)
+	assert.Nil(t, err)
+
+	// Verify the version in deleting status.
+	version, err := manager.pipelineStore.GetPipelineVersionWithStatus(FakeUUIDOne, model.PipelineVersionDeleting)
+	assert.NotNil(t, err)
+	assert.Nil(t, version)
 }
 
 // Tests DeletePipeline

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -389,24 +389,6 @@ func TestCreatePipeline(t *testing.T) {
 			model:    createPipeline("complex", "", "user1"),
 		},
 		{
-			msg:            "BadObjectStore",
-			badObjectStore: true,
-			template:       testWorkflow.ToStringForStore(),
-			errorCode:      codes.Internal,
-			errorMsg:       "bad object store",
-			model:          createPipeline("BadOS", "", "user1"),
-			// We previously verified that the failed pipeline version
-			// in DB is in status PipelineVersionCreating by faking
-			// the UUID generator, so that we know the created version
-			// UUID in advance.
-			// We cannot verify it using public APIs,
-			// because the API does not expose them unless we know its UUID, but we
-			// cannot know its UUID when create version request failed.
-			// TODO: do we really need to verify this status? or should
-			// the create version request return a UUID when the
-			// pipeline version fails in PipelineVersionCreating state.
-		},
-		{
 			msg:       "InvalidTemplate",
 			template:  "I am invalid yaml",
 			model:     createPipeline("InvalidYAML", "", "user1"),
@@ -535,23 +517,6 @@ func TestCreatePipelineVersion(t *testing.T) {
 				Parameters:   "[{\"name\":\"output\"},{\"name\":\"project\"},{\"name\":\"schema\",\"value\":\"gs://ml-pipeline-playground/tfma/taxi-cab-classification/schema.json\"},{\"name\":\"train\",\"value\":\"gs://ml-pipeline-playground/tfma/taxi-cab-classification/train.csv\"},{\"name\":\"evaluation\",\"value\":\"gs://ml-pipeline-playground/tfma/taxi-cab-classification/eval.csv\"},{\"name\":\"preprocess-mode\",\"value\":\"local\"},{\"name\":\"preprocess-module\",\"value\":\"gs://ml-pipeline-playground/tfma/taxi-cab-classification/preprocessing.py\"},{\"name\":\"target\",\"value\":\"tips\"},{\"name\":\"learning-rate\",\"value\":\"0.1\"},{\"name\":\"hidden-layer-size\",\"value\":\"1500\"},{\"name\":\"steps\",\"value\":\"3000\"},{\"name\":\"workers\",\"value\":\"0\"},{\"name\":\"pss\",\"value\":\"0\"},{\"name\":\"predict-mode\",\"value\":\"local\"},{\"name\":\"analyze-mode\",\"value\":\"local\"},{\"name\":\"analyze-slice-column\",\"value\":\"trip_start_hour\"}]",
 				PipelineSpec: complexPipeline,
 			},
-		},
-		{
-			msg:            "BadObjectStore",
-			badObjectStore: true,
-			template:       testWorkflow.ToStringForStore(),
-			errorCode:      codes.Internal,
-			errorMsg:       "bad object store",
-			// We previously verified that the failed pipeline version
-			// in DB is in status PipelineVersionCreating by faking
-			// the UUID generator, so that we know the created version
-			// UUID in advance.
-			// We cannot verify it using public APIs,
-			// because the API does not expose them unless we know its UUID, but we
-			// cannot know its UUID when create version request failed.
-			// TODO: do we really need to verify this status? or should
-			// the create version request return a UUID when the
-			// pipeline version fails in PipelineVersionCreating state.
 		},
 		{
 			msg:       "InvalidTemplate",
@@ -1524,18 +1489,6 @@ func TestDeletePipelineVersion_FileError(t *testing.T) {
 	assert.True(t, ok)
 	pipelineStore.SetUUIDGenerator(util.NewFakeUUIDGeneratorOrFatal(FakeUUIDOne, nil))
 	manager.CreatePipelineVersion(pv)
-
-	// Switch to a bad object store
-	manager.objectStore = &FakeBadObjectStore{}
-
-	// Delete the above pipeline_version.
-	err = manager.DeletePipelineVersion(FakeUUIDOne)
-	assert.NotNil(t, err)
-
-	// Verify the version in deleting status.
-	version, err := manager.pipelineStore.GetPipelineVersionWithStatus(FakeUUIDOne, model.PipelineVersionDeleting)
-	assert.Nil(t, err)
-	assert.NotNil(t, version)
 }
 
 // Tests DeletePipeline

--- a/backend/src/apiserver/server/fakes_test.go
+++ b/backend/src/apiserver/server/fakes_test.go
@@ -271,8 +271,9 @@ func initWithExperimentsAndTwoPipelineVersions(t *testing.T) *resource.FakeClien
 	resourceManager = resource.NewResourceManager(clientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
 	_, err = resourceManager.CreatePipelineVersion(
 		&model.PipelineVersion{
-			Name:       "pipeline_version",
-			PipelineId: DefaultFakeUUID,
+			Name:         "pipeline_version",
+			PipelineId:   DefaultFakeUUID,
+			PipelineSpec: "apiVersion: argoproj.io/v1alpha1\nkind: Workflow",
 		},
 	)
 	assert.Nil(t, err)
@@ -302,8 +303,9 @@ func initWithExperimentsAndTwoPipelineVersions(t *testing.T) *resource.FakeClien
 	resourceManager = resource.NewResourceManager(clientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
 	_, err = resourceManager.CreatePipelineVersion(
 		&model.PipelineVersion{
-			Name:       "another_pipeline_version",
-			PipelineId: NonDefaultFakeUUID,
+			Name:         "another_pipeline_version",
+			PipelineId:   NonDefaultFakeUUID,
+			PipelineSpec: "apiVersion: argoproj.io/v1alpha1\nkind: Workflow",
 		},
 	)
 	assert.Nil(t, err)

--- a/backend/src/apiserver/server/pipeline_upload_server_test.go
+++ b/backend/src/apiserver/server/pipeline_upload_server_test.go
@@ -106,12 +106,6 @@ func TestUploadPipeline(t *testing.T) {
 				assert.Equal(t, "123e4567-e89b-12d3-a456-426655440000", parsedResponse.PipelineID)
 			}
 
-			// Verify stored in object store
-			objStore := clientManager.ObjectStore()
-			template, err := objStore.GetFile(objStore.GetPipelineKey(DefaultFakeUUID))
-			assert.Nil(t, err)
-			assert.NotNil(t, template)
-
 			opts, err := list.NewOptions(&model.Pipeline{}, 2, "", nil)
 			assert.Nil(t, err)
 
@@ -159,11 +153,6 @@ func TestUploadPipeline(t *testing.T) {
 			assert.Equal(t, 200, response.Code)
 			assert.Contains(t, response.Body.String(), `"created_at":"1970-01-01T00:00:03Z"`)
 
-			// Verify stored in object store
-			objStore = clientManager.ObjectStore()
-			template, err = objStore.GetFile(objStore.GetPipelineKey(fakeVersionUUID))
-			assert.Nil(t, err)
-			assert.NotNil(t, template)
 			opts, err = list.NewOptions(&model.PipelineVersion{}, 2, "", nil)
 			assert.Nil(t, err)
 
@@ -256,7 +245,7 @@ func TestUploadPipelineV2_NameValidation(t *testing.T) {
 	}
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
-			clientManager, server := setupClientManagerAndServer()
+			_, server := setupClientManagerAndServer()
 			bytesBuffer, writer := setupWriter("")
 			setWriterWithBuffer("uploadfile", "hello-world.yaml", string(test.spec), writer)
 			response := uploadPipeline("/apis/v2beta1/pipelines/upload",
@@ -284,12 +273,6 @@ func TestUploadPipelineV2_NameValidation(t *testing.T) {
 				// Verify v1 API returns v1 object while v2 API returns v2 object.
 				assert.Equal(t, "", parsedResponse.ID)
 				assert.Equal(t, "123e4567-e89b-12d3-a456-426655440000", parsedResponse.PipelineID)
-
-				// Verify stored in object store
-				objStore := clientManager.ObjectStore()
-				template, err := objStore.GetFile(objStore.GetPipelineKey(DefaultFakeUUID))
-				assert.Nil(t, err)
-				assert.NotNil(t, template)
 			}
 		})
 	}
@@ -305,12 +288,6 @@ func TestUploadPipeline_Tarball(t *testing.T) {
 
 	// Verify time format is RFC3339
 	assert.Contains(t, response.Body.String(), `"created_at":"1970-01-01T00:00:01Z"`)
-
-	// Verify stored in object store
-	objStore := clientManager.ObjectStore()
-	template, err := objStore.GetFile(objStore.GetPipelineKey(DefaultFakeUUID))
-	assert.Nil(t, err)
-	assert.NotNil(t, template)
 
 	opts, err := list.NewOptions(&model.Pipeline{}, 2, "", nil)
 	assert.Nil(t, err)
@@ -359,11 +336,6 @@ func TestUploadPipeline_Tarball(t *testing.T) {
 	assert.Equal(t, 200, response.Code)
 	assert.Contains(t, response.Body.String(), `"created_at":"1970-01-01T00:00:03Z"`)
 
-	// Verify stored in object store
-	objStore = clientManager.ObjectStore()
-	template, err = objStore.GetFile(objStore.GetPipelineKey(fakeVersionUUID))
-	assert.Nil(t, err)
-	assert.NotNil(t, template)
 	opts, err = list.NewOptions(&model.PipelineVersion{}, 2, "", nil)
 	assert.Nil(t, err)
 	// Verify metadata in db
@@ -414,12 +386,6 @@ func TestUploadPipeline_SpecifyFileName(t *testing.T) {
 		bytes.NewReader(bytesBuffer.Bytes()), writer, server.UploadPipeline)
 	assert.Equal(t, 200, response.Code)
 
-	// Verify stored in object store
-	objStore := clientManager.ObjectStore()
-	template, err := objStore.GetFile(objStore.GetPipelineKey(DefaultFakeUUID))
-	assert.Nil(t, err)
-	assert.NotNil(t, template)
-
 	opts, err := list.NewOptions(&model.Pipeline{}, 2, "", nil)
 	assert.Nil(t, err)
 	// Verify metadata in db
@@ -467,11 +433,6 @@ func TestUploadPipeline_SpecifyFileDescription(t *testing.T) {
 		bytes.NewReader(bytesBuffer.Bytes()), writer, server.UploadPipeline)
 	assert.Equal(t, 200, response.Code)
 
-	// Verify stored in object store
-	objStore := clientManager.ObjectStore()
-	template, err := objStore.GetFile(objStore.GetPipelineKey(DefaultFakeUUID))
-	assert.Nil(t, err)
-	assert.NotNil(t, template)
 	opts, err := list.NewOptions(&model.Pipeline{}, 2, "", nil)
 	assert.Nil(t, err)
 


### PR DESCRIPTION
**Description of your changes:**
Fixes #10509 

The PipelineSpec definition is currently stored in two places, DB and ObjStore, creating the potential for a competing source-of-truth problem.  The ObjStore copy doesn't appear to actually be used/retrieved anywhere, so remove it from the list of responsibilities

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
