### PR TITLE
chore(deps): replace deprecated ioutil with os and io in tests

### DIFF
--- a/backend/src/apiserver/server/api_util_test.go
+++ b/backend/src/apiserver/server/api_util_test.go
@@ -15,7 +15,7 @@
 package server
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -377,7 +377,7 @@ func TestValidateRunMetric_InvalidNodeIDs(t *testing.T) {
 }
 
 func loadYaml(t *testing.T, path string) string {
-	res, err := ioutil.ReadFile(path)
+	res, err := os.ReadFile(path)
 	if err != nil {
 		t.Error(err)
 	}

--- a/backend/src/apiserver/server/pipeline_server_test.go
+++ b/backend/src/apiserver/server/pipeline_server_test.go
@@ -17,7 +17,7 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -614,7 +614,7 @@ func getMockServer(t *testing.T) *httptest.Server {
 		// Send response to be tested
 		file, err := os.Open("test" + req.URL.String())
 		assert.Nil(t, err)
-		bytes, err := ioutil.ReadAll(file)
+		bytes, err := io.ReadAll(file)
 		assert.Nil(t, err)
 
 		rw.WriteHeader(http.StatusOK)

--- a/backend/src/apiserver/server/util.go
+++ b/backend/src/apiserver/server/util.go
@@ -22,7 +22,6 @@ import (
 	"compress/gzip"
 	"errors"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/kubeflow/pipelines/backend/src/common/util"
@@ -108,7 +107,7 @@ func DecompressPipelineTarball(compressedFile []byte) ([]byte, error) {
 		}
 	}
 
-	decompressedFile, err := ioutil.ReadAll(tarReader)
+	decompressedFile, err := io.ReadAll(tarReader)
 	if err != nil {
 		return nil, util.NewInvalidInputErrorWithDetails(err, "Error reading pipeline YAML from the tarball file")
 	}
@@ -141,7 +140,7 @@ func DecompressPipelineZip(compressedFile []byte) ([]byte, error) {
 	if err != nil {
 		return nil, util.NewInvalidInputErrorWithDetails(err, "Error extracting pipeline from the zip file. Failed to read the content")
 	}
-	decompressedFile, err := ioutil.ReadAll(rc)
+	decompressedFile, err := io.ReadAll(rc)
 	if err != nil {
 		return nil, util.NewInvalidInputErrorWithDetails(err, "Error reading pipeline YAML from the zip file")
 	}

--- a/backend/src/apiserver/server/util_test.go
+++ b/backend/src/apiserver/server/util_test.go
@@ -15,7 +15,6 @@
 package server
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -47,67 +46,67 @@ func TestLoadFile_LargeDoc(t *testing.T) {
 }
 
 func TestDecompressPipelineTarball(t *testing.T) {
-	tarballByte, _ := ioutil.ReadFile("test/arguments_tarball/arguments.tar.gz")
+	tarballByte, _ := os.ReadFile("test/arguments_tarball/arguments.tar.gz")
 	pipelineFile, err := DecompressPipelineTarball(tarballByte)
 	assert.Nil(t, err)
 
-	expectedPipelineFile, _ := ioutil.ReadFile("test/arguments-parameters.yaml")
+	expectedPipelineFile, _ := os.ReadFile("test/arguments-parameters.yaml")
 	assert.Equal(t, expectedPipelineFile, pipelineFile)
 }
 
 func TestDecompressPipelineTarball_MalformattedTarball(t *testing.T) {
-	tarballByte, _ := ioutil.ReadFile("test/malformatted_tarball.tar.gz")
+	tarballByte, _ := os.ReadFile("test/malformatted_tarball.tar.gz")
 	_, err := DecompressPipelineTarball(tarballByte)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Not a valid tarball file")
 }
 
 func TestDecompressPipelineTarball_NonYamlTarball(t *testing.T) {
-	tarballByte, _ := ioutil.ReadFile("test/non_yaml_tarball/non_yaml_tarball.tar.gz")
+	tarballByte, _ := os.ReadFile("test/non_yaml_tarball/non_yaml_tarball.tar.gz")
 	_, err := DecompressPipelineTarball(tarballByte)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Expecting a pipeline.yaml file inside the tarball")
 }
 
 func TestDecompressPipelineTarball_EmptyTarball(t *testing.T) {
-	tarballByte, _ := ioutil.ReadFile("test/empty_tarball/empty.tar.gz")
+	tarballByte, _ := os.ReadFile("test/empty_tarball/empty.tar.gz")
 	_, err := DecompressPipelineTarball(tarballByte)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Not a valid tarball file")
 }
 
 func TestDecompressPipelineZip(t *testing.T) {
-	zipByte, _ := ioutil.ReadFile("test/arguments_zip/arguments-parameters.zip")
+	zipByte, _ := os.ReadFile("test/arguments_zip/arguments-parameters.zip")
 	pipelineFile, err := DecompressPipelineZip(zipByte)
 	assert.Nil(t, err)
 
-	expectedPipelineFile, _ := ioutil.ReadFile("test/arguments-parameters.yaml")
+	expectedPipelineFile, _ := os.ReadFile("test/arguments-parameters.yaml")
 	assert.Equal(t, expectedPipelineFile, pipelineFile)
 }
 
 func TestDecompressPipelineZip_MalformattedZip(t *testing.T) {
-	zipByte, _ := ioutil.ReadFile("test/malformatted_zip.zip")
+	zipByte, _ := os.ReadFile("test/malformatted_zip.zip")
 	_, err := DecompressPipelineZip(zipByte)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Not a valid zip file")
 }
 
 func TestDecompressPipelineZip_MalformedZip2(t *testing.T) {
-	zipByte, _ := ioutil.ReadFile("test/malformed_zip2.zip")
+	zipByte, _ := os.ReadFile("test/malformed_zip2.zip")
 	_, err := DecompressPipelineZip(zipByte)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Not a valid zip file")
 }
 
 func TestDecompressPipelineZip_NonYamlZip(t *testing.T) {
-	zipByte, _ := ioutil.ReadFile("test/non_yaml_zip/non_yaml_file.zip")
+	zipByte, _ := os.ReadFile("test/non_yaml_zip/non_yaml_file.zip")
 	_, err := DecompressPipelineZip(zipByte)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Expecting a pipeline.yaml file inside the zip")
 }
 
 func TestDecompressPipelineZip_EmptyZip(t *testing.T) {
-	zipByte, _ := ioutil.ReadFile("test/empty_tarball/empty.zip")
+	zipByte, _ := os.ReadFile("test/empty_tarball/empty.zip")
 	_, err := DecompressPipelineZip(zipByte)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Not a valid zip file")
@@ -118,7 +117,7 @@ func TestReadPipelineFile_YAML(t *testing.T) {
 	fileBytes, err := ReadPipelineFile("arguments-parameters.yaml", file, common.MaxFileLength)
 	assert.Nil(t, err)
 
-	expectedFileBytes, _ := ioutil.ReadFile("test/arguments-parameters.yaml")
+	expectedFileBytes, _ := os.ReadFile("test/arguments-parameters.yaml")
 	assert.Equal(t, expectedFileBytes, fileBytes)
 }
 
@@ -127,7 +126,7 @@ func TestReadPipelineFile_JSON(t *testing.T) {
 	fileBytes, err := ReadPipelineFile("v2-hello-world.json", file, common.MaxFileLength)
 	assert.Nil(t, err)
 
-	expectedFileBytes, _ := ioutil.ReadFile("test/v2-hello-world.json")
+	expectedFileBytes, _ := os.ReadFile("test/v2-hello-world.json")
 	assert.Equal(t, expectedFileBytes, fileBytes)
 }
 
@@ -136,7 +135,7 @@ func TestReadPipelineFile_Zip(t *testing.T) {
 	pipelineFile, err := ReadPipelineFile("arguments-parameters.zip", file, common.MaxFileLength)
 	assert.Nil(t, err)
 
-	expectedPipelineFile, _ := ioutil.ReadFile("test/arguments-parameters.yaml")
+	expectedPipelineFile, _ := os.ReadFile("test/arguments-parameters.yaml")
 	assert.Equal(t, expectedPipelineFile, pipelineFile)
 }
 
@@ -145,7 +144,7 @@ func TestReadPipelineFile_Zip_AnyExtension(t *testing.T) {
 	pipelineFile, err := ReadPipelineFile("arguments-parameters.pipeline", file, common.MaxFileLength)
 	assert.Nil(t, err)
 
-	expectedPipelineFile, _ := ioutil.ReadFile("test/arguments-parameters.yaml")
+	expectedPipelineFile, _ := os.ReadFile("test/arguments-parameters.yaml")
 	assert.Equal(t, expectedPipelineFile, pipelineFile)
 }
 
@@ -154,7 +153,7 @@ func TestReadPipelineFile_MultifileZip(t *testing.T) {
 	pipelineFile, err := ReadPipelineFile("pipeline_plus_component.ai-hub-package", file, common.MaxFileLength)
 	assert.Nil(t, err)
 
-	expectedPipelineFile, _ := ioutil.ReadFile("test/pipeline_plus_component/pipeline.yaml")
+	expectedPipelineFile, _ := os.ReadFile("test/pipeline_plus_component/pipeline.yaml")
 	assert.Equal(t, expectedPipelineFile, pipelineFile)
 }
 
@@ -163,7 +162,7 @@ func TestReadPipelineFile_Tarball(t *testing.T) {
 	pipelineFile, err := ReadPipelineFile("arguments.tar.gz", file, common.MaxFileLength)
 	assert.Nil(t, err)
 
-	expectedPipelineFile, _ := ioutil.ReadFile("test/arguments-parameters.yaml")
+	expectedPipelineFile, _ := os.ReadFile("test/arguments-parameters.yaml")
 	assert.Equal(t, expectedPipelineFile, pipelineFile)
 }
 
@@ -172,7 +171,7 @@ func TestReadPipelineFile_Tarball_AnyExtension(t *testing.T) {
 	pipelineFile, err := ReadPipelineFile("arguments.pipeline", file, common.MaxFileLength)
 	assert.Nil(t, err)
 
-	expectedPipelineFile, _ := ioutil.ReadFile("test/arguments-parameters.yaml")
+	expectedPipelineFile, _ := os.ReadFile("test/arguments-parameters.yaml")
 	assert.Equal(t, expectedPipelineFile, pipelineFile)
 }
 
@@ -181,7 +180,7 @@ func TestReadPipelineFile_MultifileTarball(t *testing.T) {
 	pipelineFile, err := ReadPipelineFile("pipeline_plus_component.ai-hub-package", file, common.MaxFileLength)
 	assert.Nil(t, err)
 
-	expectedPipelineFile, _ := ioutil.ReadFile("test/pipeline_plus_component/pipeline.yaml")
+	expectedPipelineFile, _ := os.ReadFile("test/pipeline_plus_component/pipeline.yaml")
 	assert.Equal(t, expectedPipelineFile, pipelineFile)
 }
 

--- a/backend/src/apiserver/server/visualization_server.go
+++ b/backend/src/apiserver/server/visualization_server.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -120,7 +120,7 @@ func (s *VisualizationServer) generateVisualizationFromRequest(request *go_clien
 		return nil, fmt.Errorf(resp.Status)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, util.Wrap(err, "Unable to parse visualization response")
 	}

--- a/backend/src/apiserver/template/template_test.go
+++ b/backend/src/apiserver/template/template_test.go
@@ -16,7 +16,7 @@ package template
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -255,7 +255,7 @@ func TestModelToCRDTrigger_Cron(t *testing.T) {
 }
 
 func loadYaml(t *testing.T, path string) string {
-	res, err := ioutil.ReadFile(path)
+	res, err := os.ReadFile(path)
 	if err != nil {
 		t.Error(err)
 	}

--- a/backend/src/cache/server/admission.go
+++ b/backend/src/cache/server/admission.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -73,7 +73,7 @@ func doServeAdmitFunc(w http.ResponseWriter, r *http.Request, admit admitFunc, c
 		return nil, fmt.Errorf("Invalid method %q, only POST requests are allowed", r.Method)
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return nil, fmt.Errorf("Could not read request body: %v", err)

--- a/backend/src/common/client/api_server/util.go
+++ b/backend/src/common/client/api_server/util.go
@@ -2,7 +2,6 @@ package api_server
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -38,7 +37,7 @@ var SATokenVolumeProjectionAuth runtime.ClientAuthInfoWriter = runtime.ClientAut
 			projectedPath = saDefaultTokenPath
 		}
 
-		content, err := ioutil.ReadFile(projectedPath)
+		content, err := os.ReadFile(projectedPath)
 		if err != nil {
 			return fmt.Errorf("Failed to read projected SA token at %s: %w", projectedPath, err)
 		}

--- a/backend/src/common/util/tgz.go
+++ b/backend/src/common/util/tgz.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"strings"
 )
 
@@ -77,7 +76,7 @@ func ExtractTgz(tgzContent string) (map[string]string, error) {
 		if hdr == nil {
 			continue
 		}
-		fileContent, err := ioutil.ReadAll(tr)
+		fileContent, err := io.ReadAll(tr)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/src/v2/cmd/compiler/main.go
+++ b/backend/src/v2/cmd/compiler/main.go
@@ -16,7 +16,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/golang/glog"
@@ -92,7 +91,7 @@ func init() {
 }
 
 func loadJob(path string) (*pipelinespec.PipelineJob, error) {
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +103,7 @@ func loadJob(path string) (*pipelinespec.PipelineJob, error) {
 }
 
 func loadSpec(path string) (*pipelinespec.PipelineJob, error) {
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -275,7 +274,7 @@ func writeFile(path string, data []byte) (err error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, data, 0o644)
+	return os.WriteFile(path, data, 0o644)
 }
 
 func newMlmdClient() (*metadata.Client, error) {

--- a/backend/src/v2/compiler/argocompiler/argo_test.go
+++ b/backend/src/v2/compiler/argocompiler/argo_test.go
@@ -17,7 +17,7 @@ package argocompiler_test
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -80,12 +80,12 @@ func Test_argo_compiler(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				err = ioutil.WriteFile(tt.argoYAMLPath, got, 0x664)
+				err = os.WriteFile(tt.argoYAMLPath, got, 0x664)
 				if err != nil {
 					t.Fatal(err)
 				}
 			}
-			argoYAML, err := ioutil.ReadFile(tt.argoYAMLPath)
+			argoYAML, err := os.ReadFile(tt.argoYAMLPath)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -125,7 +125,7 @@ func Test_argo_compiler(t *testing.T) {
 
 func load(t *testing.T, path string, platformSpecPath string) (*pipelinespec.PipelineJob, *pipelinespec.SinglePlatformSpec) {
 	t.Helper()
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		t.Error(err)
 	}
@@ -136,7 +136,7 @@ func load(t *testing.T, path string, platformSpecPath string) (*pipelinespec.Pip
 
 	platformSpec := &pipelinespec.PlatformSpec{}
 	if platformSpecPath != "" {
-		content, err = ioutil.ReadFile(platformSpecPath)
+		content, err = os.ReadFile(platformSpecPath)
 		if err != nil {
 			t.Error(err)
 		}

--- a/backend/src/v2/compiler/tektoncompiler/tekton_test.go
+++ b/backend/src/v2/compiler/tektoncompiler/tekton_test.go
@@ -17,7 +17,7 @@ package tektoncompiler_test
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"testing"
 
@@ -69,12 +69,12 @@ func Test_tekton_compiler(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				err = ioutil.WriteFile(tt.tektonYAMLPath, got, 0664)
+				err = os.WriteFile(tt.tektonYAMLPath, got, 0664)
 				if err != nil {
 					t.Fatal(err)
 				}
 			}
-			tektonYAML, err := ioutil.ReadFile(tt.tektonYAMLPath)
+			tektonYAML, err := os.ReadFile(tt.tektonYAMLPath)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -194,12 +194,12 @@ func testCompile(t *testing.T, test testInputs) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = ioutil.WriteFile(test.tektonYAMLPath, got, 0644)
+			err = os.WriteFile(test.tektonYAMLPath, got, 0644)
 			if err != nil {
 				t.Fatal(err)
 			}
 		}
-		tektonYAML, err := ioutil.ReadFile(test.tektonYAMLPath)
+		tektonYAML, err := os.ReadFile(test.tektonYAMLPath)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -221,7 +221,7 @@ func testCompile(t *testing.T, test testInputs) {
 
 func load(t *testing.T, path string, platformSpecPath string, fileType string) (*pipelinespec.PipelineJob, *pipelinespec.SinglePlatformSpec) {
 	t.Helper()
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		t.Error(err)
 	}
@@ -238,7 +238,7 @@ func load(t *testing.T, path string, platformSpecPath string, fileType string) (
 
 	platformSpec := &pipelinespec.PlatformSpec{}
 	if platformSpecPath != "" {
-		content, err = ioutil.ReadFile(platformSpecPath)
+		content, err = os.ReadFile(platformSpecPath)
 		if err != nil {
 			t.Error(err)
 		}

--- a/backend/src/v2/compiler/visitor_test.go
+++ b/backend/src/v2/compiler/visitor_test.go
@@ -15,7 +15,7 @@ package compiler_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/golang/protobuf/jsonpb"
@@ -87,7 +87,7 @@ func Test_AcceptTestVisitor(t *testing.T) {
 
 func load(t *testing.T, path string) *pipelinespec.PipelineJob {
 	t.Helper()
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		t.Error(err)
 	}

--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -365,7 +364,7 @@ func collectOutputParameters(executorInput *pipelinespec.ExecutorInput, executor
 		msg := func(err error) error {
 			return fmt.Errorf("failed to read output parameter name=%q type=%q path=%q: %w", name, paramSpec.GetParameterType(), param.GetOutputFile(), err)
 		}
-		b, err := ioutil.ReadFile(param.GetOutputFile())
+		b, err := os.ReadFile(param.GetOutputFile())
 		if err != nil {
 			return msg(err)
 		}
@@ -708,7 +707,7 @@ func getExecutorOutputFile(path string) (*pipelinespec.ExecutorOutput, error) {
 		}
 	}
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read output metadata file %q: %w", path, err)
 	}

--- a/backend/src/v2/config/env.go
+++ b/backend/src/v2/config/env.go
@@ -19,11 +19,12 @@ package config
 import (
 	"context"
 	"fmt"
-	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
-	"io/ioutil"
-	"sigs.k8s.io/yaml"
+	"os"
 	"strconv"
 	"strings"
+
+	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
+	"sigs.k8s.io/yaml"
 
 	"github.com/golang/glog"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
@@ -84,7 +85,7 @@ func (c *Config) DefaultPipelineRoot() string {
 func InPodNamespace() (string, error) {
 	// The path is available in Pods.
 	// https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/#directly-accessing-the-rest-api
-	ns, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	ns, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		return "", fmt.Errorf("failed to get namespace in Pod: %w", err)
 	}
@@ -93,7 +94,7 @@ func InPodNamespace() (string, error) {
 
 // InPodName gets the pod name from inside a Kubernetes Pod.
 func InPodName() (string, error) {
-	podName, err := ioutil.ReadFile("/etc/hostname")
+	podName, err := os.ReadFile("/etc/hostname")
 	if err != nil {
 		return "", fmt.Errorf("failed to get pod name in Pod: %w", err)
 	}

--- a/backend/src/v2/objectstore/object_store.go
+++ b/backend/src/v2/objectstore/object_store.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -97,7 +96,7 @@ func UploadBlob(ctx context.Context, bucket *blob.Bucket, localPath, blobPath st
 	}
 
 	// localPath is a directory.
-	files, err := ioutil.ReadDir(localPath)
+	files, err := os.ReadDir(localPath)
 	if err != nil {
 		return fmt.Errorf("unable to list local directory %q: %w", localPath, err)
 	}

--- a/backend/test/integration/job_api_test.go
+++ b/backend/test/integration/job_api_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -209,7 +209,7 @@ func (s *JobApiTestSuite) TestJobApis() {
 	// Make sure the job is created at least 1 second later than the first one,
 	// because sort by created_at has precision of 1 second.
 	time.Sleep(1 * time.Second)
-	argParamsBytes, err := ioutil.ReadFile("../resources/arguments-parameters.yaml")
+	argParamsBytes, err := os.ReadFile("../resources/arguments-parameters.yaml")
 	assert.Nil(t, err)
 	argParamsBytes, err = yaml.ToJSON(argParamsBytes)
 	assert.Nil(t, err)

--- a/backend/test/integration/pipeline_api_test.go
+++ b/backend/test/integration/pipeline_api_test.go
@@ -15,7 +15,7 @@
 package integration
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -232,14 +232,14 @@ func (s *PipelineApiTest) TestPipelineAPI() {
 	/* ---------- Verify get template works ---------- */
 	template, err := s.pipelineClient.GetTemplate(&params.PipelineServiceGetTemplateParams{ID: argumentYAMLPipeline.ID})
 	require.Nil(t, err)
-	bytes, err := ioutil.ReadFile("../resources/arguments-parameters.yaml")
+	bytes, err := os.ReadFile("../resources/arguments-parameters.yaml")
 	require.Nil(t, err)
 	expected, _ := pipelinetemplate.New(bytes)
 	assert.Equal(t, expected, template)
 
 	template, err = s.pipelineClient.GetTemplate(&params.PipelineServiceGetTemplateParams{ID: v2HelloPipeline.ID})
 	require.Nil(t, err)
-	bytes, err = ioutil.ReadFile("../resources/v2-hello-world.yaml")
+	bytes, err = os.ReadFile("../resources/v2-hello-world.yaml")
 	require.Nil(t, err)
 	expected, _ = pipelinetemplate.New(bytes)
 	assert.Equal(t, expected, template)

--- a/backend/test/integration/pipeline_version_api_test.go
+++ b/backend/test/integration/pipeline_version_api_test.go
@@ -15,7 +15,7 @@
 package integration
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -325,7 +325,7 @@ func (s *PipelineVersionApiTest) TestArgoSpec() {
 	/* ---------- Verify get template works ---------- */
 	template, err := s.pipelineClient.GetPipelineVersionTemplate(&params.PipelineServiceGetPipelineVersionTemplateParams{VersionID: argumentYAMLPipelineVersion.ID})
 	require.Nil(t, err)
-	bytes, err := ioutil.ReadFile("../resources/arguments-parameters.yaml")
+	bytes, err := os.ReadFile("../resources/arguments-parameters.yaml")
 	require.Nil(t, err)
 	expected, err := pipelinetemplate.New(bytes)
 	require.Nil(t, err)
@@ -358,7 +358,7 @@ func (s *PipelineVersionApiTest) TestV2Spec() {
 	/* ---------- Verify get template works ---------- */
 	template, err := s.pipelineClient.GetPipelineVersionTemplate(&params.PipelineServiceGetPipelineVersionTemplateParams{VersionID: v2Version.ID})
 	require.Nil(t, err)
-	bytes, err := ioutil.ReadFile("../resources/v2-hello-world.yaml")
+	bytes, err := os.ReadFile("../resources/v2-hello-world.yaml")
 	require.Nil(t, err)
 	expected, err := pipelinetemplate.New(bytes)
 	require.Nil(t, err)

--- a/backend/test/integration/run_api_test.go
+++ b/backend/test/integration/run_api_test.go
@@ -16,7 +16,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -176,7 +176,7 @@ func (s *RunApiTestSuite) TestRunApis() {
 	assert.Nil(t, err)
 
 	/* ---------- Create a new argument parameter run by uploading workflow manifest ---------- */
-	argParamsBytes, err := ioutil.ReadFile("../resources/arguments-parameters.yaml")
+	argParamsBytes, err := os.ReadFile("../resources/arguments-parameters.yaml")
 	assert.Nil(t, err)
 	argParamsBytes, err = yaml.ToJSON(argParamsBytes)
 	assert.Nil(t, err)
@@ -433,7 +433,7 @@ func (s *RunApiTestSuite) checkHelloWorldRunDetail(t *testing.T, runDetail *run_
 }
 
 func (s *RunApiTestSuite) checkArgParamsRunDetail(t *testing.T, runDetail *run_model.APIRunDetail, experimentId string, experimentName string) {
-	argParamsBytes, err := ioutil.ReadFile("../resources/arguments-parameters.yaml")
+	argParamsBytes, err := os.ReadFile("../resources/arguments-parameters.yaml")
 	assert.Nil(t, err)
 	argParamsBytes, err = yaml.ToJSON(argParamsBytes)
 	assert.Nil(t, err)

--- a/backend/test/integration/upgrade_test.go
+++ b/backend/test/integration/upgrade_test.go
@@ -16,7 +16,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -318,7 +318,7 @@ func (s *UpgradeTests) VerifyPipelines() {
 	/* ---------- Verify get template works ---------- */
 	template, err := s.pipelineClient.GetTemplate(&pipelineParams.PipelineServiceGetTemplateParams{ID: pipelines[0].ID})
 	require.Nil(t, err)
-	bytes, err := ioutil.ReadFile("../resources/arguments-parameters.yaml")
+	bytes, err := os.ReadFile("../resources/arguments-parameters.yaml")
 	require.Nil(t, err)
 	expected, err := pipelinetemplate.New(bytes)
 	require.Nil(t, err)

--- a/backend/test/v2/integration/pipeline_version_api_test.go
+++ b/backend/test/v2/integration/pipeline_version_api_test.go
@@ -16,7 +16,7 @@ package integration
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -285,7 +285,7 @@ func (s *PipelineVersionApiTest) TestPipelineSpec() {
 	assert.NotNil(t, pipelineVersion.CreatedAt)
 
 	/* ---------- Verify pipeline spec ---------- */
-	bytes, err := ioutil.ReadFile("../resources/arguments-parameters.yaml")
+	bytes, err := os.ReadFile("../resources/arguments-parameters.yaml")
 	require.Nil(t, err)
 	expected_bytes, err := yaml.YAMLToJSON(bytes)
 	require.Nil(t, err)
@@ -319,7 +319,7 @@ func (s *PipelineVersionApiTest) TestV2Spec() {
 	assert.Equal(t, "hello-world", v2Version.DisplayName)
 
 	/* ---------- Verify pipeline spec ---------- */
-	bytes, err := ioutil.ReadFile("../resources/hello-world.yaml")
+	bytes, err := os.ReadFile("../resources/hello-world.yaml")
 	require.Nil(t, err)
 	expected_bytes, err := yaml.YAMLToJSON(bytes)
 	require.Nil(t, err)

--- a/backend/test/v2/integration/recurring_run_api_test.go
+++ b/backend/test/v2/integration/recurring_run_api_test.go
@@ -17,7 +17,7 @@ package integration
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -197,7 +197,7 @@ func (s *RecurringRunApiTestSuite) TestRecurringRunApis() {
 	// Make sure the recurringRun is created at least 1 second later than the first one,
 	// because sort by created_at has precision of 1 second.
 	time.Sleep(1 * time.Second)
-	argParamsBytes, err := ioutil.ReadFile("../resources/arguments-parameters.yaml")
+	argParamsBytes, err := os.ReadFile("../resources/arguments-parameters.yaml")
 	assert.Nil(t, err)
 	pipeline_spec := &structpb.Struct{}
 	err = yaml.Unmarshal(argParamsBytes, pipeline_spec)

--- a/backend/test/v2/integration/run_api_test.go
+++ b/backend/test/v2/integration/run_api_test.go
@@ -17,7 +17,7 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -166,7 +166,7 @@ func (s *RunApiTestSuite) TestRunApis() {
 	assert.Nil(t, err)
 
 	/* ---------- Create a new argument parameter run by uploading workflow manifest ---------- */
-	argParamsBytes, err := ioutil.ReadFile("../resources/arguments-parameters.yaml")
+	argParamsBytes, err := os.ReadFile("../resources/arguments-parameters.yaml")
 	assert.Nil(t, err)
 	pipeline_spec := &structpb.Struct{}
 	err = yaml.Unmarshal(argParamsBytes, pipeline_spec)
@@ -389,7 +389,7 @@ func (s *RunApiTestSuite) checkHelloWorldRunDetail(t *testing.T, run *run_model.
 func (s *RunApiTestSuite) checkArgParamsRunDetail(t *testing.T, run *run_model.V2beta1Run, experimentId string) {
 
 	// Compare the pipeline spec first.
-	argParamsBytes, err := ioutil.ReadFile("../resources/arguments-parameters.yaml")
+	argParamsBytes, err := os.ReadFile("../resources/arguments-parameters.yaml")
 	assert.Nil(t, err)
 	// pipeline_spec := &structpb.Struct{}
 	// err = yaml.Unmarshal(argParamsBytes, pipeline_spec)

--- a/backend/test/v2/integration/upgrade_test.go
+++ b/backend/test/v2/integration/upgrade_test.go
@@ -17,7 +17,7 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -340,7 +340,7 @@ func (s *UpgradeTests) VerifyPipelines() {
 	assert.Equal(t, totalSize, 1)
 	pipelineVersion, err := s.pipelineClient.GetPipelineVersion(&params.PipelineServiceGetPipelineVersionParams{PipelineID: pipelines[0].PipelineID, PipelineVersionID: pipelineVersions[0].PipelineVersionID})
 	require.Nil(t, err)
-	bytes, err := ioutil.ReadFile("../resources/arguments-parameters.yaml")
+	bytes, err := os.ReadFile("../resources/arguments-parameters.yaml")
 	expected_bytes, err := yaml.YAMLToJSON(bytes)
 	require.Nil(t, err)
 	actual_bytes, err := json.Marshal(pipelineVersion.PipelineSpec)

--- a/test/tools/project-cleaner/main.go
+++ b/test/tools/project-cleaner/main.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -226,7 +225,7 @@ func main() {
 	}
 
 	var r ResourceSpec
-	yamlFile, err := ioutil.ReadFile(*resourceSpec)
+	yamlFile, err := os.ReadFile(*resourceSpec)
 	if err != nil {
 		log.Fatalf("Error reading yaml file")
 	}


### PR DESCRIPTION
**Description of your changes:**

The `ioutil` package was deprecated in go 1.16 (see [here](https://pkg.go.dev/io/ioutil)). This PR replaces it's function calls with function calls from the `os` and `io` packages (as recommended). 

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
