### PR TITLE
chore: Wrapped "Failed GetContextByTypeAndName" error for better troubleshooting

### DIFF
--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
 	"path"
 	"strconv"
@@ -1073,7 +1074,7 @@ func (c *Client) getOrInsertContext(ctx context.Context, name string, contextTyp
 	getCtxRes, err := c.svc.GetContextByTypeAndName(ctx, &pb.GetContextByTypeAndNameRequest{TypeName: contextType.Name, ContextName: proto.String(name)})
 
 	if err != nil {
-		return nil, fmt.Errorf("Failed GetContextByTypeAndName(type=%q, name=%q)", contextType.GetName(), name)
+		return nil, util.Wrap(err, fmt.Sprintf("Failed GetContextByTypeAndName(type=%q, name=%q)", contextType.GetName(), name))
 	}
 	// Bug in MLMD GetContextsByTypeAndName? It doesn't return error even when no
 	// context was found.


### PR DESCRIPTION
This PR wraps the `Failed GetContextByTypeAndName` error for better troubleshooting.

### Log without the wrap:

```
F0814 12:59:37.779133      17 main.go:81] KFP driver: driver.RootDAG(pipelineName=iris-training-pipeline, runID=362fd86b-1b90-45d3-a2be-bb16b498055a, runtimeConfig, componentSpec) failed: Failed GetContextByTypeAndName(type="system.Pipeline", name="iris-training-pipeline")
```

### Log with the wrap:

```
F0814 13:20:09.099942      18 main.go:81] KFP driver: driver.RootDAG(pipelineName=iris-training-pipeline, runID=2beffed7-7680-4f2f-b531-1b7a6bf7c7b8, runtimeConfig, componentSpec) failed: Failed GetContextByTypeAndName(type="system.Pipeline", name="iris-training-pipeline"): rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: tls: failed to verify certificate: x509: cannot validate certificate for 172.30.11.89 because it doesn't contain any IP SANs"
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
