### PR TITLE
Handle optional pipeline inputs in the driver

### DIFF
--- a/backend/src/v2/compiler/argocompiler/argo.go
+++ b/backend/src/v2/compiler/argocompiler/argo.go
@@ -72,8 +72,12 @@ func Compile(jobArg *pipelinespec.PipelineJob, kubernetesSpecArg *pipelinespec.S
 	specParams := spec.GetRoot().GetInputDefinitions().GetParameters()
 	for name, param := range specParams {
 		_, ok := job.RuntimeConfig.ParameterValues[name]
-		if !ok && param.GetDefaultValue() != nil {
-			job.RuntimeConfig.ParameterValues[name] = param.GetDefaultValue()
+		if !ok {
+			if param.GetDefaultValue() != nil {
+				job.RuntimeConfig.ParameterValues[name] = param.GetDefaultValue()
+			} else if param.IsOptional {
+				job.RuntimeConfig.ParameterValues[name] = structpb.NewNullValue()
+			}
 		}
 	}
 

--- a/samples/v2/component_with_optional_inputs.py
+++ b/samples/v2/component_with_optional_inputs.py
@@ -23,6 +23,9 @@ def component_op(
     input_str1: Optional[str] = 'string default value',
     input_str2: Optional[str] = None,
     input_str3: Optional[str] = None,
+    input_str4_from_pipeline: Optional[str] = "Some component default",
+    input_str5_from_pipeline: Optional[str] = "Some component default",
+    input_str6_from_pipeline: Optional[str] = None,
     input_bool1: Optional[bool] = True,
     input_bool2: Optional[bool] = None,
     input_dict: Optional[Dict[str, int]] = {"a": 1},
@@ -32,6 +35,9 @@ def component_op(
     print(f'input_str1: {input_str1}, type: {type(input_str1)}')
     print(f'input_str2: {input_str2}, type: {type(input_str2)}')
     print(f'input_str3: {input_str3}, type: {type(input_str3)}')
+    print(f'input_str4_from_pipeline: {input_str4_from_pipeline}, type: {type(input_str4_from_pipeline)}')
+    print(f'input_str5_from_pipeline: {input_str5_from_pipeline}, type: {type(input_str5_from_pipeline)}')
+    print(f'input_str6_from_pipeline: {input_str6_from_pipeline}, type: {type(input_str6_from_pipeline)}')
     print(f'input_bool1: {input_bool1}, type: {type(input_bool1)}')
     print(f'input_bool2: {input_bool2}, type: {type(input_bool2)}')
     print(f'input_bool: {input_dict}, type: {type(input_dict)}')
@@ -40,10 +46,13 @@ def component_op(
 
 
 @dsl.pipeline(name='v2-component-optional-input')
-def pipeline():
+def pipeline(input_str4: Optional[str] = None, input_str5: Optional[str] = "Some pipeline default", input_str6: Optional[str] = None):
     component_op(
         input_str1='Hello',
         input_str2='World',
+        input_str4_from_pipeline=input_str4,
+        input_str5_from_pipeline=input_str5,
+        input_str6_from_pipeline=input_str6,
     )
 
 

--- a/samples/v2/component_with_optional_inputs_test.py
+++ b/samples/v2/component_with_optional_inputs_test.py
@@ -38,6 +38,7 @@ def verify(t: unittest.TestCase, run: kfp_server_api.ApiRun,
                 'parameters': {
                     'input_str1': 'Hello',
                     'input_str2': 'World',
+                    'input_str5_from_pipeline': 'Some pipeline default',
                 },
             },
             'outputs': {},


### PR DESCRIPTION
If the pipeline run is submitted without specifying an optional parameter and there is no default, it was not handled by the driver. The approach taken is explicitly set null for these values and let the driver handle if the component parameter has a default that can be used.

**Description of your changes:**


**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
