### PR TITLE
fix(manifests): Upgrading metacontroller to v4.11.22

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/decorator-controller.yaml
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/decorator-controller.yaml
@@ -1,16 +1,16 @@
-# Change resyncPeriodSeconds to 1 hour from insane 20 seconds  
-# Only  sync namespaces with pipelines.kubeflow.org/enabled = "true"
 apiVersion: metacontroller.k8s.io/v1alpha1
-kind: CompositeController
+kind: DecoratorController
 metadata:
   name: kubeflow-pipelines-profile-controller
 spec:
-  generateSelector: true
   resyncPeriodSeconds: 3600
-  parentResource:
-    apiVersion: v1
+  resources:
+  - apiVersion: v1
     resource: namespaces
-  childResources:
+    labelSelector:
+      matchLabels:
+        pipelines.kubeflow.org/enabled: "true"
+  attachments:
   - apiVersion: v1
     resource: secrets
     updateStrategy:

--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/kustomization.yaml
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/kustomization.yaml
@@ -6,7 +6,7 @@ commonLabels:
 resources:
 - service.yaml
 - deployment.yaml
-- composite-controller.yaml
+- decorator-controller.yaml
 configMapGenerator:
 - name: kubeflow-pipelines-profile-controller-code
   files:

--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/sync.py
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/sync.py
@@ -99,15 +99,14 @@ def server_factory(visualization_server_image,
     Returns an HTTPServer populated with Handler with customized settings
     """
     class Controller(BaseHTTPRequestHandler):
-        def sync(self, parent, children):
+        def sync(self, parent, attachments):
             # parent is a namespace
             namespace = parent.get("metadata", {}).get("name")
-
             pipeline_enabled = parent.get("metadata", {}).get(
                 "labels", {}).get("pipelines.kubeflow.org/enabled")
 
             if pipeline_enabled != "true":
-                return {"status": {}, "children": []}
+                return {"status": {}, "attachments": []}
 
             desired_configmap_count = 1
             desired_resources = []
@@ -129,16 +128,16 @@ def server_factory(visualization_server_image,
             # Compute status based on observed state.
             desired_status = {
                 "kubeflow-pipelines-ready":
-                    len(children["Secret.v1"]) == 1 and
-                    len(children["ConfigMap.v1"]) == desired_configmap_count and
-                    len(children["Deployment.apps/v1"]) == 2 and
-                    len(children["Service.v1"]) == 2 and
-                    len(children["DestinationRule.networking.istio.io/v1alpha3"]) == 1 and
-                    len(children["AuthorizationPolicy.security.istio.io/v1beta1"]) == 1 and
+                    len(attachments["Secret.v1"]) == 1 and
+                    len(attachments["ConfigMap.v1"]) == desired_configmap_count and
+                    len(attachments["Deployment.apps/v1"]) == 2 and
+                    len(attachments["Service.v1"]) == 2 and
+                    len(attachments["DestinationRule.networking.istio.io/v1alpha3"]) == 1 and
+                    len(attachments["AuthorizationPolicy.security.istio.io/v1beta1"]) == 1 and
                     "True" or "False"
             }
 
-            # Generate the desired child object(s).
+            # Generate the desired attachment object(s).
             desired_resources += [
                 {
                     "apiVersion": "v1",
@@ -376,13 +375,13 @@ def server_factory(visualization_server_image,
                 },
             })
 
-            return {"status": desired_status, "children": desired_resources}
+            return {"status": desired_status, "attachments": desired_resources}
 
         def do_POST(self):
             # Serve the sync() function as a JSON webhook.
             observed = json.loads(
                 self.rfile.read(int(self.headers.get("content-length"))))
-            desired = self.sync(observed["parent"], observed["children"])
+            desired = self.sync(observed["object"], observed["attachments"])
 
             self.send_response(200)
             self.send_header("Content-type", "application/json")

--- a/manifests/kustomize/third-party/metacontroller/base/cluster-role.yaml
+++ b/manifests/kustomize/third-party/metacontroller/base/cluster-role.yaml
@@ -5,7 +5,10 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: [""]
+  resources: ["namespaces/status"]
+  verbs: ["get", "list", "watch", "update", "patch"]
 - apiGroups: [""]
   resources: ["secrets", "configmaps"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -24,3 +27,6 @@ rules:
 - apiGroups: ["metacontroller.k8s.io"]
   resources: ["compositecontrollers", "controllerrevisions", "decoratorcontrollers"]
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]

--- a/manifests/kustomize/third-party/metacontroller/base/crd.yaml
+++ b/manifests/kustomize/third-party/metacontroller/base/crd.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    "api-approved.kubernetes.io": "unapproved, request not yet submitted"
+    api-approved.kubernetes.io: unapproved, request not yet submitted
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: compositecontrollers.metacontroller.k8s.io
 spec:
   group: metacontroller.k8s.io
@@ -20,12 +21,17 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: CompositeController
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -41,6 +47,12 @@ spec:
                     updateStrategy:
                       properties:
                         method:
+                          enum:
+                          - OnDelete
+                          - Recreate
+                          - InPlace
+                          - RollingRecreate
+                          - RollingInPlace
                           type: string
                         statusChecks:
                           properties:
@@ -70,9 +82,34 @@ spec:
                 properties:
                   customize:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -90,6 +127,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -97,9 +135,34 @@ spec:
                     type: object
                   finalize:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -117,6 +180,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -124,9 +188,34 @@ spec:
                     type: object
                   postUpdateChild:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -144,6 +233,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -151,9 +241,34 @@ spec:
                     type: object
                   preUpdateChild:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -171,6 +286,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -178,9 +294,34 @@ spec:
                     type: object
                   sync:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -198,6 +339,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -208,6 +350,54 @@ spec:
                 properties:
                   apiVersion:
                     type: string
+                  labelSelector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An
+                      empty label selector matches all objects. A null label selector
+                      matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
                   resource:
                     type: string
                   revisionHistory:
@@ -237,19 +427,13 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    "api-approved.kubernetes.io": "unapproved, request not yet submitted"
+    api-approved.kubernetes.io: unapproved, request not yet submitted
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: controllerrevisions.metacontroller.k8s.io
 spec:
   group: metacontroller.k8s.io
@@ -263,9 +447,12 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ControllerRevision
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           children:
             items:
@@ -285,12 +472,15 @@ spec:
               type: object
             type: array
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           parentPatch:
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         required:
         - metadata
         - parentPatch
@@ -299,19 +489,13 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    "api-approved.kubernetes.io": "unapproved, request not yet submitted"
+    api-approved.kubernetes.io: unapproved, request not yet submitted
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: decoratorcontrollers.metacontroller.k8s.io
 spec:
   group: metacontroller.k8s.io
@@ -328,12 +512,17 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: DecoratorController
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -349,6 +538,12 @@ spec:
                     updateStrategy:
                       properties:
                         method:
+                          enum:
+                          - OnDelete
+                          - Recreate
+                          - InPlace
+                          - RollingRecreate
+                          - RollingInPlace
                           type: string
                       type: object
                   required:
@@ -360,9 +555,34 @@ spec:
                 properties:
                   customize:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -380,6 +600,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -387,9 +608,34 @@ spec:
                     type: object
                   finalize:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -407,6 +653,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -414,9 +661,34 @@ spec:
                     type: object
                   sync:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -434,6 +706,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -451,16 +724,25 @@ spec:
                           type: object
                         matchExpressions:
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
                             properties:
                               key:
-                                description: key is the label key that the selector applies to.
+                                description: key is the label key that the selector
+                                  applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -473,21 +755,34 @@ spec:
                     apiVersion:
                       type: string
                     labelSelector:
-                      description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                      description: A label selector is a label query over a set of
+                        resources. The result of matchLabels and matchExpressions
+                        are ANDed. An empty label selector matches all objects. A
+                        null label selector matches no objects.
                       properties:
                         matchExpressions:
-                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
                             properties:
                               key:
-                                description: key is the label key that the selector applies to.
+                                description: key is the label key that the selector
+                                  applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -499,9 +794,14 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     resource:
                       type: string
                   required:
@@ -525,9 +825,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/manifests/kustomize/third-party/metacontroller/base/stateful-set.yaml
+++ b/manifests/kustomize/third-party/metacontroller/base/stateful-set.yaml
@@ -25,10 +25,18 @@ spec:
             requests:
               cpu: 100m
               memory: 256Mi
-          command:
-            - /usr/bin/metacontroller
-            - --zap-log-level=4
-            - '--discovery-interval=3600s' # less insane than 10 seconds
+          command: ["/usr/bin/metacontroller"]
+          args:
+          - --zap-log-level=4
+          - --discovery-interval=3600s
+          livenessProbe:
+            httpGet:
+              port: 8081
+              path: /healthz
+          readinessProbe:
+            httpGet:
+              port: 8081
+              path: /readyz
           securityContext:
             seccompProfile: 
               type: RuntimeDefault
@@ -41,7 +49,7 @@ spec:
             privileged: false
             allowPrivilegeEscalation: false
           name: metacontroller
-          image: 'ghcr.io/metacontroller/metacontroller:v2.6.1'
+          image: 'ghcr.io/metacontroller/metacontroller:v4.11.22'
       serviceAccountName: meta-controller-service
   # Workaround for https://github.com/kubernetes-sigs/kustomize/issues/677
   volumeClaimTemplates: []


### PR DESCRIPTION
**Description of your changes:**
Upgrading metacontroller manifests to v4.11.22 according to this [PR](https://github.com/kubeflow/manifests/pull/2988/) in Kubeflow manifests and this [issue](https://github.com/kubeflow/manifests/issues/2970).

This entails changing metacontroller type from composite to decorator, as since metacontroller v3, it's not supported to watch namespaces which is preventing creating necessary K8s objects for KFP multi tenancy.


cc @juliusvonkohout  @hbelmiro @HumairAK 

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
