### PR TITLE
fix(backend): removed old version comment

### DIFF
--- a/backend/src/v2/README.md
+++ b/backend/src/v2/README.md
@@ -56,7 +56,7 @@ it should have the following content:
   echo "GOARCH_VALUE="$(go env GOARCH) >> .env
   ```
 
-* Install sample test python dependencies (require Python 3.7 or 3.8 due to [ml-metadata limitation](https://github.com/google/ml-metadata/issues/139)):
+* Install sample test python dependencies:
 
   ```bash
   cd test


### PR DESCRIPTION
**Description of your changes:**
The backend README.md file had the comment:
"Install sample test python dependencies (require Python 3.7 or 3.8 due to [ml-metadata limitation](https://github.com/google/ml-metadata/issues/139))"

However, visiting the link reveals this MLMD issue was resolved over a year ago. Moreover, the MLMD repository advises users that it supports Python 3.9, 3.10, and 3.11 (https://github.com/google/ml-metadata). Therefore, requiring Python 3.7 or 3.8 here is bad for a few reasons.

I have removed the comment in parentheses, as it is outdated.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
