### PR TITLE
Fix get_pipeline_id: Accept Namespace Parameter in Kubeflow Pipelines

### DIFF
--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -486,11 +486,15 @@ class Client:
 
         return experiment
 
-    def get_pipeline_id(self, name: str) -> Optional[str]:
+    def get_pipeline_id(
+            self, 
+            name: str,
+            namespace: Optional[str] = None) -> Optional[str]:
         """Gets the ID of a pipeline by its name.
 
         Args:
             name: Pipeline name.
+            namespace: Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as ``None``.
 
         Returns:
             The pipeline ID if a pipeline with the name exists.
@@ -502,7 +506,7 @@ class Client:
                 'stringValue': name,
             }]
         })
-        result = self._pipelines_api.list_pipelines(filter=pipeline_filter)
+        result = self._pipelines_api.list_pipelines(filter=pipeline_filter, namespace=namespace)
         if result.pipelines is None:
             return None
         if len(result.pipelines) == 1:


### PR DESCRIPTION
### Summary

This pull request fixes the issue where the `get_pipeline_id` function returns `None` when called for a pipelines created as private. The function now accepts a namespace parameter and passes it to the `list_pipelines` function, ensuring the correct pipeline ID is returned.

### Changes

- Modified `get_pipeline_id` function to accept a `namespace` parameter.

### Issue Reference

Fixes #10909

### Additional Context

This change ensures that the `get_pipeline_id` function works as expected in environments where namespaces are used.