### PR TITLE
refactor: fix invalid escape sequences

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,12 @@ repos:
       - id: double-quote-string-fixer
       - id: no-commit-to-branch
         args: [--branch, master]
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.1
+    hooks:
+    -   id: flake8
+        args:
+        - --select=W605
   # required formatting jobs (run these last)
 
   # add comment "noqa" to ignore an import that should not be removed

--- a/backend/src/apiserver/visualization/types/tfdv.py
+++ b/backend/src/apiserver/visualization/types/tfdv.py
@@ -72,7 +72,7 @@ def get_statistics_html(
   # facets element and then remove it once we have appended the serialized proto
   # string to the element. We do this to avoid any collision of ids when
   # displaying multiple facets output in the notebook.
-  html_template = """<iframe id='facets-iframe' width="100%" height="500px"></iframe>
+  html_template = r"""<iframe id='facets-iframe' width="100%" height="500px"></iframe>
         <script>
         facets_iframe = document.getElementById('facets-iframe');
         facets_html = '<script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js"><\/script><link rel="import" href="https://raw.githubusercontent.com/PAIR-code/facets/master/facets-dist/facets-jupyter.html"><facets-overview proto-input="protostr"></facets-overview>';

--- a/components/aws/athena/query/src/query.py
+++ b/components/aws/athena/query/src/query.py
@@ -63,7 +63,7 @@ def query(client, query, database, output, workgroup=None):
                     "OutputLocation"
                 ]
                 # could be multiple files?
-                filename = re.findall(".*\/(.*)", s3_path)[0]
+                filename = re.findall(r".*\/(.*)", s3_path)[0]
                 logging.info("S3 output file name %s", filename)
                 break
         time.sleep(5)

--- a/components/google-cloud/google_cloud_pipeline_components/container/v1/aiplatform/remote_runner.py
+++ b/components/google-cloud/google_cloud_pipeline_components/container/v1/aiplatform/remote_runner.py
@@ -88,7 +88,7 @@ def write_to_artifact(executor_input, text):
       # Add URI Prefix
       # "https://[location]-aiplatform.googleapis.com/API_VERSION/": For AI Platform resource names, current version is defined in AIPLATFORM_API_VERSION.
       if RESOURCE_NAME_PATTERN.match(text):
-        location = re.findall('locations/([\w\-]+)', text)[0]
+        location = re.findall(r'locations/([\w\-]+)', text)[0]
         uri_with_prefix = f'https://{location}-aiplatform.googleapis.com/{AIPLATFORM_API_VERSION}/{text}'
         metadata.update({'resourceName': text})
 

--- a/components/google-cloud/google_cloud_pipeline_components/v1/hyperparameter_tuning_job/component.py
+++ b/components/google-cloud/google_cloud_pipeline_components/v1/hyperparameter_tuning_job/component.py
@@ -42,7 +42,7 @@ def hyperparameter_tuning_job(
     project: str = _placeholders.PROJECT_ID_PLACEHOLDER,
 ):
   # fmt: off
-  """Creates a Vertex AI hyperparameter tuning job and waits for it to
+  r"""Creates a Vertex AI hyperparameter tuning job and waits for it to
   complete.
 
   See [more information](https://cloud.google.com/vertex-ai/docs/training/using-hyperparameter-tuning).

--- a/proxy/get_proxy_url.py
+++ b/proxy/get_proxy_url.py
@@ -40,7 +40,7 @@ def urls_for_zone(zone, location_to_urls_map):
         ...
       }
   """
-    zone_match = re.match("((([a-z]+)-[a-z]+)\d+)-[a-z]", zone)
+    zone_match = re.match(r"((([a-z]+)-[a-z]+)\d+)-[a-z]", zone)
     if not zone_match:
         raise ValueError("Incorrect zone specified: {}".format(zone))
 
@@ -55,7 +55,7 @@ def urls_for_zone(zone, location_to_urls_map):
             url for url in location_to_urls_map[region] if url not in urls
         ])
 
-    region_regex = re.compile("([a-z]+-[a-z]+)\d+")
+    region_regex = re.compile(r"([a-z]+-[a-z]+)\d+")
     for location in location_to_urls_map:
         region_match = region_regex.match(location)
         if region_match and region_match.group(1) == approx_region:

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -4445,7 +4445,7 @@ class TestConditionLogic(unittest.TestCase):
             self):
         with self.assertRaisesRegex(
                 tasks_group.InvalidControlFlowException,
-                'dsl\.Else can only be used following an upstream dsl\.If or dsl\.Elif\.'
+                r'dsl\.Else can only be used following an upstream dsl\.If or dsl\.Elif\.'
         ):
 
             @dsl.pipeline
@@ -4908,7 +4908,7 @@ class TestDslOneOf(unittest.TestCase):
     def test_nested_under_condition_returned_raises(self):
         with self.assertRaisesRegex(
                 compiler_utils.InvalidTopologyException,
-                f'Pipeline outputs may only be returned from the top level of the pipeline function scope\. Got pipeline output dsl\.OneOf from within the control flow group dsl\.If\.'
+                r'Pipeline outputs may only be returned from the top level of the pipeline function scope\. Got pipeline output dsl\.OneOf from within the control flow group dsl\.If\.'
         ):
 
             @dsl.pipeline
@@ -4961,7 +4961,7 @@ class TestDslOneOf(unittest.TestCase):
 
         with self.assertRaisesRegex(
                 compiler_utils.InvalidTopologyException,
-                f'Pipeline outputs may only be returned from the top level of the pipeline function scope\. Got pipeline output dsl\.OneOf from within the control flow group dsl\.ParallelFor\.'
+                r'Pipeline outputs may only be returned from the top level of the pipeline function scope\. Got pipeline output dsl\.OneOf from within the control flow group dsl\.ParallelFor\.'
         ):
 
             @dsl.pipeline
@@ -4983,7 +4983,7 @@ class TestDslOneOf(unittest.TestCase):
 
         with self.assertRaisesRegex(
                 compiler_utils.InvalidTopologyException,
-                f'Illegal task dependency across DSL context managers\. A downstream task cannot depend on an upstream task within a dsl\.If context unless the downstream is within that context too\. Found task print-artifact which depends on upstream task condition-branches-5 within an uncommon dsl\.If context\.'
+                r'Illegal task dependency across DSL context managers\. A downstream task cannot depend on an upstream task within a dsl\.If context unless the downstream is within that context too\. Found task print-artifact which depends on upstream task condition-branches-5 within an uncommon dsl\.If context\.'
         ):
 
             @dsl.pipeline
@@ -5006,7 +5006,7 @@ class TestDslOneOf(unittest.TestCase):
     def test_return_at_wrong_level(self):
         with self.assertRaisesRegex(
                 compiler_utils.InvalidTopologyException,
-                f'Pipeline outputs may only be returned from the top level of the pipeline function scope\. Got pipeline output dsl\.OneOf from within the control flow group dsl\.If\.'
+                r'Pipeline outputs may only be returned from the top level of the pipeline function scope\. Got pipeline output dsl\.OneOf from within the control flow group dsl\.If\.'
         ):
 
             @dsl.pipeline
@@ -5143,7 +5143,7 @@ class TestDslOneOf(unittest.TestCase):
     def test_oneof_in_fstring(self):
         with self.assertRaisesRegex(
                 NotImplementedError,
-                f'dsl\.OneOf does not support string interpolation\.'):
+                r'dsl\.OneOf does not support string interpolation\.'):
 
             @dsl.pipeline
             def roll_die_pipeline():

--- a/sdk/python/kfp/deprecated/compiler/v2_compatible_compiler_test.py
+++ b/sdk/python/kfp/deprecated/compiler/v2_compatible_compiler_test.py
@@ -88,7 +88,7 @@ class TestV2CompatibleModeCompiler(unittest.TestCase):
 
                 if 'container' in template:
                     template['container'] = json.loads(
-                        re.sub("'kfp==(\d+).(\d+).(\d+)'", 'kfp',
+                        re.sub(r"'kfp==(\d+).(\d+).(\d+)'", 'kfp',
                                json.dumps(template['container'])))
 
             return workflow
@@ -154,8 +154,8 @@ class TestV2CompatibleModeCompiler(unittest.TestCase):
         with self.assertRaisesRegex(
                 RuntimeError,
                 'Constructing ContainerOp instances directly is deprecated and not '
-                'supported when compiling to v2 \(using v2 compiler or v1 compiler '
-                'with V2_COMPATIBLE or V2_ENGINE mode\).'):
+                r'supported when compiling to v2 \(using v2 compiler or v1 compiler '
+                r'with V2_COMPATIBLE or V2_ENGINE mode\)\.'):
             compiler.Compiler(
                 mode=v1dsl.PipelineExecutionMode.V2_COMPATIBLE).compile(
                     pipeline_func=my_pipeline, package_path='result.json')

--- a/sdk/python/kfp/deprecated/components/type_annotation_utils.py
+++ b/sdk/python/kfp/deprecated/components/type_annotation_utils.py
@@ -58,7 +58,7 @@ def get_short_type_name(type_name: str) -> str:
     Returns:
       The short form type name or the original name if pattern doesn't match.
     """
-    match = re.match('(typing\.)?(?P<type>\w+)(?:\[.+\])?', type_name)
+    match = re.match(r'(typing\.)?(?P<type>\w+)(?:\[.+\])?', type_name)
     if match:
         return match.group('type')
     else:

--- a/sdk/python/kfp/deprecated/components_tests/test_python_op.py
+++ b/sdk/python/kfp/deprecated/components_tests/test_python_op.py
@@ -1224,7 +1224,7 @@ class PythonOpTestCase(unittest.TestCase):
         task_factory = comp.create_component_from_func(my_func)
         with self.assertRaisesRegex(
                 TypeError,
-                'There are no registered serializers for type "(typing.)?Sequence(\[int\])?"'
+                r'There are no registered serializers for type "(typing.)?Sequence(\[int\])?"'
         ):
             self.helper_test_component_using_local_call(
                 task_factory, arguments={'args': [1, 2, 3]})

--- a/sdk/python/kfp/deprecated/dsl/_ops_group.py
+++ b/sdk/python/kfp/deprecated/dsl/_ops_group.py
@@ -68,7 +68,7 @@ class OpsGroup(object):
         if name is None:
             return None
         name_pattern = '^' + (group_type + '-' + name + '-').replace(
-            '_', '-') + '[\d]+$'
+            '_', '-') + r'[\d]+$'
         for ops_group_already_in_pipeline in _pipeline.Pipeline.get_default_pipeline(
         ).groups:
             import re

--- a/sdk/python/kfp/dsl/executor.py
+++ b/sdk/python/kfp/dsl/executor.py
@@ -400,7 +400,7 @@ def get_short_type_name(type_name: str) -> str:
     Returns:
       The short form type name or the original name if pattern doesn't match.
     """
-    match = re.match('(typing\.)?(?P<type>\w+)(?:\[.+\])?', type_name)
+    match = re.match(r'(typing\.)?(?P<type>\w+)(?:\[.+\])?', type_name)
     return match['type'] if match else type_name
 
 

--- a/sdk/python/kfp/dsl/for_loop.py
+++ b/sdk/python/kfp/dsl/for_loop.py
@@ -44,7 +44,7 @@ def _get_loop_item_type(type_name: str) -> Optional[str]:
     Returns:
         The collection item type or None if no match found.
     """
-    match = re.match('(typing\.)?(?:\w+)(?:\[(?P<item_type>.+)\])', type_name)
+    match = re.match(r'(typing\.)?(?:\w+)(?:\[(?P<item_type>.+)\])', type_name)
     return match['item_type'].lstrip().rstrip() if match else None
 
 
@@ -64,7 +64,7 @@ def _get_subvar_type(type_name: str) -> Optional[str]:
         The dictionary value type or None if no match found.
     """
     match = re.match(
-        '(typing\.)?(?:\w+)(?:\[\s*(?:\w+)\s*,\s*(?P<value_type>.+)\])',
+        r'(typing\.)?(?:\w+)(?:\[\s*(?:\w+)\s*,\s*(?P<value_type>.+)\])',
         type_name)
     return match['value_type'].lstrip().rstrip() if match else None
 

--- a/sdk/python/kfp/dsl/placeholders_test.py
+++ b/sdk/python/kfp/dsl/placeholders_test.py
@@ -299,7 +299,7 @@ class TestContainerPlaceholdersTogether(parameterized.TestCase):
     def test_only_single_element_ifpresent_inside_concat_outer(self):
         with self.assertRaisesRegex(
                 ValueError,
-                f'Please use a single element for `then` and `else_` only\.'):
+                r'Please use a single element for `then` and `else_` only\.'):
             placeholders.ConcatPlaceholder([
                 'b',
                 placeholders.IfPresentPlaceholder(
@@ -309,7 +309,7 @@ class TestContainerPlaceholdersTogether(parameterized.TestCase):
     def test_only_single_element_ifpresent_inside_concat_recursive(self):
         with self.assertRaisesRegex(
                 ValueError,
-                f'Please use a single element for `then` and `else_` only\.'):
+                r'Please use a single element for `then` and `else_` only\.'):
             placeholders.ConcatPlaceholder([
                 'a',
                 placeholders.ConcatPlaceholder([
@@ -323,7 +323,7 @@ class TestContainerPlaceholdersTogether(parameterized.TestCase):
 
         with self.assertRaisesRegex(
                 ValueError,
-                f'Please use a single element for `then` and `else_` only\.'):
+                r'Please use a single element for `then` and `else_` only\.'):
             placeholders.ConcatPlaceholder([
                 'a',
                 placeholders.ConcatPlaceholder([
@@ -341,7 +341,7 @@ class TestContainerPlaceholdersTogether(parameterized.TestCase):
     def test_only_single_element_in_nested_ifpresent_inside_concat(self):
         with self.assertRaisesRegex(
                 ValueError,
-                f'Please use a single element for `then` and `else_` only\.'):
+                r'Please use a single element for `then` and `else_` only\.'):
             dsl.ConcatPlaceholder([
                 'my-prefix-',
                 dsl.IfPresentPlaceholder(
@@ -357,7 +357,7 @@ class TestContainerPlaceholdersTogether(parameterized.TestCase):
             self):
         with self.assertRaisesRegex(
                 ValueError,
-                f'Please use a single element for `then` and `else_` only\.'):
+                r'Please use a single element for `then` and `else_` only\.'):
             dsl.ConcatPlaceholder([
                 'my-prefix-',
                 dsl.IfPresentPlaceholder(
@@ -371,7 +371,7 @@ class TestContainerPlaceholdersTogether(parameterized.TestCase):
             self):
         with self.assertRaisesRegex(
                 ValueError,
-                f'Please use a single element for `then` and `else_` only\.'):
+                r'Please use a single element for `then` and `else_` only\.'):
             dsl.IfPresentPlaceholder(
                 input_name='input_1',
                 then=dsl.ConcatPlaceholder([
@@ -386,7 +386,7 @@ class TestContainerPlaceholdersTogether(parameterized.TestCase):
     def test_valid_then_but_invalid_else(self):
         with self.assertRaisesRegex(
                 ValueError,
-                f'Please use a single element for `then` and `else_` only\.'):
+                r'Please use a single element for `then` and `else_` only\.'):
             dsl.ConcatPlaceholder([
                 'my-prefix-',
                 dsl.IfPresentPlaceholder(

--- a/sdk/python/kfp/dsl/tasks_group_test.py
+++ b/sdk/python/kfp/dsl/tasks_group_test.py
@@ -74,7 +74,7 @@ class TestConditionDeprecated(unittest.TestCase):
         def my_pipeline(string: str):
             with self.assertWarnsRegex(
                     DeprecationWarning,
-                    'dsl\.Condition is deprecated\. Please use dsl\.If instead\.'
+                    r'dsl\.Condition is deprecated\. Please use dsl\.If instead\.'
             ):
                 with dsl.Condition(string == 'text'):
                     foo()

--- a/sdk/python/kfp/dsl/types/type_annotations.py
+++ b/sdk/python/kfp/dsl/types/type_annotations.py
@@ -227,7 +227,7 @@ def get_short_type_name(type_name: str) -> str:
     Returns:
       The short form type name or the original name if pattern doesn't match.
     """
-    match = re.match('(typing\.)?(?P<type>\w+)(?:\[.+\])?', type_name)
+    match = re.match(r'(typing\.)?(?P<type>\w+)(?:\[.+\])?', type_name)
     return match['type'] if match else type_name
 
 

--- a/sdk/python/kfp/local/config_test.py
+++ b/sdk/python/kfp/local/config_test.py
@@ -70,7 +70,7 @@ class LocalRunnerConfigTest(unittest.TestCase):
     def test_validate_fail(self):
         with self.assertRaisesRegex(
                 RuntimeError,
-                f"Local environment not initialized. Please run 'kfp\.local\.init\(\)' before executing tasks locally\."
+                r"Local environment not initialized. Please run 'kfp\.local\.init\(\)' before executing tasks locally\."
         ):
             config.LocalExecutionConfig.validate()
 

--- a/test/sample-test/sample_test_launcher.py
+++ b/test/sample-test/sample_test_launcher.py
@@ -92,7 +92,7 @@ class SampleTest(object):
         for file in list_of_files:
             # matching by .py or .ipynb, there will be yaml ( compiled ) files in the folder.
             # if you rerun the test suite twice, the test suite will fail
-            m = re.match(self._test_name + '\.(py|ipynb)$', file)
+            m = re.match(self._test_name + r'\.(py|ipynb)$', file)
             if m:
                 file_name, ext_name = os.path.splitext(file)
                 if self._is_notebook is not None:
@@ -242,14 +242,14 @@ class ComponentTest(SampleTest):
     def _injection(self):
         """Sample-specific image injection into yaml file."""
         subs = {  # Tag can look like 1.0.0-rc.3, so we need both "-" and "." in the regex.
-            'gcr\.io/ml-pipeline/ml-pipeline/ml-pipeline-local-confusion-matrix:(\w+|[.-])+':
+            r'gcr\.io/ml-pipeline/ml-pipeline/ml-pipeline-local-confusion-matrix:(\w+|[.-])+':
                 self._local_confusionmatrix_image,
-            'gcr\.io/ml-pipeline/ml-pipeline/ml-pipeline-local-roc:(\w+|[.-])+':
+            r'gcr\.io/ml-pipeline/ml-pipeline/ml-pipeline-local-roc:(\w+|[.-])+':
                 self._local_roc_image
         }
         if self._test_name == 'xgboost_training_cm':
             subs.update({
-                'gcr\.io/ml-pipeline/ml-pipeline-gcp:(\w|[.-])+':
+                r'gcr\.io/ml-pipeline/ml-pipeline-gcp:(\w|[.-])+':
                     self._dataproc_gcp_image
             })
 

--- a/test/sample-test/unittests/utils_tests.py
+++ b/test/sample-test/unittests/utils_tests.py
@@ -48,10 +48,10 @@ class TestUtils(unittest.TestCase):
   def test_file_injection(self):
     """Test file_injection function."""
     subs = {
-        'gcr\.io/ml-pipeline/ml-pipeline-local-confusion-matrix:\w+':'gcr.io/ml-pipeline/LOCAL_CONFUSION_MATRIX_IMAGE',
-        'gcr\.io/ml-pipeline/ml-pipeline-dataproc-analyze:\w+':'gcr.io/ml-pipeline/DATAPROC_ANALYZE_IMAGE',
-        'gcr\.io/ml-pipeline/ml-pipeline-dataproc-create-cluster:\w+':'gcr.io/ml-pipeline/DATAPROC_CREATE_IMAGE',
-        'gcr\.io/ml-pipeline/ml-pipeline-dataproc-delete-cluster:\w+':'gcr.io/ml-pipeline/DATAPROC_DELETE_IMAGE',
+        r'gcr\.io/ml-pipeline/ml-pipeline-local-confusion-matrix:\w+':'gcr.io/ml-pipeline/LOCAL_CONFUSION_MATRIX_IMAGE',
+        r'gcr\.io/ml-pipeline/ml-pipeline-dataproc-analyze:\w+':'gcr.io/ml-pipeline/DATAPROC_ANALYZE_IMAGE',
+        r'gcr\.io/ml-pipeline/ml-pipeline-dataproc-create-cluster:\w+':'gcr.io/ml-pipeline/DATAPROC_CREATE_IMAGE',
+        r'gcr\.io/ml-pipeline/ml-pipeline-dataproc-delete-cluster:\w+':'gcr.io/ml-pipeline/DATAPROC_DELETE_IMAGE',
     }
     utils.file_injection(
         os.path.join(_WORK_DIR, 'test_file_injection.yaml'),


### PR DESCRIPTION
**Description of your changes:**
This PR fixes SyntaxError issues in Python3.12 and deprecations in previous versions.

In python3.12, using escape sequences outside of raw strings has been [moved from a deprecation warning into a syntax error](https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes). As such, I've added a linter to track down cases where we still have this issue and fixed all said reported issues.

<details>
<summary>The original list was as follows:</summary>

```
backend/src/apiserver/visualization/types/tfdv.py:78:122: W605 invalid escape sequence '\/'
components/aws/athena/query/src/query.py:66:42: W605 invalid escape sequence '\/'
components/google-cloud/google_cloud_pipeline_components/container/v1/aiplatform/remote_runner.py:91:44: W605 invalid escape sequence '\w'
components/google-cloud/google_cloud_pipeline_components/container/v1/aiplatform/remote_runner.py:91:46: W605 invalid escape sequence '\-'
components/google-cloud/google_cloud_pipeline_components/v1/hyperparameter_tuning_job/component.py:53:431: W605 invalid escape sequence '\/'
components/google-cloud/google_cloud_pipeline_components/v1/hyperparameter_tuning_job/component.py:53:433: W605 invalid escape sequence '\/'
components/google-cloud/google_cloud_pipeline_components/v1/hyperparameter_tuning_job/component.py:53:440: W605 invalid escape sequence '\/'
components/google-cloud/google_cloud_pipeline_components/v1/hyperparameter_tuning_job/component.py:53:468: W605 invalid escape sequence '\/'
components/google-cloud/google_cloud_pipeline_components/v1/hyperparameter_tuning_job/component.py:53:470: W605 invalid escape sequence '\/'
components/google-cloud/google_cloud_pipeline_components/v1/hyperparameter_tuning_job/component.py:53:483: W605 invalid escape sequence '\/'
components/google-cloud/google_cloud_pipeline_components/v1/hyperparameter_tuning_job/component.py:53:516: W605 invalid escape sequence '\/'
components/google-cloud/google_cloud_pipeline_components/v1/hyperparameter_tuning_job/component.py:53:518: W605 invalid escape sequence '\/'
components/google-cloud/google_cloud_pipeline_components/v1/hyperparameter_tuning_job/component.py:53:524: W605 invalid escape sequence '\/'
proxy/get_proxy_url.py:43:46: W605 invalid escape sequence '\d'
proxy/get_proxy_url.py:58:47: W605 invalid escape sequence '\d'
sdk/python/kfp/compiler/compiler_test.py:4448:21: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:4448:70: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:4448:81: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:4448:87: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:4911:106: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:4911:132: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:4911:178: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:4911:182: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:4964:106: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:4964:132: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:4964:178: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:4964:191: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:4986:70: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:4986:137: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:4986:198: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:4986:301: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:4986:313: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:5009:106: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:5009:132: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:5009:178: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:5009:182: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:5146:22: W605 invalid escape sequence '\.'
sdk/python/kfp/compiler/compiler_test.py:5146:67: W605 invalid escape sequence '\.'
sdk/python/kfp/deprecated/compiler/v2_compatible_compiler_test.py:91:40: W605 invalid escape sequence '\d'
sdk/python/kfp/deprecated/compiler/v2_compatible_compiler_test.py:91:46: W605 invalid escape sequence '\d'
sdk/python/kfp/deprecated/compiler/v2_compatible_compiler_test.py:91:52: W605 invalid escape sequence '\d'
sdk/python/kfp/deprecated/compiler/v2_compatible_compiler_test.py:157:49: W605 invalid escape sequence '\('
sdk/python/kfp/deprecated/compiler/v2_compatible_compiler_test.py:158:54: W605 invalid escape sequence '\)'
sdk/python/kfp/deprecated/components/type_annotation_utils.py:61:30: W605 invalid escape sequence '\.'
sdk/python/kfp/deprecated/components/type_annotation_utils.py:61:43: W605 invalid escape sequence '\w'
sdk/python/kfp/deprecated/components/type_annotation_utils.py:61:50: W605 invalid escape sequence '\['
sdk/python/kfp/deprecated/components/type_annotation_utils.py:61:54: W605 invalid escape sequence '\]'
sdk/python/kfp/deprecated/components_tests/test_python_op.py:1227:83: W605 invalid escape sequence '\['
sdk/python/kfp/deprecated/components_tests/test_python_op.py:1227:88: W605 invalid escape sequence '\]'
sdk/python/kfp/deprecated/dsl/_ops_group.py:71:27: W605 invalid escape sequence '\d'
sdk/python/kfp/dsl/executor.py:403:30: W605 invalid escape sequence '\.'
sdk/python/kfp/dsl/executor.py:403:43: W605 invalid escape sequence '\w'
sdk/python/kfp/dsl/executor.py:403:50: W605 invalid escape sequence '\['
sdk/python/kfp/dsl/executor.py:403:54: W605 invalid escape sequence '\]'
sdk/python/kfp/dsl/for_loop.py:47:30: W605 invalid escape sequence '\.'
sdk/python/kfp/dsl/for_loop.py:47:37: W605 invalid escape sequence '\w'
sdk/python/kfp/dsl/for_loop.py:47:44: W605 invalid escape sequence '\['
sdk/python/kfp/dsl/for_loop.py:47:63: W605 invalid escape sequence '\]'
sdk/python/kfp/dsl/for_loop.py:67:17: W605 invalid escape sequence '\.'
sdk/python/kfp/dsl/for_loop.py:67:24: W605 invalid escape sequence '\w'
sdk/python/kfp/dsl/for_loop.py:67:31: W605 invalid escape sequence '\['
sdk/python/kfp/dsl/for_loop.py:67:33: W605 invalid escape sequence '\s'
sdk/python/kfp/dsl/for_loop.py:67:39: W605 invalid escape sequence '\w'
sdk/python/kfp/dsl/for_loop.py:67:43: W605 invalid escape sequence '\s'
sdk/python/kfp/dsl/for_loop.py:67:47: W605 invalid escape sequence '\s'
sdk/python/kfp/dsl/for_loop.py:67:68: W605 invalid escape sequence '\]'
sdk/python/kfp/dsl/placeholders_test.py:302:74: W605 invalid escape sequence '\.'
sdk/python/kfp/dsl/placeholders_test.py:312:74: W605 invalid escape sequence '\.'
sdk/python/kfp/dsl/placeholders_test.py:326:74: W605 invalid escape sequence '\.'
sdk/python/kfp/dsl/placeholders_test.py:344:74: W605 invalid escape sequence '\.'
sdk/python/kfp/dsl/placeholders_test.py:360:74: W605 invalid escape sequence '\.'
sdk/python/kfp/dsl/placeholders_test.py:374:74: W605 invalid escape sequence '\.'
sdk/python/kfp/dsl/placeholders_test.py:389:74: W605 invalid escape sequence '\.'
sdk/python/kfp/dsl/tasks_group_test.py:77:25: W605 invalid escape sequence '\.'
sdk/python/kfp/dsl/tasks_group_test.py:77:50: W605 invalid escape sequence '\.'
sdk/python/kfp/dsl/tasks_group_test.py:77:67: W605 invalid escape sequence '\.'
sdk/python/kfp/dsl/tasks_group_test.py:77:79: W605 invalid escape sequence '\.'
sdk/python/kfp/dsl/types/type_annotations.py:230:30: W605 invalid escape sequence '\.'
sdk/python/kfp/dsl/types/type_annotations.py:230:43: W605 invalid escape sequence '\w'
sdk/python/kfp/dsl/types/type_annotations.py:230:50: W605 invalid escape sequence '\['
sdk/python/kfp/dsl/types/type_annotations.py:230:54: W605 invalid escape sequence '\]'
sdk/python/kfp/local/config_test.py:73:69: W605 invalid escape sequence '\.'
sdk/python/kfp/local/config_test.py:73:76: W605 invalid escape sequence '\.'
sdk/python/kfp/local/config_test.py:73:82: W605 invalid escape sequence '\('
sdk/python/kfp/local/config_test.py:73:84: W605 invalid escape sequence '\)'
sdk/python/kfp/local/config_test.py:73:118: W605 invalid escape sequence '\.'
test/sample-test/sample_test_launcher.py:95:45: W605 invalid escape sequence '\.'
test/sample-test/sample_test_launcher.py:245:17: W605 invalid escape sequence '\.'
test/sample-test/sample_test_launcher.py:245:82: W605 invalid escape sequence '\w'
test/sample-test/sample_test_launcher.py:247:17: W605 invalid escape sequence '\.'
test/sample-test/sample_test_launcher.py:247:69: W605 invalid escape sequence '\w'
test/sample-test/sample_test_launcher.py:252:21: W605 invalid escape sequence '\.'
test/sample-test/sample_test_launcher.py:252:55: W605 invalid escape sequence '\w'
test/sample-test/unittests/utils_tests.py:51:13: W605 invalid escape sequence '\.'
test/sample-test/unittests/utils_tests.py:51:65: W605 invalid escape sequence '\w'
test/sample-test/unittests/utils_tests.py:52:13: W605 invalid escape sequence '\.'
test/sample-test/unittests/utils_tests.py:52:59: W605 invalid escape sequence '\w'
test/sample-test/unittests/utils_tests.py:53:13: W605 invalid escape sequence '\.'
test/sample-test/unittests/utils_tests.py:53:66: W605 invalid escape sequence '\w'
test/sample-test/unittests/utils_tests.py:54:13: W605 invalid escape sequence '\.'
test/sample-test/unittests/utils_tests.py:54:66: W605 invalid escape sequence '\w'
```
</details>


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
