### PR TITLE
chore: Added Kubernetes 1.30 and 1.31 to other tests

### DIFF
--- a/.github/workflows/kfp-kubernetes-execution-tests.yml
+++ b/.github/workflows/kfp-kubernetes-execution-tests.yml
@@ -15,6 +15,10 @@ on:
 jobs:
   kfp-kubernetes-execution-tests:
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+    name: kfp-kubernetes execution tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -26,6 +30,8 @@ jobs:
 
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster
+        with:
+          k8s_version: ${{ matrix.k8s_version }}
 
       - name: Forward API port
         run: ./.github/resources/scripts/forward-port.sh "kubeflow" "ml-pipeline" 8888 8888

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   run_tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+    name: Periodic Functional Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -16,6 +20,8 @@ jobs:
           python-version: 3.9
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster
+        with:
+          k8s_version: ${{ matrix.k8s_version }}
       - name: Port forward kfp apiserver
         run: |
           nohup kubectl port-forward --namespace kubeflow svc/ml-pipeline 8888:8888 &

--- a/.github/workflows/sdk-execution.yml
+++ b/.github/workflows/sdk-execution.yml
@@ -14,6 +14,10 @@ on:
 jobs:
   sdk-execution-tests:
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+    name: KFP SDK Execution Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -25,6 +29,8 @@ jobs:
 
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster
+        with:
+          k8s_version: ${{ matrix.k8s_version }}
 
       - name: Forward API port
         run: ./.github/resources/scripts/forward-port.sh "kubeflow" "ml-pipeline" 8888 8888


### PR DESCRIPTION
For some reason, my IDE didn't find all the occurrences of `.github/actions/kfp-cluster` when I sent https://github.com/kubeflow/pipelines/pull/11450.

This PR is a follow-up of https://github.com/kubeflow/pipelines/pull/11450.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
