### PR TITLE
Fix Istio sidecar injection by moving from annotations to labels

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/deployment.yaml
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/deployment.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 1
   template:
     metadata:
-      annotations:
+      labels:
         sidecar.istio.io/inject: "false"
     spec:
       containers:

--- a/manifests/kustomize/base/metadata/base/metadata-envoy-deployment.yaml
+++ b/manifests/kustomize/base/metadata/base/metadata-envoy-deployment.yaml
@@ -13,7 +13,6 @@ spec:
     metadata:
       labels:
         component: metadata-envoy
-      annotations:
         sidecar.istio.io/inject: "false"
     spec:
       containers:

--- a/manifests/kustomize/base/metadata/overlays/db/metadata-db-deployment.yaml
+++ b/manifests/kustomize/base/metadata/overlays/db/metadata-db-deployment.yaml
@@ -16,7 +16,6 @@ spec:
       name: db
       labels:
         component: db
-      annotations:
         sidecar.istio.io/inject: "false"
     spec:
       containers:
@@ -49,4 +48,3 @@ spec:
       - name: metadata-mysql
         persistentVolumeClaim:
           claimName: metadata-mysql
-

--- a/manifests/kustomize/base/metadata/overlays/postgres/metadata-db-deployment.yaml
+++ b/manifests/kustomize/base/metadata/overlays/postgres/metadata-db-deployment.yaml
@@ -16,15 +16,14 @@ spec:
       name: db
       labels:
         component: db
-      annotations:
         sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: db-container
         image: postgres
         env:
-          - name: PGDATA
-            value: /var/lib/postgresql/data/pgdata
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
         envFrom:
         - configMapRef:
             name: metadata-postgres-db-parameters
@@ -40,4 +39,3 @@ spec:
       - name: metadata-postgres
         persistentVolumeClaim:
           claimName: metadata-postgres
-

--- a/manifests/kustomize/third-party/metacontroller/base/stateful-set.yaml
+++ b/manifests/kustomize/third-party/metacontroller/base/stateful-set.yaml
@@ -14,7 +14,6 @@ spec:
     metadata:
       labels:
         app: metacontroller
-      annotations:
         sidecar.istio.io/inject: "false"
     spec:
       containers:
@@ -38,7 +37,7 @@ spec:
               port: 8081
               path: /readyz
           securityContext:
-            seccompProfile: 
+            seccompProfile:
               type: RuntimeDefault
             capabilities:
               drop:


### PR DESCRIPTION
**Description of your changes:**
Fix Istio sidecar injection configuration by moving from deprecated annotations to the recommended labels approach. 

This PR addresses multiple Pipelines components that were using the annotation approach, ensuring proper sidecar injection behavior with the current Istio versions.

## Issues and Related PR
Issue: https://github.com/kubeflow/manifests/issues/2798
Part of PR: https://github.com/kubeflow/manifests/pull/3044

**Checklist:**
- [x] You have [[signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention: `fix(manifests): use istio labels instead of annotations for sidecar injection. Fixes kubeflow/manifests#2798`