### PR TITLE
fix: Update broken api-connect link

### DIFF
--- a/backend/src/v2/README.md
+++ b/backend/src/v2/README.md
@@ -63,7 +63,7 @@ it should have the following content:
   pip install -r requirements.txt
   ```
 
-* [Connecting to Kubeflow Pipelines using the SDK client](https://www.kubeflow.org/docs/components/pipelines/sdk/connect-api/#configure-sdk-client-by-environment-variables).
+* [Connecting to Kubeflow Pipelines using the SDK client](https://www.kubeflow.org/docs/components/pipelines/user-guides/core-functions/connect-api/#configure-sdk-client-by-environment-variables).
 
   Recommend adding the env vars to your .bashrc or .zshrc etc to persist your config.
 

--- a/samples/test/utils/kfp/samples/test/utils.py
+++ b/samples/test/utils/kfp/samples/test/utils.py
@@ -205,8 +205,7 @@ def _run_test(callback):
     ):
         """Test file CLI entrypoint used by Fire. To configure KFP endpoint,
         configure env vars following:
-        https://www.kubeflow.org/docs/components/pipelines/sdk/connect-
-        api/#configure-sdk-client-by-environment-variables. KFP UI endpoint can
+        https://www.kubeflow.org/docs/components/pipelines/user-guides/core-functions/connect-api/#configure-sdk-client-by-environment-variables. KFP UI endpoint can
         be configured by KF_PIPELINES_UI_ENDPOINT env var.
 
         :param pipeline_root: pipeline root that holds intermediate

--- a/sdk/python/kfp/cli/utils/parsing_test.py
+++ b/sdk/python/kfp/cli/utils/parsing_test.py
@@ -128,7 +128,7 @@ class TestGetParamDescr(unittest.TestCase):
 
         self.assertEqual(
             host_descr,
-            "Host name to use to talk to Kubeflow Pipelines. If not set, the in-cluster service DNS name will be used, which only works if the current environment is a pod in the same cluster (such as a Jupyter instance spawned by Kubeflow's JupyterHub). (`More information on connecting. <https://www.kubeflow.org/docs/components/pipelines/sdk/connect-api/>`_)"
+            "Host name to use to talk to Kubeflow Pipelines. If not set, the in-cluster service DNS name will be used, which only works if the current environment is a pod in the same cluster (such as a Jupyter instance spawned by Kubeflow's JupyterHub). (`More information on connecting. <https://www.kubeflow.org/docs/components/pipelines/user-guides/core-functions/connect-api/>`_)"
         )
 
 

--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -105,7 +105,7 @@ class Client:
         host: Host name to use to talk to Kubeflow Pipelines. If not set,
             the in-cluster service DNS name will be used, which only works if
             the current environment is a pod in the same cluster (such as a
-            Jupyter instance spawned by Kubeflow's JupyterHub). (`More information on connecting. <https://www.kubeflow.org/docs/components/pipelines/sdk/connect-api/>`_)
+            Jupyter instance spawned by Kubeflow's JupyterHub). (`More information on connecting. <https://www.kubeflow.org/docs/components/pipelines/user-guides/core-functions/connect-api/>`_)
         client_id: Client ID used by Identity-Aware Proxy.
         namespace: Kubernetes namespace to use. Used for multi-user deployments. For single-user deployments, this should be left as ``None``.
         other_client_id: Client ID used to obtain the auth codes and refresh


### PR DESCRIPTION
**Description of your changes:**

To help users connect to KFP, the code referenced this doc link 
- https://www.kubeflow.org/docs/components/pipelines/sdk/connect-api/ which givers a 404. 

The correct link looks to be 
- https://www.kubeflow.org/docs/components/pipelines/user-guides/core-functions/connect-api/

I have updated the code to reference the correct link instead. The most important place where this needed to be fixed is in the sdk Client class docstring, since users reference this when they need help connecting.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
