### PR TITLE
feat(sdk)!: stop auto-populating metrics as dag output

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -7,6 +7,7 @@
 ## Breaking changes
 
 ## Deprecations
+* Deprecate the metrics artifact auto-populating feature. [\#11362](https://github.com/kubeflow/pipelines/pull/11362)
 
 ## Bug fixes and other changes
 

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -1131,67 +1131,6 @@ def build_task_spec_for_group(
     return pipeline_task_spec
 
 
-def populate_metrics_in_dag_outputs(
-    tasks: List[pipeline_task.PipelineTask],
-    task_name_to_parent_groups: Mapping[str,
-                                        List[compiler_utils.GroupOrTaskType]],
-    task_name_to_component_spec: Mapping[str, pipeline_spec_pb2.ComponentSpec],
-    pipeline_spec: pipeline_spec_pb2.PipelineSpec,
-) -> None:
-    """Populates metrics artifacts in DAG outputs.
-
-    Args:
-        tasks: The list of tasks that may produce metrics outputs.
-        task_name_to_parent_groups: The dict of task name to parent groups.
-            Key is the task's name. Value is a list of ancestor groups including
-            the task itself. The list of a given op is sorted in a way that the
-            farthest group is the first and the task itself is the last.
-        task_name_to_component_spec: The dict of task name to ComponentSpec.
-        pipeline_spec: The pipeline_spec to update in-place.
-    """
-    for task in tasks:
-        component_spec = task_name_to_component_spec[task.name]
-
-        # Get the tuple of (component_name, task_name) of all its parent groups.
-        parent_components_and_tasks = [('_root', '')]
-        # skip the op itself and the root group which cannot be retrived via name.
-        for group_name in task_name_to_parent_groups[task.name][1:-1]:
-            parent_components_and_tasks.append(
-                (utils.sanitize_component_name(group_name),
-                 utils.sanitize_task_name(group_name)))
-        # Reverse the order to make the farthest group in the end.
-        parent_components_and_tasks.reverse()
-
-        for output_name, artifact_spec in \
-            component_spec.output_definitions.artifacts.items():
-
-            if artifact_spec.artifact_type.WhichOneof(
-                    'kind'
-            ) == 'schema_title' and artifact_spec.artifact_type.schema_title in [
-                    artifact_types.Metrics.schema_title,
-                    artifact_types.ClassificationMetrics.schema_title,
-            ]:
-                unique_output_name = f'{task.name}-{output_name}'
-
-                sub_task_name = task.name
-                sub_task_output = output_name
-                for component_name, task_name in parent_components_and_tasks:
-                    group_component_spec = (
-                        pipeline_spec.root if component_name == '_root' else
-                        pipeline_spec.components[component_name])
-                    group_component_spec.output_definitions.artifacts[
-                        unique_output_name].CopyFrom(artifact_spec)
-                    group_component_spec.dag.outputs.artifacts[
-                        unique_output_name].artifact_selectors.append(
-                            pipeline_spec_pb2.DagOutputsSpec
-                            .ArtifactSelectorSpec(
-                                producer_subtask=sub_task_name,
-                                output_artifact_key=sub_task_output,
-                            ))
-                    sub_task_name = task_name
-                    sub_task_output = unique_output_name
-
-
 def modify_pipeline_spec_with_override(
     pipeline_spec: pipeline_spec_pb2.PipelineSpec,
     pipeline_name: Optional[str],
@@ -1493,14 +1432,6 @@ def build_spec_by_group(
 
     pipeline_spec.deployment_spec.update(
         json_format.MessageToDict(deployment_config))
-
-    # Surface metrics outputs to the top.
-    populate_metrics_in_dag_outputs(
-        tasks=group.tasks,
-        task_name_to_parent_groups=task_name_to_parent_groups,
-        task_name_to_component_spec=task_name_to_component_spec,
-        pipeline_spec=pipeline_spec,
-    )
 
 
 def modify_task_for_ignore_upstream_failure(

--- a/sdk/python/test_data/components/output_metrics.yaml
+++ b/sdk/python/test_data/components/output_metrics.yaml
@@ -3,7 +3,6 @@
 # Description: Dummy component that outputs metrics with a random accuracy.
 # Outputs:
 #    metrics: system.Metrics
-#    output-metrics-metrics: system.Metrics
 components:
   comp-output-metrics:
     executorLabel: exec-output-metrics
@@ -27,7 +26,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -56,10 +55,6 @@ root:
           artifactSelectors:
           - outputArtifactKey: metrics
             producerSubtask: output-metrics
-        output-metrics-metrics:
-          artifactSelectors:
-          - outputArtifactKey: metrics
-            producerSubtask: output-metrics
     tasks:
       output-metrics:
         cachingOptions:
@@ -74,9 +69,5 @@ root:
         artifactType:
           schemaTitle: system.Metrics
           schemaVersion: 0.0.1
-      output-metrics-metrics:
-        artifactType:
-          schemaTitle: system.Metrics
-          schemaVersion: 0.0.1
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0

--- a/sdk/python/test_data/pipelines/lightweight_python_functions_with_outputs.yaml
+++ b/sdk/python/test_data/pipelines/lightweight_python_functions_with_outputs.yaml
@@ -5,8 +5,6 @@
 #    first_number: int
 #    second_message: str
 #    second_number: int
-# Outputs:
-#    output-named-tuple-metrics: system.Metrics
 components:
   comp-add-numbers:
     executorLabel: exec-add-numbers
@@ -81,7 +79,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -110,7 +108,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -139,7 +137,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -168,7 +166,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -196,12 +194,6 @@ pipelineInfo:
   name: functions-with-outputs
 root:
   dag:
-    outputs:
-      artifacts:
-        output-named-tuple-metrics:
-          artifactSelectors:
-          - outputArtifactKey: metrics
-            producerSubtask: output-named-tuple
     tasks:
       add-numbers:
         cachingOptions:
@@ -274,11 +266,5 @@ root:
         parameterType: STRING
       second_number:
         parameterType: NUMBER_INTEGER
-  outputDefinitions:
-    artifacts:
-      output-named-tuple-metrics:
-        artifactType:
-          schemaTitle: system.Metrics
-          schemaVersion: 0.0.1
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0

--- a/sdk/python/test_data/pipelines/pipeline_with_metrics_outputs.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_metrics_outputs.yaml
@@ -1,17 +1,8 @@
 # PIPELINE DEFINITION
 # Name: pipeline-with-metrics-outputs
-# Outputs:
-#    output-metrics-2-metrics: system.Metrics
-#    output-metrics-metrics: system.Metrics
 components:
   comp-for-loop-2:
     dag:
-      outputs:
-        artifacts:
-          output-metrics-2-metrics:
-            artifactSelectors:
-            - outputArtifactKey: metrics
-              producerSubtask: output-metrics-2
       tasks:
         output-metrics-2:
           cachingOptions:
@@ -24,12 +15,6 @@ components:
       parameters:
         pipelinechannel--loop-item-param-1:
           parameterType: NUMBER_INTEGER
-    outputDefinitions:
-      artifacts:
-        output-metrics-2-metrics:
-          artifactType:
-            schemaTitle: system.Metrics
-            schemaVersion: 0.0.1
   comp-output-metrics:
     executorLabel: exec-output-metrics
     outputDefinitions:
@@ -60,7 +45,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -91,7 +76,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -114,16 +99,6 @@ pipelineInfo:
   name: pipeline-with-metrics-outputs
 root:
   dag:
-    outputs:
-      artifacts:
-        output-metrics-2-metrics:
-          artifactSelectors:
-          - outputArtifactKey: output-metrics-2-metrics
-            producerSubtask: for-loop-2
-        output-metrics-metrics:
-          artifactSelectors:
-          - outputArtifactKey: metrics
-            producerSubtask: output-metrics
     tasks:
       for-loop-2:
         componentRef:
@@ -141,15 +116,5 @@ root:
           name: comp-output-metrics
         taskInfo:
           name: output-metrics
-  outputDefinitions:
-    artifacts:
-      output-metrics-2-metrics:
-        artifactType:
-          schemaTitle: system.Metrics
-          schemaVersion: 0.0.1
-      output-metrics-metrics:
-        artifactType:
-          schemaTitle: system.Metrics
-          schemaVersion: 0.0.1
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0


### PR DESCRIPTION
**Description of your changes:**
The auto-population of metrics artifact was a comprised workaround to enable Vertex run comparison feature with only client side changes. 
This causes unintentional behaviors. And with the introduction of loop aggregation, this becomes more problematic when it tries to aggregate and surface out large number of metrics artifacts. 


**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
