### PR TITLE
fix(backend): modelToCRDTrigger was not including periodic schedule correctly

### DIFF
--- a/backend/src/apiserver/model/cron_schedule.go
+++ b/backend/src/apiserver/model/cron_schedule.go
@@ -1,0 +1,21 @@
+package model
+
+type CronSchedule struct {
+	// Time at which scheduling starts.
+	// If no start time is specified, the StartTime is the creation time of the schedule.
+	CronScheduleStartTimeInSec *int64 `gorm:"column:CronScheduleStartTimeInSec;"`
+
+	// Time at which scheduling ends.
+	// If no end time is specified, the EndTime is the end of time.
+	CronScheduleEndTimeInSec *int64 `gorm:"column:CronScheduleEndTimeInSec;"`
+
+	// Cron string describing when a workflow should be created within the
+	// time interval defined by StartTime and EndTime.
+	Cron *string `gorm:"column:Schedule;"`
+}
+
+func (c CronSchedule) IsEmpty() bool {
+	return c.CronScheduleStartTimeInSec == nil &&
+		c.CronScheduleEndTimeInSec == nil &&
+		(c.Cron == nil || *c.Cron == "")
+}

--- a/backend/src/apiserver/model/cron_schedule.go
+++ b/backend/src/apiserver/model/cron_schedule.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package model
 
 type CronSchedule struct {

--- a/backend/src/apiserver/model/cron_schedule.go
+++ b/backend/src/apiserver/model/cron_schedule.go
@@ -28,7 +28,7 @@ type CronSchedule struct {
 }
 
 func (c CronSchedule) IsEmpty() bool {
-	return c.CronScheduleStartTimeInSec == nil &&
-		c.CronScheduleEndTimeInSec == nil &&
+	return (c.CronScheduleStartTimeInSec == nil || *c.CronScheduleStartTimeInSec == 0) &&
+		(c.CronScheduleEndTimeInSec == nil || *c.CronScheduleEndTimeInSec == 0) &&
 		(c.Cron == nil || *c.Cron == "")
 }

--- a/backend/src/apiserver/model/job.go
+++ b/backend/src/apiserver/model/job.go
@@ -189,34 +189,6 @@ type Trigger struct {
 	PeriodicSchedule
 }
 
-type CronSchedule struct {
-	// Time at which scheduling starts.
-	// If no start time is specified, the StartTime is the creation time of the schedule.
-	CronScheduleStartTimeInSec *int64 `gorm:"column:CronScheduleStartTimeInSec;"`
-
-	// Time at which scheduling ends.
-	// If no end time is specified, the EndTime is the end of time.
-	CronScheduleEndTimeInSec *int64 `gorm:"column:CronScheduleEndTimeInSec;"`
-
-	// Cron string describing when a workflow should be created within the
-	// time interval defined by StartTime and EndTime.
-	Cron *string `gorm:"column:Schedule;"`
-}
-
-type PeriodicSchedule struct {
-	// Time at which scheduling starts.
-	// If no start time is specified, the StartTime is the creation time of the schedule.
-	PeriodicScheduleStartTimeInSec *int64 `gorm:"column:PeriodicScheduleStartTimeInSec;"`
-
-	// Time at which scheduling ends.
-	// If no end time is specified, the EndTime is the end of time.
-	PeriodicScheduleEndTimeInSec *int64 `gorm:"column:PeriodicScheduleEndTimeInSec;"`
-
-	// Interval describing when a workflow should be created within the
-	// time interval defined by StartTime and EndTime.
-	IntervalSecond *int64 `gorm:"column:IntervalSecond;"`
-}
-
 func (j Job) GetValueOfPrimaryKey() string {
 	return fmt.Sprint(j.UUID)
 }

--- a/backend/src/apiserver/model/periodic_schedule.go
+++ b/backend/src/apiserver/model/periodic_schedule.go
@@ -1,0 +1,21 @@
+package model
+
+type PeriodicSchedule struct {
+	// Time at which scheduling starts.
+	// If no start time is specified, the StartTime is the creation time of the schedule.
+	PeriodicScheduleStartTimeInSec *int64 `gorm:"column:PeriodicScheduleStartTimeInSec;"`
+
+	// Time at which scheduling ends.
+	// If no end time is specified, the EndTime is the end of time.
+	PeriodicScheduleEndTimeInSec *int64 `gorm:"column:PeriodicScheduleEndTimeInSec;"`
+
+	// Interval describing when a workflow should be created within the
+	// time interval defined by StartTime and EndTime.
+	IntervalSecond *int64 `gorm:"column:IntervalSecond;"`
+}
+
+func (p PeriodicSchedule) IsEmpty() bool {
+	return p.PeriodicScheduleStartTimeInSec == nil &&
+		p.PeriodicScheduleEndTimeInSec == nil &&
+		(p.IntervalSecond == nil || *p.IntervalSecond == 0)
+}

--- a/backend/src/apiserver/model/periodic_schedule.go
+++ b/backend/src/apiserver/model/periodic_schedule.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package model
 
 type PeriodicSchedule struct {

--- a/backend/src/apiserver/model/periodic_schedule.go
+++ b/backend/src/apiserver/model/periodic_schedule.go
@@ -28,7 +28,7 @@ type PeriodicSchedule struct {
 }
 
 func (p PeriodicSchedule) IsEmpty() bool {
-	return p.PeriodicScheduleStartTimeInSec == nil &&
-		p.PeriodicScheduleEndTimeInSec == nil &&
+	return (p.PeriodicScheduleStartTimeInSec == nil || *p.PeriodicScheduleStartTimeInSec == 0) &&
+		(p.PeriodicScheduleEndTimeInSec == nil || *p.PeriodicScheduleEndTimeInSec == 0) &&
 		(p.IntervalSecond == nil || *p.IntervalSecond == 0)
 }

--- a/backend/src/apiserver/template/template.go
+++ b/backend/src/apiserver/template/template.go
@@ -232,7 +232,7 @@ func modelToParametersMap(modelParameters string) (map[string]string, error) {
 func modelToCRDTrigger(modelTrigger model.Trigger) (scheduledworkflow.Trigger, error) {
 	crdTrigger := scheduledworkflow.Trigger{}
 	// CronSchedule and PeriodicSchedule can have at most one being non-empty
-	if modelTrigger.CronSchedule != (model.CronSchedule{}) {
+	if !modelTrigger.CronSchedule.IsEmpty() {
 		// Check if CronSchedule is non-empty
 		crdCronSchedule := scheduledworkflow.CronSchedule{}
 		if modelTrigger.Cron != nil {
@@ -247,7 +247,7 @@ func modelToCRDTrigger(modelTrigger model.Trigger) (scheduledworkflow.Trigger, e
 			crdCronSchedule.EndTime = &endTime
 		}
 		crdTrigger.CronSchedule = &crdCronSchedule
-	} else if modelTrigger.PeriodicSchedule != (model.PeriodicSchedule{}) {
+	} else if !modelTrigger.PeriodicSchedule.IsEmpty() {
 		// Check if PeriodicSchedule is non-empty
 		crdPeriodicSchedule := scheduledworkflow.PeriodicSchedule{}
 		if modelTrigger.IntervalSecond != nil {


### PR DESCRIPTION
This PR fixes the issue where `CronSchedule` and `PeriodicSchedule` structs were incorrectly evaluated as non-empty even when their fields were all nil. The issue arose because direct struct comparison with `(CronSchedule{})` or `(PeriodicSchedule{})` does not account for the semantics of pointer fields being `nil`, `""` or `0`.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
