### PR TITLE
fix: re-enable exit hanler test.

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -153,9 +153,8 @@ jobs:
       - name: Basic sample tests - sequential
         run: pip3 install -r ./test/sample-test/requirements.txt && pip3 install kfp~=2.0 && python3 ./test/sample-test/sample_test_launcher.py sample_test run_test --namespace kubeflow --test-name sequential --results-gcs-dir output
 
-#      Disabled while https://github.com/kubeflow/pipelines/issues/10885 is not resolved
-#      - name: Basic sample tests - exit_handler
-#        run: pip3 install -r ./test/sample-test/requirements.txt && pip3 install kfp~=2.0 && python3 ./test/sample-test/sample_test_launcher.py sample_test run_test --namespace kubeflow --test-name exit_handler --results-gcs-dir output
+      - name: Basic sample tests - exit_handler
+        run: pip3 install -r ./test/sample-test/requirements.txt && pip3 install kfp~=2.0 && python3 ./test/sample-test/sample_test_launcher.py sample_test run_test --namespace kubeflow --test-name exit_handler --results-gcs-dir output
 
       - name: Collect test results
         if: always()


### PR DESCRIPTION
Fix for #10885
In this case, the fail_op task fails as intended, and the ExitHandler task is executed afterward to handle the exit. The log entry "Exit handler has worked!" confirms that the ExitHandler worked as expected after the failure.

It is the "fail" log from the fail-ops task that indicates that the task performed as expected:
![image](https://github.com/user-attachments/assets/202f2684-4cf6-4072-a8eb-24877416d552), 
As a result of this failure, we were able to obtain the following result:
![image](https://github.com/user-attachments/assets/b57eab80-5c0f-48b0-8c40-fe1678a1bbed)
 "message": "Exit handler has worked!"

