### PR TITLE
test: Migrate KFP SDK Runtime Code Test to GHA

### DIFF
--- a/.github/workflows/kfp-sdk-runtime-tests.yml
+++ b/.github/workflows/kfp-sdk-runtime-tests.yml
@@ -1,0 +1,31 @@
+name: KFP Runtime Code Tests
+
+on:
+  push:
+    branches: [master]
+
+  pull_request:
+    paths:
+      - '.github/workflows/kfp-sdk-runtime-tests.yml'
+      - 'sdk/python/**'
+      - 'test/presubmit-test-kfp-runtime-code.sh'
+
+jobs:
+  kfp-runtime-tests:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Run KFP Runtime Code Tests
+        run: |
+          export PULL_NUMBER="${{ github.event.inputs.pull_number || github.event.pull_request.number }}"
+          ./test/presubmit-test-kfp-runtime-code.sh


### PR DESCRIPTION
**Description of your changes:**

**Description of your changes:**
Resolves https://github.com/kubeflow/pipelines/issues/10987

Converts the KFP SDK Runtime Code test to a GH Action Workflow.

Here's a working GH Action run on my fork: https://github.com/DharmitD/data-science-pipelines-argo/actions/runs/9863919827/job/27237733585

PR to remove the KFP Execution test from prow config: https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2318

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
