### PR TITLE
test: Integrate Git Hub Action Results into Tide

### DIFF
--- a/.github/workflows/add-ci-passed-label.yml
+++ b/.github/workflows/add-ci-passed-label.yml
@@ -1,0 +1,84 @@
+# This workflow adds the 'ci-passed' label to a pull request once the 'CI Check' workflow completes successfully.
+# Resets the 'ci-passed' label status when a pull request is synchronized or reopened, 
+# indicating that changes have been pushed and CI needs to rerun.
+name: Add CI Passed Label
+
+on:
+  workflow_run:
+    workflows: ["CI Check"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  checks: read
+  actions: read
+
+jobs:
+  fetch_data:
+    name: Fetch workflow payload
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    outputs:
+      pr_number: ${{ steps.extract.outputs.pr_number }}
+      event_action: ${{ steps.extract.outputs.event_action }}
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0        
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id}},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      
+      - name: Unzip artifact
+        run: unzip pr.zip
+
+      - name: Extract PR information
+        id: extract
+        run: |
+          pr_number=$(cat ./pr_number)
+          event_action=$(cat ./event_action)
+          echo "pr_number=${pr_number}" >> $GITHUB_OUTPUT
+          echo "event_action=${event_action}" >> $GITHUB_OUTPUT
+
+  add_ci_passed_label:
+    name: Add 'ci-passed' label
+    runs-on: ubuntu-latest    
+    needs: fetch_data
+    steps:
+      - name: Add 'ci-passed' label
+        run: |
+          echo "Adding 'ci-passed' label to PR #${{ needs.fetch_data.outputs.pr_number }}"
+          gh pr edit ${{ needs.fetch_data.outputs.pr_number }} --add-label "ci-passed" --repo $GITHUB_REPOSITORY
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  reset_ci_passed_label:
+    name: Reset 'ci-passed' label on PR Synchronization
+    runs-on: ubuntu-latest
+    needs: fetch_data
+    steps:
+      - name: Check and reset label
+        run: |
+          if [[ "${{ needs.fetch_data.outputs.event_action }}" == "synchronize" || "${{ needs.fetch_data.outputs.event_action }}" == "reopened" ]]; then
+            echo "Resetting 'ci-passed' label as changes were pushed (event: ${{ needs.fetch_data.outputs.event_action }})."
+            gh pr edit ${{ needs.fetch_data.outputs.pr_number }} --remove-label "ci-passed" --repo $GITHUB_REPOSITORY || echo "Label not present"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,0 +1,32 @@
+# This workflow checks if all CI checks have passed by polling every 5 minutes for a total of 7 attempts.
+name: CI Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check_ci_status:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read  
+      pull-requests: write        
+    steps:    
+      - name: Check if all CI checks passed
+        uses: wechuli/allcheckspassed@0b68b3b7d92e595bcbdea0c860d05605720cf479
+        with:                                 
+          delay: '5'
+          retries: '7'
+          polling_interval: '5'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Save PR payload
+        shell: bash
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.pull_request.number }} >> ./pr/pr_number          
+          echo ${{ github.event.action }} >> ./pr/event_action
+      - uses: actions/upload-artifact@v3.1.0
+        with:
+          name: pr
+          path: pr/


### PR DESCRIPTION
**Description of your changes:**

-  Introduced a GitHub Action workflow to validate the successful completion of all CI checks.
-  Automatically adds a ```ci-passed``` label once all CI checks have passed.
-  Removes the ```ci-passed``` label when the pull request is either synchronized or reopened.

**PR to update GoogleCloudPlatform/oss-test-infra**
https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2392

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
