### PR TITLE
docs: Fix environment variables names

### DIFF
--- a/kubernetes_platform/python/README.md
+++ b/kubernetes_platform/python/README.md
@@ -30,7 +30,7 @@ from kfp import kubernetes
 @dsl.component
 def print_secret():
     import os
-    print(os.environ['my-secret'])
+    print(os.environ['SECRET_VAR'])
 
 @dsl.pipeline
 def pipeline():
@@ -85,7 +85,7 @@ from kfp import kubernetes
 @dsl.component
 def print_config_map():
     import os
-    print(os.environ['my-cm'])
+    print(os.environ['CM_VAR'])
 
 @dsl.pipeline
 def pipeline():


### PR DESCRIPTION
**Description of your changes:**
Fix environment variable names 

The current code is using `os.environ['my-secret']` but we are setting the environment variable to be `SECRET_VAR`
```
    kubernetes.use_secret_as_env(task,
                                 secret_name='my-secret',
                                 secret_key_to_env={'password': 'SECRET_VAR'})
```
The code  `os.environ['my-secret']` will return an error
```
print(os.environ['my-secret'])
File "/usr/lib64/python3.9/os.py", line 679, in __getitem__
raise KeyError(key) from None
KeyError: 'my-secret'
```

The goal of this PR is to fix the doc issue.

**Checklist:**
- [ X ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
