### PR TITLE
chore: Fix pr-commands.yml to enable /ok-to-test alongside other commands

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -9,7 +9,7 @@ jobs:
   process-command:
     runs-on: ubuntu-latest
     # Fail early if the command is not recognized
-    if: github.event.comment.body == '/ok-to-test'
+    if: contains(github.event.comment.body, '/ok-to-test')
     outputs:
       PR_SHA: ${{ steps.fetch-pr-sha.outputs.PR_SHA }}
     steps:
@@ -61,7 +61,7 @@ jobs:
   approve:
     runs-on: ubuntu-latest
     needs: process-command
-    if: github.event.comment.body == '/ok-to-test'
+    if: contains(github.event.comment.body, '/ok-to-test')
     steps:
       - name: Checkout Main Branch
         uses: actions/checkout@v3


### PR DESCRIPTION
As per title.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
