### PR TITLE
fix(frontend): compatibility with pod_names v1

### DIFF
--- a/frontend/src/lib/Utils.tsx
+++ b/frontend/src/lib/Utils.tsx
@@ -199,7 +199,10 @@ export function getNodeNameFromNodeId(workflow: Workflow, nodeId: string): strin
   if (!workflow || !nodeId) {
     return '';
   }
-  if (workflow.apiVersion === 'v1') {
+
+  const podNamesAnnotation =
+    workflow.metadata.annotations?.['workflows.argoproj.io/pod-name-format'];
+  if (workflow.apiVersion === 'v1' || podNamesAnnotation === 'v1') {
     return nodeId;
   }
 


### PR DESCRIPTION
**Description of your changes:**
This PR closes a tiny edge case in backwards compatibility with AWF `POD_NAMES` `v1` as described in [this](https://github.com/kubeflow/pipelines/issues/11681) issue.

**Testing evidence:**
Given a run with the following workflow manifest...

```yaml
Name:         basic-v1-lzq5k
Namespace:    kubeflow
...
Annotations: 
              ...
              workflows.argoproj.io/pod-name-format: v1
API Version:  argoproj.io/v1alpha1
```

...(note that `API Version` is _not_ `v1` and note the presence of the `workflows.argoproj.io/pod-name-format` annotation) where `POD_NAMES` is set to "v1" on the workflow controller, here's the result when you click on the logs tab and you're running the UI from the tip of master:

<img width="736" alt="image" src="https://github.com/user-attachments/assets/de66dfc2-1cab-4075-8c1c-8487fb384da0" />

And here's the result when you try to access logs for the exact same run after the changes in this PR:
<img width="960" alt="image" src="https://github.com/user-attachments/assets/5811c81a-8b45-43bb-8b8c-b7d9f72ddc8e" />



**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
