### PR TITLE
chore: Updated Python image to 3.8 in backend/Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,7 +27,7 @@ RUN go-licenses csv ./backend/src/apiserver > /tmp/licenses.csv && \
   go-licenses save ./backend/src/apiserver --save_path /tmp/NOTICES
 
 # 2. Compile preloaded pipeline samples
-FROM python:3.7 as compiler
+FROM python:3.8 as compiler
 RUN apt-get update -y && apt-get install --no-install-recommends -y -q default-jdk python3-setuptools python3-dev jq
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
 COPY backend/requirements.txt .


### PR DESCRIPTION
**Description of your changes:**
This PR updates [backend/Dockerfile](https://github.com/kubeflow/pipelines/blob/bf5104fcff6a6c2db8d8e39522c04eca1bb3fc93/backend/Dockerfile#L30) to use Python 3.8 since Python 3.7 is no longer supported by https://bootstrap.pypa.io/pip/3.7/get-pip.py.

```
ERROR: This script does not work on Python 3.7 The minimum supported Python version is 3.8. Please use https://bootstrap.pypa.io/pip/3.7/get-pip.py instead.
Error: building at STEP "RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py": while running runtime: exit status 1
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
