### PR TITLE
fix(frontend): first time choosing a pipeline definition is VERY slow. Fixes #10897

### DIFF
--- a/frontend/src/pages/NewRunSwitcher.tsx
+++ b/frontend/src/pages/NewRunSwitcher.tsx
@@ -162,7 +162,7 @@ function NewRunSwitcher(props: PageProps) {
     recurringRunIsFetching ||
     pipelineIsFetching ||
     pipelineVersionIsFetching ||
-    v1TemplateStrIsFetching ||
+    (!isTemplateV2(templateString) && v1TemplateStrIsFetching) ||
     experimentIsFetching
   ) {
     return <div>Currently loading pipeline information</div>;


### PR DESCRIPTION
Fixes #10897.
i found that whenever a V2 pipeline is chosen for a new run, then there is a check whether v1Template is fetching and because it is not a v1 pipeline then the message is seen for long time.

so basically what i did is check whether the v1 template is fetching only when the pipeline is v1 and not v2, which cause in significant reduce in the loading time.