### PR TITLE
fix(local): warn about oci:// not supported too

### DIFF
--- a/sdk/python/kfp/dsl/types/artifact_types.py
+++ b/sdk/python/kfp/dsl/types/artifact_types.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Classes and utilities for using and creating artifacts in components."""
 
+import enum
 import os
 from typing import Dict, List, Optional, Type
 import warnings
@@ -22,10 +23,12 @@ _MINIO_LOCAL_MOUNT_PREFIX = '/minio/'
 _S3_LOCAL_MOUNT_PREFIX = '/s3/'
 _OCI_LOCAL_MOUNT_PREFIX = '/oci/'
 
-GCS_REMOTE_PREFIX = 'gs://'
-MINIO_REMOTE_PREFIX = 'minio://'
-S3_REMOTE_PREFIX = 's3://'
-OCI_REMOTE_PREFIX = 'oci://'
+
+class RemotePrefix(enum.Enum):
+    GCS = 'gs://'
+    MINIO = 'minio://'
+    S3 = 's3://'
+    OCI = 'oci://'
 
 
 class Artifact:
@@ -89,16 +92,18 @@ class Artifact:
         self._set_path(path)
 
     def _get_path(self) -> Optional[str]:
-        if self.uri.startswith(GCS_REMOTE_PREFIX):
-            return _GCS_LOCAL_MOUNT_PREFIX + self.uri[len(GCS_REMOTE_PREFIX):]
-        elif self.uri.startswith(MINIO_REMOTE_PREFIX):
-            return _MINIO_LOCAL_MOUNT_PREFIX + self.uri[len(MINIO_REMOTE_PREFIX
-                                                           ):]
-        elif self.uri.startswith(S3_REMOTE_PREFIX):
-            return _S3_LOCAL_MOUNT_PREFIX + self.uri[len(S3_REMOTE_PREFIX):]
-
-        elif self.uri.startswith(OCI_REMOTE_PREFIX):
-            escaped_uri = self.uri[len(OCI_REMOTE_PREFIX):].replace('/', '_')
+        if self.uri.startswith(RemotePrefix.GCS.value):
+            return _GCS_LOCAL_MOUNT_PREFIX + self.uri[len(RemotePrefix.GCS.value
+                                                         ):]
+        if self.uri.startswith(RemotePrefix.MINIO.value):
+            return _MINIO_LOCAL_MOUNT_PREFIX + self.uri[len(RemotePrefix.MINIO
+                                                            .value):]
+        if self.uri.startswith(RemotePrefix.S3.value):
+            return _S3_LOCAL_MOUNT_PREFIX + self.uri[len(RemotePrefix.S3.value
+                                                        ):]
+        if self.uri.startswith(RemotePrefix.OCI.value):
+            escaped_uri = self.uri[len(RemotePrefix.OCI.value):].replace(
+                '/', '_')
             return _OCI_LOCAL_MOUNT_PREFIX + escaped_uri
         # uri == path for local execution
         return self.uri
@@ -109,17 +114,17 @@ class Artifact:
 
 def convert_local_path_to_remote_path(path: str) -> str:
     if path.startswith(_GCS_LOCAL_MOUNT_PREFIX):
-        return GCS_REMOTE_PREFIX + path[len(_GCS_LOCAL_MOUNT_PREFIX):]
+        return RemotePrefix.GCS.value + path[len(_GCS_LOCAL_MOUNT_PREFIX):]
     elif path.startswith(_MINIO_LOCAL_MOUNT_PREFIX):
-        return MINIO_REMOTE_PREFIX + path[len(_MINIO_LOCAL_MOUNT_PREFIX):]
+        return RemotePrefix.MINIO.value + path[len(_MINIO_LOCAL_MOUNT_PREFIX):]
     elif path.startswith(_S3_LOCAL_MOUNT_PREFIX):
-        return S3_REMOTE_PREFIX + path[len(_S3_LOCAL_MOUNT_PREFIX):]
+        return RemotePrefix.S3.value + path[len(_S3_LOCAL_MOUNT_PREFIX):]
     elif path.startswith(_OCI_LOCAL_MOUNT_PREFIX):
         remote_path = path[len(_OCI_LOCAL_MOUNT_PREFIX):].replace('_', '/')
         if remote_path.endswith("/models"):
             remote_path = remote_path[:-len("/models")]
 
-        return OCI_REMOTE_PREFIX + remote_path
+        return RemotePrefix.OCI.value + remote_path
 
     return path
 

--- a/sdk/python/kfp/local/importer_handler.py
+++ b/sdk/python/kfp/local/importer_handler.py
@@ -124,9 +124,9 @@ def get_importer_uri(
         raise ValueError(
             f'Got unknown value of artifact_uri: {value_or_runtime_param}')
 
-    if uri.startswith(artifact_types.GCS_REMOTE_PREFIX) or uri.startswith(
-            artifact_types.S3_REMOTE_PREFIX) or uri.startswith(
-                artifact_types.MINIO_REMOTE_PREFIX):
+    if any(
+            uri.startswith(prefix)
+            for prefix in [p.value for p in artifact_types.RemotePrefix]):
         warnings.warn(
             f"It looks like you're using the remote file '{uri}' in a 'dsl.importer'. Note that you will only be able to read and write to/from local files using 'artifact.path' in local executed pipelines."
         )


### PR DESCRIPTION
**Description of your changes:**

Warn about oci:// not supported too.

AFAIU no remote schema is currently supported for Local. This patch
consolidates all possible values under an Enum and then checks the
supplied url against all possible prefixes.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
