### PR TITLE
fix(ui): Fixes V1 Run detail unnecessary reloading. Fixes #10590

### DIFF
--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -101,6 +101,7 @@ interface SelectedNodeDetails {
 
 // exported only for testing
 export interface RunDetailsInternalProps {
+  isLoading?: boolean;
   runId?: string;
   gkeMetadata: GkeMetadata;
 }
@@ -237,6 +238,10 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
   }
 
   public render(): JSX.Element {
+    if (this.props.isLoading) {
+      return <div>Currently loading run information</div>;
+    }
+
     const {
       allArtifactConfigs,
       allowCustomVisualizations,

--- a/frontend/src/pages/RunDetailsRouter.tsx
+++ b/frontend/src/pages/RunDetailsRouter.tsx
@@ -70,9 +70,5 @@ export default function RunDetailsRouter(props: RunDetailsProps) {
     }
   }
 
-  if (runIsFetching || templateStrIsFetching) {
-    return <div>Currently loading run information</div>;
-  }
-
-  return <EnhancedRunDetails {...props} />;
+  return <EnhancedRunDetails {...props} isLoading={runIsFetching || templateStrIsFetching} />;
 }


### PR DESCRIPTION
**Description of your changes:**
This PR addresses [#10590](https://github.com/kubeflow/pipelines/issues/10590). V1 Run details were unexpectedly reloading when users navigated away from the page.

This is because the loading state is derived from a query that happens in `RunDetailsRouter.tsx`, which then determines whether to show the loading message or `RunDetails.tsx`. When the loading state occurs, the `RunDetails` component is unmounted because of this condition.

To address this issue, I have established a prop for `EnhancedRunDetails` called `isLoading`. This prop is derived from the same query as before, but the condition is now leveraged within the render method of the `RunDetails` component itself, therefore preventing the component from unmounting.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
