### PR TITLE
fix(frontend): restrict file explorer to show only .yaml, .yml, .zip, and .tar.gz files

### DIFF
--- a/frontend/src/pages/NewPipelineVersion.tsx
+++ b/frontend/src/pages/NewPipelineVersion.tsx
@@ -363,6 +363,7 @@ export class NewPipelineVersion extends Page<NewPipelineVersionProps, NewPipelin
               style={{ position: 'relative' }}
               ref={this._dropzoneRef}
               inputProps={{ tabIndex: -1 }}
+              accept='.yaml,.yml,.zip,.tar.gz'
               disabled={importMethod === ImportMethod.URL}
             >
               {dropzoneActive && <div className={css.dropOverlay}>Drop files..</div>}

--- a/frontend/src/pages/__snapshots__/NewPipelineVersion.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewPipelineVersion.test.tsx.snap
@@ -90,6 +90,7 @@ exports[`NewPipelineVersion creating new pipeline renders the new pipeline page 
         onChange={[Function]}
       />
       <n
+        accept=".yaml,.yml,.zip,.tar.gz"
         disableClick={true}
         disablePreview={false}
         disabled={true}


### PR DESCRIPTION
**Description of your changes:**
Restricted the file explorer to only show .yaml, .yml, .zip, and .tar.gz files instead of all files when selecting pipeline files to improve user experience.

**Checklist:**
- [x] The title for your pull request (PR) follows our title convention
- [x] You have signed off your commits