### PR TITLE
WIP: fix(Backend+SDK): Update kubernetes.use_secret_as_env to accept secret name dynamically at runtime

### DIFF
--- a/kubernetes_platform/python/test/unit/test_secret.py
+++ b/kubernetes_platform/python/test/unit/test_secret.py
@@ -319,6 +319,36 @@ class TestUseSecretAsEnv:
             }
         }
 
+    def test_with_secret_name_param_env(self):
+        @dsl.pipeline
+        def my_pipeline(secret_name: str = 'my-secret'):
+            task = comp()
+            kubernetes.use_secret_as_env(
+                task,
+                secret_name=secret_name,
+                secret_key_to_env={'password': 'PASSWORD'}
+            )
+
+        assert json_format.MessageToDict(my_pipeline.platform_spec) == {
+            'platforms': {
+                'kubernetes': {
+                    'deploymentSpec': {
+                        'executors': {
+                            'exec-comp': {
+                                'secretAsEnv': [{
+                                    'secretName': '{{secret_name}}',
+                                    'keyToEnv': [{
+                                        'secretKey': 'password',
+                                        'envVar': 'PASSWORD'
+                                    }]
+                                }]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
     def test_preserves_secret_as_volume(self):
         # checks that use_secret_as_env respects previously set secrets as vol
 


### PR DESCRIPTION
**Description of your changes:**
Resolves https://github.com/kubeflow/pipelines/issues/10914 
Similar to https://github.com/kubeflow/pipelines/pull/11039 

- Updated SDK DSL compile code to have the secret_name accepted as a `PipelineParameterChannel` type this way:
```
@dsl.component(base_image=<base_image>)
def print_secret():
    import os
    # print(os.environ['SECRET_VAR'])

@dsl.pipeline
def pipeline(secret_name: str):
    task = print_secret()
    kubernetes.use_secret_as_env(task,
                                 secret_name=secret_name,
                                 secret_key_to_env={'password': 'SECRET_VAR'})
```
- Implemented support for dynamically specifying secret names in the `use_secret_as_env` function.
- Updated driver code to handle secret name substitution at runtime based on input parameters.
- Introduced a `{{secret_name}}` template string representation for secret names in the compiled DSL.
- Added a test to validate secret name template creation in IR.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
