### PR TITLE
chore: Enable go fmt as a lint check for Go code

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,21 @@
+name: pre-commit
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.1
+      # This is set to only run the golangci-lint pre-commit hooks 
+      # Remove in a later PR to run all hooks
+      with:
+        extra_args: golangci-lint --all-files

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,5 @@
+version: "2"
+
 run:
   timeout: 30m
   skip-files:
@@ -11,17 +13,20 @@ linters:
   disable-all: true
   enable: # please keep this alphabetized
     - gocritic
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - staticcheck
-    - stylecheck
     - unused
+  settings:
+    misspell:
+      locale: US
+    staticcheck:
+      checks:
+        - "all"
 
-linters-settings: # please keep this alphabetized
-  misspell:
-    locale: US
-  staticcheck:
-    checks:
-      - "all"
+formatters:
+  disable-all: true
+  enable:
+    - gofmt
+    - goimports

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
   # add comment "noqa" to ignore an import that should not be removed
   # (e.g., for an import with desired side-effects)
   - repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.1
+    rev: v2.5.0
     hooks:
       - id: pycln
         name: pycln
@@ -43,7 +43,7 @@ repos:
     hooks:
       - id: yapf
   - repo: https://github.com/pycqa/docformatter
-    rev: v1.4
+    rev: v1.7.7
     hooks:
       - id: docformatter
         name: docformatter
@@ -55,12 +55,20 @@ repos:
 
   # Golang pre-submit hooks
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.64.8
+    rev: v2.1.2
     hooks:
       - id: golangci-lint
         name: golangci-lint
         description: Fast linters runner for Go.
         entry: golangci-lint run --new-from-rev HEAD --fix
+        types: [go]
+        language: golang
+        require_serial: true
+        pass_filenames: false
+      - id: golangci-lint
+        name: golangci-lint fmt
+        description: Formatter for Go.
+        entry: golangci-lint fmt
         types: [go]
         language: golang
         require_serial: true

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -108,3 +108,14 @@ kind-load-driver-debug:
 
 .PHONY: kind-build-and-load-driver-debug
 kind-build-and-load-driver-debug: image_driver_debug kind-load-driver-debug
+
+.PHONY: lint-and-format
+lint-and-format: lint format
+
+.PHONY: lint
+lint:
+	golangci-lint run --new-from-rev HEAD --fix
+
+.PHONY: format
+format:
+	golangci-lint fmt

--- a/backend/src/agent/persistence/client/token_refresher.go
+++ b/backend/src/agent/persistence/client/token_refresher.go
@@ -1,10 +1,11 @@
 package client
 
 import (
-	log "github.com/sirupsen/logrus"
 	"os"
 	"sync"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type TokenRefresherInterface interface {

--- a/backend/src/agent/persistence/worker/metrics_reporter_test.go
+++ b/backend/src/agent/persistence/worker/metrics_reporter_test.go
@@ -46,7 +46,7 @@ func TestReportMetrics_NoCompletedNode_NoOP(t *testing.T) {
 		},
 		Status: workflowapi.WorkflowStatus{
 			Nodes: map[string]workflowapi.NodeStatus{
-				"node-1": workflowapi.NodeStatus{
+				"node-1": {
 					ID:           "node-1",
 					TemplateName: "template-1",
 					Phase:        workflowapi.NodeRunning,
@@ -72,7 +72,7 @@ func TestReportMetrics_NoRunID_NoOP(t *testing.T) {
 		},
 		Status: workflowapi.WorkflowStatus{
 			Nodes: map[string]workflowapi.NodeStatus{
-				"node-1": workflowapi.NodeStatus{
+				"node-1": {
 					ID:    "node-1",
 					Phase: workflowapi.NodeSucceeded,
 				},
@@ -99,7 +99,7 @@ func TestReportMetrics_NoArtifact_NoOP(t *testing.T) {
 		},
 		Status: workflowapi.WorkflowStatus{
 			Nodes: map[string]workflowapi.NodeStatus{
-				"node-1": workflowapi.NodeStatus{
+				"node-1": {
 					ID:           "node-1",
 					TemplateName: "template-1",
 					Phase:        workflowapi.NodeSucceeded,
@@ -127,7 +127,7 @@ func TestReportMetrics_NoMetricsArtifact_NoOP(t *testing.T) {
 		},
 		Status: workflowapi.WorkflowStatus{
 			Nodes: map[string]workflowapi.NodeStatus{
-				"node-1": workflowapi.NodeStatus{
+				"node-1": {
 					ID:           "node-1",
 					TemplateName: "template-1",
 					Phase:        workflowapi.NodeSucceeded,
@@ -156,7 +156,7 @@ func TestReportMetrics_Succeed(t *testing.T) {
 		},
 		Status: workflowapi.WorkflowStatus{
 			Nodes: map[string]workflowapi.NodeStatus{
-				"node-1": workflowapi.NodeStatus{
+				"node-1": {
 					ID:           "node-1",
 					TemplateName: "template-1",
 					Phase:        workflowapi.NodeSucceeded,
@@ -220,7 +220,7 @@ func TestReportMetrics_EmptyArchive_Fail(t *testing.T) {
 		},
 		Status: workflowapi.WorkflowStatus{
 			Nodes: map[string]workflowapi.NodeStatus{
-				"node-1": workflowapi.NodeStatus{
+				"node-1": {
 					ID:           "node-1",
 					TemplateName: "template-1",
 					Phase:        workflowapi.NodeSucceeded,
@@ -262,7 +262,7 @@ func TestReportMetrics_MultipleFilesInArchive_Fail(t *testing.T) {
 		},
 		Status: workflowapi.WorkflowStatus{
 			Nodes: map[string]workflowapi.NodeStatus{
-				"node-1": workflowapi.NodeStatus{
+				"node-1": {
 					ID:           "MY_NAME-template-1-1",
 					TemplateName: "template-1",
 					Phase:        workflowapi.NodeSucceeded,
@@ -306,7 +306,7 @@ func TestReportMetrics_InvalidMetricsJSON_Fail(t *testing.T) {
 		},
 		Status: workflowapi.WorkflowStatus{
 			Nodes: map[string]workflowapi.NodeStatus{
-				"node-1": workflowapi.NodeStatus{
+				"node-1": {
 					ID:           "node-1",
 					TemplateName: "template-1",
 					Phase:        workflowapi.NodeSucceeded,
@@ -349,7 +349,7 @@ func TestReportMetrics_InvalidMetricsJSON_PartialFail(t *testing.T) {
 		},
 		Status: workflowapi.WorkflowStatus{
 			Nodes: map[string]workflowapi.NodeStatus{
-				"node-1": workflowapi.NodeStatus{
+				"node-1": {
 					ID:           "node-1",
 					TemplateName: "template-1",
 					Phase:        workflowapi.NodeSucceeded,
@@ -357,7 +357,7 @@ func TestReportMetrics_InvalidMetricsJSON_PartialFail(t *testing.T) {
 						Artifacts: []workflowapi.Artifact{{Name: "mlpipeline-metrics"}},
 					},
 				},
-				"node-2": workflowapi.NodeStatus{
+				"node-2": {
 					ID:           "node-2",
 					TemplateName: "template-2",
 					Phase:        workflowapi.NodeSucceeded,
@@ -400,12 +400,12 @@ func TestReportMetrics_InvalidMetricsJSON_PartialFail(t *testing.T) {
 	expectedMetricsRequest := &api.ReportRunMetricsRequest{
 		RunId: "run-1",
 		Metrics: []*api.RunMetric{
-			&api.RunMetric{
+			{
 				Name:   "accuracy",
 				NodeId: "MY_NAME-template-2-2",
 				Value:  &api.RunMetric_NumberValue{NumberValue: 0.77},
 			},
-			&api.RunMetric{
+			{
 				Name:   "logloss",
 				NodeId: "MY_NAME-template-2-2",
 				Value:  &api.RunMetric_NumberValue{NumberValue: 1.2},
@@ -432,7 +432,7 @@ func TestReportMetrics_CorruptedArchiveFile_Fail(t *testing.T) {
 		},
 		Status: workflowapi.WorkflowStatus{
 			Nodes: map[string]workflowapi.NodeStatus{
-				"node-1": workflowapi.NodeStatus{
+				"node-1": {
 					ID:           "node-1",
 					TemplateName: "template-1",
 					Phase:        workflowapi.NodeSucceeded,
@@ -473,7 +473,7 @@ func TestReportMetrics_MultiplMetricErrors_TransientErrowWin(t *testing.T) {
 		},
 		Status: workflowapi.WorkflowStatus{
 			Nodes: map[string]workflowapi.NodeStatus{
-				"node-1": workflowapi.NodeStatus{
+				"node-1": {
 					ID:           "node-1",
 					TemplateName: "template-1",
 					Phase:        workflowapi.NodeSucceeded,
@@ -498,19 +498,19 @@ func TestReportMetrics_MultiplMetricErrors_TransientErrowWin(t *testing.T) {
 		})
 	pipelineFake.StubReportRunMetrics(&api.ReportRunMetricsResponse{
 		Results: []*api.ReportRunMetricsResponse_ReportRunMetricResult{
-			&api.ReportRunMetricsResponse_ReportRunMetricResult{
+			{
 				MetricNodeId: "node-1",
 				MetricName:   "accuracy",
 				Status:       api.ReportRunMetricsResponse_ReportRunMetricResult_OK,
 			},
 			// Invalid argument error triggers permanent error
-			&api.ReportRunMetricsResponse_ReportRunMetricResult{
+			{
 				MetricNodeId: "node-1",
 				MetricName:   "log loss",
 				Status:       api.ReportRunMetricsResponse_ReportRunMetricResult_INVALID_ARGUMENT,
 			},
 			// Internal error triggers transient error
-			&api.ReportRunMetricsResponse_ReportRunMetricResult{
+			{
 				MetricNodeId: "node-1",
 				MetricName:   "accuracy",
 				Status:       api.ReportRunMetricsResponse_ReportRunMetricResult_INTERNAL_ERROR,
@@ -537,7 +537,7 @@ func TestReportMetrics_Unauthorized(t *testing.T) {
 		},
 		Status: workflowapi.WorkflowStatus{
 			Nodes: map[string]workflowapi.NodeStatus{
-				"node-1": workflowapi.NodeStatus{
+				"node-1": {
 					ID:           "node-1",
 					TemplateName: "template-1",
 					Phase:        workflowapi.NodeSucceeded,

--- a/backend/src/apiserver/config/config.go
+++ b/backend/src/apiserver/config/config.go
@@ -17,6 +17,9 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
@@ -25,8 +28,6 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/apiserver/server"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"google.golang.org/grpc/codes"
-	"os"
-	"time"
 )
 
 // deprecated

--- a/backend/src/apiserver/config/config_test.go
+++ b/backend/src/apiserver/config/config_test.go
@@ -16,6 +16,10 @@ package config
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/kubeflow/pipelines/backend/src/apiserver/list"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
@@ -24,9 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 func fakeResourceManager() *resource.ResourceManager {

--- a/backend/src/apiserver/config/proxy/config.go
+++ b/backend/src/apiserver/config/proxy/config.go
@@ -14,8 +14,9 @@
 package proxy
 
 import (
-	k8score "k8s.io/api/core/v1"
 	"os"
+
+	k8score "k8s.io/api/core/v1"
 )
 
 const (

--- a/backend/src/apiserver/config/proxy/config_test.go
+++ b/backend/src/apiserver/config/proxy/config_test.go
@@ -15,11 +15,12 @@ package proxy
 
 import (
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k8score "k8s.io/api/core/v1"
-	"os"
-	"testing"
 )
 
 func TestNewConfigFromEnvVars(t *testing.T) {

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	scheduledworkflow "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
 	"io"
 	"net"
 	"reflect"
 	"strconv"
+
+	scheduledworkflow "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
 
 	"github.com/cenkalti/backoff"
 	"github.com/golang/glog"

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -18,10 +18,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/util/file"

--- a/backend/src/apiserver/server/experiment_server_test.go
+++ b/backend/src/apiserver/server/experiment_server_test.go
@@ -16,10 +16,11 @@ package server
 
 import (
 	"context"
-	"google.golang.org/protobuf/types/known/structpb"
-	"sigs.k8s.io/yaml"
 	"strings"
 	"testing"
+
+	"google.golang.org/protobuf/types/known/structpb"
+	"sigs.k8s.io/yaml"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/go-cmp/cmp"

--- a/backend/src/apiserver/server/fakes_test.go
+++ b/backend/src/apiserver/server/fakes_test.go
@@ -16,8 +16,9 @@ package server
 
 import (
 	"context"
-	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 	"testing"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	apiv1beta1 "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"

--- a/backend/src/apiserver/server/report_server.go
+++ b/backend/src/apiserver/server/report_server.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	authorizationv1 "k8s.io/api/authorization/v1"
 

--- a/backend/src/apiserver/server/run_server_test.go
+++ b/backend/src/apiserver/server/run_server_test.go
@@ -1650,11 +1650,11 @@ func TestRetryRun(t *testing.T) {
 
 	// Test all parameters types converted to model.RuntimeConfig.Parameters, which is string type
 	v2RuntimeParams := map[string]*structpb.Value{
-		"param1": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "world"}},
-		"param2": &structpb.Value{Kind: &structpb.Value_BoolValue{BoolValue: true}},
-		"param3": &structpb.Value{Kind: &structpb.Value_ListValue{ListValue: v2RuntimeListParams}},
-		"param4": &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: 12}},
-		"param5": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: v2RuntimeStructParams}},
+		"param1": {Kind: &structpb.Value_StringValue{StringValue: "world"}},
+		"param2": {Kind: &structpb.Value_BoolValue{BoolValue: true}},
+		"param3": {Kind: &structpb.Value_ListValue{ListValue: v2RuntimeListParams}},
+		"param4": {Kind: &structpb.Value_NumberValue{NumberValue: 12}},
+		"param5": {Kind: &structpb.Value_StructValue{StructValue: v2RuntimeStructParams}},
 	}
 
 	pipelineSpecStruct := &structpb.Struct{}

--- a/backend/src/apiserver/storage/default_experiment_store_test.go
+++ b/backend/src/apiserver/storage/default_experiment_store_test.go
@@ -15,8 +15,9 @@
 package storage
 
 import (
-	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"testing"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/backend/src/apiserver/storage/job_store_test.go
+++ b/backend/src/apiserver/storage/job_store_test.go
@@ -15,9 +15,10 @@
 package storage
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	"testing"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/filter"

--- a/backend/src/apiserver/storage/pipeline_store.go
+++ b/backend/src/apiserver/storage/pipeline_store.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"database/sql"
 	"fmt"
+
 	sq "github.com/Masterminds/squirrel"
 	"github.com/golang/glog"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/list"

--- a/backend/src/apiserver/template/template_test.go
+++ b/backend/src/apiserver/template/template_test.go
@@ -16,11 +16,12 @@ package template
 
 import (
 	"encoding/json"
-	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"

--- a/backend/src/apiserver/template/v2_template.go
+++ b/backend/src/apiserver/template/v2_template.go
@@ -374,7 +374,7 @@ func (t *V2Spec) validatePipelineJobInputs(job *pipelinespec.PipelineJob) error 
 	if runtimeConfig == nil {
 		if len(requiredParams) != 0 {
 			requiredParamNames := make([]string, 0)
-			for name, _ := range requiredParams {
+			for name := range requiredParams {
 				requiredParamNames = append(requiredParamNames, name)
 			}
 			return util.NewInvalidInputError(
@@ -436,7 +436,7 @@ func (t *V2Spec) validatePipelineJobInputs(job *pipelinespec.PipelineJob) error 
 
 	// Verify that only required parameters are provided
 	extraParams := make([]string, 0)
-	for name, _ := range runtimeConfig.GetParameterValues() {
+	for name := range runtimeConfig.GetParameterValues() {
 		if _, ok := requiredParams[name]; !ok {
 			extraParams = append(extraParams, name)
 		}

--- a/backend/src/cache/client_manager.go
+++ b/backend/src/cache/client_manager.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"encoding/json"
+
 	"github.com/cenkalti/backoff"
 	"github.com/golang/glog"
 	"github.com/jinzhu/gorm"

--- a/backend/src/common/client/api_server/v1/pipeline_client_fake.go
+++ b/backend/src/common/client/api_server/v1/pipeline_client_fake.go
@@ -42,7 +42,7 @@ func getDefaultPipeline(id string) *pipelinemodel.APIPipeline {
 		Description: "PIPELINE_DESCRIPTION",
 		ID:          id,
 		Name:        "PIPELINE_NAME",
-		Parameters: []*pipelinemodel.APIParameter{&pipelinemodel.APIParameter{
+		Parameters: []*pipelinemodel.APIParameter{{
 			Name:  "PARAM_NAME",
 			Value: "PARAM_VALUE",
 		}},

--- a/backend/src/common/client/api_server/v1/pipeline_upload_client_fake.go
+++ b/backend/src/common/client/api_server/v1/pipeline_upload_client_fake.go
@@ -36,7 +36,7 @@ func getDefaultUploadedPipeline() *model.APIPipeline {
 		CreatedAt:   strfmt.NewDateTime(),
 		Name:        "PIPELINE_NAME",
 		Description: "PIPELINE_DESCRIPTION",
-		Parameters: []*model.APIParameter{&model.APIParameter{
+		Parameters: []*model.APIParameter{{
 			Name:  "PARAM_NAME",
 			Value: "PARAM_VALUE",
 		}},

--- a/backend/src/common/util/json.go
+++ b/backend/src/common/util/json.go
@@ -18,9 +18,10 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 
 	"encoding/json"
+	"strings"
+
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
-	"strings"
 )
 
 func UnmarshalJsonOrFail(data string, v interface{}) {

--- a/backend/src/common/util/scheduled_workflow_test.go
+++ b/backend/src/common/util/scheduled_workflow_test.go
@@ -16,9 +16,10 @@ package util
 
 import (
 	"encoding/json"
-	corev1 "k8s.io/api/core/v1"
 	"testing"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	workflowapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"

--- a/backend/src/crd/controller/scheduledworkflow/util/scheduled_workflow_test.go
+++ b/backend/src/crd/controller/scheduledworkflow/util/scheduled_workflow_test.go
@@ -16,11 +16,12 @@ package util
 
 import (
 	"encoding/json"
-	corev1 "k8s.io/api/core/v1"
 	"math"
 	"strconv"
 	"testing"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	workflowapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	commonutil "github.com/kubeflow/pipelines/backend/src/common/util"

--- a/backend/src/crd/controller/viewer/main.go
+++ b/backend/src/crd/controller/viewer/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"log"
+
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"github.com/golang/glog"

--- a/backend/src/crd/controller/viewer/reconciler/reconciler_test.go
+++ b/backend/src/crd/controller/viewer/reconciler/reconciler_test.go
@@ -253,9 +253,9 @@ func TestReconcile_ViewerUsesSpecifiedVolumeMountsForDeployment(t *testing.T) {
 			PodTemplateSpec: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
-						corev1.Container{
+						{
 							VolumeMounts: []corev1.VolumeMount{
-								corev1.VolumeMount{
+								{
 									Name:      "/volume-mount-name",
 									MountPath: "/mount/path",
 								},
@@ -263,7 +263,7 @@ func TestReconcile_ViewerUsesSpecifiedVolumeMountsForDeployment(t *testing.T) {
 						},
 					},
 					Volumes: []corev1.Volume{
-						corev1.Volume{
+						{
 							Name: "/volume-mount-name",
 							VolumeSource: corev1.VolumeSource{
 								GCEPersistentDisk: &corev1.GCEPersistentDiskVolumeSource{
@@ -403,7 +403,7 @@ func TestReconcile_EachViewerCreatesAService(t *testing.T) {
 				"viewer": "viewer-123",
 			}},
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{corev1.ServicePort{
+			Ports: []corev1.ServicePort{{
 				Name:       "http",
 				Protocol:   corev1.ProtocolTCP,
 				Port:       int32(80),

--- a/backend/src/crd/kubernetes/v2beta1/pipelineversion_types.go
+++ b/backend/src/crd/kubernetes/v2beta1/pipelineversion_types.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"gopkg.in/yaml.v3"

--- a/backend/src/v2/cacheutils/cache.go
+++ b/backend/src/v2/cacheutils/cache.go
@@ -210,7 +210,7 @@ func (c *client) GenerateCacheKey(
 		cacheKey.OutputArtifactsSpec[outputArtifactName] = &outputArtifactWithUriWiped
 	}
 
-	for outputParameterName, _ := range outputs.GetParameters() {
+	for outputParameterName := range outputs.GetParameters() {
 		outputParameterType, ok := outputParametersTypeMap[outputParameterName]
 		if !ok {
 			return nil, fmt.Errorf("unknown parameter %q found in ExecutorInput_Outputs", outputParameterName)

--- a/backend/src/v2/cacheutils/cache_test.go
+++ b/backend/src/v2/cacheutils/cache_test.go
@@ -3,8 +3,9 @@ package cacheutils
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/backend/src/v2/cmd/compiler/main.go
+++ b/backend/src/v2/cmd/compiler/main.go
@@ -16,13 +16,14 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+
 	"github.com/golang/glog"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/v2/compiler/argocompiler"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
-	"os"
 	"sigs.k8s.io/yaml"
 )
 

--- a/backend/src/v2/cmd/driver/main_test.go
+++ b/backend/src/v2/cmd/driver/main_test.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"os"
+	"testing"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/kubeflow/pipelines/backend/src/v2/driver"
 	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
 )
 
 func strPtr(s string) *string {

--- a/backend/src/v2/cmd/launcher-v2/main.go
+++ b/backend/src/v2/cmd/launcher-v2/main.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/kubeflow/pipelines/backend/src/v2/component"
 	"github.com/kubeflow/pipelines/backend/src/v2/config"

--- a/backend/src/v2/compiler/argocompiler/argo.go
+++ b/backend/src/v2/compiler/argocompiler/argo.go
@@ -19,8 +19,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"strings"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 
 	wfapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"

--- a/backend/src/v2/compiler/argocompiler/argo_test.go
+++ b/backend/src/v2/compiler/argocompiler/argo_test.go
@@ -17,10 +17,11 @@ package argocompiler_test
 import (
 	"flag"
 	"fmt"
-	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 
 	wfapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/google/go-cmp/cmp"

--- a/backend/src/v2/compiler/argocompiler/dag.go
+++ b/backend/src/v2/compiler/argocompiler/dag.go
@@ -15,10 +15,11 @@ package argocompiler
 
 import (
 	"fmt"
-	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 	"os"
 	"sort"
 	"strings"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 
 	wfapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"

--- a/backend/src/v2/compiler/argocompiler/importer.go
+++ b/backend/src/v2/compiler/argocompiler/importer.go
@@ -16,11 +16,12 @@ package argocompiler
 
 import (
 	"fmt"
+	"os"
+
 	wfapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/v2/component"
 	k8score "k8s.io/api/core/v1"
-	"os"
 )
 
 func (c *workflowCompiler) Importer(name string, componentSpec *pipelinespec.ComponentSpec, importer *pipelinespec.PipelineDeploymentConfig_ImporterSpec) error {

--- a/backend/src/v2/config/env_test.go
+++ b/backend/src/v2/config/env_test.go
@@ -16,11 +16,12 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
 	"github.com/stretchr/testify/assert"
-	"os"
 	"sigs.k8s.io/yaml"
-	"testing"
 )
 
 type TestcaseData struct {

--- a/backend/src/v2/config/gcs.go
+++ b/backend/src/v2/config/gcs.go
@@ -16,9 +16,10 @@ package config
 
 import (
 	"fmt"
-	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
 	"strconv"
 	"strings"
+
+	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
 )
 
 type GCSProviderConfig struct {

--- a/backend/src/v2/config/s3.go
+++ b/backend/src/v2/config/s3.go
@@ -16,9 +16,10 @@ package config
 
 import (
 	"fmt"
-	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
 	"strconv"
 	"strings"
+
+	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
 )
 
 type S3ProviderConfig struct {

--- a/backend/src/v2/driver/cache.go
+++ b/backend/src/v2/driver/cache.go
@@ -17,14 +17,15 @@ package driver
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
 	"github.com/kubeflow/pipelines/backend/src/v2/cacheutils"
 	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
-	"strconv"
-	"time"
 )
 
 func collectOutputArtifactMetadataFromCache(ctx context.Context, executorInput *pipelinespec.ExecutorInput, cachedMLMDExecutionID int64, mlmd *metadata.Client) ([]*metadata.OutputArtifact, error) {

--- a/backend/src/v2/driver/container.go
+++ b/backend/src/v2/driver/container.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
+
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
@@ -25,7 +27,6 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/v2/expression"
 	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
 	pb "github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata"
-	"strconv"
 )
 
 func validateContainer(opts Options) (err error) {

--- a/backend/src/v2/driver/dag.go
+++ b/backend/src/v2/driver/dag.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/v2/expression"

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -16,9 +16,10 @@ package driver
 
 import (
 	"fmt"
-	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 	"slices"
 	"strings"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/v2/component"

--- a/backend/src/v2/driver/driver_test.go
+++ b/backend/src/v2/driver/driver_test.go
@@ -15,8 +15,9 @@ package driver
 
 import (
 	"encoding/json"
-	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 	"testing"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/spf13/viper"

--- a/backend/src/v2/driver/k8s.go
+++ b/backend/src/v2/driver/k8s.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
@@ -32,7 +34,6 @@ import (
 	k8sres "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"time"
 )
 
 var accessModeMap = map[string]k8score.PersistentVolumeAccessMode{

--- a/backend/src/v2/driver/k8s_test.go
+++ b/backend/src/v2/driver/k8s_test.go
@@ -2,6 +2,8 @@ package driver
 
 import (
 	"context"
+	"testing"
+
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
 	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
@@ -11,7 +13,6 @@ import (
 	k8score "k8s.io/api/core/v1"
 	k8sres "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func Test_makeVolumeMountPatch(t *testing.T) {

--- a/backend/src/v2/driver/resolve.go
+++ b/backend/src/v2/driver/resolve.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/v2/expression"

--- a/backend/src/v2/driver/root_dag.go
+++ b/backend/src/v2/driver/root_dag.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/common/util"

--- a/backend/src/v2/driver/util.go
+++ b/backend/src/v2/driver/util.go
@@ -16,9 +16,10 @@ package driver
 
 import (
 	"fmt"
+	"regexp"
+
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"google.golang.org/protobuf/types/known/structpb"
-	"regexp"
 )
 
 // inputPipelineChannelPattern define a regex pattern to match the content within single quotes

--- a/backend/src/v2/driver/util_test.go
+++ b/backend/src/v2/driver/util_test.go
@@ -15,10 +15,11 @@
 package driver
 
 import (
+	"testing"
+
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/stretchr/testify/assert"
 	structpb "google.golang.org/protobuf/types/known/structpb"
-	"testing"
 )
 
 func Test_isInputParameterChannel(t *testing.T) {

--- a/backend/src/v2/metadata/client_test.go
+++ b/backend/src/v2/metadata/client_test.go
@@ -17,10 +17,11 @@ package metadata_test
 import (
 	"context"
 	"fmt"
-	"github.com/kubeflow/pipelines/backend/src/v2/metadata/testutils"
 	"runtime/debug"
 	"sync"
 	"testing"
+
+	"github.com/kubeflow/pipelines/backend/src/v2/metadata/testutils"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/backend/src/v2/metadata/testutils/test_utils.go
+++ b/backend/src/v2/metadata/testutils/test_utils.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"fmt"
+
 	pb "github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata"
 	"google.golang.org/grpc"
 )

--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -17,6 +17,10 @@ package objectstore
 import (
 	"context"
 	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -24,9 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	"os"
-	"reflect"
-	"testing"
 
 	_ "gocloud.dev/blob/gcsblob"
 )

--- a/backend/test/v2/integration/cache_test.go
+++ b/backend/test/v2/integration/cache_test.go
@@ -3,6 +3,9 @@ package integration
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/golang/glog"
 	uploadParams "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_upload_client/pipeline_upload_service"
 	"github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_upload_model"
@@ -18,8 +21,6 @@ import (
 	pb "github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"testing"
-	"time"
 )
 
 type CacheTestSuite struct {

--- a/backend/test/v2/integration/proxy_test.go
+++ b/backend/test/v2/integration/proxy_test.go
@@ -15,6 +15,9 @@
 package integration
 
 import (
+	"testing"
+	"time"
+
 	"github.com/golang/glog"
 	experimentparams "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/experiment_client/experiment_service"
 	uploadparams "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_upload_client/pipeline_upload_service"
@@ -26,8 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"testing"
-	"time"
 )
 
 type ProxyTestSuite struct {

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
signed off by: Caroline DeVoto <cmdevoto@users.noreply.github.com>
Resolves #11825


**Description of your changes:**
Added `golangci-lint fmt` a pre commit hook with `gofmt` and `goimports` enabled to ensure standard format across Go source files. The `.golangci.yaml` file was also refactored for version 2.

Note that the `pycln` version is updated as well in the `.pre-commit-config.yaml` due to an issue with Python >=3.12 that was fixed in the [v2.2.0](https://github.com/hadialqattan/pycln/releases/tag/v2.2.0) release.


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
