### PR TITLE
feat(backend/sdk): add backend support for toleration lists.

### DIFF
--- a/backend/src/v2/driver/driver_test.go
+++ b/backend/src/v2/driver/driver_test.go
@@ -511,6 +511,7 @@ func Test_initPodSpecPatch_publishLogs(t *testing.T) {
 	}
 
 }
+
 func Test_makeVolumeMountPatch(t *testing.T) {
 	type args struct {
 		pvcMount []*kubernetesplatform.PvcMount
@@ -2132,6 +2133,165 @@ func Test_extendPodSpecPatch_Tolerations(t *testing.T) {
 				}),
 			},
 		},
+		{
+			"Valid - toleration json - toleration list",
+			&kubernetesplatform.KubernetesExecutorConfig{
+				Tolerations: []*kubernetesplatform.Toleration{
+					{
+						TolerationJson: inputParamComponent("param_1"),
+					},
+				},
+			},
+			&k8score.PodSpec{
+				Containers: []k8score.Container{
+					{
+						Name: "main",
+					},
+				},
+				Tolerations: []k8score.Toleration{
+					{
+						Key:               "key1",
+						Operator:          "Equal",
+						Value:             "value1",
+						Effect:            "NoSchedule",
+						TolerationSeconds: int64Ptr(3601),
+					},
+					{
+						Key:               "key2",
+						Operator:          "Equal",
+						Value:             "value2",
+						Effect:            "NoSchedule",
+						TolerationSeconds: int64Ptr(3602),
+					},
+					{
+						Key:               "key3",
+						Operator:          "Equal",
+						Value:             "value3",
+						Effect:            "NoSchedule",
+						TolerationSeconds: int64Ptr(3603),
+					},
+				},
+			},
+			map[string]*structpb.Value{
+				"param_1": validListOfStructsOrPanic([]map[string]interface{}{
+					{
+						"key":               "key1",
+						"operator":          "Equal",
+						"value":             "value1",
+						"effect":            "NoSchedule",
+						"tolerationSeconds": 3601,
+					},
+					{
+						"key":               "key2",
+						"operator":          "Equal",
+						"value":             "value2",
+						"effect":            "NoSchedule",
+						"tolerationSeconds": 3602,
+					},
+					{
+						"key":               "key3",
+						"operator":          "Equal",
+						"value":             "value3",
+						"effect":            "NoSchedule",
+						"tolerationSeconds": 3603,
+					},
+				}),
+			},
+		},
+		{
+			"Valid - toleration json - list toleration & single toleration & constant toleration",
+			&kubernetesplatform.KubernetesExecutorConfig{
+				Tolerations: []*kubernetesplatform.Toleration{
+					{
+						TolerationJson: inputParamComponent("param_1"),
+					},
+					{
+						TolerationJson: inputParamComponent("param_2"),
+					},
+					{
+						Key:      "key5",
+						Operator: "Equal",
+						Value:    "value5",
+						Effect:   "NoSchedule",
+					},
+				},
+			},
+			&k8score.PodSpec{
+				Containers: []k8score.Container{
+					{
+						Name: "main",
+					},
+				},
+				Tolerations: []k8score.Toleration{
+					{
+						Key:               "key1",
+						Operator:          "Equal",
+						Value:             "value1",
+						Effect:            "NoSchedule",
+						TolerationSeconds: int64Ptr(3601),
+					},
+					{
+						Key:               "key2",
+						Operator:          "Equal",
+						Value:             "value2",
+						Effect:            "NoSchedule",
+						TolerationSeconds: int64Ptr(3602),
+					},
+					{
+						Key:               "key3",
+						Operator:          "Equal",
+						Value:             "value3",
+						Effect:            "NoSchedule",
+						TolerationSeconds: int64Ptr(3603),
+					},
+					{
+						Key:               "key4",
+						Operator:          "Equal",
+						Value:             "value4",
+						Effect:            "NoSchedule",
+						TolerationSeconds: int64Ptr(3604),
+					},
+					{
+						Key:      "key5",
+						Operator: "Equal",
+						Value:    "value5",
+						Effect:   "NoSchedule",
+					},
+				},
+			},
+			map[string]*structpb.Value{
+				"param_1": validListOfStructsOrPanic([]map[string]interface{}{
+					{
+						"key":               "key1",
+						"operator":          "Equal",
+						"value":             "value1",
+						"effect":            "NoSchedule",
+						"tolerationSeconds": 3601,
+					},
+					{
+						"key":               "key2",
+						"operator":          "Equal",
+						"value":             "value2",
+						"effect":            "NoSchedule",
+						"tolerationSeconds": 3602,
+					},
+					{
+						"key":               "key3",
+						"operator":          "Equal",
+						"value":             "value3",
+						"effect":            "NoSchedule",
+						"tolerationSeconds": 3603,
+					},
+				}),
+				"param_2": validValueStructOrPanic(map[string]interface{}{
+					"key":               "key4",
+					"operator":          "Equal",
+					"value":             "value4",
+					"effect":            "NoSchedule",
+					"tolerationSeconds": 3604,
+				}),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2609,6 +2769,18 @@ func Test_extendPodSpecPatch_GenericEphemeralVolume(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.podSpec)
 		})
 	}
+}
+
+func validListOfStructsOrPanic(data []map[string]interface{}) *structpb.Value {
+	var listValues []*structpb.Value
+	for _, item := range data {
+		s, err := structpb.NewStruct(item)
+		if err != nil {
+			panic(err)
+		}
+		listValues = append(listValues, structpb.NewStructValue(s))
+	}
+	return structpb.NewListValue(&structpb.ListValue{Values: listValues})
 }
 
 func validValueStructOrPanic(data map[string]interface{}) *structpb.Value {

--- a/kubernetes_platform/python/kfp/kubernetes/toleration.py
+++ b/kubernetes_platform/python/kfp/kubernetes/toleration.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from typing import Optional, Union
 
 from google.protobuf import json_format
@@ -82,21 +81,46 @@ def add_toleration(
 
 
 def add_toleration_json(task: PipelineTask,
-                        toleration_json: Union[pipeline_channel.PipelineParameterChannel, dict]
+                        toleration_json: Union[pipeline_channel.PipelineParameterChannel, list, dict]
                         ):
-    """Add a Pod Toleration in the form of a JSON to a task.
+    """Add a Pod Toleration in the form of a Pipeline Input JSON to a task.
 
     Args:
         task:
             Pipeline task.
         toleration_json:
-            a toleration provided as dict or input parameter. Takes
-            precedence over other key, operator, value, effect,
-            and toleration_seconds.
+            a toleration that is a pipeline input parameter.
+            The input parameter must be of type dict or list.
 
+            If it is a dict, it must be a single toleration object.
+            For example a pipeline input parameter in this case could be:
+                {
+                  "key": "key1",
+                  "operator": "Equal",
+                  "value": "value1",
+                  "effect": "NoSchedule"
+                }
+
+            If it is a list, it must be list of toleration objects.
+            For example a pipeline input parameter in this case could be:
+                [
+                    {
+                      "key": "key1",
+                      "operator": "Equal",
+                      "value": "value1",
+                      "effect": "NoSchedule"
+                    },
+                    {
+                      "key": "key2",
+                      "operator": "Exists",
+                      "effect": "NoExecute"
+                    }
+                ]
     Returns:
         Task object with added toleration.
     """
+    if not isinstance(toleration_json, pipeline_channel.PipelineParameterChannel):
+        raise TypeError("toleration_json must be a Pipeline Input Parameter.")
 
     msg = common.get_existing_kubernetes_config_as_message(task)
     toleration = pb.Toleration()

--- a/kubernetes_platform/python/test/unit/test_tolerations.py
+++ b/kubernetes_platform/python/test/unit/test_tolerations.py
@@ -173,7 +173,7 @@ class TestTolerationsJSON:
         # checks that a pipeline input for
         # tasks is supported
         @dsl.pipeline
-        def my_pipeline(toleration_input: str):
+        def my_pipeline(toleration_input: dict):
             task = comp()
             kubernetes.add_toleration_json(
                 task,
@@ -204,7 +204,7 @@ class TestTolerationsJSON:
         # checks that multiple pipeline inputs for
         # different tasks are supported
         @dsl.pipeline
-        def my_pipeline(toleration_input_1: str, toleration_input_2: str):
+        def my_pipeline(toleration_input_1: dict, toleration_input_2: list):
             t1 = comp()
             kubernetes.add_toleration_json(
                 t1,

--- a/kubernetes_platform/python/test/unit/test_tolerations.py
+++ b/kubernetes_platform/python/test/unit/test_tolerations.py
@@ -254,6 +254,79 @@ class TestTolerationsJSON:
             }
         }
 
+    def test_component_pipeline_input_three(self):
+        # check list or dict types for add
+        # toleration json
+        @dsl.pipeline
+        def my_pipeline(toleration_input: dict):
+            t1 = comp()
+            kubernetes.add_toleration_json(
+                t1,
+                toleration_json=toleration_input,
+            )
+            kubernetes.add_toleration_json(
+                t1,
+                toleration_json={
+                    "key": "key3",
+                    "operator": "Equal",
+                    "value": "value3",
+                    "effect": "NoSchedule"
+                },
+            )
+            kubernetes.add_toleration_json(
+                t1,
+                toleration_json=[
+                    {
+                        "key": "key1",
+                        "operator": "Equal",
+                        "value": "value1",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "key": "key2",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    }
+                ],
+            )
+
+        assert json_format.MessageToDict(my_pipeline.platform_spec) == {
+            'platforms': {
+                'kubernetes': {
+                    'deploymentSpec': {
+                        'executors': {
+                            'exec-comp': {
+                                'tolerations': [
+                                    {
+                                        'tolerationJson': {
+                                            'componentInputParameter': 'toleration_input'
+                                        }
+                                    },
+                                    {
+                                        'key': 'key3',
+                                        'operator': 'Equal',
+                                        'value': 'value3',
+                                        'effect': 'NoSchedule',
+                                    },
+                                    {
+                                        'key': 'key1',
+                                        'operator': 'Equal',
+                                        'value': 'value1',
+                                        'effect': 'NoSchedule',
+                                    },
+                                    {
+                                        'key': 'key2',
+                                        'operator': 'Exists',
+                                        'effect': 'NoExecute',
+                                    },
+                                ]
+                            },
+                        }
+                    }
+                }
+            }
+        }
+
     def test_component_upstream_input_one(self):
         # checks that upstream task input parameters
         # are supported


### PR DESCRIPTION
It is a very reasonable usecase the user may want to provide as input a list of tolerations instead of a single toleration object. In fact, it is probably more preferable that we don't foce the user to add a new input for each new toleration entry for one of more tasks. This PR makes it so the input tolerations_json call will accept both, either a single or list of toleration input parameters. All tolerations, whether hardcoded, input list, input dicts, are appeneded into a flat list by driver.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
