### PR TITLE
docs(backend): fixed docker cmd in docs for non-amd64

### DIFF
--- a/developer_guide.md
+++ b/developer_guide.md
@@ -12,7 +12,7 @@ The Pipeline system is included in kubeflow. See [Getting Started Guide](https:/
 
 To be able to use GKE, the Docker images need to be uploaded to a public Docker repository, such as [GCR](https://cloud.google.com/container-registry/)
 
-To build the API server image and upload it to GCR on x86_64 machines:
+To build the API server image and upload it to GCR on x86_64 (amd64) machines:
 
 ```bash
 # Run in the repository root directory
@@ -26,7 +26,7 @@ To build the API server image and upload it to GCR on non-x86_64 machines (such 
 
 ```bash
 # Run in the repository root directory
-$ docker build -t gcr.io/<your-gcp-project>/api-server:latest -f backend/Dockerfile
+$ docker build --platform linux/amd64 -t gcr.io/<your-gcp-project>/api-server:latest -f backend/Dockerfile .
 # Push to GCR
 $ gcloud auth configure-docker
 $ docker push gcr.io/<your-gcp-project>/api-server:latest


### PR DESCRIPTION
**Description of your changes:**
The docker cmd for non-x86_64 machines in the docs was missing the path (.), and it needed the `--platform` specified. This should help devs building on Mac architectures.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
