### PR TITLE
WIP: test: Re-enable KFP Dockerfile-CLI component SDK unit test

### DIFF
--- a/sdk/python/kfp/cli/component_test.py
+++ b/sdk/python/kfp/cli/component_test.py
@@ -579,9 +579,6 @@ class Test(unittest.TestCase):
                 COPY . .
                 '''))
 
-    @unittest.skip(
-        "Skipping this test as it's failing. Refer to https://github.com/kubeflow/pipelines/issues/11038"
-    )
     def test_dockerfile_can_contain_custom_kfp_package(self):
         component = _make_component(
             func_name='train', target_image='custom-image')


### PR DESCRIPTION
Removed the skip unit test decorator that was previously added to bypass the test due to failure (referencing issue #11038).

The issue reported in #11038 was caused due to the Dockerfile referencing to Python 3.7. With the Python version updated to 3.9 (done as part of [this commit](https://github.com/kubeflow/pipelines/commit/123ed1eb30c26290546429ffce6360d0910b8eee#diff-dd6f2caaca60c10dc9a15fddf7c7e844e853a9c6a8917f036b304be71fbf376d)), the test now passes consistently. This commit re-enables the test to ensure proper validation of Dockerfile creation and KFP package.

**Description of your changes:**


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
