### PR TITLE
fix(ui): request task logs only if pod was created

### DIFF
--- a/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
+++ b/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
@@ -321,15 +321,17 @@ async function getLogsInfo(execution: Execution, runId?: string): Promise<Map<st
     return logsInfo; // Early return if it is from cache.
   }
 
-  try {
-    logsDetails = await Apis.getPodLogs(runId!, podName, podNameSpace, createdAt);
-    logsInfo.set(LOGS_DETAILS, logsDetails);
-  } catch (err) {
-    let errMsg = await errorToMessage(err);
-    logsBannerMessage = 'Failed to retrieve pod logs.';
-    logsInfo.set(LOGS_BANNER_MESSAGE, logsBannerMessage);
-    logsBannerAdditionalInfo = 'Error response: ' + errMsg;
-    logsInfo.set(LOGS_BANNER_ADDITIONAL_INFO, logsBannerAdditionalInfo);
+  if (podName && podName !== '') {
+    try {
+      logsDetails = await Apis.getPodLogs(runId!, podName, podNameSpace, createdAt);
+      logsInfo.set(LOGS_DETAILS, logsDetails);
+    } catch (err) {
+      let errMsg = await errorToMessage(err);
+      logsBannerMessage = 'Failed to retrieve pod logs.';
+      logsInfo.set(LOGS_BANNER_MESSAGE, logsBannerMessage);
+      logsBannerAdditionalInfo = 'Error response: ' + errMsg;
+      logsInfo.set(LOGS_BANNER_ADDITIONAL_INFO, logsBannerAdditionalInfo);
+    }
   }
   return logsInfo;
 }


### PR DESCRIPTION
**Description of your changes:**

Request the task logs only if the pod was created and the pod name is available.

Scenario: a new task in run is about to start
1. Execution record in mlmd was created with a status of Running (in the -system-container-driver- Pod)
2. -system-container-impl- pod has not yet been started and Launcher has not yet saved the pod name into the MLMD execution 
3. At this point, the Run Details/Logs tab starts pulling logs and may request them before the pod name is available, leading to an error (see attached), which could confuse the user

This issue is resolved by not requesting the log if the pod name is still unavailable. Instead of the error, the user will see an empty console until the pod is created
<img width="799" alt="Снимок экрана 2024-12-11 в 22 34 55" src="https://github.com/user-attachments/assets/00acf816-5a21-48ff-bb27-17e3b2745655" />

