### PR TITLE
chore(test): Fixed namespace in tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -109,9 +109,12 @@ jobs:
       - name: Forward API port
         run: ./.github/resources/scripts/forward-port.sh "kubeflow" "ml-pipeline" 8888 8888
 
+      - name: Forward MySQL port
+        run: ./.github/resources/scripts/forward-port.sh "kubeflow" "mysql" 3306 3306
+
       - name: API integration tests v1
         working-directory: ./backend/test/integration
-        run: go test -v ./... -namespace ${NAMESPACE} -args -runIntegrationTests=true
+        run: go test -v ./... -namespace kubeflow -args -runIntegrationTests=true
 
       - name: Collect test results
         if: always()
@@ -145,7 +148,7 @@ jobs:
 
       - name: API integration tests v2
         working-directory: ./backend/test/v2/integration
-        run: go test -v ./... -namespace ${NAMESPACE} -args -runIntegrationTests=true
+        run: go test -v ./... -namespace kubeflow -args -runIntegrationTests=true
 
       - name: Collect test results
         if: always()

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -33,18 +33,21 @@ jobs:
         with:
           k8s_version: ${{ matrix.k8s_version }}
 
+      - name: Forward API port
+        run: ./.github/resources/scripts/forward-port.sh "kubeflow" "ml-pipeline" 8888 8888
+
       - name: Prepare upgrade tests
         working-directory: backend/test/integration
-        run: go test -v ./... -namespace ${NAMESPACE} -args -runUpgradeTests=true -testify.m=Prepare
+        run: go test -v ./... -namespace kubeflow -args -runUpgradeTests=true -testify.m=Prepare
 
       - name: Prepare verification tests
         working-directory: backend/test/integration
-        run: go test -v ./... -namespace ${NAMESPACE} -args -runUpgradeTests=true -testify.m=Verify
+        run: go test -v ./... -namespace kubeflow -args -runUpgradeTests=true -testify.m=Verify
 
       - name: Prepare upgrade tests v2
         working-directory: backend/test/v2/integration/
-        run: go test -v ./... -namespace ${NAMESPACE} -args -runUpgradeTests=true -testify.m=Prepare
+        run: go test -v ./... -namespace kubeflow -args -runUpgradeTests=true -testify.m=Prepare
 
       - name: Prepare verification tests v2
         working-directory: backend/test/v2/integration
-        run: go test -v ./... -namespace ${NAMESPACE} -args -runUpgradeTests=true -testify.m=Verify
+        run: go test -v ./... -namespace kubeflow -args -runUpgradeTests=true -testify.m=Verify

--- a/backend/test/integration/db_test.go
+++ b/backend/test/integration/db_test.go
@@ -48,9 +48,7 @@ func (s *DBTestSuite) TestInitDBClient_MySQL() {
 	viper.Set("DBDriverName", "mysql")
 	viper.Set("DBConfig.MySQLConfig.DBName", "mlpipeline")
 	// The default port-forwarding IP address that test uses is different compared to production
-	if *localTest {
-		viper.Set("DBConfig.MySQLConfig.Host", "localhost")
-	}
+	viper.Set("DBConfig.MySQLConfig.Host", "localhost")
 	duration, _ := time.ParseDuration("1m")
 	db := cm.InitDBClient(duration)
 	assert.NotNil(t, db)


### PR DESCRIPTION
This PR replaces the `${NAMESPACE}` variable with `kubeflow`.
For some reason, some tests were being skipped and started to run when I added the namespace. That required me to forward ports and change one test.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
