### PR TITLE
test: Fix ci-passed label update on PR synchronization

### DIFF
--- a/.github/workflows/add-ci-passed-label.yml
+++ b/.github/workflows/add-ci-passed-label.yml
@@ -74,7 +74,7 @@ jobs:
   add_ci_passed_label:
     name: Add 'ci-passed' label
     runs-on: ubuntu-latest    
-    needs: fetch_data
+    needs: [fetch_data, reset_ci_passed_label]
     steps:
       - name: Add 'ci-passed' label
         run: |


### PR DESCRIPTION
**Description of your changes:**

-  This PR addresses the issue with adding ci-passed label during PR Synchronization. Reference PR [#11354](https://github.com/kubeflow/pipelines/pull/11354)
-  The issue was caused by the parallel execution of the ```reset_ci_passed_label``` and ```add_ci_passed_label``` steps in the "Add CI Passed Label" GitHub Action workflow.
-  The workflow has been updated to execute the ```reset_ci_passed_label``` and ``add_ci_passed_label`` steps sequentially, ensuring that the ci-passed label is correctly added on PR synchronization.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
