### PR TITLE
fix(sdk): dsl.component docstring typo

### DIFF
--- a/sdk/python/kfp/dsl/component_decorator.py
+++ b/sdk/python/kfp/dsl/component_decorator.py
@@ -54,7 +54,7 @@ def component(func: Optional[Callable] = None,
             a plain parameter, or a path to a file).
         base_image: Image to use when executing the Python function. It should
             contain a default Python interpreter that is compatible with KFP.
-        target_image: Image to when creating containerized components.
+        target_image: Image to use when creating containerized components.
         packages_to_install: List of packages to install before
             executing the Python function. These will always be installed at component runtime.
         pip_index_urls: Python Package Index base URLs from which to


### PR DESCRIPTION
**Description of your changes:**
One of the parameters (`target_image`) to the `kfp.dsl.component` decorator had a word missing in the docstring, which made it confusing. This PR adds the word. 

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
