### PR TITLE
chore(test): Bumped ubuntu runner to 24.04 in rerun-pr-jobs.yml

### DIFF
--- a/.github/workflows/rerun-pr-jobs.yml
+++ b/.github/workflows/rerun-pr-jobs.yml
@@ -8,7 +8,7 @@ jobs:
   rerun_pr_tests:
     name: rerun_pr_tests
     if: ${{ github.event.issue.pull_request }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: hbelmiro/rerun-actions@01c46bec8d69a84b217e3deb104ef24994c2beee # https://github.com/hbelmiro/rerun-actions/releases/tag/v0.4.0
       with:


### PR DESCRIPTION
**Description of your changes:**
`ubuntu-20.04` is going to be deprecated this month.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
