### PR TITLE
fix(sdk): accelerator type setting in kfp

### DIFF
--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -667,6 +667,10 @@ def build_container_spec_for_task(
                         task.container_spec.resources.accelerator_type),
                     resource_count=convert_to_placeholder(
                         task.container_spec.resources.accelerator_count),
+                    type=convert_to_placeholder(
+                        task.container_spec.resources.accelerator_type),
+                    count=convert_to_placeholder(
+                        int(task.container_spec.resources.accelerator_count)),
                 ))
 
     return container_spec

--- a/sdk/python/test_data/pipelines/pipeline_with_resource_spec.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_resource_spec.yaml
@@ -61,6 +61,8 @@ deploymentSpec:
         image: gcr.io/my-project/my-fancy-trainer
         resources:
           accelerator:
+            count: '1'
+            type: tpu-v3
             resourceCount: '1'
             resourceType: tpu-v3
           resourceCpuLimit: '4'


### PR DESCRIPTION
In [this](https://github.com/kubeflow/pipelines/pull/11075/files#diff-10e2c4a2ff87025a7653623f21bfe47a39844ba69f8117b4d82d8902ae5893ddR776-R782) PR, new API fields were introduced to set accelerator resources via pipeline spec. Note that `type` and `count` were deprecated. However in the follow up implementation pr [here](https://github.com/kubeflow/pipelines/pull/11097/files#diff-42a6e18d166f33d4a0992ab9609966d24389846045972a99e9f286bba08d4014R665-R668) we can see that these fields are removed entirely from the compilation step. This has basically broken setting accelerator types in KFP, because [the driver is expecting](https://github.com/kubeflow/pipelines/blob/master/backend/src/v2/driver/driver.go#L449-L457) `type` and `count` to be present, and these are thus not being set at all. 

This PR re-introduces these fields, see test case for how the pipeline spec will look like. This is to allow for a proper deprecation period on the api, so we can adjust the driver changes accordingly. 

To verify the changes you can use the following sample pipeline on the changes before/after: 

```python
from kfp import dsl
from kfp import compiler
@dsl.component(base_image="docker.io/python:3.9.17")
def empty_component():
    pass

@dsl.pipeline(name='pipeline-accel')
def pipeline_accel():
    task = empty_component()
    task.set_accelerator_type("nvidia.com/gpu").set_accelerator_limit("1")


compiler.Compiler().compile(
    pipeline_func=pipeline_accel,
    package_path=__file__.replace('.py', '-v2.yaml'))
```

After the changes this should compile to: 

```yaml
...
deploymentSpec:
  executors:
    exec-empty-component:
      container:
        args: ..omitted
        command: ..omitted
        image: ...
        resources:
          accelerator:
            count: '1'
            resourceCount: '1'
            resourceType: nvidia.com/gpu
            type: nvidia.com/gpu
...
```

The resulting executor pod should have: 

```yaml
resources:
        limits:
          nvidia.com/gpu: '1'
        requests:
          nvidia.com/gpu: '1'
```

