### PR TITLE
docs: modified the ConfigMap as Env variable example in README.md with right key_name within use_config_map_as_env() block.

### DIFF
--- a/kubernetes_platform/python/README.md
+++ b/kubernetes_platform/python/README.md
@@ -92,7 +92,7 @@ def pipeline():
     task = print_config_map()
     kubernetes.use_config_map_as_env(task,
                                  config_map_name='my-cm',
-                                 secret_key_to_env={'foo': 'CM_VAR'})
+                                 config_map_key_to_env={'foo': 'CM_VAR'})
 ```
 
 ### ConfigMap: As mounted volume


### PR DESCRIPTION
Referring the [kfp-kubernetes Reference Documentation](https://kfp-kubernetes.readthedocs.io/en/kfp-kubernetes-1.2.0/#configmap-as-environment-variable) the "ConfigMap: As environment variable" example contains incorrect key_name in kubernetes.use_config_map_as_env() code block.

Modification: secret_key_to_env to config_map_key_to_env

Supporting reference for modification: [use_config_map_as_env code reference](https://github.com/kubeflow/pipelines/blob/master/kubernetes_platform/python/kfp/kubernetes/config_map.py#L26)

Updated the README.md, this change should be reflected in kfp-kubernetes readthedocs.