### PR TITLE
fix: resolve issue where pre-release versions of google-api-core are installed

### DIFF
--- a/components/google-cloud/setup.py
+++ b/components/google-cloud/setup.py
@@ -81,7 +81,7 @@ setuptools.setup(
     install_requires=[
         # Pin google-api-core version for the bug fixing in 1.31.5
         # https://github.com/googleapis/python-api-core/releases/tag/v1.31.5
-        "google-api-core>=1.31.5,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
+        "google-api-core>=1.31.5,<3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
         "kfp>=2.6.0,<2.11.0",
         "google-cloud-aiplatform>=1.14.0,<2",
         "Jinja2>=3.1.2,<4",


### PR DESCRIPTION
Remove `dev` from `setup.py` to avoid installing pre-release versions of dependency `google-api-core`. See https://github.com/googleapis/google-cloud-python/issues/13585 for more information.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
