### PR TITLE
chore: use local proto go packages for ci

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,6 +19,8 @@ WORKDIR /go/src/github.com/kubeflow/pipelines
 
 COPY ./go.mod ./
 COPY ./go.sum ./
+COPY ./kubernetes_platform/go.mod ./kubernetes_platform/go.mod
+COPY ./api/go.mod ./api/go.mod
 
 RUN GO111MODULE=on go mod download
 

--- a/backend/Dockerfile.driver
+++ b/backend/Dockerfile.driver
@@ -20,6 +20,8 @@ WORKDIR /go/src/github.com/kubeflow/pipelines
 
 COPY ./go.mod ./
 COPY ./go.sum ./
+COPY ./kubernetes_platform/go.mod ./kubernetes_platform/go.mod
+COPY ./api/go.mod ./api/go.mod
 
 RUN GO111MODULE=on go mod download
 

--- a/backend/Dockerfile.launcher
+++ b/backend/Dockerfile.launcher
@@ -18,6 +18,8 @@ WORKDIR /go/src/github.com/kubeflow/pipelines
 
 COPY ./go.mod ./
 COPY ./go.sum ./
+COPY ./kubernetes_platform/go.mod ./kubernetes_platform/go.mod
+COPY ./api/go.mod ./api/go.mod
 
 RUN GO111MODULE=on go mod download
 

--- a/backend/Dockerfile.persistenceagent
+++ b/backend/Dockerfile.persistenceagent
@@ -18,6 +18,8 @@ WORKDIR /go/src/github.com/kubeflow/pipelines
 
 COPY ./go.mod ./
 COPY ./go.sum ./
+COPY ./kubernetes_platform/go.mod ./kubernetes_platform/go.mod
+COPY ./api/go.mod ./api/go.mod
 
 RUN GO111MODULE=on go mod download
 

--- a/backend/Dockerfile.scheduledworkflow
+++ b/backend/Dockerfile.scheduledworkflow
@@ -18,6 +18,8 @@ WORKDIR /go/src/github.com/kubeflow/pipelines
 
 COPY ./go.mod ./
 COPY ./go.sum ./
+COPY ./kubernetes_platform/go.mod ./kubernetes_platform/go.mod
+COPY ./api/go.mod ./api/go.mod
 
 RUN GO111MODULE=on go mod download
 

--- a/go.mod
+++ b/go.mod
@@ -232,4 +232,10 @@ replace (
 	github.com/kubeflow/kfp-tekton/tekton-catalog/objectstore => github.com/kubeflow/kfp-tekton/tekton-catalog/objectstore v0.0.0-20240417221339-0b894195443c
 )
 
+// These dependencies are managed relative to project root
+replace (
+	github.com/kubeflow/pipelines/api => ./api
+	github.com/kubeflow/pipelines/kubernetes_platform => ./kubernetes_platform
+)
+
 exclude github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f

--- a/go.sum
+++ b/go.sum
@@ -632,10 +632,6 @@ github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-exithandler v0.0.0-20240417
 github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-exithandler v0.0.0-20240417221339-0b894195443c/go.mod h1:a6DSo/UxoG4hkJXJMo4nSmHURDEEiEVremmXy4GwdII=
 github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-kfptask v0.0.0-20240417221339-0b894195443c h1:/BevRDQhW+0ULFnDhYTq6JKiml0rORDW3qTnnOgGPnc=
 github.com/kubeflow/kfp-tekton/tekton-catalog/tekton-kfptask v0.0.0-20240417221339-0b894195443c/go.mod h1:PGwbV4v8F6E8RXuvtJ9qpnIiESpK8LL3JDSsGo6nT+o=
-github.com/kubeflow/pipelines/api v0.0.0-20250102152816-873e9dedd766 h1:ZXz+Ki+hxez8vsr5hWHsjYWpa9V/dkp3iI4XTtMBH7A=
-github.com/kubeflow/pipelines/api v0.0.0-20250102152816-873e9dedd766/go.mod h1:puPWVUzB1VCb8lVq4g06IR2rIXuSpejDTd/FkSr6nvc=
-github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240725205754-d911c8b73b49 h1:Xf1qun8x4ZJj/nLZpUSIaphDK04NKeV7WME31qIC8Xo=
-github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240725205754-d911c8b73b49/go.mod h1:UhJrmpVSWawsAsSr1OzZfsEZTvQce+GvGwcZ58ULEhM=
 github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20240416215826-da804407ad31 h1:t1G2SexX+SwtYiaFrwH1lzGRSiXYMjd2QDT9842Ytpc=
 github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20240416215826-da804407ad31/go.mod h1:gh5+EFvuVywvSOYxqT0N91VKuPtScUke/F66RT0NJ80=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=


### PR DESCRIPTION
**Description of your changes:**

This adds a simple change to allow our CI to reference the local proto packages. This will prevent ci failures when: 

* a proto file is changed 
* code using golang proto built packages are affected by such a change
* builds fail because it's referencing the golang proto packages remotely and not the updated changes 

Instead, this pr will now reference the updated proto changes locally present within the PR itself. 


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

