### PR TITLE
feat(SDK): Add SemaphoreKey and MutexName fields to DSL

### DIFF
--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -4336,6 +4336,67 @@ class TestPlatformConfig(unittest.TestCase):
                     pipeline_func=my_pipeline, package_path=output_yaml)
 
 
+class TestPipelineSemaphoreMutex(unittest.TestCase):
+
+    def test_pipeline_with_semaphore(self):
+        """Test that pipeline config correctly sets the semaphore key."""
+        config = PipelineConfig()
+        config.semaphore_key = 'semaphore'
+
+        @dsl.pipeline(pipeline_config=config)
+        def my_pipeline():
+            task = comp()
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            output_yaml = os.path.join(tempdir, 'pipeline.yaml')
+            compiler.Compiler().compile(
+                pipeline_func=my_pipeline, package_path=output_yaml)
+
+            with open(output_yaml, 'r') as f:
+                pipeline_docs = list(yaml.safe_load_all(f))
+
+        platform_spec = None
+        for doc in pipeline_docs:
+            if 'platforms' in doc:
+                platform_spec = doc
+                break
+
+        self.assertIsNotNone(platform_spec,
+                             'No platforms section found in compiled output')
+        kubernetes_spec = platform_spec['platforms']['kubernetes'][
+            'pipelineConfig']
+        self.assertEqual(kubernetes_spec['semaphoreKey'], 'semaphore')
+
+    def test_pipeline_with_mutex(self):
+        """Test that pipeline config correctly sets the mutex name."""
+        config = PipelineConfig()
+        config.mutex_name = 'mutex'
+
+        @dsl.pipeline(pipeline_config=config)
+        def my_pipeline():
+            task = comp()
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            output_yaml = os.path.join(tempdir, 'pipeline.yaml')
+            compiler.Compiler().compile(
+                pipeline_func=my_pipeline, package_path=output_yaml)
+
+            with open(output_yaml, 'r') as f:
+                pipeline_docs = list(yaml.safe_load_all(f))
+
+        platform_spec = None
+        for doc in pipeline_docs:
+            if 'platforms' in doc:
+                platform_spec = doc
+                break
+
+        self.assertIsNotNone(platform_spec,
+                             'No platforms section found in compiled output')
+        kubernetes_spec = platform_spec['platforms']['kubernetes'][
+            'pipelineConfig']
+        self.assertEqual(kubernetes_spec['mutexName'], 'mutex')
+
+
 class ExtractInputOutputDescription(unittest.TestCase):
 
     def test_no_descriptions(self):

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -2242,14 +2242,20 @@ def _write_kubernetes_manifest_to_file(
 
 def _merge_pipeline_config(pipelineConfig: pipeline_config.PipelineConfig,
                            platformSpec: pipeline_spec_pb2.PlatformSpec):
-    workspace = pipelineConfig.workspace
-    if workspace is None:
-        return platformSpec
+    config_dict = {}
 
-    json_format.ParseDict(
-        {'pipelineConfig': {
-            'workspace': workspace.get_workspace(),
-        }}, platformSpec.platforms['kubernetes'])
+    workspace = pipelineConfig.workspace
+    if workspace is not None:
+        config_dict['workspace'] = workspace.get_workspace()
+
+    if pipelineConfig.semaphore_key is not None:
+        config_dict['semaphoreKey'] = pipelineConfig.semaphore_key
+    if pipelineConfig.mutex_name is not None:
+        config_dict['mutexName'] = pipelineConfig.mutex_name
+
+    if config_dict:
+        json_format.ParseDict({'pipelineConfig': config_dict},
+                              platformSpec.platforms['kubernetes'])
 
     return platformSpec
 

--- a/sdk/python/kfp/dsl/pipeline_config.py
+++ b/sdk/python/kfp/dsl/pipeline_config.py
@@ -96,5 +96,57 @@ class WorkspaceConfig:
 class PipelineConfig:
     """PipelineConfig contains pipeline-level config options."""
 
-    def __init__(self, workspace: Optional[WorkspaceConfig] = None):
+    def __init__(self,
+                 workspace: Optional[WorkspaceConfig] = None,
+                 semaphore_key: Optional[str] = None,
+                 mutex_name: Optional[str] = None):
         self.workspace = workspace
+        self._semaphore_key = semaphore_key
+        self._mutex_name = mutex_name
+
+    @property
+    def semaphore_key(self) -> Optional[str]:
+        """Get the semaphore key for controlling pipeline concurrency.
+
+        Returns:
+            Optional[str]: The semaphore key, or None if not set.
+        """
+        return self._semaphore_key
+
+    @semaphore_key.setter
+    def semaphore_key(self, value: str):
+        """Set the semaphore key to control pipeline concurrency.
+
+        Pipelines with the same semaphore key will be limited to a configured maximum
+        number of concurrent executions. This allows you to control resource usage by
+        ensuring that only a specific number of pipelines can run simultaneously.
+
+        Note: A pipeline can use both semaphores and mutexes together. The pipeline
+        will wait until all required locks are available before starting.
+
+        Args:
+            value (str): The semaphore key name for controlling concurrent executions.
+        """
+        self._semaphore_key = (value and value.strip()) or None
+
+    @property
+    def mutex_name(self) -> Optional[str]:
+        """Get the mutex name for exclusive pipeline execution.
+
+        Returns:
+            Optional[str]: The mutex name, or None if not set.
+        """
+        return self._mutex_name
+
+    @mutex_name.setter
+    def mutex_name(self, value: str):
+        """Set the name of the mutex to ensure mutual exclusion.
+
+        Pipelines with the same mutex name will only run one at a time. This ensures
+        exclusive access to shared resources and prevents conflicts when multiple
+        pipelines would otherwise compete for the same resources.
+
+        Args:
+            value (str): Name of the mutex for exclusive pipeline execution.
+        """
+        self._mutex_name = (value and value.strip()) or None


### PR DESCRIPTION
**Description of your changes:**
This PR introduces `semaphoreKey` and `mutexName` fields in `PipelineConfig` to support pipeline-level concurrency controls in KFP SDK.

This PR should be merged only after https://github.com/kubeflow/pipelines/pull/11384 gets merged. 

**Testing instructions**

Create a Python virtualenv and install the SDK and IR YAML API packages locally:
```
$ python -m venv .venv
$ source .venv/bin/activate
$ pip install wheel setuptools protobuf grpcio grpcio-tools
$ pip install -r sdk/python/requirements-dev.txt
$ pip install -e api/v2alpha1/python
$ pip install -e sdk/python
```
Use the [example code](https://gist.github.com/DharmitD/57a04c25e4211ffb9cf8891ddb34e1ce) to compile
```
$ kfp dsl compile --py main.py --output main.yaml
```
You should be able to compile and find the following snippet in the main.yaml file:
```
---
platforms:
  kubernetes:
    pipelineConfig:
      mutexName: mutex
      semaphoreKey: semaphore
```

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
