### PR TITLE
fix(backend): ignore unknown fields for pb json unmarshaling

### DIFF
--- a/backend/src/apiserver/server/list_request_util.go
+++ b/backend/src/apiserver/server/list_request_util.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/golang/protobuf/jsonpb"
 	apiv1beta1 "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
 	apiv2beta1 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
@@ -148,13 +147,13 @@ func parseAPIFilter(encoded string, apiVersion string) (interface{}, error) {
 	switch apiVersion {
 	case "v2beta1":
 		f := &apiv2beta1.Filter{}
-		if err := jsonpb.UnmarshalString(decoded, f); err != nil {
+		if err := util.UnmarshalString(decoded, f); err != nil {
 			return nil, util.NewInvalidInputError("failed to parse valid filter from %q: %v", encoded, err)
 		}
 		return f, nil
 	case "v1beta1":
 		f := &apiv1beta1.Filter{}
-		if err := jsonpb.UnmarshalString(decoded, f); err != nil {
+		if err := util.UnmarshalString(decoded, f); err != nil {
 			return nil, util.NewInvalidInputError("failed to parse valid filter from %q: %v", encoded, err)
 		}
 		return f, nil

--- a/backend/src/common/util/json.go
+++ b/backend/src/common/util/json.go
@@ -15,9 +15,12 @@
 package util
 
 import (
-	"encoding/json"
+	"github.com/golang/protobuf/jsonpb"
 
+	"encoding/json"
 	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"strings"
 )
 
 func UnmarshalJsonOrFail(data string, v interface{}) {
@@ -62,4 +65,11 @@ func UnmarshalJsonWithError(data interface{}, v *interface{}) error {
 		return Wrapf(err, "Failed to unmarshal the object: %+v", v)
 	}
 	return nil
+}
+
+// UnmarshalString unmarshals a JSON object from s into m.
+// Allows unknown fields
+func UnmarshalString(s string, m proto.Message) error {
+	unmarshaler := jsonpb.Unmarshaler{AllowUnknownFields: true}
+	return unmarshaler.Unmarshal(strings.NewReader(s), m)
 }

--- a/backend/src/common/util/pipelinerun.go
+++ b/backend/src/common/util/pipelinerun.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
-	"github.com/golang/protobuf/jsonpb"
 	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
 	exec "github.com/kubeflow/pipelines/backend/src/common"
 	swfregister "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow"
@@ -664,7 +663,7 @@ func collectTaskRunMetricsOrNil(
 	// ReportRunMetricsRequest as a workaround to hold user's metrics, which is a superset of what
 	// user can provide.
 	reportMetricsRequest := new(api.ReportRunMetricsRequest)
-	err = jsonpb.UnmarshalString(metricsJSON, reportMetricsRequest)
+	err = UnmarshalString(metricsJSON, reportMetricsRequest)
 	if err != nil {
 		// User writes invalid metrics JSON.
 		// TODO(#1426): report the error back to api server to notify user

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -29,7 +29,6 @@ import (
 	"github.com/argoproj/argo-workflows/v3/workflow/packer"
 	"github.com/argoproj/argo-workflows/v3/workflow/validate"
 	"github.com/golang/glog"
-	"github.com/golang/protobuf/jsonpb"
 	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
 	exec "github.com/kubeflow/pipelines/backend/src/common"
 	swfregister "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow"
@@ -517,7 +516,7 @@ func collectNodeMetricsOrNil(runID string, nodeStatus *workflowapi.NodeStatus, r
 	// ReportRunMetricsRequest as a workaround to hold user's metrics, which is a superset of what
 	// user can provide.
 	reportMetricsRequest := new(api.ReportRunMetricsRequest)
-	err = jsonpb.UnmarshalString(metricsJSON, reportMetricsRequest)
+	err = UnmarshalString(metricsJSON, reportMetricsRequest)
 	if err != nil {
 		// User writes invalid metrics JSON.
 		// TODO(#1426): report the error back to api server to notify user

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -16,13 +16,13 @@ package argocompiler
 
 import (
 	"fmt"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"os"
 	"strconv"
 	"strings"
 
 	wfapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/golang/glog"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/v2/component"
 	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
@@ -419,7 +419,7 @@ func (c *workflowCompiler) addContainerExecutorTemplate(refName string) string {
 
 	if kubernetesConfigParam != nil {
 		k8sExecCfg := &kubernetesplatform.KubernetesExecutorConfig{}
-		if err := jsonpb.UnmarshalString(string(*kubernetesConfigParam.Value), k8sExecCfg); err == nil {
+		if err := util.UnmarshalString(string(*kubernetesConfigParam.Value), k8sExecCfg); err == nil {
 			extendPodMetadata(&executor.Metadata, k8sExecCfg)
 		}
 	}

--- a/backend/src/v2/compiler/visitor.go
+++ b/backend/src/v2/compiler/visitor.go
@@ -24,6 +24,7 @@ package compiler
 import (
 	"bytes"
 	"fmt"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"sort"
 
 	"github.com/golang/protobuf/jsonpb"
@@ -187,7 +188,7 @@ func GetPipelineSpec(job *pipelinespec.PipelineJob) (*pipelinespec.PipelineSpec,
 		return nil, fmt.Errorf("failed marshal pipeline spec to json: %w", err)
 	}
 	spec := &pipelinespec.PipelineSpec{}
-	if err := jsonpb.UnmarshalString(json, spec); err != nil {
+	if err := util.UnmarshalString(json, spec); err != nil {
 		return nil, fmt.Errorf("failed to parse pipeline spec: %v", err)
 	}
 	return spec, nil

--- a/backend/src/v2/compiler/visitor_test.go
+++ b/backend/src/v2/compiler/visitor_test.go
@@ -15,10 +15,10 @@ package compiler_test
 
 import (
 	"fmt"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"os"
 	"testing"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/google/go-cmp/cmp"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/v2/compiler"
@@ -93,7 +93,7 @@ func load(t *testing.T, path string) *pipelinespec.PipelineJob {
 	}
 	json := string(content)
 	job := &pipelinespec.PipelineJob{}
-	if err := jsonpb.UnmarshalString(json, job); err != nil {
+	if err := util.UnmarshalString(json, job); err != nil {
 		t.Errorf("Failed to parse pipeline job, error: %s, job: %v", err, json)
 	}
 	return job


### PR DESCRIPTION
**Description of your changes:**

When new proto api fields are added to the spec, these break the driver due to unknown field constraints. For example: 

Today the driver understands this kubernetes execution config: 
```yaml
platforms:
  kubernetes:
    deploymentSpec:
      executors:
        exec-some-component:
          configMapAsEnv:
          - configMapName: my-configmap    # this exists in the api today
```

Now suppose we are on kfp 2.4, and in 2.5 we add support for a new field, deprecated the old field `configMapName`: 

```yaml
platforms:
  kubernetes:
    deploymentSpec:
      executors:
        exec-some-component:
          configMapAsEnv:
          - configMapName: my-configmap           # this is now deprecated and configNameParameter is preferred
            configNameParameter:
              runtimeValue:
                constant: my-configmap
```

And we add backend support for the new field in 2.5, and then the functional sdk changes. The pipeline compiled using the new sdk will not work for 2.4 because 2.4 drivers will not be able to unmarshal this field `configNameParameter` because it does not recognize it. This change will allow older versions to just drop this field, making new api additions more friendly to older kfp versions. 

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

