### PR TITLE
fix(sdk): Add error handling. Fixes #11164

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -8,6 +8,7 @@
 ## Deprecations
 
 ## Bug fixes and other changes
+* Add error handling for image build/push failures in KFP SDK. [\#11164](https://github.com/kubeflow/pipelines/pull/11356)
 
 ## Documentation updates
 

--- a/sdk/python/kfp/cli/component_test.py
+++ b/sdk/python/kfp/cli/component_test.py
@@ -449,6 +449,34 @@ class Test(unittest.TestCase):
         self._docker_client.api.build.assert_called_once()
         self._docker_client.images.push.assert_not_called()
 
+    def test_docker_client_failed_to_build_img(self):
+        self._docker_client.api.build.return_value = [{'error': 'Error log'}]
+        created_component = _make_component(
+            func_name='train', target_image='custom-image')
+        _write_components('components.py', created_component)
+
+        result = self.runner.invoke(
+            self.cli,
+            ['build', str(self._working_dir), '--push-image'],
+        )
+
+        self.assertEqual(result.exit_code, 1)
+        self._docker_client.api.build.assert_called_once()
+        self._docker_client.images.push.assert_not_called()
+
+    def test_docker_client_failed_to_push_img(self):
+        self._docker_client.images.push.return_value = [{'error': 'Error log'}]
+        created_component = _make_component(
+            func_name='train', target_image='custom-image')
+        _write_components('components.py', created_component)
+
+        result = self.runner.invoke(
+            self.cli,
+            ['build', str(self._working_dir), '--push-image'],
+        )
+        self.assertEqual(result.exit_code, 1)
+        self._docker_client.images.push.assert_called_once()
+
     @mock.patch('kfp.__version__', '1.2.3')
     def test_docker_file_is_created_correctly(self):
         component = _make_component(


### PR DESCRIPTION
**Description of your changes:**

Fixes #11164  by adding error handling for image build/push failures in the KFP SDK. Now, errors trigger a clear error message and a non-zero exit code, ensuring accurate feedback to users.


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x]  The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
