### PR TITLE
Add an environment variable and CLI option to enable/disable default caching

### DIFF
--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -18,6 +18,7 @@ import enum
 import functools
 import inspect
 import itertools
+import os
 import re
 from typing import Any, Dict, List, Mapping, Optional, Union
 import warnings
@@ -130,7 +131,8 @@ class PipelineTask:
             inputs=dict(args.items()),
             dependent_tasks=[],
             component_ref=component_spec.name,
-            enable_caching=True)
+            enable_caching=os.getenv('KFP_EXECUTION_CACHING_ENABLED_BY_DEFAULT',
+                                     'enabled').lower() == 'enabled')
         self._run_after: List[str] = []
 
         self.importer_spec = None

--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -17,6 +17,7 @@ import ast
 import collections
 import dataclasses
 import itertools
+import os
 import re
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 import uuid
@@ -420,7 +421,8 @@ class TaskSpec:
     trigger_strategy: Optional[str] = None
     iterator_items: Optional[Any] = None
     iterator_item_input: Optional[str] = None
-    enable_caching: bool = True
+    enable_caching: bool = os.getenv('KFP_EXECUTION_CACHING_ENABLED_BY_DEFAULT',
+                                     'enabled').lower() == 'enabled'
     display_name: Optional[str] = None
     retry_policy: Optional[RetryPolicy] = None
 


### PR DESCRIPTION
Resolves https://github.com/kubeflow/pipelines/issues/11092 
**Description of your changes:**
An environment variable and a CLI option have been added to control whether task-level caching is enabled by default. The CLI flag `--execution-caching-enabled-by-default` takes precedence over the environment variable `KFP_EXECUTION_CACHING_ENABLED_BY_DEFAULT`. Here's how it works:

1.  **CLI Flag Precedence:** If the `--execution-caching-enabled-by-default` flag is provided, it directly controls whether caching is enabled or disabled, setting the environment variable to `enabled` or `disabled` accordingly.

2.  **Environment Variable Fallback:** If the CLI flag is not provided, the environment variable `KFP_EXECUTION_CACHING_ENABLED_BY_DEFAULT` determines the caching behavior. If this variable is set to `enabled`, caching is enabled; if set to `disabled`, caching is disabled.

3.  **Default Behavior:** If neither the CLI flag nor the environment variable is set, caching defaults to enabled.

### Example Cases

#### **Case 1: Default Behavior (No CLI Flag, No Environment Variable Set)**

-   **Command:**

    ```
    kfp dsl compile --py cache.py --output output-default.yaml
    ```

-   **Environment Variable:** Not set.
-   **CLI Flag:** Not provided.
-   **Outcome:** Caching is **enabled** by default (because the environment variable defaults to `enabled`).

#### **Case 2: Environment Variable Set to `enabled`, No CLI Flag**

-   **Command:**

    ```
    export KFP_EXECUTION_CACHING_ENABLED_BY_DEFAULT=enabled
    kfp dsl compile --py cache.py --output output-env-enabled.yaml
    ```

-   **Environment Variable:** Set to `enabled`.
-   **CLI Flag:** Not provided.
-   **Outcome:** Caching is **enabled**.

#### **Case 3: Environment Variable Set to `disabled`, No CLI Flag**

-   **Command:**

    ```
    export KFP_EXECUTION_CACHING_ENABLED_BY_DEFAULT=disabled
    kfp dsl compile --py cache.py --output output-env-disabled.yaml
    ```

-   **Environment Variable:** Set to `disabled`.
-   **CLI Flag:** Not provided.
-   **Outcome:** Caching is **disabled**.

#### **Case 4: CLI Flag Set to `enabled`, Environment Variable Set to `enabled`**

-   **Command:**

    ```
    export KFP_EXECUTION_CACHING_ENABLED_BY_DEFAULT=enabled
    kfp dsl compile --py cache.py --output output-flag-env-enabled.yaml --execution-caching-enabled-by-default=enabled
    ```

-   **Environment Variable:** Set to `enabled`.
-   **CLI Flag:** Set to `enabled`.
-   **Outcome:** Caching is **enabled** because the CLI flag confirms it, and it takes precedence.

#### **Case 5: CLI Flag Set to `disabled`, Environment Variable Set to `enabled`**

-   **Command:**

    ```
    export KFP_EXECUTION_CACHING_ENABLED_BY_DEFAULT=enabled
    kfp dsl compile --py cache.py --output output-flag-disabled-env-enabled.yaml --execution-caching-enabled-by-default=disabled
    ```

-   **Environment Variable:** Set to `enabled`.
-   **CLI Flag:** Set to `disabled`.
-   **Outcome:** Caching is **disabled** because the CLI flag takes precedence over the environment variable.

#### **Case 6: CLI Flag Set to `enabled`, Environment Variable Set to `disabled`**

-   **Command:**

    ```
    export KFP_EXECUTION_CACHING_ENABLED_BY_DEFAULT=disabled
    kfp dsl compile --py cache.py --output output-flag-enabled-env-disabled.yaml --execution-caching-enabled-by-default=enabled
    ```

-   **Environment Variable:** Set to `disabled`.
-   **CLI Flag:** Set to `enabled`.
-   **Outcome:** Caching is **enabled** because the CLI flag takes precedence over the environment variable.

#### **Case 7: CLI Flag Set to `disabled`, Environment Variable Set to `disabled`**

-   **Command:**

    ```
    export KFP_EXECUTION_CACHING_ENABLED_BY_DEFAULT=disabled
    kfp dsl compile --py cache.py --output output-flag-env-disabled.yaml --execution-caching-enabled-by-default=disabled
    ```

-   **Environment Variable:** Set to `disabled`.
-   **CLI Flag:** Set to `disabled`.
-   **Outcome:** Caching is **disabled** because both the environment variable and CLI flag indicate that caching should be disabled.

### Summary of Precedence and Outcomes

-   **Default Behavior:** Caching is enabled by default if no environment variable or CLI flag is set.
-   **Environment Variable Controls:** If the CLI flag is absent, the environment variable dictates whether caching is enabled or disabled.
-   **CLI Flag Overrides Environment Variable:** The CLI flag takes precedence over the environment variable and sets the final behavior (and the environment variable) accordingly.

This logic provides flexibility while ensuring that the user’s explicit command-line instructions (the CLI flag) take precedence over environment settings.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
