### PR TITLE
chore: Add an option to re-run GHA workflows

### DIFF
--- a/.github/workflows/rerun-pr-jobs.yaml
+++ b/.github/workflows/rerun-pr-jobs.yaml
@@ -1,0 +1,16 @@
+name: Re-Run PR tests
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rerun_pr_tests:
+    name: rerun_pr_tests
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: estroz/rerun-actions@main
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        comment_id: ${{ github.event.comment.id }}


### PR DESCRIPTION
**Description of your changes:**

## Re-running failed tests
The following commands are supported by this action:

`/rerun-all` - rerun all failed workflows.
`/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.

Some notes:
The PR either must have an `ok-to-test` label present on the PR, or the user who writes a command must be an organization member, or repo owner, contributor, or collaborator.
Typically `ok-to-test` can/should only be applied by repo reviewers/approvers to prevent spam and abuse.

Reference: https://github.com/estroz/rerun-actions

cc @chensun @zijianjoy @connor-mccarthy 


**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
