### PR TITLE
fix(backend): return error properly

### DIFF
--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -2018,7 +2018,7 @@ func createCache(
 ) error {
 	id := execution.GetID()
 	if id == 0 {
-		fmt.Errorf("failed to get id from createdExecution")
+		return fmt.Errorf("failed to get id from createdExecution")
 	}
 	task := &api.Task{
 		//TODO how to differentiate between shared pipeline and namespaced pipeline


### PR DESCRIPTION
The `return` statement was missing when `id == 0`.

**Description of your changes:**

e26d3ec5e fix(backend): return error properly

commit e26d3ec5ed06aa13cfdf6a45234945ac04634969
Author: Sébastien Han <seb@redhat.com>
Date:   Mon Dec 2 11:42:49 2024 +0100

    fix(backend): return error properly
    
    The `return` statement was missing when `id == 0`.
    
    Signed-off-by: Sébastien Han <seb@redhat.com>

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
