### PR TITLE
feat(backend): Allow recurring runs to always use the latest pipeline version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,5 +86,8 @@ __pycache__
 # kfp local execution default directory
 local_outputs/
 
+# Ignore the Kind cluster kubeconfig
+kubeconfig_dev-pipelines-api
+
 # Ignore debug Driver Dockerfile produced from `make -C backend image_driver_debug`
 backend/Dockerfile.driver-debug

--- a/backend/README.md
+++ b/backend/README.md
@@ -159,6 +159,39 @@ You can also directly connect to the MariaDB database server with:
 mysql -h 127.0.0.1 -u root
 ```
 
+### Scheduled Workflow Development
+
+If you also want to run the Scheduled Workflow controller locally, stop the controller on the cluster with:
+
+```bash
+kubectl -n kubeflow scale deployment ml-pipeline-scheduledworkflow --replicas=0
+```
+
+Then you may leverage the following sample `.vscode/launch.json` file to run the Scheduled Workflow controller locally:
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Scheduled Workflow controller (Kind)",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/backend/src/crd/controller/scheduledworkflow",
+            "env": {
+                "CRON_SCHEDULE_TIMEZONE": "UTC"
+            },
+            "args": [
+                "-namespace=kubeflow",
+                "-kubeconfig=${workspaceFolder}/kubeconfig_dev-pipelines-api",
+                "-mlPipelineAPIServerName=localhost"
+            ]
+        }
+    ]
+}
+```
+
 ### Remote Debug the Driver
 
 These instructions assume you are leveraging the Kind cluster in the

--- a/backend/api/Makefile
+++ b/backend/api/Makefile
@@ -17,6 +17,8 @@
 IMAGE_TAG=kfp-api-generator
 # Contact chensun or zijianjoy if this remote image needs an update.
 REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator
+# Assume the latest API version by default.
+API_VERSION ?= v2beta1
 
 # Keep in sync with the version used in test/release/Dockerfile.release
 PREBUILT_REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator:1.0

--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -12,7 +12,7 @@ Tools needed:
 Set the environment variable `API_VERSION` to the version that you want to generate. We use `v1beta1` as example here.
 
 ```bash
-export API_VERSION="v1beta1"
+export API_VERSION="v2beta1"
 ```
 
 ## Compiling `.proto` files to Go client and swagger definitions

--- a/backend/api/v1beta1/job.proto
+++ b/backend/api/v1beta1/job.proto
@@ -210,9 +210,9 @@ message Job {
   // Optional input field. Describing the purpose of the job
   string description = 3;
 
-  // Required input field.
+  // Optional input field.
   // Describing what the pipeline manifest and parameters to use
-  // for the scheduled job.
+  // for the scheduled job. If unset, fetch the pipline_spec at runtime.
   PipelineSpec pipeline_spec = 4;
 
   // Optional input field. Specify which resource this job belongs to.

--- a/backend/api/v2beta1/go_client/recurring_run.pb.go
+++ b/backend/api/v2beta1/go_client/recurring_run.pb.go
@@ -159,7 +159,7 @@ type RecurringRun struct {
 	// Optional input field. Describes the purpose of the recurring run.
 	Description string `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
 	// Required input field. Specifies the source of the pipeline spec for this
-	// recurring run. Can be either a pipeline version id, or a pipeline spec.
+	// recurring run. Can be either a pipeline id, pipeline version id, or a pipeline spec.
 	//
 	// Types that are assignable to PipelineSource:
 	//

--- a/backend/api/v2beta1/go_client/run.pb.go
+++ b/backend/api/v2beta1/go_client/run.pb.go
@@ -411,7 +411,7 @@ type Run_PipelineSpec struct {
 }
 
 type Run_PipelineVersionReference struct {
-	// Reference to a pipeline version containing pipeline_id and pipeline_version_id.
+	// Reference to a pipeline containing pipeline_id and optionally the pipeline_version_id.
 	PipelineVersionReference *PipelineVersionReference `protobuf:"bytes,18,opt,name=pipeline_version_reference,json=pipelineVersionReference,proto3,oneof"`
 }
 
@@ -429,7 +429,7 @@ type PipelineVersionReference struct {
 
 	// Input. Required. Unique ID of the parent pipeline.
 	PipelineId string `protobuf:"bytes,1,opt,name=pipeline_id,json=pipelineId,proto3" json:"pipeline_id,omitempty"`
-	// Input. Required. Unique ID of an existing pipeline version.
+	// Input. Optional. Unique ID of an existing pipeline version. If unset, the latest pipeline version is used.
 	PipelineVersionId string `protobuf:"bytes,2,opt,name=pipeline_version_id,json=pipelineVersionId,proto3" json:"pipeline_version_id,omitempty"`
 }
 

--- a/backend/api/v2beta1/go_http_client/recurring_run_model/v2beta1_pipeline_version_reference.go
+++ b/backend/api/v2beta1/go_http_client/recurring_run_model/v2beta1_pipeline_version_reference.go
@@ -18,7 +18,7 @@ type V2beta1PipelineVersionReference struct {
 	// Input. Required. Unique ID of the parent pipeline.
 	PipelineID string `json:"pipeline_id,omitempty"`
 
-	// Input. Required. Unique ID of an existing pipeline version.
+	// Input. Optional. Unique ID of an existing pipeline version. If unset, the latest pipeline version is used.
 	PipelineVersionID string `json:"pipeline_version_id,omitempty"`
 }
 

--- a/backend/api/v2beta1/go_http_client/run_model/v2beta1_pipeline_version_reference.go
+++ b/backend/api/v2beta1/go_http_client/run_model/v2beta1_pipeline_version_reference.go
@@ -18,7 +18,7 @@ type V2beta1PipelineVersionReference struct {
 	// Input. Required. Unique ID of the parent pipeline.
 	PipelineID string `json:"pipeline_id,omitempty"`
 
-	// Input. Required. Unique ID of an existing pipeline version.
+	// Input. Optional. Unique ID of an existing pipeline version. If unset, the latest pipeline version is used.
 	PipelineVersionID string `json:"pipeline_version_id,omitempty"`
 }
 

--- a/backend/api/v2beta1/go_http_client/run_model/v2beta1_run.go
+++ b/backend/api/v2beta1/go_http_client/run_model/v2beta1_run.go
@@ -49,7 +49,7 @@ type V2beta1Run struct {
 	// This field is Deprecated. The pipeline version id is under pipeline_version_reference for v2.
 	PipelineVersionID string `json:"pipeline_version_id,omitempty"`
 
-	// Reference to a pipeline version containing pipeline_id and pipeline_version_id.
+	// Reference to a pipeline containing pipeline_id and optionally the pipeline_version_id.
 	PipelineVersionReference *V2beta1PipelineVersionReference `json:"pipeline_version_reference,omitempty"`
 
 	// ID of the recurring run that triggered this run.

--- a/backend/api/v2beta1/recurring_run.proto
+++ b/backend/api/v2beta1/recurring_run.proto
@@ -89,7 +89,7 @@ message RecurringRun {
   string description = 3;
 
   // Required input field. Specifies the source of the pipeline spec for this 
-  // recurring run. Can be either a pipeline version id, or a pipeline spec.
+  // recurring run. Can be either a pipeline id, pipeline version id, or a pipeline spec.
   oneof pipeline_source {
     // This field is Deprecated. The pipeline version id is under pipeline_version_reference for v2.
     string pipeline_version_id = 4 [deprecated=true];

--- a/backend/api/v2beta1/run.proto
+++ b/backend/api/v2beta1/run.proto
@@ -168,7 +168,7 @@ message Run {
     // Pipeline spec.
     google.protobuf.Struct pipeline_spec = 7;
 
-    // Reference to a pipeline version containing pipeline_id and pipeline_version_id.
+    // Reference to a pipeline containing pipeline_id and optionally the pipeline_version_id.
     PipelineVersionReference pipeline_version_reference = 18;
   }
  
@@ -213,7 +213,7 @@ message PipelineVersionReference {
   // Input. Required. Unique ID of the parent pipeline.
   string pipeline_id = 1;
 
-  // Input. Required. Unique ID of an existing pipeline version.
+  // Input. Optional. Unique ID of an existing pipeline version. If unset, the latest pipeline version is used.
   string pipeline_version_id = 2;
 }
 

--- a/backend/api/v2beta1/swagger/kfp_api_single_file.swagger.json
+++ b/backend/api/v2beta1/swagger/kfp_api_single_file.swagger.json
@@ -2020,7 +2020,7 @@
         },
         "pipeline_version_id": {
           "type": "string",
-          "description": "Input. Required. Unique ID of an existing pipeline version."
+          "description": "Input. Optional. Unique ID of an existing pipeline version. If unset, the latest pipeline version is used."
         }
       },
       "description": "Reference to an existing pipeline version."
@@ -2349,7 +2349,7 @@
         },
         "pipeline_version_reference": {
           "$ref": "#/definitions/v2beta1PipelineVersionReference",
-          "description": "Reference to a pipeline version containing pipeline_id and pipeline_version_id."
+          "description": "Reference to a pipeline containing pipeline_id and optionally the pipeline_version_id."
         },
         "runtime_config": {
           "$ref": "#/definitions/v2beta1RuntimeConfig",

--- a/backend/api/v2beta1/swagger/recurring_run.swagger.json
+++ b/backend/api/v2beta1/swagger/recurring_run.swagger.json
@@ -390,7 +390,7 @@
         },
         "pipeline_version_id": {
           "type": "string",
-          "description": "Input. Required. Unique ID of an existing pipeline version."
+          "description": "Input. Optional. Unique ID of an existing pipeline version. If unset, the latest pipeline version is used."
         }
       },
       "description": "Reference to an existing pipeline version."

--- a/backend/api/v2beta1/swagger/run.swagger.json
+++ b/backend/api/v2beta1/swagger/run.swagger.json
@@ -619,7 +619,7 @@
         },
         "pipeline_version_id": {
           "type": "string",
-          "description": "Input. Required. Unique ID of an existing pipeline version."
+          "description": "Input. Optional. Unique ID of an existing pipeline version. If unset, the latest pipeline version is used."
         }
       },
       "description": "Reference to an existing pipeline version."
@@ -667,7 +667,7 @@
         },
         "pipeline_version_reference": {
           "$ref": "#/definitions/v2beta1PipelineVersionReference",
-          "description": "Reference to a pipeline version containing pipeline_id and pipeline_version_id."
+          "description": "Reference to a pipeline containing pipeline_id and optionally the pipeline_version_id."
         },
         "runtime_config": {
           "$ref": "#/definitions/v2beta1RuntimeConfig",

--- a/backend/src/apiserver/client/sql.go
+++ b/backend/src/apiserver/client/sql.go
@@ -22,8 +22,9 @@ import (
 )
 
 const (
-	MYSQL_TEXT_FORMAT string = "longtext not null"
-	MYSQL_EXIST_ERROR string = "database exists"
+	MYSQL_TEXT_FORMAT      string = "longtext not null"
+	MYSQL_TEXT_FORMAT_NULL string = "longtext"
+	MYSQL_EXIST_ERROR      string = "database exists"
 
 	PGX_TEXT_FORMAT string = "text"
 	PGX_EXIST_ERROR string = "already exists"

--- a/backend/src/apiserver/client_manager/client_manager.go
+++ b/backend/src/apiserver/client_manager/client_manager.go
@@ -345,6 +345,12 @@ func InitDBClient(initConnectionTimeout time.Duration) *storage.DB {
 		if ignoreAlreadyExistError(driverName, response.Error) != nil {
 			glog.Fatalf("Failed to create a foreign key for RunUUID in task table. Error: %s", response.Error)
 		}
+
+		// This is a workaround because AutoMigration does not detect that the column went from not null to nullable.
+		response = db.Model(&model.Job{}).ModifyColumn("WorkflowSpecManifest", client.MYSQL_TEXT_FORMAT_NULL)
+		if response.Error != nil {
+			glog.Fatalf("Failed to make the WorkflowSpecManifest column nullable on jobs. Error: %s", response.Error)
+		}
 	default:
 		glog.Fatalf("Driver %v is not supported, use \"mysql\" for MySQL, or \"pgx\" for PostgreSQL", driverName)
 	}

--- a/backend/src/apiserver/model/pipeline_spec.go
+++ b/backend/src/apiserver/model/pipeline_spec.go
@@ -33,7 +33,8 @@ type PipelineSpec struct {
 	PipelineSpecManifest string `gorm:"column:PipelineSpecManifest; size:33554432;"`
 
 	// Argo workflow YAML definition. This is the Argo Spec converted from Pipeline YAML.
-	WorkflowSpecManifest string `gorm:"column:WorkflowSpecManifest; not null; size:33554432;"`
+	// This is deprecated. Use the pipeline ID, pipeline version ID, or pipeline spec manifest.
+	WorkflowSpecManifest string `gorm:"column:WorkflowSpecManifest; size:33554432;"`
 
 	// Store parameters key-value pairs as serialized string.
 	// This field is only used for V1 API. For V2, use the `Parameters` field in RuntimeConfig.

--- a/backend/src/apiserver/server/api_converter.go
+++ b/backend/src/apiserver/server/api_converter.go
@@ -1869,10 +1869,13 @@ func toModelJob(j interface{}) (*model.Job, error) {
 	case *apiv2beta1.RecurringRun:
 		pipelineId = apiJob.GetPipelineVersionReference().GetPipelineId()
 		pipelineVersionId = apiJob.GetPipelineVersionReference().GetPipelineVersionId()
-		if spec, err := pipelineSpecStructToYamlString(apiJob.GetPipelineSpec()); err == nil {
-			pipelineSpec = spec
-		} else {
-			return nil, util.Wrap(err, "Failed to convert API recurring run to its internal representation due to pipeline spec conversion error")
+
+		if apiJob.GetPipelineSpec() != nil {
+			if spec, err := pipelineSpecStructToYamlString(apiJob.GetPipelineSpec()); err == nil {
+				pipelineSpec = spec
+			} else {
+				return nil, util.Wrap(err, "Failed to convert API recurring run to its internal representation due to pipeline spec conversion error")
+			}
 		}
 
 		cfg, err := toModelRuntimeConfig(apiJob.GetRuntimeConfig())
@@ -1933,6 +1936,7 @@ func toModelJob(j interface{}) (*model.Job, error) {
 	} else if pipelineVersionId != "" {
 		pipelineName = fmt.Sprintf("pipelines/%v", pipelineVersionId)
 	}
+
 	status := model.StatusStateUnspecified
 	if isEnabled {
 		status = model.StatusStateEnabled

--- a/backend/src/apiserver/server/job_server_test.go
+++ b/backend/src/apiserver/server/job_server_test.go
@@ -148,10 +148,11 @@ func TestCreateJob_WrongInput(t *testing.T) {
 					Trigger: &apiv1beta1.Trigger_CronSchedule{CronSchedule: &apiv1beta1.CronSchedule{
 						StartTime: &timestamp.Timestamp{Seconds: 1},
 						Cron:      "1 * * * *",
-					}}},
+					}},
+				},
 				ResourceReferences: validReference,
 			},
-			"Failed to fetch a template with an empty pipeline spec manifest",
+			"Failed to create a recurring run: Cannot create a job with an empty pipeline ID",
 		},
 		{
 			"invalid pipeline spec",
@@ -172,7 +173,8 @@ func TestCreateJob_WrongInput(t *testing.T) {
 					{Key: &apiv1beta1.ResourceKey{Type: apiv1beta1.ResourceType_EXPERIMENT, Id: experiment.UUID}, Relationship: apiv1beta1.Relationship_OWNER},
 				},
 			},
-			"Failed to get the latest pipeline version as pipeline was not found: ResourceNotFoundError: Pipeline not_exist_pipeline not found",
+			"Failed to fetch a pipeline version from pipeline not_exist_pipeline: Failed to get the latest " +
+				"pipeline version as pipeline was not found: ResourceNotFoundError: Pipeline not_exist_pipeline not found",
 		},
 		{
 			"invalid cron",
@@ -240,7 +242,11 @@ func TestCreateJob_WrongInput(t *testing.T) {
 	for _, tt := range tests {
 		got, err := server.CreateJob(context.Background(), &apiv1beta1.CreateJobRequest{Job: tt.arg})
 		assert.NotNil(t, err)
-		assert.Contains(t, err.Error(), tt.errMsg)
+		errMsg := ""
+		if err != nil {
+			errMsg = err.Error()
+		}
+		assert.Contains(t, errMsg, tt.errMsg)
 		assert.Nil(t, got)
 	}
 }

--- a/backend/src/apiserver/template/template.go
+++ b/backend/src/apiserver/template/template.go
@@ -169,7 +169,7 @@ func modelToPipelineJobRuntimeConfig(modelRuntimeConfig *model.RuntimeConfig) (*
 // Assumes that the serialized parameters will take a form of
 // map[string]*structpb.Value, which works for runtimeConfig.Parameters  such as
 // {"param1":"value1","param2":"value2"}.
-func stringMapToCRDParameters(modelParams string) ([]scheduledworkflow.Parameter, error) {
+func StringMapToCRDParameters(modelParams string) ([]scheduledworkflow.Parameter, error) {
 	var swParams []scheduledworkflow.Parameter
 	var parameters map[string]*structpb.Value
 	if modelParams == "" {

--- a/backend/src/apiserver/template/v2_template.go
+++ b/backend/src/apiserver/template/v2_template.go
@@ -41,9 +41,38 @@ type V2Spec struct {
 	platformSpec *pipelinespec.PlatformSpec
 }
 
-var (
-	Launcher = ""
-)
+var Launcher = ""
+
+func NewGenericScheduledWorkflow(modelJob *model.Job) (*scheduledworkflow.ScheduledWorkflow, error) {
+	swfGeneratedName, err := toSWFCRDResourceGeneratedName(modelJob.K8SName)
+	if err != nil {
+		return nil, util.Wrap(err, "Create job failed")
+	}
+
+	crdTrigger, err := modelToCRDTrigger(modelJob.Trigger)
+	if err != nil {
+		return nil, util.Wrap(err, "converting model trigger to crd trigger failed")
+	}
+
+	return &scheduledworkflow.ScheduledWorkflow{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kubeflow.org/v2beta1",
+			Kind:       "ScheduledWorkflow",
+		},
+		ObjectMeta: metav1.ObjectMeta{GenerateName: swfGeneratedName},
+		Spec: scheduledworkflow.ScheduledWorkflowSpec{
+			Enabled:           modelJob.Enabled,
+			MaxConcurrency:    &modelJob.MaxConcurrency,
+			Trigger:           crdTrigger,
+			NoCatchup:         util.BoolPointer(modelJob.NoCatchup),
+			ExperimentId:      modelJob.ExperimentId,
+			PipelineId:        modelJob.PipelineId,
+			PipelineName:      modelJob.PipelineName,
+			PipelineVersionId: modelJob.PipelineVersionId,
+			ServiceAccount:    modelJob.ServiceAccount,
+		},
+	}, nil
+}
 
 // Converts modelJob to ScheduledWorkflow.
 func (t *V2Spec) ScheduledWorkflow(modelJob *model.Job) (*scheduledworkflow.ScheduledWorkflow, error) {
@@ -102,41 +131,23 @@ func (t *V2Spec) ScheduledWorkflow(modelJob *model.Job) (*scheduledworkflow.Sche
 	}
 	// Disable istio sidecar injection if not specified
 	executionSpec.SetAnnotationsToAllTemplatesIfKeyNotExist(util.AnnotationKeyIstioSidecarInject, util.AnnotationValueIstioSidecarInjectDisabled)
-	swfGeneratedName, err := toSWFCRDResourceGeneratedName(modelJob.K8SName)
-	if err != nil {
-		return nil, util.Wrap(err, "Create job failed")
-	}
-	parameters, err := stringMapToCRDParameters(modelJob.RuntimeConfig.Parameters)
+	parameters, err := StringMapToCRDParameters(modelJob.RuntimeConfig.Parameters)
 	if err != nil {
 		return nil, util.Wrap(err, "Converting runtime config's parameters to CDR parameters failed")
 	}
-	crdTrigger, err := modelToCRDTrigger(modelJob.Trigger)
+
+	scheduledWorkflow, err := NewGenericScheduledWorkflow(modelJob)
 	if err != nil {
-		return nil, util.Wrap(err, "converting model trigger to crd trigger failed")
+		return nil, err
 	}
 
-	scheduledWorkflow := &scheduledworkflow.ScheduledWorkflow{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kubeflow.org/v2beta1",
-			Kind:       "ScheduledWorkflow",
-		},
-		ObjectMeta: metav1.ObjectMeta{GenerateName: swfGeneratedName},
-		Spec: scheduledworkflow.ScheduledWorkflowSpec{
-			Enabled:        modelJob.Enabled,
-			MaxConcurrency: &modelJob.MaxConcurrency,
-			Trigger:        crdTrigger,
-			Workflow: &scheduledworkflow.WorkflowResource{
-				Parameters: parameters,
-				Spec:       executionSpec.ToStringForSchedule(),
-			},
-			NoCatchup:         util.BoolPointer(modelJob.NoCatchup),
-			ExperimentId:      modelJob.ExperimentId,
-			PipelineId:        modelJob.PipelineId,
-			PipelineName:      modelJob.PipelineName,
-			PipelineVersionId: modelJob.PipelineVersionId,
-			ServiceAccount:    executionSpec.ServiceAccount(),
-		},
+	scheduledWorkflow.Spec.Workflow = &scheduledworkflow.WorkflowResource{
+		Parameters: parameters,
+		Spec:       executionSpec.ToStringForSchedule(),
 	}
+
+	scheduledWorkflow.Spec.ServiceAccount = executionSpec.ServiceAccount()
+
 	return scheduledWorkflow, nil
 }
 

--- a/backend/src/common/util/service.go
+++ b/backend/src/common/util/service.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -92,6 +93,16 @@ func GetKubernetesClientFromClientConfig(clientConfig clientcmd.ClientConfig) (
 			"Failed to create client set during K8s client initialization")
 	}
 	return clientSet, config, namespace, nil
+}
+
+func GetRpcConnectionWithTimeout(address string, timeout time.Time) (*grpc.ClientConn, error) {
+	ctx, _ := context.WithDeadline(context.Background(), timeout)
+
+	conn, err := grpc.DialContext(ctx, address, grpc.WithInsecure(), grpc.WithBlock())
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to create gRPC connection")
+	}
+	return conn, nil
 }
 
 func GetRpcConnection(address string) (*grpc.ClientConn, error) {

--- a/backend/src/crd/controller/scheduledworkflow/controller.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	workflowapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	api "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
 	commonutil "github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/kubeflow/pipelines/backend/src/crd/controller/scheduledworkflow/client"
 	"github.com/kubeflow/pipelines/backend/src/crd/controller/scheduledworkflow/util"
@@ -30,6 +31,8 @@ import (
 	swfinformers "github.com/kubeflow/pipelines/backend/src/crd/pkg/client/informers/externalversions"
 	wraperror "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/structpb"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -40,6 +43,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -60,6 +64,7 @@ type Controller struct {
 	kubeClient     *client.KubeClient
 	swfClient      *client.ScheduledWorkflowClient
 	workflowClient *client.WorkflowClient
+	runClient      api.RunServiceClient
 
 	// workqueue is a rate limited work queue. This is used to queue work to be
 	// processed instead of performing it as soon as a change happens. This
@@ -73,6 +78,10 @@ type Controller struct {
 
 	// the timezone loation which the scheduled will use
 	location *time.Location
+
+	// tokenSrc provides a way to get the latest refreshed token when authentication to the REST API server is enabled.
+	// This will be nil when authentication is not enabled (e.g. Kubeconfig does not have token based authentication).
+	tokenSrc transport.ResettableTokenSource
 }
 
 // NewController returns a new sample controller
@@ -80,10 +89,12 @@ func NewController(
 	kubeClientSet kubernetes.Interface,
 	swfClientSet swfclientset.Interface,
 	workflowClientSet commonutil.ExecutionClient,
+	runClient api.RunServiceClient,
 	swfInformerFactory swfinformers.SharedInformerFactory,
 	executionInformer commonutil.ExecutionInformer,
 	time commonutil.TimeInterface,
 	location *time.Location,
+	tokenSrc transport.ResettableTokenSource,
 ) (*Controller, error) {
 	// obtain references to shared informers
 	swfInformer := swfInformerFactory.Scheduledworkflow().V1beta1().ScheduledWorkflows()
@@ -102,11 +113,13 @@ func NewController(
 	controller := &Controller{
 		kubeClient:     client.NewKubeClient(kubeClientSet, recorder),
 		swfClient:      client.NewScheduledWorkflowClient(swfClientSet, swfInformer),
+		runClient:      runClient,
 		workflowClient: client.NewWorkflowClient(workflowClientSet, executionInformer),
 		workqueue: workqueue.NewNamedRateLimitingQueue(
 			workqueue.NewItemExponentialFailureRateLimiter(DefaultJobBackOff, MaxJobBackOff), swfregister.Kind),
 		time:     time,
 		location: location,
+		tokenSrc: tokenSrc,
 	}
 
 	log.Info("Setting up event handlers")
@@ -507,12 +520,72 @@ func (c *Controller) submitNewWorkflowIfNotAlreadySubmitted(
 	}
 
 	// If the workflow is not found, we need to create it.
-	newWorkflow, err := swf.NewWorkflow(nextScheduledEpoch, nowEpoch)
-	createdWorkflow, err := c.workflowClient.Create(ctx, swf.Namespace, newWorkflow)
-	if err != nil {
-		return false, "", err
+	if swf.Spec.Workflow != nil && swf.Spec.Workflow.Spec != nil {
+		newWorkflow, err := swf.NewWorkflow(nextScheduledEpoch, nowEpoch)
+		if err != nil {
+			return false, "", err
+		}
+
+		createdWorkflow, err := c.workflowClient.Create(ctx, swf.Namespace, newWorkflow)
+		if err != nil {
+			return false, "", err
+		}
+		return true, createdWorkflow.ExecutionName(), nil
 	}
-	return true, createdWorkflow.ExecutionName(), nil
+
+	if c.tokenSrc != nil {
+		token, err := c.tokenSrc.Token()
+		if err != nil {
+			return false, "", fmt.Errorf("Failed to get a token to communicate with the REST API: %w", err)
+		}
+
+		ctx = metadata.AppendToOutgoingContext(ctx, "Authorization", "Bearer "+token.AccessToken)
+	}
+
+	var runtimeConfig *api.RuntimeConfig
+
+	if swf.Spec.Workflow != nil {
+		runtimeConfig = &api.RuntimeConfig{
+			Parameters:   map[string]*structpb.Value{},
+			PipelineRoot: swf.Spec.Workflow.PipelineRoot,
+		}
+
+		for _, param := range swf.Spec.Workflow.Parameters {
+			val := &structpb.Value{}
+
+			err := val.UnmarshalJSON([]byte(param.Value))
+			if err != nil {
+				return false, "", err
+			}
+
+			runtimeConfig.Parameters[param.Name] = val
+		}
+	}
+
+	run, err := c.runClient.CreateRun(ctx, &api.CreateRunRequest{
+		ExperimentId: swf.Spec.ExperimentId,
+		Run: &api.Run{
+			ExperimentId:   swf.Spec.ExperimentId,
+			DisplayName:    swf.NextResourceName(),
+			RecurringRunId: string(swf.UID),
+			RuntimeConfig:  runtimeConfig,
+			PipelineSource: &api.Run_PipelineVersionReference{
+				PipelineVersionReference: &api.PipelineVersionReference{
+					PipelineId: swf.Spec.PipelineId,
+					// This can be empty, which causes the latest pipeline version to be selected.
+					PipelineVersionId: swf.Spec.PipelineVersionId,
+				},
+			},
+			ServiceAccount: swf.Spec.ServiceAccount,
+		},
+	})
+	if err != nil {
+		return false, "", fmt.Errorf(
+			"failed to create a run from the scheduled workflow (%s/%s): %w", swf.Namespace, swf.Name, err,
+		)
+	}
+
+	return true, run.DisplayName, nil
 }
 
 func (c *Controller) updateStatus(

--- a/backend/src/crd/controller/scheduledworkflow/controller.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller.go
@@ -80,7 +80,7 @@ type Controller struct {
 	location *time.Location
 
 	// tokenSrc provides a way to get the latest refreshed token when authentication to the REST API server is enabled.
-	// This will be nil when authentication is not enabled (e.g. Kubeconfig does not have token based authentication).
+	// This will be nil when authentication is not enabled.
 	tokenSrc transport.ResettableTokenSource
 }
 

--- a/backend/src/crd/controller/scheduledworkflow/main.go
+++ b/backend/src/crd/controller/scheduledworkflow/main.go
@@ -16,9 +16,12 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"os"
 	"strings"
 	"time"
 
+	api "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
 	commonutil "github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/kubeflow/pipelines/backend/src/crd/controller/scheduledworkflow/util"
 	swfclientset "github.com/kubeflow/pipelines/backend/src/crd/pkg/client/clientset/versioned"
@@ -29,16 +32,27 @@ import (
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/transport"
 )
 
 var (
-	logLevel    string
-	masterURL   string
-	kubeconfig  string
-	namespace   string
-	location    *time.Location
-	clientQPS   float64
-	clientBurst int
+	logLevel                  string
+	masterURL                 string
+	kubeconfig                string
+	namespace                 string
+	location                  *time.Location
+	clientQPS                 float64
+	clientBurst               int
+	mlPipelineAPIServerName   string
+	mlPipelineServiceGRPCPort string
+)
+
+const (
+	// These flags match the persistence agent
+	mlPipelineAPIServerBasePathFlagName = "mlPipelineAPIServerBasePath"
+	mlPipelineAPIServerNameFlagName     = "mlPipelineAPIServerName"
+	mlPipelineAPIServerGRPCPortFlagName = "mlPipelineServiceGRPCPort"
+	apiTokenFile                        = "/var/run/secrets/kubeflow/tokens/scheduledworkflow-sa-token"
 )
 
 func main() {
@@ -85,14 +99,35 @@ func main() {
 		scheduleInformerFactory = swfinformers.NewFilteredSharedInformerFactory(scheduleClient, time.Second*30, namespace, nil)
 	}
 
+	grpcAddress := fmt.Sprintf("%s:%s", mlPipelineAPIServerName, mlPipelineServiceGRPCPort)
+
+	log.Infof("Connecting the API server over GRPC at: %s", grpcAddress)
+	apiConnection, err := commonutil.GetRpcConnectionWithTimeout(grpcAddress, time.Now().Add(time.Minute))
+	if err != nil {
+		log.Fatalf("Error connecting to the API server after trying for one minute: %v", err)
+	}
+
+	var tokenSrc transport.ResettableTokenSource
+
+	if _, err := os.Stat(apiTokenFile); err == nil {
+		tokenSrc = transport.NewCachedFileTokenSource(apiTokenFile)
+	}
+
+	runClient := api.NewRunServiceClient(apiConnection)
+
+	log.Info("Successfully connected to the API server")
+
 	controller, err := NewController(
 		kubeClient,
 		scheduleClient,
 		execClient,
+		runClient,
 		scheduleInformerFactory,
 		execInformer,
 		commonutil.NewRealTime(),
-		location)
+		location,
+		tokenSrc,
+	)
 	if err != nil {
 		log.Fatalf("Failed to instantiate the controller: %v", err)
 	}
@@ -123,6 +158,8 @@ func init() {
 	// Use default value of client QPS (5) & burst (10) defined in
 	// k8s.io/client-go/rest/config.go#RESTClientFor
 	flag.Float64Var(&clientQPS, "clientQPS", 5, "The maximum QPS to the master from this client.")
+	flag.StringVar(&mlPipelineAPIServerName, mlPipelineAPIServerNameFlagName, "ml-pipeline", "Name of the ML pipeline API server.")
+	flag.StringVar(&mlPipelineServiceGRPCPort, mlPipelineAPIServerGRPCPortFlagName, "8887", "GRPC Port of the ML pipeline API server.")
 	flag.IntVar(&clientBurst, "clientBurst", 10, "Maximum burst for throttle from this client.")
 	var err error
 	location, err = util.GetLocation()

--- a/backend/src/crd/controller/scheduledworkflow/util/scheduled_workflow.go
+++ b/backend/src/crd/controller/scheduledworkflow/util/scheduled_workflow.go
@@ -17,11 +17,12 @@ package util
 import (
 	"fmt"
 	"hash/fnv"
-	corev1 "k8s.io/api/core/v1"
 	"math"
 	"sort"
 	"strconv"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	commonutil "github.com/kubeflow/pipelines/backend/src/common/util"
 	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"

--- a/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1/types.go
+++ b/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1/types.go
@@ -108,10 +108,14 @@ type WorkflowResource struct {
 
 	Parameters []Parameter `json:"parameters,omitempty"`
 
+	PipelineRoot string `json:"pipelineRoot,omitempty"`
+
 	// Specification of the workflow to start.
 	// Use interface{} for backward compatibility
 	// TODO: change it to string and avoid type casting
 	//       after several releases
+	// This is deprecated. In a future release, this will be ignored and this will be compiled by the API server
+	// at runtime.
 	Spec interface{} `json:"spec,omitempty"`
 }
 

--- a/backend/test/v2/integration/recurring_run_api_test.go
+++ b/backend/test/v2/integration/recurring_run_api_test.go
@@ -373,6 +373,73 @@ func (s *RecurringRunApiTestSuite) TestRecurringRunApis() {
 	}
 }
 
+func (s *RecurringRunApiTestSuite) TestRecurringRunApisUseLatest() {
+	t := s.T()
+
+	/* ---------- Upload pipelines YAML ---------- */
+	helloWorldPipeline, err := s.pipelineUploadClient.UploadFile("../resources/hello-world.yaml", upload_params.NewUploadPipelineParams())
+	assert.Nil(t, err)
+
+	/* ---------- Upload pipeline version YAML ---------- */
+	time.Sleep(1 * time.Second)
+	helloWorldPipelineVersion, err := s.pipelineUploadClient.UploadPipelineVersion(
+		"../resources/hello-world.yaml", &upload_params.UploadPipelineVersionParams{
+			Name:       util.StringPointer("hello-world-version"),
+			Pipelineid: util.StringPointer(helloWorldPipeline.PipelineID),
+		})
+	assert.Nil(t, err)
+
+	/* ---------- Create a new hello world experiment ---------- */
+	experiment := test.MakeExperiment("hello world experiment", "", s.resourceNamespace)
+	helloWorldExperiment, err := s.experimentClient.Create(&experiment_params.ExperimentServiceCreateExperimentParams{Body: experiment})
+	assert.Nil(t, err)
+
+	/* ---------- Create a new hello world recurringRun by specifying pipeline ID without a version ---------- */
+	createRecurringRunRequest := &recurring_run_params.RecurringRunServiceCreateRecurringRunParams{Body: &recurring_run_model.V2beta1RecurringRun{
+		DisplayName:  "hello world with latest pipeline version",
+		Description:  "this is hello world",
+		ExperimentID: helloWorldExperiment.ExperimentID,
+		PipelineVersionReference: &recurring_run_model.V2beta1PipelineVersionReference{
+			PipelineID: helloWorldPipelineVersion.PipelineID,
+		},
+		MaxConcurrency: 10,
+		Mode:           recurring_run_model.RecurringRunModeENABLE,
+	}}
+	helloWorldRecurringRun, err := s.recurringRunClient.Create(createRecurringRunRequest)
+	assert.Nil(t, err)
+
+	// The scheduledWorkflow CRD would create the run and it synced to the DB by persistent agent.
+	// This could take a few seconds to finish.
+
+	/* ---------- Check run for hello world recurringRun ---------- */
+	var helloWorldRun *run_model.V2beta1Run
+
+	if err := retrier.New(retrier.ConstantBackoff(8, 5*time.Second), nil).Run(func() error {
+		runs, totalSize, _, err := s.runClient.List(&run_params.RunServiceListRunsParams{
+			ExperimentID: util.StringPointer(helloWorldExperiment.ExperimentID),
+		})
+		if err != nil {
+			return err
+		}
+		if len(runs) != 1 {
+			return fmt.Errorf("expected runs to be length 1, got: %v", len(runs))
+		}
+		if totalSize != 1 {
+			return fmt.Errorf("expected total size 1, got: %v", totalSize)
+		}
+		helloWorldRun = runs[0]
+		return s.checkHelloWorldRun(helloWorldRun, helloWorldExperiment.ExperimentID, helloWorldRecurringRun.RecurringRunID)
+	}); err != nil {
+		assert.Nil(t, err)
+		assert.FailNow(t, "Timed out waiting for the recurring run")
+	}
+
+	// Verify the latest pipeline version was selected
+	assert.Equal(
+		t, helloWorldPipelineVersion.PipelineVersionID, helloWorldRun.PipelineVersionReference.PipelineVersionID,
+	)
+}
+
 func (s *RecurringRunApiTestSuite) TestRecurringRunApis_noCatchupOption() {
 	t := s.T()
 

--- a/manifests/kustomize/base/installs/multi-user/scheduled-workflow/cluster-role.yaml
+++ b/manifests/kustomize/base/installs/multi-user/scheduled-workflow/cluster-role.yaml
@@ -16,6 +16,12 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - pipelines.kubeflow.org
+  resources:
+  - runs
+  verbs:
+  - create
+- apiGroups:
   - kubeflow.org
   resources:
   - scheduledworkflows

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
@@ -41,4 +41,15 @@ spec:
           capabilities:
             drop:
             - ALL
+        volumeMounts:
+          - mountPath: /var/run/secrets/kubeflow/tokens
+            name: scheduledworkflow-sa-token
       serviceAccountName: ml-pipeline-scheduledworkflow
+      volumes:
+        - name: scheduledworkflow-sa-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: scheduledworkflow-sa-token
+                  expirationSeconds: 3600
+                  audience: pipelines.kubeflow.org

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-role.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-role.yaml
@@ -31,6 +31,12 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - pipelines.kubeflow.org
+  resources:
+  - runs
+  verbs:
+  - create
+- apiGroups:
   - ''
   resources:
   - events


### PR DESCRIPTION
**Description of your changes:**

This makes the pipeline_version_id optional and makes the
Scheduled Workflow controller levarege the REST API to launch the run
rather than rely on compiled Argo Workflows stored in the
ScheduledWorkflow object.

The previous behavior is preserved if the user is using the v1 API or
specifies a pipeline version ID or pipeline spec manifest.

Resolves:
https://github.com/kubeflow/pipelines/issues/11542

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 