### PR TITLE
chore(backend): Fixed ServiceAccount in job creation

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1005,18 +1005,19 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 	for _, modelRef := range job.ResourceReferences {
 		modelRef.ResourceUUID = string(swf.UID)
 	}
-	// Get the service account
-	serviceAccount := ""
-	if swf.Spec.Workflow != nil {
-		execSpec, err := util.ScheduleSpecToExecutionSpec(util.ArgoWorkflow, swf.Spec.Workflow)
-		if err == nil {
-			serviceAccount = execSpec.ServiceAccount()
-		}
-	}
-	job.ServiceAccount = serviceAccount
 	if tmpl.GetTemplateType() == template.V1 {
+		// Get the service account
+		serviceAccount := ""
+		if swf.Spec.Workflow != nil {
+			execSpec, err := util.ScheduleSpecToExecutionSpec(util.ArgoWorkflow, swf.Spec.Workflow)
+			if err == nil {
+				serviceAccount = execSpec.ServiceAccount()
+			}
+		}
+		job.ServiceAccount = serviceAccount
 		job.PipelineSpec.WorkflowSpecManifest = manifest
 	} else {
+		job.ServiceAccount = newScheduledWorkflow.Spec.ServiceAccount
 		job.PipelineSpec.PipelineSpecManifest = manifest
 	}
 	return r.jobStore.CreateJob(job)

--- a/backend/src/apiserver/template/template_test.go
+++ b/backend/src/apiserver/template/template_test.go
@@ -217,9 +217,10 @@ func TestScheduledWorkflow(t *testing.T) {
 				Parameters: []scheduledworkflow.Parameter{{Name: "y", Value: "\"world\""}},
 				Spec:       "",
 			},
-			PipelineId:   "1",
-			PipelineName: "pipeline name",
-			NoCatchup:    util.BoolPointer(true),
+			PipelineId:     "1",
+			PipelineName:   "pipeline name",
+			NoCatchup:      util.BoolPointer(true),
+			ServiceAccount: "pipeline-runner",
 		},
 	}
 

--- a/backend/src/apiserver/template/v2_template.go
+++ b/backend/src/apiserver/template/v2_template.go
@@ -97,7 +97,9 @@ func (t *V2Spec) ScheduledWorkflow(modelJob *model.Job) (*scheduledworkflow.Sche
 	if modelJob.Namespace != "" {
 		executionSpec.SetExecutionNamespace(modelJob.Namespace)
 	}
-	setDefaultServiceAccount(executionSpec, modelJob.ServiceAccount)
+	if executionSpec.ServiceAccount() == "" {
+		setDefaultServiceAccount(executionSpec, modelJob.ServiceAccount)
+	}
 	// Disable istio sidecar injection if not specified
 	executionSpec.SetAnnotationsToAllTemplatesIfKeyNotExist(util.AnnotationKeyIstioSidecarInject, util.AnnotationValueIstioSidecarInjectDisabled)
 	swfGeneratedName, err := toSWFCRDResourceGeneratedName(modelJob.K8SName)
@@ -132,7 +134,7 @@ func (t *V2Spec) ScheduledWorkflow(modelJob *model.Job) (*scheduledworkflow.Sche
 			PipelineId:        modelJob.PipelineId,
 			PipelineName:      modelJob.PipelineName,
 			PipelineVersionId: modelJob.PipelineVersionId,
-			ServiceAccount:    modelJob.ServiceAccount,
+			ServiceAccount:    executionSpec.ServiceAccount(),
 		},
 	}
 	return scheduledWorkflow, nil


### PR DESCRIPTION
When creating recurring runs, the ScheduledWorkflow CR is created with no ServiceAccount set.
This PR fixes that.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
