### PR TITLE
fix(tests): free up space in some test runners

### DIFF
--- a/.github/workflows/kfp-kubernetes-execution-tests.yml
+++ b/.github/workflows/kfp-kubernetes-execution-tests.yml
@@ -31,10 +31,17 @@ jobs:
         with:
           python-version: '3.9'
 
+      # This is intended to address disk space issues that have surfaced
+      # intermittently during CI -
+      # https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
       - name: Free up space in /dev/root
         run: |
+            echo "Disk usage before clean up:"
+            df -h
             sudo rm -rf /usr/share/dotnet
             sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+            echo "Disk usage after clean up:"
+            df -h
 
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster

--- a/.github/workflows/kfp-kubernetes-execution-tests.yml
+++ b/.github/workflows/kfp-kubernetes-execution-tests.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           python-version: '3.9'
 
+      - name: Free up space in /dev/root
+        run: |
+            sudo rm -rf /usr/share/dotnet
+            sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster
         with:

--- a/.github/workflows/sdk-execution.yml
+++ b/.github/workflows/sdk-execution.yml
@@ -30,10 +30,17 @@ jobs:
         with:
           python-version: 3.9
 
+      # This is intended to address disk space issues that have surfaced
+      # intermittently during CI -
+      # https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
       - name: Free up space in /dev/root
         run: |
+            echo "Disk usage before clean up:"
+            df -h
             sudo rm -rf /usr/share/dotnet
             sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+            echo "Disk usage after clean up:"
+            df -h
 
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster

--- a/.github/workflows/sdk-execution.yml
+++ b/.github/workflows/sdk-execution.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: Free up space in /dev/root
+        run: |
+            sudo rm -rf /usr/share/dotnet
+            sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster
         with:


### PR DESCRIPTION
**Description of your changes:**

This PR follows a suggestion documented [here](https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930) to free up 8GB of space on `/dev/root` on the sdk execution test runners. This is intended to address disk space issues that have surfaced intermittently during CI.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
