### PR TITLE
test: Resolve ci-check failures in long-running CI tests

### DIFF
--- a/.github/workflows/add-ci-passed-label.yml
+++ b/.github/workflows/add-ci-passed-label.yml
@@ -56,19 +56,7 @@ jobs:
           event_action=$(cat ./event_action)
           echo "pr_number=${pr_number}" >> $GITHUB_OUTPUT
           echo "event_action=${event_action}" >> $GITHUB_OUTPUT
-
-  add_ci_passed_label:
-    name: Add 'ci-passed' label
-    runs-on: ubuntu-latest    
-    needs: fetch_data
-    steps:
-      - name: Add 'ci-passed' label
-        run: |
-          echo "Adding 'ci-passed' label to PR #${{ needs.fetch_data.outputs.pr_number }}"
-          gh pr edit ${{ needs.fetch_data.outputs.pr_number }} --add-label "ci-passed" --repo $GITHUB_REPOSITORY
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+          
   reset_ci_passed_label:
     name: Reset 'ci-passed' label on PR Synchronization
     runs-on: ubuntu-latest
@@ -80,5 +68,17 @@ jobs:
             echo "Resetting 'ci-passed' label as changes were pushed (event: ${{ needs.fetch_data.outputs.event_action }})."
             gh pr edit ${{ needs.fetch_data.outputs.pr_number }} --remove-label "ci-passed" --repo $GITHUB_REPOSITORY || echo "Label not present"
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  add_ci_passed_label:
+    name: Add 'ci-passed' label
+    runs-on: ubuntu-latest    
+    needs: fetch_data
+    steps:
+      - name: Add 'ci-passed' label
+        run: |
+          echo "Adding 'ci-passed' label to PR #${{ needs.fetch_data.outputs.pr_number }}"
+          gh pr edit ${{ needs.fetch_data.outputs.pr_number }} --add-label "ci-passed" --repo $GITHUB_REPOSITORY
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,9 +1,9 @@
-# This workflow checks if all CI checks have passed by polling every 5 minutes for a total of 7 attempts.
+# This workflow checks if all CI checks have passed by polling every 5 minutes for a total of 8 attempts.
 name: CI Check
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   check_ci_status:
@@ -11,12 +11,32 @@ jobs:
     permissions:
       checks: read  
       pull-requests: write        
-    steps:    
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Check for 'needs-ok-to-test' and 'ok-to-test' labels
+        id: label_check
+        run: |          
+          LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')          
+          if echo "$LABELS" | grep -q 'needs-ok-to-test'; then
+            echo "Label 'needs-ok-to-test' found. Skipping the workflow."
+            exit 0
+          fi                    
+          if echo "$LABELS" | grep -q 'ok-to-test'; then
+            echo "Label 'ok-to-test' found. Continuing the workflow."
+          else
+            echo "Label 'ok-to-test' not found. Skipping the workflow."
+            exit 0
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check if all CI checks passed
         uses: wechuli/allcheckspassed@0b68b3b7d92e595bcbdea0c860d05605720cf479
         with:                                 
           delay: '5'
-          retries: '7'
+          retries: '8'
           polling_interval: '5'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
-  Increased the retry count to support long-running tests.
- Added a label check to ensure the ci-check runs only when the ```needs-ok-to-test``` label is absent.
- The workflow is triggered when the ```ok-to-test``` label is present.