### PR TITLE
WIP: fix(Backend+SDK): Update kubernetes.use_secret_as_volume to accept secret name dynamically at runtime

### DIFF
--- a/kubernetes_platform/python/kfp/kubernetes/secret.py
+++ b/kubernetes_platform/python/kfp/kubernetes/secret.py
@@ -18,7 +18,8 @@ from google.protobuf import json_format
 from kfp.dsl import PipelineTask
 from kfp.kubernetes import common
 from kfp.kubernetes import kubernetes_executor_config_pb2 as pb
-
+from typing import Union
+from kfp.dsl.pipeline_channel import PipelineParameterChannel
 
 def use_secret_as_env(
     task: PipelineTask,
@@ -59,7 +60,7 @@ def use_secret_as_env(
 
 def use_secret_as_volume(
     task: PipelineTask,
-    secret_name: str,
+    secret_name: Union[str, PipelineParameterChannel],
     mount_path: str,
     optional: bool = False,
 ) -> PipelineTask:
@@ -75,7 +76,9 @@ def use_secret_as_volume(
     Returns:
         Task object with updated secret configuration.
     """
-
+    # Extract the actual string value if secret_name is a PipelineParameterChannel
+    if isinstance(secret_name, PipelineParameterChannel):
+        secret_name = secret_name.name
     msg = common.get_existing_kubernetes_config_as_message(task)
 
     secret_as_vol = pb.SecretAsVolume(

--- a/kubernetes_platform/python/kfp/kubernetes/secret.py
+++ b/kubernetes_platform/python/kfp/kubernetes/secret.py
@@ -76,13 +76,16 @@ def use_secret_as_volume(
     Returns:
         Task object with updated secret configuration.
     """
-    # Extract the actual string value if secret_name is a PipelineParameterChannel
-    if isinstance(secret_name, PipelineParameterChannel):
-        secret_name = secret_name.name
     msg = common.get_existing_kubernetes_config_as_message(task)
 
+    val = secret_name
+    # if secret_name is a PipelineParameterChannel, then we don't know what secret to mount until RUNTIME
+    # so, treat is as a map KEY instead of a secret name
+    if isinstance(secret_name, PipelineParameterChannel):
+        val = "{{" + secret_name.name + "}}"
+
     secret_as_vol = pb.SecretAsVolume(
-        secret_name=secret_name,
+        secret_name=val,
         mount_path=mount_path,
         optional=optional,
     )

--- a/kubernetes_platform/python/test/unit/test_secret.py
+++ b/kubernetes_platform/python/test/unit/test_secret.py
@@ -164,7 +164,7 @@ class TestUseSecretAsVolume:
                         'executors': {
                             'exec-comp': {
                                 'secretAsVolume': [{
-                                    'secretName': 'secret_name',
+                                    'secretName': '{{secret_name}}',
                                     'mountPath': 'secretpath',
                                     'optional': False
                                 }]

--- a/kubernetes_platform/python/test/unit/test_secret.py
+++ b/kubernetes_platform/python/test/unit/test_secret.py
@@ -147,6 +147,34 @@ class TestUseSecretAsVolume:
             }
         }
 
+    def test_with_secret_name_param(self):
+        @dsl.pipeline
+        def my_pipeline(secret_name: str = 'my-secret'):
+            task = comp()
+            kubernetes.use_secret_as_volume(
+                task,
+                secret_name=secret_name,
+                mount_path='secretpath',
+            )
+
+        assert json_format.MessageToDict(my_pipeline.platform_spec) == {
+            'platforms': {
+                'kubernetes': {
+                    'deploymentSpec': {
+                        'executors': {
+                            'exec-comp': {
+                                'secretAsVolume': [{
+                                    'secretName': 'secret_name',
+                                    'mountPath': 'secretpath',
+                                    'optional': False
+                                }]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
     def test_preserves_secret_as_env(self):
         # checks that use_secret_as_volume respects previously set secrets as env
 


### PR DESCRIPTION
**Description of your changes:**
Resolves https://github.com/kubeflow/pipelines/issues/10914 

Attempting to pass the `secret_name` parameter in the dsl compile this way:

```
from kfp import dsl
from kfp import kubernetes

@dsl.component(base_image="python:3.10")
def print_secret():
    with open('/mnt/my_vol') as f:
        print(f.read())

@dsl.pipeline
def pipeline(secret_name: str = 'my-secret'):
    task = print_secret()
    kubernetes.use_secret_as_volume(task,
                                    secret_name=secret_name,
                                    mount_path='/mnt/my_vol')
```

results in this error:
```
File "/home/ddalvi/PycharmProjects/pythonProject2/main.py", line 23, in pipeline
    kubernetes.use_secret_as_volume(task,
  File "/home/ddalvi/miniconda3/envs/kfp_pipe_secret_env/lib/python3.11/site-packages/kfp/kubernetes/secret.py", line 81, in use_secret_as_volume
    secret_as_vol = pb.SecretAsVolume(
                    ^^^^^^^^^^^^^^^^^^
TypeError: bad argument type for built-in operation
```

The secret_name parameter was originally expected to be a string (str). However, in this case, it was being provided as a an object of the `PipelineParameterChannel` class , leading to a type mismatch error when the code tried to use it as a string.
Updated `secret_name` to accept either a `str` or `PipelineParameterChannel` using `Union[str, PipelineParameterChannel]` and added a check to convert `PipelineParameterChannel` to its string representation.

Furthermore,
- Implemented support for dynamically specifying secret names in the `use_secret_as_volume` function.
- Updated driver code to handle secret name substitution at runtime based on input parameters.
- Introduced a `{{secret_name}}` template string representation for secret names in the compiled DSL.
- Added a test to validate secret name template creation in IR.

Refer to [this comment](https://github.com/kubeflow/pipelines/issues/10914#issuecomment-2285049104) to understand why the driver code change is required.

Please refer to a [PoC](https://github.com/opendatahub-io/data-science-pipelines/pull/71) wherein we've listed out different test cases - four different pairs of DSL compile code and resulting pipeline yaml IRs with which we tested this update.

Collaborated with @gregsheremeta for this contribution, it was a joint effort. Thanks Greg for your contributions! :)

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
