### PR TITLE
fix(backend) fix execution-level retry on the Argo Workflows backend

### DIFF
--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -16,6 +16,7 @@ package argocompiler
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"os"
 	"strconv"
 	"strings"
@@ -239,7 +240,7 @@ func (c *workflowCompiler) containerExecutorTask(name string, inputs containerEx
 	}
 	task := &wfapi.DAGTask{
 		Name:     name,
-		Template: c.addContainerExecutorTemplate(refName),
+		Template: c.addContainerExecutorTemplate(name, refName),
 		When:     when,
 		Arguments: wfapi.Arguments{
 			Parameters: []wfapi.Parameter{
@@ -258,10 +259,15 @@ func (c *workflowCompiler) containerExecutorTask(name string, inputs containerEx
 // any container component task.
 // During runtime, it's expected that pod-spec-patch will specify command, args
 // and resources etc, that are different for different tasks.
-func (c *workflowCompiler) addContainerExecutorTemplate(refName string) string {
+func (c *workflowCompiler) addContainerExecutorTemplate(name string, refName string) string {
 	// container template is parent of container implementation template
 	nameContainerExecutor := "system-container-executor"
 	nameContainerImpl := "system-container-impl"
+	taskRetrySpec := c.getTaskRetryPolicySpec(name)
+	if taskRetrySpec != nil {
+		nameContainerExecutor = name + "-" + nameContainerExecutor
+		nameContainerImpl = name + "-" + "system-container-impl"
+	}
 	_, ok := c.templates[nameContainerExecutor]
 	if ok {
 		return nameContainerExecutor
@@ -302,7 +308,8 @@ func (c *workflowCompiler) addContainerExecutorTemplate(refName string) string {
 		args = append(args, "--log_level", value)
 	}
 	executor := &wfapi.Template{
-		Name: nameContainerImpl,
+		Name:          nameContainerImpl,
+		RetryStrategy: c.getTaskRetryStrategy(name),
 		Inputs: wfapi.Inputs{
 			Parameters: []wfapi.Parameter{
 				{Name: paramPodSpecPatch},
@@ -479,6 +486,60 @@ func (c *workflowCompiler) addContainerExecutorTemplate(refName string) string {
 	c.templates[nameContainerImpl] = executor
 	c.wf.Spec.Templates = append(c.wf.Spec.Templates, *container, *executor)
 	return nameContainerExecutor
+}
+
+func (c *workflowCompiler) findTaskSpecByName(name string) *pipelinespec.PipelineTaskSpec {
+	if c.spec == nil || c.spec.Root == nil || c.spec.Root.GetDag() == nil {
+		return nil
+	}
+	rootDag := c.spec.Root.GetDag()
+	return rootDag.Tasks[name]
+}
+
+func (c *workflowCompiler) getTaskRetryPolicySpec(name string) *pipelinespec.PipelineTaskSpec_RetryPolicy {
+	if c.spec == nil || c.spec.Root == nil || c.spec.Root.GetDag() == nil {
+		return nil
+	}
+	rootDag := c.spec.Root.GetDag()
+	taskSpec := rootDag.Tasks[name]
+	if taskSpec == nil {
+		return nil
+	}
+	return taskSpec.RetryPolicy
+}
+
+func (c *workflowCompiler) getTaskRetryStrategy(name string) *wfapi.RetryStrategy {
+	retryPolicy := c.getTaskRetryPolicySpec(name)
+	if retryPolicy == nil {
+		return nil
+	}
+
+	argoBackOffDuration := "0"
+	backoffDuration := retryPolicy.GetBackoffDuration()
+	if backoffDuration != nil {
+		argoBackOffDuration = strconv.FormatInt(backoffDuration.Seconds, 10)
+	}
+
+	var argoMaxDuration string
+	backoffMaxDuration := retryPolicy.GetBackoffMaxDuration()
+	if backoffMaxDuration != nil {
+		argoMaxDuration = strconv.FormatInt(backoffMaxDuration.Seconds, 10)
+	}
+	backoff := &wfapi.Backoff{
+		Factor: &intstr.IntOrString{
+			Type:   intstr.Int,
+			IntVal: int32(retryPolicy.GetBackoffFactor()),
+		},
+		MaxDuration: argoMaxDuration,
+		Duration:    argoBackOffDuration,
+	}
+	return &wfapi.RetryStrategy{
+		Limit: &intstr.IntOrString{
+			Type:   intstr.Int,
+			IntVal: retryPolicy.MaxRetryCount,
+		},
+		Backoff: backoff,
+	}
 }
 
 // Extends the PodMetadata to include Kubernetes-specific executor config.

--- a/backend/src/v2/compiler/argocompiler/container_test.go
+++ b/backend/src/v2/compiler/argocompiler/container_test.go
@@ -59,7 +59,7 @@ func TestAddContainerExecutorTemplate(t *testing.T) {
 				},
 			}
 
-			c.addContainerExecutorTemplate("test-ref")
+			c.addContainerExecutorTemplate("test-ref", "comp-test-ref")
 			assert.NotEmpty(t, "system-container-impl", "Template name should not be empty")
 
 			executorTemplate, exists := c.templates["system-container-impl"]

--- a/backend/src/v2/compiler/argocompiler/testdata/hello_world_with_retry.yaml
+++ b/backend/src/v2/compiler/argocompiler/testdata/hello_world_with_retry.yaml
@@ -1,0 +1,308 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  annotations:
+    pipelines.kubeflow.org/components-comp-hello-world: '{"executorLabel":"exec-hello-world","inputDefinitions":{"parameters":{"text":{"type":"STRING"}}}}'
+    pipelines.kubeflow.org/components-root: '{"dag":{"tasks":{"hello-world":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-hello-world"},"inputs":{"parameters":{"text":{"componentInputParameter":"text"}}},"retryPolicy":{"backoffFactor":2,"backoffMaxDuration":"3600s","maxRetryCount":2},"taskInfo":{"name":"hello-world"}}}},"inputDefinitions":{"parameters":{"text":{"type":"STRING"}}}}'
+    pipelines.kubeflow.org/implementations-comp-hello-world:
+      '{"args":["--text","{{$.inputs.parameters[''text'']}}"],"command":["sh","-ec","program_path=$(mktemp)\nprintf
+      \"%s\" \"$0\" \u003e \"$program_path\"\npython3 -u \"$program_path\" \"$@\"\n","def
+      hello_world(text):\n    print(text)\n    return text\n\nimport argparse\n_parser
+      = argparse.ArgumentParser(prog=''Hello world'', description='''')\n_parser.add_argument(\"--text\",
+      dest=\"text\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
+      = vars(_parser.parse_args())\n\n_outputs = hello_world(**_parsed_args)\n"],"image":"python:3.7"}'
+  creationTimestamp: null
+  generateName: hello-world-
+spec:
+  arguments: {}
+  entrypoint: entrypoint
+  podMetadata:
+    annotations:
+      pipelines.kubeflow.org/v2_component: "true"
+    labels:
+      pipelines.kubeflow.org/v2_component: "true"
+  serviceAccountName: pipeline-runner
+  templates:
+    - container:
+        args:
+          - --type
+          - CONTAINER
+          - --pipeline_name
+          - namespace/n1/pipeline/hello-world
+          - --run_id
+          - "{{workflow.uid}}"
+          - --dag_execution_id
+          - "{{inputs.parameters.parent-dag-id}}"
+          - --component
+          - "{{inputs.parameters.component}}"
+          - --task
+          - "{{inputs.parameters.task}}"
+          - --container
+          - "{{inputs.parameters.container}}"
+          - --iteration_index
+          - "{{inputs.parameters.iteration-index}}"
+          - --cached_decision_path
+          - "{{outputs.parameters.cached-decision.path}}"
+          - --pod_spec_patch_path
+          - "{{outputs.parameters.pod-spec-patch.path}}"
+          - --condition_path
+          - "{{outputs.parameters.condition.path}}"
+          - --kubernetes_config
+          - "{{inputs.parameters.kubernetes-config}}"
+        command:
+          - driver
+        image: gcr.io/ml-pipeline/kfp-driver
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi
+      inputs:
+        parameters:
+          - name: component
+          - name: task
+          - name: container
+          - name: parent-dag-id
+          - default: "-1"
+            name: iteration-index
+          - default: ""
+            name: kubernetes-config
+      metadata: {}
+      name: system-container-driver
+      outputs:
+        parameters:
+          - name: pod-spec-patch
+            valueFrom:
+              default: ""
+              path: /tmp/outputs/pod-spec-patch
+          - default: "false"
+            name: cached-decision
+            valueFrom:
+              default: "false"
+              path: /tmp/outputs/cached-decision
+          - name: condition
+            valueFrom:
+              default: "true"
+              path: /tmp/outputs/condition
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: pod-spec-patch
+                  value: "{{inputs.parameters.pod-spec-patch}}"
+            name: executor
+            template: hello-world-system-container-impl
+            when: "{{inputs.parameters.cached-decision}} != true"
+      inputs:
+        parameters:
+          - name: pod-spec-patch
+          - default: "false"
+            name: cached-decision
+      metadata: {}
+      name: hello-world-system-container-executor
+      outputs: {}
+    - containerSet:
+        containers:
+          - command:
+              - should-be-overridden-during-runtime
+            env:
+              - name: KFP_POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: KFP_POD_UID
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.uid
+            envFrom:
+              - configMapRef:
+                  name: metadata-grpc-configmap
+                  optional: true
+            image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+            name: main
+            resources: {}
+            volumeMounts:
+              - mountPath: /kfp-launcher
+                name: kfp-launcher
+          - command:
+              - watcher
+            env:
+              - name: KFP_POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: KFP_POD_UID
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.uid
+            envFrom:
+              - configMapRef:
+                  name: metadata-grpc-configmap
+                  optional: true
+            name: watcher
+            resources:
+              limits:
+                cpu: 500m
+                memory: 128Mi
+              requests:
+                cpu: 100m
+      initContainers:
+        - command:
+            - launcher-v2
+            - --copy
+            - /kfp-launcher/launch
+          image: gcr.io/ml-pipeline/kfp-launcher
+          name: kfp-launcher
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+          volumeMounts:
+            - mountPath: /kfp-launcher
+              name: kfp-launcher
+      inputs:
+        parameters:
+          - name: pod-spec-patch
+      metadata: {}
+      name: hello-world-system-container-impl
+      outputs: {}
+      podSpecPatch: "{{inputs.parameters.pod-spec-patch}}"
+      retryStrategy:
+        backoff:
+          duration: "0"
+          factor: 2
+          maxDuration: "3600"
+        limit: 2
+      volumes:
+        - emptyDir: {}
+          name: kfp-launcher
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: component
+                  value: "{{workflow.annotations.pipelines.kubeflow.org/components-comp-hello-world}}"
+                - name: task
+                  value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-hello-world"},"inputs":{"parameters":{"text":{"componentInputParameter":"text"}}},"retryPolicy":{"backoffFactor":2,"backoffMaxDuration":"3600s","maxRetryCount":2},"taskInfo":{"name":"hello-world"}}'
+                - name: container
+                  value: "{{workflow.annotations.pipelines.kubeflow.org/implementations-comp-hello-world}}"
+                - name: parent-dag-id
+                  value: "{{inputs.parameters.parent-dag-id}}"
+            name: hello-world-driver
+            template: system-container-driver
+          - arguments:
+              parameters:
+                - name: pod-spec-patch
+                  value: "{{tasks.hello-world-driver.outputs.parameters.pod-spec-patch}}"
+                - default: "false"
+                  name: cached-decision
+                  value: "{{tasks.hello-world-driver.outputs.parameters.cached-decision}}"
+            depends: hello-world-driver.Succeeded
+            name: hello-world
+            template: hello-world-system-container-executor
+      inputs:
+        parameters:
+          - name: parent-dag-id
+      metadata: {}
+      name: root
+      outputs: {}
+    - container:
+        args:
+          - --type
+          - "{{inputs.parameters.driver-type}}"
+          - --pipeline_name
+          - namespace/n1/pipeline/hello-world
+          - --run_id
+          - "{{workflow.uid}}"
+          - --dag_execution_id
+          - "{{inputs.parameters.parent-dag-id}}"
+          - --component
+          - "{{inputs.parameters.component}}"
+          - --task
+          - "{{inputs.parameters.task}}"
+          - --runtime_config
+          - "{{inputs.parameters.runtime-config}}"
+          - --iteration_index
+          - "{{inputs.parameters.iteration-index}}"
+          - --execution_id_path
+          - "{{outputs.parameters.execution-id.path}}"
+          - --iteration_count_path
+          - "{{outputs.parameters.iteration-count.path}}"
+          - --condition_path
+          - "{{outputs.parameters.condition.path}}"
+          - --run_metadata
+          - "{{inputs.parameters.run-metadata}}"
+        command:
+          - driver
+        image: gcr.io/ml-pipeline/kfp-driver
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi
+      inputs:
+        parameters:
+          - name: component
+          - default: ""
+            name: runtime-config
+          - default: ""
+            name: task
+          - default: "0"
+            name: parent-dag-id
+          - default: "-1"
+            name: iteration-index
+          - default: DAG
+            name: driver-type
+          - default: ""
+            name: run-metadata
+      metadata: {}
+      name: system-dag-driver
+      outputs:
+        parameters:
+          - name: execution-id
+            valueFrom:
+              path: /tmp/outputs/execution-id
+          - name: iteration-count
+            valueFrom:
+              default: "0"
+              path: /tmp/outputs/iteration-count
+          - name: condition
+            valueFrom:
+              default: "true"
+              path: /tmp/outputs/condition
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: component
+                  value: "{{workflow.annotations.pipelines.kubeflow.org/components-root}}"
+                - name: runtime-config
+                  value: '{"parameters":{"text":{"stringValue":"hi there"}}}'
+                - name: driver-type
+                  value: ROOT_DAG
+            name: root-driver
+            template: system-dag-driver
+          - arguments:
+              parameters:
+                - name: parent-dag-id
+                  value: "{{tasks.root-driver.outputs.parameters.execution-id}}"
+                - name: condition
+                  value: ""
+            depends: root-driver.Succeeded
+            name: root
+            template: root
+      inputs: {}
+      metadata: {}
+      name: entrypoint
+      outputs: {}
+status:
+  finishedAt: null
+  startedAt: null

--- a/backend/src/v2/compiler/testdata/hello_world_with_retry.json
+++ b/backend/src/v2/compiler/testdata/hello_world_with_retry.json
@@ -1,0 +1,83 @@
+{
+  "pipelineSpec": {
+    "components": {
+      "comp-hello-world": {
+        "executorLabel": "exec-hello-world",
+        "inputDefinitions": {
+          "parameters": {
+            "text": {
+              "type": "STRING"
+            }
+          }
+        }
+      }
+    },
+    "deploymentSpec": {
+      "executors": {
+        "exec-hello-world": {
+          "container": {
+            "args": [
+              "--text",
+              "{{$.inputs.parameters['text']}}"
+            ],
+            "command": [
+              "sh",
+              "-ec",
+              "program_path=$(mktemp)\nprintf \"%s\" \"$0\" > \"$program_path\"\npython3 -u \"$program_path\" \"$@\"\n",
+              "def hello_world(text):\n    print(text)\n    return text\n\nimport argparse\n_parser = argparse.ArgumentParser(prog='Hello world', description='')\n_parser.add_argument(\"--text\", dest=\"text\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args = vars(_parser.parse_args())\n\n_outputs = hello_world(**_parsed_args)\n"
+            ],
+            "image": "python:3.9"
+          }
+        }
+      }
+    },
+    "pipelineInfo": {
+      "name": "namespace/n1/pipeline/hello-world"
+    },
+    "root": {
+      "dag": {
+        "tasks": {
+          "hello-world": {
+            "cachingOptions": {
+              "enableCache": true
+            },
+            "componentRef": {
+              "name": "comp-hello-world"
+            },
+            "retryPolicy": {
+              "backoffFactor": 2,
+              "backoffMaxDuration": "3600s",
+              "maxRetryCount": 2
+            },
+            "inputs": {
+              "parameters": {
+                "text": {
+                  "componentInputParameter": "text"
+                }
+              }
+            },
+            "taskInfo": {
+              "name": "hello-world"
+            }
+          }
+        }
+      },
+      "inputDefinitions": {
+        "parameters": {
+          "text": {
+            "type": "STRING"
+          }
+        }
+      }
+    },
+    "schemaVersion": "2.0.0",
+    "sdkVersion": "kfp-1.6.5"
+  },
+  "runtimeConfig": {
+    "parameters": {
+      "text": {
+        "stringValue": "hi there"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Description of your changes:**


**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

close https://github.com/kubeflow/pipelines/issues/9950 


In this [PR](https://github.com/kubeflow/pipelines/pull/11585), the manual retry via the Pipeline Run UI Page button was fixed.
However [set_retry]( https://kubeflow-pipelines.readthedocs.io/en/latest/source/dsl.html#kfp.dsl.PipelineTask.set_retry) at the execution level still does not work (for a different reason).

**Description of changes**: 
- `retryPolicy` is present in the generated KFP Pipeline Spec, but it is not translated into the Argo Workflow spec. Argo Workflows uses the [retryStrategy](https://argo-workflows.readthedocs.io/en/latest/retries/) instead.
- `retryPolicy` from the KFP Pipeline spec is mapped into the Argo Workflow spec under dag.task.input.retryPolicy, but Argo Workflows ignores it. I would assume that input.retryPolicy should be handled somewhere in the launcher; however, the only usage of this field I found is in the UI, and it doesn’t look like retry handling.

This PR adds the conversion of retryPolicy to the Argo Workflow retryStrategy for tasks.

in attached the Argo yaml spec which was generated in master branch from [this](https://github.com/kubeflow/pipelines/pull/11673/files#diff-b8ad378407da3d23983f50ce8c20238c8851530f9c836c1139ae73440b1afdfb) pipeline spec



[hello-world-with-retry-master.txt](https://github.com/user-attachments/files/19027510/hello-world-with-retry-master.txt)


