### PR TITLE
fix(ui): turn off GKE metadata by default

### DIFF
--- a/frontend/server/configs.ts
+++ b/frontend/server/configs.ts
@@ -101,7 +101,7 @@ export function loadConfigs(argv: string[], env: ProcessEnv): UIConfigs {
     /** The main container name of a pod where logs are retrieved */
     POD_LOG_CONTAINER_NAME = 'main',
     /** Disables GKE metadata endpoint. */
-    DISABLE_GKE_METADATA = 'false',
+    DISABLE_GKE_METADATA = 'true',
     /** Enable authorization checks for multi user mode. */
     ENABLE_AUTHZ = 'false',
     /** Deployment type. */

--- a/manifests/kustomize/env/gcp/gcp-configurations-patch.yaml
+++ b/manifests/kustomize/env/gcp/gcp-configurations-patch.yaml
@@ -20,3 +20,16 @@ spec:
                 configMapKeyRef:
                   name: pipeline-install-config
                   key: gcsProjectId
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-ui
+spec:
+  template:
+    spec:
+      containers:
+        - name: ml-pipeline-ui
+          env:
+            - name: DISABLE_GKE_METADATA
+              value: 'false'


### PR DESCRIPTION
**Description of your changes:**

Since GKE is only one of many platforms, change the default value of `DISABLE_GKE_METADATA` to `true`. Edit the gcp manifest to override that to `false` on GCP.

Fixes: #11247

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
