### PR TITLE
test: install kfp on github periodic functional tests workflow

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -10,13 +10,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Create k8s Kind Cluster
-        uses: container-tools/kind-action@v2
-        with:
-          cluster_name: kfp-tekton
-          kubectl_version: v1.29.2
-          version: v0.22.0
-          node_image: kindest/node:v1.29.2
+      - name: Create KFP cluster
+        uses: ./.github/actions/kfp-cluster
       - name: Run Functional Tests
         run: |
           log_dir=$(mktemp -d)

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -12,6 +12,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster
+      - name: Port forward kfp apiserver
+        run: |
+          nohup kubectl port-forward --namespace kubeflow svc/ml-pipeline 8888:8888 &
       - name: Run Functional Tests
         run: |
           log_dir=$(mktemp -d)

--- a/test/kfp-functional-test/kfp-functional-test.sh
+++ b/test/kfp-functional-test/kfp-functional-test.sh
@@ -15,4 +15,4 @@
 
 source_root="$(pwd)"
 python3 -m pip install -r "${source_root}/test/kfp-functional-test/requirements.txt"
-python3 "${source_root}/test/kfp-functional-test/run_kfp_functional_test.py" --host ""
+python3 "${source_root}/test/kfp-functional-test/run_kfp_functional_test.py" --host "http://localhost:8888"  # host configured in workflow file

--- a/test/kfp-functional-test/kfp-functional-test.sh
+++ b/test/kfp-functional-test/kfp-functional-test.sh
@@ -12,11 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-sudo apt-get update -y
-sudo apt --no-install-recommends -y -q install curl
+
 source_root="$(pwd)"
-
 python3 -m pip install -r "${source_root}/test/kfp-functional-test/requirements.txt"
-HOST="https://$(curl https://raw.githubusercontent.com/kubeflow/testing/master/test-infra/kfp/endpoint)"
-
-python3 "${source_root}/test/kfp-functional-test/run_kfp_functional_test.py" --host "${HOST}"
+python3 "${source_root}/test/kfp-functional-test/run_kfp_functional_test.py" --host ""


### PR DESCRIPTION
**Description of your changes:**
Hopefully last fix for periodic functional tests. Current problems (https://github.com/kubeflow/pipelines/issues/10851):
1. Tests fail in GH workflows as they try to connect to the same GCP cluster that prow tests run on. The corresponding environment is not configured in GitHub.
2. Tests fail in prow as they try to run `sudo` which is not available on python3.7-slim (runs on debian).

Solutions:
1. For GH actions, use the kind cluster defined in the workflow file to run the test instead of GCP test cluster. This requires actually installing kfp on this kind cluster. I copypasted installation from the [backend test workflow file](https://github.com/kubeflow/pipelines/blob/master/.github/workflows/backend.yml). Let me know if there is a simpler/faster solution (test runs for 15 mins), [standalone kfp deployment](https://www.kubeflow.org/docs/components/pipelines/v1/installation/standalone-deployment/) didn't work for me.
3. Make tests aware of the environment they are running on. If running in GitHub actions (we can check if `KIND_REGISTRY` env var created by kind action is available), tests work without indicating [host](https://github.com/kubeflow/pipelines/blob/master/sdk/python/kfp/client/client.py#L105). For prow tests, run `apt` without `sudo`, as it was [initially](https://github.com/kubeflow/pipelines/blob/7b4ddf658c77bc5d4663ca100bdd2392d2c4f109/test/kfp-functional-test/kfp-functional-test.sh) defined.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
