### PR TITLE
fix: Incorrect typing in samples/cores/loop_parallism and fixing loop_parameter examples

### DIFF
--- a/samples/core/loop_parallelism/loop_parallelism.py
+++ b/samples/core/loop_parallelism/loop_parallelism.py
@@ -15,7 +15,7 @@
 from kfp import compiler, dsl
 
 @dsl.component()
-def print_op(s: str):
+def print_op(s: int):
     print(s)
 
 @dsl.pipeline(name='my-pipeline')

--- a/samples/core/loop_parameter/loop_parameter.py
+++ b/samples/core/loop_parameter/loop_parameter.py
@@ -14,10 +14,8 @@ def concat_op(a: str, b: str) -> str:
 
 
 @dsl.component
-def generate_op() -> str:
-    import json
-    return json.dumps([{'a': i, 'b': i * 10} for i in range(1, 5)])
-
+def generate_op() -> list:
+    return [{'a': i, 'b': i * 10} for i in range(1, 5)]
 
 @dsl.pipeline(name='pipeline-with-loop-parameter')
 def my_pipeline(


### PR DESCRIPTION
**Description of your changes:**

The type hint on `loop_parallelism` is incorrect, leading to a failure in compiling with the latest version of `kfp` Version: 2.8.0. Without this MR you get the following error:

```bash
Traceback (most recent call last):
...
    raise InconsistentTypeException(error_text)
kfp.dsl.types.type_utils.InconsistentTypeException: Incompatible argument passed to the input 's' of component 'print-op': Argument type 'NUMBER_INTEGER' is incompatible with the input type 'STRING'
```

I also took the time to fix `loop_parameter.py` 

It was throwing this error without the changes applied in this MR

```python
    raise ValueError(
ValueError: Cannot iterate over a single parameter using `dsl.ParallelFor`. Expected a list of parameters as argument to `items`.
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
