### PR TITLE
Chore: fix the PPC image for the dockerhub ratelimit and add the securitycontext

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/deployment.yaml
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: profile-controller
-        image: python:3.9
+        image: public.ecr.aws/docker/library/python:3.12
         command: ["python", "/hooks/sync.py"]
         envFrom:
         - configMapRef:

--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/deployment.yaml
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/deployment.yaml
@@ -11,6 +11,16 @@ spec:
     spec:
       containers:
       - name: profile-controller
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 0
+          capabilities:
+            drop:
+            - ALL
         image: public.ecr.aws/docker/library/python:3.12
         command: ["python", "/hooks/sync.py"]
         envFrom:


### PR DESCRIPTION
This PR and

- https://github.com/kubeflow/pipelines/pull/11656
- https://github.com/kubeflow/pipelines/pull/11585
- https://github.com/kubeflow/pipelines/pull/11578
- https://github.com/kubeflow/pipelines/pull/11673 is also worth a look
- https://github.com/kubeflow/pipelines/pull/11678 is also worth a look

Should make the KFP 2.4.1 release @hbelmiro @HumairAK 

I am running this for a long time on 3.12 and the integration test is also successful https://github.com/kubeflow/manifests/pull/3014

See also https://github.com/kubeflow/manifests/issues/3010#issuecomment-2677977953

See also https://github.com/akagami-harsh/manifests/blob/test-pss/experimental/security/PSS/patches/kubeflow-pipelines-profile-controller.yaml