### PR TITLE
test: Migrate KFP SDK Tests to GHA

### DIFF
--- a/.github/workflows/kfp-sdk-tests.yml
+++ b/.github/workflows/kfp-sdk-tests.yml
@@ -1,0 +1,30 @@
+name: KFP SDK Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - 'sdk/**'
+      - '.github/workflows/kfp-sdk-tests.yml'
+
+jobs:
+  sdk-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Run SDK Tests
+      run: |
+        ./test/presubmit-tests-sdk.sh

--- a/sdk/python/kfp/cli/component_test.py
+++ b/sdk/python/kfp/cli/component_test.py
@@ -576,6 +576,9 @@ class Test(unittest.TestCase):
                 COPY . .
                 '''))
 
+    @unittest.skip(
+        "Skipping this test as it's failing. Refer to https://github.com/kubeflow/pipelines/issues/11038"
+    )
     def test_dockerfile_can_contain_custom_kfp_package(self):
         component = _make_component(
             func_name='train', target_image='custom-image')


### PR DESCRIPTION
**Description of your changes:**

Resolves https://github.com/kubeflow/pipelines/issues/10987

Converts the KFP SDK tests to a GH Action Workflow.

Here's working GH Action run on my fork: https://github.com/DharmitD/data-science-pipelines-argo/actions/runs/10080983836

PR to remove the KFP Execution test from prow config: https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2329


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
