### PR TITLE
switch selenium image to ghcr

### DIFF
--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -84,6 +84,6 @@ API generator image is defined in [Dockerfile](`./Dockerfile`). If you need to u
 1. Login to GHCR container registry: `echo "<PAT>" | docker login ghcr.io -u <USERNAME> --password-stdin` 
    * Replace `<PAT>` with a GitHub Personal Access Token (PAT) with the write:packages and `read:packages` scopes, as well as `delete:packages` if needed. 
 1. Update the [Dockerfile](`./Dockerfile`) and build the image by running `docker build -t ghcr.io/kubeflow/kfp-api-generator:$VERSION .`
-1. Push the new container by running `docker push ghcr.io/kubeflow/kfp-api-generator:$VERSION` (requires to be [authenticated](https://cloud.google.com/container-registry/docs/advanced-authentication)).
+1. Push the new container by running `docker push ghcr.io/kubeflow/kfp-api-generator:$VERSION`.
 1. Update the `PREBUILT_REMOTE_IMAGE` variable in the [Makefile](./Makefile) to point to your new image.
 1. Similarly, push a new version of the release tools image to `ghcr.io/kubeflow/kfp-release:$VERSION` and run `make push` in [test/release/Makefile](../../test/release/Makefile).

--- a/test/frontend-integration-test/Dockerfile
+++ b/test/frontend-integration-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/ml-pipeline-test/selenium-standalone-chrome-gcloud-nodejs:v20230322-2.0.0b11-144-g87e1c5fcf-dirty-2ca4f7
+FROM ghcr.io/kubeflow/kfp-selenium-standalone-chrome-gcloud-nodejs:main-e21bbbaf225dc0d5470df55d6d7254b7e2dd066c
 #To build this image: cd selenium-standalone-chrome-gcloud-nodejs.Docker && make push
 
 COPY --chown=seluser . /src

--- a/test/frontend-integration-test/selenium-standalone-chrome-gcloud-nodejs.Docker/README.md
+++ b/test/frontend-integration-test/selenium-standalone-chrome-gcloud-nodejs.Docker/README.md
@@ -1,0 +1,8 @@
+### Build and Push this image to KFP GHCR
+
+1. Login to GHCR container registry: `echo "<PAT>" | docker login ghcr.io -u <USERNAME> --password-stdin`
+    * Replace `<PAT>` with a GitHub Personal Access Token (PAT) with the write:packages and `read:packages` scopes, as well as `delete:packages` if needed.
+1. Set `TAG=` to `main-<commit-hash>` where `<commit-hash>` is the commit used to build the image on (your current HEAD)/
+1. Update the [Dockerfile](`./Dockerfile`) and build the image by running `docker build -t ghcr.io/kubeflow/kfp-selenium-standalone-chrome-gcloud-nodejs:$TAG .`
+1. Push the new container by running `docker push ghcr.io/kubeflow/kfp-selenium-standalone-chrome-gcloud-nodejs:$TAG`.
+1. Update the version in front end integration [Dockerfile](test/frontend-integration-test/Dockerfile) to point to your new image.


### PR DESCRIPTION
Image is now behind an auth layer 

Resolves: 

```
ERROR: failed to solve: gcr.io/ml-pipeline-test/selenium-standalone-chrome-gcloud-nodejs:v20230322-2.0.0b11-144-g87e1c5fcf-dirty-2ca4f7: failed to resolve source metadata for gcr.io/ml-pipeline-test/selenium-standalone-chrome-gcloud-nodejs:v20230322-2.0.0b11-144-g87e1c5fcf-dirty-2ca4f7: failed to authorize: failed to fetch anonymous token: unexpected status from GET request to https://gcr.io/v2/token?scope=repository%3Aml-pipeline-test%2Fgcr.io%2Fselenium-standalone-chrome-gcloud-nodejs%3Apull&scope=repository%3Aml-pipeline-test%2Fselenium-standalone-chrome-gcloud-nodejs%3Apull&service=gcr.io: 403 Forbidden
```

in ci failures [here](https://github.com/kubeflow/pipelines/actions/runs/14666688041/job/41163106579?pr=11860)