### PR TITLE
update driver & launcher image handling

### DIFF
--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -32,12 +32,16 @@ import (
 )
 
 const (
-	volumeNameKFPLauncher    = "kfp-launcher"
-	volumeNameCABundle       = "ca-bundle"
-	DefaultLauncherImage     = "ghcr.io/kubeflow/kfp-launcher:2.4.0"
-	LauncherImageEnvVar      = "V2_LAUNCHER_IMAGE"
-	DefaultDriverImage       = "ghcr.io/kubeflow/kfp-driver:2.4.0"
-	DriverImageEnvVar        = "V2_DRIVER_IMAGE"
+	volumeNameKFPLauncher = "kfp-launcher"
+	volumeNameCABundle    = "ca-bundle"
+	LauncherImageEnvVar   = "V2_LAUNCHER_IMAGE"
+	DriverImageEnvVar     = "V2_DRIVER_IMAGE"
+	// DefaultLauncherImage & DefaultDriverImage are set as latest here
+	// but are overridden by environment variables set via k8s manifests.
+	// For releases, the manifest will have the correct release version set.
+	// this is to avoid hardcoding releases in code here.
+	DefaultLauncherImage     = "ghcr.io/kubeflow/kfp-launcher:latest"
+	DefaultDriverImage       = "ghcr.io/kubeflow/kfp-driver:latest"
 	DefaultDriverCommand     = "driver"
 	DriverCommandEnvVar      = "V2_DRIVER_COMMAND"
 	PipelineRunAsUserEnvVar  = "PIPELINE_RUN_AS_USER"

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -115,6 +115,10 @@ spec:
             secretKeyRef:
               name: mlpipeline-minio-artifact
               key: secretkey
+        - name: V2_DRIVER_IMAGE
+          value: ghcr.io/kubeflow/kfp-driver:2.4.1
+        - name: V2_LAUNCHER_IMAGE
+          value: ghcr.io/kubeflow/kfp-launcher:2.4.1
         image: ghcr.io/kubeflow/kfp-api-server:dummy
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-api-server

--- a/manifests/kustomize/hack/release.sh
+++ b/manifests/kustomize/hack/release.sh
@@ -40,3 +40,14 @@ do
 done
 
 yq w -i "${MANIFEST_DIR}/base/installs/generic/pipeline-install-config.yaml" data.appVersion "$TAG_NAME"
+
+## Driver & Launcher images are added as environment variables
+API_SERVER_MANIFEST="${MANIFEST_DIR}/base/pipeline/ml-pipeline-apiserver-deployment.yaml"
+
+yq w -i ${API_SERVER_MANIFEST} \
+  "spec.template.spec.containers.(name==ml-pipeline-api-server).env.(name==V2_LAUNCHER_IMAGE).value" \
+  "ghcr.io/kubeflow/kfp-launcher:${TAG_NAME}"
+
+yq w -i ${API_SERVER_MANIFEST} \
+  "spec.template.spec.containers.(name==ml-pipeline-api-server).env.(name==V2_DRIVER_IMAGE).value" \
+  "ghcr.io/kubeflow/kfp-driver:${TAG_NAME}"


### PR DESCRIPTION
**Description of your changes:**

This change relies on manifest yamls to specify the launcher & driver that is pinned to a specific KFP version. The goal is to decouple having to build launcher/driver at separate stages relative to api server.

This is accomplished by setting the hardcoded default to point to "latest" and during release, api server is built with this hardcoding, and the images for driver/launcher are patched into manifests post build along with the other images.

The apiserver deployment manifest is reformatted using yq so the next time the release.sh is ran, the user is not surprised by the entire file reformatting unexpectedly.

A PR with update to the release docs will follow. 


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
