### PR TITLE
feat[frontend]: implement artifact-repositories configmap support

### DIFF
--- a/frontend/server/configs.ts
+++ b/frontend/server/configs.ts
@@ -96,6 +96,13 @@ export function loadConfigs(argv: string[], env: ProcessEnv): UIConfigs {
      * https://github.com/kubeflow/pipelines/blob/7b7918ebf8c30e6ceec99283ef20dbc02fdf6a42/manifests/kustomize/third-party/argo/base/workflow-controller-configmap-patch.yaml#L28
      */
     ARGO_KEYFORMAT = 'artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}',
+    /** Argo Workflows lets you specify a unique artifact repository for each
+     * namespace by adding an appropriately formatted configmap to the namespace
+     * as documented here:
+     * https://argo-workflows.readthedocs.io/en/latest/artifact-repository-ref/.
+     * Use this field to enable this lookup. It defaults to false.
+     */
+    ARGO_ARTIFACT_REPOSITORIES_LOOKUP = 'false',
     /** Should use server API for log streaming? */
     STREAM_LOGS_FROM_SERVER_API = 'false',
     /** The main container name of a pod where logs are retrieved */
@@ -132,6 +139,7 @@ export function loadConfigs(argv: string[], env: ProcessEnv): UIConfigs {
       archiveBucketName: ARGO_ARCHIVE_BUCKETNAME,
       archiveLogs: asBool(ARGO_ARCHIVE_LOGS),
       keyFormat: ARGO_KEYFORMAT,
+      artifactRepositoriesLookup: asBool(ARGO_ARTIFACT_REPOSITORIES_LOOKUP),
     },
     pod: {
       logContainerName: POD_LOG_CONTAINER_NAME,
@@ -259,6 +267,7 @@ export interface ArgoConfigs {
   archiveArtifactory: string;
   archiveBucketName: string;
   keyFormat: string;
+  artifactRepositoriesLookup: boolean;
 }
 export interface ServerConfigs {
   basePath: string;

--- a/frontend/server/handlers/pod-logs.ts
+++ b/frontend/server/handlers/pod-logs.ts
@@ -39,7 +39,13 @@ export function getPodLogsHandler(
   },
   podLogContainerName: string,
 ): Handler {
-  const { archiveLogs, archiveArtifactory, archiveBucketName, keyFormat } = argoOptions;
+  const {
+    archiveLogs,
+    archiveArtifactory,
+    archiveBucketName,
+    keyFormat,
+    artifactRepositoriesLookup,
+  } = argoOptions;
 
   // get pod log from the provided bucket and keyFormat.
   const getPodLogsStreamFromArchive = toGetPodLogsStream(
@@ -47,6 +53,7 @@ export function getPodLogsHandler(
       archiveArtifactory === 'minio' ? artifactsOptions.minio : artifactsOptions.aws,
       archiveBucketName,
       keyFormat,
+      artifactRepositoriesLookup,
     ),
   );
 

--- a/frontend/server/k8s-helper.ts
+++ b/frontend/server/k8s-helper.ts
@@ -19,6 +19,7 @@ import {
   V1DeleteOptions,
   V1Pod,
   V1EventList,
+  V1ConfigMap,
 } from '@kubernetes/client-node';
 import * as crypto from 'crypto-js';
 import * as fs from 'fs';
@@ -273,6 +274,25 @@ export async function getPod(
   } catch (error) {
     const { message, additionalInfo } = await parseError(error);
     const userMessage = `Could not get pod ${podName} in namespace ${podNamespace}: ${message}`;
+    return [undefined, { message: userMessage, additionalInfo }];
+  }
+}
+
+/**
+ * Retrieves a configmap.
+ * @param configMapName name of the configmap
+ * @param configMapNamespace namespace of the configmap
+ */
+export async function getConfigMap(
+  configMapName: string,
+  configMapNamespace: string,
+): Promise<[V1ConfigMap, undefined] | [undefined, K8sError]> {
+  try {
+    const { body } = await k8sV1Client.readNamespacedConfigMap(configMapName, configMapNamespace);
+    return [body, undefined];
+  } catch (error) {
+    const { message, additionalInfo } = await parseError(error);
+    const userMessage = `Could not get configMap ${configMapName} in namespace ${configMapNamespace}: ${message}`;
     return [undefined, { message: userMessage, additionalInfo }];
   }
 }

--- a/frontend/server/workflow-helper.ts
+++ b/frontend/server/workflow-helper.ts
@@ -13,8 +13,9 @@
 // limitations under the License.
 import { PassThrough, Stream } from 'stream';
 import { ClientOptions as MinioClientOptions } from 'minio';
-import { getK8sSecret, getArgoWorkflow, getPodLogs } from './k8s-helper';
+import { getK8sSecret, getArgoWorkflow, getPodLogs, getConfigMap } from './k8s-helper';
 import { createMinioClient, MinioRequestConfig, getObjectStream } from './minio-helper';
+import * as JsYaml from 'js-yaml';
 
 export interface PartialArgoWorkflow {
   status: {
@@ -142,18 +143,78 @@ export function toGetPodLogsStream(
   };
 }
 
+/** PartialArtifactRepositoriesValue is used to deserialize the contents of the
+ * artifact-repositories configmap.
+ */
+interface PartialArtifactRepositoriesValue {
+  s3?: {
+    keyFormat: string;
+  };
+  gcs?: {
+    keyFormat: string;
+  };
+  oss?: {
+    keyFormat: string;
+  };
+  artifactory?: {
+    keyFormat: string;
+  };
+}
+
 /**
- * Returns a MinioRequestConfig with the provided minio options (a MinioRequestConfig
- * object contains the artifact bucket and keys, with the corresponding minio
- * client).
+ * getKeyFormatFromArtifactRepositories attempts to retrieve an
+ * artifact-repositories configmap from a specified namespace. It then parses
+ * the configmap and returns a keyFormat value in its data field.
+ * @param namespace namespace of the configmap
+ */
+export async function getKeyFormatFromArtifactRepositories(
+  namespace: string,
+): Promise<string | undefined> {
+  try {
+    const [configMap] = await getConfigMap('artifact-repositories', namespace);
+    if (configMap === undefined) {
+      // If there is no artifact-repositories configmap, return undefined. The
+      // caller will just use keyFormat as specified in configs.ts.
+      return undefined;
+    }
+    let artifactRepositories = configMap?.data['artifact-repositories'];
+    const artifactRepositoriesValue = JsYaml.safeLoad(
+      artifactRepositories,
+    ) as PartialArtifactRepositoriesValue;
+    if ('s3' in artifactRepositoriesValue) {
+      return artifactRepositoriesValue.s3?.keyFormat;
+    } else if ('gcs' in artifactRepositoriesValue) {
+      return artifactRepositoriesValue.gcs?.keyFormat;
+    } else if ('oss' in artifactRepositoriesValue) {
+      return artifactRepositoriesValue.oss?.keyFormat;
+    } else if ('artifactory' in artifactRepositoriesValue) {
+      return artifactRepositoriesValue.artifactory?.keyFormat;
+    } else {
+      throw new Error(
+        'artifact-repositories configmap missing one of [s3|gcs|oss|artifactory] fields.',
+      );
+    }
+  } catch (error) {
+    console.log(error);
+    return undefined;
+  }
+}
+
+/**
+ * Returns a MinioRequestConfig with the provided minio options (a
+ * MinioRequestConfig object contains the artifact bucket and keys, with the
+ * corresponding minio client).
  * @param minioOptions Minio options to create a minio client.
  * @param bucket bucket containing the pod logs artifacts.
- * @param keyFormat the keyFormat for pod logs artifacts stored in the bucket.
+ * @param keyFormatDefault the default keyFormat for pod logs artifacts stored
+ * in the bucket. This is overriden if there's an "artifact-repositories"
+ * configmap in the target namespace with a keyFormat field.
  */
 export function createPodLogsMinioRequestConfig(
   minioOptions: MinioClientOptions,
   bucket: string,
-  keyFormat: string,
+  keyFormatDefault: string,
+  artifactRepositoriesLookup: boolean,
 ) {
   return async (
     podName: string,
@@ -164,7 +225,21 @@ export function createPodLogsMinioRequestConfig(
     const client = await createMinioClient(minioOptions, 's3');
     const createdAtArray = createdAt.split('-');
 
-    let key: string = keyFormat
+    // If artifactRepositoriesLookup is enabled, try to extract they keyformat
+    // from the configmap. Otherwise, just used the default keyFormat specified
+    // in configs.ts.
+    let keyFormatFromConfigMap = undefined;
+    if (artifactRepositoriesLookup) {
+      keyFormatFromConfigMap = await getKeyFormatFromArtifactRepositories(namespace);
+    }
+    let key: string;
+    if (keyFormatFromConfigMap !== undefined) {
+      key = keyFormatFromConfigMap;
+    } else {
+      key = keyFormatDefault;
+    }
+
+    key = key
       .replace(/\s+/g, '') // Remove all whitespace.
       .replace('{{workflow.name}}', podName.replace(/-system-container-impl-.*/, ''))
       .replace('{{workflow.creationTimestamp.Y}}', createdAtArray[0])

--- a/frontend/server/workflow-helper.ts
+++ b/frontend/server/workflow-helper.ts
@@ -171,13 +171,11 @@ export async function getKeyFormatFromArtifactRepositories(
   namespace: string,
 ): Promise<string | undefined> {
   try {
-    const [configMap] = await getConfigMap('artifact-repositories', namespace);
+    const [configMap, k8sError] = await getConfigMap('artifact-repositories', namespace);
     if (configMap === undefined) {
-      // If there is no artifact-repositories configmap, return undefined. The
-      // caller will just use keyFormat as specified in configs.ts.
-      return undefined;
+      throw k8sError;
     }
-    let artifactRepositories = configMap?.data['artifact-repositories'];
+    const artifactRepositories = configMap?.data['artifact-repositories'];
     const artifactRepositoriesValue = JsYaml.safeLoad(
       artifactRepositories,
     ) as PartialArtifactRepositoriesValue;

--- a/manifests/kustomize/base/pipeline/ml-pipeline-ui-role.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-ui-role.yaml
@@ -22,6 +22,7 @@ rules:
   - ""
   resources:
   - secrets
+  - configmaps
   verbs:
   - get
   - list


### PR DESCRIPTION
**Description of your changes:**

Argo Workflows supports the ability to specify an artifact repository for archived logs uniquely for each namespace rather than just globally as documented [here](https://argo-workflows.readthedocs.io/en/latest/configure-artifact-repository/).

This PR adds support for this functionality to the KFP UI. If a workflow runs and...

1. The corresponding pods are deleted
2. The corresponding workflow is deleted
3. There is an `artifact-repositories` configmap in the target namespace that provides a unique, namespaced `keyFormat`

...this PR ensures that logs are still accessible in the UI. This functionality is disabled by default to avoid unnecessary network calls (for end users who don't leverage namespace-specific `artifact-repositories`). It can be toggled on through `configs.ts` or an environment variable.

Co-authored with @quinnovator 🌟 . 

Fixes: https://github.com/kubeflow/pipelines/issues/11339

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
