### PR TITLE
chore: switch to using gh container registry in manifests

### DIFF
--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -30,9 +30,9 @@ import (
 const (
 	volumeNameKFPLauncher    = "kfp-launcher"
 	volumeNameCABundle       = "ca-bundle"
-	DefaultLauncherImage     = "gcr.io/ml-pipeline/kfp-launcher@sha256:bef55a344574a25c557256d7c66cb19edacfd2008d694e5b6bb5b612d59feae0"
+	DefaultLauncherImage     = "ghcr.io/kubeflow/kfp-launcher:2.4.0"
 	LauncherImageEnvVar      = "V2_LAUNCHER_IMAGE"
-	DefaultDriverImage       = "gcr.io/ml-pipeline/kfp-driver@sha256:dc8b56a2eb071f30409828a8884d621092e68385af11a6c06aa9e9fbcfbb19de"
+	DefaultDriverImage       = "ghcr.io/kubeflow/kfp-driver:2.4.0"
 	DriverImageEnvVar        = "V2_DRIVER_IMAGE"
 	DefaultDriverCommand     = "driver"
 	DriverCommandEnvVar      = "V2_DRIVER_COMMAND"

--- a/manifests/kustomize/base/cache-deployer/cache-deployer-deployment.yaml
+++ b/manifests/kustomize/base/cache-deployer/cache-deployer-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: gcr.io/ml-pipeline/cache-deployer:dummy
+        image: ghcr.io/kubeflow/kfp-cache-deployer:dummy
         imagePullPolicy: Always
         env:
         - name: NAMESPACE_TO_WATCH

--- a/manifests/kustomize/base/cache-deployer/kustomization.yaml
+++ b/manifests/kustomize/base/cache-deployer/kustomization.yaml
@@ -7,5 +7,5 @@ resources:
 commonLabels:
   app: cache-deployer
 images:
-  - name: gcr.io/ml-pipeline/cache-deployer
-    newTag: 2.3.0
+  - name: ghcr.io/kubeflow/kfp-cache-deployer
+    newTag: 2.4.0

--- a/manifests/kustomize/base/cache/cache-deployment.yaml
+++ b/manifests/kustomize/base/cache/cache-deployment.yaml
@@ -26,7 +26,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: gcr.io/ml-pipeline/cache-server:dummy
+        image: ghcr.io/kubeflow/kfp-cache-server:dummy
         env:
           - name: DEFAULT_CACHE_STALENESS
             valueFrom:

--- a/manifests/kustomize/base/cache/kustomization.yaml
+++ b/manifests/kustomize/base/cache/kustomization.yaml
@@ -9,5 +9,5 @@ resources:
 commonLabels:
   app: cache-server
 images:
-  - name: gcr.io/ml-pipeline/cache-server
-    newTag: 2.3.0
+  - name: ghcr.io/kubeflow/kfp-cache-server
+    newTag: 2.4.0

--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/sync.py
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/sync.py
@@ -36,9 +36,9 @@ def get_settings_from_env(controller_port=None,
     Settings are pulled from the all-caps version of the setting name.  The
     following defaults are used if those environment variables are not set
     to enable backwards compatibility with previous versions of this script:
-        visualization_server_image: gcr.io/ml-pipeline/visualization-server
+        visualization_server_image: ghcr.io/kubeflow/kfp-visualization-server
         visualization_server_tag: value of KFP_VERSION environment variable
-        frontend_image: gcr.io/ml-pipeline/frontend
+        frontend_image: ghcr.io/kubeflow/kfp-frontend
         frontend_tag: value of KFP_VERSION environment variable
         disable_istio_sidecar: Required (no default)
         minio_access_key: Required (no default)
@@ -51,11 +51,11 @@ def get_settings_from_env(controller_port=None,
 
     settings["visualization_server_image"] = \
         visualization_server_image or \
-        os.environ.get("VISUALIZATION_SERVER_IMAGE", "gcr.io/ml-pipeline/visualization-server")
+        os.environ.get("VISUALIZATION_SERVER_IMAGE", "ghcr.io/kubeflow/kfp-visualization-server")
 
     settings["frontend_image"] = \
         frontend_image or \
-        os.environ.get("FRONTEND_IMAGE", "gcr.io/ml-pipeline/frontend")
+        os.environ.get("FRONTEND_IMAGE", "ghcr.io/kubeflow/kfp-frontend")
 
     # Look for specific tags for each image first, falling back to
     # previously used KFP_VERSION environment variable for backwards

--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/test_sync.py
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/test_sync.py
@@ -49,8 +49,8 @@ DATA_CORRECT_CHILDREN = {
 DATA_MISSING_PIPELINE_ENABLED = {"parent": {}, "children": {}}
 
 # Default values when environments are not explicit
-DEFAULT_FRONTEND_IMAGE = "gcr.io/ml-pipeline/frontend"
-DEFAULT_VISUALIZATION_IMAGE = "gcr.io/ml-pipeline/visualization-server"
+DEFAULT_FRONTEND_IMAGE = "ghcr.io/kubeflow/kfp-frontend"
+DEFAULT_VISUALIZATION_IMAGE = "ghcr.io/kubeflow/kfp-visualization-server"
 
 # Variables used for environment variable sets
 VISUALIZATION_SERVER_IMAGE = "vis-image"

--- a/manifests/kustomize/base/metadata/base/kustomization.yaml
+++ b/manifests/kustomize/base/metadata/base/kustomization.yaml
@@ -9,5 +9,5 @@ resources:
   - metadata-envoy-service.yaml
   - metadata-grpc-sa.yaml
 images:
-  - name: gcr.io/ml-pipeline/metadata-envoy
-    newTag: 2.3.0
+  - name: ghcr.io/kubeflow/kfp-metadata-envoy
+    newTag: 2.4.0

--- a/manifests/kustomize/base/metadata/base/metadata-envoy-deployment.yaml
+++ b/manifests/kustomize/base/metadata/base/metadata-envoy-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/ml-pipeline/metadata-envoy:dummy
+        image: ghcr.io/kubeflow/kfp-metadata-envoy:dummy
         ports:
         - name: md-envoy
           containerPort: 9090

--- a/manifests/kustomize/base/pipeline/kustomization.yaml
+++ b/manifests/kustomize/base/pipeline/kustomization.yaml
@@ -35,15 +35,15 @@ resources:
   - viewer-sa.yaml
   - kfp-launcher-configmap.yaml
 images:
-  - name: gcr.io/ml-pipeline/api-server
-    newTag: 2.3.0
-  - name: gcr.io/ml-pipeline/persistenceagent
-    newTag: 2.3.0
-  - name: gcr.io/ml-pipeline/scheduledworkflow
-    newTag: 2.3.0
-  - name: gcr.io/ml-pipeline/frontend
-    newTag: 2.3.0
-  - name: gcr.io/ml-pipeline/viewer-crd-controller
-    newTag: 2.3.0
-  - name: gcr.io/ml-pipeline/visualization-server
-    newTag: 2.3.0
+  - name: ghcr.io/kubeflow/kfp-api-server
+    newTag: 2.4.0
+  - name: ghcr.io/kubeflow/kfp-persistence-agent
+    newTag: 2.4.0
+  - name: ghcr.io/kubeflow/kfp-scheduled-workflow-controller
+    newTag: 2.4.0
+  - name: ghcr.io/kubeflow/kfp-frontend
+    newTag: 2.4.0
+  - name: ghcr.io/kubeflow/kfp-viewer-crd-controller
+    newTag: 2.4.0
+  - name: ghcr.io/kubeflow/kfp-visualization-server
+    newTag: 2.4.0

--- a/manifests/kustomize/base/pipeline/metadata-writer/kustomization.yaml
+++ b/manifests/kustomize/base/pipeline/metadata-writer/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - metadata-writer-rolebinding.yaml
   - metadata-writer-sa.yaml
 images:
-  - name: gcr.io/ml-pipeline/metadata-writer
-    newTag: 2.3.0
+  - name: ghcr.io/kubeflow/kfp-metadata-writer
+    newTag: 2.4.0

--- a/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: gcr.io/ml-pipeline/metadata-writer:dummy
+        image: ghcr.io/kubeflow/kfp-metadata-writer:dummy
         env:
         - name: NAMESPACE_TO_WATCH
           valueFrom:

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -109,7 +109,7 @@ spec:
             secretKeyRef:
               name: mlpipeline-minio-artifact
               key: secretkey
-        image: gcr.io/ml-pipeline/api-server:dummy
+        image: ghcr.io/kubeflow/kfp-api-server:dummy
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-api-server
         ports:

--- a/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             value: "2"
           - name: LOG_LEVEL
             value: "info"
-        image: gcr.io/ml-pipeline/persistenceagent:dummy
+        image: ghcr.io/kubeflow/kfp-persistence-agent:dummy
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-persistenceagent
         resources:

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       containers:
-      - image: gcr.io/ml-pipeline/scheduledworkflow:dummy
+      - image: ghcr.io/kubeflow/kfp-scheduled-workflow-controller:dummy
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-scheduledworkflow
         env:

--- a/manifests/kustomize/base/pipeline/ml-pipeline-ui-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-ui-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         configMap:
           name: ml-pipeline-ui-configmap
       containers:
-      - image: gcr.io/ml-pipeline/frontend:dummy
+      - image: ghcr.io/kubeflow/kfp-frontend:dummy
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-ui
         ports:

--- a/manifests/kustomize/base/pipeline/ml-pipeline-viewer-crd-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-viewer-crd-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       containers:
-      - image: gcr.io/ml-pipeline/viewer-crd-controller:dummy
+      - image: ghcr.io/kubeflow/kfp-viewer-crd-controller:dummy
         imagePullPolicy: Always
         name: ml-pipeline-viewer-crd
         env:

--- a/manifests/kustomize/base/pipeline/ml-pipeline-visualization-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-visualization-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       containers:
-      - image: gcr.io/ml-pipeline/visualization-server:dummy
+      - image: ghcr.io/kubeflow/kfp-visualization-server:dummy
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-visualizationserver
         ports:

--- a/manifests/kustomize/env/gcp/inverse-proxy/kustomization.yaml
+++ b/manifests/kustomize/env/gcp/inverse-proxy/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-  - name: gcr.io/ml-pipeline/inverse-proxy-agent
-    newTag: 2.3.0
+  - name: ghcr.io/kubeflow/kfp-inverse-proxy-agent
+    newTag: 2.4.0
 resources:
   - proxy-configmap.yaml
   - proxy-deployment.yaml

--- a/manifests/kustomize/env/gcp/inverse-proxy/proxy-deployment.yaml
+++ b/manifests/kustomize/env/gcp/inverse-proxy/proxy-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - image: gcr.io/ml-pipeline/inverse-proxy-agent:dummy
+      - image: ghcr.io/kubeflow/kfp-inverse-proxy-agent:dummy
         imagePullPolicy: IfNotPresent
         name: proxy-agent
       serviceAccountName: proxy-agent-runner


### PR DESCRIPTION
**Description of your changes:**

This change switches majority of the images coming from gcr repository to the ghcr repository. For this, various manifests were updated, as well as the hardcoded launcher/driver images. All images that are regularly updated during the release process have been switched over to ghcr.

Note: I will follow up with updates to release instructions once we are done with the 2.4 release. 

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

