### PR TITLE
Limit the number of parallel tests in SDK execution tests

### DIFF
--- a/.github/workflows/sdk-execution.yml
+++ b/.github/workflows/sdk-execution.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           export KFP_ENDPOINT="http://localhost:8888"
           export TIMEOUT_SECONDS=2700
-          pytest ./test/sdk-execution-tests/sdk_execution_tests.py --asyncio-task-timeout $TIMEOUT_SECONDS
+          pytest -v -n 5 ./test/sdk-execution-tests/sdk_execution_tests.py
         continue-on-error: true
 
       - name: Collect failed logs

--- a/test/sdk-execution-tests/requirements.txt
+++ b/test/sdk-execution-tests/requirements.txt
@@ -1,3 +1,3 @@
 sdk/python
 pytest==8.3.2
-pytest-asyncio-cooperative==0.37.0
+pytest-xdist==2.5.0

--- a/test/sdk-execution-tests/sdk_execution_tests.py
+++ b/test/sdk-execution-tests/sdk_execution_tests.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import asyncio
 import dataclasses
 import functools
 import os
@@ -112,18 +111,15 @@ dsl.component = functools.partial(
     dsl.component, kfp_package_path=get_kfp_package_path())
 
 
-@pytest.mark.asyncio_cooperative
 @pytest.mark.parametrize('test_case', create_test_case_parameters())
-async def test(test_case: TestCase) -> None:
-    """Asynchronously runs all samples and test that they succeed."""
-    event_loop = asyncio.get_running_loop()
+def test(test_case: TestCase) -> None:
     try:
         run_url, run_result = run(test_case)
     except Exception as e:
         raise RuntimeError(
             f'Error triggering pipeline {test_case.name}.') from e
 
-    api_run = await event_loop.run_in_executor(None, wait, run_result)
+    api_run = wait(run_result)
     assert api_run.state == test_case.expected_state, f'Pipeline {test_case.name} ended with incorrect status: {api_run.state}. More info: {run_url}'
 
 


### PR DESCRIPTION
**Description of your changes:**

Often times, pods could not be scheduled because of insufficient CPU and the worker runs out of temporary disk space.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 