### PR TITLE
Fix typo in documentation for contribution and developer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Consult the [Python SDK reference docs](https://kubeflow-pipelines.readthedocs.i
 
 ## Contributing to Kubeflow Pipelines
 
-Before you start contributing to Kubeflow Pipelines, read the guidelines in [How to Contribute](./CONTRIBUTING.md). To learn how to build and deploy Kubeflow Pipelines from source code, reagd the [developer guide](./developer_guide.md).
+Before you start contributing to Kubeflow Pipelines, read the guidelines in [How to Contribute](./CONTRIBUTING.md). To learn how to build and deploy Kubeflow Pipelines from source code, read the [developer guide](./developer_guide.md).
 
 ## Kubeflow Pipelines Community
 


### PR DESCRIPTION
### What this PR does:
This pull request fixes a minor typo in the Kubeflow Pipelines documentation. Specifically:
- The word "**reagd**" was corrected to "**read**" in the sentence: "To learn how to build and deploy Kubeflow Pipelines from source code, read the developer guide".

### Why this is important:
Ensuring the documentation is clear and free from errors is essential for improving the developer experience, especially for new contributors.

### Checklist:
- [x] Corrected typo in the developer guide reference.
- [x] Verified that links in the sentence point to the correct resources.

Thank you for reviewing this PR!
