### PR TITLE
test: Fail fast when image build fails on tests #11102

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # 1. Build api server application
-FROM golang:1.21.7-bookworm as builder
+FRAM golang:1.21.7-bookworm as builder
 RUN apt-get update && apt-get install -y cmake clang musl-dev openssl
 WORKDIR /go/src/github.com/kubeflow/pipelines
 COPY . .


### PR DESCRIPTION
added check in build-images.sh to check if the build has failed then kill the process with error.
fix https://github.com/kubeflow/pipelines/issues/11102