### PR TITLE
feat(backend): implement logs as artifacts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
 
   # Golang pre-submit hooks
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.52.2
+    rev: v1.64.8
     hooks:
       - id: golangci-lint
         name: golangci-lint

--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -19,7 +19,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+
 	"github.com/kubeflow/pipelines/backend/src/common/util"
+
+	"os"
+	"path/filepath"
+	"strconv"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/jsonpb"
@@ -29,9 +34,6 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/v2/driver"
 	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
 	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
-	"os"
-	"path/filepath"
-	"strconv"
 )
 
 const (
@@ -70,6 +72,7 @@ var (
 	cachedDecisionPath = flag.String("cached_decision_path", "", "Cached Decision output path")
 	conditionPath      = flag.String("condition_path", "", "Condition output path")
 	logLevel           = flag.String("log_level", "1", "The verbosity level to log.")
+	publishLogs        = flag.String("publish_logs", "true", "Whether to publish component logs to the object store")
 )
 
 // func RootDAG(pipelineName string, runID string, component *pipelinespec.ComponentSpec, task *pipelinespec.PipelineTaskSpec, mlmd *metadata.Client) (*Execution, error) {
@@ -167,6 +170,7 @@ func drive() (err error) {
 		DAGExecutionID:   *dagExecutionID,
 		IterationIndex:   *iterationIndex,
 		PipelineLogLevel: *logLevel,
+		PublishLogs:      *publishLogs,
 	}
 	var execution *driver.Execution
 	var driverErr error

--- a/backend/src/v2/cmd/launcher-v2/main.go
+++ b/backend/src/v2/cmd/launcher-v2/main.go
@@ -42,6 +42,7 @@ var (
 	mlmdServerAddress = flag.String("mlmd_server_address", "", "The MLMD gRPC server address.")
 	mlmdServerPort    = flag.String("mlmd_server_port", "8080", "The MLMD gRPC server port.")
 	logLevel          = flag.String("log_level", "1", "The verbosity level to log.")
+	publishLogs       = flag.String("publish_logs", "true", "Whether to publish component logs to the object store")
 )
 
 func main() {
@@ -79,6 +80,7 @@ func run() error {
 		MLMDServerPort:    *mlmdServerPort,
 		PipelineName:      *pipelineName,
 		RunID:             *runID,
+		PublishLogs:       *publishLogs,
 	}
 
 	switch *executorType {

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -16,10 +16,11 @@ package argocompiler
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"os"
 	"strconv"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	wfapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/golang/glog"
@@ -41,6 +42,7 @@ const (
 	DriverCommandEnvVar      = "V2_DRIVER_COMMAND"
 	PipelineRunAsUserEnvVar  = "PIPELINE_RUN_AS_USER"
 	PipelineLogLevelEnvVar   = "PIPELINE_LOG_LEVEL"
+	PublishLogsEnvVar        = "PUBLISH_LOGS"
 	gcsScratchLocation       = "/gcs"
 	gcsScratchName           = "gcs-scratch"
 	s3ScratchLocation        = "/s3"
@@ -184,6 +186,9 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 	if value, ok := os.LookupEnv(PipelineLogLevelEnvVar); ok {
 		args = append(args, "--log_level", value)
 	}
+	if value, ok := os.LookupEnv(PublishLogsEnvVar); ok {
+		args = append(args, "--publish_logs", value)
+	}
 
 	t := &wfapi.Template{
 		Name: name,
@@ -306,6 +311,9 @@ func (c *workflowCompiler) addContainerExecutorTemplate(name string, refName str
 	}
 	if value, ok := os.LookupEnv(PipelineLogLevelEnvVar); ok {
 		args = append(args, "--log_level", value)
+	}
+	if value, ok := os.LookupEnv(PublishLogsEnvVar); ok {
+		args = append(args, "--publish_logs", value)
 	}
 	executor := &wfapi.Template{
 		Name:          nameContainerImpl,

--- a/backend/src/v2/compiler/argocompiler/dag.go
+++ b/backend/src/v2/compiler/argocompiler/dag.go
@@ -555,6 +555,9 @@ func (c *workflowCompiler) addDAGDriverTemplate() string {
 	if value, ok := os.LookupEnv(PipelineLogLevelEnvVar); ok {
 		args = append(args, "--log_level", value)
 	}
+	if value, ok := os.LookupEnv(PublishLogsEnvVar); ok {
+		args = append(args, "--publish_logs", value)
+	}
 
 	t := &wfapi.Template{
 		Name: name,

--- a/backend/src/v2/compiler/argocompiler/importer.go
+++ b/backend/src/v2/compiler/argocompiler/importer.go
@@ -85,6 +85,9 @@ func (c *workflowCompiler) addImporterTemplate() string {
 	if value, ok := os.LookupEnv(PipelineLogLevelEnvVar); ok {
 		args = append(args, "--log_level", value)
 	}
+	if value, ok := os.LookupEnv(PublishLogsEnvVar); ok {
+		args = append(args, "--publish_logs", value)
+	}
 	importerTemplate := &wfapi.Template{
 		Name: name,
 		Inputs: wfapi.Inputs{

--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,6 +73,7 @@ type kubernetesClient struct {
 	Clientset kubernetes.Interface
 }
 
+// NewLauncherV2 is a factory function that returns an instance of LauncherV2.
 func NewLauncherV2(ctx context.Context, executionID int64, executorInputJSON, componentSpecJSON string, cmdArgs []string, opts *LauncherV2Options) (l *LauncherV2, err error) {
 	defer func() {
 		if err != nil {
@@ -163,6 +165,7 @@ func stopWaitingArtifacts(artifacts map[string]*pipelinespec.ArtifactList) {
 	}
 }
 
+// Execute calls executeV2, updates the cache, and publishes the results to MLMD.
 func (l *LauncherV2) Execute(ctx context.Context) (err error) {
 	defer func() {
 		if err != nil {
@@ -243,6 +246,7 @@ func (l *LauncherV2) Execute(ctx context.Context) (err error) {
 		}
 		return l.cacheClient.CreateExecutionCache(ctx, task)
 	}
+
 	return nil
 }
 
@@ -319,6 +323,8 @@ func (l *LauncherV2) publish(
 	return l.metadataClient.PublishExecution(ctx, execution, outputParameters, outputArtifacts, status)
 }
 
+// executeV2 handles placeholder substitution for inputs, calls execute to
+// execute end user logic, and uploads the resulting output Artifacts.
 func executeV2(
 	ctx context.Context,
 	executorInput *pipelinespec.ExecutorInput,
@@ -427,6 +433,46 @@ func prettyPrint(jsonStr string) string {
 
 const OutputMetadataFilepath = "/tmp/kfp_outputs/output_metadata.json"
 
+// We overwrite this as a DI mechanism for testing getLogWriter. We could make
+// it an explicit input to getLogWriter, but then it would have to be an input
+// in getLogWriter's caller as well.
+var osCreateFunc = os.Create
+
+// getLogWriter returns an io.Writer that can either be single-channel to stdout
+// or dual-channel to stdout AND a log file based on the URI of a log artifact
+// in the supplied ArtifactList. Downstream, the resulting log file gets
+// uploaded to the object store.
+func getLogWriter(artifacts map[string]*pipelinespec.ArtifactList) (writer io.Writer) {
+	logsArtifactList, ok := artifacts["logs"]
+
+	if !ok || len(logsArtifactList.Artifacts) == 0 {
+		return os.Stdout
+	}
+
+	logURI := logsArtifactList.Artifacts[0].Uri
+	logFilePath, err := LocalPathForURI(logURI)
+	if err != nil {
+		glog.Errorf("Error converting log artifact URI, %s, to file path.", logURI)
+		return os.Stdout
+	}
+
+	logFile, err := osCreateFunc(logFilePath)
+	if err != nil {
+		glog.Errorf("Error creating logFilePath, %s.", logFilePath)
+		return os.Stdout
+	}
+
+	return io.MultiWriter(os.Stdout, logFile)
+}
+
+// TODO: Clarify the differences between the various execution functions. Are
+// all of them necessary? Do the existing partitions make sense? Can the
+// function names more effectively encapsulate the division in responsibilities?
+// We have tried to clarify this with some  basic function doc strings, but a
+// deeper refactor might be advisable.
+
+// execute downloads input artifacts, prepares the execution environment,
+// executes the end user code, and returns the outputs.
 func execute(
 	ctx context.Context,
 	executorInput *pipelinespec.ExecutorInput,
@@ -445,17 +491,21 @@ func execute(
 		return nil, err
 	}
 
-	// Run user program.
-	executor := exec.Command(cmd, args...)
-	executor.Stdin = os.Stdin
-	executor.Stdout = os.Stdout
-	executor.Stderr = os.Stderr
+	writer := getLogWriter(executorInput.Outputs.GetArtifacts())
+
+	// Prepare command that will execute end user code.
+	command := exec.Command(cmd, args...)
+	command.Stdin = os.Stdin
+	// Pipe stdout/stderr to the aforementioned multiWriter.
+	command.Stdout = writer
+	command.Stderr = writer
 	defer glog.Flush()
-	if err := executor.Run(); err != nil {
+
+	// Execute end user code.
+	if err := command.Run(); err != nil {
 		return nil, err
 	}
 
-	// Collect outputs from output metadata file.
 	return getExecutorOutputFile(executorInput.GetOutputs().GetOutputFile())
 }
 
@@ -472,47 +522,49 @@ func uploadOutputArtifacts(ctx context.Context, executorInput *pipelinespec.Exec
 		if len(artifactList.Artifacts) == 0 {
 			continue
 		}
-		// TODO: Support multiple artifacts someday, probably through the v2 engine.
-		outputArtifact := artifactList.Artifacts[0]
 
-		// Merge executor output artifact info with executor input
-		if list, ok := executorOutput.Artifacts[name]; ok && len(list.Artifacts) > 0 {
-			mergeRuntimeArtifacts(list.Artifacts[0], outputArtifact)
-		}
+		for _, outputArtifact := range artifactList.Artifacts {
+			glog.Infof("outputArtifact in uploadOutputArtifacts call: ", outputArtifact)
 
-		// Upload artifacts from local path to remote storages.
-		localDir, err := LocalPathForURI(outputArtifact.Uri)
-		if err != nil {
-			glog.Warningf("Output Artifact %q does not have a recognized storage URI %q. Skipping uploading to remote storage.", name, outputArtifact.Uri)
-		} else if !strings.HasPrefix(outputArtifact.Uri, "oci://") {
-			blobKey, err := opts.bucketConfig.KeyFromURI(outputArtifact.Uri)
-			if err != nil {
-				return nil, fmt.Errorf("failed to upload output artifact %q: %w", name, err)
+			// Merge executor output artifact info with executor input
+			if list, ok := executorOutput.Artifacts[name]; ok && len(list.Artifacts) > 0 {
+				mergeRuntimeArtifacts(list.Artifacts[0], outputArtifact)
 			}
-			if err := objectstore.UploadBlob(ctx, opts.bucket, localDir, blobKey); err != nil {
-				//  We allow components to not produce output files
-				if errors.Is(err, os.ErrNotExist) {
-					glog.Warningf("Local filepath %q does not exist", localDir)
-				} else {
-					return nil, fmt.Errorf("failed to upload output artifact %q to remote storage URI %q: %w", name, outputArtifact.Uri, err)
+
+			// Upload artifacts from local path to remote storages.
+			localDir, err := LocalPathForURI(outputArtifact.Uri)
+			if err != nil {
+				glog.Warningf("Output Artifact %q does not have a recognized storage URI %q. Skipping uploading to remote storage.", name, outputArtifact.Uri)
+			} else if !strings.HasPrefix(outputArtifact.Uri, "oci://") {
+				blobKey, err := opts.bucketConfig.KeyFromURI(outputArtifact.Uri)
+				if err != nil {
+					return nil, fmt.Errorf("failed to upload output artifact %q: %w", name, err)
+				}
+				if err := objectstore.UploadBlob(ctx, opts.bucket, localDir, blobKey); err != nil {
+					//  We allow components to not produce output files
+					if errors.Is(err, os.ErrNotExist) {
+						glog.Warningf("Local filepath %q does not exist", localDir)
+					} else {
+						return nil, fmt.Errorf("failed to upload output artifact %q to remote storage URI %q: %w", name, outputArtifact.Uri, err)
+					}
 				}
 			}
-		}
 
-		// Write out the metadata.
-		metadataErr := func(err error) error {
-			return fmt.Errorf("unable to produce MLMD artifact for output %q: %w", name, err)
+			// Write out the metadata.
+			metadataErr := func(err error) error {
+				return fmt.Errorf("unable to produce MLMD artifact for output %q: %w", name, err)
+			}
+			// TODO(neuromage): Consider batching these instead of recording one by one.
+			schema, err := getArtifactSchema(outputArtifact.GetType())
+			if err != nil {
+				return nil, fmt.Errorf("failed to determine schema for output %q: %w", name, err)
+			}
+			mlmdArtifact, err := opts.metadataClient.RecordArtifact(ctx, name, schema, outputArtifact, pb.Artifact_LIVE, opts.bucketConfig)
+			if err != nil {
+				return nil, metadataErr(err)
+			}
+			outputArtifacts = append(outputArtifacts, mlmdArtifact)
 		}
-		// TODO(neuromage): Consider batching these instead of recording one by one.
-		schema, err := getArtifactSchema(outputArtifact.GetType())
-		if err != nil {
-			return nil, fmt.Errorf("failed to determine schema for output %q: %w", name, err)
-		}
-		mlmdArtifact, err := opts.metadataClient.RecordArtifact(ctx, name, schema, outputArtifact, pb.Artifact_LIVE, opts.bucketConfig)
-		if err != nil {
-			return nil, metadataErr(err)
-		}
-		outputArtifacts = append(outputArtifacts, mlmdArtifact)
 	}
 	return outputArtifacts, nil
 }
@@ -833,15 +885,17 @@ func prepareOutputFolders(executorInput *pipelinespec.ExecutorInput) error {
 		if len(artifactList.Artifacts) == 0 {
 			continue
 		}
-		outputArtifact := artifactList.Artifacts[0]
 
-		localPath, err := LocalPathForURI(outputArtifact.Uri)
-		if err != nil {
-			return fmt.Errorf("failed to generate local storage path for output artifact %q: %w", name, err)
-		}
+		for _, outputArtifact := range artifactList.Artifacts {
 
-		if err := os.MkdirAll(filepath.Dir(localPath), 0755); err != nil {
-			return fmt.Errorf("unable to create directory %q for output artifact %q: %w", filepath.Dir(localPath), name, err)
+			localPath, err := LocalPathForURI(outputArtifact.Uri)
+			if err != nil {
+				return fmt.Errorf("failed to generate local storage path for output artifact %q: %w", name, err)
+			}
+
+			if err := os.MkdirAll(filepath.Dir(localPath), 0755); err != nil {
+				return fmt.Errorf("unable to create directory %q for output artifact %q: %w", filepath.Dir(localPath), name, err)
+			}
 		}
 	}
 

--- a/backend/src/v2/component/launcher_v2_test.go
+++ b/backend/src/v2/component/launcher_v2_test.go
@@ -141,7 +141,7 @@ func Test_get_log_Writer(t *testing.T) {
 		{
 			"multiwriter",
 			map[string]*pipelinespec.ArtifactList{
-				"logs": {
+				"executor-logs": {
 					Artifacts: []*pipelinespec.RuntimeArtifact{
 						{
 							Uri: "minio://testinguri",

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -1898,7 +1898,7 @@ func provisionOutputs(pipelineRoot, taskName string, outputsSpec *pipelinespec.C
 	if artifacts == nil {
 		artifacts = make(map[string]*pipelinespec.ComponentOutputsSpec_ArtifactSpec)
 	}
-	artifacts["logs"] = &pipelinespec.ComponentOutputsSpec_ArtifactSpec{
+	artifacts["executor-logs"] = &pipelinespec.ComponentOutputsSpec_ArtifactSpec{
 		ArtifactType: &pipelinespec.ArtifactTypeSchema{
 			Kind: &pipelinespec.ArtifactTypeSchema_SchemaTitle{
 				SchemaTitle: "system.Artifact",

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -83,6 +83,8 @@ type Options struct {
 	RunDisplayName string
 
 	PipelineLogLevel string
+
+	PublishLogs string
 }
 
 // Identifying information used for error messages
@@ -287,7 +289,13 @@ func Container(ctx context.Context, opts Options, mlmd *metadata.Client, cacheCl
 		execution.Condition = &willTrigger
 	}
 	if execution.WillTrigger() {
-		executorInput.Outputs = provisionOutputs(pipeline.GetPipelineRoot(), opts.Task.GetTaskInfo().GetName(), opts.Component.GetOutputDefinitions(), uuid.NewString())
+		executorInput.Outputs = provisionOutputs(
+			pipeline.GetPipelineRoot(),
+			opts.Task.GetTaskInfo().GetName(),
+			opts.Component.GetOutputDefinitions(),
+			uuid.NewString(),
+			opts.PublishLogs,
+		)
 	}
 
 	ecfg, err := metadata.GenerateExecutionConfig(executorInput)
@@ -350,7 +358,16 @@ func Container(ctx context.Context, opts Options, mlmd *metadata.Client, cacheCl
 		return execution, nil
 	}
 
-	podSpec, err := initPodSpecPatch(opts.Container, opts.Component, executorInput, execution.ID, opts.PipelineName, opts.RunID, opts.PipelineLogLevel)
+	podSpec, err := initPodSpecPatch(
+		opts.Container,
+		opts.Component,
+		executorInput,
+		execution.ID,
+		opts.PipelineName,
+		opts.RunID,
+		opts.PipelineLogLevel,
+		opts.PublishLogs,
+	)
 	if err != nil {
 		return execution, err
 	}
@@ -413,6 +430,7 @@ func initPodSpecPatch(
 	pipelineName string,
 	runID string,
 	pipelineLogLevel string,
+	publishLogs string,
 ) (*k8score.PodSpec, error) {
 	executorInputJSON, err := protojson.Marshal(executorInput)
 	if err != nil {
@@ -448,10 +466,14 @@ func initPodSpecPatch(
 		fmt.Sprintf("$(%s)", component.EnvMetadataHost),
 		"--mlmd_server_port",
 		fmt.Sprintf("$(%s)", component.EnvMetadataPort),
+		"--publish_logs", publishLogs,
 	}
 	if pipelineLogLevel != "1" {
 		// Add log level to user code launcher if not default (set to 1)
 		launcherCmd = append(launcherCmd, "--log_level", pipelineLogLevel)
+	}
+	if publishLogs == "true" {
+		launcherCmd = append(launcherCmd, "--publish_logs", publishLogs)
 	}
 	launcherCmd = append(launcherCmd, "--") // separater before user command and args
 	res := k8score.ResourceRequirements{
@@ -1884,26 +1906,34 @@ func resolveUpstreamArtifacts(cfg resolveUpstreamOutputsConfig) (*pipelinespec.A
 }
 
 // provisionOuutputs prepares output references that will get saved to MLMD.
-func provisionOutputs(pipelineRoot, taskName string, outputsSpec *pipelinespec.ComponentOutputsSpec, outputUriSalt string) *pipelinespec.ExecutorInput_Outputs {
+func provisionOutputs(
+	pipelineRoot,
+	taskName string,
+	outputsSpec *pipelinespec.ComponentOutputsSpec,
+	outputURISalt string,
+	publishOutput string,
+) *pipelinespec.ExecutorInput_Outputs {
 	outputs := &pipelinespec.ExecutorInput_Outputs{
 		Artifacts:  make(map[string]*pipelinespec.ArtifactList),
 		Parameters: make(map[string]*pipelinespec.ExecutorInput_OutputParameter),
 		OutputFile: component.OutputMetadataFilepath,
 	}
-	// TODO: Consider putting this behind a feature flag.
-	//
-	// Add a placeholder for a log artifact that will be written to by the
-	// subsequent executor.
 	artifacts := outputsSpec.GetArtifacts()
-	if artifacts == nil {
-		artifacts = make(map[string]*pipelinespec.ComponentOutputsSpec_ArtifactSpec)
-	}
-	artifacts["executor-logs"] = &pipelinespec.ComponentOutputsSpec_ArtifactSpec{
-		ArtifactType: &pipelinespec.ArtifactTypeSchema{
-			Kind: &pipelinespec.ArtifactTypeSchema_SchemaTitle{
-				SchemaTitle: "system.Artifact",
+
+	// TODO: Check if there's a more idiomatic way to handle this.
+	if publishOutput == "true" {
+		// Add a placeholder for a log artifact that will be written to by the
+		// subsequent executor.
+		if artifacts == nil {
+			artifacts = make(map[string]*pipelinespec.ComponentOutputsSpec_ArtifactSpec)
+		}
+		artifacts["executor-logs"] = &pipelinespec.ComponentOutputsSpec_ArtifactSpec{
+			ArtifactType: &pipelinespec.ArtifactTypeSchema{
+				Kind: &pipelinespec.ArtifactTypeSchema_SchemaTitle{
+					SchemaTitle: "system.Artifact",
+				},
 			},
-		},
+		}
 	}
 
 	for name, artifact := range artifacts {
@@ -1912,7 +1942,7 @@ func provisionOutputs(pipelineRoot, taskName string, outputsSpec *pipelinespec.C
 				{
 					// Do not preserve the query string for output artifacts, as otherwise
 					// they'd appear in file and artifact names.
-					Uri:      metadata.GenerateOutputURI(pipelineRoot, []string{taskName, outputUriSalt, name}, false),
+					Uri:      metadata.GenerateOutputURI(pipelineRoot, []string{taskName, outputURISalt, name}, false),
 					Type:     artifact.GetArtifactType(),
 					Metadata: artifact.GetMetadata(),
 				},

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -1883,13 +1883,30 @@ func resolveUpstreamArtifacts(cfg resolveUpstreamOutputsConfig) (*pipelinespec.A
 	}
 }
 
+// provisionOuutputs prepares output references that will get saved to MLMD.
 func provisionOutputs(pipelineRoot, taskName string, outputsSpec *pipelinespec.ComponentOutputsSpec, outputUriSalt string) *pipelinespec.ExecutorInput_Outputs {
 	outputs := &pipelinespec.ExecutorInput_Outputs{
 		Artifacts:  make(map[string]*pipelinespec.ArtifactList),
 		Parameters: make(map[string]*pipelinespec.ExecutorInput_OutputParameter),
 		OutputFile: component.OutputMetadataFilepath,
 	}
-	for name, artifact := range outputsSpec.GetArtifacts() {
+	// TODO: Consider putting this behind a feature flag.
+	//
+	// Add a placeholder for a log artifact that will be written to by the
+	// subsequent executor.
+	artifacts := outputsSpec.GetArtifacts()
+	if artifacts == nil {
+		artifacts = make(map[string]*pipelinespec.ComponentOutputsSpec_ArtifactSpec)
+	}
+	artifacts["logs"] = &pipelinespec.ComponentOutputsSpec_ArtifactSpec{
+		ArtifactType: &pipelinespec.ArtifactTypeSchema{
+			Kind: &pipelinespec.ArtifactTypeSchema_SchemaTitle{
+				SchemaTitle: "system.Artifact",
+			},
+		},
+	}
+
+	for name, artifact := range artifacts {
 		outputs.Artifacts[name] = &pipelinespec.ArtifactList{
 			Artifacts: []*pipelinespec.RuntimeArtifact{
 				{
@@ -1908,6 +1925,7 @@ func provisionOutputs(pipelineRoot, taskName string, outputsSpec *pipelinespec.C
 			OutputFile: fmt.Sprintf("/tmp/kfp/outputs/%s", name),
 		}
 	}
+
 	return outputs
 }
 

--- a/backend/src/v2/driver/driver_test.go
+++ b/backend/src/v2/driver/driver_test.go
@@ -41,6 +41,7 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 		pipelineName     string
 		runID            string
 		pipelineLogLevel string
+		publishLogs      string
 	}
 	tests := []struct {
 		name    string
@@ -84,6 +85,7 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 				"MyPipeline",
 				"a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6",
 				"1",
+				"false",
 			},
 			`"nvidia.com/gpu":"1"`,
 			false,
@@ -124,6 +126,7 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 				"MyPipeline",
 				"a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6",
 				"1",
+				"false",
 			},
 			`"amd.com/gpu":"1"`,
 			false,
@@ -164,6 +167,7 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 				"MyPipeline",
 				"a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6",
 				"1",
+				"false",
 			},
 			`"cloud-tpus.google.com/v3":"1"`,
 			false,
@@ -204,6 +208,7 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 				"MyPipeline",
 				"a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6",
 				"1",
+				"false",
 			},
 			`"cloud-tpus.google.com/v2":"1"`,
 			false,
@@ -244,6 +249,7 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 				"MyPipeline",
 				"a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6",
 				"1",
+				"false",
 			},
 			`"custom.example.com/accelerator-v1":"1"`,
 			false,
@@ -252,7 +258,16 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			podSpec, err := initPodSpecPatch(tt.args.container, tt.args.componentSpec, tt.args.executorInput, tt.args.executionID, tt.args.pipelineName, tt.args.runID, tt.args.pipelineLogLevel)
+			podSpec, err := initPodSpecPatch(
+				tt.args.container,
+				tt.args.componentSpec,
+				tt.args.executorInput,
+				tt.args.executionID,
+				tt.args.pipelineName,
+				tt.args.runID,
+				tt.args.pipelineLogLevel,
+				tt.args.publishLogs,
+			)
 			if tt.wantErr {
 				assert.Nil(t, podSpec)
 				assert.NotNil(t, err)
@@ -352,7 +367,14 @@ func Test_initPodSpecPatch_resource_placeholders(t *testing.T) {
 	}
 
 	podSpec, err := initPodSpecPatch(
-		containerSpec, componentSpec, executorInput, 27, "test", "0254beba-0be4-4065-8d97-7dc5e3adf300", "1",
+		containerSpec,
+		componentSpec,
+		executorInput,
+		27,
+		"test",
+		"0254beba-0be4-4065-8d97-7dc5e3adf300",
+		"1",
+		"false",
 	)
 	assert.Nil(t, err)
 	assert.Len(t, podSpec.Containers, 1)
@@ -385,7 +407,14 @@ func Test_initPodSpecPatch_legacy_resources(t *testing.T) {
 	executorInput := &pipelinespec.ExecutorInput{}
 
 	podSpec, err := initPodSpecPatch(
-		containerSpec, componentSpec, executorInput, 27, "test", "0254beba-0be4-4065-8d97-7dc5e3adf300", "1",
+		containerSpec,
+		componentSpec,
+		executorInput,
+		27,
+		"test",
+		"0254beba-0be4-4065-8d97-7dc5e3adf300",
+		"1",
+		"false",
 	)
 	assert.Nil(t, err)
 	assert.Len(t, podSpec.Containers, 1)
@@ -420,7 +449,14 @@ func Test_initPodSpecPatch_modelcar_input_artifact(t *testing.T) {
 	}
 
 	podSpec, err := initPodSpecPatch(
-		containerSpec, componentSpec, executorInput, 27, "test", "0254beba-0be4-4065-8d97-7dc5e3adf300", "1",
+		containerSpec,
+		componentSpec,
+		executorInput,
+		27,
+		"test",
+		"0254beba-0be4-4065-8d97-7dc5e3adf300",
+		"1",
+		"false",
 	)
 	assert.Nil(t, err)
 
@@ -446,6 +482,31 @@ func Test_initPodSpecPatch_modelcar_input_artifact(t *testing.T) {
 	assert.Equal(t, podSpec.Containers[1].VolumeMounts[0].SubPath, "registry.domain.local_my-model:latest")
 }
 
+// Validate that setting publishLogs to true propagates to the driver container
+// commands in the podSpec.
+func Test_initPodSpecPatch_publishLogs(t *testing.T) {
+	podSpec, err := initPodSpecPatch(
+		&pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec{},
+		&pipelinespec.ComponentSpec{},
+		&pipelinespec.ExecutorInput{},
+		// executorInput,
+		27,
+		"test",
+		"0254beba-0be4-4065-8d97-7dc5e3adf300",
+		"1",
+		"true",
+	)
+	assert.Nil(t, err)
+	cmd := podSpec.Containers[0].Command
+	assert.Contains(t, cmd, "--publish_logs")
+	// TODO: There may be a simpler way to check this.
+	for idx, val := range cmd {
+		if val == "--publish_logs" {
+			assert.Equal(t, cmd[idx+1], "true")
+		}
+	}
+
+}
 func Test_makeVolumeMountPatch(t *testing.T) {
 	type args struct {
 		pvcMount []*kubernetesplatform.PvcMount
@@ -546,6 +607,7 @@ func Test_initPodSpecPatch_resourceRequests(t *testing.T) {
 		pipelineName     string
 		runID            string
 		pipelineLogLevel string
+		publishLogs      string
 	}
 	tests := []struct {
 		name    string
@@ -586,6 +648,7 @@ func Test_initPodSpecPatch_resourceRequests(t *testing.T) {
 				"MyPipeline",
 				"a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6",
 				"1",
+				"false",
 			},
 			`"resources":{"limits":{"cpu":"2","memory":"1500M"},"requests":{"cpu":"1","memory":"650M"}}`,
 			"",
@@ -623,6 +686,7 @@ func Test_initPodSpecPatch_resourceRequests(t *testing.T) {
 				"MyPipeline",
 				"a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6",
 				"1",
+				"false",
 			},
 			`"resources":{"limits":{"cpu":"2","memory":"1500M"}}`,
 			`"requests"`,
@@ -638,6 +702,7 @@ func Test_initPodSpecPatch_resourceRequests(t *testing.T) {
 				tt.args.pipelineName,
 				tt.args.runID,
 				tt.args.pipelineLogLevel,
+				tt.args.publishLogs,
 			)
 			assert.Nil(t, err)
 			assert.NotEmpty(t, podSpec)

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -20,6 +20,9 @@ spec:
           type: RuntimeDefault
       containers:
       - env:
+        # Whether or not to publish component logs to the object store.
+        - name: PUBLISH_LOGS
+          value: "true"
         - name: LOG_LEVEL
           value: "info"
         # Driver / launcher log level during pipeline execution


### PR DESCRIPTION
**Description of your changes:**
This PR updates the backend driver and launcher to support execution logs as proper artifacts. This makes logs available after pod and workflow garbage collection and closes many relevant open issues, such as https://github.com/kubeflow/pipelines/issues/11761, https://github.com/kubeflow/pipelines/issues/11357, and https://github.com/kubeflow/pipelines/issues/10036.

The changes were based on [this design proposal](https://docs.google.com/document/d/1GeMTWGHqHO5YLxr_S77McW6Gl4doMoOTMW2m8mODFsY/edit?usp=sharing) that was approved on a community call.

To our pleasant surprise, the UI does not render log artifacts as nodes in the graph. Here's a screenshot for reference:
![image](https://github.com/user-attachments/assets/4ea13a94-bc84-41cb-95f8-773de52eb9f1)

As you can see, the dataset artifact gets a dedicated node and the log artifact does not.

This PR paves the way for some future simplification in the UI. Currently, it does some complex, convoluted, and poorly tested guess work to try to figure out where the log artifact is stored. As a result, the `logs` tab is broken under various circumstances. Once this PR is merged, we can update the UI's logic to simply fetch the precise, unequivocal path of the logs from MLMD.

We can register and upload DAG driver and container driver logs in a follow up PR.

We added a few simple doc strings to the launcher functions to clarify and disambiguate them, which will hopefully be a prelude to some comprehensive refactoring, clarification, and testing.


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
