### PR TITLE
chore(docs): clean up kfp-kubernetes documentation index page

### DIFF
--- a/kubernetes_platform/python/README.md
+++ b/kubernetes_platform/python/README.md
@@ -1,18 +1,22 @@
-# Kubernetes Platform-specific Features
+# Kubeflow Pipelines SDK kfp-kubernetes API Reference
 
-The `kfp-kubernetes` Python library enables authoring [Kubeflow pipelines](https://www.kubeflow.org/docs/components/pipelines/v2/) with Kubernetes-specific features. These features are supported by the [default KFP open source BE](https://github.com/kubeflow/pipelines/tree/master/backend). Specifically, the `kfp-kubernetes` library supports authoring pipelines that use:
+The Kubeflow Pipelines SDK kfp-kubernetes python library (part of the [Kubeflow Pipelines](https://www.kubeflow.org/docs/components/pipelines/) project) is an addon to the [Kubeflow Pipelines SDK](https://kubeflow-pipelines.readthedocs.io/) that enables authoring Kubeflow pipelines with Kubernetes-specific features and concepts, such as:
 
 * [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
 * [PersistentVolumeClaims](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims)
-* [ImagePullPolicy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy)
+* [ImagePullPolicies](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy)
+* [Ephemeral volumes](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/)
+* [Node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
+* [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
+* [Labels and annotations](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/#ObjectMeta)
+* and more
 
-See the [`kfp-kubernetes` reference documentation](https://kfp-kubernetes.readthedocs.io/).
+Be sure to check out the full [API Reference](https://kfp-kubernetes.readthedocs.io/) for more details.
 
 ## Installation
-The `kfp-kubernetes` package can be installed as a `kfp` SDK extra dependency with `kfp==2.x.x`:
-<!-- TODO: remove --pre when kfp v2 goes to GA -->
+The `kfp-kubernetes` package can be installed as a KFP SDK extra dependency.
 ```sh
-pip install kfp[kubernetes] --pre
+pip install kfp[kubernetes]
 ```
 
 Or installed independently:
@@ -20,8 +24,10 @@ Or installed independently:
 pip install kfp-kubernetes
 ```
 
-## Example usage
-<!-- TODO: test these examples once the BE implementation exists -->
+## Getting started
+
+The following is an example of a simple pipeline that uses the kfp-kubernetes library to mount a pre-existing secret as an environment variable available in the task's container.
+
 ### Secret: As environment variable
 ```python
 from kfp import dsl
@@ -39,6 +45,10 @@ def pipeline():
                                  secret_name='my-secret',
                                  secret_key_to_env={'password': 'SECRET_VAR'})
 ```
+
+## Other examples
+
+Here is a non-exhaustive list of some other examples of how to use the kfp-kubernetes library. Be sure to check out the full [API Reference](https://kfp-kubernetes.readthedocs.io/) for more details.
 
 ### Secret: As mounted volume
 ```python

--- a/kubernetes_platform/python/docs/conf.py
+++ b/kubernetes_platform/python/docs/conf.py
@@ -77,7 +77,7 @@ autodoc_default_options = {
 }
 
 html_theme = 'sphinx_immaterial'
-html_title = 'kfp-kubernetes Reference Documentation'
+html_title = 'KFP SDK kfp-kubernetes API Reference'
 html_static_path = ['_static']
 html_css_files = ['custom.css']
 html_logo = '_static/kubeflow.png'


### PR DESCRIPTION
**Description of your changes:**

The entry page for kfp-kubernetes was a little lacking. Clean it up a bit.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 