### PR TITLE
chore: have ci check run from default branch

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -2,7 +2,7 @@
 name: CI Check
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled]
 
 jobs:


### PR DESCRIPTION
**Description of your changes:**


This change will ensure that CI check wf always uses the one in the base repository. Read more about it [here](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target).