### PR TITLE
chore: Added Kubernetes 1.30 and 1.31 to e2e tests

### DIFF
--- a/.github/actions/kfp-cluster/action.yml
+++ b/.github/actions/kfp-cluster/action.yml
@@ -1,6 +1,11 @@
 name: "Set up KFP on KinD"
 description: "Step to start and configure KFP on KinD"
 
+inputs:
+  k8s_version:
+    description: "The Kubernetes version to use for the Kind cluster"
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -8,9 +13,9 @@ runs:
       uses: container-tools/kind-action@v2
       with:
         cluster_name: kfp
-        kubectl_version: v1.29.2
-        version: v0.22.0
-        node_image: kindest/node:v1.29.2
+        kubectl_version: ${{ inputs.k8s_version }}
+        version: v0.25.0
+        node_image: kindest/node:${{ inputs.k8s_version }}
 
     - name: Build images
       shell: bash

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -19,6 +19,10 @@ on:
 jobs:
   initialization-tests-v1:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+    name: Initialization tests v1 - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -30,6 +34,8 @@ jobs:
 
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster
+        with:
+          k8s_version: ${{ matrix.k8s_version }}
 
       - name: Forward API port
         run: ./.github/resources/scripts/forward-port.sh "kubeflow" "ml-pipeline" 8888 8888
@@ -42,11 +48,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: kfp-initialization-tests-v1-artifacts
+          name: kfp-initialization-tests-v1-artifacts-k8s-${{ matrix.k8s_version }}
           path: /tmp/tmp.*/*
 
   initialization-tests-v2:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+    name: Initialization tests v2 - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -58,6 +68,9 @@ jobs:
 
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster
+        with:
+          k8s_version: ${{ matrix.k8s_version }}
+
 
       - name: Forward API port
         run: ./.github/resources/scripts/forward-port.sh "kubeflow" "ml-pipeline" 8888 8888
@@ -70,11 +83,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: kfp-initialization-tests-v2-artifacts
+          name: kfp-initialization-tests-v2-artifacts-k8s-${{ matrix.k8s_version }}
           path: /tmp/tmp.*/*
 
   api-integration-tests-v1:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+    name: API integration tests v1 - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -86,6 +103,8 @@ jobs:
 
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster
+        with:
+          k8s_version: ${{ matrix.k8s_version }}
 
       - name: Forward API port
         run: ./.github/resources/scripts/forward-port.sh "kubeflow" "ml-pipeline" 8888 8888
@@ -98,11 +117,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: kfp-api-integration-tests-v1-artifacts
+          name: kfp-api-integration-tests-v1-artifacts-k8s-${{ matrix.k8s_version }}
           path: /tmp/tmp.*/*
 
   api-integration-tests-v2:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+    name: API integration tests v2 - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -114,6 +137,8 @@ jobs:
 
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster
+        with:
+          k8s_version: ${{ matrix.k8s_version }}
 
       - name: Forward API port
         run: ./.github/resources/scripts/forward-port.sh "kubeflow" "ml-pipeline" 8888 8888
@@ -126,11 +151,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: kfp-api-integration-tests-v2-artifacts
+          name: kfp-api-integration-tests-v2-artifacts-k8s-${{ matrix.k8s_version }}
           path: /tmp/tmp.*/*
 
   frontend-integration-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+    name: Frontend Integration Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -142,6 +171,8 @@ jobs:
 
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster
+        with:
+          k8s_version: ${{ matrix.k8s_version }}
 
       - name: Forward API port
         run: ./.github/resources/scripts/forward-port.sh "kubeflow" "ml-pipeline" 8888 8888
@@ -160,11 +191,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: kfp-frontend-integration-test-artifacts
+          name: kfp-frontend-integration-test-artifacts-k8s-${{ matrix.k8s_version }}
           path: /tmp/tmp.*/*
 
   basic-sample-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+    name: Basic Sample Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -176,6 +211,8 @@ jobs:
 
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster
+        with:
+          k8s_version: ${{ matrix.k8s_version }}
 
       - name: Forward API port
         run: ./.github/resources/scripts/forward-port.sh "kubeflow" "ml-pipeline" 8888 8888
@@ -193,5 +230,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: kfp-basic-sample-tests-artifacts
+          name: kfp-basic-sample-tests-artifacts-k8s-${{ matrix.k8s_version }}
           path: /tmp/tmp.*/*


### PR DESCRIPTION
[From Kubeflow 1.10, all components must support 3 versions of Kubernetes](https://github.com/kubeflow/community/issues/767#issuecomment-2512189405). This PR adds versions 1.30 and 1.31 of Kubernetes to KFP end-to-end tests. With that, KFP supports Kubernetes from 1.29 to 1.31.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
