### PR TITLE
fix(CI) Github action is vulnerable to code execution via `comment body`

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -19,8 +19,9 @@ jobs:
           ref: ${{ env.DEFAULT_BRANCH }}
       - name: Check if the author is a member or Owner
         id: check-condition
+        env:
+          slash_command: ${{github.event.comment.body}}
         run: |
-          echo "slash_command=${{github.event.comment.body}}" >> $GITHUB_ENV
           if [[ "${{ github.event.comment.author_association }}" == "MEMBER" || "${{ github.event.comment.author_association }}" == "OWNER" ]]; then
             echo "condition_met=true" >> $GITHUB_ENV
           else

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -19,8 +19,6 @@ jobs:
           ref: ${{ env.DEFAULT_BRANCH }}
       - name: Check if the author is a member or Owner
         id: check-condition
-        env:
-          slash_command: ${{github.event.comment.body}}
         run: |
           if [[ "${{ github.event.comment.author_association }}" == "MEMBER" || "${{ github.event.comment.author_association }}" == "OWNER" ]]; then
             echo "condition_met=true" >> $GITHUB_ENV


### PR DESCRIPTION
**Description of your changes:**
Comment body injected directly in GitHub action which can cause code execution with write permission on the repository

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
