### PR TITLE
feat(backend): Allow the launcher command to be configurable

### DIFF
--- a/backend/src/v2/compiler/argocompiler/argo.go
+++ b/backend/src/v2/compiler/argocompiler/argo.go
@@ -134,12 +134,13 @@ func Compile(jobArg *pipelinespec.PipelineJob, kubernetesSpecArg *pipelinespec.S
 		wf:        wf,
 		templates: make(map[string]*wfapi.Template),
 		// TODO(chensun): release process and update the images.
-		launcherImage: GetLauncherImage(),
-		driverImage:   GetDriverImage(),
-		driverCommand: GetDriverCommand(),
-		job:           job,
-		spec:          spec,
-		executors:     deploy.GetExecutors(),
+		launcherImage:   GetLauncherImage(),
+		launcherCommand: GetLauncherCommand(),
+		driverImage:     GetDriverImage(),
+		driverCommand:   GetDriverCommand(),
+		job:             job,
+		spec:            spec,
+		executors:       deploy.GetExecutors(),
 	}
 	if opts != nil {
 		if opts.DriverImage != "" {
@@ -170,11 +171,12 @@ type workflowCompiler struct {
 	spec      *pipelinespec.PipelineSpec
 	executors map[string]*pipelinespec.PipelineDeploymentConfig_ExecutorSpec
 	// state
-	wf            *wfapi.Workflow
-	templates     map[string]*wfapi.Template
-	driverImage   string
-	driverCommand []string
-	launcherImage string
+	wf              *wfapi.Workflow
+	templates       map[string]*wfapi.Template
+	driverImage     string
+	driverCommand   []string
+	launcherImage   string
+	launcherCommand []string
 }
 
 func (c *workflowCompiler) Resolver(name string, component *pipelinespec.ComponentSpec, resolver *pipelinespec.PipelineDeploymentConfig_ResolverSpec) error {

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -42,6 +42,8 @@ const (
 	// For releases, the manifest will have the correct release version set.
 	// this is to avoid hardcoding releases in code here.
 	DefaultLauncherImage     = "ghcr.io/kubeflow/kfp-launcher:latest"
+	LauncherCommandEnvVar    = "V2_LAUNCHER_COMMAND"
+	DefaultLauncherCommand   = "launcher-v2"
 	DefaultDriverImage       = "ghcr.io/kubeflow/kfp-driver:latest"
 	DefaultDriverCommand     = "driver"
 	DriverCommandEnvVar      = "V2_DRIVER_COMMAND"
@@ -111,6 +113,14 @@ func GetDriverCommand() []string {
 		driverCommand = DefaultDriverCommand
 	}
 	return strings.Split(driverCommand, " ")
+}
+
+func GetLauncherCommand() []string {
+	launcherCommand := os.Getenv(LauncherCommandEnvVar)
+	if launcherCommand == "" {
+		launcherCommand = DefaultLauncherCommand
+	}
+	return strings.Split(launcherCommand, " ")
 }
 
 func GetPipelineRunAsUser() *int64 {
@@ -384,7 +394,7 @@ func (c *workflowCompiler) addContainerExecutorTemplate(name string, refName str
 			Container: k8score.Container{
 				Name:    "kfp-launcher",
 				Image:   c.launcherImage,
-				Command: []string{"launcher-v2"},
+				Command: c.launcherCommand,
 				Args:    args,
 				VolumeMounts: []k8score.VolumeMount{
 					{

--- a/backend/src/v2/compiler/argocompiler/importer.go
+++ b/backend/src/v2/compiler/argocompiler/importer.go
@@ -100,7 +100,7 @@ func (c *workflowCompiler) addImporterTemplate() string {
 		},
 		Container: &k8score.Container{
 			Image:     c.launcherImage,
-			Command:   []string{"launcher-v2"},
+			Command:   c.launcherCommand,
 			Args:      args,
 			EnvFrom:   []k8score.EnvFromSource{metadataEnvFrom},
 			Env:       commonEnvs,


### PR DESCRIPTION
**Description of your changes:**

This allows the launcher command to be overridden with the V2_LAUNCHER_COMMAND environment variable. This is useful if you need to override the command to launch Delve for debugging or you have a situation that requires using a different binary in the container image based on the environment.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 