### PR TITLE
fix: minio fsgroup for popular clusters

### DIFF
--- a/manifests/kustomize/third-party/minio/base/minio-deployment.yaml
+++ b/manifests/kustomize/third-party/minio/base/minio-deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app: minio
     spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
       - args:
         - server


### PR DESCRIPTION
Copy of https://github.com/kubeflow/manifests/pull/3045

See also https://github.com/kubeflow/manifests/issues/3040 for more information.