### PR TITLE
fix(kubernetes_platform): fix api-generator docker mount for SELinux

### DIFF
--- a/kubernetes_platform/Makefile
+++ b/kubernetes_platform/Makefile
@@ -25,7 +25,7 @@ clean: clean-go clean-python
 golang: proto/*.proto
 	docker run --interactive --rm \
 		--user $$(id -u):$$(id -g) \
-		--mount type=bind,source="$$(pwd)/..",target=/go/src/github.com/kubeflow/pipelines \
+		-v "$$(pwd)/..":"/go/src/github.com/kubeflow/pipelines":z \
 		$(PREBUILT_REMOTE_IMAGE)  \
 		sh -c 'cd /go/src/github.com/kubeflow/pipelines/kubernetes_platform && make generate-go-in-container'
 


### PR DESCRIPTION
**Description of your changes:**

On Fedora, which runs SELinux, mounting the container to the local filesystem results in permission issues because the labels mismatch: `make: stat: Makefile: Permission denied`

To fix this, change the directory mount to use the `-v` syntax and add the `:z` option at the end. Ref:
https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
