### PR TITLE
chore: upstream our authorization changes for oauth2-proxy

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/istio-authorization-config.yaml
+++ b/manifests/kustomize/base/installs/multi-user/istio-authorization-config.yaml
@@ -8,10 +8,21 @@ spec:
     matchLabels:
       app: ml-pipeline-ui
   rules:
+  # Allow all requests from the ingress gateway
   - from:
     - source:
-        namespaces:
-        - istio-system
+        principals:
+        - cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account
+
+  # Allow all requests with an `authorization` header but NOT a `kubeflow-userid` header.
+  # This is needed to allow Kubernetes JWTs to be passed to the KFP API.
+  - when:
+    - key: request.headers[authorization]
+      values:
+      - "*"
+    - key: request.headers[kubeflow-userid]
+      notValues:
+      - "*"
 ---
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
@@ -32,7 +43,7 @@ spec:
         - cluster.local/ns/kubeflow/sa/ml-pipeline-scheduledworkflow
         - cluster.local/ns/kubeflow/sa/ml-pipeline-viewer-crd-service-account
         - cluster.local/ns/kubeflow/sa/kubeflow-pipelines-cache
-  # For user workloads, which cannot user http headers for authentication
+  # Allow all requests that dont have a `kubeflow-userid` header.
   - when:
     - key: request.headers[kubeflow-userid]
       notValues: ['*']


### PR DESCRIPTION
This upstreams our changes in https://github.com/kubeflow/manifests/blob/master/apps/pipeline/upstream/base/installs/multi-user/istio-authorization-config.yaml for oauth2-proxy in Kubeflow 1.9/1.9.1. It is an exact copy of the file and must be included in the next KFP release or it will break our synchronization scripts at https://github.com/kubeflow/manifests/blob/master/hack/synchronize-kubeflow-manifests.sh. for the 1.10 release.

closes https://github.com/kubeflow/manifests/issues/2804

@HumairAK @rimolive @kimwnasptd 


