### PR TITLE
chore(test): Replaced the unmaintained rerun action

### DIFF
--- a/.github/workflows/rerun-pr-jobs.yml
+++ b/.github/workflows/rerun-pr-jobs.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-20.04
     steps:
-    - uses: estroz/rerun-actions@6da343594fa5cc0869523be9b43ed9256c68d39b # https://github.com/estroz/rerun-actions/releases/tag/v0.3.0
+    - uses: hbelmiro/rerun-actions@01c46bec8d69a84b217e3deb104ef24994c2beee # https://github.com/hbelmiro/rerun-actions/releases/tag/v0.4.0
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         comment_id: ${{ github.event.comment.id }}


### PR DESCRIPTION
**Description of your changes:**
https://github.com/estroz/rerun-actions is [no longer maintained](https://github.com/estroz/rerun-actions/pull/3).
It has a bug that prevents us from re-running specific tests.
There was a discussion in the past about forking https://github.com/estroz/rerun-actions in the Kubeflow org, but it didn't advance.
I fixed the bug on my fork. We can use it while the Kubeflow fork is not ready.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
