### PR TITLE
feat(backend): implement subdag output resolution

### DIFF
--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -85,6 +85,7 @@ func init() {
 	flag.Set("logtostderr", "true")
 	// Change the WARNING to INFO level for debugging.
 	flag.Set("stderrthreshold", "WARNING")
+	flag.Set("v", "4")
 }
 
 func validate() error {

--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -85,7 +85,8 @@ func init() {
 	flag.Set("logtostderr", "true")
 	// Change the WARNING to INFO level for debugging.
 	flag.Set("stderrthreshold", "WARNING")
-	flag.Set("v", "4")
+	// Enable V(4) logging level for more verbose debugging.
+	// flag.Set("v", "4")
 }
 
 func validate() error {

--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -85,8 +85,6 @@ func init() {
 	flag.Set("logtostderr", "true")
 	// Change the WARNING to INFO level for debugging.
 	flag.Set("stderrthreshold", "WARNING")
-	// Enable V(4) logging level for more verbose debugging.
-	// flag.Set("v", "4")
 }
 
 func validate() error {

--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -148,8 +148,8 @@ func (l *LauncherV2) Execute(ctx context.Context) (err error) {
 			}
 		}
 		glog.Infof("publish success.")
-		// At the end of the current task, we check the statuses of all tasks in the current DAG and update the DAG's status accordingly.
-		// TODO: If there's a pipeline whose only components are DAGs, this launcher logic will never run and as a result the dag status will never be updated. We need to implement a mechanism to handle this edge case.
+		// At the end of the current task, we check the statuses of all tasks in
+		// the current DAG and update the DAG's status accordingly.
 		dag, err := l.metadataClient.GetDAG(ctx, execution.GetExecution().CustomProperties["parent_dag_id"].GetIntValue())
 		if err != nil {
 			glog.Errorf("DAG Status Update: failed to get DAG: %s", err.Error())

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -1267,6 +1267,7 @@ func resolveInputs(ctx context.Context, dag *metadata.DAG, iterationIndex *int, 
 				} else {
 					// The producer subtask is not a DAG, so we exit the loop.
 					producerSubTaskMaybeDAG = false
+					inputs.ParameterValues[name] = producerOutputs[taskOutput.GetOutputParameterKey()]
 				}
 			}
 

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -1353,7 +1353,7 @@ func resolveUpstreamArtifacts(cfg resolveUpstreamArtifactsConfig) error {
 	}
 	glog.V(4).Info("producer: ", producer)
 	currentTask := producer
-	var outputArtifactKey string = taskOutput.GetOutputArtifactKey()
+	outputArtifactKey := taskOutput.GetOutputArtifactKey()
 	currentSubTaskMaybeDAG := true
 	// Continue looping until we reach a sub-task that is NOT a DAG.
 	for currentSubTaskMaybeDAG {
@@ -1371,9 +1371,9 @@ func resolveUpstreamArtifacts(cfg resolveUpstreamArtifactsConfig) error {
 			glog.V(4).Infof("Deserialized outputArtifacts: %v", outputArtifacts)
 			// Adding support for multiple output artifacts
 			var subTaskName string
-			value := outputArtifacts[outputArtifactKey].GetArtifactSelectors()
+			artifactSelectors := outputArtifacts[outputArtifactKey].GetArtifactSelectors()
 
-			for _, v := range value {
+			for _, v := range artifactSelectors {
 				glog.V(4).Infof("v: %v", v)
 				glog.V(4).Infof("v.ProducerSubtask: %v", v.ProducerSubtask)
 				glog.V(4).Infof("v.OutputArtifactKey: %v", v.OutputArtifactKey)

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -1245,7 +1245,8 @@ func getDAGTasks(
 			// within a single DAG, which results in an error when
 			// mlmd.GetExecutionsInDAG is called. ParallelFor outputs should be
 			// handled with dsl.Collected.
-			if _, ok := v.GetExecution().GetCustomProperties()["iteration_index"]; !ok {
+			iterationIndex, ok := v.GetExecution().GetCustomProperties()["iteration_index"]
+			if ok && iterationIndex != nil {
 				continue
 			}
 			glog.V(4).Infof("Found a task, %v, with an execution type of system.DAGExecution. Adding its tasks to the task list.", v.TaskName())

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -1245,8 +1245,9 @@ func getDAGTasks(
 			// within a single DAG, which results in an error when
 			// mlmd.GetExecutionsInDAG is called. ParallelFor outputs should be
 			// handled with dsl.Collected.
-			iterationIndex, ok := v.GetExecution().GetCustomProperties()["iteration_index"]
-			if ok && iterationIndex != nil {
+			_, ok := v.GetExecution().GetCustomProperties()["iteration_count"]
+			if ok {
+				glog.Infof("Found a ParallelFor task, %v. Skipping it.", v.TaskName())
 				continue
 			}
 			glog.V(4).Infof("Found a task, %v, with an execution type of system.DAGExecution. Adding its tasks to the task list.", v.TaskName())

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -1240,7 +1240,7 @@ func getDAGTasks(
 	for _, v := range currentExecutionTasks {
 
 		if v.GetExecution().GetType() == "system.DAGExecution" {
-			// Iteration index is only applied when using ParallelFor, and in
+			// Iteration count is only applied when using ParallelFor, and in
 			// that scenario you're guaranteed to have redundant task names even
 			// within a single DAG, which results in an error when
 			// mlmd.GetExecutionsInDAG is called. ParallelFor outputs should be

--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -136,8 +136,6 @@ type ExecutionConfig struct {
 	ParentDagID      int64 // parent DAG execution ID. Only the root DAG does not have a parent DAG.
 	InputParameters  map[string]*structpb.Value
 	OutputParameters map[string]*structpb.Value
-	// OutputArtifacts  map[string]*structpb.Value
-	// OutputArtifacts  []*pipelinespec.DagOutputsSpec_ArtifactSelectorSpec
 	OutputArtifacts  map[string]*pipelinespec.DagOutputsSpec_DagOutputArtifactSpec
 	InputArtifactIDs map[string][]int64
 	IterationIndex   *int // Index of the iteration.

--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -849,6 +849,13 @@ func (c *Client) GetExecutionsInDAG(ctx context.Context, dag *DAG, pipeline *Pip
 			}
 			existing, ok := executionsMap[taskName]
 			if ok {
+				// TODO: The failure to handle this results in a specific edge
+				// case which has yet to be solved for. If you have three nested
+				// pipelines: A, which calls B, which calls C, and B and C share
+				// a task that A does not have but depends on in a producer
+				// subtask, when GetExecutionsInDAG is called, it will raise
+				// this error.
+
 				// TODO(Bobgy): to support retry, we need to handle multiple tasks with the same task name.
 				return nil, fmt.Errorf("two tasks have the same task name %q, id1=%v id2=%v", taskName, existing.GetID(), execution.GetID())
 			}

--- a/backend/src/v2/metadata/client_fake.go
+++ b/backend/src/v2/metadata/client_fake.go
@@ -19,6 +19,7 @@ package metadata
 
 import (
 	"context"
+
 	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
 
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
@@ -64,10 +65,15 @@ func (c *FakeClient) GetPipelineFromExecution(ctx context.Context, id int64) (*P
 	return nil, nil
 }
 
-func (c *FakeClient) GetExecutionsInDAG(ctx context.Context, dag *DAG, pipeline *Pipeline) (executionsMap map[string]*Execution, err error) {
+func (c *FakeClient) GetExecutionsInDAG(ctx context.Context, dag *DAG, pipeline *Pipeline, filter bool) (executionsMap map[string]*Execution, err error) {
 	return nil, nil
 }
-
+func (c *FakeClient) UpdateDAGExecutionsState(ctx context.Context, dag *DAG, pipeline *Pipeline) (err error) {
+	return nil
+}
+func (c *FakeClient) PutDAGExecutionState(ctx context.Context, executionID int64, state pb.Execution_State) (err error) {
+	return nil
+}
 func (c *FakeClient) GetEventsByArtifactIDs(ctx context.Context, artifactIds []int64) ([]*pb.Event, error) {
 	return nil, nil
 }

--- a/backend/src/v2/metadata/client_test.go
+++ b/backend/src/v2/metadata/client_test.go
@@ -311,7 +311,7 @@ func Test_DAG(t *testing.T) {
 		t.Fatal(err)
 	}
 	rootDAG := &metadata.DAG{Execution: root}
-	rootChildren, err := client.GetExecutionsInDAG(ctx, rootDAG, pipeline)
+	rootChildren, err := client.GetExecutionsInDAG(ctx, rootDAG, pipeline, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -324,7 +324,7 @@ func Test_DAG(t *testing.T) {
 	if rootChildren["task2"].GetID() != task2.GetID() {
 		t.Errorf("executions[\"task2\"].GetID()=%v, task2.GetID()=%v. Not equal", rootChildren["task2"].GetID(), task2.GetID())
 	}
-	task1Children, err := client.GetExecutionsInDAG(ctx, &metadata.DAG{Execution: task1DAG}, pipeline)
+	task1Children, err := client.GetExecutionsInDAG(ctx, &metadata.DAG{Execution: task1DAG}, pipeline, true)
 	if len(task1Children) != 1 {
 		t.Errorf("len(task1Children)=%v, expect 1", len(task1Children))
 	}

--- a/backend/src/v2/objectstore/object_store.go
+++ b/backend/src/v2/objectstore/object_store.go
@@ -17,6 +17,13 @@ package objectstore
 import (
 	"context"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -27,14 +34,8 @@ import (
 	"gocloud.dev/blob/s3blob"
 	"gocloud.dev/gcp"
 	"golang.org/x/oauth2/google"
-	"io"
-	"io/ioutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
 )
 
 func OpenBucket(ctx context.Context, k8sClient kubernetes.Interface, namespace string, config *Config) (bucket *blob.Bucket, err error) {

--- a/samples/v2/sample_test.py
+++ b/samples/v2/sample_test.py
@@ -11,20 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import unittest
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+import inspect
+import os
 from pprint import pprint
 from typing import List
+import unittest
 
+import component_with_optional_inputs
+import hello_world
 import kfp
 from kfp.dsl.graph_component import GraphComponent
-import component_with_optional_inputs
-import pipeline_with_env
-import hello_world
-import producer_consumer_param
 import pipeline_container_no_input
+import pipeline_with_env
+import producer_consumer_param
 import two_step_pipeline_containerized
 
 _MINUTE = 60  # seconds
@@ -38,16 +40,21 @@ class TestCase:
 
 
 class SampleTest(unittest.TestCase):
-    _kfp_host_and_port = os.getenv('KFP_API_HOST_AND_PORT', 'http://localhost:8888')
-    _kfp_ui_and_port = os.getenv('KFP_UI_HOST_AND_PORT', 'http://localhost:8080')
+    _kfp_host_and_port = os.getenv('KFP_API_HOST_AND_PORT',
+                                   'http://localhost:8888')
+    _kfp_ui_and_port = os.getenv('KFP_UI_HOST_AND_PORT',
+                                 'http://localhost:8080')
     _client = kfp.Client(host=_kfp_host_and_port, ui_host=_kfp_ui_and_port)
 
     def test(self):
         test_cases: List[TestCase] = [
             TestCase(pipeline_func=hello_world.pipeline_hello_world),
-            TestCase(pipeline_func=producer_consumer_param.producer_consumer_param_pipeline),
-            TestCase(pipeline_func=pipeline_container_no_input.pipeline_container_no_input),
-            TestCase(pipeline_func=two_step_pipeline_containerized.two_step_pipeline_containerized),
+            TestCase(pipeline_func=producer_consumer_param
+                     .producer_consumer_param_pipeline),
+            TestCase(pipeline_func=pipeline_container_no_input
+                     .pipeline_container_no_input),
+            TestCase(pipeline_func=two_step_pipeline_containerized
+                     .two_step_pipeline_containerized),
             TestCase(pipeline_func=component_with_optional_inputs.pipeline),
             TestCase(pipeline_func=pipeline_with_env.pipeline_with_env),
 
@@ -56,27 +63,51 @@ class SampleTest(unittest.TestCase):
             # TestCase(pipeline_func=pipeline_with_volume.pipeline_with_volume),
             # TestCase(pipeline_func=pipeline_with_secret_as_volume.pipeline_secret_volume),
             # TestCase(pipeline_func=pipeline_with_secret_as_env.pipeline_secret_env),
+
+            # This next set of tests needs to be commented out until issue
+            # https://github.com/kubeflow/pipelines/issues/11239#issuecomment-2374792592
+            # is addressed or the driver image that is used in CI is updated
+            # because otherwise the tests are run against incompatible version
+            # of the driver. In the meantime, for local validation, these tests
+            # can be executed (once you've manually deployed an updated driver
+            # image).
+
+            # TestCase(pipeline_func=subdagio.parameter.crust),
+            # TestCase(pipeline_func=subdagio.parameter_cache.crust),
+            # TestCase(pipeline_func=subdagio.artifact_cache.crust),
+            # TestCase(pipeline_func=subdagio.artifact.crust),
+            # TestCase(pipeline_func=subdagio.mixed_parameters.crust),
+            # TestCase(pipeline_func=subdagio.multiple_parameters_namedtuple.crust)
+            # TestCase(pipeline_func=subdagio.multiple_artifacts_namedtuple.crust),
         ]
 
         with ThreadPoolExecutor() as executor:
             futures = [
-                executor.submit(self.run_test_case, test_case.pipeline_func, test_case.timeout)
-                for test_case in test_cases
+                executor.submit(self.run_test_case, test_case.pipeline_func,
+                                test_case.timeout) for test_case in test_cases
             ]
             for future in as_completed(futures):
                 future.result()
 
     def run_test_case(self, pipeline_func: GraphComponent, timeout: int):
         with self.subTest(pipeline=pipeline_func, msg=pipeline_func.name):
-            run_result = self._client.create_run_from_pipeline_func(pipeline_func=pipeline_func)
+            print(
+                f'Running pipeline: {inspect.getmodule(pipeline_func.pipeline_func).__name__}/{pipeline_func.name}.'
+            )
+            run_result = self._client.create_run_from_pipeline_func(
+                pipeline_func=pipeline_func)
 
             run_response = run_result.wait_for_run_completion(timeout)
 
             pprint(run_response.run_details)
-            print("Run details page URL:")
-            print(f"{self._kfp_ui_and_port}/#/runs/details/{run_response.run_id}")
+            print('Run details page URL:')
+            print(
+                f'{self._kfp_ui_and_port}/#/runs/details/{run_response.run_id}')
 
-            self.assertEqual(run_response.state, "SUCCEEDED")
+            self.assertEqual(run_response.state, 'SUCCEEDED')
+            print(
+                f'Pipeline, {inspect.getmodule(pipeline_func.pipeline_func).__name__}/{pipeline_func.name}, succeeded.'
+            )
 
 
 if __name__ == '__main__':

--- a/samples/v2/sample_test.py
+++ b/samples/v2/sample_test.py
@@ -28,6 +28,8 @@ import pipeline_container_no_input
 import pipeline_with_env
 import producer_consumer_param
 import two_step_pipeline_containerized
+# import subdagio
+
 
 _MINUTE = 60  # seconds
 _DEFAULT_TIMEOUT = 5 * _MINUTE
@@ -74,10 +76,11 @@ class SampleTest(unittest.TestCase):
 
             # TestCase(pipeline_func=subdagio.parameter.crust),
             # TestCase(pipeline_func=subdagio.parameter_cache.crust),
+            # TestCase(pipeline_func=subdagio.mixed_parameters.crust),
+            # TestCase(pipeline_func=subdagio.multiple_parameters_namedtuple.crust),
+            # TestCase(pipeline_func=subdagio.parameter_oneof.crust),
             # TestCase(pipeline_func=subdagio.artifact_cache.crust),
             # TestCase(pipeline_func=subdagio.artifact.crust),
-            # TestCase(pipeline_func=subdagio.mixed_parameters.crust),
-            # TestCase(pipeline_func=subdagio.multiple_parameters_namedtuple.crust)
             # TestCase(pipeline_func=subdagio.multiple_artifacts_namedtuple.crust),
         ]
 

--- a/samples/v2/sample_test.py
+++ b/samples/v2/sample_test.py
@@ -27,9 +27,8 @@ from kfp.dsl.graph_component import GraphComponent
 import pipeline_container_no_input
 import pipeline_with_env
 import producer_consumer_param
+import subdagio
 import two_step_pipeline_containerized
-# import subdagio
-
 
 _MINUTE = 60  # seconds
 _DEFAULT_TIMEOUT = 5 * _MINUTE
@@ -65,23 +64,16 @@ class SampleTest(unittest.TestCase):
             # TestCase(pipeline_func=pipeline_with_volume.pipeline_with_volume),
             # TestCase(pipeline_func=pipeline_with_secret_as_volume.pipeline_secret_volume),
             # TestCase(pipeline_func=pipeline_with_secret_as_env.pipeline_secret_env),
-
-            # This next set of tests needs to be commented out until issue
-            # https://github.com/kubeflow/pipelines/issues/11239#issuecomment-2374792592
-            # is addressed or the driver image that is used in CI is updated
-            # because otherwise the tests are run against incompatible version
-            # of the driver. In the meantime, for local validation, these tests
-            # can be executed (once you've manually deployed an updated driver
-            # image).
-
-            # TestCase(pipeline_func=subdagio.parameter.crust),
-            # TestCase(pipeline_func=subdagio.parameter_cache.crust),
-            # TestCase(pipeline_func=subdagio.mixed_parameters.crust),
-            # TestCase(pipeline_func=subdagio.multiple_parameters_namedtuple.crust),
-            # TestCase(pipeline_func=subdagio.parameter_oneof.crust),
-            # TestCase(pipeline_func=subdagio.artifact_cache.crust),
-            # TestCase(pipeline_func=subdagio.artifact.crust),
-            # TestCase(pipeline_func=subdagio.multiple_artifacts_namedtuple.crust),
+            TestCase(pipeline_func=subdagio.parameter.crust),
+            TestCase(pipeline_func=subdagio.parameter_cache.crust),
+            TestCase(pipeline_func=subdagio.mixed_parameters.crust),
+            TestCase(
+                pipeline_func=subdagio.multiple_parameters_namedtuple.crust),
+            TestCase(pipeline_func=subdagio.parameter_oneof.crust),
+            TestCase(pipeline_func=subdagio.artifact_cache.crust),
+            TestCase(pipeline_func=subdagio.artifact.crust),
+            TestCase(
+                pipeline_func=subdagio.multiple_artifacts_namedtuple.crust),
         ]
 
         with ThreadPoolExecutor() as executor:

--- a/samples/v2/subdagio/__init__.py
+++ b/samples/v2/subdagio/__init__.py
@@ -5,3 +5,4 @@ from subdagio import multiple_artifacts_namedtuple
 from subdagio import multiple_parameters_namedtuple
 from subdagio import parameter
 from subdagio import parameter_cache
+from subdagio import parameter_oneof

--- a/samples/v2/subdagio/__init__.py
+++ b/samples/v2/subdagio/__init__.py
@@ -1,0 +1,7 @@
+from subdagio import artifact
+from subdagio import artifact_cache
+from subdagio import mixed_parameters
+from subdagio import multiple_artifacts_namedtuple
+from subdagio import multiple_parameters_namedtuple
+from subdagio import parameter
+from subdagio import parameter_cache

--- a/samples/v2/subdagio/artifact.py
+++ b/samples/v2/subdagio/artifact.py
@@ -1,0 +1,47 @@
+import os
+
+from kfp import Client
+from kfp import dsl
+
+
+@dsl.component
+def core_comp(dataset: dsl.Output[dsl.Dataset]):
+    with open(dataset.path, 'w') as f:
+        f.write('foo')
+
+
+@dsl.component
+def crust_comp(input: dsl.Dataset):
+    with open(input.path, 'r') as f:
+        print('input: ', f.read())
+
+
+@dsl.pipeline
+def core() -> dsl.Dataset:
+    task = core_comp()
+    task.set_caching_options(False)
+
+    return task.output
+
+
+@dsl.pipeline
+def mantle() -> dsl.Dataset:
+    dag_task = core()
+    dag_task.set_caching_options(False)
+
+    return dag_task.output
+
+
+@dsl.pipeline(name=os.path.basename(__file__).removesuffix('.py') + '-pipeline')
+def crust():
+    dag_task = mantle()
+    dag_task.set_caching_options(False)
+
+    task = crust_comp(input=dag_task.output)
+    task.set_caching_options(False)
+
+
+if __name__ == '__main__':
+    # Compiler().compile(pipeline_func=crust, package_path=f"{__file__.removesuffix('.py')}.yaml")
+    client = Client()
+    client.create_run_from_pipeline_func(crust)

--- a/samples/v2/subdagio/artifact_cache.py
+++ b/samples/v2/subdagio/artifact_cache.py
@@ -1,0 +1,42 @@
+import os
+
+from kfp import Client
+from kfp import dsl
+
+
+@dsl.component
+def core_comp(dataset: dsl.Output[dsl.Dataset]):
+    with open(dataset.path, 'w') as f:
+        f.write('foo')
+
+
+@dsl.component
+def crust_comp(input: dsl.Dataset):
+    with open(input.path, 'r') as f:
+        print('input: ', f.read())
+
+
+@dsl.pipeline
+def core() -> dsl.Dataset:
+    task = core_comp()
+
+    return task.output
+
+
+@dsl.pipeline
+def mantle() -> dsl.Dataset:
+    dag_task = core()
+    return dag_task.output
+
+
+@dsl.pipeline(name=os.path.basename(__file__).removesuffix('.py') + '-pipeline')
+def crust():
+    dag_task = mantle()
+
+    task = crust_comp(input=dag_task.output)
+
+
+if __name__ == '__main__':
+    # Compiler().compile(pipeline_func=crust, package_path=f"{__file__.removesuffix('.py')}.yaml")
+    client = Client()
+    client.create_run_from_pipeline_func(crust)

--- a/samples/v2/subdagio/mixed_parameters.py
+++ b/samples/v2/subdagio/mixed_parameters.py
@@ -1,0 +1,48 @@
+import os
+
+from kfp import Client
+from kfp import dsl
+from kfp.compiler import Compiler
+
+
+@dsl.component
+def core_comp() -> int:
+    return 1
+
+
+@dsl.component
+def crust_comp(x: int, y: int):
+    print('sum :', x + y)
+
+
+@dsl.pipeline
+def core() -> int:
+    task = core_comp()
+    task.set_caching_options(False)
+
+    return task.output
+
+
+@dsl.pipeline
+def mantle() -> int:
+    dag_task = core()
+    dag_task.set_caching_options(False)
+
+    return dag_task.output
+
+
+@dsl.pipeline(name=os.path.basename(__file__).removesuffix('.py') + '-pipeline')
+def crust():
+    dag_task = mantle()
+    dag_task.set_caching_options(False)
+
+    task = crust_comp(x=2, y=dag_task.output)
+    task.set_caching_options(False)
+
+
+if __name__ == '__main__':
+    Compiler().compile(
+        pipeline_func=crust,
+        package_path=f"{__file__.removesuffix('.py')}.yaml")
+    client = Client()
+    client.create_run_from_pipeline_func(crust)

--- a/samples/v2/subdagio/multiple_artifacts_namedtuple.py
+++ b/samples/v2/subdagio/multiple_artifacts_namedtuple.py
@@ -1,0 +1,66 @@
+import os
+from typing import NamedTuple
+
+from kfp import Client
+from kfp import dsl
+
+
+@dsl.component
+def core_comp(ds1: dsl.Output[dsl.Dataset], ds2: dsl.Output[dsl.Dataset]):
+    with open(ds1.path, 'w') as f:
+        f.write('foo')
+    with open(ds2.path, 'w') as f:
+        f.write('bar')
+
+
+@dsl.component
+def crust_comp(
+    ds1: dsl.Dataset,
+    ds2: dsl.Dataset,
+):
+    with open(ds1.path, 'r') as f:
+        print('ds1: ', f.read())
+    with open(ds2.path, 'r') as f:
+        print('ds2: ', f.read())
+
+
+@dsl.pipeline
+def core() -> NamedTuple(
+    'outputs',
+    ds1=dsl.Dataset,
+    ds2=dsl.Dataset,
+):  # type: ignore
+    task = core_comp()
+    task.set_caching_options(False)
+
+    return task.outputs
+
+
+@dsl.pipeline
+def mantle() -> NamedTuple(
+    'outputs',
+    ds1=dsl.Dataset,
+    ds2=dsl.Dataset,
+):  # type: ignore
+    dag_task = core()
+    dag_task.set_caching_options(False)
+
+    return dag_task.outputs
+
+
+@dsl.pipeline(name=os.path.basename(__file__).removesuffix('.py') + '-pipeline')
+def crust():
+    dag_task = mantle()
+    dag_task.set_caching_options(False)
+
+    task = crust_comp(
+        ds1=dag_task.outputs['ds1'],
+        ds2=dag_task.outputs['ds2'],
+    )
+    task.set_caching_options(False)
+
+
+if __name__ == '__main__':
+    # Compiler().compile(pipeline_func=crust, package_path=f"{__file__.removesuffix('.py')}.yaml")
+    client = Client()
+    client.create_run_from_pipeline_func(crust)

--- a/samples/v2/subdagio/multiple_parameters_namedtuple.py
+++ b/samples/v2/subdagio/multiple_parameters_namedtuple.py
@@ -1,0 +1,51 @@
+import os
+from typing import NamedTuple
+
+from kfp import Client
+from kfp import dsl
+
+
+@dsl.component
+def core_comp() -> NamedTuple('outputs', val1=str, val2=str):  # type: ignore
+    outputs = NamedTuple('outputs', val1=str, val2=str)
+    return outputs('foo', 'bar')
+
+
+@dsl.component
+def crust_comp(val1: str, val2: str):
+    print('val1: ', val1)
+    print('val2: ', val2)
+
+
+@dsl.pipeline
+def core() -> NamedTuple('outputs', val1=str, val2=str):  # type: ignore
+    task = core_comp()
+    task.set_caching_options(False)
+
+    return task.outputs
+
+
+@dsl.pipeline
+def mantle() -> NamedTuple('outputs', val1=str, val2=str):  # type: ignore
+    dag_task = core()
+    dag_task.set_caching_options(False)
+
+    return dag_task.outputs
+
+
+@dsl.pipeline(name=os.path.basename(__file__).removesuffix('.py') + '-pipeline')
+def crust():
+    dag_task = mantle()
+    dag_task.set_caching_options(False)
+
+    task = crust_comp(
+        val1=dag_task.outputs['val1'],
+        val2=dag_task.outputs['val2'],
+    )
+    task.set_caching_options(False)
+
+
+if __name__ == '__main__':
+    # Compiler().compile(pipeline_func=crust, package_path=f"{__file__.removesuffix('.py')}.yaml")
+    client = Client()
+    client.create_run_from_pipeline_func(crust)

--- a/samples/v2/subdagio/parameter.py
+++ b/samples/v2/subdagio/parameter.py
@@ -1,0 +1,45 @@
+import os
+
+from kfp import Client
+from kfp import dsl
+
+
+@dsl.component
+def core_comp() -> str:
+    return 'foo'
+
+
+@dsl.component
+def crust_comp(input: str):
+    print('input :', input)
+
+
+@dsl.pipeline
+def core() -> str:
+    task = core_comp()
+    task.set_caching_options(False)
+
+    return task.output
+
+
+@dsl.pipeline
+def mantle() -> str:
+    dag_task = core()
+    dag_task.set_caching_options(False)
+
+    return dag_task.output
+
+
+@dsl.pipeline(name=os.path.basename(__file__).removesuffix('.py') + '-pipeline')
+def crust():
+    dag_task = mantle()
+    dag_task.set_caching_options(False)
+
+    task = crust_comp(input=dag_task.output)
+    task.set_caching_options(False)
+
+
+if __name__ == '__main__':
+    # Compiler().compile(pipeline_func=crust, package_path=f"{__file__.removesuffix('.py')}.yaml")
+    client = Client()
+    client.create_run_from_pipeline_func(crust)

--- a/samples/v2/subdagio/parameter_cache.py
+++ b/samples/v2/subdagio/parameter_cache.py
@@ -1,0 +1,40 @@
+import os
+
+from kfp import Client
+from kfp import dsl
+
+
+@dsl.component
+def core_comp() -> str:
+    return 'foo'
+
+
+@dsl.component
+def crust_comp(input: str):
+    print('input :', input)
+
+
+@dsl.pipeline
+def core() -> str:
+    task = core_comp()
+
+    return task.output
+
+
+@dsl.pipeline
+def mantle() -> str:
+    dag_task = core()
+
+    return dag_task.output
+
+
+@dsl.pipeline(name=os.path.basename(__file__).removesuffix('.py') + '-pipeline')
+def crust():
+    dag_task = mantle()
+    task = crust_comp(input=dag_task.output)
+
+
+if __name__ == '__main__':
+    # Compiler().compile(pipeline_func=crust, package_path=f"{__file__.removesuffix('.py')}.yaml")
+    client = Client()
+    client.create_run_from_pipeline_func(crust)

--- a/samples/v2/subdagio/parameter_oneof.py
+++ b/samples/v2/subdagio/parameter_oneof.py
@@ -1,0 +1,54 @@
+import os
+
+from kfp import Client
+from kfp import dsl
+
+@dsl.component
+def flip_coin() -> str:
+    import random
+    return 'heads' if random.randint(0, 1) == 0 else 'tails'
+
+@dsl.component
+def core_comp(input: str) -> str:
+    print('input :', input)
+    return input
+
+@dsl.component
+def core_output_comp(input: str, output_key: dsl.OutputPath(str)):
+    print('input :', input)
+    with open(output_key, 'w') as f:
+        f.write(input)
+
+@dsl.component
+def crust_comp(input: str):
+    print('input :', input)
+
+@dsl.pipeline
+def core() -> str:
+    flip_coin_task = flip_coin().set_caching_options(False)
+    with dsl.If(flip_coin_task.output == 'heads'):
+        t1 = core_comp(input='Got heads!').set_caching_options(False)
+    with dsl.Else():
+        t2 = core_output_comp(input='Got tails!').set_caching_options(False)
+    return dsl.OneOf(t1.output, t2.outputs['output_key'])
+
+@dsl.pipeline
+def mantle() -> str:
+    dag_task = core()
+    dag_task.set_caching_options(False)
+
+    return dag_task.output
+
+@dsl.pipeline(name=os.path.basename(__file__).removesuffix('.py') + '-pipeline')
+def crust():
+    dag_task = mantle()
+    dag_task.set_caching_options(False)
+
+    task = crust_comp(input=dag_task.output)
+    task.set_caching_options(False)
+
+
+if __name__ == '__main__':
+    # Compiler().compile(pipeline_func=crust, package_path=f"{__file__.removesuffix('.py')}.yaml")
+    client = Client()
+    client.create_run_from_pipeline_func(crust)

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -1872,7 +1872,9 @@ def validate_pipeline_outputs_dict(
                     f'Pipeline outputs may only be returned from the top level of the pipeline function scope. Got pipeline output from within the control flow group dsl.{channel.task.parent_task_group.__class__.__name__}.'
                 )
         else:
-            raise ValueError(f'Got unknown pipeline output: {channel}.')
+            raise ValueError(
+                f'Got unknown pipeline output, {channel}, of type {type(channel)}.'
+            )
 
 
 def create_pipeline_spec(
@@ -2006,13 +2008,18 @@ def convert_pipeline_outputs_to_dict(
     output name to PipelineChannel."""
     if pipeline_outputs is None:
         return {}
+    elif isinstance(pipeline_outputs, dict):
+        # This condition is required to support pipelines that return NamedTuples.
+        return pipeline_outputs
     elif isinstance(pipeline_outputs, pipeline_channel.PipelineChannel):
         return {component_factory.SINGLE_OUTPUT_NAME: pipeline_outputs}
     elif isinstance(pipeline_outputs, tuple) and hasattr(
             pipeline_outputs, '_asdict'):
         return dict(pipeline_outputs._asdict())
     else:
-        raise ValueError(f'Got unknown pipeline output: {pipeline_outputs}')
+        raise ValueError(
+            f'Got unknown pipeline output, {pipeline_outputs}, of type {type(pipeline_outputs)}.'
+        )
 
 
 def write_pipeline_spec_to_file(

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -2009,7 +2009,9 @@ def convert_pipeline_outputs_to_dict(
     if pipeline_outputs is None:
         return {}
     elif isinstance(pipeline_outputs, dict):
-        # This condition is required to support pipelines that return NamedTuples.
+        # This condition is required to support the case where a nested pipeline
+        # returns a namedtuple but its output is converted into a dict by
+        # earlier invocations of this function (a few lines down).
         return pipeline_outputs
     elif isinstance(pipeline_outputs, pipeline_channel.PipelineChannel):
         return {component_factory.SINGLE_OUTPUT_NAME: pipeline_outputs}


### PR DESCRIPTION
**Description of your changes:**

This PR:
- Implements input resolution for outputs that come from (multiple layers of) nested DAGs. Without this, the usefulness of pipelines as components is severely compromised. This is achieved by recording the relationship between DAGs and their producer subtasks in MLMD as custom properties, which are consumed and resolved downstream by `resolveInputs` in `driver.go`.
- Begins functional decomposition in `driver.go`, paving the way for small tests.
- Implements extensive large test cases to validate the many different scenarios. The full set of test cases is summarized in a table below. These test cases are not incorporated into CI yet but will be once #11239 is resolved.
- Implements extensive, togglable debug level logs throughout the driver and mlmd client to improve troubleshooting.

Test file | Description 
--- | ---
artifact.py | Passing an artifact output through two nested pipelines.
artifact_cache.py | Same as above but with cache enabled.
mixed_parameters.py | Passing mixed parameters through two nested pipelines.
multiple_artifacts_namedtuple.py | Passing multiple artifacts through two nested pipelines.
multiple_parameters_namedtuple.py | Passing multiple parameters through two nested pipelines.
parameter.py | Passing a parameter through two nested pipelines.
parameter_cache.py | Same as above but with cache enabled.
parameter_oneof.py | Passing a parameter through a nested pipeline using dsl.OneOf.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
