### PR TITLE
fix(workflows): patch reversed launcher / driver in workflow matrix

### DIFF
--- a/.github/workflows/image-builds.yml
+++ b/.github/workflows/image-builds.yml
@@ -88,9 +88,9 @@ jobs:
           - image: kfp-visualization-server
             dockerfile: backend/Dockerfile.visualization
           - image: kfp-launcher
-            dockerfile: backend/Dockerfile.driver
-          - image: kfp-driver
             dockerfile: backend/Dockerfile.launcher
+          - image: kfp-driver
+            dockerfile: backend/Dockerfile.driver
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
**Description of your changes:** Driver / image docker file and labels were reversed in recently added workflow. This is patched here.