### PR TITLE
feat(component): execute in a virtual env

### DIFF
--- a/components/google-cloud/RELEASE.md
+++ b/components/google-cloud/RELEASE.md
@@ -2,6 +2,7 @@
 * Remove default prediction column names in `v1.model_evaluation.regression_component` component to fix pipeline errors when using bigquery data source.
 * Add reservation_affinition support in `v1.create_custom_training_job_from_component`.
 * Deprecate `preview.custom_job` module.
+* Add a new `use_venv` field to the component decorator, enabling the component to run inside a virtual environment.
 
 ## Release 2.17.0
 * Fix Gemini batch prediction support to `v1.model_evaluation.autosxs_pipeline` after output schema change.

--- a/sdk/python/kfp/dsl/component_decorator.py
+++ b/sdk/python/kfp/dsl/component_decorator.py
@@ -28,7 +28,8 @@ def component(func: Optional[Callable] = None,
               output_component_file: Optional[str] = None,
               install_kfp_package: bool = True,
               kfp_package_path: Optional[str] = None,
-              pip_trusted_hosts: Optional[List[str]] = None):
+              pip_trusted_hosts: Optional[List[str]] = None,
+              use_venv: bool = False):
     """Decorator for Python-function based components.
 
     A KFP component can either be a lightweight component or a containerized
@@ -75,6 +76,9 @@ def component(func: Optional[Callable] = None,
             as that used when this component was created. Component authors can
             choose to override this to point to a GitHub pull request or
             other pip-compatible package server.
+        use_venv: Specifies if the component should be executed in a virtual environment.
+            The environment will be created in a temporary directory and will inherit the system site packages.
+            This is useful in restricted environments where most of the system is read-only.
 
     Returns:
         A component task factory that can be used in pipeline definitions.
@@ -116,7 +120,8 @@ def component(func: Optional[Callable] = None,
             output_component_file=output_component_file,
             install_kfp_package=install_kfp_package,
             kfp_package_path=kfp_package_path,
-            pip_trusted_hosts=pip_trusted_hosts)
+            pip_trusted_hosts=pip_trusted_hosts,
+            use_venv=use_venv)
 
     return component_factory.create_component_from_func(
         func,
@@ -127,4 +132,5 @@ def component(func: Optional[Callable] = None,
         output_component_file=output_component_file,
         install_kfp_package=install_kfp_package,
         kfp_package_path=kfp_package_path,
-        pip_trusted_hosts=pip_trusted_hosts)
+        pip_trusted_hosts=pip_trusted_hosts,
+        use_venv=use_venv)

--- a/sdk/python/test_data/components/component_with_pip_install_in_venv.py
+++ b/sdk/python/test_data/components/component_with_pip_install_in_venv.py
@@ -1,0 +1,34 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from kfp.dsl import component
+
+
+@component(
+    pip_index_urls=["https://pypi.org/simple"],
+    packages_to_install=["yapf"],
+    use_venv=True,
+)
+def component_with_pip_install():
+    import yapf
+
+    print(dir(yapf))
+
+
+if __name__ == "__main__":
+    from kfp import compiler
+
+    compiler.Compiler().compile(
+        pipeline_func=component_with_pip_install,
+        package_path=__file__.replace(".py", ".yaml"),
+    )

--- a/sdk/python/test_data/components/component_with_pip_install_in_venv.yaml
+++ b/sdk/python/test_data/components/component_with_pip_install_in_venv.yaml
@@ -1,0 +1,55 @@
+# PIPELINE DEFINITION
+# Name: component-with-pip-install
+components:
+  comp-component-with-pip-install:
+    executorLabel: exec-component-with-pip-install
+deploymentSpec:
+  executors:
+    exec-component-with-pip-install:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - component_with_pip_install
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ \nexport PIP_DISABLE_PIP_VERSION_CHECK=1\ntmp=$(mktemp -d)\npython3 -m\
+          \ venv \"$tmp/venv\" --system-site-packages\n. \"$tmp/venv/bin/activate\"\
+          \n python3 -m pip install --quiet --no-warn-script-location --index-url\
+          \ https://pypi.org/simple --trusted-host https://pypi.org/simple 'kfp==2.9.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
+          \  python3 -m pip install --quiet --no-warn-script-location --index-url\
+          \ https://pypi.org/simple --trusted-host https://pypi.org/simple 'yapf'\
+          \ && \"$0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef component_with_pip_install():\n    import yapf\n\n    print(dir(yapf))\n\
+          \n"
+        image: python:3.9
+pipelineInfo:
+  name: component-with-pip-install
+root:
+  dag:
+    tasks:
+      component-with-pip-install:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-component-with-pip-install
+        taskInfo:
+          name: component-with-pip-install
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.9.0


### PR DESCRIPTION
**Description of your changes:**

This commit introduces the ability to run the component inside a virtual environment, which is particularly useful when the Python system site package directory is read-only, causing pip to fail during the installation of kfp and other dependencies.

To bypass this issue, a writable temporary directory is selected to create a virtual environment that inherits the global system site packages. The entire workflow is then executed from within this virtual environment.

Furthermore, a new field, `use_venv`, has been added to the component decorator, with a default value of `False`.

Signed-off-by: Sébastien Han <seb@redhat.com>

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
