### PR TITLE
fix(ui): Disable GKE Metadata as default Fixes: #11247, fixes #11260 

### DIFF
--- a/frontend/server/app.test.ts
+++ b/frontend/server/app.test.ts
@@ -188,7 +188,7 @@ describe('UIServer apis', () => {
             ? Promise.resolve({ ok: true, text: () => Promise.resolve('test-cluster') })
             : Promise.reject('Unexpected request'),
         );
-        app = new UIServer(loadConfigs(argv, {}));
+        app = new UIServer(loadConfigs(argv, { DISABLE_GKE_METADATA: 'false' }));
 
         const request = requests(app.start());
         request
@@ -202,7 +202,7 @@ describe('UIServer apis', () => {
             ? Promise.resolve({ ok: false, text: () => Promise.resolve('404 not found') })
             : Promise.reject('Unexpected request'),
         );
-        app = new UIServer(loadConfigs(argv, {}));
+        app = new UIServer(loadConfigs(argv, { DISABLE_GKE_METADATA: 'false' }));
 
         const request = requests(app.start());
         request.get('/system/cluster-name').expect(500, 'Failed fetching GKE cluster name', done);
@@ -225,7 +225,7 @@ describe('UIServer apis', () => {
             ? Promise.resolve({ ok: true, text: () => Promise.resolve('test-project') })
             : Promise.reject('Unexpected request'),
         );
-        app = new UIServer(loadConfigs(argv, {}));
+        app = new UIServer(loadConfigs(argv, { DISABLE_GKE_METADATA: 'false' }));
 
         const request = requests(app.start());
         request.get('/system/project-id').expect(200, 'test-project', done);
@@ -236,7 +236,7 @@ describe('UIServer apis', () => {
             ? Promise.resolve({ ok: false, text: () => Promise.resolve('404 not found') })
             : Promise.reject('Unexpected request'),
         );
-        app = new UIServer(loadConfigs(argv, {}));
+        app = new UIServer(loadConfigs(argv, { DISABLE_GKE_METADATA: 'false' }));
 
         const request = requests(app.start());
         request.get('/system/project-id').expect(500, 'Failed fetching GKE project id', done);

--- a/frontend/server/configs.ts
+++ b/frontend/server/configs.ts
@@ -108,7 +108,7 @@ export function loadConfigs(argv: string[], env: ProcessEnv): UIConfigs {
     /** The main container name of a pod where logs are retrieved */
     POD_LOG_CONTAINER_NAME = 'main',
     /** Disables GKE metadata endpoint. */
-    DISABLE_GKE_METADATA = 'false',
+    DISABLE_GKE_METADATA = 'true',
     /** Enable authorization checks for multi user mode. */
     ENABLE_AUTHZ = 'false',
     /** Deployment type. */

--- a/manifests/kustomize/env/gcp/gcp-configurations-patch.yaml
+++ b/manifests/kustomize/env/gcp/gcp-configurations-patch.yaml
@@ -20,3 +20,17 @@ spec:
                 configMapKeyRef:
                   name: pipeline-install-config
                   key: gcsProjectId
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-ui
+spec:
+  template:
+    spec:
+      containers:
+        - name: ml-pipeline-ui
+          env:
+            - name: DISABLE_GKE_METADATA
+              value: 'false'


### PR DESCRIPTION
**Description of your changes:**

-  UI presents errors when deployed outside GKE as pointed in #11260.
- _DISABLE_GKE_METADATA_ was set true as default and patched for GKE environments
- Tests were also adjusted

Fixes: #11247 & #11260

Duplicated from #11321 to include tests.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
