### PR TITLE
fix(backend): Stop logging the strack trace on benign user errors

### DIFF
--- a/backend/src/common/util/error.go
+++ b/backend/src/common/util/error.go
@@ -275,7 +275,7 @@ func (e *UserError) wrap(message string) *UserError {
 func (e *UserError) Log() {
 	switch e.externalStatusCode {
 	case codes.Aborted, codes.InvalidArgument, codes.NotFound, codes.Internal:
-		glog.Infof("%+v", e.internalError)
+		glog.Infof("%v", e.internalError)
 	default:
 		glog.Errorf("%+v", e.internalError)
 	}


### PR DESCRIPTION
**Description of your changes:**

Prior to this change, if a user requested a pipeline version that no longer exists, it'd cause a whole stack trace to be displayed in the logs. For benign errors, this now is a single info log.

Before:

```
I0430 16:22:03.808263 1259085 error.go:278] ResourceNotFoundError: PipelineVersion ecc2da09-e6ee-4417-bb3c-5e909b335542 not found
github.com/kubeflow/pipelines/backend/src/common/util.NewResourceNotFoundError
	/home/mprahl/git/pipelines/backend/src/common/util/error.go:170
github.com/kubeflow/pipelines/backend/src/apiserver/storage.(*PipelineStore).getPipelineVersionByCol
	/home/mprahl/git/pipelines/backend/src/apiserver/storage/pipeline_store.go:863
github.com/kubeflow/pipelines/backend/src/apiserver/storage.(*PipelineStore).GetPipelineVersionWithStatus
	/home/mprahl/git/pipelines/backend/src/apiserver/storage/pipeline_store.go:831
github.com/kubeflow/pipelines/backend/src/apiserver/storage.(*PipelineStore).GetPipelineVersion
	/home/mprahl/git/pipelines/backend/src/apiserver/storage/pipeline_store.go:822
github.com/kubeflow/pipelines/backend/src/apiserver/resource.(*ResourceManager).GetPipelineVersion
	/home/mprahl/git/pipelines/backend/src/apiserver/resource/resource_manager.go:1685
github.com/kubeflow/pipelines/backend/src/apiserver/server.(*PipelineServer).getPipelineVersion
	/home/mprahl/git/pipelines/backend/src/apiserver/server/pipeline_server.go:765
github.com/kubeflow/pipelines/backend/src/apiserver/server.(*PipelineServer).GetPipelineVersion
	/home/mprahl/git/pipelines/backend/src/apiserver/server/pipeline_server.go:793
github.com/kubeflow/pipelines/backend/api/v2beta1/go_client._PipelineService_GetPipelineVersion_Handler.func1
	/home/mprahl/git/pipelines/backend/api/v2beta1/go_client/pipeline.pb.go:1980
main.apiServerInterceptor
	/home/mprahl/git/pipelines/backend/src/apiserver/interceptor.go:30
github.com/kubeflow/pipelines/backend/api/v2beta1/go_client._PipelineService_GetPipelineVersion_Handler
	/home/mprahl/git/pipelines/backend/api/v2beta1/go_client/pipeline.pb.go:1982
google.golang.org/grpc.(*Server).processUnaryRPC
	/home/mprahl/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1379
google.golang.org/grpc.(*Server).handleStream
	/home/mprahl/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1790
google.golang.org/grpc.(*Server).serveStreams.func2.1
	/home/mprahl/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1029
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1700
Failed to get a pipeline version with id ecc2da09-e6ee-4417-bb3c-5e909b335542
github.com/kubeflow/pipelines/backend/src/common/util.(*UserError).wrapf
	/home/mprahl/git/pipelines/backend/src/common/util/error.go:266
github.com/kubeflow/pipelines/backend/src/common/util.Wrapf
	/home/mprahl/git/pipelines/backend/src/common/util/error.go:337
github.com/kubeflow/pipelines/backend/src/apiserver/resource.(*ResourceManager).GetPipelineVersion
	/home/mprahl/git/pipelines/backend/src/apiserver/resource/resource_manager.go:1686
github.com/kubeflow/pipelines/backend/src/apiserver/server.(*PipelineServer).getPipelineVersion
	/home/mprahl/git/pipelines/backend/src/apiserver/server/pipeline_server.go:765
github.com/kubeflow/pipelines/backend/src/apiserver/server.(*PipelineServer).GetPipelineVersion
	/home/mprahl/git/pipelines/backend/src/apiserver/server/pipeline_server.go:793
github.com/kubeflow/pipelines/backend/api/v2beta1/go_client._PipelineService_GetPipelineVersion_Handler.func1
	/home/mprahl/git/pipelines/backend/api/v2beta1/go_client/pipeline.pb.go:1980
main.apiServerInterceptor
	/home/mprahl/git/pipelines/backend/src/apiserver/interceptor.go:30
github.com/kubeflow/pipelines/backend/api/v2beta1/go_client._PipelineService_GetPipelineVersion_Handler
	/home/mprahl/git/pipelines/backend/api/v2beta1/go_client/pipeline.pb.go:1982
google.golang.org/grpc.(*Server).processUnaryRPC
	/home/mprahl/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1379
google.golang.org/grpc.(*Server).handleStream
	/home/mprahl/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1790
google.golang.org/grpc.(*Server).serveStreams.func2.1
	/home/mprahl/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1029
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1700
Failed to get a pipeline version ecc2da09-e6ee-4417-bb3c-5e909b335542
github.com/kubeflow/pipelines/backend/src/common/util.(*UserError).wrapf
	/home/mprahl/git/pipelines/backend/src/common/util/error.go:266
github.com/kubeflow/pipelines/backend/src/common/util.Wrapf
	/home/mprahl/git/pipelines/backend/src/common/util/error.go:337
github.com/kubeflow/pipelines/backend/src/apiserver/server.(*PipelineServer).GetPipelineVersion
	/home/mprahl/git/pipelines/backend/src/apiserver/server/pipeline_server.go:795
github.com/kubeflow/pipelines/backend/api/v2beta1/go_client._PipelineService_GetPipelineVersion_Handler.func1
	/home/mprahl/git/pipelines/backend/api/v2beta1/go_client/pipeline.pb.go:1980
main.apiServerInterceptor
	/home/mprahl/git/pipelines/backend/src/apiserver/interceptor.go:30
github.com/kubeflow/pipelines/backend/api/v2beta1/go_client._PipelineService_GetPipelineVersion_Handler
	/home/mprahl/git/pipelines/backend/api/v2beta1/go_client/pipeline.pb.go:1982
google.golang.org/grpc.(*Server).processUnaryRPC
	/home/mprahl/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1379
google.golang.org/grpc.(*Server).handleStream
	/home/mprahl/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1790
google.golang.org/grpc.(*Server).serveStreams.func2.1
	/home/mprahl/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1029
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1700
/kubeflow.pipelines.backend.api.v2beta1.PipelineService/GetPipelineVersion call failed
github.com/kubeflow/pipelines/backend/src/common/util.(*UserError).wrapf
	/home/mprahl/git/pipelines/backend/src/common/util/error.go:266
github.com/kubeflow/pipelines/backend/src/common/util.Wrapf
	/home/mprahl/git/pipelines/backend/src/common/util/error.go:337
main.apiServerInterceptor
	/home/mprahl/git/pipelines/backend/src/apiserver/interceptor.go:32
github.com/kubeflow/pipelines/backend/api/v2beta1/go_client._PipelineService_GetPipelineVersion_Handler
	/home/mprahl/git/pipelines/backend/api/v2beta1/go_client/pipeline.pb.go:1982
google.golang.org/grpc.(*Server).processUnaryRPC
	/home/mprahl/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1379
google.golang.org/grpc.(*Server).handleStream
	/home/mprahl/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1790
google.golang.org/grpc.(*Server).serveStreams.func2.1
	/home/mprahl/go/pkg/mod/google.golang.org/grpc@v1.65.0/server.go:1029
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1700
```

After:

```
I0430 16:23:02.750582 1260657 error.go:278] /kubeflow.pipelines.backend.api.v2beta1.PipelineService/GetPipelineVersion call failed: Failed to get a pipeline version ecc2da09-e6ee-4417-bb3c-5e909b335542: Failed to get a pipeline version with id ecc2da09-e6ee-4417-bb3c-5e909b335542: ResourceNotFoundError: PipelineVersion ecc2da09-e6ee-4417-bb3c-5e909b335542 not found
```


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 