### PR TITLE
feat(sdk/backend): Add support for placeholders in resource limits

### DIFF
--- a/backend/third_party_licenses/apiserver.csv
+++ b/backend/third_party_licenses/apiserver.csv
@@ -83,7 +83,7 @@ github.com/klauspost/pgzip,https://github.com/klauspost/pgzip/blob/v1.2.6/LICENS
 github.com/kubeflow/kfp-tekton/tekton-catalog/pipeline-loops/pkg/apis/pipelineloop,https://github.com/kubeflow/kfp-tekton/blob/0b894195443c/tekton-catalog/pipeline-loops/LICENSE,Apache-2.0
 github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-exithandler/pkg/apis/exithandler,https://github.com/kubeflow/kfp-tekton/blob/0b894195443c/tekton-catalog/tekton-exithandler/LICENSE,Apache-2.0
 github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-kfptask/pkg/apis/kfptask,https://github.com/kubeflow/kfp-tekton/blob/0b894195443c/tekton-catalog/tekton-kfptask/LICENSE,Apache-2.0
-github.com/kubeflow/pipelines/api/v2alpha1/go,https://github.com/kubeflow/pipelines/blob/da804407ad31/api/LICENSE,Apache-2.0
+github.com/kubeflow/pipelines/api/v2alpha1/go,https://github.com/kubeflow/pipelines/blob/873e9dedd766/api/LICENSE,Apache-2.0
 github.com/kubeflow/pipelines/backend,https://github.com/kubeflow/pipelines/blob/HEAD/LICENSE,Apache-2.0
 github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform,https://github.com/kubeflow/pipelines/blob/d911c8b73b49/kubernetes_platform/LICENSE,Apache-2.0
 github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata,https://github.com/kubeflow/pipelines/blob/da804407ad31/third_party/ml-metadata/LICENSE,Apache-2.0

--- a/backend/third_party_licenses/driver.csv
+++ b/backend/third_party_licenses/driver.csv
@@ -71,7 +71,7 @@ github.com/josharian/intern,https://github.com/josharian/intern/blob/v1.0.0/lice
 github.com/json-iterator/go,https://github.com/json-iterator/go/blob/v1.1.12/LICENSE,MIT
 github.com/klauspost/compress/flate,https://github.com/klauspost/compress/blob/v1.16.7/LICENSE,Apache-2.0
 github.com/klauspost/pgzip,https://github.com/klauspost/pgzip/blob/v1.2.6/LICENSE,MIT
-github.com/kubeflow/pipelines/api/v2alpha1/go,https://github.com/kubeflow/pipelines/blob/da804407ad31/api/LICENSE,Apache-2.0
+github.com/kubeflow/pipelines/api/v2alpha1/go,https://github.com/kubeflow/pipelines/blob/873e9dedd766/api/LICENSE,Apache-2.0
 github.com/kubeflow/pipelines/backend,https://github.com/kubeflow/pipelines/blob/HEAD/LICENSE,Apache-2.0
 github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform,https://github.com/kubeflow/pipelines/blob/d911c8b73b49/kubernetes_platform/LICENSE,Apache-2.0
 github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata,https://github.com/kubeflow/pipelines/blob/da804407ad31/third_party/ml-metadata/LICENSE,Apache-2.0

--- a/backend/third_party_licenses/launcher.csv
+++ b/backend/third_party_licenses/launcher.csv
@@ -71,7 +71,7 @@ github.com/josharian/intern,https://github.com/josharian/intern/blob/v1.0.0/lice
 github.com/json-iterator/go,https://github.com/json-iterator/go/blob/v1.1.12/LICENSE,MIT
 github.com/klauspost/compress/flate,https://github.com/klauspost/compress/blob/v1.16.7/LICENSE,Apache-2.0
 github.com/klauspost/pgzip,https://github.com/klauspost/pgzip/blob/v1.2.6/LICENSE,MIT
-github.com/kubeflow/pipelines/api/v2alpha1/go,https://github.com/kubeflow/pipelines/blob/da804407ad31/api/LICENSE,Apache-2.0
+github.com/kubeflow/pipelines/api/v2alpha1/go,https://github.com/kubeflow/pipelines/blob/873e9dedd766/api/LICENSE,Apache-2.0
 github.com/kubeflow/pipelines/backend,https://github.com/kubeflow/pipelines/blob/HEAD/LICENSE,Apache-2.0
 github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata,https://github.com/kubeflow/pipelines/blob/da804407ad31/third_party/ml-metadata/LICENSE,Apache-2.0
 github.com/lestrrat-go/strftime,https://github.com/lestrrat-go/strftime/blob/v1.0.4/LICENSE,MIT

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/kubeflow/kfp-tekton/tekton-catalog/pipeline-loops v0.0.0-20240417221339-0b894195443c
 	github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-exithandler v0.0.0-20240417221339-0b894195443c
 	github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-kfptask v0.0.0-20240417221339-0b894195443c
-	github.com/kubeflow/pipelines/api v0.0.0-20240416215826-da804407ad31
+	github.com/kubeflow/pipelines/api v0.0.0-20250102152816-873e9dedd766
 	github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240725205754-d911c8b73b49
 	github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20240416215826-da804407ad31
 	github.com/lestrrat-go/strftime v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -664,8 +664,8 @@ github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-exithandler v0.0.0-20240417
 github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-exithandler v0.0.0-20240417221339-0b894195443c/go.mod h1:a6DSo/UxoG4hkJXJMo4nSmHURDEEiEVremmXy4GwdII=
 github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-kfptask v0.0.0-20240417221339-0b894195443c h1:/BevRDQhW+0ULFnDhYTq6JKiml0rORDW3qTnnOgGPnc=
 github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-kfptask v0.0.0-20240417221339-0b894195443c/go.mod h1:PGwbV4v8F6E8RXuvtJ9qpnIiESpK8LL3JDSsGo6nT+o=
-github.com/kubeflow/pipelines/api v0.0.0-20240416215826-da804407ad31 h1:I4DTAdIkzWlSuVXlIxjJhwK0TxYH2/CEWP7DO7RGSJg=
-github.com/kubeflow/pipelines/api v0.0.0-20240416215826-da804407ad31/go.mod h1:T7TOQB36gGe97yUdfVAnYK5uuT0+uQbLNHDUHxYkmE4=
+github.com/kubeflow/pipelines/api v0.0.0-20250102152816-873e9dedd766 h1:ZXz+Ki+hxez8vsr5hWHsjYWpa9V/dkp3iI4XTtMBH7A=
+github.com/kubeflow/pipelines/api v0.0.0-20250102152816-873e9dedd766/go.mod h1:puPWVUzB1VCb8lVq4g06IR2rIXuSpejDTd/FkSr6nvc=
 github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240725205754-d911c8b73b49 h1:Xf1qun8x4ZJj/nLZpUSIaphDK04NKeV7WME31qIC8Xo=
 github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240725205754-d911c8b73b49/go.mod h1:UhJrmpVSWawsAsSr1OzZfsEZTvQce+GvGwcZ58ULEhM=
 github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20240416215826-da804407ad31 h1:t1G2SexX+SwtYiaFrwH1lzGRSiXYMjd2QDT9842Ytpc=
@@ -1378,7 +1378,6 @@ google.golang.org/genproto v0.0.0-20210420162539-3c870d7478d2/go.mod h1:P3QM42oQ
 google.golang.org/genproto v0.0.0-20210423144448-3a41ef94ed2b/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210429181445-86c259c2b4ab/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210506142907-4a47615972c2/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
-google.golang.org/genproto v0.0.0-20211026145609-4688e4c4e024/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211221231510-d629cc9a93d5/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20231212172506-995d672761c0 h1:YJ5pD9rF8o9Qtta0Cmy9rdBwkSjrTCT6XTiUQVOtIos=
 google.golang.org/genproto v0.0.0-20231212172506-995d672761c0/go.mod h1:l/k7rMz0vFTBPy+tFSGvXEd3z+BcoG1k7EHbqm+YBsY=

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -3501,9 +3501,6 @@ class TestResourceConfig(unittest.TestCase):
         self.assertEqual(
             '5', dict_format['deploymentSpec']['executors']['exec-return-1-2']
             ['container']['resources']['resourceCpuLimit'])
-        self.assertEqual(
-            5.0, dict_format['deploymentSpec']['executors']['exec-return-1-2']
-            ['container']['resources']['cpuLimit'])
         self.assertNotIn(
             'memoryLimit', dict_format['deploymentSpec']['executors']
             ['exec-return-1-2']['container']['resources'])
@@ -3511,9 +3508,6 @@ class TestResourceConfig(unittest.TestCase):
         self.assertEqual(
             '50G', dict_format['deploymentSpec']['executors']['exec-return-1-3']
             ['container']['resources']['resourceMemoryLimit'])
-        self.assertEqual(
-            50.0, dict_format['deploymentSpec']['executors']['exec-return-1-3']
-            ['container']['resources']['memoryLimit'])
         self.assertNotIn(
             'cpuLimit', dict_format['deploymentSpec']['executors']
             ['exec-return-1-3']['container']['resources'])
@@ -3522,26 +3516,14 @@ class TestResourceConfig(unittest.TestCase):
             '2', dict_format['deploymentSpec']['executors']['exec-return-1-4']
             ['container']['resources']['resourceCpuRequest'])
         self.assertEqual(
-            2.0, dict_format['deploymentSpec']['executors']['exec-return-1-4']
-            ['container']['resources']['cpuRequest'])
-        self.assertEqual(
             '5', dict_format['deploymentSpec']['executors']['exec-return-1-4']
             ['container']['resources']['resourceCpuLimit'])
-        self.assertEqual(
-            5.0, dict_format['deploymentSpec']['executors']['exec-return-1-4']
-            ['container']['resources']['cpuLimit'])
         self.assertEqual(
             '4G', dict_format['deploymentSpec']['executors']['exec-return-1-4']
             ['container']['resources']['resourceMemoryRequest'])
         self.assertEqual(
-            4.0, dict_format['deploymentSpec']['executors']['exec-return-1-4']
-            ['container']['resources']['memoryRequest'])
-        self.assertEqual(
             '50G', dict_format['deploymentSpec']['executors']['exec-return-1-4']
             ['container']['resources']['resourceMemoryLimit'])
-        self.assertEqual(
-            50.0, dict_format['deploymentSpec']['executors']['exec-return-1-4']
-            ['container']['resources']['memoryLimit'])
 
 
 class TestPlatformConfig(unittest.TestCase):

--- a/sdk/python/kfp/compiler/compiler_utils.py
+++ b/sdk/python/kfp/compiler/compiler_utils.py
@@ -15,7 +15,6 @@
 
 import collections
 import copy
-import re
 from typing import DefaultDict, Dict, List, Mapping, Set, Tuple, Union
 
 from kfp import dsl
@@ -805,79 +804,3 @@ def recursive_replace_placeholders(data: Union[Dict, List], old_value: str,
         if isinstance(data, pipeline_channel.PipelineChannel):
             data = str(data)
         return new_value if data == old_value else data
-
-
-def validate_cpu_request_limit_to_float(cpu: str) -> float:
-    """Validates cpu request/limit string and converts to its numeric float
-    value.
-
-    Args:
-        cpu: CPU requests or limits. This string should be a number or a
-            number followed by an "m" to indicate millicores (1/1000). For
-            more information, see `Specify a CPU Request and a CPU Limit
-            <https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/#specify-a-cpu-request-and-a-cpu-limit>`_.
-
-    Raises:
-        ValueError if the cpu request/limit string value is invalid.
-
-    Returns:
-        The numeric value (float) of the cpu request/limit.
-    """
-    if re.match(r'([0-9]*[.])?[0-9]+m?$', cpu) is None:
-        raise ValueError(
-            'Invalid cpu string. Should be float or integer, or integer'
-            ' followed by "m".')
-
-    return float(cpu[:-1]) / 1000 if cpu.endswith('m') else float(cpu)
-
-
-def validate_memory_request_limit_to_float(memory: str) -> float:
-    """Validates memory request/limit string and converts to its numeric value.
-
-    Args:
-        memory: Memory requests or limits. This string should be a number or
-            a number followed by one of "E", "Ei", "P", "Pi", "T", "Ti", "G",
-            "Gi", "M", "Mi", "K", or "Ki".
-
-    Raises:
-        ValueError if the memory request/limit string value is invalid.
-
-    Returns:
-        The numeric value (float) of the memory request/limit.
-    """
-    if re.match(r'^[0-9]+(E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki){0,1}$',
-                memory) is None:
-        raise ValueError(
-            'Invalid memory string. Should be a number or a number '
-            'followed by one of "E", "Ei", "P", "Pi", "T", "Ti", "G", '
-            '"Gi", "M", "Mi", "K", "Ki".')
-
-    if memory.endswith('E'):
-        memory = float(memory[:-1]) * constants._E / constants._G
-    elif memory.endswith('Ei'):
-        memory = float(memory[:-2]) * constants._EI / constants._G
-    elif memory.endswith('P'):
-        memory = float(memory[:-1]) * constants._P / constants._G
-    elif memory.endswith('Pi'):
-        memory = float(memory[:-2]) * constants._PI / constants._G
-    elif memory.endswith('T'):
-        memory = float(memory[:-1]) * constants._T / constants._G
-    elif memory.endswith('Ti'):
-        memory = float(memory[:-2]) * constants._TI / constants._G
-    elif memory.endswith('G'):
-        memory = float(memory[:-1])
-    elif memory.endswith('Gi'):
-        memory = float(memory[:-2]) * constants._GI / constants._G
-    elif memory.endswith('M'):
-        memory = float(memory[:-1]) * constants._M / constants._G
-    elif memory.endswith('Mi'):
-        memory = float(memory[:-2]) * constants._MI / constants._G
-    elif memory.endswith('K'):
-        memory = float(memory[:-1]) * constants._K / constants._G
-    elif memory.endswith('Ki'):
-        memory = float(memory[:-2]) * constants._KI / constants._G
-    else:
-        # By default interpret as a plain integer, in the unit of Bytes.
-        memory = float(memory) / constants._G
-
-    return memory

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -650,32 +650,17 @@ def build_container_spec_for_task(
 
     if task.container_spec.resources is not None:
         if task.container_spec.resources.cpu_request is not None:
-            container_spec.resources.resource_cpu_request = (
-                convert_to_placeholder(
-                    task.container_spec.resources.cpu_request))
-            container_spec.resources.cpu_request = compiler_utils.validate_cpu_request_limit_to_float(
-                cpu=convert_to_placeholder(
-                    task.container_spec.resources.cpu_request))
+            container_spec.resources.resource_cpu_request = convert_to_placeholder(
+                task.container_spec.resources.cpu_request)
         if task.container_spec.resources.cpu_limit is not None:
-            container_spec.resources.resource_cpu_limit = (
-                convert_to_placeholder(task.container_spec.resources.cpu_limit))
-            container_spec.resources.cpu_limit = compiler_utils.validate_cpu_request_limit_to_float(
-                cpu=convert_to_placeholder(
-                    task.container_spec.resources.cpu_limit))
+            container_spec.resources.resource_cpu_limit = convert_to_placeholder(
+                task.container_spec.resources.cpu_limit)
         if task.container_spec.resources.memory_request is not None:
-            container_spec.resources.resource_memory_request = (
-                convert_to_placeholder(
-                    task.container_spec.resources.memory_request))
-            container_spec.resources.memory_request = compiler_utils.validate_memory_request_limit_to_float(
-                memory=convert_to_placeholder(
-                    task.container_spec.resources.memory_request))
+            container_spec.resources.resource_memory_request = convert_to_placeholder(
+                task.container_spec.resources.memory_request)
         if task.container_spec.resources.memory_limit is not None:
-            container_spec.resources.resource_memory_limit = (
-                convert_to_placeholder(
-                    task.container_spec.resources.memory_limit))
-            container_spec.resources.memory_limit = compiler_utils.validate_memory_request_limit_to_float(
-                memory=convert_to_placeholder(
-                    task.container_spec.resources.memory_limit))
+            container_spec.resources.resource_memory_limit = convert_to_placeholder(
+                task.container_spec.resources.memory_limit)
         if task.container_spec.resources.accelerator_count is not None:
             container_spec.resources.accelerator.CopyFrom(
                 pipeline_spec_pb2.PipelineDeploymentConfig.PipelineContainerSpec
@@ -684,10 +669,6 @@ def build_container_spec_for_task(
                         task.container_spec.resources.accelerator_type),
                     resource_count=convert_to_placeholder(
                         task.container_spec.resources.accelerator_count),
-                    type=convert_to_placeholder(
-                        task.container_spec.resources.accelerator_type),
-                    count=convert_to_placeholder(
-                        int(task.container_spec.resources.accelerator_count)),
                 ))
 
     return container_spec

--- a/sdk/python/test_data/pipelines/pipeline_with_resource_spec.yaml
+++ b/sdk/python/test_data/pipelines/pipeline_with_resource_spec.yaml
@@ -61,18 +61,12 @@ deploymentSpec:
         image: gcr.io/my-project/my-fancy-trainer
         resources:
           accelerator:
-            count: '1'
-            type: 'tpu-v3'
             resourceCount: '1'
-            resourceType: 'tpu-v3'
-          cpuLimit: 4.0
-          cpuRequest: 2.0
-          memoryLimit: 15.032385536
-          memoryRequest: 4.294967296
+            resourceType: tpu-v3
           resourceCpuLimit: '4'
           resourceCpuRequest: '2'
-          resourceMemoryLimit: '14Gi'
-          resourceMemoryRequest: '4Gi'
+          resourceMemoryLimit: 14Gi
+          resourceMemoryRequest: 4Gi
 pipelineInfo:
   description: A linear two-step pipeline with resource specification.
   name: two-step-pipeline-with-resource-spec
@@ -125,4 +119,4 @@ root:
         isOptional: true
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.8.0
+sdkVersion: kfp-2.11.0


### PR DESCRIPTION
**Description of your changes:**

The API introduced new fields prefixed with Resource (e.g. ResourceCpuLimit) to replace the old fields without the prefix. The Driver hadn't been updated to honor those fields but the SDK started using them which led to unexpected behavior.

The Driver now honors both fields but prioritizes the new fields. The SDK now only sets the new fields.

The outcome is that resource limits/requests can now use input parameters.

Note that pipeline_spec_builder.py was doing some validation on the limits/requests being set, but that's already handled in the user facing method (e.g. set_cpu_limit).

Resolves:
https://github.com/kubeflow/pipelines/issues/11500

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
