### PR TITLE
Enable or Disable cache for the Compiler

### DIFF
--- a/sdk/python/kfp/cli/compile_.py
+++ b/sdk/python/kfp/cli/compile_.py
@@ -22,6 +22,7 @@ from typing import Callable, Dict, Optional
 
 import click
 from kfp import compiler
+from kfp.cli.utils import parsing
 from kfp.dsl import base_component
 from kfp.dsl import graph_component
 
@@ -133,12 +134,19 @@ def parse_parameters(parameters: Optional[str]) -> Dict:
     is_flag=True,
     default=False,
     help='Whether to disable type checking.')
+@click.option(
+    '--enable-caching/--disable-caching',
+    type=bool,
+    default=None,
+    help=parsing.get_param_descr(compiler.Compiler.compile, 'enable_caching'),
+)
 def compile_(
     py: str,
     output: str,
     function_name: Optional[str] = None,
     pipeline_parameters: Optional[str] = None,
     disable_type_check: bool = False,
+    enable_caching: Optional[bool] = None,
 ) -> None:
     """Compiles a pipeline or component written in a .py file."""
     pipeline_func = collect_pipeline_or_component_func(
@@ -149,7 +157,8 @@ def compile_(
         pipeline_func=pipeline_func,
         pipeline_parameters=parsed_parameters,
         package_path=package_path,
-        type_check=not disable_type_check)
+        type_check=not disable_type_check,
+        enable_caching=enable_caching)
 
     click.echo(package_path)
 

--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -33,6 +33,7 @@ from kfp import compiler
 from kfp.client import auth
 from kfp.client import set_volume_credentials
 from kfp.client.token_credentials_base import TokenCredentialsBase
+from kfp.compiler.compiler import override_caching_options
 from kfp.dsl import base_component
 from kfp.pipeline_spec import pipeline_spec_pb2
 import kfp_server_api
@@ -955,8 +956,8 @@ class Client:
             # Caching option set at submission time overrides the compile time
             # settings.
             if enable_caching is not None:
-                _override_caching_options(pipeline_doc.pipeline_spec,
-                                          enable_caching)
+                override_caching_options(pipeline_doc.pipeline_spec,
+                                         enable_caching)
             pipeline_spec = pipeline_doc.to_dict()
 
         pipeline_version_reference = None
@@ -1676,17 +1677,3 @@ def _extract_pipeline_yaml(package_file: str) -> _PipelineDoc:
         raise ValueError(
             f'The package_file {package_file} should end with one of the '
             'following formats: [.tar.gz, .tgz, .zip, .yaml, .yml].')
-
-
-def _override_caching_options(
-    pipeline_spec: pipeline_spec_pb2.PipelineSpec,
-    enable_caching: bool,
-) -> None:
-    """Overrides caching options.
-
-    Args:
-        pipeline_spec: The PipelineSpec object to update in-place.
-        enable_caching: Overrides options, one of True, False.
-    """
-    for _, task_spec in pipeline_spec.root.dag.tasks.items():
-        task_spec.caching_options.enable_cache = enable_caching

--- a/sdk/python/kfp/client/client_test.py
+++ b/sdk/python/kfp/client/client_test.py
@@ -24,7 +24,8 @@ from absl.testing import parameterized
 from google.protobuf import json_format
 from kfp.client import auth
 from kfp.client import client
-from kfp.compiler import Compiler
+from kfp.compiler.compiler import Compiler
+from kfp.compiler.compiler import override_caching_options
 from kfp.dsl import component
 from kfp.dsl import pipeline
 from kfp.pipeline_spec import pipeline_spec_pb2
@@ -88,7 +89,7 @@ class TestOverrideCachingOptions(parameterized.TestCase):
                 pipeline_obj = yaml.safe_load(f)
                 pipeline_spec = json_format.ParseDict(
                     pipeline_obj, pipeline_spec_pb2.PipelineSpec())
-                client._override_caching_options(pipeline_spec, True)
+                override_caching_options(pipeline_spec, True)
                 pipeline_obj = json_format.MessageToDict(pipeline_spec)
                 self.assertTrue(pipeline_obj['root']['dag']['tasks']
                                 ['hello-word']['cachingOptions']['enableCache'])


### PR DESCRIPTION
**Description of your changes:**

Support for enabling or disabling caching for the entire pipeline is being introduced. This functionality mirrors the one provided by the `client::run` method (see https://github.com/kubeflow/pipelines/blob/master/sdk/python/kfp/client/client.py#L707). The aim is to offer a similar feature using the same parameter names to prevent confusion.

Note that this PR does not address changing the default value for `structures.TaskSpec::enable_caching`. That functionality will be introduced in a separate PR and is unrelated to this one.

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
