### PR TITLE
fix(backend): the metacontroller is broken since #11474

### DIFF
--- a/manifests/kustomize/third-party/metacontroller/base/cluster-role-binding.yaml
+++ b/manifests/kustomize/third-party/metacontroller/base/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: kubeflow-metacontroller
 subjects:
 - kind: ServiceAccount
   name: meta-controller-service

--- a/manifests/kustomize/third-party/metacontroller/base/cluster-role.yaml
+++ b/manifests/kustomize/third-party/metacontroller/base/cluster-role.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-metacontroller
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["secrets", "configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["networking.istio.io"]
+  resources: ["destinationrules"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["security.istio.io"]
+  resources: ["authorizationpolicies"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["metacontroller.k8s.io"]
+  resources: ["compositecontrollers", "controllerrevisions", "decoratorcontrollers"]
+  verbs: ["get", "list", "watch"]

--- a/manifests/kustomize/third-party/metacontroller/base/kustomization.yaml
+++ b/manifests/kustomize/third-party/metacontroller/base/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
 resources:
+- cluster-role.yaml
 - cluster-role-binding.yaml
 - crd.yaml
 - service-account.yaml
 - stateful-set.yaml
 commonLabels:
   kustomize.component: metacontroller
-
 # Update metacontroller CRD:
 # Copy the upstream file to crd.yaml in this folder.
 # Upstream file: https://github.com/metacontroller/metacontroller/blob/master/manifests/production/metacontroller-crds-v1.yaml

--- a/manifests/kustomize/third-party/metacontroller/base/stateful-set.yaml
+++ b/manifests/kustomize/third-party/metacontroller/base/stateful-set.yaml
@@ -41,7 +41,7 @@ spec:
             privileged: false
             allowPrivilegeEscalation: false
           name: metacontroller
-          image: 'ghcr.io/metacontroller/metacontroller:v4.11.21'
+          image: 'ghcr.io/metacontroller/metacontroller:v2.6.1'
       serviceAccountName: meta-controller-service
   # Workaround for https://github.com/kubernetes-sigs/kustomize/issues/677
   volumeClaimTemplates: []


### PR DESCRIPTION
**Description of your changes:**

This fixes the metacontroller after https://github.com/kubeflow/pipelines/pull/11474 for multi-user KFP as done in https://github.com/kubeflow/manifests/pull/2953/

@hbelmiro 

@tarekabouzeid @biswassri I did not get feedback for a week in https://github.com/kubeflow/manifests/issues/2970#issuecomment-2647615231, so I created https://github.com/kubeflow/pipelines/pull/11608 to at least fix the broken upstream KFP. Afterwards you can still upgrade metacontroller from 2.6.1 to 4.x
