### PR TITLE
Use the correct SDK version in the SDK execution tests CI

### DIFF
--- a/.github/workflows/kfp-samples.yml
+++ b/.github/workflows/kfp-samples.yml
@@ -48,6 +48,7 @@ jobs:
       id: tests
       env:
         PULL_NUMBER: ${{ github.event.pull_request.number }}
+        REPO_NAME: ${{ github.repository }}
       run: |
         ./backend/src/v2/test/sample-test.sh
       continue-on-error: true

--- a/.github/workflows/kfp-sdk-runtime-tests.yml
+++ b/.github/workflows/kfp-sdk-runtime-tests.yml
@@ -28,4 +28,5 @@ jobs:
       - name: Run KFP Runtime Code Tests
         run: |
           export PULL_NUMBER="${{ github.event.inputs.pull_number || github.event.pull_request.number }}"
+          export REPO_NAME="${{ github.repository }}"
           ./test/presubmit-test-kfp-runtime-code.sh

--- a/.github/workflows/sdk-execution.yml
+++ b/.github/workflows/sdk-execution.yml
@@ -66,6 +66,9 @@ jobs:
 
       - name: Run tests
         id: tests
+        env:
+          PULL_NUMBER: ${{ github.event.pull_request.number }}
+          REPO_NAME: ${{ github.repository }}
         run: |
           export KFP_ENDPOINT="http://localhost:8888"
           export TIMEOUT_SECONDS=2700

--- a/backend/src/v2/test/sample-test.sh
+++ b/backend/src/v2/test/sample-test.sh
@@ -23,10 +23,12 @@ python3 -m pip install -r ./requirements-sample-test.txt
 
 popd
 
+REPO_NAME="${REPO_NAME:-kubeflow/pipelines}"
+
 if [[ -n "${PULL_NUMBER}" ]]; then
-  export KFP_PACKAGE_PATH="git+https://github.com/kubeflow/pipelines@refs/pull/${PULL_NUMBER}/merge#egg=kfp&subdirectory=sdk/python"
+  export KFP_PACKAGE_PATH="git+https://github.com/${REPO_NAME}@refs/pull/${PULL_NUMBER}/merge#egg=kfp&subdirectory=sdk/python"
 else
-  export KFP_PACKAGE_PATH='git+https://github.com/kubeflow/pipelines#egg=kfp&subdirectory=sdk/python'
+  export KFP_PACKAGE_PATH="git+https://github.com/${REPO_NAME}#egg=kfp&subdirectory=sdk/python"
 fi
 
 python3 -m pip install $KFP_PACKAGE_PATH

--- a/backend/src/v2/test/scripts/ci-env.sh
+++ b/backend/src/v2/test/scripts/ci-env.sh
@@ -18,11 +18,12 @@ GCS_ROOT="gs://${PROJECT}/${COMMIT_SHA}/v2-sample-test"
 GCR_ROOT="gcr.io/${PROJECT}/${COMMIT_SHA}/v2-sample-test"
 # This is kfp-ci endpoint.
 HOST=${HOST:-"https://$(curl https://raw.githubusercontent.com/kubeflow/testing/master/test-infra/kfp/endpoint)"}
+REPO_NAME="${REPO_NAME:-kubeflow/pipelines}"
 
 if [[ -z "${PULL_NUMBER}" ]]; then
-  KFP_PACKAGE_PATH='git+https://github.com/kubeflow/pipelines\#egg=kfp&subdirectory=sdk/python'
+  KFP_PACKAGE_PATH="git+https://github.com/${REPO_NAME}#egg=kfp&subdirectory=sdk/python"
 else
-  KFP_PACKAGE_PATH='git+https://github.com/kubeflow/pipelines@refs/pull/${PULL_NUMBER}/merge\#egg=kfp&subdirectory=sdk/python'
+  KFP_PACKAGE_PATH="git+https://github.com/${REPO_NAME}@refs/pull/${PULL_NUMBER}/merge#egg=kfp&subdirectory=sdk/python"
 fi
 
 cat <<EOF >kfp-ci.env

--- a/test/kfp-kubernetes-execution-tests/sdk_execution_tests.py
+++ b/test/kfp-kubernetes-execution-tests/sdk_execution_tests.py
@@ -110,10 +110,11 @@ def run(test_case: TestCase) -> Tuple[str, client.client.RunPipelineResult]:
 
 
 def get_kfp_package_path() -> str:
+    repo_name = os.environ.get('REPO_NAME', 'kubeflow/pipelines')
     if os.environ.get('PULL_NUMBER') is not None:
-        path = f'git+https://github.com/kubeflow/pipelines.git@refs/pull/{os.environ.get("PULL_NUMBER")}/merge#subdirectory=sdk/python'
+        path = f'git+https://github.com/{repo_name}.git@refs/pull/{os.environ["PULL_NUMBER"]}/merge#subdirectory=sdk/python'
     else:
-        path = 'git+https://github.com/kubeflow/pipelines.git@master#subdirectory=sdk/python'
+        path = 'git+https://github.com/{repo_name}.git@master#subdirectory=sdk/python'
     print(f'Using the following KFP package path for tests: {path}')
     return path
 

--- a/test/presubmit-tests-sdk.sh
+++ b/test/presubmit-tests-sdk.sh
@@ -36,7 +36,8 @@ pytest sdk/python/kfp --cov=kfp
 set +x
 # export COVERALLS_REPO_TOKEN=$(gsutil cat gs://ml-pipeline-test-keys/coveralls_repo_token)
 set -x
-REPO_BASE="https://github.com/kubeflow/pipelines"
+REPO_NAME="${REPO_NAME:-kubeflow/pipelines}"
+REPO_BASE="https://github.com/${REPO_NAME}"
 export COVERALLS_SERVICE_NAME="prow"
 export COVERALLS_SERVICE_JOB_ID=$PROW_JOB_ID
 export CI_PULL_REQUEST="$REPO_BASE/pull/$PULL_NUMBER"

--- a/test/sdk-execution-tests/sdk_execution_tests.py
+++ b/test/sdk-execution-tests/sdk_execution_tests.py
@@ -99,10 +99,11 @@ def run(test_case: TestCase) -> Tuple[str, client.client.RunPipelineResult]:
 
 
 def get_kfp_package_path() -> str:
+    repo_name = os.environ.get('REPO_NAME', 'kubeflow/pipelines')
     if os.environ.get('PULL_NUMBER') is not None:
-        path = f'git+https://github.com/kubeflow/pipelines.git@refs/pull/{os.environ.get("PULL_NUMBER")}/merge#subdirectory=sdk/python'
+        path = f'git+https://github.com/{repo_name}.git@refs/pull/{os.environ["PULL_NUMBER"]}/merge#subdirectory=sdk/python'
     else:
-        path = 'git+https://github.com/kubeflow/pipelines.git@master#subdirectory=sdk/python'
+        path = 'git+https://github.com/{repo_name}.git@master#subdirectory=sdk/python'
     print(f'Using the following KFP package path for tests: {path}')
     return path
 


### PR DESCRIPTION
**Description of your changes:**

The KFP SDK execution tests weren't using the SDK from the pull request. Additionally, this commit adds support for choosing the right SDK in forks.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 