### PR TITLE
test: Migrate KFP SDK YAPF test to a GHA Workflow

### DIFF
--- a/.github/workflows/sdk-yapf.yml
+++ b/.github/workflows/sdk-yapf.yml
@@ -1,0 +1,36 @@
+name: KFP SDK YAPF Tests
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'sdk/python/**'
+      - 'test/presubmit-yapf-sdk.sh'
+      - '.github/workflows/sdk-yapf.yml'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'sdk/python/**'
+      - 'test/presubmit-yapf-sdk.sh'
+      - '.github/workflows/sdk-yapf.yml'
+
+jobs:
+  yapf-sdk:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+
+    - name: Install dependencies
+      run: pip install yapf
+
+    - name: Run YAPF SDK Tests
+      run: ./test/presubmit-yapf-sdk.sh


### PR DESCRIPTION
**Description of your changes:**
Resolves https://github.com/kubeflow/pipelines/issues/10925

Converts the KFP SDK YAPF test to a GH Action Workflow.

Here's a working GH Action run on my fork: https://github.com/DharmitD/data-science-pipelines-argo/actions/runs/9672832818

PR to remove the KFP SDK YAPF test from prow config: https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2310

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
