### PR TITLE
feat(sdk): Allow disabling default caching via a CLI flag and env var

### DIFF
--- a/sdk/python/kfp/cli/compile_.py
+++ b/sdk/python/kfp/cli/compile_.py
@@ -26,6 +26,7 @@ from kfp.dsl import base_component
 from kfp.dsl import graph_component
 from kfp.dsl.pipeline_context import Pipeline
 
+
 def is_pipeline_func(func: Callable) -> bool:
     """Checks if a function is a pipeline function.
 

--- a/sdk/python/kfp/cli/compile_.py
+++ b/sdk/python/kfp/cli/compile_.py
@@ -24,7 +24,7 @@ import click
 from kfp import compiler
 from kfp.dsl import base_component
 from kfp.dsl import graph_component
-
+from kfp.dsl.pipeline_context import Pipeline
 
 def is_pipeline_func(func: Callable) -> bool:
     """Checks if a function is a pipeline function.
@@ -133,14 +133,23 @@ def parse_parameters(parameters: Optional[str]) -> Dict:
     is_flag=True,
     default=False,
     help='Whether to disable type checking.')
+@click.option(
+    '--disable-execution-caching-by-default',
+    is_flag=True,
+    default=False,
+    envvar='KFP_DISABLE_EXECUTION_CACHING_BY_DEFAULT',
+    help='Whether to disable execution caching by default.')
 def compile_(
     py: str,
     output: str,
     function_name: Optional[str] = None,
     pipeline_parameters: Optional[str] = None,
     disable_type_check: bool = False,
+    disable_execution_caching_by_default: bool = False,
 ) -> None:
     """Compiles a pipeline or component written in a .py file."""
+
+    Pipeline._execution_caching_default = not disable_execution_caching_by_default
     pipeline_func = collect_pipeline_or_component_func(
         python_file=py, function_name=function_name)
     parsed_parameters = parse_parameters(parameters=pipeline_parameters)

--- a/sdk/python/kfp/dsl/base_component.py
+++ b/sdk/python/kfp/dsl/base_component.py
@@ -103,7 +103,8 @@ class BaseComponent(abc.ABC):
             args=task_inputs,
             execute_locally=pipeline_context.Pipeline.get_default_pipeline() is
             None,
-            execution_caching_default=pipeline_context.Pipeline.get_execution_caching_default(),
+            execution_caching_default=pipeline_context.Pipeline
+            .get_execution_caching_default(),
         )
 
     @property

--- a/sdk/python/kfp/dsl/base_component.py
+++ b/sdk/python/kfp/dsl/base_component.py
@@ -103,6 +103,7 @@ class BaseComponent(abc.ABC):
             args=task_inputs,
             execute_locally=pipeline_context.Pipeline.get_default_pipeline() is
             None,
+            execution_caching_default=pipeline_context.Pipeline.get_execution_caching_default(),
         )
 
     @property

--- a/sdk/python/kfp/dsl/pipeline_context.py
+++ b/sdk/python/kfp/dsl/pipeline_context.py
@@ -14,14 +14,13 @@
 """Definition for Pipeline."""
 
 import functools
+import os
 from typing import Callable, Optional
 
 from kfp.dsl import component_factory
 from kfp.dsl import pipeline_task
 from kfp.dsl import tasks_group
 from kfp.dsl import utils
-
-import os
 
 
 def pipeline(func: Optional[Callable] = None,
@@ -107,7 +106,9 @@ class Pipeline:
     # or the env var KFP_DISABLE_EXECUTION_CACHING_BY_DEFAULT.
     # align with click's treatment of env vars for boolean flags.
     # per click doc, "1", "true", "t", "yes", "y", and "on" are all converted to True
-    _execution_caching_default = not str(os.getenv('KFP_DISABLE_EXECUTION_CACHING_BY_DEFAULT')).strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+    _execution_caching_default = not str(
+        os.getenv('KFP_DISABLE_EXECUTION_CACHING_BY_DEFAULT')).strip().lower(
+        ) in {'1', 'true', 't', 'yes', 'y', 'on'}
 
     @staticmethod
     def get_execution_caching_default():

--- a/sdk/python/kfp/dsl/pipeline_context.py
+++ b/sdk/python/kfp/dsl/pipeline_context.py
@@ -21,6 +21,8 @@ from kfp.dsl import pipeline_task
 from kfp.dsl import tasks_group
 from kfp.dsl import utils
 
+import os
+
 
 def pipeline(func: Optional[Callable] = None,
              *,
@@ -100,6 +102,17 @@ class Pipeline:
     def get_default_pipeline():
         """Gets the default pipeline."""
         return Pipeline._default_pipeline
+
+    # _execution_caching_default can be disabled via the click option --disable-execution-caching-by-default
+    # or the env var KFP_DISABLE_EXECUTION_CACHING_BY_DEFAULT.
+    # align with click's treatment of env vars for boolean flags.
+    # per click doc, "1", "true", "t", "yes", "y", and "on" are all converted to True
+    _execution_caching_default = not str(os.getenv('KFP_DISABLE_EXECUTION_CACHING_BY_DEFAULT')).strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+    @staticmethod
+    def get_execution_caching_default():
+        """Gets the default execution caching."""
+        return Pipeline._execution_caching_default
 
     def __init__(self, name: str):
         """Creates a new instance of Pipeline.

--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -98,6 +98,7 @@ class PipelineTask:
         component_spec: structures.ComponentSpec,
         args: Dict[str, Any],
         execute_locally: bool = False,
+        execution_caching_default: bool = True,
     ) -> None:
         """Initilizes a PipelineTask instance."""
         # import within __init__ to avoid circular import
@@ -130,7 +131,7 @@ class PipelineTask:
             inputs=dict(args.items()),
             dependent_tasks=[],
             component_ref=component_spec.name,
-            enable_caching=True)
+            enable_caching=execution_caching_default)
         self._run_after: List[str] = []
 
         self.importer_spec = None


### PR DESCRIPTION
**Description of your changes:**
Allow setting a default of execution caching disabled via a compiler CLI flag and env var.
Resolves https://github.com/kubeflow/pipelines/issues/11092

#### Key Changes:

CLI Update (kfp dsl compile):\
A new flag `--disable-execution-caching-by-default` is added. When set, this flag disables caching for all pipeline tasks by default. Behavior specified in pipeline code still takes precedence.

A corresponding Environment Variable `KFP_DISABLE_EXECUTION_CACHING_BY_DEFAULT` is added as well.

#### Details:

By default, tasks default to caching enabled if the pipeline code doesn't specify a desired behavior via set_caching_options. For example:
```
@dsl.pipeline(name='my-pipeline')
def my_pipeline():
    task_1 = create_dataset()
    task_2 = create_dataset()
    task_1.set_caching_options(False)
```
In this example, task 1 won't try to use the cache, but task 2 will, even though the author didn't specify anything about task 2. The resulting pipeline spec will look like this:
```
root:
  dag:
    tasks:
      task-1:
        cachingOptions: {}
      task-2:
        cachingOptions:
          enableCache: true
```
This PR enhances the DSL compiler to allow the user to override that default behavior via a command line flag. This change is done:

-   in an additive way, using an optional feature flag

-   in a way that doesn't alter the DSL or pipeline spec interfaces

-   In a way that doesn't change the default behavior for those who prefer the default of caching enabled

After this change, this command will continue to result in the default behavior:
```
kfp dsl compile --py my_pipeline.py --output my_pipeline.yaml
```
Whereas this command will cause tasks to default to caching disabled if no desired caching behavior is specified in code:
```
kfp dsl compile --py my_pipeline.py --output my_pipeline.yaml --disable-execution-caching-by-default
```
For example, this pipeline compiled with `--disable-execution-caching-by-default`
```
@dsl.pipeline(name='my-pipeline')
def my_pipeline():
    task_1 = create_dataset()
    task_2 = create_dataset()
    task_1.set_caching_options(False)
```
would then result in both tasks having caching disabled:
```
root:
  dag:
    tasks:
      task-1:
        cachingOptions: {}
      task-2:
        cachingOptions: {}
```
even though nothing was specified about task_2 in the code.

#### Usage

CLI flag for dsl compile.

A new flag `--disable-execution-caching-by-default` is added. When set, this flag disables caching for all pipeline tasks by default.

Example:
```
kfp dsl compile --py my_pipeline.py --output my_pipeline.yaml --disable-execution-caching-by-default
```
Environment Variable `KFP_DISABLE_EXECUTION_CACHING_BY_DEFAULT`. 

You can also set the default caching behavior by using the environment variable. When set to true, 1, or other truthy values, it will disable execution caching by default for all pipelines. When set to false or when absent, the default of caching enabled remains.\
Example:
```
KFP_DISABLE_EXECUTION_CACHING_BY_DEFAULT=true \
kfp dsl compile --py my_pipeline.py --output my_pipeline.yaml
```
This environment variable also works for `Compiler().compile()`.

Given the following pipeline file my_pipeline.py:
```
ffrom kfp import dsl
from kfp.compiler import Compiler

@dsl.component
def create_dataset():
    pass

@dsl.pipeline(name='my-pipeline')
def my_pipeline():
    task_1 = create_dataset()
    task_2 = create_dataset()
    task_1.set_caching_options(False)

Compiler().compile(
    pipeline_func=my_pipeline,
    package_path='my_pipeline.yaml',
)
```
Executing this
```
KFP_DISABLE_EXECUTION_CACHING_BY_DEFAULT=true \
python my_pipeline.py
```
will result in task_2 having caching disabled.

This PR is made in collaboration with @gregsheremeta. Thank you, Greg for your contributions!

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
