### PR TITLE
replaced deprecated image repos with registry.k8s.io

### DIFF
--- a/backend/src/apiserver/config/config.json
+++ b/backend/src/apiserver/config/config.json
@@ -23,6 +23,6 @@
   "DEFAULTPIPELINERUNNERSERVICEACCOUNT": "pipeline-runner",
   "CacheEnabled": "true",
   "CRON_SCHEDULE_TIMEZONE": "UTC",
-  "CACHE_IMAGE": "gcr.io/google-containers/busybox",
+  "CACHE_IMAGE": "registry.k8s.io/busybox",
   "CACHE_NODE_RESTRICTIONS": "false"
 }

--- a/backend/src/cache/server/mutation.go
+++ b/backend/src/cache/server/mutation.go
@@ -167,7 +167,7 @@ func MutatePodIfCached(req *v1beta1.AdmissionRequest, clientMgr ClientManagerInt
 
 		// Image selected from Google Container Register(gcr) for it small size, gcr since there
 		// is not image pull rate limit. For more info see issue: https://github.com/kubeflow/pipelines/issues/4099
-		image := "gcr.io/google-containers/busybox"
+		image := "registry.k8s.io/busybox"
 		if v, ok := os.LookupEnv("CACHE_IMAGE"); ok {
 			image = v
 		}

--- a/backend/src/cache/server/mutation_test.go
+++ b/backend/src/cache/server/mutation_test.go
@@ -198,7 +198,7 @@ func TestDefaultImage(t *testing.T) {
 	patchOperation, err := MutatePodIfCached(&fakeAdmissionRequest, fakeClientManager)
 	assert.Nil(t, err)
 	container := patchOperation[0].Value.([]corev1.Container)[0]
-	require.Equal(t, "gcr.io/google-containers/busybox", container.Image)
+	require.Equal(t, "registry.k8s.io/busybox", container.Image)
 }
 
 func TestSetImage(t *testing.T) {

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/cache.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/cache.yaml
@@ -190,7 +190,7 @@ data:
   mysql_driver: "mysql"
   mysql_host: "mysql"
   mysql_port: "3306"
-  cache_image: "gcr.io/google-containers/busybox"
+  cache_image: "registry.k8s.io/busybox"
   cache_node_restrictions: "false"
 ---
 apiVersion: apps/v1

--- a/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
@@ -63,8 +63,8 @@ data:
   ## cacheImage is the image that the mutating webhook will use to patch
   ## cached steps with. Will be used to echo a message announcing that 
   ## the cached step result will be used. If not set it will default to 
-  ## 'gcr.io/google-containers/busybox'
-  cacheImage: "gcr.io/google-containers/busybox"
+  ## 'registry.k8s.io/busybox'
+  cacheImage: "registry.k8s.io/busybox"
   ## cacheNodeRestrictions the dummy container runing if output is cached
   ## will run with the same affinity and node selector as the default pipeline
   ## step. This is defaulted to 'false' to allow the pod to be scheduled on 

--- a/manifests/kustomize/base/installs/generic/postgres/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/postgres/pipeline-install-config.yaml
@@ -63,8 +63,8 @@ data:
   ## cacheImage is the image that the mutating webhook will use to patch
   ## cached steps with. Will be used to echo a message announcing that 
   ## the cached step result will be used. If not set it will default to 
-  ## 'gcr.io/google-containers/busybox'
-  cacheImage: "gcr.io/google-containers/busybox"
+  ## 'registry.k8s.io/busybox'
+  cacheImage: "registry.k8s.io/busybox"
   ## cacheNodeRestrictions the dummy container runing if output is cached
   ## will run with the same affinity and node selector as the default pipeline
   ## step. This is defaulted to 'false' to allow the pod to be scheduled on 

--- a/samples/core/resource_ops/resource_ops.py
+++ b/samples/core/resource_ops/resource_ops.py
@@ -36,7 +36,7 @@ _CONTAINER_MANIFEST = """
             "spec": {
                 "containers": [{
                     "name": "sample-container",
-                    "image": "k8s.gcr.io/busybox",
+                    "image": "registry.k8s.io/busybox",
                     "command": ["/usr/bin/env"]
                 }],
                 "restartPolicy": "Never"

--- a/samples/test/placeholder_concat.py
+++ b/samples/test/placeholder_concat.py
@@ -23,7 +23,7 @@ inputs:
 - {name: input_two, type: String}
 implementation:
   container:
-    image: gcr.io/google-containers/busybox
+    image: registry.k8s.io/busybox
     command:
     - sh
     - -ec

--- a/samples/test/placeholder_if.py
+++ b/samples/test/placeholder_if.py
@@ -23,7 +23,7 @@ inputs:
 - {name: optional_input_2, type: String, optional: true}
 implementation:
   container:
-    image: gcr.io/google-containers/busybox
+    image: registry.k8s.io/busybox
     command:
     - echo
     args:

--- a/samples/test/placeholder_if_v2.py
+++ b/samples/test/placeholder_if_v2.py
@@ -22,7 +22,7 @@ inputs:
 - {name: optional_input_2, type: String, optional: true}
 implementation:
   container:
-    image: gcr.io/google-containers/busybox
+    image: registry.k8s.io/busybox
     command:
     - echo
     args:


### PR DESCRIPTION
Resolve: https://github.com/kubeflow/pipelines/issues/10615#issuecomment-2315801652 

I didn't do any manual test, but seems like a safe change. There is effectively no difference between these images: 

```bash
~ $ podman image diff --format json registry.k8s.io/busybox gcr.io/google-containers/busybox
{}
~$ podman image diff --format json registry.k8s.io/busybox k8s.gcr.io/busybox
{}
```

This change was applied via a sed replace like manner.