### PR TITLE
fix(frontend): retrieve archived logs from correct location

### DIFF
--- a/frontend/server/configs.ts
+++ b/frontend/server/configs.ts
@@ -91,7 +91,10 @@ export function loadConfigs(argv: string[], env: ProcessEnv): UIConfigs {
     ARGO_ARCHIVE_ARTIFACTORY = 'minio',
     /** Bucket to retrive logs from */
     ARGO_ARCHIVE_BUCKETNAME = 'mlpipeline',
-    /** This should match the keyFormat specified in the Argo workflow-controller-configmap */
+    /** This should match the keyFormat specified in the Argo workflow-controller-configmap.
+     * It's set here in the manifests:
+     * https://github.com/kubeflow/pipelines/blob/7b7918ebf8c30e6ceec99283ef20dbc02fdf6a42/manifests/kustomize/third-party/argo/base/workflow-controller-configmap-patch.yaml#L28
+     */
     ARGO_KEYFORMAT = 'artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}',
     /** Should use server API for log streaming? */
     STREAM_LOGS_FROM_SERVER_API = 'false',

--- a/frontend/server/configs.ts
+++ b/frontend/server/configs.ts
@@ -91,8 +91,8 @@ export function loadConfigs(argv: string[], env: ProcessEnv): UIConfigs {
     ARGO_ARCHIVE_ARTIFACTORY = 'minio',
     /** Bucket to retrive logs from */
     ARGO_ARCHIVE_BUCKETNAME = 'mlpipeline',
-    /** Prefix to logs. */
-    ARGO_ARCHIVE_PREFIX = 'logs',
+    /** This should match the keyFormat specified in the Argo workflow-controller-configmap */
+    ARGO_KEYFORMAT = 'artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}',
     /** Should use server API for log streaming? */
     STREAM_LOGS_FROM_SERVER_API = 'false',
     /** The main container name of a pod where logs are retrieved */
@@ -127,7 +127,7 @@ export function loadConfigs(argv: string[], env: ProcessEnv): UIConfigs {
       archiveArtifactory: ARGO_ARCHIVE_ARTIFACTORY,
       archiveBucketName: ARGO_ARCHIVE_BUCKETNAME,
       archiveLogs: asBool(ARGO_ARCHIVE_LOGS),
-      archivePrefix: ARGO_ARCHIVE_PREFIX,
+      keyFormat: ARGO_KEYFORMAT,
     },
     pod: {
       logContainerName: POD_LOG_CONTAINER_NAME,
@@ -253,7 +253,7 @@ export interface ArgoConfigs {
   archiveLogs: boolean;
   archiveArtifactory: string;
   archiveBucketName: string;
-  archivePrefix: string;
+  keyFormat: string;
 }
 export interface ServerConfigs {
   basePath: string;

--- a/frontend/server/handlers/pod-logs.ts
+++ b/frontend/server/handlers/pod-logs.ts
@@ -39,21 +39,21 @@ export function getPodLogsHandler(
   },
   podLogContainerName: string,
 ): Handler {
-  const { archiveLogs, archiveArtifactory, archiveBucketName, archivePrefix = '' } = argoOptions;
+  const { archiveLogs, archiveArtifactory, archiveBucketName, keyFormat } = argoOptions;
 
-  // get pod log from the provided bucket and prefix.
+  // get pod log from the provided bucket and keyFormat.
   const getPodLogsStreamFromArchive = toGetPodLogsStream(
     createPodLogsMinioRequestConfig(
       archiveArtifactory === 'minio' ? artifactsOptions.minio : artifactsOptions.aws,
       archiveBucketName,
-      archivePrefix,
+      keyFormat,
     ),
   );
 
   // get the pod log stream (with fallbacks).
   const getPodLogsStream = composePodLogsStreamHandler(
-    (podName: string, namespace?: string) => {
-      return getPodLogsStreamFromK8s(podName, namespace, podLogContainerName);
+    (podName: string, createdAt: string, namespace?: string) => {
+      return getPodLogsStreamFromK8s(podName, createdAt, namespace, podLogContainerName);
     },
     // if archive logs flag is set, then final attempt will try to retrieve the artifacts
     // from the bucket and prefix provided in the config. Otherwise, only attempts
@@ -69,13 +69,14 @@ export function getPodLogsHandler(
       return;
     }
     const podName = decodeURIComponent(req.query.podname);
+    const createdAt = decodeURIComponent(req.query.createdat);
 
     // This is optional.
     // Note decodeURIComponent(undefined) === 'undefined', so I cannot pass the argument directly.
     const podNamespace = decodeURIComponent(req.query.podnamespace || '') || undefined;
 
     try {
-      const stream = await getPodLogsStream(podName, podNamespace);
+      const stream = await getPodLogsStream(podName, createdAt, podNamespace);
       stream.on('error', err => {
         if (
           err?.message &&

--- a/frontend/server/workflow-helper.test.ts
+++ b/frontend/server/workflow-helper.test.ts
@@ -147,31 +147,28 @@ describe('workflow-helper', () => {
         apiVersion: 'argoproj.io/v1alpha1',
         kind: 'Workflow',
         status: {
+          artifactRepositoryRef: {
+            artifactRepository: {
+              archiveLogs: true,
+              s3: {
+                accessKeySecret: { key: 'accessKey', name: 'accessKeyName' },
+                bucket: 'bucket',
+                endpoint: 'minio-service.kubeflow',
+                insecure: true,
+                key:
+                  'prefix/workflow-name/workflow-name-system-container-impl-abc/some-artifact.csv',
+                secretKeySecret: { key: 'secretKey', name: 'secretKeyName' },
+              },
+            },
+          },
           nodes: {
             'workflow-name-abc': {
               outputs: {
                 artifacts: [
                   {
-                    name: 'some-artifact.csv',
+                    name: 'main-logs',
                     s3: {
-                      accessKeySecret: { key: 'accessKey', name: 'accessKeyName' },
-                      bucket: 'bucket',
-                      endpoint: 'minio-service.kubeflow',
-                      insecure: true,
-                      key: 'prefix/workflow-name/workflow-name-abc/some-artifact.csv',
-                      secretKeySecret: { key: 'secretKey', name: 'secretKeyName' },
-                    },
-                  },
-                  {
-                    archiveLogs: true,
-                    name: 'main.log',
-                    s3: {
-                      accessKeySecret: { key: 'accessKey', name: 'accessKeyName' },
-                      bucket: 'bucket',
-                      endpoint: 'minio-service.kubeflow',
-                      insecure: true,
-                      key: 'prefix/workflow-name/workflow-name-abc/main.log',
-                      secretKeySecret: { key: 'secretKey', name: 'secretKeyName' },
+                      key: 'prefix/workflow-name/workflow-name-system-container-impl-abc/main.log',
                     },
                   },
                 ],
@@ -193,7 +190,10 @@ describe('workflow-helper', () => {
       mockedClientGetObject.mockResolvedValueOnce(objStream);
       objStream.end('some fake logs.');
 
-      const stream = await getPodLogsStreamFromWorkflow('workflow-name-abc', '2024-07-09');
+      const stream = await getPodLogsStreamFromWorkflow(
+        'workflow-name-system-container-impl-abc',
+        '2024-07-09',
+      );
 
       expect(mockedGetArgoWorkflow).toBeCalledWith('workflow-name');
 
@@ -212,7 +212,7 @@ describe('workflow-helper', () => {
       expect(mockedClientGetObject).toBeCalledTimes(1);
       expect(mockedClientGetObject).toBeCalledWith(
         'bucket',
-        'prefix/workflow-name/workflow-name-abc/main.log',
+        'prefix/workflow-name/workflow-name-system-container-impl-abc/main.log',
       );
     });
   });

--- a/frontend/server/workflow-helper.test.ts
+++ b/frontend/server/workflow-helper.test.ts
@@ -39,40 +39,49 @@ describe('workflow-helper', () => {
   describe('composePodLogsStreamHandler', () => {
     it('returns the stream from the default handler if there is no errors.', async () => {
       const defaultStream = new PassThrough();
-      const defaultHandler = jest.fn((_podName: string, _namespace?: string) =>
+      const defaultHandler = jest.fn((_podName: string, _createdAt: string, _namespace?: string) =>
         Promise.resolve(defaultStream),
       );
-      const stream = await composePodLogsStreamHandler(defaultHandler)('podName', 'namespace');
-      expect(defaultHandler).toBeCalledWith('podName', 'namespace');
+      const stream = await composePodLogsStreamHandler(defaultHandler)(
+        'podName',
+        '2024-08-13',
+        'namespace',
+      );
+      expect(defaultHandler).toBeCalledWith('podName', '2024-08-13', 'namespace');
       expect(stream).toBe(defaultStream);
     });
 
     it('returns the stream from the fallback handler if there is any error.', async () => {
       const fallbackStream = new PassThrough();
-      const defaultHandler = jest.fn((_podName: string, _namespace?: string) =>
+      const defaultHandler = jest.fn((_podName: string, _createdAt: string, _namespace?: string) =>
         Promise.reject('unknown error'),
       );
-      const fallbackHandler = jest.fn((_podName: string, _namespace?: string) =>
+      const fallbackHandler = jest.fn((_podName: string, _createdAt: string, _namespace?: string) =>
         Promise.resolve(fallbackStream),
       );
       const stream = await composePodLogsStreamHandler(defaultHandler, fallbackHandler)(
         'podName',
+        '2024-08-13',
         'namespace',
       );
-      expect(defaultHandler).toBeCalledWith('podName', 'namespace');
-      expect(fallbackHandler).toBeCalledWith('podName', 'namespace');
+      expect(defaultHandler).toBeCalledWith('podName', '2024-08-13', 'namespace');
+      expect(fallbackHandler).toBeCalledWith('podName', '2024-08-13', 'namespace');
       expect(stream).toBe(fallbackStream);
     });
 
     it('throws error if both handler and fallback fails.', async () => {
-      const defaultHandler = jest.fn((_podName: string, _namespace?: string) =>
+      const defaultHandler = jest.fn((_podName: string, _createdAt: string, _namespace?: string) =>
         Promise.reject('unknown error for default'),
       );
-      const fallbackHandler = jest.fn((_podName: string, _namespace?: string) =>
+      const fallbackHandler = jest.fn((_podName: string, _createdAt: string, _namespace?: string) =>
         Promise.reject('unknown error for fallback'),
       );
       await expect(
-        composePodLogsStreamHandler(defaultHandler, fallbackHandler)('podName', 'namespace'),
+        composePodLogsStreamHandler(defaultHandler, fallbackHandler)(
+          'podName',
+          '2024-08-13',
+          'namespace',
+        ),
       ).rejects.toEqual('unknown error for fallback');
     });
   });
@@ -82,7 +91,7 @@ describe('workflow-helper', () => {
       const mockedGetPodLogs: jest.Mock = getPodLogs as any;
       mockedGetPodLogs.mockResolvedValueOnce('pod logs');
 
-      const stream = await getPodLogsStreamFromK8s('podName', 'namespace');
+      const stream = await getPodLogsStreamFromK8s('podName', '', 'namespace');
       expect(mockedGetPodLogs).toBeCalledWith('podName', 'namespace', 'main');
       expect(stream.read().toString()).toBe('pod logs');
     });
@@ -101,10 +110,10 @@ describe('workflow-helper', () => {
         client,
         key: 'folder/key',
       };
-      const createRequest = jest.fn((_podName: string, _namespace?: string) =>
+      const createRequest = jest.fn((_podName: string, _createdAt: string, _namespace?: string) =>
         Promise.resolve(configs),
       );
-      const stream = await toGetPodLogsStream(createRequest)('podName', 'namespace');
+      const stream = await toGetPodLogsStream(createRequest)('podName', '2024-08-13', 'namespace');
       expect(mockedClientGetObject).toBeCalledWith('bucket', 'folder/key');
     });
   });
@@ -112,13 +121,23 @@ describe('workflow-helper', () => {
   describe('createPodLogsMinioRequestConfig', () => {
     it('returns a MinioRequestConfig factory with the provided minioClientOptions, bucket, and prefix.', async () => {
       const mockedClient: jest.Mock = MinioClient as any;
-      const requestFunc = await createPodLogsMinioRequestConfig(minioConfig, 'bucket', 'prefix');
-      const request = await requestFunc('workflow-name-abc', 'namespace');
+      const requestFunc = await createPodLogsMinioRequestConfig(
+        minioConfig,
+        'bucket',
+        'artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}',
+      );
+      const request = await requestFunc(
+        'workflow-name-system-container-impl-foo',
+        '2024-08-13',
+        'namespace',
+      );
 
       expect(mockedClient).toBeCalledWith(minioConfig);
       expect(request.client).toBeInstanceOf(MinioClient);
       expect(request.bucket).toBe('bucket');
-      expect(request.key).toBe('prefix/workflow-name/workflow-name-abc/main.log');
+      expect(request.key).toBe(
+        'artifacts/workflow-name/2024/08/13/workflow-name-system-container-impl-foo/main.log',
+      );
     });
   });
 
@@ -174,7 +193,7 @@ describe('workflow-helper', () => {
       mockedClientGetObject.mockResolvedValueOnce(objStream);
       objStream.end('some fake logs.');
 
-      const stream = await getPodLogsStreamFromWorkflow('workflow-name-abc', "2024-07-09");
+      const stream = await getPodLogsStreamFromWorkflow('workflow-name-abc', '2024-07-09');
 
       expect(mockedGetArgoWorkflow).toBeCalledWith('workflow-name');
 

--- a/frontend/server/workflow-helper.test.ts
+++ b/frontend/server/workflow-helper.test.ts
@@ -174,7 +174,7 @@ describe('workflow-helper', () => {
       mockedClientGetObject.mockResolvedValueOnce(objStream);
       objStream.end('some fake logs.');
 
-      const stream = await getPodLogsStreamFromWorkflow('workflow-name-abc');
+      const stream = await getPodLogsStreamFromWorkflow('workflow-name-abc', "2024-07-09");
 
       expect(mockedGetArgoWorkflow).toBeCalledWith('workflow-name');
 

--- a/frontend/server/workflow-helper.ts
+++ b/frontend/server/workflow-helper.ts
@@ -162,9 +162,6 @@ export function createPodLogsMinioRequestConfig(
     }
     key = key + 'main.log';
 
-    console.log('keyFormat: ', keyFormat);
-    console.log('key: ', key);
-
     // If there are unresolved template tags in the keyFormat, throw an error
     // that surfaces in the frontend's console log.
     if (key.includes('{') || key.includes('}')) {

--- a/frontend/server/workflow-helper.ts
+++ b/frontend/server/workflow-helper.ts
@@ -141,6 +141,7 @@ export function createPodLogsMinioRequestConfig(
     const createdAtArray = createdAt.split("-")
 
     let key: string = keyFormat
+      .replace(/\s+/g, '')  // Remove all whitespace.
       .replace("{{workflow.name}}", podName.replace(/-system-container-impl-.*/, ''))
       .replace("{{workflow.creationTimestamp.Y}}", createdAtArray[0])
       .replace("{{workflow.creationTimestamp.m}}", createdAtArray[1])

--- a/frontend/server/workflow-helper.ts
+++ b/frontend/server/workflow-helper.ts
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import path from 'path';
 import { PassThrough, Stream } from 'stream';
 import { ClientOptions as MinioClientOptions } from 'minio';
 import { getK8sSecret, getArgoWorkflow, getPodLogs } from './k8s-helper';
@@ -19,8 +18,18 @@ import { createMinioClient, MinioRequestConfig, getObjectStream } from './minio-
 
 export interface PartialArgoWorkflow {
   status: {
+    artifactRepositoryRef?: ArtifactRepositoryRef;
     nodes?: ArgoWorkflowStatusNode;
   };
+}
+
+export interface ArtifactRepositoryRef {
+  artifactRepository?: ArtifactRepository;
+}
+
+export interface ArtifactRepository {
+  archiveLogs?: boolean;
+  s3?: S3Artifact;
 }
 
 export interface ArgoWorkflowStatusNode {
@@ -34,9 +43,12 @@ export interface ArgoWorkflowStatusNodeInfo {
 }
 
 export interface ArtifactRecord {
-  archiveLogs?: boolean;
-  name: string;
-  s3?: S3Artifact;
+  name?: string;
+  s3: S3Key;
+}
+
+export interface S3Key {
+  key: string;
 }
 
 export interface S3Artifact {
@@ -80,6 +92,7 @@ export function composePodLogsStreamHandler<T = Stream>(
 /**
  * Returns a stream containing the pod logs using kubernetes api.
  * @param podName name of the pod.
+ * @param createdAt YYYY-MM-DD run was created. Not used.
  * @param namespace namespace of the pod (uses the same namespace as the server if not provided).
  * @param containerName container's name of the pod, the default value is 'main'.
  */
@@ -91,7 +104,9 @@ export async function getPodLogsStreamFromK8s(
 ) {
   const stream = new PassThrough();
   stream.end(await getPodLogs(podName, namespace, containerName));
-  console.log(`Getting logs for pod:${podName} in namespace ${namespace}.`);
+  console.log(
+    `Getting logs for pod, ${podName}, in namespace, ${namespace}, by calling the Kubernetes API.`,
+  );
   return stream;
 }
 
@@ -99,6 +114,7 @@ export async function getPodLogsStreamFromK8s(
  * Returns a stream containing the pod logs using the information provided in the
  * workflow status (uses k8s api to retrieve the workflow and secrets).
  * @param podName name of the pod.
+ * @param createdAt YYYY-MM-DD run was created. Not used.
  * @param namespace namespace of the pod (uses the same namespace as the server if not provided).
  */
 export const getPodLogsStreamFromWorkflow = toGetPodLogsStream(
@@ -121,7 +137,7 @@ export function toGetPodLogsStream(
 ) {
   return async (podName: string, createdAt: string, namespace?: string) => {
     const request = await getMinioRequestConfig(podName, createdAt, namespace);
-    console.log(`Getting logs for pod:${podName} from ${request.bucket}/${request.key}.`);
+    console.log(`Getting logs for pod, ${podName}, from ${request.bucket}/${request.key}.`);
     return await getObjectStream(request);
   };
 }
@@ -193,33 +209,42 @@ export async function getPodLogsMinioRequestConfigfromWorkflow(
   podName: string,
 ): Promise<MinioRequestConfig> {
   let workflow: PartialArgoWorkflow;
+  // We should probably parameterize this replace statement. It's brittle to
+  // changes in implementation. But brittle is better than completely broken.
+  let workflowName = podName.replace(/-system-container-impl-.*/, '');
   try {
-    workflow = await getArgoWorkflow(workflowNameFromPodName(podName));
+    workflow = await getArgoWorkflow(workflowName);
   } catch (err) {
     throw new Error(`Unable to retrieve workflow status: ${err}.`);
   }
 
+  // archiveLogs can be set globally for the workflow as a whole and / or for
+  // each individual task. The compiler sets it globally so we look for it in
+  // the global field, which is documented here:
+  // https://argo-workflows.readthedocs.io/en/release-3.4/fields/#workflow
+  if (!workflow.status.artifactRepositoryRef?.artifactRepository?.archiveLogs) {
+    throw new Error('Unable to retrieve logs from artifact store; archiveLogs is disabled.');
+  }
+
   let artifacts: ArtifactRecord[] | undefined;
-  // check if required fields are available
   if (workflow.status && workflow.status.nodes) {
-    const node = workflow.status.nodes[podName];
-    if (node && node.outputs && node.outputs.artifacts) {
-      artifacts = node.outputs.artifacts;
-    }
+    const nodeName = podName.replace('-system-container-impl', '');
+    const node = workflow.status.nodes[nodeName];
+    artifacts = node?.outputs?.artifacts || undefined;
   }
   if (!artifacts) {
-    throw new Error('Unable to find pod info in workflow status to retrieve logs.');
+    throw new Error('Unable to find corresponding log artifact in node.');
   }
 
-  const archiveLogs: ArtifactRecord[] = artifacts.filter((artifact: any) => artifact.archiveLogs);
-
-  if (archiveLogs.length === 0) {
-    throw new Error('Unable to find pod log archive information from workflow status.');
+  const logKey =
+    artifacts.find((artifact: ArtifactRecord) => artifact.name === 'main-logs')?.s3.key || false;
+  if (!logKey) {
+    throw new Error('No artifact named "main-logs" for node.');
   }
 
-  const s3Artifact = archiveLogs[0].s3;
+  const s3Artifact = workflow.status.artifactRepositoryRef.artifactRepository.s3 || false;
   if (!s3Artifact) {
-    throw new Error('Unable to find s3 artifact info from workflow status.');
+    throw new Error('Unable to find artifact repository information from workflow status.');
   }
 
   const { host, port } = urlSplit(s3Artifact.endpoint, s3Artifact.insecure);
@@ -228,6 +253,10 @@ export async function getPodLogsMinioRequestConfigfromWorkflow(
   const client = await createMinioClient(
     {
       accessKey,
+      // TODO: endPoint needs to be set to 'localhost' for local development.
+      // start-proxy-and-server.sh sets MINIO_HOST=localhost, but it doesn't
+      // seem to be respected when running the server in development mode.
+      // Investigate and fix this.
       endPoint: host,
       port,
       secretKey,
@@ -238,7 +267,7 @@ export async function getPodLogsMinioRequestConfigfromWorkflow(
   return {
     bucket: s3Artifact.bucket,
     client,
-    key: s3Artifact.key,
+    key: logKey,
   };
 }
 
@@ -267,14 +296,4 @@ function urlSplit(uri: string, insecure: boolean) {
     return { host: chunks[0], port: insecure ? 80 : 443 };
   }
   return { host: chunks[0], port: parseInt(chunks[1], 10) };
-}
-
-/**
- * Infers workflow name from pod name.
- * @param podName name of the pod.
- */
-function workflowNameFromPodName(podName: string) {
-  const chunks = podName.split('-');
-  chunks.pop();
-  return chunks.join('-');
 }

--- a/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
+++ b/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
@@ -306,7 +306,7 @@ async function getLogsInfo(execution: Execution, runId?: string): Promise<Map<st
   let logsBannerMessage = '';
   let logsBannerAdditionalInfo = '';
   const customPropertiesMap = execution.getCustomPropertiesMap();
-  const createdAt = new Date(execution.getCreateTimeSinceEpoch()).toISOString().split('T')[0]
+  const createdAt = new Date(execution.getCreateTimeSinceEpoch()).toISOString().split('T')[0];
 
   if (execution) {
     podName = customPropertiesMap.get(KfpExecutionProperties.POD_NAME)?.getStringValue() || '';

--- a/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
+++ b/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
@@ -306,6 +306,7 @@ async function getLogsInfo(execution: Execution, runId?: string): Promise<Map<st
   let logsBannerMessage = '';
   let logsBannerAdditionalInfo = '';
   const customPropertiesMap = execution.getCustomPropertiesMap();
+  const createdAt = new Date(execution.getCreateTimeSinceEpoch()).toISOString().split('T')[0]
 
   if (execution) {
     podName = customPropertiesMap.get(KfpExecutionProperties.POD_NAME)?.getStringValue() || '';
@@ -321,7 +322,7 @@ async function getLogsInfo(execution: Execution, runId?: string): Promise<Map<st
   }
 
   try {
-    logsDetails = await Apis.getPodLogs(runId!, podName, podNameSpace);
+    logsDetails = await Apis.getPodLogs(runId!, podName, podNameSpace, createdAt);
     logsInfo.set(LOGS_DETAILS, logsDetails);
   } catch (err) {
     let errMsg = await errorToMessage(err);

--- a/frontend/src/lib/Apis.test.ts
+++ b/frontend/src/lib/Apis.test.ts
@@ -60,7 +60,9 @@ describe('Apis', () => {
 
   it('getPodLogs', async () => {
     const spy = fetchSpy('http://some/address');
-    expect(await Apis.getPodLogs('a-run-id', 'some-pod-name', 'ns')).toEqual('http://some/address');
+    expect(await Apis.getPodLogs('a-run-id', 'some-pod-name', 'ns', '')).toEqual(
+      'http://some/address',
+    );
     expect(spy).toHaveBeenCalledWith(
       'k8s/pod/logs?podname=some-pod-name&runid=a-run-id&podnamespace=ns',
       {
@@ -71,11 +73,24 @@ describe('Apis', () => {
 
   it('getPodLogs in a specific namespace', async () => {
     const spy = fetchSpy('http://some/address');
-    expect(await Apis.getPodLogs('a-run-id', 'some-pod-name', 'some-namespace-name')).toEqual(
+    expect(await Apis.getPodLogs('a-run-id', 'some-pod-name', 'some-namespace-name', '')).toEqual(
       'http://some/address',
     );
     expect(spy).toHaveBeenCalledWith(
       'k8s/pod/logs?podname=some-pod-name&runid=a-run-id&podnamespace=some-namespace-name',
+      {
+        credentials: 'same-origin',
+      },
+    );
+  });
+
+  it('getPodLogs with createdat specified', async () => {
+    const spy = fetchSpy('http://some/address');
+    expect(await Apis.getPodLogs('a-run-id', 'some-pod-name', 'ns', '2024-08-13')).toEqual(
+      'http://some/address',
+    );
+    expect(spy).toHaveBeenCalledWith(
+      'k8s/pod/logs?podname=some-pod-name&runid=a-run-id&podnamespace=ns&createdat=2024-08-13',
       {
         credentials: 'same-origin',
       },

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -108,13 +108,14 @@ export class Apis {
   /**
    * Get pod logs
    */
-  public static getPodLogs(runId: string, podName: string, podNamespace: string): Promise<string> {
+  public static getPodLogs(runId: string, podName: string, podNamespace: string, createdAt: string): Promise<string> {
     let query = `k8s/pod/logs?podname=${encodeURIComponent(podName)}&runid=${encodeURIComponent(
       runId,
     )}`;
     if (podNamespace) {
       query += `&podnamespace=${encodeURIComponent(podNamespace)}`;
     }
+    query += `&createdat=${encodeURIComponent(createdAt)}`;
     return this._fetch(query);
   }
 

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -108,14 +108,21 @@ export class Apis {
   /**
    * Get pod logs
    */
-  public static getPodLogs(runId: string, podName: string, podNamespace: string, createdAt: string): Promise<string> {
+  public static getPodLogs(
+    runId: string,
+    podName: string,
+    podNamespace: string,
+    createdAt: string,
+  ): Promise<string> {
     let query = `k8s/pod/logs?podname=${encodeURIComponent(podName)}&runid=${encodeURIComponent(
       runId,
     )}`;
     if (podNamespace) {
       query += `&podnamespace=${encodeURIComponent(podNamespace)}`;
     }
-    query += `&createdat=${encodeURIComponent(createdAt)}`;
+    if (createdAt) {
+      query += `&createdat=${encodeURIComponent(createdAt)}`;
+    }
     return this._fetch(query);
   }
 

--- a/frontend/src/pages/RunDetails.test.tsx
+++ b/frontend/src/pages/RunDetails.test.tsx
@@ -1165,6 +1165,7 @@ describe('RunDetails', () => {
         'test-run-id',
         'workflow1-template1-node1',
         'ns',
+        '',
       );
       expect(tree).toMatchSnapshot();
     });
@@ -1255,6 +1256,7 @@ describe('RunDetails', () => {
         'test-run-id',
         'workflow1-template1-node1',
         'username',
+        '',
       );
     });
 

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -1062,7 +1062,7 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
 
     try {
       const nodeName = getNodeNameFromNodeId(this.state.workflow!, selectedNodeDetails.id);
-      selectedNodeDetails.logs = await Apis.getPodLogs(runId, nodeName, namespace);
+      selectedNodeDetails.logs = await Apis.getPodLogs(runId, nodeName, namespace, '');
     } catch (err) {
       let errMsg = await errorToMessage(err);
       logsBannerMessage = 'Failed to retrieve pod logs.';


### PR DESCRIPTION
**Description of your changes:**
This PR solves https://github.com/kubeflow/pipelines/issues/10036 by making it possible to inject the AWF `keyFormat`, which determines where archived workflow container logs are saved, into the UI via `configs.ts` / env vars so that the UI retrieves them from the correct location.

Currently, for v2, the UI is looking in the wrong object store path (which is hard-coded) and coming up empty. We could update the hard-coded path, but loading it from `configs.ts` makes it more future proof and flexible in case end users want to modify the `keyFormat` for any reason.

This is an interim solution that's still a huge improvement over the current state of affairs (logs are inaccessible in v2 once the AWF CR has been GCed), but it has two important drawbacks that we want to delineate:

1. It doesn't show logs for the dag driver or the task driver(s). This can be helpful if there are issues in the driver rather than the component code. The only way to debug this currently is to interact directly with the pods via the K8s API. This PR doesn't introduce this limitation. It just doesn't solve for it.
2. If the AWF `keyFormat` is updated in both the `workflow-controller-configmap` and the UI (via `configs.ts` / env vars), the logs of new runs will be accessible, but the logs of old runs will no longer be accessible. In defense of this PR as an interim solution, the logs of NO runs are currently accessible.

In spite of these drawbacks, we still think it may be worthwhile to merge this PR as an interim fix since `keyFormat` is rarely modified and this will solve 99% of use cases for a really significant regression (with, at present, 21 👍 emojis). 

Looking forward to feedback. Thanks!

PS. We can add support for additional AWF template tags, as long as the actual parameters are available to the handler. We can also list supported tags via comments in the configmap.

PPS. I am not a frontend engineer.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
