### PR TITLE
fix(backend): handle client side HTTP timeouts to fix crashes of metadata-writer. Fixes #8200

### DIFF
--- a/backend/metadata_writer/requirements.txt
+++ b/backend/metadata_writer/requirements.txt
@@ -22,7 +22,7 @@ grpcio==1.66.1
     # via ml-metadata
 idna==3.10
     # via requests
-kubernetes==10.0.1
+kubernetes==31.0.0
     # via -r -
 lru-dict==1.3.0
     # via -r -

--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -402,4 +402,5 @@ while True:
 
     except urllib3.exceptions.ReadTimeoutError as e:
         # Client side timeout, continue watching.
-        pass
+        continue
+ 

--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -398,6 +398,7 @@ while True:
                 pods_with_written_metadata[obj.metadata.name] = None
 
         # Server side timeout, continue watching.
+        pass
 
     except urllib3.exceptions.ReadTimeoutError as e:
         # Client side timeout, continue watching.

--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -19,6 +19,7 @@ import re
 import collections
 import kubernetes
 import yaml
+import urllib3
 from time import sleep
 import lru
 
@@ -30,7 +31,10 @@ pod_name_to_execution_id_size = os.environ.get('POD_NAME_TO_EXECUTION_ID_SIZE', 
 workflow_name_to_context_id_size = os.environ.get('WORKFLOW_NAME_TO_CONTEXT_ID_SIZE', 5000)
 pods_with_written_metadata_size = os.environ.get('PODS_WITH_WRITTEN_METADATA_SIZE', 5000)
 debug_files_size = os.environ.get('DEBUG_FILES_SIZE', 5000)
-
+# See the documentation on settings k8s_watch timeouts:
+# https://github.com/kubernetes-client/python/blob/master/examples/watch/timeout-settings.md
+k8s_watch_server_side_timeout = os.environ.get('K8S_WATCH_SERVER_SIDE_TIMEOUT', 1800)
+k8s_watch_client_side_timeout = os.environ.get('K8S_WATCH_CLIENT_SIDE_TIMEOUT', 60)
 
 kubernetes.config.load_incluster_config()
 k8s_api = kubernetes.client.CoreV1Api()
@@ -150,18 +154,18 @@ while True:
             k8s_api.list_namespaced_pod,
             namespace=namespace_to_watch,
             label_selector=ARGO_WORKFLOW_LABEL_KEY,
-            timeout_seconds=1800,  # Sometimes watch gets stuck
-            _request_timeout=2000,  # Sometimes HTTP GET gets stuck
+            timeout_seconds=k8s_watch_server_side_timeout, 
+            _request_timeout=k8s_watch_client_side_timeout,
         )
     else:
         pod_stream = k8s_watch.stream(
             k8s_api.list_pod_for_all_namespaces,
             label_selector=ARGO_WORKFLOW_LABEL_KEY,
-            timeout_seconds=1800,  # Sometimes watch gets stuck
-            _request_timeout=2000,  # Sometimes HTTP GET gets stuck
+            timeout_seconds=k8s_watch_server_side_timeout, 
+            _request_timeout=k8s_watch_client_side_timeout,
         )
-    for event in pod_stream:
-        try:
+    try:
+        for event in pod_stream:
             obj = event['object']
             print('Kubernetes Pod event: ', event['type'], obj.metadata.name, obj.metadata.resource_version)
             if event['type'] == 'ERROR':
@@ -393,6 +397,12 @@ while True:
 
                 pods_with_written_metadata[obj.metadata.name] = None
 
-        except Exception as e:
-            import traceback
-            print(traceback.format_exc())
+        # Server side timeout, continue watching.
+
+    except urllib3.exceptions.ReadTimeoutError as e:
+        # Client side timeout, continue watching.
+        pass
+
+    except Exception as e:
+        import traceback
+        print(traceback.format_exc())

--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -397,7 +397,7 @@ while True:
 
                 pods_with_written_metadata[obj.metadata.name] = None
 
-        # Server side timeout, continue watching.
+        # If the for loop ended, a server-side timeout occurred. Continue watching.
         pass
 
     except urllib3.exceptions.ReadTimeoutError as e:

--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -402,7 +402,3 @@ while True:
     except urllib3.exceptions.ReadTimeoutError as e:
         # Client side timeout, continue watching.
         pass
-
-    except Exception as e:
-        import traceback
-        print(traceback.format_exc())


### PR DESCRIPTION
**Description of your changes:**

* Handles client side timeouts (`urllib3.exceptions.ReadTimeoutError`) of `k8s_watch.stream` to prevent crashes of `metadata-writer` pod. Without this `metadata-writer` pod fails in cases when a connection error causes a client timeout. This should fix #8200.
* Adjusts the client side timeout according to [the recommendations of Kubernetes Python client authors](https://github.com/kubernetes-client/python/blob/master/examples/watch/timeout-settings.md). 
  >It is recommended to set this [server] timeout value to a higher number such as 3600 seconds (1 hour).
  >It is recommended to set this [client] timeout value to a lower number (for eg. ~ maybe 60 seconds).
  * The benefit of this for the `metadata-writer` use case is that, currently, with a client side timeout of 2000 seconds (33.3 minutes) if a connection error happens during this period, `metadata-writer` stops doing its job for up to 33.3 minutes. After this change `metadata-writer` will only be disconneted for up to the new client timeout, 60 seconds.
  * Since the client timeout is now smaller than the server timeout, if no events occur within the client timeout period, a `ReadTimeoutError` is thrown and caught even in the absence of errors.
* Makes client side and server side timeout configurable via environment variables.
* Updates Kubernetes Python client to the latest version.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
