### PR TITLE
test: Migrate KFP SDK Upgrade Test to GHA

### DIFF
--- a/.github/workflows/sdk-upgrade.yml
+++ b/.github/workflows/sdk-upgrade.yml
@@ -1,0 +1,26 @@
+name: KFP SDK Upgrade Test
+
+on:
+  push:
+    branches: [master]
+
+  pull_request:
+    paths:
+      - 'sdk/python/**'
+      - 'test/presubmit-test-sdk-upgrade.sh'
+      - '.github/workflows/sdk-upgrade.yml'
+
+jobs:
+  test-upgrade-kfp-sdk:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: Run SDK upgrade tests
+        run: ./test/presubmit-test-sdk-upgrade.sh


### PR DESCRIPTION
**Description of your changes:**
Resolves https://github.com/kubeflow/pipelines/issues/10987

Converts the KFP SDK Upgrade test to a GH Action Workflow.

Here's a working GH Action run on my fork: https://github.com/DharmitD/data-science-pipelines-argo/actions/runs/9862965921/job/27234673632
PR to remove the KFP SDK Upgrade test from prow config: https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2317

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
