### PR TITLE
feat(sdk): add a volumes argument to local.DockerRunner

### DIFF
--- a/sdk/python/kfp/local/config.py
+++ b/sdk/python/kfp/local/config.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Objects for configuring local execution."""
+
 import abc
 import dataclasses
+from dataclasses import field
 import os
-from typing import Union
+from typing import Dict, Union
 
 from kfp import local
 
@@ -42,13 +44,20 @@ class SubprocessRunner:
     Args:
         use_venv: Whether to run the subprocess in a virtual environment. If True, dependencies will be installed in the virtual environment. If False, dependencies will be installed in the current environment. Using a virtual environment is recommended.
     """
+
     use_venv: bool = True
 
 
 @dataclasses.dataclass
 class DockerRunner:
     """Runner that indicates that local tasks should be run as a Docker
-    container."""
+    container.
+
+    Args:
+        volumes: Additional volumes you wnat to mount to task containers.
+    """
+
+    volumes: Dict[str, Dict[str, str]] = field(default_factory=dict)
 
     def __post_init__(self):
         try:

--- a/sdk/python/kfp/local/config_test.py
+++ b/sdk/python/kfp/local/config_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for config.py."""
+
 import os
 import unittest
 from unittest import mock
@@ -70,7 +71,7 @@ class LocalRunnerConfigTest(unittest.TestCase):
     def test_validate_fail(self):
         with self.assertRaisesRegex(
                 RuntimeError,
-                r"Local environment not initialized. Please run 'kfp\.local\.init\(\)' before executing tasks locally\."
+                r"Local environment not initialized. Please run 'kfp\.local\.init\(\)' before executing tasks locally\.",
         ):
             config.LocalExecutionConfig.validate()
 
@@ -116,7 +117,7 @@ class TestInitCalls(unittest.TestCase):
         """Test config instance attributes with multiple init() calls."""
         with self.assertRaisesRegex(
                 ValueError,
-                r'Got unknown runner foo of type str\. Runner should be one of the following types: SubprocessRunner\.'
+                r'Got unknown runner foo of type str\. Runner should be one of the following types: SubprocessRunner\.',
         ):
             local.init(runner='foo')
 
@@ -127,7 +128,7 @@ class TestDockerRunner(unittest.TestCase):
         with mock.patch.dict('sys.modules', {'docker': None}):
             with self.assertRaisesRegex(
                     ImportError,
-                    r"Package 'docker' must be installed to use 'DockerRunner'\. Install it using 'pip install docker'\."
+                    r"Package 'docker' must be installed to use 'DockerRunner'\. Install it using 'pip install docker'\.",
             ):
                 local.DockerRunner()
 

--- a/sdk/python/kfp/local/docker_task_handler.py
+++ b/sdk/python/kfp/local/docker_task_handler.py
@@ -43,13 +43,20 @@ class DockerTaskHandler(task_handler_interface.ITaskHandler):
             raise ValueError(
                 "'pipeline_root' should be an absolute path to correctly construct the volume mount specification."
             )
-        return {self.pipeline_root: {'bind': self.pipeline_root, 'mode': 'rw'}}
+        default_volume = {
+            self.pipeline_root: {
+                'bind': self.pipeline_root,
+                'mode': 'rw'
+            }
+        }
+        return default_volume | self.runner.volumes
 
     def run(self) -> status.Status:
         """Runs the Docker container and returns the status."""
         # nest docker import in case not available in user env so that
         # this module is runnable, even if not using DockerRunner
         import docker
+
         client = docker.from_env()
         try:
             volumes = self.get_volumes_to_mount()


### PR DESCRIPTION
**Description of your changes:**

Issue: #11562

I added a `volumes` argument to local.DockerRunner. It is merged with `pipeline_root` in get_volumes_to_mount method of DockerTaskHandler. The volumes format must follow the format written in [python-docker](https://docker-py.readthedocs.io/en/stable/containers.html).

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
