### PR TITLE
feat(cli): expose existing_token client property

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -1,6 +1,7 @@
 # Current Version (in development)
 
 ## Features
+* Expose `--existing-token` flag in `kfp` CLI to allow users to provide an existing token for authentication. [\#11400](https://github.com/kubeflow/pipelines/pull/11400)
 
 ## Breaking changes
 

--- a/sdk/python/kfp/cli/cli.py
+++ b/sdk/python/kfp/cli/cli.py
@@ -86,6 +86,9 @@ def _install_completion(shell: str) -> None:
     '--other-client-secret',
     help=parsing.get_param_descr(client.Client, 'other_client_secret'))
 @click.option(
+    '--existing-token',
+    help=parsing.get_param_descr(client.Client, 'existing_token'))
+@click.option(
     '--output',
     type=click.Choice(list(map(lambda x: x.name, OutputFormat))),
     default=OutputFormat.table.name,
@@ -94,8 +97,8 @@ def _install_completion(shell: str) -> None:
 @click.pass_context
 @click.version_option(version=kfp.__version__, message='%(prog)s %(version)s')
 def cli(ctx: click.Context, endpoint: str, iap_client_id: str, namespace: str,
-        other_client_id: str, other_client_secret: str, output: OutputFormat,
-        show_completion: str, install_completion: str):
+        other_client_id: str, other_client_secret: str, existing_token: str,
+        output: OutputFormat, show_completion: str, install_completion: str):
     """Kubeflow Pipelines CLI."""
     if show_completion:
         click.echo(_create_completion(show_completion))
@@ -113,6 +116,7 @@ def cli(ctx: click.Context, endpoint: str, iap_client_id: str, namespace: str,
         # Do not create a client for these subcommands
         return
     ctx.obj['client'] = client.Client(endpoint, iap_client_id, namespace,
-                                      other_client_id, other_client_secret)
+                                      other_client_id, other_client_secret,
+                                      existing_token)
     ctx.obj['namespace'] = namespace
     ctx.obj['output'] = output


### PR DESCRIPTION
**Description of your changes:**

This PR exposes `existing_token` option of `kfp.Client` to the CLI.

Resolves: https://github.com/kubeflow/pipelines/issues/11399

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
