### PR TITLE
fix(backend): fixes DAG status update to reflect completion of all tasks

### DIFF
--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -849,6 +849,10 @@ func DAG(ctx context.Context, opts Options, mlmd *metadata.Client) (execution *E
 	ecfg.OutputArtifacts = opts.Component.GetDag().GetOutputs().GetArtifacts()
 	glog.V(4).Info("outputArtifacts: ", ecfg.OutputArtifacts)
 
+	totalDagTasks := len(opts.Component.GetDag().GetTasks())
+	ecfg.TotalDagTasks = &totalDagTasks
+	glog.V(4).Info("totalDagTasks: ", *ecfg.TotalDagTasks)
+
 	if opts.Task.GetArtifactIterator() != nil {
 		return execution, fmt.Errorf("ArtifactIterator is not implemented")
 	}

--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -148,6 +148,7 @@ type ExecutionConfig struct {
 
 	// DAGExecution custom properties
 	IterationCount *int // Number of iterations for an iterator DAG.
+	TotalDagTasks  *int // Number of tasks inside the DAG
 }
 
 // InputArtifact is a wrapper around an MLMD artifact used as component inputs.
@@ -526,6 +527,7 @@ const (
 	keyParentDagID           = "parent_dag_id" // Parent DAG Execution ID.
 	keyIterationIndex        = "iteration_index"
 	keyIterationCount        = "iteration_count"
+	keyTotalDagTasks         = "total_dag_tasks"
 )
 
 // CreateExecution creates a new MLMD execution under the specified Pipeline.
@@ -620,6 +622,9 @@ func (c *Client) CreateExecution(ctx context.Context, pipeline *Pipeline, config
 		}
 		e.CustomProperties[keyArtifactProducerTask] = StringValue(string(b))
 	}
+	if config.TotalDagTasks != nil {
+		e.CustomProperties[keyTotalDagTasks] = intValue(int64(*config.TotalDagTasks))
+	}
 
 	req := &pb.PutExecutionRequest{
 		Execution: e,
@@ -690,11 +695,13 @@ func (c *Client) UpdateDAGExecutionsState(ctx context.Context, dag *DAG, pipelin
 	if err != nil {
 		return err
 	}
+
+	totalDagTasks := dag.Execution.execution.CustomProperties["total_dag_tasks"].GetIntValue()
+
 	glog.V(4).Infof("tasks: %v", tasks)
 	glog.V(4).Infof("Checking Tasks' State")
 	completedTasks := 0
 	failedTasks := 0
-	totalTasks := len(tasks)
 	for _, task := range tasks {
 		taskState := task.GetExecution().LastKnownState.String()
 		glog.V(4).Infof("task: %s", task.TaskName())
@@ -712,10 +719,10 @@ func (c *Client) UpdateDAGExecutionsState(ctx context.Context, dag *DAG, pipelin
 	}
 	glog.V(4).Infof("completedTasks: %d", completedTasks)
 	glog.V(4).Infof("failedTasks: %d", failedTasks)
-	glog.V(4).Infof("totalTasks: %d", totalTasks)
+	glog.V(4).Infof("totalTasks: %d", totalDagTasks)
 
 	glog.Infof("Attempting to update DAG state")
-	if completedTasks == totalTasks {
+	if completedTasks == int(totalDagTasks) {
 		c.PutDAGExecutionState(ctx, dag.Execution.GetID(), pb.Execution_COMPLETE)
 	} else if failedTasks > 0 {
 		c.PutDAGExecutionState(ctx, dag.Execution.GetID(), pb.Execution_FAILED)


### PR DESCRIPTION
**Description of your changes:**
This PR resolves [#11572](https://github.com/kubeflow/pipelines/issues/11572)
Subdags are being updated as soon as the first task within the subdag completes, which is incorrect behavior. The subdag status should only be updated once all tasks have completed.

This fix ensures that the subdag status is updated only after all tasks have been executed.

**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
