### PR TITLE
feat(sdk): support collections of params/artifacts for component I/O. Addresses #10840 

### DIFF
--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -193,15 +193,31 @@ def check_task_input_types(input_value, input_name, pipeline_task_spec, task,
 
     elif isinstance(input_value, list):
         for item in input_value:
-            check_task_input_types(item, input_name, pipeline_task_spec, task,
-                                   parent_component_inputs,
-                                   tasks_in_current_dag)
+            if isinstance(item, (pipeline_channel.PipelineArtifactChannel,
+                                 pipeline_channel.PipelineParameterChannel)):
+                check_task_input_types(item, input_name, pipeline_task_spec,
+                                       task, parent_component_inputs,
+                                       tasks_in_current_dag)
+            elif isinstance(item, (str, int, float, bool)):
+                pipeline_task_spec.inputs.parameters[
+                    input_name].runtime_value.constant.CopyFrom(
+                        to_protobuf_value(input_value))
 
     elif isinstance(input_value, dict):
-        for _, value in input_value.items():
-            check_task_input_types(value, input_name, pipeline_task_spec, task,
-                                   parent_component_inputs,
-                                   tasks_in_current_dag)
+        for key, value in input_value.items():
+            if isinstance(value, (pipeline_channel.PipelineArtifactChannel,
+                                  pipeline_channel.PipelineParameterChannel)):
+                check_task_input_types(value, input_name, pipeline_task_spec,
+                                       task, parent_component_inputs,
+                                       tasks_in_current_dag)
+
+            elif isinstance(value, (str, int, float, bool)):
+                pipeline_task_spec.inputs.parameters[
+                    input_name].runtime_value.constant.CopyFrom(
+                        to_protobuf_value(input_value))
+            # check_task_input_types(value, input_name, pipeline_task_spec, task,
+            #                        parent_component_inputs,
+            #                        tasks_in_current_dag)
 
     elif isinstance(input_value, (str, int, float, bool)):
         pipeline_channels = (


### PR DESCRIPTION
**Description of your changes:**
This PR is intended to resolve #10840.

In v1, users were able to dynamically collect and store variables of component outputs and pass references to those pipeline parameter types at compilation time to downstream components. This allowed for a dynamic pipeline generation, however with the release of v2 this capability was not available with the new compiler.

The major piece was that elements in lists & dicts did not have their types checked, so the compiler inferred their types were python primitives and attempted to pull the corresponding protobuf value. 

The approach for the solution was to add separate conditions for lists and dicts and check the types on their inputs separate from the primitive catch all here https://github.com/kubeflow/pipelines/blob/581b7e5b7e888a12652a48f81d9fcd3f5e195e37/sdk/python/kfp/compiler/pipeline_spec_builder.py#L241 and pull out the logic for checking the different types as a function to be reused.

Here is a sample showcasing this new capability:
```python
import kfp
from kfp.dsl import component, pipeline

@component(base_image="python:3.9",)
def create_dataset_paths(name:str, input_dfs:dict={})->dict:
    
    print(f"{name}")

    if input_dfs:
        
        print(input_dfs.items())
    
    dataset_paths = {
        'wine': 's3://my-bucket/datasets/wine_dataset.csv',
        'iris': 's3://my-bucket/datasets/iris_dataset.csv',
        'cancer': 's3://my-bucket/datasets/cancer_dataset.csv'
    }

    return dataset_paths

@component(base_image="python:3.9",)
def process_datasets(name:str, dataset_artifact: dict):
    
    for name, path in dataset_artifact.items():
        print(f"Looking at {name} dataset at S3 path: {path}")

@pipeline(name="dynamic-pipeline-example")
def dynamic_pipeline():
    fruits = {
       'apple': ['banana', 'orange'],
      'banana': ['orange'],
     'orange': [],
   }
    sorted_fruits = dict(sorted(fruits.items(), key=lambda item: len(item[1])))
    output_pool = {}
    for fruit, children in sorted_fruits.items():
        if children:
            current_task = create_dataset_paths(name=fruit, input_dfs={child:output_pool[child] for child in children})#.set_display_name(f"{fruit}-task")
        else:
            current_task = create_dataset_paths(name=fruit)#.set_display_name(f"{fruit}-task")
        current_task.set_caching_options(False)
        output_pool[fruit] = current_task.output
        process_datasets(name=fruit, dataset_artifact=current_task.output).set_caching_options(False)#.set_display_name(f"{fruit}-process")

endpoint = 'http://localhost:80'
kfp_client = kfp.client.Client(host=endpoint)
run = kfp_client.create_run_from_pipeline_func(
    dynamic_pipeline,
    arguments={},
)
```
![image](https://github.com/user-attachments/assets/6c3afbd1-46b0-44a4-a76b-12ab3177ec3a)

Associated IR
```yaml
components:
  comp-create-dataset-paths:
    executorLabel: exec-create-dataset-paths
    inputDefinitions:
      parameters:
        input_dfs:
          defaultValue: {}
          isOptional: true
          parameterType: STRUCT
        name:
          parameterType: STRING
    outputDefinitions:
      parameters:
        Output:
          parameterType: STRUCT
  comp-create-dataset-paths-2:
    executorLabel: exec-create-dataset-paths-2
    inputDefinitions:
      parameters:
        input_dfs:
          defaultValue: {}
          isOptional: true
          parameterType: STRUCT
        name:
          parameterType: STRING
    outputDefinitions:
      parameters:
        Output:
          parameterType: STRUCT
  comp-create-dataset-paths-3:
    executorLabel: exec-create-dataset-paths-3
    inputDefinitions:
      parameters:
        input_dfs:
          defaultValue: {}
          isOptional: true
          parameterType: STRUCT
        name:
          parameterType: STRING
    outputDefinitions:
      parameters:
        Output:
          parameterType: STRUCT
  comp-process-datasets:
    executorLabel: exec-process-datasets
    inputDefinitions:
      parameters:
        dataset_artifact:
          parameterType: STRUCT
        name:
          parameterType: STRING
  comp-process-datasets-2:
    executorLabel: exec-process-datasets-2
    inputDefinitions:
      parameters:
        dataset_artifact:
          parameterType: STRUCT
        name:
          parameterType: STRING
  comp-process-datasets-3:
    executorLabel: exec-process-datasets-3
    inputDefinitions:
      parameters:
        dataset_artifact:
          parameterType: STRUCT
        name:
          parameterType: STRING
deploymentSpec:
  executors:
    exec-create-dataset-paths:
      container:
        args:
          - '--executor_input'
          - '{{$}}'
          - '--function_to_execute'
          - create_dataset_paths
        command:
          - sh
          - '-c'
          - >

            if ! [ -x "$(command -v pip)" ]; then
                python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip
            fi


            PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet
            --no-warn-script-location 'kfp==2.9.0' '--no-deps'
            'typing-extensions>=3.7.4,<5; python_version<"3.9"' && "$0" "$@"
          - sh
          - '-ec'
          - >
            program_path=$(mktemp -d)


            printf "%s" "$0" > "$program_path/ephemeral_component.py"

            _KFP_RUNTIME=true python3 -m
            kfp.dsl.executor_main                        
            --component_module_path                        
            "$program_path/ephemeral_component.py"                         "$@"
          - |+

            import kfp
            from kfp import dsl
            from kfp.dsl import *
            from typing import *

            def create_dataset_paths(name:str, input_dfs:dict={})->dict:

                if input_dfs:

                    print(input_dfs.items())

                dataset_paths = {
                    'wine': 's3://my-bucket/datasets/wine_dataset.csv',
                    'iris': 's3://my-bucket/datasets/iris_dataset.csv',
                    'cancer': 's3://my-bucket/datasets/cancer_dataset.csv'
                }

                return dataset_paths

        image: 'python:3.9'
    exec-create-dataset-paths-2:
      container:
        args:
          - '--executor_input'
          - '{{$}}'
          - '--function_to_execute'
          - create_dataset_paths
        command:
          - sh
          - '-c'
          - >

            if ! [ -x "$(command -v pip)" ]; then
                python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip
            fi


            PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet
            --no-warn-script-location 'kfp==2.9.0' '--no-deps'
            'typing-extensions>=3.7.4,<5; python_version<"3.9"' && "$0" "$@"
          - sh
          - '-ec'
          - >
            program_path=$(mktemp -d)


            printf "%s" "$0" > "$program_path/ephemeral_component.py"

            _KFP_RUNTIME=true python3 -m
            kfp.dsl.executor_main                        
            --component_module_path                        
            "$program_path/ephemeral_component.py"                         "$@"
          - |+

            import kfp
            from kfp import dsl
            from kfp.dsl import *
            from typing import *

            def create_dataset_paths(name:str, input_dfs:dict={})->dict:

                if input_dfs:

                    print(input_dfs.items())

                dataset_paths = {
                    'wine': 's3://my-bucket/datasets/wine_dataset.csv',
                    'iris': 's3://my-bucket/datasets/iris_dataset.csv',
                    'cancer': 's3://my-bucket/datasets/cancer_dataset.csv'
                }

                return dataset_paths

        image: 'python:3.9'
    exec-create-dataset-paths-3:
      container:
        args:
          - '--executor_input'
          - '{{$}}'
          - '--function_to_execute'
          - create_dataset_paths
        command:
          - sh
          - '-c'
          - >

            if ! [ -x "$(command -v pip)" ]; then
                python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip
            fi


            PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet
            --no-warn-script-location 'kfp==2.9.0' '--no-deps'
            'typing-extensions>=3.7.4,<5; python_version<"3.9"' && "$0" "$@"
          - sh
          - '-ec'
          - >
            program_path=$(mktemp -d)


            printf "%s" "$0" > "$program_path/ephemeral_component.py"

            _KFP_RUNTIME=true python3 -m
            kfp.dsl.executor_main                        
            --component_module_path                        
            "$program_path/ephemeral_component.py"                         "$@"
          - |+

            import kfp
            from kfp import dsl
            from kfp.dsl import *
            from typing import *

            def create_dataset_paths(name:str, input_dfs:dict={})->dict:

                if input_dfs:

                    print(input_dfs.items())

                dataset_paths = {
                    'wine': 's3://my-bucket/datasets/wine_dataset.csv',
                    'iris': 's3://my-bucket/datasets/iris_dataset.csv',
                    'cancer': 's3://my-bucket/datasets/cancer_dataset.csv'
                }

                return dataset_paths

        image: 'python:3.9'
    exec-process-datasets:
      container:
        args:
          - '--executor_input'
          - '{{$}}'
          - '--function_to_execute'
          - process_datasets
        command:
          - sh
          - '-c'
          - >

            if ! [ -x "$(command -v pip)" ]; then
                python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip
            fi


            PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet
            --no-warn-script-location 'kfp==2.9.0' '--no-deps'
            'typing-extensions>=3.7.4,<5; python_version<"3.9"' && "$0" "$@"
          - sh
          - '-ec'
          - >
            program_path=$(mktemp -d)


            printf "%s" "$0" > "$program_path/ephemeral_component.py"

            _KFP_RUNTIME=true python3 -m
            kfp.dsl.executor_main                        
            --component_module_path                        
            "$program_path/ephemeral_component.py"                         "$@"
          - |+

            import kfp
            from kfp import dsl
            from kfp.dsl import *
            from typing import *

            def process_datasets(name:str, dataset_artifact: dict):

                for name, path in dataset_artifact.items():
                    print(f"Looking at {name} dataset at S3 path: {path}")

        image: 'python:3.9'
    exec-process-datasets-2:
      container:
        args:
          - '--executor_input'
          - '{{$}}'
          - '--function_to_execute'
          - process_datasets
        command:
          - sh
          - '-c'
          - >

            if ! [ -x "$(command -v pip)" ]; then
                python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip
            fi


            PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet
            --no-warn-script-location 'kfp==2.9.0' '--no-deps'
            'typing-extensions>=3.7.4,<5; python_version<"3.9"' && "$0" "$@"
          - sh
          - '-ec'
          - >
            program_path=$(mktemp -d)


            printf "%s" "$0" > "$program_path/ephemeral_component.py"

            _KFP_RUNTIME=true python3 -m
            kfp.dsl.executor_main                        
            --component_module_path                        
            "$program_path/ephemeral_component.py"                         "$@"
          - |+

            import kfp
            from kfp import dsl
            from kfp.dsl import *
            from typing import *

            def process_datasets(name:str, dataset_artifact: dict):

                for name, path in dataset_artifact.items():
                    print(f"Looking at {name} dataset at S3 path: {path}")

        image: 'python:3.9'
    exec-process-datasets-3:
      container:
        args:
          - '--executor_input'
          - '{{$}}'
          - '--function_to_execute'
          - process_datasets
        command:
          - sh
          - '-c'
          - >

            if ! [ -x "$(command -v pip)" ]; then
                python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip
            fi


            PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet
            --no-warn-script-location 'kfp==2.9.0' '--no-deps'
            'typing-extensions>=3.7.4,<5; python_version<"3.9"' && "$0" "$@"
          - sh
          - '-ec'
          - >
            program_path=$(mktemp -d)


            printf "%s" "$0" > "$program_path/ephemeral_component.py"

            _KFP_RUNTIME=true python3 -m
            kfp.dsl.executor_main                        
            --component_module_path                        
            "$program_path/ephemeral_component.py"                         "$@"
          - |+

            import kfp
            from kfp import dsl
            from kfp.dsl import *
            from typing import *

            def process_datasets(name:str, dataset_artifact: dict):

                for name, path in dataset_artifact.items():
                    print(f"Looking at {name} dataset at S3 path: {path}")

        image: 'python:3.9'
pipelineInfo:
  name: dynamic-pipeline-example
root:
  dag:
    tasks:
      create-dataset-paths:
        cachingOptions: {}
        componentRef:
          name: comp-create-dataset-paths
        inputs:
          parameters:
            name:
              runtimeValue:
                constant: orange
        taskInfo:
          name: create-dataset-paths
      create-dataset-paths-2:
        cachingOptions: {}
        componentRef:
          name: comp-create-dataset-paths-2
        dependentTasks:
          - create-dataset-paths
        inputs:
          parameters:
            input_dfs:
              taskOutputParameter:
                outputParameterKey: Output
                producerTask: create-dataset-paths
            name:
              runtimeValue:
                constant: banana
        taskInfo:
          name: create-dataset-paths-2
      create-dataset-paths-3:
        cachingOptions: {}
        componentRef:
          name: comp-create-dataset-paths-3
        dependentTasks:
          - create-dataset-paths
          - create-dataset-paths-2
        inputs:
          parameters:
            input_dfs:
              taskOutputParameter:
                outputParameterKey: Output
                producerTask: create-dataset-paths
            name:
              runtimeValue:
                constant: apple
        taskInfo:
          name: create-dataset-paths-3
      process-datasets:
        cachingOptions: {}
        componentRef:
          name: comp-process-datasets
        dependentTasks:
          - create-dataset-paths
        inputs:
          parameters:
            dataset_artifact:
              taskOutputParameter:
                outputParameterKey: Output
                producerTask: create-dataset-paths
            name:
              runtimeValue:
                constant: orange
        taskInfo:
          name: process-datasets
      process-datasets-2:
        cachingOptions: {}
        componentRef:
          name: comp-process-datasets-2
        dependentTasks:
          - create-dataset-paths-2
        inputs:
          parameters:
            dataset_artifact:
              taskOutputParameter:
                outputParameterKey: Output
                producerTask: create-dataset-paths-2
            name:
              runtimeValue:
                constant: banana
        taskInfo:
          name: process-datasets-2
      process-datasets-3:
        cachingOptions: {}
        componentRef:
          name: comp-process-datasets-3
        dependentTasks:
          - create-dataset-paths-3
        inputs:
          parameters:
            dataset_artifact:
              taskOutputParameter:
                outputParameterKey: Output
                producerTask: create-dataset-paths-3
            name:
              runtimeValue:
                constant: apple
        taskInfo:
          name: process-datasets-3
schemaVersion: 2.1.0
sdkVersion: kfp-2.9.0
```

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
