### PR TITLE
docs: mention that `set_container_image` works with dynamic images

### DIFF
--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -642,11 +642,17 @@ class PipelineTask:
             self,
             name: Union[str,
                         pipeline_channel.PipelineChannel]) -> 'PipelineTask':
-        """Sets container  type to use when executing this task. Takes
-        precedence over @component(base_image=...)
+        """Sets the container image to use when executing this task.
+
+        Takes precedence over the `base_image` specified in the `@component` decorator.
+
+        Unlike `base_image`, this method supports dynamic values such as
+        Pipeline Parameters or outputs from previous tasks, which are resolved at runtime.
 
         Args:
-            name: The name of the image, e.g. "python:3.9-alpine".
+            name: The container image name as a static string (e.g., "python:3.9-alpine")
+                or a dynamic reference (e.g., a PipelineParameter instance or
+                a task output like `task.outputs['image_name']`).
 
         Returns:
             Self return to allow chained setting calls.


### PR DESCRIPTION
Adds some missing info to the docs on `set_container_image`, clarifying that dynamic images can be used.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
