### PR TITLE
feat(workflows): use built images in Github workflows

### DIFF
--- a/scripts/deploy/github/build-images.sh
+++ b/scripts/deploy/github/build-images.sh
@@ -46,6 +46,19 @@ then
   exit $EXIT_CODE
 fi
 
+docker build -q -t "${REGISTRY}/driver:${TAG}" -f backend/Dockerfile.driver . && docker push "${REGISTRY}/driver:${TAG}" || EXIT_CODE=$?
+if [[ $EXIT_CODE -ne 0 ]]
+then
+  echo "Failed to build driver image."
+  exit $EXIT_CODE
+fi
+
+docker build -q -t "${REGISTRY}/launcher:${TAG}" -f backend/Dockerfile.launcher . && docker push "${REGISTRY}/launcher:${TAG}" || EXIT_CODE=$?
+if [[ $EXIT_CODE -ne 0 ]]
+then
+  echo "Failed to build launcher image."
+  exit $EXIT_CODE
+fi
 
 # clean up intermittent build caches to free up disk space
 docker system prune -a -f

--- a/scripts/deploy/github/deploy-kfp.sh
+++ b/scripts/deploy/github/deploy-kfp.sh
@@ -44,7 +44,7 @@ fi
 echo "Patching deployments to use built docker images..."
 # Patch API server
 kubectl patch deployment ml-pipeline -p '{"spec": {"template": {"spec": {"containers": [{"name": "ml-pipeline-api-server", "image": "kind-registry:5000/apiserver"}]}}}}' -n kubeflow
-# Patch persistance agent
+# Patch persistence agent
 kubectl patch deployment.apps/ml-pipeline-persistenceagent -p '{"spec": {"template": {"spec": {"containers": [{"name": "ml-pipeline-persistenceagent", "image": "kind-registry:5000/persistenceagent"}]}}}}' -n kubeflow
 # Patch scheduled workflow
 kubectl patch deployment.apps/ml-pipeline-scheduledworkflow -p '{"spec": {"template": {"spec": {"containers": [{"name": "ml-pipeline-scheduledworkflow", "image": "kind-registry:5000/scheduledworkflow"}]}}}}' -n kubeflow

--- a/scripts/deploy/github/deploy-kfp.sh
+++ b/scripts/deploy/github/deploy-kfp.sh
@@ -41,6 +41,14 @@ then
   exit 1
 fi
 
+echo "Patching deployments to use built docker images..."
+# Patch API server
+kubectl patch deployment ml-pipeline -p '{"spec": {"template": {"spec": {"containers": [{"name": "ml-pipeline-api-server", "image": "kind-registry:5000/apiserver"}]}}}}' -n kubeflow
+# Patch persistance agent
+kubectl patch deployment.apps/ml-pipeline-persistenceagent -p '{"spec": {"template": {"spec": {"containers": [{"name": "ml-pipeline-persistenceagent", "image": "kind-registry:5000/persistenceagent"}]}}}}' -n kubeflow
+# Patch scheduled workflow
+kubectl patch deployment.apps/ml-pipeline-scheduledworkflow -p '{"spec": {"template": {"spec": {"containers": [{"name": "ml-pipeline-scheduledworkflow", "image": "kind-registry:5000/scheduledworkflow"}]}}}}' -n kubeflow
+
 # Check if all pods are running - (10 minutes)
 wait_for_pods || EXIT_CODE=$?
 if [[ $EXIT_CODE -ne 0 ]]

--- a/scripts/deploy/github/deploy-kfp.sh
+++ b/scripts/deploy/github/deploy-kfp.sh
@@ -49,6 +49,10 @@ kubectl patch deployment.apps/ml-pipeline-persistenceagent -p '{"spec": {"templa
 # Patch scheduled workflow
 kubectl patch deployment.apps/ml-pipeline-scheduledworkflow -p '{"spec": {"template": {"spec": {"containers": [{"name": "ml-pipeline-scheduledworkflow", "image": "kind-registry:5000/scheduledworkflow"}]}}}}' -n kubeflow
 
+# Update environment variables to override driver / launcher
+kubectl set env deployments/ml-pipeline V2_DRIVER_IMAGE=kind-registry:5000/driver -n kubeflow
+kubectl set env deployments/ml-pipeline V2_LAUNCHER_IMAGE=kind-registry:5000/launcher -n kubeflow
+
 # Check if all pods are running - (10 minutes)
 wait_for_pods || EXIT_CODE=$?
 if [[ $EXIT_CODE -ne 0 ]]

--- a/scripts/deploy/github/kfp-readiness/wait_for_pods.py
+++ b/scripts/deploy/github/kfp-readiness/wait_for_pods.py
@@ -30,9 +30,9 @@ def get_pod_statuses():
                 ready += 1
             if status.state.waiting is not None:
                 if status.state.waiting.message is not None:
-                    waiting_messages.append(f'CONTAINER: {status.name} - {status.state.waiting.reason}: {status.state.waiting.message}')
+                    waiting_messages.append(f'Waiting on Container: {status.name} - {status.state.waiting.reason}: {status.state.waiting.message}')
                 else:
-                    waiting_messages.append(f'CONTAINER: {status.name} - {status.state.waiting.reason}')
+                    waiting_messages.append(f'Waiting on Container: {status.name} - {status.state.waiting.reason}')
         statuses[pod_name] = (pod_status, ready, total, waiting_messages)
     return statuses
 


### PR DESCRIPTION
### Description of your changes:

This PR is an MVP which gets the images built and deployments patched to use those images. **The PR is intended to be iterated on with more formalization / improvement in the future** while also getting testing working in the meantime. This addition is related to #11239, but also makes changes related to `apiserver`, `persistenceagent`, and `scheduledworkflow` images, more discussion will be added to that issue.

The PR primarily modifies the scripts in `scripts/deploy/github/` which are used by the [GitHub action here](https://github.com/CarterFendley/pipelines/blob/627a3dbb7e5f0758877fb3b4681e59a88fe3b840/.github/actions/kfp-cluster/action.yml). The `kubectl patch` command is used to patch deployment images, and `kubectl set env` to modify environment variables.

**Other changes**

Some minor changes were made to the [wait_for_pods.py](https://github.com/CarterFendley/pipelines/blob/627a3dbb7e5f0758877fb3b4681e59a88fe3b840/scripts/deploy/github/kfp-readiness/wait_for_pods.py) tooling, to display more information in cases where there are errors. See the screenshot below of a case in which this helped me while working on this PR :P

![Screenshot 2024-10-10 at 2 18 13 PM](https://github.com/user-attachments/assets/41100af7-0264-4ecf-aaec-50868f620e94)

### Checklist:
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->

### Other comments

Since we are building more images, this does slow down the workflows a bit (`~17min` -> `~22min`), will try to think if we can speed that up a little because 22 minute waits are painful.
