### PR TITLE
fix(sdk): resolve issue when creating pipeline version from pipeline name using the cli. Fixes #11810

### DIFF
--- a/sdk/python/kfp/cli/pipeline.py
+++ b/sdk/python/kfp/cli/pipeline.py
@@ -110,7 +110,6 @@ def create_version(ctx: click.Context,
         pipeline_package_path=package_file,
         pipeline_version_name=pipeline_version,
         pipeline_id=pipeline_id,
-        pipeline_name=pipeline_name,
         description=description)
     output.print_output(
         version,


### PR DESCRIPTION
**Description of your changes:**
When trying to create a new pipeline version using the cli it is checked that not both pipeline id and pipeline name are passed in as parameters. However, in the case of passing in the pipeline name the pipeline id is fetched via the client and then both values are passed to `upload_pipeline_version` defeating the initial check and raising an error.

Simply removing the `pipeline_name` argument from the call to `upload_pipeline_version` fixes this as the `pipeline_id` will always be set.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
