### PR TITLE
fix(sdk): Add required auth scopes to RegistryClient for GCP service accounts credentials

### DIFF
--- a/sdk/python/kfp/registry/context/kfp_pkg_dev.json
+++ b/sdk/python/kfp/registry/context/kfp_pkg_dev.json
@@ -16,5 +16,6 @@
    "delete_version_url":"https://artifactregistry.googleapis.com/v1/projects/{project_id}/locations/{location}/repositories/{repo_id}/packages/{package_name}/versions/{version}",
    "package_format":"projects/{project_id}/locations/{location}/repositories/{repo_id}/packages/{package_name}",
    "tag_format":"projects/{project_id}/locations/{location}/repositories/{repo_id}/packages/{package_name}/tags/{tag}",
-   "version_format":"projects/{project_id}/locations/{location}/repositories/{repo_id}/packages/{package_name}/versions/{version}"
+   "version_format":"projects/{project_id}/locations/{location}/repositories/{repo_id}/packages/{package_name}/versions/{version}",
+   "auth_scopes": "https://www.googleapis.com/auth/cloud-platform"
 }

--- a/sdk/python/kfp/registry/registry_client.py
+++ b/sdk/python/kfp/registry/registry_client.py
@@ -189,7 +189,9 @@ class RegistryClient:
             return auth
         elif self._is_ar_host():
             auth, _ = google.auth.default()
-            return auth
+            auth_scopes = self._config.get('auth_scopes')
+            auth_scopes = auth_scopes.split(',') if auth_scopes else None
+            return credentials.with_scopes_if_required(auth, auth_scopes)
         elif auth_file:
             if os.path.exists(auth_file):
                 # Fetch auth token using the locally stored credentials.

--- a/sdk/python/kfp/registry/registry_client_test.py
+++ b/sdk/python/kfp/registry/registry_client_test.py
@@ -55,14 +55,10 @@ class RegistryClientTest(parameterized.TestCase):
         host = _DEFAULT_HOST
         client = RegistryClient(host=host, auth=ApiAuth(''))
         expected_config = {
-            'host':
-                host,
-            'upload_url':
-                host,
-            'download_version_url':
-                f'{host}/{{package_name}}/{{version}}',
-            'download_tag_url':
-                f'{host}/{{package_name}}/{{tag}}',
+            'host': host,
+            'upload_url': host,
+            'download_version_url': f'{host}/{{package_name}}/{{version}}',
+            'download_tag_url': f'{host}/{{package_name}}/{{tag}}',
             'get_package_url':
                 ('https://artifactregistry.googleapis.com/v1/projects/'
                  'proj/locations/us-central1/repositories'
@@ -114,7 +110,8 @@ class RegistryClientTest(parameterized.TestCase):
                            '/repo/packages/{package_name}/tags/{tag}'),
             'version_format':
                 ('projects/proj/locations/us-central1/repositories'
-                 '/repo/packages/{package_name}/versions/{version}')
+                 '/repo/packages/{package_name}/versions/{version}'),
+            'auth_scopes': 'https://www.googleapis.com/auth/cloud-platform'
         }
         self.assertEqual(self._mock_open.call_args_list[0][0],
                          (_KFP_CONFIG_FILE, 'r'))


### PR DESCRIPTION
The scopes are defined in registry context file. Additional scopes must be comma separated.

Fixes #8878. Previous PR #8895 was approved, but tests failed and became stale.

I fixed the tests, and confirmed it worked for my case. Using a GCP Service Account with RegistryClient no longer requires me to explicitly provide the required scopes.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
