### PR TITLE
feat(backend/sdk): enable dsl.Collected for parameters & artifacts

### DIFF
--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -139,29 +139,31 @@ func stopWaitingArtifacts(artifacts map[string]*pipelinespec.ArtifactList) {
 		}
 
 		// Following the convention of downloadArtifacts in the launcher to only look at the first in the list.
-		inputArtifact := artifactList.Artifacts[0]
+		for _, artifact := range artifactList.Artifacts {
+			inputArtifact := artifact
 
-		// This should ideally verify that this is also a model input artifact, but this metadata doesn't seem to
-		// be set on inputArtifact.
-		if !strings.HasPrefix(inputArtifact.Uri, "oci://") {
-			continue
-		}
+			// This should ideally verify that this is also a model input artifact, but this metadata doesn't seem to
+			// be set on inputArtifact.
+			if !strings.HasPrefix(inputArtifact.Uri, "oci://") {
+				continue
+			}
 
-		localPath, err := LocalPathForURI(inputArtifact.Uri)
-		if err != nil {
-			continue
-		}
+			localPath, err := LocalPathForURI(inputArtifact.Uri)
+			if err != nil {
+				continue
+			}
 
-		glog.Infof("Stopping Modelcar container for artifact %s", inputArtifact.Uri)
+			glog.Infof("Stopping Modelcar container for artifact %s", inputArtifact.Uri)
 
-		launcherCompleteFile := strings.TrimSuffix(localPath, "/models") + "/launcher-complete"
-		_, err = os.Create(launcherCompleteFile)
-		if err != nil {
-			glog.Errorf(
-				"Failed to stop the artifact %s by creating %s: %v", inputArtifact.Uri, launcherCompleteFile, err,
-			)
+			launcherCompleteFile := strings.TrimSuffix(localPath, "/models") + "/launcher-complete"
+			_, err = os.Create(launcherCompleteFile)
+			if err != nil {
+				glog.Errorf(
+					"Failed to stop the artifact %s by creating %s: %v", inputArtifact.Uri, launcherCompleteFile, err,
+				)
 
-			continue
+				continue
+			}
 		}
 	}
 }

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -19,11 +19,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 	"slices"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
@@ -628,7 +629,7 @@ func addModelcarsToPodSpec(
 			continue
 		}
 		// Following the convention of downloadArtifacts in the launcher to look at the entire list.
-		for _, artifact := range artifactList.Artifacts {
+		for index, artifact := range artifactList.Artifacts {
 			inputArtifact := artifact
 
 			// This should ideally verify that this is also a model input artifact, but this metadata doesn't seem to
@@ -637,8 +638,9 @@ func addModelcarsToPodSpec(
 				continue
 			}
 
-			modelcarArtifacts[name] = inputArtifact
-			modelcarArtifactNames = append(modelcarArtifactNames, name)
+			artifactName := fmt.Sprintf("%s-%d", name, index)
+			modelcarArtifacts[artifactName] = inputArtifact
+			modelcarArtifactNames = append(modelcarArtifactNames, artifactName)
 		}
 	}
 
@@ -1685,7 +1687,7 @@ func resolveInputParameterStr(
 
 	if typedVal, ok := val.GetKind().(*structpb.Value_StringValue); ok && typedVal != nil {
 		if typedVal.StringValue == "" {
-			return nil, fmt.Errorf("resolving input parameter with spec %s. Expected a non-empty string.", paramSpec)
+			return nil, fmt.Errorf("resolving input parameter with spec %s. Expected a non-empty string", paramSpec)
 		}
 	} else {
 		return nil, fmt.Errorf("resolving input parameter with spec %s. Expected a string but got: %T", paramSpec, val.GetKind())
@@ -1812,16 +1814,20 @@ func resolveUpstreamParameters(cfg resolveUpstreamOutputsConfig) (*structpb.Valu
 		return nil, cfg.err(fmt.Errorf("output parameter key is empty"))
 	}
 
-	// For the scenario where 2 tasks are defined within a ParallelFor and 1 receives the output of the other we must ensure that the downstream task resolves the approriate output of the iteration it is in. With knowing if we are resolving inputs for a task within a ParallelFor DAG we can add the iteration index to the producerTaskName so that we can resolve the correct iteration of that task.
-	isParallelForDAG := cfg.dag.Execution.GetExecution().GetCustomProperties()["iteration_index"] != nil
-	if isParallelForDAG {
-		// This is needed to support tasks within a ParallelFor Loop that do not leverage the iterator values but still consume outputs from ones that do
-		task_iteration_index := cfg.dag.Execution.GetExecution().GetCustomProperties()["iteration_index"].GetIntValue()
-		producerTaskName = metadata.GetParallelForTaskName(producerTaskName, task_iteration_index)
-		glog.Infof("Attempting to retrieve DAG Tasks from a parallelFor DAG")
-	}
-	// Get a list of tasks for the current DAG first.
-	// The reason we use getDAGTasks instead of mlmd.GetExecutionsInDAG without the dag filter is because the latter does not handle task name collisions in the map which results in a bunch of unhandled edge cases and test failures.
+	producerTaskName = metadata.GetTaskNameWithDagID(producerTaskName, cfg.dag.Execution.GetID())
+	// For the scenario where 2 tasks are defined within a ParallelFor and 1
+	// receives the output of the other we must ensure that the downstream task
+	// resolves the approriate output of the iteration it is in. With knowing if
+	// we are resolving inputs for a task within a ParallelFor DAG we can add
+	// the iteration index to the producerTaskName so that we can resolve the
+	// correct iteration of that task.
+	producerTaskName = InferIndexedTaskName(producerTaskName, cfg.dag.Execution)
+	// Get a list of tasks for the current DAG first. The reason we use
+	// getDAGTasks instead of mlmd.GetExecutionsInDAG without the dag filter is
+	// because the latter does not handle task name collisions in the map which
+	// results in a bunch of unhandled edge cases and test failures.
+	glog.V(4).Infof("producerTaskName: %v", producerTaskName)
+	glog.V(4).Infof("outputParameterKey: %v", outputParameterKey)
 	tasks, err := getDAGTasks(cfg.ctx, cfg.dag, cfg.pipeline, cfg.mlmd, nil)
 	if err != nil {
 		return nil, cfg.err(err)
@@ -1834,6 +1840,7 @@ func resolveUpstreamParameters(cfg resolveUpstreamOutputsConfig) (*structpb.Valu
 	glog.V(4).Info("producer: ", producer)
 	glog.V(4).Infof("tasks: %#v", tasks)
 	currentTask := producer
+	subTaskName := producerTaskName
 	// Continue looping until we reach a sub-task that is NOT a DAG.
 	for {
 		glog.V(4).Info("currentTask: ", currentTask.TaskName())
@@ -1863,74 +1870,36 @@ func resolveUpstreamParameters(cfg resolveUpstreamOutputsConfig) (*structpb.Valu
 
 			glog.V(4).Infof("Deserialized dagOutputParametersMap: %v", dagOutputParametersMap)
 
+			// For this section, if the currentTask we are looking for is within
+			// a ParallelFor DAG, this means the actual task that produced the
+			// output we need has multiple iterations so we have to gather all
+			// them and fan them in by collecting them into a list i.e.
+			// kfp.dsl.Collected support.
+			parentDAG, err := cfg.mlmd.GetExecution(cfg.ctx, currentTask.GetExecution().GetCustomProperties()["parent_dag_id"].GetIntValue())
+			if err != nil {
+				return nil, cfg.err(err)
+			}
+			iterations := getParallelForIterationCount(currentTask, parentDAG)
+			if iterations > 0 {
+				parameterList, _, err := CollectInputs(cfg, subTaskName, tasks, outputParameterKey, false)
+				if err != nil {
+					return nil, cfg.err(err)
+				}
+				return parameterList, nil
+			}
 			// Support for the 2 DagOutputParameterSpec types:
 			// ValueFromParameter & ValueFromOneof
-			var subTaskName string
-			switch dagOutputParametersMap[outputParameterKey].Kind.(type) {
-			case *pipelinespec.DagOutputsSpec_DagOutputParameterSpec_ValueFromParameter:
-				subTaskName = dagOutputParametersMap[outputParameterKey].GetValueFromParameter().GetProducerSubtask()
-				outputParameterKey = dagOutputParametersMap[outputParameterKey].GetValueFromParameter().GetOutputParameterKey()
-			case *pipelinespec.DagOutputsSpec_DagOutputParameterSpec_ValueFromOneof:
-				// When OneOf is specified in a pipeline, the output of only 1 task is consumed even though there may be more than 1 task output set. In this case we will attempt to grab the first successful task output.
-				paramSelectors := dagOutputParametersMap[outputParameterKey].GetValueFromOneof().GetParameterSelectors()
-				glog.V(4).Infof("paramSelectors: %v", paramSelectors)
-				// Since we have the tasks map, we can iterate through the parameterSelectors if the ProducerSubTask is not present in the task map and then assign the new OutputParameterKey only if it exists.
-				successfulOneOfTask := false
-				for !successfulOneOfTask {
-					for _, paramSelector := range paramSelectors {
-						subTaskName = paramSelector.GetProducerSubtask()
-						glog.V(4).Infof("subTaskName from paramSelector: %v", subTaskName)
-						glog.V(4).Infof("outputParameterKey from paramSelector: %v", paramSelector.GetOutputParameterKey())
-						if subTask, ok := tasks[subTaskName]; ok {
-							subTaskState := subTask.GetExecution().LastKnownState.String()
-							glog.V(4).Infof("subTask: %w , subTaskState: %v", subTaskName, subTaskState)
-							if subTaskState == "CACHED" || subTaskState == "COMPLETE" {
-
-								outputParameterKey = paramSelector.GetOutputParameterKey()
-								successfulOneOfTask = true
-								break
-							}
-						}
-					}
-					if !successfulOneOfTask {
-						return nil, cfg.err(fmt.Errorf("processing OneOf: No successful task found"))
-					}
-				}
+			subTaskName, outputParameterKey, err = GetProducerTask(currentTask, tasks, subTaskName, outputParameterKey, false)
+			if err != nil {
+				return nil, cfg.err(err)
 			}
 			glog.V(4).Infof("SubTaskName from outputParams: %v", subTaskName)
 			glog.V(4).Infof("OutputParameterKey from outputParams: %v", outputParameterKey)
 			if subTaskName == "" {
 				return nil, cfg.err(fmt.Errorf("producer_subtask not in outputParams"))
 			}
-			// For this section, if the currentTask we are looking for is within a ParallelFor DAG, this means the actual task that produced the output we need has multiple iterations so we have to gather all them  and fan them in by collecting them into a list i.e. kfp.dsl.Collected support.
-			if currentTask.GetExecution().GetCustomProperties()["iteration_count"] != nil {
-				glog.V(4).Infof("currentTask, %v, is a ParallelFor DAG. Attempting to gather all producer_subtask iterations of %w", currentTask.TaskName(), subTaskName)
 
-				parallelForOutputList := make([]*structpb.Value, 0)
-				// Iterate over the parallelFor task iterations and gather the output of the subTask.
-				for i := range currentTask.GetExecution().GetCustomProperties()["iteration_count"].GetIntValue() {
-					// Follow the convention set in mlmd.GetExecutionsInDAG for ParallelFor tasks
-					subTaskIterationName := metadata.GetParallelForTaskName(subTaskName, i)
-					glog.V(4).Infof("subTaskIterationName: %v", subTaskIterationName)
-					subTask, ok := tasks[subTaskIterationName]
-					if !ok {
-						return nil, cfg.err(fmt.Errorf("subTaskName, %v, not in tasks", subTaskName))
-					}
-					_, outputParametersCustomProperty, err := subTask.GetParameters()
-					if err != nil {
-						return nil, err
-					}
-					parallelForOutputList = append(parallelForOutputList, outputParametersCustomProperty[outputParameterKey])
-				}
-				return &structpb.Value{
-					Kind: &structpb.Value_ListValue{
-						ListValue: &structpb.ListValue{
-							Values: parallelForOutputList,
-						},
-					},
-				}, nil
-			}
-
+			// If the sub-task is a DAG, reassign currentTask and run
 			glog.V(4).Infof(
 				"Overriding currentTask, %v, output with currentTask's producer_subtask, %v, output.",
 				currentTask.TaskName(),
@@ -1967,84 +1936,62 @@ func resolveUpstreamArtifacts(cfg resolveUpstreamOutputsConfig) (*pipelinespec.A
 	if taskOutput.GetOutputArtifactKey() == "" {
 		cfg.err(fmt.Errorf("output artifact key is empty"))
 	}
-
-	isParallelForDAG := cfg.dag.Execution.GetExecution().GetCustomProperties()["iteration_index"] != nil
-	if isParallelForDAG {
-		// This is needed to support tasks within a ParallelFor Loop that do not leverage the iterator values but still consume outputs from ones that do
-		task_iteration_index := cfg.dag.Execution.GetExecution().GetCustomProperties()["iteration_index"].GetIntValue()
-		producerTaskName = metadata.GetParallelForTaskName(producerTaskName, task_iteration_index)
-		glog.Infof("Attempting to retrieve DAG Tasks from a parallelFor DAG")
-	}
-
+	producerTaskName = metadata.GetTaskNameWithDagID(producerTaskName, cfg.dag.Execution.GetID())
+	// The main difference between the root ParallelFor DAG and its iteration
+	// DAGs is that the root contains the custom property "iteration_count"
+	// while the iterations contain "iteration_index". We can use this to
+	// determine if we are in a ParallelFor DAG or not. The iteration DAGs will
+	// contain the "iteration_index" which is used to resolve the correct output
+	// artifact for the downstream task within the iteration. ParallelFor
+	// iterations are DAGs themselves, we can verify if we are in a iteration by
+	// confirming that the "iteration_index" exists for the DAG of the current
+	// task we are attempting to resolve. If the dag contains the
+	// "iteration_index", the producerTaskName will be updated appropriately
+	producerTaskName = InferIndexedTaskName(producerTaskName, cfg.dag.Execution)
+	glog.V(4).Infof("producerTaskName: %v", producerTaskName)
 	tasks, err := getDAGTasks(cfg.ctx, cfg.dag, cfg.pipeline, cfg.mlmd, nil)
 	if err != nil {
-		cfg.err(err)
+		return nil, cfg.err(err)
 	}
 
 	producer, ok := tasks[producerTaskName]
 	if !ok {
-		cfg.err(
+		return nil, cfg.err(
 			fmt.Errorf("cannot find producer task %q", producerTaskName),
 		)
 	}
 	glog.V(4).Info("producer: ", producer)
+	glog.V(4).Infof("tasks: %#v", tasks)
 	currentTask := producer
 	outputArtifactKey := taskOutput.GetOutputArtifactKey()
-
-	// Continue looping until we reach a sub-task that is either a ParallelFor task or a Container task.
+	subTaskName := producerTaskName
+	// Continue looping until we reach a sub-task that is either a ParallelFor
+	// task or a Container task.
 	for {
 		glog.V(4).Info("currentTask: ", currentTask.TaskName())
 		// If the current task is a DAG:
 		if *currentTask.GetExecution().Type == "system.DAGExecution" {
 			// Get the sub-task.
-			outputArtifactsCustomProperty := currentTask.GetExecution().GetCustomProperties()["artifact_producer_task"]
-			// Deserialize the output artifacts.
-			var outputArtifacts map[string]*pipelinespec.DagOutputsSpec_DagOutputArtifactSpec
-			err := json.Unmarshal([]byte(outputArtifactsCustomProperty.GetStringValue()), &outputArtifacts)
+			parentDAG, err := cfg.mlmd.GetExecution(cfg.ctx, currentTask.GetExecution().GetCustomProperties()["parent_dag_id"].GetIntValue())
 			if err != nil {
-				return nil, err
+				return nil, cfg.err(err)
 			}
-			glog.V(4).Infof("Deserialized outputArtifacts: %v", outputArtifacts)
-			// Adding support for multiple output artifacts
-			var subTaskName string
-			artifactSelectors := outputArtifacts[outputArtifactKey].GetArtifactSelectors()
-			artifactSelectorValue := artifactSelectors[len(artifactSelectors)-1]
-
-			subTaskName = artifactSelectorValue.ProducerSubtask
-			outputArtifactKey = artifactSelectorValue.OutputArtifactKey
+			iterations := getParallelForIterationCount(currentTask, parentDAG)
+			if iterations > 0 {
+				_, artifactList, err := CollectInputs(cfg, subTaskName, tasks, outputArtifactKey, true)
+				if err != nil {
+					return nil, cfg.err(err)
+				}
+				return artifactList, nil
+			}
+			subTaskName, outputArtifactKey, err = GetProducerTask(currentTask, tasks, subTaskName, outputArtifactKey, true)
+			if err != nil {
+				return nil, cfg.err(err)
+			}
 			glog.V(4).Infof("ProducerSubtask: %v", subTaskName)
 			glog.V(4).Infof("OutputArtifactKey: %v", outputArtifactKey)
-
-			// For this section, it's the same as the one in resolveUpstreamParameters, but for artifacts.
-			//TODO: Conslidate Paremeter and Artifact resolution logic.
-			if currentTask.GetExecution().GetCustomProperties()["iteration_count"] != nil {
-				glog.V(4).Infof("currentTask, %v, is a ParallelFor DAG. Attempting to gather all producer_subtask iterations of %w", currentTask.TaskName(), subTaskName)
-
-				parallelForOutputList := make([]*pipelinespec.RuntimeArtifact, 0)
-				for i := range currentTask.GetExecution().GetCustomProperties()["iteration_count"].GetIntValue() {
-					// Follow the task name convention set in mlmd.GetExecutionsInDAG for ParallelFor tasks
-					subTaskIterationName := metadata.GetParallelForTaskName(subTaskName, i)
-					glog.V(4).Infof("subTaskIterationName: %v", subTaskIterationName)
-					subTask, ok := tasks[subTaskIterationName]
-					if !ok {
-						return nil, cfg.err(fmt.Errorf("subTaskName, %v, not in tasks", subTaskName))
-					}
-					outputArtifacts, err := cfg.mlmd.GetOutputArtifactsByExecutionId(cfg.ctx, subTask.GetID())
-					if err != nil {
-						return nil, err
-					}
-
-					runtimeArtifact, err := outputArtifacts[outputArtifactKey].ToRuntimeArtifact()
-					if err != nil {
-						return nil, cfg.err(err)
-					}
-					parallelForOutputList = append(parallelForOutputList, runtimeArtifact)
-				}
-				return &pipelinespec.ArtifactList{
-					Artifacts: parallelForOutputList,
-				}, nil
-			}
 			// If the sub-task is a DAG, reassign currentTask and run
+			glog.V(4).Infof("currentTask ID: %v", currentTask.GetID())
 			glog.V(4).Infof(
 				"Overriding currentTask, %v, output with currentTask's producer_subtask, %v, output.",
 				currentTask.TaskName(),
@@ -2054,7 +2001,6 @@ func resolveUpstreamArtifacts(cfg resolveUpstreamOutputsConfig) (*pipelinespec.A
 			if !ok {
 				return nil, cfg.err(fmt.Errorf("subTaskName, %v, not in tasks", subTaskName))
 			}
-
 		} else {
 			// Base case, currentTask is a container, not a DAG.
 			outputs, err := cfg.mlmd.GetOutputArtifactsByExecutionId(cfg.ctx, currentTask.GetID())
@@ -2084,7 +2030,274 @@ func resolveUpstreamArtifacts(cfg resolveUpstreamOutputsConfig) (*pipelinespec.A
 	}
 }
 
-// provisionOuutputs prepares output references that will get saved to MLMD.
+// CollectInputs performs artifact/parameter collection across a DAG/tree
+// using a breadth first search traversal.
+func CollectInputs(
+	cfg resolveUpstreamOutputsConfig,
+	parallelForDAGTaskName string,
+	tasks map[string]*metadata.Execution,
+	outputKey string,
+	isArtifact bool,
+) (outputParameterList *structpb.Value, outputArtifactList *pipelinespec.ArtifactList, err error) {
+	glog.V(4).Infof("currentTask is a ParallelFor DAG. Attempting to gather all nested producer_subtasks")
+	// Set some helpers for the start and looping for BFS
+	var currentTask *metadata.Execution
+	var workingSubTaskName string
+	workingOutputKey := outputKey
+	previousWorkingOutputKey := outputKey
+	// Instantiate the lists values that will hold all values pulled from the
+	// tasks of each iteration.
+	parallelForParameterList := make([]*structpb.Value, 0)
+	parallelForArtifactList := make([]*pipelinespec.RuntimeArtifact, 0)
+	tasksToResolve := make([]string, 0)
+	// Set up the queue for BFS by setting the parallelFor DAG task as the
+	// initial node. The loop will add the iteration dag task names for us into
+	// the slice/queue.
+	tasksToResolve = append(tasksToResolve, parallelForDAGTaskName)
+	previousTaskName := tasks[tasksToResolve[0]].TaskName()
+
+	for len(tasksToResolve) > 0 {
+		// The starterQueue contains the first set of child DAGs from the
+		// parallelFor, i.e. the iteration dags.
+		glog.V(4).Infof("tasksToResolve: %v", tasksToResolve)
+		currentTaskName := tasksToResolve[0]
+		tasksToResolve = tasksToResolve[1:]
+
+		currentTask = tasks[currentTaskName]
+
+		// We check if these values need to be updated going through the
+		// resolution of dags/tasks Most commonly the subTaskName will change
+		// for both parameter & artifact resolution. For parameter resolutions,
+		// the outputParameterKey can change, and is used for extracting the
+		// appropriate field off of the struct set for the outputs on the task
+		// in question.
+
+		// An issue arises if we update the outputParameterKey but there exists
+		// multiple iterations of the same task and we haven't fully parsed all
+		// iterations. We will encounter a scenario where we will attempt to
+		// extract fields from the struct with the wrong key. Hence, the
+		// condition below. NOTE: This is only an issue for Parameter resolution
+		// and does not interfere with Artifact resolution.
+		if currentTask.TaskName() == previousTaskName {
+			workingOutputKey = previousWorkingOutputKey
+		}
+
+		previousTaskName = currentTask.TaskName()
+		previousWorkingOutputKey = workingOutputKey
+		workingSubTaskName, workingOutputKey, _ = GetProducerTask(currentTask, tasks, workingSubTaskName, workingOutputKey, isArtifact)
+
+		glog.V(4).Infof("currentTask ID: %v", currentTask.GetID())
+		glog.V(4).Infof("currentTask Name: %v", currentTask.TaskName())
+		glog.V(4).Infof("currentTask Type: %v", currentTask.GetExecution().GetType())
+		glog.V(4).Infof("workingSubTaskName %v", workingSubTaskName)
+		glog.V(4).Infof("workingOutputKey: %v", workingOutputKey)
+
+		iterations := currentTask.GetExecution().GetCustomProperties()["iteration_count"]
+		iterationIndex := currentTask.GetExecution().GetCustomProperties()["iteration_index"]
+
+		// Base cases for handling the task that actually maps to the task that
+		// created the artifact/parameter we are searching for.
+
+		//  Base case 1: currentTask is a ContainerExecution that we can load
+		//  the values off of.
+		if *currentTask.GetExecution().Type == "system.ContainerExecution" {
+			glog.V(4).Infof("currentTask, %v, is a ContainerExecution", currentTaskName)
+			paramValue, artifact, err := collectContainerOutput(cfg, currentTask, workingOutputKey, isArtifact)
+			if err != nil {
+				return nil, nil, err
+			}
+			if isArtifact {
+				parallelForArtifactList = append(parallelForArtifactList, artifact)
+				glog.V(4).Infof("parallelForArtifactList: %v", parallelForArtifactList)
+			} else {
+				parallelForParameterList = append(parallelForParameterList, paramValue)
+				glog.V(4).Infof("parallelForParameterList: %v", parallelForParameterList)
+			}
+			continue
+		}
+		// Base case 2: currentTask is a DAGExecution within a loop but is
+		// NOT a ParallelFor Head DAG
+		if iterations == nil {
+			tempSubTaskName := workingSubTaskName
+			if iterationIndex != nil {
+				// handle for parallel iteration dag, i.e one of the DAG
+				// instances of the loop.
+				tempSubTaskName = metadata.GetParallelForTaskName(tempSubTaskName, iterationIndex.GetIntValue())
+				glog.V(4).Infof("subTaskIterationName: %v", tempSubTaskName)
+			}
+			glog.V(4).Infof("tempSubTaskName: %v", tempSubTaskName)
+			tasksToResolve = append(tasksToResolve, tempSubTaskName)
+			continue
+		}
+
+		// If the currentTask is not a ContainerExecution AND we have the
+		// custom property set for "iteration_count", we can deduce that
+		// currentTask is in fact a ParallelFor Head DAG, thus we need to add
+		// its iteration DAGs to the queue.
+
+		for i := range iterations.GetIntValue() {
+			loopName := metadata.GetTaskNameWithDagID(currentTask.TaskName(), currentTask.GetID())
+			loopIterationName := metadata.GetParallelForTaskName(loopName, i)
+			glog.V(4).Infof("loopIterationName: %v", loopIterationName)
+			tasksToResolve = append(tasksToResolve, loopIterationName)
+		}
+	}
+
+	outputParameterList = &structpb.Value{
+		Kind: &structpb.Value_ListValue{
+			ListValue: &structpb.ListValue{
+				Values: parallelForParameterList,
+			},
+		},
+	}
+	outputArtifactList = &pipelinespec.ArtifactList{
+		Artifacts: parallelForArtifactList,
+	}
+	glog.V(4).Infof("outputParameterList: %#v", outputParameterList)
+	glog.V(4).Infof("outputArtifactList: %#v", outputArtifactList)
+	return outputParameterList, outputArtifactList, nil
+}
+
+// collectContainerOutput pulls either the artifact or parameter that is a
+// task's output where said task was called within a parallelFor loop
+func collectContainerOutput(
+	cfg resolveUpstreamOutputsConfig,
+	currentTask *metadata.Execution,
+	workingOutputKey string,
+	isArtifact bool,
+) (*structpb.Value, *pipelinespec.RuntimeArtifact, error) {
+	var param *structpb.Value
+	var artifact *pipelinespec.RuntimeArtifact
+	if isArtifact {
+		outputArtifacts, err := cfg.mlmd.GetOutputArtifactsByExecutionId(cfg.ctx, currentTask.GetID())
+		if err != nil {
+			return nil, nil, err
+		}
+		glog.V(4).Infof("outputArtifacts: %#v", outputArtifacts)
+		glog.V(4).Infof("outputKey: %v", workingOutputKey)
+		artifact, err = outputArtifacts[workingOutputKey].ToRuntimeArtifact()
+		if err != nil {
+			return nil, nil, cfg.err(err)
+		}
+		glog.V(4).Infof("runtimeArtifact: %v", artifact)
+	} else {
+		_, outputParameters, err := currentTask.GetParameters()
+		glog.V(4).Infof("outputParameters: %v", outputParameters)
+		if err != nil {
+			return nil, nil, cfg.err(err)
+		}
+		param = outputParameters[workingOutputKey]
+	}
+	return param, artifact, nil
+}
+
+// GetProducerTask gets the updated ProducerSubTask /
+// Output[Artifact|Parameter]Key if they exists, else it returns the original
+// input.
+func GetProducerTask(parentTask *metadata.Execution, tasks map[string]*metadata.Execution, subTaskName string, outputKey string, isArtifact bool) (producerSubTaskName string, tempOutputKey string, err error) {
+	tempOutputKey = outputKey
+	if isArtifact {
+		producerTaskValue := parentTask.GetExecution().GetCustomProperties()["artifact_producer_task"]
+		if producerTaskValue != nil {
+			var tempOutputArtifacts map[string]*pipelinespec.DagOutputsSpec_DagOutputArtifactSpec
+			err := json.Unmarshal([]byte(producerTaskValue.GetStringValue()), &tempOutputArtifacts)
+			if err != nil {
+				return "", "", err
+			}
+			glog.V(4).Infof("tempOutputsArtifacts: %v", tempOutputArtifacts)
+			glog.V(4).Infof("outputArtifactKey: %v", outputKey)
+			tempSelectors := tempOutputArtifacts[outputKey].GetArtifactSelectors()
+			if len(tempSelectors) > 0 {
+				producerSubTaskName = tempSelectors[len(tempSelectors)-1].ProducerSubtask
+				tempOutputKey = tempSelectors[len(tempSelectors)-1].OutputArtifactKey
+			}
+		}
+
+	} else {
+		producerTaskValue := parentTask.GetExecution().GetCustomProperties()["parameter_producer_task"]
+		if producerTaskValue != nil {
+			tempOutputParametersMap := make(map[string]*pipelinespec.DagOutputsSpec_DagOutputParameterSpec)
+			for name, value := range producerTaskValue.GetStructValue().GetFields() {
+				outputSpec := &pipelinespec.DagOutputsSpec_DagOutputParameterSpec{}
+				err := protojson.Unmarshal([]byte(value.GetStringValue()), outputSpec)
+				if err != nil {
+					return "", "", err
+				}
+				tempOutputParametersMap[name] = outputSpec
+			}
+			glog.V(4).Infof("tempOutputParametersMap: %#v", tempOutputParametersMap)
+			switch tempOutputParametersMap[tempOutputKey].Kind.(type) {
+			case *pipelinespec.DagOutputsSpec_DagOutputParameterSpec_ValueFromParameter:
+				producerSubTaskName = tempOutputParametersMap[tempOutputKey].GetValueFromParameter().GetProducerSubtask()
+				tempOutputKey = tempOutputParametersMap[tempOutputKey].GetValueFromParameter().GetOutputParameterKey()
+			case *pipelinespec.DagOutputsSpec_DagOutputParameterSpec_ValueFromOneof:
+				// When OneOf is specified in a pipeline, the output of only 1
+				// task is consumed even though there may be more than 1 task
+				// output set. In this case we will attempt to grab the first
+				// successful task output.
+				paramSelectors := tempOutputParametersMap[tempOutputKey].GetValueFromOneof().GetParameterSelectors()
+				glog.V(4).Infof("paramSelectors: %v", paramSelectors)
+				// Since we have the tasks map, we can iterate through the
+				// parameterSelectors if the ProducerSubTask is not present in
+				// the task map and then assign the new OutputParameterKey only
+				// if it exists.
+				successfulOneOfTask := false
+				for _, paramSelector := range paramSelectors {
+					producerSubTaskName = paramSelector.GetProducerSubtask()
+					// Used just for retrieval since we lookup the task in the map
+					updatedSubTaskName := metadata.GetTaskNameWithDagID(producerSubTaskName, parentTask.GetID())
+					glog.V(4).Infof("subTaskName with Dag ID from paramSelector: %v", updatedSubTaskName)
+					glog.V(4).Infof("outputParameterKey from paramSelector: %v", paramSelector.GetOutputParameterKey())
+					if subTask, ok := tasks[updatedSubTaskName]; ok {
+						subTaskState := subTask.GetExecution().GetLastKnownState().String()
+						glog.V(4).Infof("subTask: %w , subTaskState: %v", updatedSubTaskName, subTaskState)
+						if subTaskState == "CACHED" || subTaskState == "COMPLETE" {
+							tempOutputKey = paramSelector.GetOutputParameterKey()
+							successfulOneOfTask = true
+							break
+						}
+					}
+				}
+				if !successfulOneOfTask {
+					return "", "", fmt.Errorf("processing OneOf: No successful task found")
+				}
+			}
+		}
+	}
+	if producerSubTaskName != "" {
+		producerSubTaskName = metadata.GetTaskNameWithDagID(producerSubTaskName, parentTask.GetID())
+	} else {
+		producerSubTaskName = subTaskName
+	}
+	return producerSubTaskName, tempOutputKey, nil
+}
+
+// Helper for determining if the current producerTask in question needs to pull from an iteration dag that it may exist in.
+func InferIndexedTaskName(producerTaskName string, dag *metadata.Execution) string {
+	// Check if the DAG in question is a parallelFor iteration DAG. If it is, we need to
+	// update the producerTaskName so the downstream task resolves the appropriate index.
+	if dag.GetExecution().GetCustomProperties()["iteration_index"] != nil {
+		task_iteration_index := dag.GetExecution().GetCustomProperties()["iteration_index"].GetIntValue()
+		producerTaskName = metadata.GetParallelForTaskName(producerTaskName, task_iteration_index)
+		glog.V(4).Infof("TaskIteration - ProducerTaskName: %v", producerTaskName)
+		glog.Infof("Attempting to retrieve outputs from a ParallelFor iteration")
+	}
+	return producerTaskName
+}
+
+// Helper for checking if collecting outputs is required for downstream tasks.
+func getParallelForIterationCount(task *metadata.Execution, dag *metadata.Execution) int64 {
+	iterations := task.GetExecution().GetCustomProperties()["iteration_count"]
+	glog.V(4).Infof("task: %v, iterations: %v", task.TaskName(), iterations)
+	if iterations == nil {
+		glog.V(4).Infof("No iteration_count found on task %v, checking associated DAG", task.TaskName())
+		iterations = dag.GetExecution().GetCustomProperties()["iteration_count"]
+		glog.V(4).Infof("dag: %v, iterations: %v", dag.TaskName(), iterations)
+	}
+	return iterations.GetIntValue()
+}
+
+// provisionOutputs prepares output references that will get saved to MLMD.
 func provisionOutputs(
 	pipelineRoot,
 	taskName string,

--- a/samples/v2/collected_artifacts.py
+++ b/samples/v2/collected_artifacts.py
@@ -2,10 +2,16 @@ from typing import List
 
 import kfp
 from kfp import dsl
-from kfp.dsl import Artifact
+from kfp.dsl import Artifact, Dataset, Model
 from kfp.dsl import Output
-import kfp.kubernetes
 
+# This sample pipeline is meant to cover the following cases during artifact resolution:
+# 1. ParallelFor task consuming input from another task within the same loop.
+# 2. A nested ParallelFor task consuming input from another ParallelFor Iterator.
+# 3. Resolving input with dsl.Collected inside another ParallelFor loop.
+# 4. Resolving input that comes from a subdag using dsl.Collected inside of a ParallelFor loop.
+# 5. Returning a dsl.Collected, loop-nested, task as subdag's output.
+# 6. Feeding in the subdag's collected output as input for a downstream task.
 
 @dsl.component()
 def split_ids(model_ids: str) -> list:
@@ -37,27 +43,97 @@ def read_single_file(file: Artifact) -> str:
 
     return file.uri
 
+@dsl.component()
+def split_chars(model_ids: str) -> list:
+    return model_ids.split(',')
+
+
+@dsl.component()
+def create_dataset(data: Output[Dataset], content: str):
+    print(f'Creating file with content: {content}')
+    with open(data.path, 'w') as f:
+        f.write(content)
+
+
+@dsl.component()
+def read_datasets(data: List[Dataset]) -> str:
+    for d in data:
+        print(f'Reading dataset {d.name} file: {d.path}')
+        with open(d.path, 'r') as f:
+            print(f.read())
+
+    return 'files read'
+
+
+@dsl.component()
+def read_single_dataset_generate_model(data: Dataset, id: str, results:Output[Model]):
+    print(f'Reading file: {data.path}')
+    with open(data.path, 'r') as f:
+        info = f.read()
+        with open(results.path, 'w') as f2:
+            f2.write(f"{info}-{id}")
+            results.metadata['model'] = info
+            results.metadata['model_name'] = f"model-artifact-inner-iteration-{info}-{id}"
+
+
+@dsl.component()
+def read_models(models: List[Model],) -> str:
+    for m in models:
+        print(f'Reading model {m.name} file: {m.path}')
+        with open(m.path, 'r') as f:
+            info = f.read()
+            print(f"Model raw data: {info}")
+            print(f"Model metadata: {m.metadata}")
+    return 'models read'
+    
+@dsl.pipeline()
+def single_node_dag(char:str)-> Dataset:
+    create_dataset_op = create_dataset(content=char)
+    create_dataset_op.set_caching_options(False)
+    return create_dataset_op.outputs["data"]
 
 @dsl.pipeline()
-def collecting_artifacts(model_ids: str = '',) -> List[Artifact]:
+def collecting_artifacts(model_ids: str = '', model_chars: str = '') -> List[Model]:
     ids_split_op = split_ids(model_ids=model_ids)
+    ids_split_op.set_caching_options(False)
+
+    char_split_op = split_chars(model_ids=model_chars)
+    char_split_op.set_caching_options(False)
+    
     with dsl.ParallelFor(ids_split_op.output) as model_id:
         create_file_op = create_file(content=model_id)
+        create_file_op.set_caching_options(False)
 
         read_single_file_op = read_single_file(
             file=create_file_op.outputs['file'])
+        read_single_file_op.set_caching_options(False)
 
-    read_file_op = read_files(
-        files=dsl.Collected(create_file_op.outputs['file']))
+        with dsl.ParallelFor(char_split_op.output) as model_char:
+            single_dag_op = single_node_dag(char=model_char)
+            single_dag_op.set_caching_options(False)
 
-    return dsl.Collected(create_file_op.outputs['file'])
+            random_subdag_op = read_single_dataset_generate_model_op = read_single_dataset_generate_model(data=single_dag_op.output, id=model_id)
+            read_single_dataset_generate_model_op.set_caching_options(False)
+        
+        read_models_op = read_models(
+            models=dsl.Collected(read_single_dataset_generate_model_op.outputs['results']))
+        read_models_op.set_caching_options(False)
+
+        read_datasets_op = read_datasets(
+            data=dsl.Collected(single_dag_op.output))
+        read_datasets_op.set_caching_options(False)
+    
+    return dsl.Collected(read_single_dataset_generate_model_op.outputs["results"])
 
 
 @dsl.pipeline()
 def collected_artifact_pipeline():
     model_ids = 's1,s2,s3'
-    dag = collecting_artifacts(model_ids=model_ids)
-    read_files_op = read_files(files=dag.output)
+    model_chars = 'x,y,z'
+    dag = collecting_artifacts(model_ids=model_ids, model_chars=model_chars)
+    dag.set_caching_options(False)
+    read_files_op = read_models(models=dag.output)
+    read_files_op.set_caching_options(False)
 
 
 if __name__ == '__main__':

--- a/samples/v2/collected_artifacts.py
+++ b/samples/v2/collected_artifacts.py
@@ -1,0 +1,69 @@
+from typing import List
+
+import kfp
+from kfp import dsl
+from kfp.dsl import Artifact
+from kfp.dsl import Output
+import kfp.kubernetes
+
+
+@dsl.component()
+def split_ids(model_ids: str) -> list:
+    return model_ids.split(',')
+
+
+@dsl.component()
+def create_file(file: Output[Artifact], content: str):
+    print(f'Creating file with content: {content}')
+    with open(file.path, 'w') as f:
+        f.write(content)
+
+
+@dsl.component()
+def read_files(files: List[Artifact]) -> str:
+    for f in files:
+        print(f'Reading artifact {f.name} file: {f.path}')
+        with open(f.path, 'r') as f:
+            print(f.read())
+
+    return 'files read'
+
+
+@dsl.component()
+def read_single_file(file: Artifact) -> str:
+    print(f'Reading file: {file.path}')
+    with open(file.path, 'r') as f:
+        print(f.read())
+
+    return file.uri
+
+
+@dsl.pipeline()
+def collecting_artifacts(model_ids: str = '',) -> List[Artifact]:
+    ids_split_op = split_ids(model_ids=model_ids)
+    with dsl.ParallelFor(ids_split_op.output) as model_id:
+        create_file_op = create_file(content=model_id)
+
+        read_single_file_op = read_single_file(
+            file=create_file_op.outputs['file'])
+
+    read_file_op = read_files(
+        files=dsl.Collected(create_file_op.outputs['file']))
+
+    return dsl.Collected(create_file_op.outputs['file'])
+
+
+@dsl.pipeline()
+def collected_artifact_pipeline():
+    model_ids = 's1,s2,s3'
+    dag = collecting_artifacts(model_ids=model_ids)
+    read_files_op = read_files(files=dag.output)
+
+
+if __name__ == '__main__':
+    client = kfp.Client()
+    run = client.create_run_from_pipeline_func(
+        collected_artifact_pipeline,
+        arguments={},
+        enable_caching=False,
+    )

--- a/samples/v2/collected_parameters.py
+++ b/samples/v2/collected_parameters.py
@@ -2,7 +2,6 @@ from typing import List
 
 import kfp
 from kfp import dsl
-import kfp.kubernetes
 
 
 @dsl.component()
@@ -34,10 +33,13 @@ def collecting_parameters(model_ids: str = '',) -> List[str]:
     ids_split_op = split_ids(ids=model_ids)
     with dsl.ParallelFor(ids_split_op.output) as model_id:
         prepend_id_op = prepend_id(content=model_id)
-
+        prepend_id_op.set_caching_options(False)
+        
         consume_single_id_op = consume_single_id(id=prepend_id_op.output)
-
+        consume_single_id_op.set_caching_options(False)
+    
     consume_ids_op = consume_ids(ids=dsl.Collected(prepend_id_op.output))
+    consume_ids_op.set_caching_options(False)
 
     return dsl.Collected(prepend_id_op.output)
 
@@ -46,9 +48,10 @@ def collecting_parameters(model_ids: str = '',) -> List[str]:
 def collected_param_pipeline():
     model_ids = 's1,s2,s3'
     dag = collecting_parameters(model_ids=model_ids)
-
+    dag.set_caching_options(False)
+    
     consume_ids_op = consume_ids(ids=dag.output)
-
+    consume_ids_op.set_caching_options(False)
 
 if __name__ == '__main__':
     client = kfp.Client()

--- a/samples/v2/collected_parameters.py
+++ b/samples/v2/collected_parameters.py
@@ -1,0 +1,59 @@
+from typing import List
+
+import kfp
+from kfp import dsl
+import kfp.kubernetes
+
+
+@dsl.component()
+def split_ids(ids: str) -> list:
+    return ids.split(',')
+
+
+@dsl.component()
+def prepend_id(content: str) -> str:
+    print(f"prepending: {content} with 'model_id'")
+    return f'model_id_{content}'
+
+
+@dsl.component()
+def consume_ids(ids: List[str]) -> str:
+    for id in ids:
+        print(f'Consuming: {id}')
+    return 'completed'
+
+
+@dsl.component()
+def consume_single_id(id: str) -> str:
+    print(f'Consuming single: {id}')
+    return 'completed'
+
+
+@dsl.pipeline()
+def collecting_parameters(model_ids: str = '',) -> List[str]:
+    ids_split_op = split_ids(ids=model_ids)
+    with dsl.ParallelFor(ids_split_op.output) as model_id:
+        prepend_id_op = prepend_id(content=model_id)
+
+        consume_single_id_op = consume_single_id(id=prepend_id_op.output)
+
+    consume_ids_op = consume_ids(ids=dsl.Collected(prepend_id_op.output))
+
+    return dsl.Collected(prepend_id_op.output)
+
+
+@dsl.pipeline()
+def collected_param_pipeline():
+    model_ids = 's1,s2,s3'
+    dag = collecting_parameters(model_ids=model_ids)
+
+    consume_ids_op = consume_ids(ids=dag.output)
+
+
+if __name__ == '__main__':
+    client = kfp.Client()
+    run = client.create_run_from_pipeline_func(
+        collected_param_pipeline,
+        arguments={},
+        enable_caching=False,
+    )

--- a/sdk/python/kfp/dsl/executor.py
+++ b/sdk/python/kfp/dsl/executor.py
@@ -70,11 +70,17 @@ class Executor:
                     type_annotations.is_list_of_artifacts(annotation.__origin__)
                 ) or type_annotations.is_list_of_artifacts(annotation)
                 if is_list_of_artifacts:
+                    # Get the annotation of the inner type of the list
+                    # to use when creating the artifacts
+                    inner_annotation = type_annotations.get_inner_type(
+                        annotation)
+
                     self.input_artifacts[name] = [
                         self.make_artifact(
                             msg,
                             name,
                             self.func,
+                            annotation=inner_annotation,
                         ) for msg in list_of_artifact_proto_structs
                     ]
                 else:
@@ -102,8 +108,10 @@ class Executor:
         runtime_artifact: Dict,
         name: str,
         func: Callable,
+        annotation: Optional[Any] = None,
     ) -> Any:
-        annotation = func.__annotations__.get(name)
+        annotation = func.__annotations__.get(
+            name) if annotation is None else annotation
         if isinstance(annotation, type_annotations.InputPath):
             schema_title, _ = annotation.type.split('@')
             if schema_title in artifact_types._SCHEMA_TITLE_TO_TYPE:


### PR DESCRIPTION
**Description of your changes:**
Jumping off from #11627, these changes resolve #10050 in regards to the using `dsl.Collected` for both parameters and artifacts in pipelines. Currently for artifacts, the executor needs to be updated in the sdk and have a release prior to tests being enabled. As for parameters that should work out of the box with solely backend changes.

This PR introduces a few new methods to help ease with detecting and resolving collected inputs as well as cleaning up some of the shared logic between `resolveUpstreamParameters` & `resolveUpstreamArtifacts`.

A few things to keep in mind:
A **parallelFor** creates `x+1` dags, where `x` is the number of iterations. The extra dag is something I like to refer to as the **parallelFor** **_Head_** dag, being that it only contains the iteration dags within it.

With these changes, the keys within the task map returned from `getDAGTasks` will now contain the parent dag id associated with the task. This is to help maintain uniqueness, also when detecting a parallelFor iteration task/dag, the index will be added to the task name to further prevent any potential collisions and map the appropriate tasks within the same iteration for input/output resolution.

When resolving the inputs, if the current Task is a DAG the driver now first checks if the it is a **parallelFor** by inspecting if there exists an `iteration_count` custom property, as only **parallelFor heads** have that property. If found, the iteration dag names will be added to a queue that the `CollectInputs` will use to start the resolution search.

New methods:
* `CollectInputs` - Performs a BFS on the tasks passed to reach the final producer task iterations and collects the values into the appropriate structure for either Artifacts or Parameters
* `CollectContainerOutput` - Helper function for processing the output of a containerExecution, currently only used in the `CollectInputs`.
*` GetProducerTask` - Performs the check on a task for the potential new producer task and output parameter/artifact key and returns the updated value if found.
* `InferIndexedTaskName` - Used to update the producer task with the appropriate index if the current dag context is a parallelFor iteration dag i.e. resolving task inputs within the loop.
* `getParallelForIterationCount` - Helper to get the number of iterations / determine if a parallelFor head dag.
* `GetParallelForTaskName` - Used to update the task name with the iteration value supplied.
* `GetTaskNameWithDagID` - Used to update the task name with the it's parent's dag id.


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
