### PR TITLE
feat(backend): Add TTL Strategy in Workflow Spec for Post-Completion Cleanup

### DIFF
--- a/backend/src/v2/compiler/visitor.go
+++ b/backend/src/v2/compiler/visitor.go
@@ -109,7 +109,7 @@ func (state *pipelineDFS) dfs(name string, component *pipelinespec.ComponentSpec
 		}
 
 		// Add kubernetes spec to annotation
-		if state.kubernetesSpec != nil {
+		if state.kubernetesSpec != nil && state.kubernetesSpec.DeploymentSpec != nil {
 			kubernetesExecSpec, ok := state.kubernetesSpec.DeploymentSpec.Executors[executorLabel]
 			if ok {
 				state.visitor.AddKubernetesSpec(name, kubernetesExecSpec)


### PR DESCRIPTION
**Description of your changes:**

- Added the TTLStrategy field in Workflow Spec, configured to use SecondsAfterCompletion.
- Uses the pipeline_ttlseconds variable to define the TTL duration.
- This field automates cleanup of completed workflows.

### **This PR should be merged only after #11758

**Testing Instruxtions:**

* Build the API Server image and push to an image registry
* Upload `main.yaml` file from [here](https://gist.githubusercontent.com/rimolive/fc900c8172e661a470a6890555159f97/raw/3ae92cd319a633859673f327653438a7a32efe2a/main.yaml)
* Check in KFP UI `Pipeline Spec` tab if the following snippet is present:
```
platform_spec:
  platforms:
    kubernetes:
      pipelineConfig:
        pipelineTtl: 60
```
* Create a run and check if TTL configuration is present in `Workflow` CR:
```
$ oc get workflow -o yaml $(oc get workflow --no-headers | awk '{print $1}') | yq .spec.ttlStrategy
secondsAfterCompletion: 60
```

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
