### PR TITLE
Fix format string in get_kfp_package_path

### DIFF
--- a/.github/workflows/kfp-kubernetes-execution-tests.yml
+++ b/.github/workflows/kfp-kubernetes-execution-tests.yml
@@ -74,6 +74,9 @@ jobs:
 
       - name: Run tests
         id: test
+        env:
+          PULL_NUMBER: ${{ github.event.pull_request.number }}
+          REPO_NAME: ${{ github.repository }}
         run: |
           export KFP_ENDPOINT="http://localhost:8888"
           export TIMEOUT_SECONDS=2700

--- a/test/kfp-kubernetes-execution-tests/sdk_execution_tests.py
+++ b/test/kfp-kubernetes-execution-tests/sdk_execution_tests.py
@@ -114,7 +114,7 @@ def get_kfp_package_path() -> str:
     if os.environ.get('PULL_NUMBER') is not None:
         path = f'git+https://github.com/{repo_name}.git@refs/pull/{os.environ["PULL_NUMBER"]}/merge#subdirectory=sdk/python'
     else:
-        path = 'git+https://github.com/{repo_name}.git@master#subdirectory=sdk/python'
+        path = f'git+https://github.com/{repo_name}.git@master#subdirectory=sdk/python'
     print(f'Using the following KFP package path for tests: {path}')
     return path
 

--- a/test/sdk-execution-tests/sdk_execution_tests.py
+++ b/test/sdk-execution-tests/sdk_execution_tests.py
@@ -103,7 +103,7 @@ def get_kfp_package_path() -> str:
     if os.environ.get('PULL_NUMBER') is not None:
         path = f'git+https://github.com/{repo_name}.git@refs/pull/{os.environ["PULL_NUMBER"]}/merge#subdirectory=sdk/python'
     else:
-        path = 'git+https://github.com/{repo_name}.git@master#subdirectory=sdk/python'
+        path = f'git+https://github.com/{repo_name}.git@master#subdirectory=sdk/python'
     print(f'Using the following KFP package path for tests: {path}')
     return path
 


### PR DESCRIPTION
**Description of your changes:**

This also now uses the in repo SDK for "k8s execution tests".


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 